### PR TITLE
OCPBUGS-52241: rename 'master' to 'main' for cloud-credential-operator

### DIFF
--- a/ci-operator/config/openshift-priv/cloud-credential-operator/openshift-priv-cloud-credential-operator-main.yaml
+++ b/ci-operator/config/openshift-priv/cloud-credential-operator/openshift-priv-cloud-credential-operator-main.yaml
@@ -8,8 +8,8 @@ base_images:
     namespace: hypershift
     tag: latest
   ocp_4.21_base-rhel9:
-    name: "4.22"
-    namespace: ocp
+    name: 4.22-priv
+    namespace: ocp-private
     tag: base-rhel9
   ocp_builder_rhel-8-golang-1.24-openshift-4.21:
     name: builder
@@ -26,6 +26,7 @@ base_images:
 binary_build_commands: make build-no-gen
 build_root:
   from_repository: true
+canonical_go_repository: github.com/openshift/cloud-credential-operator
 images:
 - inputs:
     ocp_4.21_base-rhel9:
@@ -40,18 +41,18 @@ images:
   to: cloud-credential-operator
 promotion:
   to:
-  - name: "4.22"
-    namespace: ocp
+  - name: 4.22-priv
+    namespace: ocp-private
 releases:
   initial:
     integration:
-      name: "4.22"
-      namespace: ocp
+      name: 4.22-priv
+      namespace: ocp-private
   latest:
     integration:
       include_built_images: true
-      name: "4.22"
-      namespace: ocp
+      name: 4.22-priv
+      namespace: ocp-private
 resources:
   '*':
     requests:
@@ -90,16 +91,6 @@ tests:
       SNYK_CODE_ADDITIONAL_ARGS: --severity-threshold=high
       SNYK_ENABLE_DEPS_SCAN: "true"
     workflow: openshift-ci-security
-- as: publish-coverage
-  commands: |
-    export CODECOV_TOKEN=$(cat /tmp/secret/CODECOV_TOKEN)
-    make coverage
-  container:
-    from: src
-  postsubmit: true
-  secret:
-    mount_path: /tmp/secret
-    name: cloud-credential-operator-codecov-token
 - as: e2e-aws-ovn
   skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
   steps:
@@ -195,6 +186,6 @@ tests:
     - ref: openshift-e2e-test-qe-report
     workflow: cucushift-installer-rehearse-aws-ipi
 zz_generated_metadata:
-  branch: master
-  org: openshift
+  branch: main
+  org: openshift-priv
   repo: cloud-credential-operator

--- a/ci-operator/config/openshift/cloud-credential-operator/openshift-cloud-credential-operator-main.yaml
+++ b/ci-operator/config/openshift/cloud-credential-operator/openshift-cloud-credential-operator-main.yaml
@@ -8,8 +8,8 @@ base_images:
     namespace: hypershift
     tag: latest
   ocp_4.21_base-rhel9:
-    name: 4.22-priv
-    namespace: ocp-private
+    name: "4.22"
+    namespace: ocp
     tag: base-rhel9
   ocp_builder_rhel-8-golang-1.24-openshift-4.21:
     name: builder
@@ -26,7 +26,6 @@ base_images:
 binary_build_commands: make build-no-gen
 build_root:
   from_repository: true
-canonical_go_repository: github.com/openshift/cloud-credential-operator
 images:
 - inputs:
     ocp_4.21_base-rhel9:
@@ -41,18 +40,18 @@ images:
   to: cloud-credential-operator
 promotion:
   to:
-  - name: 4.22-priv
-    namespace: ocp-private
+  - name: "4.22"
+    namespace: ocp
 releases:
   initial:
     integration:
-      name: 4.22-priv
-      namespace: ocp-private
+      name: "4.22"
+      namespace: ocp
   latest:
     integration:
       include_built_images: true
-      name: 4.22-priv
-      namespace: ocp-private
+      name: "4.22"
+      namespace: ocp
 resources:
   '*':
     requests:
@@ -91,6 +90,16 @@ tests:
       SNYK_CODE_ADDITIONAL_ARGS: --severity-threshold=high
       SNYK_ENABLE_DEPS_SCAN: "true"
     workflow: openshift-ci-security
+- as: publish-coverage
+  commands: |
+    export CODECOV_TOKEN=$(cat /tmp/secret/CODECOV_TOKEN)
+    make coverage
+  container:
+    from: src
+  postsubmit: true
+  secret:
+    mount_path: /tmp/secret
+    name: cloud-credential-operator-codecov-token
 - as: e2e-aws-ovn
   skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
   steps:
@@ -186,6 +195,6 @@ tests:
     - ref: openshift-e2e-test-qe-report
     workflow: cucushift-installer-rehearse-aws-ipi
 zz_generated_metadata:
-  branch: master
-  org: openshift-priv
+  branch: main
+  org: openshift
   repo: cloud-credential-operator

--- a/ci-operator/config/openshift/cloud-credential-operator/openshift-cloud-credential-operator-main__okd-scos.yaml
+++ b/ci-operator/config/openshift/cloud-credential-operator/openshift-cloud-credential-operator-main__okd-scos.yaml
@@ -55,7 +55,7 @@ tests:
     cluster_profile: aws
     workflow: openshift-e2e-aws
 zz_generated_metadata:
-  branch: master
+  branch: main
   org: openshift
   repo: cloud-credential-operator
   variant: okd-scos

--- a/ci-operator/jobs/openshift-priv/cloud-credential-operator/openshift-priv-cloud-credential-operator-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/cloud-credential-operator/openshift-priv-cloud-credential-operator-main-postsubmits.yaml
@@ -3,8 +3,8 @@ postsubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    cluster: build09
+    - ^main$
+    cluster: build01
     decorate: true
     decoration_config:
       oauth_token_secret:
@@ -15,7 +15,7 @@ postsubmits:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-openshift-priv-cloud-credential-operator-master-images
+    name: branch-ci-openshift-priv-cloud-credential-operator-main-images
     path_alias: github.com/openshift/cloud-credential-operator
     spec:
       containers:

--- a/ci-operator/jobs/openshift-priv/cloud-credential-operator/openshift-priv-cloud-credential-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/cloud-credential-operator/openshift-priv-cloud-credential-operator-main-presubmits.yaml
@@ -3,9 +3,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build02
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/coverage
     decorate: true
     decoration_config:
@@ -16,7 +16,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cloud-credential-operator-master-coverage
+    name: pull-ci-openshift-priv-cloud-credential-operator-main-coverage
     path_alias: github.com/openshift/cloud-credential-operator
     rerun_command: /test coverage
     run_if_changed: \.go$
@@ -74,9 +74,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build03
     context: ci/prow/e2e-aws-manual-oidc
     decorate: true
     decoration_config:
@@ -89,7 +89,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-2
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cloud-credential-operator-master-e2e-aws-manual-oidc
+    name: pull-ci-openshift-priv-cloud-credential-operator-main-e2e-aws-manual-oidc
     optional: true
     path_alias: github.com/openshift/cloud-credential-operator
     rerun_command: /test e2e-aws-manual-oidc
@@ -157,9 +157,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build03
     context: ci/prow/e2e-aws-ovn
     decorate: true
     decoration_config:
@@ -172,7 +172,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-4
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cloud-credential-operator-master-e2e-aws-ovn
+    name: pull-ci-openshift-priv-cloud-credential-operator-main-e2e-aws-ovn
     path_alias: github.com/openshift/cloud-credential-operator
     rerun_command: /test e2e-aws-ovn
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
@@ -240,9 +240,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build03
     context: ci/prow/e2e-aws-qe
     decorate: true
     decoration_config:
@@ -255,7 +255,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-qe
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cloud-credential-operator-master-e2e-aws-qe
+    name: pull-ci-openshift-priv-cloud-credential-operator-main-e2e-aws-qe
     optional: true
     path_alias: github.com/openshift/cloud-credential-operator
     rerun_command: /test e2e-aws-qe
@@ -324,9 +324,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build02
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/e2e-azure
     decorate: true
     decoration_config:
@@ -339,7 +339,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: azure-2
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cloud-credential-operator-master-e2e-azure
+    name: pull-ci-openshift-priv-cloud-credential-operator-main-e2e-azure
     optional: true
     path_alias: github.com/openshift/cloud-credential-operator
     rerun_command: /test e2e-azure
@@ -407,9 +407,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build02
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/e2e-azure-manual-oidc
     decorate: true
     decoration_config:
@@ -422,7 +422,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: azure4
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cloud-credential-operator-master-e2e-azure-manual-oidc
+    name: pull-ci-openshift-priv-cloud-credential-operator-main-e2e-azure-manual-oidc
     path_alias: github.com/openshift/cloud-credential-operator
     rerun_command: /test e2e-azure-manual-oidc
     run_if_changed: pkg/cmd/provisioning/azure/
@@ -490,9 +490,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build02
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/e2e-azure-upgrade
     decorate: true
     decoration_config:
@@ -505,7 +505,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: azure4
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cloud-credential-operator-master-e2e-azure-upgrade
+    name: pull-ci-openshift-priv-cloud-credential-operator-main-e2e-azure-upgrade
     optional: true
     path_alias: github.com/openshift/cloud-credential-operator
     rerun_command: /test e2e-azure-upgrade
