### PR TITLE
openshift-loki: Add ci config for branch upstream-v2.9.4

### DIFF
--- a/ci-operator/config/openshift/loki/openshift-loki-upstream-v2.9.4.yaml
+++ b/ci-operator/config/openshift/loki/openshift-loki-upstream-v2.9.4.yaml
@@ -1,0 +1,58 @@
+base_images:
+  base:
+    name: "4.14"
+    namespace: ocp
+    tag: base-rhel9
+  ocp_builder_rhel-9-golang-1.20-openshift-4.14:
+    name: builder
+    namespace: ocp
+    tag: rhel-9-golang-1.20-openshift-4.14
+build_root:
+  image_stream_tag:
+    name: builder
+    namespace: ocp
+    tag: rhel-9-golang-1.20-openshift-4.14
+images:
+- dockerfile_path: Dockerfile.ocp
+  from: base
+  inputs:
+    ocp_builder_rhel-9-golang-1.20-openshift-4.14:
+      as:
+      - registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.14
+  to: loki
+- dockerfile_path: Dockerfile.promtail.ocp
+  from: base
+  inputs:
+    ocp_builder_rhel-9-golang-1.20-openshift-4.14:
+      as:
+      - registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.14
+  to: promtail
+promotion:
+  to:
+  - name: v2.9.4
+    namespace: logging
+releases:
+  latest:
+    release:
+      channel: stable
+      version: "4.14"
+resources:
+  '*':
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: test
+  steps:
+    test:
+    - as: unit
+      commands: GOFLAGS="" make test
+      from: src
+      resources:
+        requests:
+          cpu: 100m
+          memory: 200Mi
+zz_generated_metadata:
+  branch: upstream-v2.9.4
+  org: openshift
+  repo: loki

--- a/ci-operator/jobs/openshift/loki/openshift-loki-upstream-v2.9.4-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/loki/openshift-loki-upstream-v2.9.4-postsubmits.yaml
@@ -1,0 +1,62 @@
+postsubmits:
+  openshift/loki:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^upstream-v2\.9\.4$
+    cluster: build03
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/is-promotion: "true"
+      ci.openshift.io/generator: prowgen
+    max_concurrency: 1
+    name: branch-ci-openshift-loki-upstream-v2.9.4-images
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --image-mirror-push-secret=/etc/push-secret/.dockerconfigjson
+        - --promote
+        - --report-credentials-file=/etc/report/credentials
+        - --target=[images]
+        command:
+        - ci-operator
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/push-secret
+          name: push-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: push-secret
+        secret:
+          secretName: registry-push-credentials-ci-central
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator

--- a/ci-operator/jobs/openshift/loki/openshift-loki-upstream-v2.9.4-presubmits.yaml
+++ b/ci-operator/jobs/openshift/loki/openshift-loki-upstream-v2.9.4-presubmits.yaml
@@ -1,0 +1,119 @@
+presubmits:
+  openshift/loki:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^upstream-v2\.9\.4$
+    - ^upstream-v2\.9\.4-
+    cluster: build03
+    context: ci/prow/images
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-loki-upstream-v2.9.4-images
+    rerun_command: /test images
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=[images]
+        command:
+        - ci-operator
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )images,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^upstream-v2\.9\.4$
+    - ^upstream-v2\.9\.4-
+    cluster: build03
+    context: ci/prow/test
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-loki-upstream-v2.9.4-test
+    rerun_command: /test test
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=test
+        command:
+        - ci-operator
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )test,?($|\s.*)

--- a/core-services/image-mirroring/openshift-logging/mapping_logging_loki_quay
+++ b/core-services/image-mirroring/openshift-logging/mapping_logging_loki_quay
@@ -1,4 +1,6 @@
 registry.ci.openshift.org/logging/v2.9.2:loki quay.io/openshift-logging/loki:v2.9.2
 registry.ci.openshift.org/logging/v2.9.2:promtail quay.io/openshift-logging/promtail:v2.9.2
-registry.ci.openshift.org/logging/v2.9.3:loki quay.io/openshift-logging/loki:v2.9.3 quay.io/openshift-logging/loki:latest
-registry.ci.openshift.org/logging/v2.9.3:promtail quay.io/openshift-logging/promtail:v2.9.3 quay.io/openshift-logging/promtail:latest
+registry.ci.openshift.org/logging/v2.9.3:loki quay.io/openshift-logging/loki:v2.9.3
+registry.ci.openshift.org/logging/v2.9.3:promtail quay.io/openshift-logging/promtail:v2.9.3
+registry.ci.openshift.org/logging/v2.9.4:loki quay.io/openshift-logging/loki:v2.9.4 quay.io/openshift-logging/loki:latest
+registry.ci.openshift.org/logging/v2.9.4:promtail quay.io/openshift-logging/promtail:v2.9.4 quay.io/openshift-logging/promtail:latest


### PR DESCRIPTION
Add CI configuration and image mirroring for the openshift/loki `upstream-v2.9.4` branch.

Ref: [LOG-5011](https://issues.redhat.com//browse/LOG-5011)

/cc @xperimental