### PR TITLE
OCPBUGS-52383: rename 'master' to 'main' for driver-toolkit

### DIFF
--- a/ci-operator/config/openshift-priv/driver-toolkit/openshift-priv-driver-toolkit-main.yaml
+++ b/ci-operator/config/openshift-priv/driver-toolkit/openshift-priv-driver-toolkit-main.yaml
@@ -66,6 +66,6 @@ tests:
     cluster_profile: aws-3
     workflow: openshift-upgrade-aws
 zz_generated_metadata:
-  branch: master
+  branch: main
   org: openshift-priv
   repo: driver-toolkit

--- a/ci-operator/config/openshift/driver-toolkit/openshift-driver-toolkit-main.yaml
+++ b/ci-operator/config/openshift/driver-toolkit/openshift-driver-toolkit-main.yaml
@@ -65,6 +65,6 @@ tests:
     cluster_profile: aws-3
     workflow: openshift-upgrade-aws
 zz_generated_metadata:
-  branch: master
+  branch: main
   org: openshift
   repo: driver-toolkit

--- a/ci-operator/config/openshift/driver-toolkit/openshift-driver-toolkit-main__okd-scos.yaml
+++ b/ci-operator/config/openshift/driver-toolkit/openshift-driver-toolkit-main__okd-scos.yaml
@@ -38,7 +38,7 @@ tests:
     cluster_profile: aws
     workflow: openshift-e2e-aws
 zz_generated_metadata:
-  branch: master
+  branch: main
   org: openshift
   repo: driver-toolkit
   variant: okd-scos

--- a/ci-operator/jobs/openshift-priv/driver-toolkit/openshift-priv-driver-toolkit-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/driver-toolkit/openshift-priv-driver-toolkit-main-postsubmits.yaml
@@ -3,8 +3,8 @@ postsubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    cluster: build09
+    - ^main$
+    cluster: build01
     decorate: true
     decoration_config:
       oauth_token_secret:
@@ -15,7 +15,7 @@ postsubmits:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-openshift-priv-driver-toolkit-master-images
+    name: branch-ci-openshift-priv-driver-toolkit-main-images
     path_alias: github.com/openshift/driver-toolkit
     spec:
       containers:

--- a/ci-operator/jobs/openshift-priv/driver-toolkit/openshift-priv-driver-toolkit-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/driver-toolkit/openshift-priv-driver-toolkit-main-presubmits.yaml
@@ -3,9 +3,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build03
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/check-commits-count
     decorate: true
     decoration_config:
@@ -16,7 +16,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-driver-toolkit-master-check-commits-count
+    name: pull-ci-openshift-priv-driver-toolkit-main-check-commits-count
     path_alias: github.com/openshift/driver-toolkit
     rerun_command: /test check-commits-count
     spec:
@@ -66,9 +66,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build09
+    - ^main$
+    - ^main-
+    cluster: build06
     context: ci/prow/e2e-aws
     decorate: true
     decoration_config:
@@ -81,7 +81,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-driver-toolkit-master-e2e-aws
+    name: pull-ci-openshift-priv-driver-toolkit-main-e2e-aws
     path_alias: github.com/openshift/driver-toolkit
     rerun_command: /test e2e-aws
     spec:
@@ -148,9 +148,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build09
+    - ^main$
+    - ^main-
+    cluster: build06
     context: ci/prow/e2e-upgrade
     decorate: true
     decoration_config:
@@ -163,7 +163,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-3
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-driver-toolkit-master-e2e-upgrade
+    name: pull-ci-openshift-priv-driver-toolkit-main-e2e-upgrade
     path_alias: github.com/openshift/driver-toolkit
     rerun_command: /test e2e-upgrade
     spec:
@@ -230,9 +230,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build03
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/images
     decorate: true
     decoration_config:
@@ -243,7 +243,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-driver-toolkit-master-images
+    name: pull-ci-openshift-priv-driver-toolkit-main-images
     path_alias: github.com/openshift/driver-toolkit
     rerun_command: /test images
     spec:
@@ -294,9 +294,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build03
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/verify
     decorate: true
     decoration_config:
@@ -307,7 +307,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-driver-toolkit-master-verify
+    name: pull-ci-openshift-priv-driver-toolkit-main-verify
     path_alias: github.com/openshift/driver-toolkit
     rerun_command: /test verify
     spec:
@@ -357,9 +357,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build03
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/verify-image-content
     decorate: true
     decoration_config:
@@ -370,7 +370,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-driver-toolkit-master-verify-image-content
+    name: pull-ci-openshift-priv-driver-toolkit-main-verify-image-content
     path_alias: github.com/openshift/driver-toolkit
     rerun_command: /test verify-image-content
     spec:

--- a/ci-operator/jobs/openshift/driver-toolkit/openshift-driver-toolkit-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/driver-toolkit/openshift-driver-toolkit-main-postsubmits.yaml
@@ -3,14 +3,14 @@ postsubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    cluster: build08
+    - ^main$
+    cluster: build01
     decorate: true
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-openshift-driver-toolkit-master-images
+    name: branch-ci-openshift-driver-toolkit-main-images
     spec:
       containers:
       - args:
@@ -62,8 +62,8 @@ postsubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    cluster: build08
+    - ^main$
+    cluster: build01
     decorate: true
     decoration_config:
       skip_cloning: true
@@ -72,7 +72,7 @@ postsubmits:
       ci-operator.openshift.io/variant: okd-scos
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-openshift-driver-toolkit-master-okd-scos-images
+    name: branch-ci-openshift-driver-toolkit-main-okd-scos-images
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift/driver-toolkit/openshift-driver-toolkit-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/driver-toolkit/openshift-driver-toolkit-main-presubmits.yaml
@@ -3,15 +3,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build03
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/check-commits-count
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-driver-toolkit-master-check-commits-count
+    name: pull-ci-openshift-driver-toolkit-main-check-commits-count
     rerun_command: /test check-commits-count
     spec:
       containers:
@@ -56,9 +56,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build10
+    - ^main$
+    - ^main-
+    cluster: build07
     context: ci/prow/e2e-aws
     decorate: true
     labels:
@@ -66,7 +66,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-driver-toolkit-master-e2e-aws
+    name: pull-ci-openshift-driver-toolkit-main-e2e-aws
     rerun_command: /test e2e-aws
     spec:
       containers:
@@ -128,9 +128,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build10
+    - ^main$
+    - ^main-
+    cluster: build07
     context: ci/prow/e2e-upgrade
     decorate: true
     labels:
@@ -138,7 +138,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-3
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-driver-toolkit-master-e2e-upgrade
+    name: pull-ci-openshift-driver-toolkit-main-e2e-upgrade
     rerun_command: /test e2e-upgrade
     spec:
       containers:
@@ -200,15 +200,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build03
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/images
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-driver-toolkit-master-images
+    name: pull-ci-openshift-driver-toolkit-main-images
     rerun_command: /test images
     spec:
       containers:
@@ -255,9 +255,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build10
+    - ^main$
+    - ^main-
+    cluster: build07
     context: ci/prow/okd-scos-e2e-aws-ovn
     decorate: true
     decoration_config:
@@ -268,7 +268,7 @@ presubmits:
       ci-operator.openshift.io/variant: okd-scos
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-driver-toolkit-master-okd-scos-e2e-aws-ovn
+    name: pull-ci-openshift-driver-toolkit-main-okd-scos-e2e-aws-ovn
     optional: true
     rerun_command: /test okd-scos-e2e-aws-ovn
     spec:
@@ -332,9 +332,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build03
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/okd-scos-images
     decorate: true
     decoration_config:
@@ -343,7 +343,7 @@ presubmits:
       ci-operator.openshift.io/variant: okd-scos
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-driver-toolkit-master-okd-scos-images
+    name: pull-ci-openshift-driver-toolkit-main-okd-scos-images
     rerun_command: /test okd-scos-images
     spec:
       containers:
@@ -390,15 +390,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build03
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/verify
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-driver-toolkit-master-verify
+    name: pull-ci-openshift-driver-toolkit-main-verify
     rerun_command: /test verify
     spec:
       containers:
@@ -443,15 +443,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build03
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/verify-image-content
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-driver-toolkit-master-verify-image-content
+    name: pull-ci-openshift-driver-toolkit-main-verify-image-content
     rerun_command: /test verify-image-content
     spec:
       containers:


### PR DESCRIPTION

This PR is in support of renaming the default branch for https://github.com/openshift/driver-toolkit from 'master' to 'main'.

Unhold this PR only when:

* the default branch for https://github.com/openshift/driver-toolkit has been renamed to 'main'
* You have verified that the CI jobs are working as expected either by running '/pj-rehearse' or by inspection.

/hold
