### PR TITLE
OCPBUGS-52384: rename 'master' to 'main' for images

### DIFF
--- a/ci-operator/config/openshift-priv/images/openshift-priv-images-main.yaml
+++ b/ci-operator/config/openshift-priv/images/openshift-priv-images-main.yaml
@@ -89,6 +89,6 @@ tests:
     test:
     - ref: go-verify-deps
 zz_generated_metadata:
-  branch: master
+  branch: main
   org: openshift-priv
   repo: images

--- a/ci-operator/config/openshift/images/openshift-images-main.yaml
+++ b/ci-operator/config/openshift/images/openshift-images-main.yaml
@@ -88,6 +88,6 @@ tests:
     test:
     - ref: go-verify-deps
 zz_generated_metadata:
-  branch: master
+  branch: main
   org: openshift
   repo: images

--- a/ci-operator/config/openshift/images/openshift-images-main__okd-scos.yaml
+++ b/ci-operator/config/openshift/images/openshift-images-main__okd-scos.yaml
@@ -52,7 +52,7 @@ tests:
     cluster_profile: aws
     workflow: openshift-e2e-aws
 zz_generated_metadata:
-  branch: master
+  branch: main
   org: openshift
   repo: images
   variant: okd-scos

--- a/ci-operator/jobs/openshift-priv/images/openshift-priv-images-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/images/openshift-priv-images-main-postsubmits.yaml
@@ -3,8 +3,8 @@ postsubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    cluster: build09
+    - ^main$
+    cluster: build01
     decorate: true
     decoration_config:
       oauth_token_secret:
@@ -15,7 +15,7 @@ postsubmits:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-openshift-priv-images-master-images
+    name: branch-ci-openshift-priv-images-main-images
     path_alias: github.com/openshift/images
     spec:
       containers:

--- a/ci-operator/jobs/openshift-priv/images/openshift-priv-images-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/images/openshift-priv-images-main-presubmits.yaml
@@ -3,9 +3,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build06
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/e2e-aws
     decorate: true
     decoration_config:
@@ -18,7 +18,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-2
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-images-master-e2e-aws
+    name: pull-ci-openshift-priv-images-main-e2e-aws
     path_alias: github.com/openshift/images
     rerun_command: /test e2e-aws
     spec:
@@ -85,9 +85,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build06
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/e2e-aws-upgrade
     decorate: true
     decoration_config:
@@ -100,7 +100,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-2
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-images-master-e2e-aws-upgrade
+    name: pull-ci-openshift-priv-images-main-e2e-aws-upgrade
     path_alias: github.com/openshift/images
     rerun_command: /test e2e-aws-upgrade
     spec:
@@ -167,9 +167,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build10
+    - ^main$
+    - ^main-
+    cluster: build07
     context: ci/prow/e2e-metal-ipi-ovn-ipv6
     decorate: true
     decoration_config:
@@ -183,7 +183,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-images-master-e2e-metal-ipi-ovn-ipv6
+    name: pull-ci-openshift-priv-images-main-e2e-metal-ipi-ovn-ipv6
     path_alias: github.com/openshift/images
     rerun_command: /test e2e-metal-ipi-ovn-ipv6
     spec:
@@ -250,9 +250,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build08
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/images
     decorate: true
     decoration_config:
@@ -263,7 +263,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-images-master-images
+    name: pull-ci-openshift-priv-images-main-images
     path_alias: github.com/openshift/images
     rerun_command: /test images
     spec:
@@ -313,9 +313,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build08
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/unit
     decorate: true
     decoration_config:
@@ -326,7 +326,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-images-master-unit
+    name: pull-ci-openshift-priv-images-main-unit
     path_alias: github.com/openshift/images
     rerun_command: /test unit
     spec:
@@ -376,9 +376,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build08
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/verify-deps
     decorate: true
     decoration_config:
@@ -389,7 +389,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-images-master-verify-deps
+    name: pull-ci-openshift-priv-images-main-verify-deps
     path_alias: github.com/openshift/images
     rerun_command: /test verify-deps
     spec:

--- a/ci-operator/jobs/openshift/images/openshift-images-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/images/openshift-images-main-postsubmits.yaml
@@ -3,14 +3,14 @@ postsubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    cluster: build08
+    - ^main$
+    cluster: build01
     decorate: true
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-openshift-images-master-images
+    name: branch-ci-openshift-images-main-images
     spec:
       containers:
       - args:
@@ -61,8 +61,8 @@ postsubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    cluster: build08
+    - ^main$
+    cluster: build01
     decorate: true
     decoration_config:
       skip_cloning: true
@@ -71,7 +71,7 @@ postsubmits:
       ci-operator.openshift.io/variant: okd-scos
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-openshift-images-master-okd-scos-images
+    name: branch-ci-openshift-images-main-okd-scos-images
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift/images/openshift-images-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/images/openshift-images-main-presubmits.yaml
@@ -3,9 +3,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build03
     context: ci/prow/e2e-aws
     decorate: true
     labels:
@@ -13,7 +13,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-2
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-images-master-e2e-aws
+    name: pull-ci-openshift-images-main-e2e-aws
     rerun_command: /test e2e-aws
     spec:
       containers:
@@ -75,9 +75,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build03
     context: ci/prow/e2e-aws-upgrade
     decorate: true
     labels:
@@ -85,7 +85,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-2
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-images-master-e2e-aws-upgrade
+    name: pull-ci-openshift-images-main-e2e-aws-upgrade
     rerun_command: /test e2e-aws-upgrade
     spec:
       containers:
@@ -147,9 +147,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build10
+    - ^main$
+    - ^main-
+    cluster: build07
     context: ci/prow/e2e-metal-ipi-ovn-ipv6
     decorate: true
     labels:
@@ -158,7 +158,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-images-master-e2e-metal-ipi-ovn-ipv6
+    name: pull-ci-openshift-images-main-e2e-metal-ipi-ovn-ipv6
     rerun_command: /test e2e-metal-ipi-ovn-ipv6
     spec:
       containers:
@@ -220,15 +220,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build09
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/images
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-images-master-images
+    name: pull-ci-openshift-images-main-images
     rerun_command: /test images
     spec:
       containers:
@@ -274,9 +274,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build03
     context: ci/prow/okd-scos-e2e-aws-ovn
     decorate: true
     decoration_config:
@@ -287,7 +287,7 @@ presubmits:
       ci-operator.openshift.io/variant: okd-scos
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-images-master-okd-scos-e2e-aws-ovn
+    name: pull-ci-openshift-images-main-okd-scos-e2e-aws-ovn
     optional: true
     rerun_command: /test okd-scos-e2e-aws-ovn
     spec:
@@ -351,9 +351,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build09
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/okd-scos-images
     decorate: true
     decoration_config:
@@ -362,7 +362,7 @@ presubmits:
       ci-operator.openshift.io/variant: okd-scos
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-images-master-okd-scos-images
+    name: pull-ci-openshift-images-main-okd-scos-images
     rerun_command: /test okd-scos-images
     spec:
       containers:
@@ -409,15 +409,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build09
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/unit
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-images-master-unit
+    name: pull-ci-openshift-images-main-unit
     rerun_command: /test unit
     spec:
       containers:
@@ -462,15 +462,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build09
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/verify-deps
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-images-master-verify-deps
+    name: pull-ci-openshift-images-main-verify-deps
     rerun_command: /test verify-deps
     spec:
       containers:


### PR DESCRIPTION

This PR is in support of renaming the default branch for https://github.com/openshift/images from 'master' to 'main'.

Unhold this PR only when:

* the default branch for https://github.com/openshift/images has been renamed to 'main'
* You have verified that the CI jobs are working as expected either by running '/pj-rehearse' or by inspection.

/hold
