### PR TITLE
OCPBUGS-53011: rename 'master' to 'main' for cluster-api-provider-vsphere

### DIFF
--- a/ci-operator/config/openshift-priv/cluster-api-provider-vsphere/openshift-priv-cluster-api-provider-vsphere-main.yaml
+++ b/ci-operator/config/openshift-priv/cluster-api-provider-vsphere/openshift-priv-cluster-api-provider-vsphere-main.yaml
@@ -107,7 +107,7 @@ tests:
     workflow: cucushift-installer-rehearse-vsphere-ipi
 - as: verify-commits
   commands: |
-    commitchecker --start ${PULL_BASE_SHA:-master}
+    commitchecker --start ${PULL_BASE_SHA:-main}
   container:
     from: commitchecker
   optional: true
@@ -118,6 +118,6 @@ tests:
     test:
     - ref: go-verify-deps
 zz_generated_metadata:
-  branch: master
+  branch: main
   org: openshift-priv
   repo: cluster-api-provider-vsphere

--- a/ci-operator/config/openshift/cluster-api-provider-vsphere/openshift-cluster-api-provider-vsphere-main.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-vsphere/openshift-cluster-api-provider-vsphere-main.yaml
@@ -107,7 +107,7 @@ tests:
     workflow: cucushift-installer-rehearse-vsphere-ipi
 - as: verify-commits
   commands: |
-    commitchecker --start ${PULL_BASE_SHA:-master}
+    commitchecker --start ${PULL_BASE_SHA:-main}
   container:
     from: commitchecker
   optional: true
@@ -118,6 +118,6 @@ tests:
     test:
     - ref: go-verify-deps
 zz_generated_metadata:
-  branch: master
+  branch: main
   org: openshift
   repo: cluster-api-provider-vsphere

--- a/ci-operator/config/openshift/cluster-api-provider-vsphere/openshift-cluster-api-provider-vsphere-main__okd-scos.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-vsphere/openshift-cluster-api-provider-vsphere-main__okd-scos.yaml
@@ -47,7 +47,7 @@ tests:
     cluster_profile: aws
     workflow: openshift-e2e-aws
 zz_generated_metadata:
-  branch: master
+  branch: main
   org: openshift
   repo: cluster-api-provider-vsphere
   variant: okd-scos

--- a/ci-operator/jobs/openshift-priv/cluster-api-provider-vsphere/openshift-priv-cluster-api-provider-vsphere-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/cluster-api-provider-vsphere/openshift-priv-cluster-api-provider-vsphere-main-postsubmits.yaml
@@ -3,7 +3,7 @@ postsubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
+    - ^main$
     cluster: vsphere02
     decorate: true
     decoration_config:
@@ -15,7 +15,7 @@ postsubmits:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-openshift-priv-cluster-api-provider-vsphere-master-images
+    name: branch-ci-openshift-priv-cluster-api-provider-vsphere-main-images
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
       containers:

--- a/ci-operator/jobs/openshift-priv/cluster-api-provider-vsphere/openshift-priv-cluster-api-provider-vsphere-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/cluster-api-provider-vsphere/openshift-priv-cluster-api-provider-vsphere-main-presubmits.yaml
@@ -3,8 +3,8 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: vsphere02
     context: ci/prow/e2e-vsphere
     decorate: true
@@ -18,7 +18,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-api-provider-vsphere-master-e2e-vsphere
+    name: pull-ci-openshift-priv-cluster-api-provider-vsphere-main-e2e-vsphere
     optional: true
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     rerun_command: /test e2e-vsphere
@@ -86,8 +86,8 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: vsphere02
     context: ci/prow/e2e-vsphere-capi-techpreview
     decorate: true
@@ -101,7 +101,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-api-provider-vsphere-master-e2e-vsphere-capi-techpreview
+    name: pull-ci-openshift-priv-cluster-api-provider-vsphere-main-e2e-vsphere-capi-techpreview
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     rerun_command: /test e2e-vsphere-capi-techpreview
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
@@ -169,8 +169,8 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: vsphere02
     context: ci/prow/e2e-vsphere-serial
     decorate: true
