### PR TITLE
ipifmw

### DIFF
--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22__amd64-nightly.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22__amd64-nightly.yaml
@@ -6356,6 +6356,21 @@ tests:
     test:
     - chain: openshift-e2e-test-qe
     workflow: baremetal-lab-upi-dual-stack
+- as: metal-upi-ovn-dualstack-primaryv6-f7
+  capabilities:
+  - intranet
+  cron: 20 13 4,13,20,27 * *
+  steps:
+    cluster_profile: equinix-ocp-metal-qe
+    env:
+      AUX_HOST: openshift-qe-metal-ci.arm.eng.rdu2.redhat.com
+      PRIMARY_NET: ipv6
+      architecture: amd64
+      masters: "3"
+      workers: "2"
+    test:
+    - chain: openshift-e2e-test-qe
+    workflow: baremetal-lab-upi-dual-stack
 - as: metal-upi-ovn-ipsec-ipv6-fips-f7
   capabilities:
   - intranet
@@ -6438,6 +6453,38 @@ tests:
     test:
     - chain: openshift-e2e-test-hypershift-qe
     workflow: cucushift-installer-rehearse-azure-hypershift
+- as: metal-ipi-ovn-dualstack-vmedia-f7
+  capabilities:
+  - intranet
+  cron: 3 13 6,15,22,29 * *
+  steps:
+    cluster_profile: equinix-ocp-metal-qe
+    env:
+      AUX_HOST: openshift-qe-metal-ci.arm.eng.rdu2.redhat.com
+      PRIMARY_NET: ipv6
+      RESERVE_BOOTSTRAP: "false"
+      architecture: amd64
+      ipv6_enabled: "true"
+      masters: "3"
+      workers: "2"
+    test:
+    - chain: openshift-e2e-test-qe
+    workflow: baremetal-lab-ipi-virtual-media
+- as: metal-ipi-ovn-ipv6-static-vmedia-f14
+  capabilities:
+  - intranet
+  cron: 46 21 9,25 * *
+  steps:
+    cluster_profile: equinix-ocp-metal-qe
+    env:
+      AUX_HOST: openshift-qe-metal-ci.arm.eng.rdu2.redhat.com
+      RESERVE_BOOTSTRAP: "false"
+      architecture: amd64
+      masters: "3"
+      workers: "2"
+    test:
+    - chain: openshift-e2e-test-qe
+    workflow: baremetal-lab-ipi-virtual-media-ipv6-static
 zz_generated_metadata:
   branch: release-4.22
   org: openshift

--- a/ci-operator/step-registry/baremetal/lab/ipi/install/baremetal-lab-ipi-install-commands.sh
+++ b/ci-operator/step-registry/baremetal/lab/ipi/install/baremetal-lab-ipi-install-commands.sh
@@ -92,6 +92,8 @@ INSTALL_DIR="/tmp/installer"
 BASE_DOMAIN=$(<"${CLUSTER_PROFILE_DIR}/base_domain")
 CLUSTER_NAME=$(<"${SHARED_DIR}/cluster_name")
 
+export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE="registry.build10.ci.openshift.org/ci-ln-tpmpr3t/release:latest"
+export MULTI_RELEASE_IMAGE="registry.build10.ci.openshift.org/ci-ln-tpmpr3t/release:latest"
 echo "[INFO] Installing from initial release ${OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE}..."
 echo "[INFO] Extracting the baremetal-installer from ${MULTI_RELEASE_IMAGE}..."
 echo "[INFO] Set OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY to true for nightly payload"

--- a/ci-operator/step-registry/baremetal/lab/ipi/install/baremetal-lab-ipi-install-commands.sh
+++ b/ci-operator/step-registry/baremetal/lab/ipi/install/baremetal-lab-ipi-install-commands.sh
@@ -93,6 +93,9 @@ INSTALL_DIR="/tmp/installer"
 BASE_DOMAIN=$(<"${CLUSTER_PROFILE_DIR}/base_domain")
 CLUSTER_NAME=$(<"${SHARED_DIR}/cluster_name")
 
+export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE="registry.build10.ci.openshift.org/ci-ln-299kd42/release:latest"
+export MULTI_RELEASE_IMAGE="registry.build10.ci.openshift.org/ci-ln-299kd42/release:latest"
+
 echo "[INFO] Installing from initial release ${OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE}..."
 echo "[INFO] Extracting the baremetal-installer from ${MULTI_RELEASE_IMAGE}..."
 echo "[INFO] Set OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY to true for nightly payload"

--- a/ci-operator/step-registry/baremetal/lab/post/baremetal-lab-post-chain.yaml
+++ b/ci-operator/step-registry/baremetal/lab/post/baremetal-lab-post-chain.yaml
@@ -1,8 +1,9 @@
 chain:
   as: baremetal-lab-post
   steps:
-    - ref: baremetal-lab-agent-gather
-    - chain: gather
+   # - ref: baremetal-lab-agent-gather
+   # - chain: gather
+    - ref: baremetal-lab-wait
     - ref: baremetal-lab-post-dhcp-pxe-conf
     - ref: baremetal-lab-post-wipe
     - ref: baremetal-lab-post-dns

--- a/ci-operator/step-registry/baremetal/lab/pre/dhcp-conf/baremetal-lab-pre-dhcp-conf-commands.sh
+++ b/ci-operator/step-registry/baremetal/lab/pre/dhcp-conf/baremetal-lab-pre-dhcp-conf-commands.sh
@@ -22,8 +22,8 @@ fi
 
 echo "Generating the DHCP/PXE config..."
 
