### PR TITLE
OCPBUGS-53010: rename 'master' to 'main' for cluster-api-provider-gcp

### DIFF
--- a/ci-operator/config/openshift-priv/cluster-api-provider-gcp/openshift-priv-cluster-api-provider-gcp-main.yaml
+++ b/ci-operator/config/openshift-priv/cluster-api-provider-gcp/openshift-priv-cluster-api-provider-gcp-main.yaml
@@ -106,7 +106,7 @@ tests:
     workflow: cucushift-installer-rehearse-gcp-ipi
 - as: verify-commits
   commands: |
-    commitchecker --start ${PULL_BASE_SHA:-master}
+    commitchecker --start ${PULL_BASE_SHA:-main}
   container:
     from: commitchecker
   optional: true
@@ -117,6 +117,6 @@ tests:
     test:
     - ref: go-verify-deps
 zz_generated_metadata:
-  branch: master
+  branch: main
   org: openshift-priv
   repo: cluster-api-provider-gcp

--- a/ci-operator/config/openshift/cluster-api-provider-gcp/openshift-cluster-api-provider-gcp-main.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-gcp/openshift-cluster-api-provider-gcp-main.yaml
@@ -106,7 +106,7 @@ tests:
     workflow: cucushift-installer-rehearse-gcp-ipi
 - as: verify-commits
   commands: |
-    commitchecker --start ${PULL_BASE_SHA:-master}
+    commitchecker --start ${PULL_BASE_SHA:-main}
   container:
     from: commitchecker
   optional: true
@@ -117,6 +117,6 @@ tests:
     test:
     - ref: go-verify-deps
 zz_generated_metadata:
-  branch: master
+  branch: main
   org: openshift
   repo: cluster-api-provider-gcp

--- a/ci-operator/config/openshift/cluster-api-provider-gcp/openshift-cluster-api-provider-gcp-main__okd-scos.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-gcp/openshift-cluster-api-provider-gcp-main__okd-scos.yaml
@@ -47,7 +47,7 @@ tests:
     cluster_profile: aws
     workflow: openshift-e2e-aws
 zz_generated_metadata:
-  branch: master
+  branch: main
   org: openshift
   repo: cluster-api-provider-gcp
   variant: okd-scos

--- a/ci-operator/jobs/openshift-priv/cluster-api-provider-gcp/openshift-priv-cluster-api-provider-gcp-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/cluster-api-provider-gcp/openshift-priv-cluster-api-provider-gcp-main-postsubmits.yaml
@@ -3,8 +3,8 @@ postsubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    cluster: build09
+    - ^main$
+    cluster: build01
     decorate: true
     decoration_config:
       oauth_token_secret:
@@ -15,7 +15,7 @@ postsubmits:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-openshift-priv-cluster-api-provider-gcp-master-images
+    name: branch-ci-openshift-priv-cluster-api-provider-gcp-main-images
     path_alias: sigs.k8s.io/cluster-api-provider-gcp
     spec:
       containers:

--- a/ci-operator/jobs/openshift-priv/cluster-api-provider-gcp/openshift-priv-cluster-api-provider-gcp-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/cluster-api-provider-gcp/openshift-priv-cluster-api-provider-gcp-main-presubmits.yaml
@@ -3,9 +3,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build08
+    - ^main$
+    - ^main-
+    cluster: build02
     context: ci/prow/e2e-gcp
     decorate: true
     decoration_config:
@@ -18,7 +18,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-api-provider-gcp-master-e2e-gcp
+    name: pull-ci-openshift-priv-cluster-api-provider-gcp-main-e2e-gcp
     path_alias: sigs.k8s.io/cluster-api-provider-gcp
     rerun_command: /test e2e-gcp
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
@@ -86,9 +86,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build08
+    - ^main$
+    - ^main-
+    cluster: build02
     context: ci/prow/e2e-gcp-capi-techpreview
     decorate: true
     decoration_config:
@@ -101,7 +101,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-api-provider-gcp-master-e2e-gcp-capi-techpreview
+    name: pull-ci-openshift-priv-cluster-api-provider-gcp-main-e2e-gcp-capi-techpreview
     path_alias: sigs.k8s.io/cluster-api-provider-gcp
     rerun_command: /test e2e-gcp-capi-techpreview
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
@@ -169,9 +169,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build08
+    - ^main$
+    - ^main-
+    cluster: build02
     context: ci/prow/e2e-gcp-ovn-techpreview
     decorate: true
     decoration_config:
@@ -184,7 +184,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp-3
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-api-provider-gcp-master-e2e-gcp-ovn-techpreview
+    name: pull-ci-openshift-priv-cluster-api-provider-gcp-main-e2e-gcp-ovn-techpreview
     path_alias: sigs.k8s.io/cluster-api-provider-gcp
     rerun_command: /test e2e-gcp-ovn-techpreview
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
@@ -252,9 +252,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build08
+    - ^main$
+    - ^main-
+    cluster: build02
     context: ci/prow/e2e-gcp-serial
     decorate: true
     decoration_config:
@@ -267,7 +267,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-api-provider-gcp-master-e2e-gcp-serial
+    name: pull-ci-openshift-priv-cluster-api-provider-gcp-main-e2e-gcp-serial
     path_alias: sigs.k8s.io/cluster-api-provider-gcp
     rerun_command: /test e2e-gcp-serial
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
@@ -335,9 +335,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build08
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/images
     decorate: true
     decoration_config:
@@ -348,7 +348,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-api-provider-gcp-master-images
+    name: pull-ci-openshift-priv-cluster-api-provider-gcp-main-images
     path_alias: sigs.k8s.io/cluster-api-provider-gcp
     rerun_command: /test images
     spec:
@@ -398,9 +398,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build08
+    - ^main$
+    - ^main-
+    cluster: build02
     context: ci/prow/regression-clusterinfra-gcp-ipi-techpreview-capi
     decorate: true
     decoration_config:
@@ -413,7 +413,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-api-provider-gcp-master-regression-clusterinfra-gcp-ipi-techpreview-capi
+    name: pull-ci-openshift-priv-cluster-api-provider-gcp-main-regression-clusterinfra-gcp-ipi-techpreview-capi
     optional: true
     path_alias: sigs.k8s.io/cluster-api-provider-gcp
     rerun_command: /test regression-clusterinfra-gcp-ipi-techpreview-capi
@@ -482,9 +482,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build08
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/unit
     decorate: true
     decoration_config:
@@ -495,7 +495,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-api-provider-gcp-master-unit
+    name: pull-ci-openshift-priv-cluster-api-provider-gcp-main-unit
     path_alias: sigs.k8s.io/cluster-api-provider-gcp
     rerun_command: /test unit
     spec:
@@ -545,9 +545,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build08
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/verify-commits
     decorate: true
     decoration_config:
@@ -558,7 +558,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-api-provider-gcp-master-verify-commits
+    name: pull-ci-openshift-priv-cluster-api-provider-gcp-main-verify-commits
     optional: true
     path_alias: sigs.k8s.io/cluster-api-provider-gcp
     rerun_command: /test verify-commits
@@ -609,9 +609,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build08
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/verify-deps
     decorate: true
     decoration_config:
@@ -622,7 +622,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-api-provider-gcp-master-verify-deps
+    name: pull-ci-openshift-priv-cluster-api-provider-gcp-main-verify-deps
     path_alias: sigs.k8s.io/cluster-api-provider-gcp
     rerun_command: /test verify-deps
     spec:

--- a/ci-operator/jobs/openshift/cluster-api-provider-gcp/openshift-cluster-api-provider-gcp-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-gcp/openshift-cluster-api-provider-gcp-main-postsubmits.yaml
@@ -3,14 +3,14 @@ postsubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    cluster: build09
+    - ^main$
+    cluster: build01
     decorate: true
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-openshift-cluster-api-provider-gcp-master-images
+    name: branch-ci-openshift-cluster-api-provider-gcp-main-images
     path_alias: sigs.k8s.io/cluster-api-provider-gcp
     spec:
       containers:
@@ -62,8 +62,8 @@ postsubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    cluster: build09
+    - ^main$
+    cluster: build01
     decorate: true
     decoration_config:
       skip_cloning: true
@@ -72,7 +72,7 @@ postsubmits:
       ci-operator.openshift.io/variant: okd-scos
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-openshift-cluster-api-provider-gcp-master-okd-scos-images
+    name: branch-ci-openshift-cluster-api-provider-gcp-main-okd-scos-images
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift/cluster-api-provider-gcp/openshift-cluster-api-provider-gcp-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-gcp/openshift-cluster-api-provider-gcp-main-presubmits.yaml
@@ -3,9 +3,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build02
+    - ^main$
+    - ^main-
+    cluster: build04
     context: ci/prow/e2e-gcp
     decorate: true
     labels:
@@ -13,7 +13,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-api-provider-gcp-master-e2e-gcp
+    name: pull-ci-openshift-cluster-api-provider-gcp-main-e2e-gcp
     path_alias: sigs.k8s.io/cluster-api-provider-gcp
     rerun_command: /test e2e-gcp
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
@@ -77,9 +77,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build02
+    - ^main$
+    - ^main-
+    cluster: build04
     context: ci/prow/e2e-gcp-capi-techpreview
     decorate: true
     labels:
@@ -87,7 +87,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-api-provider-gcp-master-e2e-gcp-capi-techpreview
+    name: pull-ci-openshift-cluster-api-provider-gcp-main-e2e-gcp-capi-techpreview
     path_alias: sigs.k8s.io/cluster-api-provider-gcp
     rerun_command: /test e2e-gcp-capi-techpreview
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
@@ -151,9 +151,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build02
+    - ^main$
+    - ^main-
+    cluster: build04
     context: ci/prow/e2e-gcp-ovn-techpreview
     decorate: true
     labels:
@@ -161,7 +161,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp-3
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-api-provider-gcp-master-e2e-gcp-ovn-techpreview
+    name: pull-ci-openshift-cluster-api-provider-gcp-main-e2e-gcp-ovn-techpreview
     path_alias: sigs.k8s.io/cluster-api-provider-gcp
     rerun_command: /test e2e-gcp-ovn-techpreview
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
@@ -225,9 +225,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build02
+    - ^main$
+    - ^main-
+    cluster: build04
     context: ci/prow/e2e-gcp-serial
     decorate: true
     labels:
@@ -235,7 +235,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-api-provider-gcp-master-e2e-gcp-serial
+    name: pull-ci-openshift-cluster-api-provider-gcp-main-e2e-gcp-serial
     path_alias: sigs.k8s.io/cluster-api-provider-gcp
     rerun_command: /test e2e-gcp-serial
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
@@ -299,15 +299,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build02
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/images
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-api-provider-gcp-master-images
+    name: pull-ci-openshift-cluster-api-provider-gcp-main-images
     path_alias: sigs.k8s.io/cluster-api-provider-gcp
     rerun_command: /test images
     spec:
@@ -354,9 +354,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build03
     context: ci/prow/okd-scos-e2e-aws-ovn
     decorate: true
     decoration_config:
@@ -367,7 +367,7 @@ presubmits:
       ci-operator.openshift.io/variant: okd-scos
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-api-provider-gcp-master-okd-scos-e2e-aws-ovn
+    name: pull-ci-openshift-cluster-api-provider-gcp-main-okd-scos-e2e-aws-ovn
     optional: true
     rerun_command: /test okd-scos-e2e-aws-ovn
     spec:
@@ -431,9 +431,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build02
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/okd-scos-images
     decorate: true
     decoration_config:
@@ -442,7 +442,7 @@ presubmits:
       ci-operator.openshift.io/variant: okd-scos
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-api-provider-gcp-master-okd-scos-images
+    name: pull-ci-openshift-cluster-api-provider-gcp-main-okd-scos-images
     rerun_command: /test okd-scos-images
     spec:
       containers:
@@ -489,9 +489,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build02
+    - ^main$
+    - ^main-
+    cluster: build04
     context: ci/prow/regression-clusterinfra-gcp-ipi-techpreview-capi
     decorate: true
     labels:
@@ -499,7 +499,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-api-provider-gcp-master-regression-clusterinfra-gcp-ipi-techpreview-capi
+    name: pull-ci-openshift-cluster-api-provider-gcp-main-regression-clusterinfra-gcp-ipi-techpreview-capi
     optional: true
     path_alias: sigs.k8s.io/cluster-api-provider-gcp
     rerun_command: /test regression-clusterinfra-gcp-ipi-techpreview-capi
@@ -564,15 +564,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build02
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/unit
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-api-provider-gcp-master-unit
+    name: pull-ci-openshift-cluster-api-provider-gcp-main-unit
     path_alias: sigs.k8s.io/cluster-api-provider-gcp
     rerun_command: /test unit
     spec:
@@ -618,15 +618,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build02
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/verify-commits
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-api-provider-gcp-master-verify-commits
+    name: pull-ci-openshift-cluster-api-provider-gcp-main-verify-commits
     optional: true
     path_alias: sigs.k8s.io/cluster-api-provider-gcp
     rerun_command: /test verify-commits
@@ -673,15 +673,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build02
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/verify-deps
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-api-provider-gcp-master-verify-deps
+    name: pull-ci-openshift-cluster-api-provider-gcp-main-verify-deps
     path_alias: sigs.k8s.io/cluster-api-provider-gcp
     rerun_command: /test verify-deps
     spec:


### PR DESCRIPTION

This PR is in support of renaming the default branch for https://github.com/openshift/cluster-api-provider-gcp from 'master' to 'main'.

Unhold this PR only when:

* the default branch for https://github.com/openshift/cluster-api-provider-gcp has been renamed to 'main'
* You have verified that the CI jobs are working as expected either by running '/pj-rehearse' or by inspection.

/hold