@@ -185,7 +185,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-api-provider-vsphere-master-e2e-vsphere-serial
+    name: pull-ci-openshift-priv-cluster-api-provider-vsphere-main-e2e-vsphere-serial
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     rerun_command: /test e2e-vsphere-serial
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
@@ -253,8 +253,8 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: vsphere02
     context: ci/prow/e2e-vsphere-techpreview
     decorate: true
@@ -268,7 +268,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-api-provider-vsphere-master-e2e-vsphere-techpreview
+    name: pull-ci-openshift-priv-cluster-api-provider-vsphere-main-e2e-vsphere-techpreview
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     rerun_command: /test e2e-vsphere-techpreview
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
@@ -336,8 +336,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: vsphere02
     context: ci/prow/images
     decorate: true
@@ -349,7 +349,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-api-provider-vsphere-master-images
+    name: pull-ci-openshift-priv-cluster-api-provider-vsphere-main-images
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     rerun_command: /test images
     spec:
@@ -399,8 +399,8 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: vsphere02
     context: ci/prow/regression-clusterinfra-vsphere-ipi-techpreview-capi
     decorate: true
@@ -414,7 +414,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-api-provider-vsphere-master-regression-clusterinfra-vsphere-ipi-techpreview-capi
+    name: pull-ci-openshift-priv-cluster-api-provider-vsphere-main-regression-clusterinfra-vsphere-ipi-techpreview-capi
     optional: true
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     rerun_command: /test regression-clusterinfra-vsphere-ipi-techpreview-capi
@@ -483,8 +483,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: vsphere02
     context: ci/prow/unit
     decorate: true
@@ -496,7 +496,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-api-provider-vsphere-master-unit
+    name: pull-ci-openshift-priv-cluster-api-provider-vsphere-main-unit
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     rerun_command: /test unit
     spec:
@@ -546,8 +546,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: vsphere02
     context: ci/prow/verify-commits
     decorate: true
@@ -559,7 +559,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-api-provider-vsphere-master-verify-commits
+    name: pull-ci-openshift-priv-cluster-api-provider-vsphere-main-verify-commits
     optional: true
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     rerun_command: /test verify-commits
@@ -610,8 +610,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: vsphere02
     context: ci/prow/verify-deps
     decorate: true
@@ -623,7 +623,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-api-provider-vsphere-master-verify-deps
+    name: pull-ci-openshift-priv-cluster-api-provider-vsphere-main-verify-deps
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     rerun_command: /test verify-deps
     spec:

--- a/ci-operator/jobs/openshift/cluster-api-provider-vsphere/openshift-cluster-api-provider-vsphere-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-vsphere/openshift-cluster-api-provider-vsphere-main-postsubmits.yaml
@@ -3,14 +3,14 @@ postsubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
+    - ^main$
     cluster: vsphere02
     decorate: true
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-openshift-cluster-api-provider-vsphere-master-images
+    name: branch-ci-openshift-cluster-api-provider-vsphere-main-images
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
       containers:
@@ -62,7 +62,7 @@ postsubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
+    - ^main$
     cluster: vsphere02
     decorate: true
     decoration_config:
@@ -72,7 +72,7 @@ postsubmits:
       ci-operator.openshift.io/variant: okd-scos
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-openshift-cluster-api-provider-vsphere-master-okd-scos-images
+    name: branch-ci-openshift-cluster-api-provider-vsphere-main-okd-scos-images
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift/cluster-api-provider-vsphere/openshift-cluster-api-provider-vsphere-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-vsphere/openshift-cluster-api-provider-vsphere-main-presubmits.yaml
@@ -3,8 +3,8 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: vsphere02
     context: ci/prow/e2e-vsphere
     decorate: true
@@ -13,7 +13,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-api-provider-vsphere-master-e2e-vsphere
+    name: pull-ci-openshift-cluster-api-provider-vsphere-main-e2e-vsphere
     optional: true
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     rerun_command: /test e2e-vsphere
@@ -77,8 +77,8 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: vsphere02
     context: ci/prow/e2e-vsphere-capi-techpreview
     decorate: true
