### PR TITLE
OCPBUGS-52375: rename 'master' to 'main' for cluster-openshift-controller-manager-operator

### DIFF
--- a/ci-operator/config/openshift-priv/cluster-openshift-controller-manager-operator/openshift-priv-cluster-openshift-controller-manager-operator-main.yaml
+++ b/ci-operator/config/openshift-priv/cluster-openshift-controller-manager-operator/openshift-priv-cluster-openshift-controller-manager-operator-main.yaml
@@ -1,7 +1,7 @@
 base_images:
   ocp_4.21_base-rhel9:
-    name: "4.22"
-    namespace: ocp
+    name: 4.22-priv
+    namespace: ocp-private
     tag: base-rhel9
   ocp_builder_rhel-9-golang-1.24-openshift-4.21:
     name: builder
@@ -10,6 +10,7 @@ base_images:
 binary_build_commands: make build --warn-undefined-variables
 build_root:
   from_repository: true
+canonical_go_repository: github.com/openshift/cluster-openshift-controller-manager-operator
 images:
 - inputs:
     ocp_4.21_base-rhel9:
@@ -21,18 +22,18 @@ images:
   to: cluster-openshift-controller-manager-operator
 promotion:
   to:
-  - name: "4.22"
-    namespace: ocp
+  - name: 4.22-priv
+    namespace: ocp-private
 releases:
   initial:
     integration:
-      name: "4.22"
-      namespace: ocp
+      name: 4.22-priv
+      namespace: ocp-private
   latest:
     integration:
       include_built_images: true
-      name: "4.22"
-      namespace: ocp
+      name: 4.22-priv
+      namespace: ocp-private
 resources:
   '*':
     requests:
@@ -96,6 +97,6 @@ tests:
     test:
     - ref: go-verify-deps
 zz_generated_metadata:
-  branch: master
-  org: openshift
+  branch: main
+  org: openshift-priv
   repo: cluster-openshift-controller-manager-operator

--- a/ci-operator/config/openshift/cluster-openshift-controller-manager-operator/openshift-cluster-openshift-controller-manager-operator-main.yaml
+++ b/ci-operator/config/openshift/cluster-openshift-controller-manager-operator/openshift-cluster-openshift-controller-manager-operator-main.yaml
@@ -1,7 +1,7 @@
 base_images:
   ocp_4.21_base-rhel9:
-    name: 4.22-priv
-    namespace: ocp-private
+    name: "4.22"
+    namespace: ocp
     tag: base-rhel9
   ocp_builder_rhel-9-golang-1.24-openshift-4.21:
     name: builder
@@ -10,7 +10,6 @@ base_images:
 binary_build_commands: make build --warn-undefined-variables
 build_root:
   from_repository: true
-canonical_go_repository: github.com/openshift/cluster-openshift-controller-manager-operator
 images:
 - inputs:
     ocp_4.21_base-rhel9:
@@ -22,18 +21,18 @@ images:
   to: cluster-openshift-controller-manager-operator
 promotion:
   to:
-  - name: 4.22-priv
-    namespace: ocp-private
+  - name: "4.22"
+    namespace: ocp
 releases:
   initial:
     integration:
-      name: 4.22-priv
-      namespace: ocp-private
+      name: "4.22"
+      namespace: ocp
   latest:
     integration:
       include_built_images: true
-      name: 4.22-priv
-      namespace: ocp-private
+      name: "4.22"
+      namespace: ocp
 resources:
   '*':
     requests:
@@ -97,6 +96,6 @@ tests:
     test:
     - ref: go-verify-deps
 zz_generated_metadata:
-  branch: master
-  org: openshift-priv
+  branch: main
+  org: openshift
   repo: cluster-openshift-controller-manager-operator