@@ -573,9 +573,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build02
+    - ^main$
+    - ^main-
+    cluster: build04
     context: ci/prow/e2e-gcp
     decorate: true
     decoration_config:
@@ -588,7 +588,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cloud-credential-operator-master-e2e-gcp
+    name: pull-ci-openshift-priv-cloud-credential-operator-main-e2e-gcp
     optional: true
     path_alias: github.com/openshift/cloud-credential-operator
     rerun_command: /test e2e-gcp
@@ -656,9 +656,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build02
+    - ^main$
+    - ^main-
+    cluster: build04
     context: ci/prow/e2e-gcp-manual-oidc
     decorate: true
     decoration_config:
@@ -671,7 +671,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cloud-credential-operator-master-e2e-gcp-manual-oidc
+    name: pull-ci-openshift-priv-cloud-credential-operator-main-e2e-gcp-manual-oidc
     optional: true
     path_alias: github.com/openshift/cloud-credential-operator
     rerun_command: /test e2e-gcp-manual-oidc
@@ -739,9 +739,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build02
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/e2e-hypershift
     decorate: true
     decoration_config:
@@ -754,7 +754,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: hypershift
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cloud-credential-operator-master-e2e-hypershift
+    name: pull-ci-openshift-priv-cloud-credential-operator-main-e2e-hypershift
     path_alias: github.com/openshift/cloud-credential-operator
     rerun_command: /test e2e-hypershift
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
@@ -822,9 +822,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build03
     context: ci/prow/e2e-openstack
     decorate: true
     decoration_config:
@@ -837,7 +837,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cloud-credential-operator-master-e2e-openstack
+    name: pull-ci-openshift-priv-cloud-credential-operator-main-e2e-openstack
     optional: true
     path_alias: github.com/openshift/cloud-credential-operator
     rerun_command: /test e2e-openstack
@@ -905,9 +905,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build03
     context: ci/prow/e2e-openstack-parallel
     decorate: true
     decoration_config:
@@ -920,7 +920,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cloud-credential-operator-master-e2e-openstack-parallel
+    name: pull-ci-openshift-priv-cloud-credential-operator-main-e2e-openstack-parallel
     optional: true
     path_alias: github.com/openshift/cloud-credential-operator
     rerun_command: /test e2e-openstack-parallel
@@ -988,9 +988,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build03
     context: ci/prow/e2e-upgrade
     decorate: true
     decoration_config:
@@ -1003,7 +1003,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-5
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cloud-credential-operator-master-e2e-upgrade
+    name: pull-ci-openshift-priv-cloud-credential-operator-main-e2e-upgrade
     path_alias: github.com/openshift/cloud-credential-operator
     rerun_command: /test e2e-upgrade
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
@@ -1071,9 +1071,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build02
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/images
     decorate: true
     decoration_config:
@@ -1084,7 +1084,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cloud-credential-operator-master-images
+    name: pull-ci-openshift-priv-cloud-credential-operator-main-images
     path_alias: github.com/openshift/cloud-credential-operator
     rerun_command: /test images
     spec:
@@ -1134,9 +1134,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build02
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/security
     decorate: true
     decoration_config:
@@ -1147,7 +1147,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cloud-credential-operator-master-security
+    name: pull-ci-openshift-priv-cloud-credential-operator-main-security
     path_alias: github.com/openshift/cloud-credential-operator
     rerun_command: /test security
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
@@ -1205,9 +1205,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build02
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/unit
     decorate: true
     decoration_config:
@@ -1218,7 +1218,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cloud-credential-operator-master-unit
+    name: pull-ci-openshift-priv-cloud-credential-operator-main-unit
     path_alias: github.com/openshift/cloud-credential-operator
     rerun_command: /test unit
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
@@ -1269,9 +1269,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build02
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/verify
     decorate: true
     decoration_config:
@@ -1282,7 +1282,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cloud-credential-operator-master-verify
+    name: pull-ci-openshift-priv-cloud-credential-operator-main-verify
     path_alias: github.com/openshift/cloud-credential-operator
     rerun_command: /test verify
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
@@ -1333,9 +1333,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build02
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/verify-deps
     decorate: true
     decoration_config:
@@ -1346,7 +1346,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cloud-credential-operator-master-verify-deps
+    name: pull-ci-openshift-priv-cloud-credential-operator-main-verify-deps
     path_alias: github.com/openshift/cloud-credential-operator
     rerun_command: /test verify-deps
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$

