### PR TITLE
OCPBUGS-52400: rename 'master' to 'main' for openshift-controller-manager

### DIFF
--- a/ci-operator/config/openshift-priv/openshift-controller-manager/openshift-priv-openshift-controller-manager-main.yaml
+++ b/ci-operator/config/openshift-priv/openshift-controller-manager/openshift-priv-openshift-controller-manager-main.yaml
@@ -114,6 +114,6 @@ tests:
     test:
     - ref: go-verify-deps
 zz_generated_metadata:
-  branch: master
+  branch: main
   org: openshift-priv
   repo: openshift-controller-manager

--- a/ci-operator/config/openshift/openshift-controller-manager/openshift-openshift-controller-manager-main.yaml
+++ b/ci-operator/config/openshift/openshift-controller-manager/openshift-openshift-controller-manager-main.yaml
@@ -113,6 +113,6 @@ tests:
     test:
     - ref: go-verify-deps
 zz_generated_metadata:
-  branch: master
+  branch: main
   org: openshift
   repo: openshift-controller-manager

--- a/ci-operator/config/openshift/openshift-controller-manager/openshift-openshift-controller-manager-main__okd-scos.yaml
+++ b/ci-operator/config/openshift/openshift-controller-manager/openshift-openshift-controller-manager-main__okd-scos.yaml
@@ -47,7 +47,7 @@ tests:
     cluster_profile: aws
     workflow: openshift-e2e-aws
 zz_generated_metadata:
-  branch: master
+  branch: main
   org: openshift
   repo: openshift-controller-manager
   variant: okd-scos

--- a/ci-operator/jobs/openshift-priv/openshift-controller-manager/openshift-priv-openshift-controller-manager-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/openshift-controller-manager/openshift-priv-openshift-controller-manager-main-postsubmits.yaml
@@ -3,8 +3,8 @@ postsubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    cluster: build09
+    - ^main$
+    cluster: build01
     decorate: true
     decoration_config:
       oauth_token_secret:
@@ -15,7 +15,7 @@ postsubmits:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-openshift-priv-openshift-controller-manager-master-images
+    name: branch-ci-openshift-priv-openshift-controller-manager-main-images
     path_alias: github.com/openshift/openshift-controller-manager
     spec:
       containers:

--- a/ci-operator/jobs/openshift-priv/openshift-controller-manager/openshift-priv-openshift-controller-manager-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/openshift-controller-manager/openshift-priv-openshift-controller-manager-main-presubmits.yaml
@@ -3,9 +3,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build01
+    - ^main$
+    - ^main-
+    cluster: build09
     context: ci/prow/e2e-aws-builds
     decorate: true
     decoration_config:
@@ -18,7 +18,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-3
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-openshift-controller-manager-master-e2e-aws-builds
+    name: pull-ci-openshift-priv-openshift-controller-manager-main-e2e-aws-builds
     path_alias: github.com/openshift/openshift-controller-manager
     rerun_command: /test e2e-aws-builds
     run_if_changed: ^(pkg/build)
@@ -86,9 +86,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build01
+    - ^main$
+    - ^main-
+    cluster: build09
     context: ci/prow/e2e-aws-ovn
     decorate: true
     decoration_config:
@@ -101,7 +101,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-2
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-openshift-controller-manager-master-e2e-aws-ovn
+    name: pull-ci-openshift-priv-openshift-controller-manager-main-e2e-aws-ovn
     path_alias: github.com/openshift/openshift-controller-manager
     rerun_command: /test e2e-aws-ovn
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
@@ -169,9 +169,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build01
+    - ^main$
+    - ^main-
+    cluster: build09
     context: ci/prow/e2e-aws-ovn-proxy
     decorate: true
     decoration_config:
@@ -184,7 +184,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-3
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-openshift-controller-manager-master-e2e-aws-ovn-proxy
+    name: pull-ci-openshift-priv-openshift-controller-manager-main-e2e-aws-ovn-proxy
     optional: true
     path_alias: github.com/openshift/openshift-controller-manager
     rerun_command: /test e2e-aws-ovn-proxy