@@ -87,7 +87,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-api-provider-vsphere-master-e2e-vsphere-capi-techpreview
+    name: pull-ci-openshift-cluster-api-provider-vsphere-main-e2e-vsphere-capi-techpreview
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     rerun_command: /test e2e-vsphere-capi-techpreview
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
@@ -151,8 +151,8 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: vsphere02
     context: ci/prow/e2e-vsphere-serial
     decorate: true
@@ -163,7 +163,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-api-provider-vsphere-master-e2e-vsphere-serial
+    name: pull-ci-openshift-cluster-api-provider-vsphere-main-e2e-vsphere-serial
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     rerun_command: /test e2e-vsphere-serial
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
@@ -227,8 +227,8 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: vsphere02
     context: ci/prow/e2e-vsphere-techpreview
     decorate: true
@@ -237,7 +237,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-api-provider-vsphere-master-e2e-vsphere-techpreview
+    name: pull-ci-openshift-cluster-api-provider-vsphere-main-e2e-vsphere-techpreview
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     rerun_command: /test e2e-vsphere-techpreview
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
@@ -301,15 +301,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: vsphere02
     context: ci/prow/images
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-api-provider-vsphere-master-images
+    name: pull-ci-openshift-cluster-api-provider-vsphere-main-images
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     rerun_command: /test images
     spec:
@@ -356,8 +356,8 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: vsphere02
     context: ci/prow/okd-scos-e2e-aws-ovn
     decorate: true
@@ -369,7 +369,7 @@ presubmits:
       ci-operator.openshift.io/variant: okd-scos
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-api-provider-vsphere-master-okd-scos-e2e-aws-ovn
+    name: pull-ci-openshift-cluster-api-provider-vsphere-main-okd-scos-e2e-aws-ovn
     optional: true
     rerun_command: /test okd-scos-e2e-aws-ovn
     spec:
@@ -433,8 +433,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: vsphere02
     context: ci/prow/okd-scos-images
     decorate: true
@@ -444,7 +444,7 @@ presubmits:
       ci-operator.openshift.io/variant: okd-scos
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-api-provider-vsphere-master-okd-scos-images
+    name: pull-ci-openshift-cluster-api-provider-vsphere-main-okd-scos-images
     rerun_command: /test okd-scos-images
     spec:
       containers:
@@ -491,8 +491,8 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: vsphere02
     context: ci/prow/regression-clusterinfra-vsphere-ipi-techpreview-capi
     decorate: true
@@ -501,7 +501,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-api-provider-vsphere-master-regression-clusterinfra-vsphere-ipi-techpreview-capi
+    name: pull-ci-openshift-cluster-api-provider-vsphere-main-regression-clusterinfra-vsphere-ipi-techpreview-capi
     optional: true
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     rerun_command: /test regression-clusterinfra-vsphere-ipi-techpreview-capi
@@ -566,15 +566,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: vsphere02
     context: ci/prow/unit
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-api-provider-vsphere-master-unit
+    name: pull-ci-openshift-cluster-api-provider-vsphere-main-unit
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     rerun_command: /test unit
     spec:
@@ -620,15 +620,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: vsphere02
     context: ci/prow/verify-commits
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-api-provider-vsphere-master-verify-commits
+    name: pull-ci-openshift-cluster-api-provider-vsphere-main-verify-commits
     optional: true
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     rerun_command: /test verify-commits
@@ -675,15 +675,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: vsphere02
     context: ci/prow/verify-deps
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-api-provider-vsphere-master-verify-deps
+    name: pull-ci-openshift-cluster-api-provider-vsphere-main-verify-deps
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     rerun_command: /test verify-deps
     spec:


### PR DESCRIPTION

This PR is in support of renaming the default branch for https://github.com/openshift/cluster-api-provider-vsphere from 'master' to 'main'.

Unhold this PR only when:

* the default branch for https://github.com/openshift/cluster-api-provider-vsphere has been renamed to 'main'
* You have verified that the CI jobs are working as expected either by running '/pj-rehearse' or by inspection.

/hold