--- a/ci-operator/jobs/openshift/cloud-credential-operator/openshift-cloud-credential-operator-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-credential-operator/openshift-cloud-credential-operator-main-postsubmits.yaml
@@ -3,14 +3,14 @@ postsubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    cluster: build06
+    - ^main$
+    cluster: build01
     decorate: true
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-openshift-cloud-credential-operator-master-images
+    name: branch-ci-openshift-cloud-credential-operator-main-images
     spec:
       containers:
       - args:
@@ -61,8 +61,8 @@ postsubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    cluster: build06
+    - ^main$
+    cluster: build01
     decorate: true
     decoration_config:
       skip_cloning: true
@@ -71,7 +71,7 @@ postsubmits:
       ci-operator.openshift.io/variant: okd-scos
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-openshift-cloud-credential-operator-master-okd-scos-images
+    name: branch-ci-openshift-cloud-credential-operator-main-okd-scos-images
     spec:
       containers:
       - args:
@@ -123,13 +123,13 @@ postsubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    cluster: build06
+    - ^main$
+    cluster: build01
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-openshift-cloud-credential-operator-master-publish-coverage
+    name: branch-ci-openshift-cloud-credential-operator-main-publish-coverage
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift/cloud-credential-operator/openshift-cloud-credential-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-credential-operator/openshift-cloud-credential-operator-main-presubmits.yaml
@@ -3,15 +3,15 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build04
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/coverage
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cloud-credential-operator-master-coverage
+    name: pull-ci-openshift-cloud-credential-operator-main-coverage
     rerun_command: /test coverage
     run_if_changed: \.go$
     spec:
@@ -64,9 +64,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build09
+    - ^main$
+    - ^main-
+    cluster: build06
     context: ci/prow/e2e-aws-manual-oidc
     decorate: true
     labels:
@@ -74,7 +74,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-2
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cloud-credential-operator-master-e2e-aws-manual-oidc
+    name: pull-ci-openshift-cloud-credential-operator-main-e2e-aws-manual-oidc
     optional: true
     rerun_command: /test e2e-aws-manual-oidc
     spec:
@@ -137,9 +137,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build09
+    - ^main$
+    - ^main-
+    cluster: build06
     context: ci/prow/e2e-aws-ovn
     decorate: true
     labels:
@@ -147,7 +147,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-4
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cloud-credential-operator-master-e2e-aws-ovn
+    name: pull-ci-openshift-cloud-credential-operator-main-e2e-aws-ovn
     rerun_command: /test e2e-aws-ovn
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
     spec:
@@ -210,9 +210,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build09
+    - ^main$
+    - ^main-
+    cluster: build06
     context: ci/prow/e2e-aws-qe
     decorate: true
     labels:
@@ -220,7 +220,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-qe
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cloud-credential-operator-master-e2e-aws-qe
+    name: pull-ci-openshift-cloud-credential-operator-main-e2e-aws-qe
     optional: true
     rerun_command: /test e2e-aws-qe
     run_if_changed: \.go$|^go\.
@@ -284,9 +284,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build04
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/e2e-azure
     decorate: true
     labels:
@@ -294,7 +294,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: azure-2
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cloud-credential-operator-master-e2e-azure
+    name: pull-ci-openshift-cloud-credential-operator-main-e2e-azure
     optional: true
     rerun_command: /test e2e-azure
     spec:
@@ -357,9 +357,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build04
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/e2e-azure-manual-oidc
     decorate: true
     labels:
@@ -367,7 +367,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: azure4
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cloud-credential-operator-master-e2e-azure-manual-oidc
+    name: pull-ci-openshift-cloud-credential-operator-main-e2e-azure-manual-oidc
     rerun_command: /test e2e-azure-manual-oidc
     run_if_changed: pkg/cmd/provisioning/azure/
     spec:
@@ -430,9 +430,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build04
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/e2e-azure-upgrade
     decorate: true
     labels:
@@ -440,7 +440,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: azure4
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cloud-credential-operator-master-e2e-azure-upgrade
+    name: pull-ci-openshift-cloud-credential-operator-main-e2e-azure-upgrade
     optional: true
     rerun_command: /test e2e-azure-upgrade
     spec:
@@ -503,9 +503,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build04
+    - ^main$
+    - ^main-
+    cluster: build08
     context: ci/prow/e2e-gcp
     decorate: true
     labels:
@@ -513,7 +513,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cloud-credential-operator-master-e2e-gcp
+    name: pull-ci-openshift-cloud-credential-operator-main-e2e-gcp
     optional: true
     rerun_command: /test e2e-gcp
     spec:
@@ -576,9 +576,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build04
+    - ^main$
+    - ^main-
+    cluster: build08
     context: ci/prow/e2e-gcp-manual-oidc
     decorate: true
     labels:
@@ -586,7 +586,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cloud-credential-operator-master-e2e-gcp-manual-oidc
+    name: pull-ci-openshift-cloud-credential-operator-main-e2e-gcp-manual-oidc
     optional: true
     rerun_command: /test e2e-gcp-manual-oidc
     spec:
@@ -649,9 +649,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build04
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/e2e-hypershift
     decorate: true
     labels:
@@ -659,7 +659,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: hypershift
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cloud-credential-operator-master-e2e-hypershift
+    name: pull-ci-openshift-cloud-credential-operator-main-e2e-hypershift
     rerun_command: /test e2e-hypershift
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
     spec:
@@ -722,9 +722,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build09
+    - ^main$
+    - ^main-
+    cluster: build06
     context: ci/prow/e2e-openstack
     decorate: true
     labels:
@@ -732,7 +732,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cloud-credential-operator-master-e2e-openstack
+    name: pull-ci-openshift-cloud-credential-operator-main-e2e-openstack
     optional: true
     rerun_command: /test e2e-openstack
     spec:
@@ -795,9 +795,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build09
+    - ^main$
+    - ^main-
+    cluster: build06
     context: ci/prow/e2e-openstack-parallel
     decorate: true
     labels:
@@ -805,7 +805,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cloud-credential-operator-master-e2e-openstack-parallel
+    name: pull-ci-openshift-cloud-credential-operator-main-e2e-openstack-parallel
     optional: true
     rerun_command: /test e2e-openstack-parallel
     spec:
@@ -868,9 +868,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build09
+    - ^main$
+    - ^main-
+    cluster: build06
     context: ci/prow/e2e-upgrade
     decorate: true
     labels:
@@ -878,7 +878,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-5
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cloud-credential-operator-master-e2e-upgrade
+    name: pull-ci-openshift-cloud-credential-operator-main-e2e-upgrade
     rerun_command: /test e2e-upgrade
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
     spec:
@@ -939,19 +939,18 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-upgrade,?($|\s.*)
   - agent: kubernetes
-    always_run: false
+    always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build04
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/images
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cloud-credential-operator-master-images
+    name: pull-ci-openshift-cloud-credential-operator-main-images
     rerun_command: /test images
-    skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
     spec:
       containers:
       - args:
@@ -996,9 +995,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build09
+    - ^main$
+    - ^main-
+    cluster: build06
     context: ci/prow/okd-scos-e2e-aws-ovn
     decorate: true
     decoration_config:
@@ -1009,7 +1008,7 @@ presubmits:
       ci-operator.openshift.io/variant: okd-scos
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cloud-credential-operator-master-okd-scos-e2e-aws-ovn
+    name: pull-ci-openshift-cloud-credential-operator-main-okd-scos-e2e-aws-ovn
     optional: true
     rerun_command: /test okd-scos-e2e-aws-ovn
     spec:
@@ -1073,9 +1072,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build04
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/okd-scos-images
     decorate: true
     decoration_config:
@@ -1084,7 +1083,7 @@ presubmits:
       ci-operator.openshift.io/variant: okd-scos
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cloud-credential-operator-master-okd-scos-images
+    name: pull-ci-openshift-cloud-credential-operator-main-okd-scos-images
     rerun_command: /test okd-scos-images
     spec:
       containers:
@@ -1131,15 +1130,15 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build04
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/security
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cloud-credential-operator-master-security
+    name: pull-ci-openshift-cloud-credential-operator-main-security
     rerun_command: /test security
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
     spec:
@@ -1192,15 +1191,15 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build04
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/unit
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cloud-credential-operator-master-unit
+    name: pull-ci-openshift-cloud-credential-operator-main-unit
     rerun_command: /test unit
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
     spec:
@@ -1246,15 +1245,15 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build04
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/verify
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cloud-credential-operator-master-verify
+    name: pull-ci-openshift-cloud-credential-operator-main-verify
     rerun_command: /test verify
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
     spec:
@@ -1300,15 +1299,15 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build04
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/verify-deps
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cloud-credential-operator-master-verify-deps
+    name: pull-ci-openshift-cloud-credential-operator-main-verify-deps
     rerun_command: /test verify-deps
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
     spec:


### PR DESCRIPTION

This PR is in support of renaming the default branch for https://github.com/openshift/cloud-credential-operator from 'master' to 'main'.

Unhold this PR only when:

* the default branch for https://github.com/openshift/cloud-credential-operator has been renamed to 'main'
* You have verified that the CI jobs are working as expected either by running '/pj-rehearse' or by inspection.

/hold