@@ -252,9 +252,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build01
+    - ^main$
+    - ^main-
+    cluster: build09
     context: ci/prow/e2e-aws-ovn-upgrade
     decorate: true
     decoration_config:
@@ -267,7 +267,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-openshift-controller-manager-master-e2e-aws-ovn-upgrade
+    name: pull-ci-openshift-priv-openshift-controller-manager-main-e2e-aws-ovn-upgrade
     path_alias: github.com/openshift/openshift-controller-manager
     rerun_command: /test e2e-aws-ovn-upgrade
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
@@ -335,9 +335,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build02
+    - ^main$
+    - ^main-
+    cluster: build04
     context: ci/prow/e2e-gcp-ovn
     decorate: true
     decoration_config:
@@ -350,7 +350,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-openshift-controller-manager-master-e2e-gcp-ovn
+    name: pull-ci-openshift-priv-openshift-controller-manager-main-e2e-gcp-ovn
     path_alias: github.com/openshift/openshift-controller-manager
     rerun_command: /test e2e-gcp-ovn
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
@@ -418,9 +418,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build02
+    - ^main$
+    - ^main-
+    cluster: build04
     context: ci/prow/e2e-gcp-ovn-builds
     decorate: true
     decoration_config:
@@ -433,7 +433,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-openshift-controller-manager-master-e2e-gcp-ovn-builds
+    name: pull-ci-openshift-priv-openshift-controller-manager-main-e2e-gcp-ovn-builds
     path_alias: github.com/openshift/openshift-controller-manager
     rerun_command: /test e2e-gcp-ovn-builds
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
@@ -501,9 +501,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build04
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/e2e-hypershift-conformance
     decorate: true
     decoration_config:
@@ -516,7 +516,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: hypershift
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-openshift-controller-manager-master-e2e-hypershift-conformance
+    name: pull-ci-openshift-priv-openshift-controller-manager-main-e2e-hypershift-conformance
     path_alias: github.com/openshift/openshift-controller-manager
     rerun_command: /test e2e-hypershift-conformance
     spec:
@@ -583,9 +583,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build04
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/images
     decorate: true
     decoration_config:
@@ -596,7 +596,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-openshift-controller-manager-master-images
+    name: pull-ci-openshift-priv-openshift-controller-manager-main-images
     path_alias: github.com/openshift/openshift-controller-manager
     rerun_command: /test images
     spec:
@@ -646,9 +646,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build01
+    - ^main$
+    - ^main-
+    cluster: build09
     context: ci/prow/openshift-e2e-aws-ovn-builds-techpreview
     decorate: true
     decoration_config:
@@ -661,7 +661,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-2
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-openshift-controller-manager-master-openshift-e2e-aws-ovn-builds-techpreview
+    name: pull-ci-openshift-priv-openshift-controller-manager-main-openshift-e2e-aws-ovn-builds-techpreview
     optional: true
     path_alias: github.com/openshift/openshift-controller-manager
     rerun_command: /test openshift-e2e-aws-ovn-builds-techpreview
@@ -729,9 +729,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build04
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/security
     decorate: true
     decoration_config:
@@ -742,7 +742,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-openshift-controller-manager-master-security
+    name: pull-ci-openshift-priv-openshift-controller-manager-main-security
     optional: true
     path_alias: github.com/openshift/openshift-controller-manager
     rerun_command: /test security
@@ -800,9 +800,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build04
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/unit
     decorate: true
     decoration_config:
@@ -813,7 +813,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-openshift-controller-manager-master-unit
+    name: pull-ci-openshift-priv-openshift-controller-manager-main-unit
     path_alias: github.com/openshift/openshift-controller-manager
     rerun_command: /test unit
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
@@ -864,9 +864,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build04
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/verify
     decorate: true
     decoration_config:
@@ -877,7 +877,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-openshift-controller-manager-master-verify
+    name: pull-ci-openshift-priv-openshift-controller-manager-main-verify
     path_alias: github.com/openshift/openshift-controller-manager
     rerun_command: /test verify
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
@@ -928,9 +928,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build04
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/verify-deps
     decorate: true
     decoration_config:
@@ -941,7 +941,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-openshift-controller-manager-master-verify-deps
+    name: pull-ci-openshift-priv-openshift-controller-manager-main-verify-deps
     path_alias: github.com/openshift/openshift-controller-manager
     rerun_command: /test verify-deps
     spec:

--- a/ci-operator/jobs/openshift/openshift-controller-manager/openshift-openshift-controller-manager-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/openshift-controller-manager/openshift-openshift-controller-manager-main-postsubmits.yaml
@@ -3,14 +3,14 @@ postsubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    cluster: build08
+    - ^main$
+    cluster: build01
     decorate: true
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-openshift-openshift-controller-manager-master-images
+    name: branch-ci-openshift-openshift-controller-manager-main-images
     spec:
       containers:
       - args:
@@ -61,8 +61,8 @@ postsubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    cluster: build08
+    - ^main$
+    cluster: build01
     decorate: true
     decoration_config:
       skip_cloning: true
@@ -71,7 +71,7 @@ postsubmits:
       ci-operator.openshift.io/variant: okd-scos
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-openshift-openshift-controller-manager-master-okd-scos-images
+    name: branch-ci-openshift-openshift-controller-manager-main-okd-scos-images
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift/openshift-controller-manager/openshift-openshift-controller-manager-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/openshift-controller-manager/openshift-openshift-controller-manager-main-presubmits.yaml
@@ -3,9 +3,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build03
+    - ^main$
+    - ^main-
+    cluster: build10
     context: ci/prow/e2e-aws-builds
     decorate: true
     labels:
@@ -13,7 +13,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-3
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-openshift-controller-manager-master-e2e-aws-builds
+    name: pull-ci-openshift-openshift-controller-manager-main-e2e-aws-builds
     rerun_command: /test e2e-aws-builds
     run_if_changed: ^(pkg/build)
     spec:
@@ -76,9 +76,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build03
+    - ^main$
+    - ^main-
+    cluster: build10
     context: ci/prow/e2e-aws-ovn
     decorate: true
     labels:
@@ -86,7 +86,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-2
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-openshift-controller-manager-master-e2e-aws-ovn
+    name: pull-ci-openshift-openshift-controller-manager-main-e2e-aws-ovn
     rerun_command: /test e2e-aws-ovn
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
     spec:
@@ -149,9 +149,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build03
+    - ^main$
+    - ^main-
+    cluster: build10
     context: ci/prow/e2e-aws-ovn-proxy
     decorate: true
     labels:
@@ -159,7 +159,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-3
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-openshift-controller-manager-master-e2e-aws-ovn-proxy
+    name: pull-ci-openshift-openshift-controller-manager-main-e2e-aws-ovn-proxy
     optional: true
     rerun_command: /test e2e-aws-ovn-proxy
     spec:
@@ -222,9 +222,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build03
+    - ^main$
+    - ^main-
+    cluster: build10
     context: ci/prow/e2e-aws-ovn-upgrade
     decorate: true
     labels:
@@ -232,7 +232,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-openshift-controller-manager-master-e2e-aws-ovn-upgrade
+    name: pull-ci-openshift-openshift-controller-manager-main-e2e-aws-ovn-upgrade
     rerun_command: /test e2e-aws-ovn-upgrade
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
     spec:
@@ -295,9 +295,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build04
+    - ^main$
+    - ^main-
+    cluster: build08
     context: ci/prow/e2e-gcp-ovn
     decorate: true
     labels:
@@ -305,7 +305,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-openshift-controller-manager-master-e2e-gcp-ovn
+    name: pull-ci-openshift-openshift-controller-manager-main-e2e-gcp-ovn
     rerun_command: /test e2e-gcp-ovn
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
     spec:
@@ -368,9 +368,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build04
+    - ^main$
+    - ^main-
+    cluster: build08
     context: ci/prow/e2e-gcp-ovn-builds
     decorate: true
     labels:
@@ -378,7 +378,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-openshift-controller-manager-master-e2e-gcp-ovn-builds
+    name: pull-ci-openshift-openshift-controller-manager-main-e2e-gcp-ovn-builds
     rerun_command: /test e2e-gcp-ovn-builds
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
     spec:
@@ -441,9 +441,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build03
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/e2e-hypershift-conformance
     decorate: true
     labels:
@@ -451,7 +451,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: hypershift
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-openshift-controller-manager-master-e2e-hypershift-conformance
+    name: pull-ci-openshift-openshift-controller-manager-main-e2e-hypershift-conformance
     rerun_command: /test e2e-hypershift-conformance
     spec:
       containers:
@@ -511,19 +511,18 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-hypershift-conformance,?($|\s.*)
   - agent: kubernetes
-    always_run: false
+    always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build03
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/images
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-openshift-controller-manager-master-images
+    name: pull-ci-openshift-openshift-controller-manager-main-images
     rerun_command: /test images
-    skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
     spec:
       containers:
       - args:
@@ -568,9 +567,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build03
+    - ^main$
+    - ^main-
+    cluster: build10
     context: ci/prow/okd-scos-e2e-aws-ovn
     decorate: true
     decoration_config:
@@ -581,7 +580,7 @@ presubmits:
       ci-operator.openshift.io/variant: okd-scos
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-openshift-controller-manager-master-okd-scos-e2e-aws-ovn
+    name: pull-ci-openshift-openshift-controller-manager-main-okd-scos-e2e-aws-ovn
     optional: true
     rerun_command: /test okd-scos-e2e-aws-ovn
     spec:
@@ -645,9 +644,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build03
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/okd-scos-images
     decorate: true
     decoration_config:
@@ -656,7 +655,7 @@ presubmits:
       ci-operator.openshift.io/variant: okd-scos
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-openshift-controller-manager-master-okd-scos-images
+    name: pull-ci-openshift-openshift-controller-manager-main-okd-scos-images
     rerun_command: /test okd-scos-images
     spec:
       containers:
@@ -703,9 +702,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build03
+    - ^main$
+    - ^main-
+    cluster: build10
     context: ci/prow/openshift-e2e-aws-ovn-builds-techpreview
     decorate: true
     labels:
@@ -713,7 +712,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-2
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-openshift-controller-manager-master-openshift-e2e-aws-ovn-builds-techpreview
+    name: pull-ci-openshift-openshift-controller-manager-main-openshift-e2e-aws-ovn-builds-techpreview
     optional: true
     rerun_command: /test openshift-e2e-aws-ovn-builds-techpreview
     spec:
@@ -776,15 +775,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build03
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/security
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-openshift-controller-manager-master-security
+    name: pull-ci-openshift-openshift-controller-manager-main-security
     optional: true
     rerun_command: /test security
     spec:
@@ -837,15 +836,15 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build03
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/unit
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-openshift-controller-manager-master-unit
+    name: pull-ci-openshift-openshift-controller-manager-main-unit
     rerun_command: /test unit
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
     spec:
@@ -891,15 +890,15 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build03
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/verify
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-openshift-controller-manager-master-verify
+    name: pull-ci-openshift-openshift-controller-manager-main-verify
     rerun_command: /test verify
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
     spec:
@@ -945,15 +944,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build03
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/verify-deps
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-openshift-controller-manager-master-verify-deps
+    name: pull-ci-openshift-openshift-controller-manager-main-verify-deps
     rerun_command: /test verify-deps
     spec:
       containers:


### PR DESCRIPTION

This PR is in support of renaming the default branch for https://github.com/openshift/openshift-controller-manager from 'master' to 'main'.

Unhold this PR only when:

* the default branch for https://github.com/openshift/openshift-controller-manager has been renamed to 'main'
* You have verified that the CI jobs are working as expected either by running '/pj-rehearse' or by inspection.

/hold