--- a/ci-operator/config/openshift/cluster-openshift-controller-manager-operator/openshift-cluster-openshift-controller-manager-operator-main__okd-scos.yaml
+++ b/ci-operator/config/openshift/cluster-openshift-controller-manager-operator/openshift-cluster-openshift-controller-manager-operator-main__okd-scos.yaml
@@ -47,7 +47,7 @@ tests:
     cluster_profile: aws
     workflow: openshift-e2e-aws
 zz_generated_metadata:
-  branch: master
+  branch: main
   org: openshift
   repo: cluster-openshift-controller-manager-operator
   variant: okd-scos

--- a/ci-operator/jobs/openshift-priv/cluster-openshift-controller-manager-operator/openshift-priv-cluster-openshift-controller-manager-operator-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/cluster-openshift-controller-manager-operator/openshift-priv-cluster-openshift-controller-manager-operator-main-postsubmits.yaml
@@ -3,8 +3,8 @@ postsubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    cluster: build02
+    - ^main$
+    cluster: build01
     decorate: true
     decoration_config:
       oauth_token_secret:
@@ -15,7 +15,7 @@ postsubmits:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-openshift-priv-cluster-openshift-controller-manager-operator-master-images
+    name: branch-ci-openshift-priv-cluster-openshift-controller-manager-operator-main-images
     path_alias: github.com/openshift/cluster-openshift-controller-manager-operator
     spec:
       containers:

--- a/ci-operator/jobs/openshift-priv/cluster-openshift-controller-manager-operator/openshift-priv-cluster-openshift-controller-manager-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/cluster-openshift-controller-manager-operator/openshift-priv-cluster-openshift-controller-manager-operator-main-presubmits.yaml
@@ -3,9 +3,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build10
+    - ^main$
+    - ^main-
+    cluster: build07
     context: ci/prow/e2e-aws-operator
     decorate: true
     decoration_config:
@@ -18,7 +18,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-2
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-openshift-controller-manager-operator-master-e2e-aws-operator
+    name: pull-ci-openshift-priv-cluster-openshift-controller-manager-operator-main-e2e-aws-operator
     path_alias: github.com/openshift/cluster-openshift-controller-manager-operator
     rerun_command: /test e2e-aws-operator
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
@@ -86,9 +86,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build10
+    - ^main$
+    - ^main-
+    cluster: build07
     context: ci/prow/e2e-aws-ovn
     decorate: true
     decoration_config:
@@ -101,7 +101,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-openshift-controller-manager-operator-master-e2e-aws-ovn
+    name: pull-ci-openshift-priv-cluster-openshift-controller-manager-operator-main-e2e-aws-ovn
     path_alias: github.com/openshift/cluster-openshift-controller-manager-operator
     rerun_command: /test e2e-aws-ovn
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
@@ -169,9 +169,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build10
+    - ^main$
+    - ^main-
+    cluster: build07
     context: ci/prow/e2e-upgrade
     decorate: true
     decoration_config:
@@ -184,7 +184,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-3
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-openshift-controller-manager-operator-master-e2e-upgrade
+    name: pull-ci-openshift-priv-cluster-openshift-controller-manager-operator-main-e2e-upgrade
     path_alias: github.com/openshift/cluster-openshift-controller-manager-operator
     rerun_command: /test e2e-upgrade
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
@@ -252,9 +252,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build03
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/images
     decorate: true
     decoration_config:
@@ -265,7 +265,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-openshift-controller-manager-operator-master-images
+    name: pull-ci-openshift-priv-cluster-openshift-controller-manager-operator-main-images
     path_alias: github.com/openshift/cluster-openshift-controller-manager-operator
     rerun_command: /test images
     spec:
@@ -315,9 +315,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build10
+    - ^main$
+    - ^main-
+    cluster: build07
     context: ci/prow/openshift-e2e-aws-builds-techpreview
     decorate: true
     decoration_config:
@@ -330,7 +330,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-3
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-openshift-controller-manager-operator-master-openshift-e2e-aws-builds-techpreview
+    name: pull-ci-openshift-priv-cluster-openshift-controller-manager-operator-main-openshift-e2e-aws-builds-techpreview
     optional: true
     path_alias: github.com/openshift/cluster-openshift-controller-manager-operator
     rerun_command: /test openshift-e2e-aws-builds-techpreview
@@ -398,9 +398,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build03
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/security
     decorate: true
     decoration_config:
@@ -411,7 +411,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-openshift-controller-manager-operator-master-security
+    name: pull-ci-openshift-priv-cluster-openshift-controller-manager-operator-main-security
     optional: true
     path_alias: github.com/openshift/cluster-openshift-controller-manager-operator
     rerun_command: /test security
@@ -469,9 +469,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build03
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/unit
     decorate: true
     decoration_config:
@@ -482,7 +482,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-openshift-controller-manager-operator-master-unit
+    name: pull-ci-openshift-priv-cluster-openshift-controller-manager-operator-main-unit
     path_alias: github.com/openshift/cluster-openshift-controller-manager-operator
     rerun_command: /test unit
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
@@ -533,9 +533,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build03
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/verify
     decorate: true
     decoration_config:
@@ -546,7 +546,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-openshift-controller-manager-operator-master-verify
+    name: pull-ci-openshift-priv-cluster-openshift-controller-manager-operator-main-verify
     path_alias: github.com/openshift/cluster-openshift-controller-manager-operator
     rerun_command: /test verify
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
@@ -597,9 +597,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build03
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/verify-deps
     decorate: true
     decoration_config:
@@ -610,7 +610,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-openshift-controller-manager-operator-master-verify-deps
+    name: pull-ci-openshift-priv-cluster-openshift-controller-manager-operator-main-verify-deps
     path_alias: github.com/openshift/cluster-openshift-controller-manager-operator
     rerun_command: /test verify-deps
     spec:

--- a/ci-operator/jobs/openshift/cluster-openshift-controller-manager-operator/openshift-cluster-openshift-controller-manager-operator-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-openshift-controller-manager-operator/openshift-cluster-openshift-controller-manager-operator-main-postsubmits.yaml
@@ -3,14 +3,14 @@ postsubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    cluster: build09
+    - ^main$
+    cluster: build01
     decorate: true
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-openshift-cluster-openshift-controller-manager-operator-master-images
+    name: branch-ci-openshift-cluster-openshift-controller-manager-operator-main-images
     spec:
       containers:
       - args:
@@ -61,8 +61,8 @@ postsubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    cluster: build09
+    - ^main$
+    cluster: build01
     decorate: true
     decoration_config:
       skip_cloning: true
@@ -71,7 +71,7 @@ postsubmits:
       ci-operator.openshift.io/variant: okd-scos
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-openshift-cluster-openshift-controller-manager-operator-master-okd-scos-images
+    name: branch-ci-openshift-cluster-openshift-controller-manager-operator-main-okd-scos-images
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift/cluster-openshift-controller-manager-operator/openshift-cluster-openshift-controller-manager-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-openshift-controller-manager-operator/openshift-cluster-openshift-controller-manager-operator-main-presubmits.yaml
@@ -3,9 +3,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build01
+    - ^main$
+    - ^main-
+    cluster: build09
     context: ci/prow/e2e-aws-operator
     decorate: true
     labels:
@@ -13,7 +13,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-2
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-openshift-controller-manager-operator-master-e2e-aws-operator
+    name: pull-ci-openshift-cluster-openshift-controller-manager-operator-main-e2e-aws-operator
     rerun_command: /test e2e-aws-operator
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
     spec:
@@ -76,9 +76,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build01
+    - ^main$
+    - ^main-
+    cluster: build09
     context: ci/prow/e2e-aws-ovn
     decorate: true
     labels:
@@ -86,7 +86,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-openshift-controller-manager-operator-master-e2e-aws-ovn
+    name: pull-ci-openshift-cluster-openshift-controller-manager-operator-main-e2e-aws-ovn
     rerun_command: /test e2e-aws-ovn
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
     spec:
@@ -149,9 +149,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build01
+    - ^main$
+    - ^main-
+    cluster: build09
     context: ci/prow/e2e-upgrade
     decorate: true
     labels:
@@ -159,7 +159,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-3
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-openshift-controller-manager-operator-master-e2e-upgrade
+    name: pull-ci-openshift-cluster-openshift-controller-manager-operator-main-e2e-upgrade
     rerun_command: /test e2e-upgrade
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
     spec:
@@ -220,19 +220,18 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-upgrade,?($|\s.*)
   - agent: kubernetes
-    always_run: false
+    always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build06
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/images
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-openshift-controller-manager-operator-master-images
+    name: pull-ci-openshift-cluster-openshift-controller-manager-operator-main-images
     rerun_command: /test images
-    skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
     spec:
       containers:
       - args:
@@ -277,9 +276,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build01
+    - ^main$
+    - ^main-
+    cluster: build09
     context: ci/prow/okd-scos-e2e-aws-ovn
     decorate: true
     decoration_config:
@@ -290,7 +289,7 @@ presubmits:
       ci-operator.openshift.io/variant: okd-scos
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-openshift-controller-manager-operator-master-okd-scos-e2e-aws-ovn
+    name: pull-ci-openshift-cluster-openshift-controller-manager-operator-main-okd-scos-e2e-aws-ovn
     optional: true
     rerun_command: /test okd-scos-e2e-aws-ovn
     spec:
@@ -354,9 +353,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build06
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/okd-scos-images
     decorate: true
     decoration_config:
@@ -365,7 +364,7 @@ presubmits:
       ci-operator.openshift.io/variant: okd-scos
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-openshift-controller-manager-operator-master-okd-scos-images
+    name: pull-ci-openshift-cluster-openshift-controller-manager-operator-main-okd-scos-images
     rerun_command: /test okd-scos-images
     spec:
       containers:
@@ -412,9 +411,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build01
+    - ^main$
+    - ^main-
+    cluster: build09
     context: ci/prow/openshift-e2e-aws-builds-techpreview
     decorate: true
     labels:
@@ -422,7 +421,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-3
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-openshift-controller-manager-operator-master-openshift-e2e-aws-builds-techpreview
+    name: pull-ci-openshift-cluster-openshift-controller-manager-operator-main-openshift-e2e-aws-builds-techpreview
     optional: true
     rerun_command: /test openshift-e2e-aws-builds-techpreview
     spec:
@@ -485,15 +484,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build06
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/security
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-openshift-controller-manager-operator-master-security
+    name: pull-ci-openshift-cluster-openshift-controller-manager-operator-main-security
     optional: true
     rerun_command: /test security
     spec:
@@ -546,15 +545,15 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build06
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/unit
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-openshift-controller-manager-operator-master-unit
+    name: pull-ci-openshift-cluster-openshift-controller-manager-operator-main-unit
     rerun_command: /test unit
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
     spec:
@@ -600,15 +599,15 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build06
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/verify
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-openshift-controller-manager-operator-master-verify
+    name: pull-ci-openshift-cluster-openshift-controller-manager-operator-main-verify
     rerun_command: /test verify
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
     spec:
@@ -654,15 +653,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build06
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/verify-deps
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-openshift-controller-manager-operator-master-verify-deps
+    name: pull-ci-openshift-cluster-openshift-controller-manager-operator-main-verify-deps
     rerun_command: /test verify-deps
     spec:
       containers:


### PR DESCRIPTION

This PR is in support of renaming the default branch for https://github.com/openshift/cluster-openshift-controller-manager-operator from 'master' to 'main'.

Unhold this PR only when:

* the default branch for https://github.com/openshift/cluster-openshift-controller-manager-operator has been renamed to 'main'
* You have verified that the CI jobs are working as expected either by running '/pj-rehearse' or by inspection.

/hold