-# DHCP unique identifier (DUID)
-DUID="00:03:00:01"
+## DHCP unique identifier (DUID)
+#DUID="00:03:00:01"
 
 DHCP_CONF_OPTS="
 tag:$CLUSTER_NAME,15,$CLUSTER_NAME.$BASE_DOMAIN
@@ -49,14 +49,16 @@ $mac,$ip,set:$CLUSTER_NAME,infinite"
       echo "Error when parsing the Bare Metal Host metadata"
       exit 1
     fi
+#    DHCP_CONF="${DHCP_CONF}
+#id:$DUID:$mac,$name,[$ipv6],infinite"
     DHCP_CONF="${DHCP_CONF}
-id:$DUID:$mac,$name,[$ipv6],infinite"
+$mac,$name,[$ipv6],infinite"
   fi
 done
 
 DHCP_CONF="${DHCP_CONF}
 $(<"${SHARED_DIR}/ipi_bootstrap_mac_address"),$(<"${SHARED_DIR}/ipi_bootstrap_ip_address"),set:$CLUSTER_NAME,infinite
-id:$DUID:$(<"${SHARED_DIR}/ipi_bootstrap_mac_address"),$CLUSTER_NAME,[$(<"${SHARED_DIR}/ipi_bootstrap_ipv6_address")],infinite"
+$(<"${SHARED_DIR}/ipi_bootstrap_mac_address"),$CLUSTER_NAME,[$(<"${SHARED_DIR}/ipi_bootstrap_ipv6_address")],infinite"
 
 echo "Setting the DHCP/PXE config in the auxiliary host..."
 timeout -s 9 10m ssh "${SSHOPTS[@]}" "root@${AUX_HOST}" bash -s -- \

--- a/ci-operator/step-registry/baremetal/lab/wait/baremetal-lab-wait-ref.yaml
+++ b/ci-operator/step-registry/baremetal/lab/wait/baremetal-lab-wait-ref.yaml
@@ -1,6 +1,9 @@
 ref:
   as: baremetal-lab-wait
-  from: cli
+  from_image:
+    namespace: ci
+    name: "baremetal-qe-base"
+    tag: latest
   commands: baremetal-lab-wait-commands.sh
   resources:
     requests:
@@ -9,7 +12,7 @@ ref:
   timeout: 72h
   env:
     - name: CLUSTER_DURATION
-      default: "9000"
+      default: "259200"
       documentation: >-
         This configures how long this step waits for in seconds.
   documentation: >-

--- a/ci-operator/step-registry/openshift/e2e/test/qe/openshift-e2e-test-qe-chain.yaml
+++ b/ci-operator/step-registry/openshift/e2e/test/qe/openshift-e2e-test-qe-chain.yaml
@@ -2,15 +2,15 @@ chain:
   as: openshift-e2e-test-qe
   steps:
   - chain: cucushift-installer-check-cluster-health
-  - ref: idp-htpasswd
-  - ref: fips-check-fips-or-die
-  - ref: fips-check-node-scan
-  - ref: cucushift-pre
-  - ref: openshift-extended-test
-  - ref: cucushift-e2e
-  - ref: openshift-extended-web-tests
-  - ref: openshift-extended-test-supplementary
-  - ref: openshift-e2e-test-clusterinfra-qe
-  - ref: openshift-e2e-test-qe-report
+#  - ref: idp-htpasswd
+#  - ref: fips-check-fips-or-die
+#  - ref: fips-check-node-scan
+#  - ref: cucushift-pre
+#  - ref: openshift-extended-test
+#  - ref: cucushift-e2e
+#  - ref: openshift-extended-web-tests
+#  - ref: openshift-extended-test-supplementary
+#  - ref: openshift-e2e-test-clusterinfra-qe
+#  - ref: openshift-e2e-test-qe-report
   documentation: |-
     Execute e2e tests from QE, which include golang (openshift-extended-test), cucushift (cucushift-e2e), cypress (openshift-extended-web-tests), ...(more to add)


### PR DESCRIPTION
testing bmo PR 355

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

This PR modifies the OpenShift release repository's CI infrastructure configuration to support new baremetal dual-stack (IPv6) test scenarios and adjusts the underlying test pipeline behavior.

**Infrastructure Changes:**

The PR adds three new periodic baremetal lab jobs to the release-4.22 test schedule:
- A UPI-based dual-stack job with primary IPv6 network configuration (`metal-upi-ovn-dualstack-primaryv6-f7`)
- Two IPI-based virtual-media jobs with dual-stack and static IPv6 configurations (`metal-ipi-ovn-dualstack-vmedia-f7` and `metal-ipi-ovn-ipv6-static-vmedia-f14`)

These jobs enable testing of baremetal deployments across different network configurations (dual-stack with IPv6 priority, static IPv6) and provisioning methods (UPI/IPI).

**Test Pipeline Adjustments:**

The PR significantly streamlines the baremetal lab test execution chain by:
- Commenting out the agent data-gathering step in the post-chain, reducing diagnostic telemetry collection
- Disabling most test steps in the e2e-test-qe pipeline, keeping only the cluster health check—this appears to be part of a larger test refinement where actual test execution may be handled elsewhere or disabled during this rehearsal phase
- Increasing the cluster test duration timeout from 2.5 hours to 72 hours in the wait step, accommodating longer-running baremetal scenarios
- Switching the baremetal IPI installer to use a mirrored release image from `registry.build10.ci.openshift.org` instead of default image sources

These configuration changes support testing baremetal infrastructure with IPv6 networking while optimizing the CI pipeline for extended test runs against mirrored registries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->