### PR TITLE
Reduce number of AWS jobs triggered automatically

### DIFF
--- a/ci-operator/config/openshift/installer/openshift-installer-main.yaml
+++ b/ci-operator/config/openshift/installer/openshift-installer-main.yaml
@@ -392,9 +392,9 @@ tests:
     cluster_profile: aws
     workflow: openshift-e2e-aws-upi-proxy
   timeout: 6h0m0s
-- as: e2e-aws-ovn-shared-vpc-custom-security-groups
+- always_run: false
+  as: e2e-aws-ovn-shared-vpc-custom-security-groups
   optional: true
-  run_if_changed: aws
   steps:
     cluster_profile: aws
     env:
@@ -438,7 +438,6 @@ tests:
   timeout: 6h0m0s
 - always_run: false
   as: e2e-aws-default-config
-  optional: true
   run_if_changed: aws
   steps:
     cluster_profile: aws
@@ -455,7 +454,6 @@ tests:
 - always_run: false
   as: e2e-aws-ovn-edge-zones
   optional: true
-  run_if_changed: aws
   steps:
     cluster_profile: aws
     env:
@@ -465,23 +463,22 @@ tests:
 - always_run: false
   as: e2e-aws-ovn-shared-vpc-edge-zones
   optional: true
-  run_if_changed: aws
   steps:
     cluster_profile: aws
     env:
       AWS_INSTALL_USE_MINIMAL_PERMISSIONS: "yes"
     workflow: openshift-e2e-aws-edge-zones-byo-vpc
   timeout: 6h0m0s
-- always_run: true
+- always_run: false
   as: e2e-aws-ovn-edge-zones-manifest-validation
   run_if_changed: aws
   steps:
     cluster_profile: aws
     workflow: openshift-installer-manifests-aws-edge-zones
   timeout: 3h0m0s
-- as: e2e-aws-ovn-imdsv2
+- always_run: false
+  as: e2e-aws-ovn-imdsv2
   optional: true
-  run_if_changed: aws
   steps:
     cluster_profile: aws
     env:
@@ -937,9 +934,9 @@ tests:
     cluster_profile: packet-assisted
     workflow: assisted-ofcir-baremetal
   timeout: 6h0m0s
-- as: e2e-aws-ovn-single-node
+- always_run: false
+  as: e2e-aws-ovn-single-node
   optional: true
-  run_if_changed: aws
   steps:
     cluster_profile: aws
     workflow: openshift-e2e-aws-single-node
@@ -1200,9 +1197,9 @@ tests:
       PLATFORM_EXTERNAL_CCM_ENABLED: "yes"
     workflow: openshift-e2e-external-aws
   timeout: 6h0m0s
-- as: e2e-aws-ovn-heterogeneous
+- always_run: false
+  as: e2e-aws-ovn-heterogeneous
   optional: true
-  run_if_changed: aws
   steps:
     cluster_profile: aws
     dependencies:

--- a/ci-operator/jobs/openshift/installer/openshift-installer-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/installer/openshift-installer-main-presubmits.yaml
@@ -3472,7 +3472,6 @@ presubmits:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-installer-main-e2e-aws-default-config
-    optional: true
     rerun_command: /test e2e-aws-default-config
     run_if_changed: aws
     spec:


### PR DESCRIPTION
We are running A LOT of AWS jobs anytime 'aws' is matched in the path. Reduce many of these jobs so they are manually trigerred.