### PR TITLE
OCPBUGS-52385: rename 'master' to 'main' for insights-operator

### DIFF
--- a/ci-operator/config/openshift-priv/insights-operator/openshift-priv-insights-operator-main.yaml
+++ b/ci-operator/config/openshift-priv/insights-operator/openshift-priv-insights-operator-main.yaml
@@ -235,6 +235,6 @@ tests:
     test:
     - ref: go-verify-deps
 zz_generated_metadata:
-  branch: master
+  branch: main
   org: openshift-priv
   repo: insights-operator

--- a/ci-operator/config/openshift/insights-operator/openshift-insights-operator-main.yaml
+++ b/ci-operator/config/openshift/insights-operator/openshift-insights-operator-main.yaml
@@ -245,6 +245,6 @@ tests:
     test:
     - ref: go-verify-deps
 zz_generated_metadata:
-  branch: master
+  branch: main
   org: openshift
   repo: insights-operator

--- a/ci-operator/config/openshift/insights-operator/openshift-insights-operator-main__okd-scos.yaml
+++ b/ci-operator/config/openshift/insights-operator/openshift-insights-operator-main__okd-scos.yaml
@@ -47,7 +47,7 @@ tests:
     cluster_profile: aws
     workflow: openshift-e2e-aws
 zz_generated_metadata:
-  branch: master
+  branch: main
   org: openshift
   repo: insights-operator
   variant: okd-scos

--- a/ci-operator/jobs/openshift-priv/insights-operator/openshift-priv-insights-operator-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/insights-operator/openshift-priv-insights-operator-main-postsubmits.yaml
@@ -3,8 +3,8 @@ postsubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    cluster: build09
+    - ^main$
+    cluster: build01
     decorate: true
     decoration_config:
       oauth_token_secret:
@@ -15,7 +15,7 @@ postsubmits:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-openshift-priv-insights-operator-master-images
+    name: branch-ci-openshift-priv-insights-operator-main-images
     path_alias: github.com/openshift/insights-operator
     spec:
       containers:

--- a/ci-operator/jobs/openshift-priv/insights-operator/openshift-priv-insights-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/insights-operator/openshift-priv-insights-operator-main-presubmits.yaml
@@ -3,9 +3,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build04
+    - ^main$
+    - ^main-
+    cluster: build08
     context: ci/prow/e2e
     decorate: true
     decoration_config:
@@ -18,7 +18,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp-3
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-insights-operator-master-e2e
+    name: pull-ci-openshift-priv-insights-operator-main-e2e
     path_alias: github.com/openshift/insights-operator
     rerun_command: /test e2e
     skip_if_only_changed: ^docs/|\.(md|adoc)$|^(README|LICENSE|OWNERS)$|_test.go$
@@ -86,9 +86,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build06
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/e2e-agnostic-upgrade
     decorate: true
     decoration_config:
@@ -101,7 +101,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: azure4
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-insights-operator-master-e2e-agnostic-upgrade
+    name: pull-ci-openshift-priv-insights-operator-main-e2e-agnostic-upgrade
     path_alias: github.com/openshift/insights-operator
     rerun_command: /test e2e-agnostic-upgrade
     skip_if_only_changed: ^docs/|\.(md|adoc)$|^(README|LICENSE|OWNERS)$|_test.go$
@@ -169,9 +169,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build04
+    - ^main$
+    - ^main-
+    cluster: build08
     context: ci/prow/e2e-gcp-ovn-techpreview
     decorate: true
     decoration_config:
@@ -184,7 +184,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp-3
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-insights-operator-master-e2e-gcp-ovn-techpreview
+    name: pull-ci-openshift-priv-insights-operator-main-e2e-gcp-ovn-techpreview
     path_alias: github.com/openshift/insights-operator
     rerun_command: /test e2e-gcp-ovn-techpreview
     spec:
@@ -251,9 +251,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build03
+    - ^main$
+    - ^main-
+    cluster: build09
     context: ci/prow/e2e-metal-ipi-ovn-ipv6
     decorate: true
     decoration_config:
@@ -267,7 +267,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-insights-operator-master-e2e-metal-ipi-ovn-ipv6
+    name: pull-ci-openshift-priv-insights-operator-main-e2e-metal-ipi-ovn-ipv6
     optional: true
     path_alias: github.com/openshift/insights-operator
     rerun_command: /test e2e-metal-ipi-ovn-ipv6
@@ -335,9 +335,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build06
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/images
     decorate: true
     decoration_config:
@@ -348,7 +348,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-insights-operator-master-images
+    name: pull-ci-openshift-priv-insights-operator-main-images
     path_alias: github.com/openshift/insights-operator
     rerun_command: /test images
     spec:
@@ -398,9 +398,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build04
+    - ^main$
+    - ^main-
+    cluster: build08
     context: ci/prow/insights-operator-e2e-tests
     decorate: true
     decoration_config:
@@ -413,7 +413,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-insights-operator-master-insights-operator-e2e-tests
+    name: pull-ci-openshift-priv-insights-operator-main-insights-operator-e2e-tests
     path_alias: github.com/openshift/insights-operator
     rerun_command: /test insights-operator-e2e-tests
     skip_if_only_changed: ^docs/|\.(md|adoc)$|^(README|LICENSE|OWNERS)$|_test.go$
@@ -481,9 +481,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build06
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/lint
     decorate: true
     decoration_config:
@@ -494,7 +494,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-insights-operator-master-lint
+    name: pull-ci-openshift-priv-insights-operator-main-lint
     path_alias: github.com/openshift/insights-operator
     rerun_command: /test lint
     spec:
@@ -544,9 +544,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build06
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/unit
     decorate: true
     decoration_config:
@@ -557,7 +557,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-insights-operator-master-unit
+    name: pull-ci-openshift-priv-insights-operator-main-unit
     path_alias: github.com/openshift/insights-operator
     rerun_command: /test unit
     spec:
@@ -614,9 +614,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build06
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/verify-deps
     decorate: true
     decoration_config:
@@ -627,7 +627,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-insights-operator-master-verify-deps
+    name: pull-ci-openshift-priv-insights-operator-main-verify-deps
     path_alias: github.com/openshift/insights-operator
     rerun_command: /test verify-deps
     spec:

--- a/ci-operator/jobs/openshift/insights-operator/openshift-insights-operator-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/insights-operator/openshift-insights-operator-main-postsubmits.yaml
@@ -3,14 +3,14 @@ postsubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    cluster: build06
+    - ^main$
+    cluster: build01
     decorate: true
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-openshift-insights-operator-master-images
+    name: branch-ci-openshift-insights-operator-main-images
     spec:
       containers:
       - args:
@@ -61,8 +61,8 @@ postsubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    cluster: build06
+    - ^main$
+    cluster: build01
     decorate: true
     decoration_config:
       skip_cloning: true
@@ -71,7 +71,7 @@ postsubmits:
       ci-operator.openshift.io/variant: okd-scos
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-openshift-insights-operator-master-okd-scos-images
+    name: branch-ci-openshift-insights-operator-main-okd-scos-images
     spec:
       containers:
       - args:
@@ -123,13 +123,13 @@ postsubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    cluster: build06
+    - ^main$
+    cluster: build01
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-openshift-insights-operator-master-publish-coverage
+    name: branch-ci-openshift-insights-operator-main-publish-coverage
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift/insights-operator/openshift-insights-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/insights-operator/openshift-insights-operator-main-presubmits.yaml
@@ -3,9 +3,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build08
+    - ^main$
+    - ^main-
+    cluster: build02
     context: ci/prow/e2e
     decorate: true
     labels:
@@ -13,7 +13,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp-3
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-insights-operator-master-e2e
+    name: pull-ci-openshift-insights-operator-main-e2e
     rerun_command: /test e2e
     skip_if_only_changed: ^docs/|\.(md|adoc)$|^(README|LICENSE|OWNERS)$|_test.go$
     spec:
@@ -76,9 +76,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build06
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/e2e-agnostic-upgrade
     decorate: true
     labels:
@@ -86,7 +86,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: azure4
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-insights-operator-master-e2e-agnostic-upgrade
+    name: pull-ci-openshift-insights-operator-main-e2e-agnostic-upgrade
     rerun_command: /test e2e-agnostic-upgrade
     skip_if_only_changed: ^docs/|\.(md|adoc)$|^(README|LICENSE|OWNERS)$|_test.go$
     spec:
@@ -149,9 +149,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build08
+    - ^main$
+    - ^main-
+    cluster: build02
     context: ci/prow/e2e-gcp-ovn-techpreview
     decorate: true
     labels:
@@ -159,7 +159,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp-3
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-insights-operator-master-e2e-gcp-ovn-techpreview
+    name: pull-ci-openshift-insights-operator-main-e2e-gcp-ovn-techpreview
     rerun_command: /test e2e-gcp-ovn-techpreview
     spec:
       containers:
@@ -221,9 +221,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build03
+    - ^main$
+    - ^main-
+    cluster: build09
     context: ci/prow/e2e-metal-ipi-ovn-ipv6
     decorate: true
     labels:
@@ -232,7 +232,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-insights-operator-master-e2e-metal-ipi-ovn-ipv6
+    name: pull-ci-openshift-insights-operator-main-e2e-metal-ipi-ovn-ipv6
     optional: true
     rerun_command: /test e2e-metal-ipi-ovn-ipv6
     spec:
@@ -295,15 +295,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build06
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/images
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-insights-operator-master-images
+    name: pull-ci-openshift-insights-operator-main-images
     rerun_command: /test images
     spec:
       containers:
@@ -349,9 +349,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build08
+    - ^main$
+    - ^main-
+    cluster: build02
     context: ci/prow/insights-operator-e2e-tests
     decorate: true
     labels:
@@ -359,7 +359,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-insights-operator-master-insights-operator-e2e-tests
+    name: pull-ci-openshift-insights-operator-main-insights-operator-e2e-tests
     rerun_command: /test insights-operator-e2e-tests
     skip_if_only_changed: ^docs/|\.(md|adoc)$|^(README|LICENSE|OWNERS)$|_test.go$
     spec:
@@ -422,15 +422,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build06
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/lint
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-insights-operator-master-lint
+    name: pull-ci-openshift-insights-operator-main-lint
     rerun_command: /test lint
     spec:
       containers:
@@ -475,9 +475,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build06
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/okd-scos-e2e-aws-ovn
     decorate: true
     decoration_config:
@@ -488,7 +488,7 @@ presubmits:
       ci-operator.openshift.io/variant: okd-scos
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-insights-operator-master-okd-scos-e2e-aws-ovn
+    name: pull-ci-openshift-insights-operator-main-okd-scos-e2e-aws-ovn
     optional: true
     rerun_command: /test okd-scos-e2e-aws-ovn
     spec:
@@ -552,9 +552,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build06
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/okd-scos-images
     decorate: true
     decoration_config:
@@ -563,7 +563,7 @@ presubmits:
       ci-operator.openshift.io/variant: okd-scos
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-insights-operator-master-okd-scos-images
+    name: pull-ci-openshift-insights-operator-main-okd-scos-images
     rerun_command: /test okd-scos-images
     spec:
       containers:
@@ -610,15 +610,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build06
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/unit
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-insights-operator-master-unit
+    name: pull-ci-openshift-insights-operator-main-unit
     rerun_command: /test unit
     spec:
       containers:
@@ -670,15 +670,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build06
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/verify-deps
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-insights-operator-master-verify-deps
+    name: pull-ci-openshift-insights-operator-main-verify-deps
     rerun_command: /test verify-deps
     spec:
       containers:


### PR DESCRIPTION

This PR is in support of renaming the default branch for https://github.com/openshift/insights-operator from 'master' to 'main'.

Unhold this PR only when:

* the default branch for https://github.com/openshift/insights-operator has been renamed to 'main'
* You have verified that the CI jobs are working as expected either by running '/pj-rehearse' or by inspection.

/hold
