### PR TITLE
OCPBUGS-53187: rename 'master' to 'main' for cluster-network-operator

### DIFF
--- a/ci-operator/config/openshift-priv/cluster-network-operator/openshift-priv-cluster-network-operator-main.yaml
+++ b/ci-operator/config/openshift-priv/cluster-network-operator/openshift-priv-cluster-network-operator-main.yaml
@@ -459,6 +459,6 @@ tests:
     cluster_profile: equinix-ocp-metal
     workflow: baremetalds-e2e-ovn-bgp-dualstack-local-gw
 zz_generated_metadata:
-  branch: master
+  branch: main
   org: openshift-priv
   repo: cluster-network-operator

--- a/ci-operator/config/openshift/cluster-network-operator/openshift-cluster-network-operator-main.yaml
+++ b/ci-operator/config/openshift/cluster-network-operator/openshift-cluster-network-operator-main.yaml
@@ -472,6 +472,6 @@ tests:
     cluster_profile: equinix-ocp-metal
     workflow: baremetalds-e2e-ovn-bgp-dualstack-local-gw
 zz_generated_metadata:
-  branch: master
+  branch: main
   org: openshift
   repo: cluster-network-operator

--- a/ci-operator/config/openshift/cluster-network-operator/openshift-cluster-network-operator-main__4.22-upgrade-from-stable-4.21.yaml
+++ b/ci-operator/config/openshift/cluster-network-operator/openshift-cluster-network-operator-main__4.22-upgrade-from-stable-4.21.yaml
@@ -67,7 +67,7 @@ tests:
     workflow: openshift-upgrade-gcp-ovn
   timeout: 6h0m0s
 zz_generated_metadata:
-  branch: master
+  branch: main
   org: openshift
   repo: cluster-network-operator
   variant: 4.22-upgrade-from-stable-4.21

--- a/ci-operator/config/openshift/cluster-network-operator/openshift-cluster-network-operator-main__okd-scos.yaml
+++ b/ci-operator/config/openshift/cluster-network-operator/openshift-cluster-network-operator-main__okd-scos.yaml
@@ -47,7 +47,7 @@ tests:
     cluster_profile: aws
     workflow: openshift-e2e-aws
 zz_generated_metadata:
-  branch: master
+  branch: main
   org: openshift
   repo: cluster-network-operator
   variant: okd-scos

--- a/ci-operator/jobs/openshift-priv/cluster-network-operator/openshift-priv-cluster-network-operator-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/cluster-network-operator/openshift-priv-cluster-network-operator-main-postsubmits.yaml
@@ -3,8 +3,8 @@ postsubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    cluster: build09
+    - ^main$
+    cluster: build01
     decorate: true
     decoration_config:
       oauth_token_secret:
@@ -15,7 +15,7 @@ postsubmits:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-openshift-priv-cluster-network-operator-master-images
+    name: branch-ci-openshift-priv-cluster-network-operator-main-images
     path_alias: github.com/openshift/cluster-network-operator
     spec:
       containers:

--- a/ci-operator/jobs/openshift-priv/cluster-network-operator/openshift-priv-cluster-network-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/cluster-network-operator/openshift-priv-cluster-network-operator-main-presubmits.yaml
@@ -3,9 +3,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build06
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/e2e-aws-hypershift-ovn-kubevirt
     decorate: true
     decoration_config:
@@ -18,7 +18,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-3
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-network-operator-master-e2e-aws-hypershift-ovn-kubevirt
+    name: pull-ci-openshift-priv-cluster-network-operator-main-e2e-aws-hypershift-ovn-kubevirt
     optional: true
     path_alias: github.com/openshift/cluster-network-operator
     rerun_command: /test e2e-aws-hypershift-ovn-kubevirt
@@ -86,9 +86,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build10
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/e2e-aws-ovn-hypershift-conformance
     decorate: true
     decoration_config:
@@ -101,7 +101,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: hypershift
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-network-operator-master-e2e-aws-ovn-hypershift-conformance
+    name: pull-ci-openshift-priv-cluster-network-operator-main-e2e-aws-ovn-hypershift-conformance
     path_alias: github.com/openshift/cluster-network-operator
     rerun_command: /test e2e-aws-ovn-hypershift-conformance
     spec:
@@ -168,9 +168,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build06
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/e2e-aws-ovn-local-to-shared-gateway-mode-migration
     decorate: true
     decoration_config:
@@ -183,7 +183,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-3
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-network-operator-master-e2e-aws-ovn-local-to-shared-gateway-mode-migration
+    name: pull-ci-openshift-priv-cluster-network-operator-main-e2e-aws-ovn-local-to-shared-gateway-mode-migration
     optional: true
     path_alias: github.com/openshift/cluster-network-operator
     rerun_command: /test e2e-aws-ovn-local-to-shared-gateway-mode-migration
@@ -251,9 +251,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build06
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/e2e-aws-ovn-serial-1of2
     decorate: true
     decoration_config:
@@ -266,7 +266,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-network-operator-master-e2e-aws-ovn-serial-1of2
+    name: pull-ci-openshift-priv-cluster-network-operator-main-e2e-aws-ovn-serial-1of2
     path_alias: github.com/openshift/cluster-network-operator
     rerun_command: /test e2e-aws-ovn-serial-1of2
     spec:
@@ -334,9 +334,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build06
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/e2e-aws-ovn-serial-2of2
     decorate: true
     decoration_config:
@@ -349,7 +349,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-network-operator-master-e2e-aws-ovn-serial-2of2
+    name: pull-ci-openshift-priv-cluster-network-operator-main-e2e-aws-ovn-serial-2of2
     path_alias: github.com/openshift/cluster-network-operator
     rerun_command: /test e2e-aws-ovn-serial-2of2
     spec:
@@ -417,9 +417,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build06
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/e2e-aws-ovn-serial-ipsec-1of2
     decorate: true
     decoration_config:
@@ -432,7 +432,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-network-operator-master-e2e-aws-ovn-serial-ipsec-1of2
+    name: pull-ci-openshift-priv-cluster-network-operator-main-e2e-aws-ovn-serial-ipsec-1of2
     optional: true
     path_alias: github.com/openshift/cluster-network-operator
     rerun_command: /test e2e-aws-ovn-serial-ipsec-1of2
@@ -501,9 +501,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build06
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/e2e-aws-ovn-serial-ipsec-2of2
     decorate: true
     decoration_config:
@@ -516,7 +516,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-network-operator-master-e2e-aws-ovn-serial-ipsec-2of2
+    name: pull-ci-openshift-priv-cluster-network-operator-main-e2e-aws-ovn-serial-ipsec-2of2
     optional: true
     path_alias: github.com/openshift/cluster-network-operator
     rerun_command: /test e2e-aws-ovn-serial-ipsec-2of2
@@ -585,9 +585,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build06
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/e2e-aws-ovn-shared-to-local-gateway-mode-migration
     decorate: true
     decoration_config:
@@ -600,7 +600,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-3
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-network-operator-master-e2e-aws-ovn-shared-to-local-gateway-mode-migration
+    name: pull-ci-openshift-priv-cluster-network-operator-main-e2e-aws-ovn-shared-to-local-gateway-mode-migration
     optional: true
     path_alias: github.com/openshift/cluster-network-operator
     rerun_command: /test e2e-aws-ovn-shared-to-local-gateway-mode-migration
@@ -668,9 +668,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build06
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/e2e-aws-ovn-single-node
     decorate: true
     decoration_config:
@@ -683,7 +683,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-3
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-network-operator-master-e2e-aws-ovn-single-node
+    name: pull-ci-openshift-priv-cluster-network-operator-main-e2e-aws-ovn-single-node
     optional: true
     path_alias: github.com/openshift/cluster-network-operator
     rerun_command: /test e2e-aws-ovn-single-node
@@ -751,9 +751,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build06
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/e2e-aws-ovn-techpreview-serial-1of2
     decorate: true
     decoration_config:
@@ -766,7 +766,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-3
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-network-operator-master-e2e-aws-ovn-techpreview-serial-1of2
+    name: pull-ci-openshift-priv-cluster-network-operator-main-e2e-aws-ovn-techpreview-serial-1of2
     optional: true
     path_alias: github.com/openshift/cluster-network-operator
     rerun_command: /test e2e-aws-ovn-techpreview-serial-1of2
@@ -835,9 +835,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build06
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/e2e-aws-ovn-techpreview-serial-2of2
     decorate: true
     decoration_config:
@@ -850,7 +850,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-3
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-network-operator-master-e2e-aws-ovn-techpreview-serial-2of2
+    name: pull-ci-openshift-priv-cluster-network-operator-main-e2e-aws-ovn-techpreview-serial-2of2
     optional: true
     path_alias: github.com/openshift/cluster-network-operator
     rerun_command: /test e2e-aws-ovn-techpreview-serial-2of2
@@ -919,9 +919,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build06
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/e2e-aws-ovn-upgrade
     decorate: true
     decoration_config:
@@ -934,7 +934,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-4
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-network-operator-master-e2e-aws-ovn-upgrade
+    name: pull-ci-openshift-priv-cluster-network-operator-main-e2e-aws-ovn-upgrade
     path_alias: github.com/openshift/cluster-network-operator
     rerun_command: /test e2e-aws-ovn-upgrade
     spec:
@@ -1001,9 +1001,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build06
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/e2e-aws-ovn-upgrade-ipsec
     decorate: true
     decoration_config:
@@ -1016,7 +1016,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-network-operator-master-e2e-aws-ovn-upgrade-ipsec
+    name: pull-ci-openshift-priv-cluster-network-operator-main-e2e-aws-ovn-upgrade-ipsec
     path_alias: github.com/openshift/cluster-network-operator
     rerun_command: /test e2e-aws-ovn-upgrade-ipsec
     spec:
@@ -1083,9 +1083,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build06
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/e2e-aws-ovn-windows
     decorate: true
     decoration_config:
@@ -1098,7 +1098,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-network-operator-master-e2e-aws-ovn-windows
+    name: pull-ci-openshift-priv-cluster-network-operator-main-e2e-aws-ovn-windows
     path_alias: github.com/openshift/cluster-network-operator
     rerun_command: /test e2e-aws-ovn-windows
     spec:
@@ -1165,9 +1165,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build10
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/e2e-azure-ovn
     decorate: true
     decoration_config:
@@ -1180,7 +1180,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: azure-2
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-network-operator-master-e2e-azure-ovn
+    name: pull-ci-openshift-priv-cluster-network-operator-main-e2e-azure-ovn
     optional: true
     path_alias: github.com/openshift/cluster-network-operator
     rerun_command: /test e2e-azure-ovn
@@ -1248,9 +1248,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build10
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/e2e-azure-ovn-dualstack
     decorate: true
     decoration_config:
@@ -1263,7 +1263,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: azure-2
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-network-operator-master-e2e-azure-ovn-dualstack
+    name: pull-ci-openshift-priv-cluster-network-operator-main-e2e-azure-ovn-dualstack
     optional: true
     path_alias: github.com/openshift/cluster-network-operator
     rerun_command: /test e2e-azure-ovn-dualstack
@@ -1331,9 +1331,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build10
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/e2e-azure-ovn-manual-oidc
     decorate: true
     decoration_config:
@@ -1346,7 +1346,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: azure-2
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-network-operator-master-e2e-azure-ovn-manual-oidc
+    name: pull-ci-openshift-priv-cluster-network-operator-main-e2e-azure-ovn-manual-oidc
     optional: true
     path_alias: github.com/openshift/cluster-network-operator
     rerun_command: /test e2e-azure-ovn-manual-oidc
@@ -1414,9 +1414,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build10
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/e2e-azure-ovn-upgrade
     decorate: true
     decoration_config:
@@ -1429,7 +1429,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: azure-2
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-network-operator-master-e2e-azure-ovn-upgrade
+    name: pull-ci-openshift-priv-cluster-network-operator-main-e2e-azure-ovn-upgrade
     path_alias: github.com/openshift/cluster-network-operator
     rerun_command: /test e2e-azure-ovn-upgrade
     spec:
@@ -1496,9 +1496,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build08
+    - ^main$
+    - ^main-
+    cluster: build02
     context: ci/prow/e2e-gcp-ovn
     decorate: true
     decoration_config:
@@ -1511,7 +1511,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-network-operator-master-e2e-gcp-ovn
+    name: pull-ci-openshift-priv-cluster-network-operator-main-e2e-gcp-ovn
     path_alias: github.com/openshift/cluster-network-operator
     rerun_command: /test e2e-gcp-ovn
     spec:
@@ -1578,9 +1578,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build08
+    - ^main$
+    - ^main-
+    cluster: build02
     context: ci/prow/e2e-gcp-ovn-techpreview
     decorate: true
     decoration_config:
@@ -1593,7 +1593,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-network-operator-master-e2e-gcp-ovn-techpreview
+    name: pull-ci-openshift-priv-cluster-network-operator-main-e2e-gcp-ovn-techpreview
     path_alias: github.com/openshift/cluster-network-operator
     rerun_command: /test e2e-gcp-ovn-techpreview
     spec:
@@ -1660,9 +1660,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build08
+    - ^main$
+    - ^main-
+    cluster: build02
     context: ci/prow/e2e-gcp-ovn-upgrade
     decorate: true
     decoration_config:
@@ -1675,7 +1675,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-network-operator-master-e2e-gcp-ovn-upgrade
+    name: pull-ci-openshift-priv-cluster-network-operator-main-e2e-gcp-ovn-upgrade
     path_alias: github.com/openshift/cluster-network-operator
     rerun_command: /test e2e-gcp-ovn-upgrade
     spec:
@@ -1742,9 +1742,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build03
     context: ci/prow/e2e-metal-ipi-ovn-dualstack-bgp
     decorate: true
     decoration_config:
@@ -1758,7 +1758,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-network-operator-master-e2e-metal-ipi-ovn-dualstack-bgp
+    name: pull-ci-openshift-priv-cluster-network-operator-main-e2e-metal-ipi-ovn-dualstack-bgp
     path_alias: github.com/openshift/cluster-network-operator
     rerun_command: /test e2e-metal-ipi-ovn-dualstack-bgp
     spec:
@@ -1825,9 +1825,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build03
     context: ci/prow/e2e-metal-ipi-ovn-dualstack-bgp-local-gw
     decorate: true
     decoration_config:
@@ -1841,7 +1841,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-network-operator-master-e2e-metal-ipi-ovn-dualstack-bgp-local-gw
+    name: pull-ci-openshift-priv-cluster-network-operator-main-e2e-metal-ipi-ovn-dualstack-bgp-local-gw
     path_alias: github.com/openshift/cluster-network-operator
     rerun_command: /test e2e-metal-ipi-ovn-dualstack-bgp-local-gw
     spec:
@@ -1908,9 +1908,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build03
     context: ci/prow/e2e-metal-ipi-ovn-ipv6
     decorate: true
     decoration_config:
@@ -1924,7 +1924,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-network-operator-master-e2e-metal-ipi-ovn-ipv6
+    name: pull-ci-openshift-priv-cluster-network-operator-main-e2e-metal-ipi-ovn-ipv6
     path_alias: github.com/openshift/cluster-network-operator
     rerun_command: /test e2e-metal-ipi-ovn-ipv6
     spec:
@@ -1991,9 +1991,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build03
     context: ci/prow/e2e-metal-ipi-ovn-ipv6-ipsec
     decorate: true
     decoration_config:
@@ -2007,7 +2007,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-network-operator-master-e2e-metal-ipi-ovn-ipv6-ipsec
+    name: pull-ci-openshift-priv-cluster-network-operator-main-e2e-metal-ipi-ovn-ipv6-ipsec
     path_alias: github.com/openshift/cluster-network-operator
     rerun_command: /test e2e-metal-ipi-ovn-ipv6-ipsec
     spec:
@@ -2074,9 +2074,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build08
+    - ^main$
+    - ^main-
+    cluster: build02
     context: ci/prow/e2e-network-mtu-migration-ovn-ipv4
     decorate: true
     decoration_config:
@@ -2089,7 +2089,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp-3
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-network-operator-master-e2e-network-mtu-migration-ovn-ipv4
+    name: pull-ci-openshift-priv-cluster-network-operator-main-e2e-network-mtu-migration-ovn-ipv4
     optional: true
     path_alias: github.com/openshift/cluster-network-operator
     rerun_command: /test e2e-network-mtu-migration-ovn-ipv4
@@ -2157,9 +2157,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build03
     context: ci/prow/e2e-network-mtu-migration-ovn-ipv6
     decorate: true
     decoration_config:
@@ -2173,7 +2173,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-network-operator-master-e2e-network-mtu-migration-ovn-ipv6
+    name: pull-ci-openshift-priv-cluster-network-operator-main-e2e-network-mtu-migration-ovn-ipv6
     optional: true
     path_alias: github.com/openshift/cluster-network-operator
     rerun_command: /test e2e-network-mtu-migration-ovn-ipv6
@@ -2241,9 +2241,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build06
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/e2e-openstack-ovn
     decorate: true
     decoration_config:
@@ -2256,7 +2256,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-network-operator-master-e2e-openstack-ovn
+    name: pull-ci-openshift-priv-cluster-network-operator-main-e2e-openstack-ovn
     optional: true
     path_alias: github.com/openshift/cluster-network-operator
     rerun_command: /test e2e-openstack-ovn
@@ -2324,9 +2324,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build06
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/e2e-ovn-hybrid-step-registry
     decorate: true
     decoration_config:
@@ -2339,7 +2339,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-5
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-network-operator-master-e2e-ovn-hybrid-step-registry
+    name: pull-ci-openshift-priv-cluster-network-operator-main-e2e-ovn-hybrid-step-registry
     optional: true
     path_alias: github.com/openshift/cluster-network-operator
     rerun_command: /test e2e-ovn-hybrid-step-registry
@@ -2407,9 +2407,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build06
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/e2e-ovn-ipsec-step-registry
     decorate: true
     decoration_config:
@@ -2422,7 +2422,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-5
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-network-operator-master-e2e-ovn-ipsec-step-registry
+    name: pull-ci-openshift-priv-cluster-network-operator-main-e2e-ovn-ipsec-step-registry
     path_alias: github.com/openshift/cluster-network-operator
     rerun_command: /test e2e-ovn-ipsec-step-registry
     spec:
@@ -2489,9 +2489,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build06
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/e2e-ovn-step-registry
     decorate: true
     decoration_config:
@@ -2504,7 +2504,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-4
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-network-operator-master-e2e-ovn-step-registry
+    name: pull-ci-openshift-priv-cluster-network-operator-main-e2e-ovn-step-registry
     optional: true
     path_alias: github.com/openshift/cluster-network-operator
     rerun_command: /test e2e-ovn-step-registry
@@ -2572,8 +2572,8 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: vsphere02
     context: ci/prow/e2e-vsphere-ovn
     decorate: true
@@ -2587,7 +2587,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-network-operator-master-e2e-vsphere-ovn
+    name: pull-ci-openshift-priv-cluster-network-operator-main-e2e-vsphere-ovn
     optional: true
     path_alias: github.com/openshift/cluster-network-operator
     rerun_command: /test e2e-vsphere-ovn
@@ -2655,8 +2655,8 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: vsphere02
     context: ci/prow/e2e-vsphere-ovn-dualstack
     decorate: true
@@ -2670,7 +2670,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-network-operator-master-e2e-vsphere-ovn-dualstack
+    name: pull-ci-openshift-priv-cluster-network-operator-main-e2e-vsphere-ovn-dualstack
     optional: true
     path_alias: github.com/openshift/cluster-network-operator
     rerun_command: /test e2e-vsphere-ovn-dualstack
@@ -2738,8 +2738,8 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: vsphere02
     context: ci/prow/e2e-vsphere-ovn-dualstack-primaryv6
     decorate: true
@@ -2753,7 +2753,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-network-operator-master-e2e-vsphere-ovn-dualstack-primaryv6
+    name: pull-ci-openshift-priv-cluster-network-operator-main-e2e-vsphere-ovn-dualstack-primaryv6
     optional: true
     path_alias: github.com/openshift/cluster-network-operator
     rerun_command: /test e2e-vsphere-ovn-dualstack-primaryv6
@@ -2821,8 +2821,8 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: vsphere02
     context: ci/prow/e2e-vsphere-ovn-windows
     decorate: true
@@ -2836,7 +2836,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-network-operator-master-e2e-vsphere-ovn-windows
+    name: pull-ci-openshift-priv-cluster-network-operator-main-e2e-vsphere-ovn-windows
     optional: true
     path_alias: github.com/openshift/cluster-network-operator
     rerun_command: /test e2e-vsphere-ovn-windows
@@ -2904,9 +2904,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build03
     context: ci/prow/frrk8s-e2e
     decorate: true
     decoration_config:
@@ -2920,7 +2920,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-network-operator-master-frrk8s-e2e
+    name: pull-ci-openshift-priv-cluster-network-operator-main-frrk8s-e2e
     optional: true
     path_alias: github.com/openshift/cluster-network-operator
     rerun_command: /test frrk8s-e2e
@@ -2989,9 +2989,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build10
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/hypershift-e2e-aks
     decorate: true
     decoration_config:
@@ -3004,7 +3004,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: hypershift
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-network-operator-master-hypershift-e2e-aks
+    name: pull-ci-openshift-priv-cluster-network-operator-main-hypershift-e2e-aks
     path_alias: github.com/openshift/cluster-network-operator
     rerun_command: /test hypershift-e2e-aks
     spec:
@@ -3071,9 +3071,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build10
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/images
     decorate: true
     decoration_config:
@@ -3084,7 +3084,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-network-operator-master-images
+    name: pull-ci-openshift-priv-cluster-network-operator-main-images
     path_alias: github.com/openshift/cluster-network-operator
     rerun_command: /test images
     spec:
@@ -3134,9 +3134,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build10
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/lint
     decorate: true
     decoration_config:
@@ -3147,7 +3147,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-network-operator-master-lint
+    name: pull-ci-openshift-priv-cluster-network-operator-main-lint
     path_alias: github.com/openshift/cluster-network-operator
     rerun_command: /test lint
     spec:
@@ -3197,9 +3197,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build06
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/qe-perfscale-aws-ovn-medium-cluster-density
     decorate: true
     decoration_config:
@@ -3212,7 +3212,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-network-operator-master-qe-perfscale-aws-ovn-medium-cluster-density
+    name: pull-ci-openshift-priv-cluster-network-operator-main-qe-perfscale-aws-ovn-medium-cluster-density
     optional: true
     path_alias: github.com/openshift/cluster-network-operator
     rerun_command: /test qe-perfscale-aws-ovn-medium-cluster-density
@@ -3280,9 +3280,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build06
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/qe-perfscale-aws-ovn-medium-node-density-cni
     decorate: true
     decoration_config:
@@ -3295,7 +3295,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-network-operator-master-qe-perfscale-aws-ovn-medium-node-density-cni
+    name: pull-ci-openshift-priv-cluster-network-operator-main-qe-perfscale-aws-ovn-medium-node-density-cni
     optional: true
     path_alias: github.com/openshift/cluster-network-operator
     rerun_command: /test qe-perfscale-aws-ovn-medium-node-density-cni
@@ -3363,9 +3363,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build06
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/qe-perfscale-aws-ovn-small-cluster-density
     decorate: true
     decoration_config:
@@ -3378,7 +3378,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-network-operator-master-qe-perfscale-aws-ovn-small-cluster-density
+    name: pull-ci-openshift-priv-cluster-network-operator-main-qe-perfscale-aws-ovn-small-cluster-density
     optional: true
     path_alias: github.com/openshift/cluster-network-operator
     rerun_command: /test qe-perfscale-aws-ovn-small-cluster-density
@@ -3446,9 +3446,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build06
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/qe-perfscale-aws-ovn-small-node-density-cni
     decorate: true
     decoration_config:
@@ -3461,7 +3461,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-network-operator-master-qe-perfscale-aws-ovn-small-node-density-cni
+    name: pull-ci-openshift-priv-cluster-network-operator-main-qe-perfscale-aws-ovn-small-node-density-cni
     optional: true
     path_alias: github.com/openshift/cluster-network-operator
     rerun_command: /test qe-perfscale-aws-ovn-small-node-density-cni
@@ -3529,9 +3529,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build10
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/security
     decorate: true
     decoration_config:
@@ -3542,7 +3542,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-network-operator-master-security
+    name: pull-ci-openshift-priv-cluster-network-operator-main-security
     optional: true
     path_alias: github.com/openshift/cluster-network-operator
     rerun_command: /test security
@@ -3600,9 +3600,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build10
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/unit
     decorate: true
     decoration_config:
@@ -3613,7 +3613,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-network-operator-master-unit
+    name: pull-ci-openshift-priv-cluster-network-operator-main-unit
     path_alias: github.com/openshift/cluster-network-operator
     rerun_command: /test unit
     spec:
@@ -3663,9 +3663,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build10
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/verify
     decorate: true
     decoration_config:
@@ -3676,7 +3676,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-network-operator-master-verify
+    name: pull-ci-openshift-priv-cluster-network-operator-main-verify
     path_alias: github.com/openshift/cluster-network-operator
     rerun_command: /test verify
     spec:
@@ -3726,9 +3726,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build10
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/verify-deps
     decorate: true
     decoration_config:
@@ -3739,7 +3739,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-network-operator-master-verify-deps
+    name: pull-ci-openshift-priv-cluster-network-operator-main-verify-deps
     path_alias: github.com/openshift/cluster-network-operator
     rerun_command: /test verify-deps
     spec:

--- a/ci-operator/jobs/openshift/cluster-network-operator/openshift-cluster-network-operator-main-periodics.yaml
+++ b/ci-operator/jobs/openshift/cluster-network-operator/openshift-cluster-network-operator-main-periodics.yaml
@@ -4,7 +4,7 @@ periodics:
   cron: 0 3 * * 0,2,4,6
   decorate: true
   extra_refs:
-  - base_ref: master
+  - base_ref: main
     org: openshift
     repo: cluster-network-operator
   labels:
@@ -74,7 +74,7 @@ periodics:
   cron: 0 3 * * 0,2,4,6
   decorate: true
   extra_refs:
-  - base_ref: master
+  - base_ref: main
     org: openshift
     repo: cluster-network-operator
   labels:

--- a/ci-operator/jobs/openshift/cluster-network-operator/openshift-cluster-network-operator-main-periodics.yaml
+++ b/ci-operator/jobs/openshift/cluster-network-operator/openshift-cluster-network-operator-main-periodics.yaml
@@ -1,6 +1,6 @@
 periodics:
 - agent: kubernetes
-  cluster: build06
+  cluster: build01
   cron: 0 3 * * 0,2,4,6
   decorate: true
   extra_refs:
@@ -12,7 +12,7 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-3
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-cluster-network-operator-master-e2e-aws-ovn-clusternetwork-cidr-expansion
+  name: periodic-ci-openshift-cluster-network-operator-main-e2e-aws-ovn-clusternetwork-cidr-expansion
   spec:
     containers:
     - args:
@@ -70,7 +70,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build06
+  cluster: build01
   cron: 0 3 * * 0,2,4,6
   decorate: true
   extra_refs:
@@ -82,7 +82,7 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-3
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-cluster-network-operator-master-e2e-aws-ovn-subnet-configs
+  name: periodic-ci-openshift-cluster-network-operator-main-e2e-aws-ovn-subnet-configs
   spec:
     containers:
     - args:

--- a/ci-operator/jobs/openshift/cluster-network-operator/openshift-cluster-network-operator-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-network-operator/openshift-cluster-network-operator-main-postsubmits.yaml
@@ -3,14 +3,14 @@ postsubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    cluster: build08
+    - ^main$
+    cluster: build01
     decorate: true
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-openshift-cluster-network-operator-master-images
+    name: branch-ci-openshift-cluster-network-operator-main-images
     spec:
       containers:
       - args:
@@ -61,8 +61,8 @@ postsubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    cluster: build08
+    - ^main$
+    cluster: build01
     decorate: true
     decoration_config:
       skip_cloning: true
@@ -71,7 +71,7 @@ postsubmits:
       ci-operator.openshift.io/variant: okd-scos
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-openshift-cluster-network-operator-master-okd-scos-images
+    name: branch-ci-openshift-cluster-network-operator-main-okd-scos-images
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift/cluster-network-operator/openshift-cluster-network-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-network-operator/openshift-cluster-network-operator-main-presubmits.yaml
@@ -3,9 +3,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build03
     context: ci/prow/4.22-upgrade-from-stable-4.21-e2e-aws-ovn-upgrade
     decorate: true
     decoration_config:
@@ -16,7 +16,7 @@ presubmits:
       ci-operator.openshift.io/variant: 4.22-upgrade-from-stable-4.21
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-4.22-upgrade-from-stable-4.21-e2e-aws-ovn-upgrade
+    name: pull-ci-openshift-cluster-network-operator-main-4.22-upgrade-from-stable-4.21-e2e-aws-ovn-upgrade
     optional: true
     rerun_command: /test 4.22-upgrade-from-stable-4.21-e2e-aws-ovn-upgrade
     spec:
@@ -80,9 +80,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build03
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/4.22-upgrade-from-stable-4.21-e2e-azure-ovn-upgrade
     decorate: true
     decoration_config:
@@ -93,7 +93,7 @@ presubmits:
       ci-operator.openshift.io/variant: 4.22-upgrade-from-stable-4.21
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-4.22-upgrade-from-stable-4.21-e2e-azure-ovn-upgrade
+    name: pull-ci-openshift-cluster-network-operator-main-4.22-upgrade-from-stable-4.21-e2e-azure-ovn-upgrade
     optional: true
     rerun_command: /test 4.22-upgrade-from-stable-4.21-e2e-azure-ovn-upgrade
     spec:
@@ -157,9 +157,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build02
+    - ^main$
+    - ^main-
+    cluster: build04
     context: ci/prow/4.22-upgrade-from-stable-4.21-e2e-gcp-ovn-upgrade
     decorate: true
     decoration_config:
@@ -170,7 +170,7 @@ presubmits:
       ci-operator.openshift.io/variant: 4.22-upgrade-from-stable-4.21
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-4.22-upgrade-from-stable-4.21-e2e-gcp-ovn-upgrade
+    name: pull-ci-openshift-cluster-network-operator-main-4.22-upgrade-from-stable-4.21-e2e-gcp-ovn-upgrade
     optional: true
     rerun_command: /test 4.22-upgrade-from-stable-4.21-e2e-gcp-ovn-upgrade
     spec:
@@ -234,16 +234,16 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build03
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/4.22-upgrade-from-stable-4.21-images
     decorate: true
     labels:
       ci-operator.openshift.io/variant: 4.22-upgrade-from-stable-4.21
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-4.22-upgrade-from-stable-4.21-images
+    name: pull-ci-openshift-cluster-network-operator-main-4.22-upgrade-from-stable-4.21-images
     rerun_command: /test 4.22-upgrade-from-stable-4.21-images
     spec:
       containers:
@@ -289,9 +289,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build03
     context: ci/prow/e2e-aws-hypershift-ovn-kubevirt
     decorate: true
     labels:
@@ -299,7 +299,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-3
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-e2e-aws-hypershift-ovn-kubevirt
+    name: pull-ci-openshift-cluster-network-operator-main-e2e-aws-hypershift-ovn-kubevirt
     optional: true
     rerun_command: /test e2e-aws-hypershift-ovn-kubevirt
     spec:
@@ -362,9 +362,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build03
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/e2e-aws-ovn-hypershift-conformance
     decorate: true
     labels:
@@ -372,7 +372,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: hypershift
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-e2e-aws-ovn-hypershift-conformance
+    name: pull-ci-openshift-cluster-network-operator-main-e2e-aws-ovn-hypershift-conformance
     rerun_command: /test e2e-aws-ovn-hypershift-conformance
     spec:
       containers:
@@ -434,9 +434,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build03
     context: ci/prow/e2e-aws-ovn-local-to-shared-gateway-mode-migration
     decorate: true
     labels:
@@ -444,7 +444,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-3
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-e2e-aws-ovn-local-to-shared-gateway-mode-migration
+    name: pull-ci-openshift-cluster-network-operator-main-e2e-aws-ovn-local-to-shared-gateway-mode-migration
     optional: true
     rerun_command: /test e2e-aws-ovn-local-to-shared-gateway-mode-migration
     spec:
@@ -507,9 +507,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build03
     context: ci/prow/e2e-aws-ovn-serial-1of2
     decorate: true
     labels:
@@ -517,7 +517,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-e2e-aws-ovn-serial-1of2
+    name: pull-ci-openshift-cluster-network-operator-main-e2e-aws-ovn-serial-1of2
     rerun_command: /test e2e-aws-ovn-serial-1of2
     spec:
       containers:
@@ -580,9 +580,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build03
     context: ci/prow/e2e-aws-ovn-serial-2of2
     decorate: true
     labels:
@@ -590,7 +590,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-e2e-aws-ovn-serial-2of2
+    name: pull-ci-openshift-cluster-network-operator-main-e2e-aws-ovn-serial-2of2
     rerun_command: /test e2e-aws-ovn-serial-2of2
     spec:
       containers:
@@ -653,9 +653,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build03
     context: ci/prow/e2e-aws-ovn-serial-ipsec-1of2
     decorate: true
     labels:
@@ -663,7 +663,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-e2e-aws-ovn-serial-ipsec-1of2
+    name: pull-ci-openshift-cluster-network-operator-main-e2e-aws-ovn-serial-ipsec-1of2
     optional: true
     rerun_command: /test e2e-aws-ovn-serial-ipsec-1of2
     spec:
@@ -727,9 +727,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build03
     context: ci/prow/e2e-aws-ovn-serial-ipsec-2of2
     decorate: true
     labels:
@@ -737,7 +737,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-e2e-aws-ovn-serial-ipsec-2of2
+    name: pull-ci-openshift-cluster-network-operator-main-e2e-aws-ovn-serial-ipsec-2of2
     optional: true
     rerun_command: /test e2e-aws-ovn-serial-ipsec-2of2
     spec:
@@ -801,9 +801,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build03
     context: ci/prow/e2e-aws-ovn-shared-to-local-gateway-mode-migration
     decorate: true
     labels:
@@ -811,7 +811,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-3
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-e2e-aws-ovn-shared-to-local-gateway-mode-migration
+    name: pull-ci-openshift-cluster-network-operator-main-e2e-aws-ovn-shared-to-local-gateway-mode-migration
     optional: true
     rerun_command: /test e2e-aws-ovn-shared-to-local-gateway-mode-migration
     spec:
@@ -874,9 +874,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build03
     context: ci/prow/e2e-aws-ovn-single-node
     decorate: true
     labels:
@@ -884,7 +884,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-3
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-e2e-aws-ovn-single-node
+    name: pull-ci-openshift-cluster-network-operator-main-e2e-aws-ovn-single-node
     optional: true
     rerun_command: /test e2e-aws-ovn-single-node
     spec:
@@ -947,9 +947,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build03
     context: ci/prow/e2e-aws-ovn-techpreview-serial-1of2
     decorate: true
     labels:
@@ -957,7 +957,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-3
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-e2e-aws-ovn-techpreview-serial-1of2
+    name: pull-ci-openshift-cluster-network-operator-main-e2e-aws-ovn-techpreview-serial-1of2
     optional: true
     rerun_command: /test e2e-aws-ovn-techpreview-serial-1of2
     spec:
@@ -1021,9 +1021,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build03
     context: ci/prow/e2e-aws-ovn-techpreview-serial-2of2
     decorate: true
     labels:
@@ -1031,7 +1031,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-3
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-e2e-aws-ovn-techpreview-serial-2of2
+    name: pull-ci-openshift-cluster-network-operator-main-e2e-aws-ovn-techpreview-serial-2of2
     optional: true
     rerun_command: /test e2e-aws-ovn-techpreview-serial-2of2
     spec:
@@ -1095,9 +1095,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build03
     context: ci/prow/e2e-aws-ovn-upgrade
     decorate: true
     labels:
@@ -1105,7 +1105,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-4
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-e2e-aws-ovn-upgrade
+    name: pull-ci-openshift-cluster-network-operator-main-e2e-aws-ovn-upgrade
     rerun_command: /test e2e-aws-ovn-upgrade
     spec:
       containers:
@@ -1167,9 +1167,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build03
     context: ci/prow/e2e-aws-ovn-upgrade-ipsec
     decorate: true
     labels:
@@ -1177,7 +1177,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-e2e-aws-ovn-upgrade-ipsec
+    name: pull-ci-openshift-cluster-network-operator-main-e2e-aws-ovn-upgrade-ipsec
     rerun_command: /test e2e-aws-ovn-upgrade-ipsec
     spec:
       containers:
@@ -1239,9 +1239,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build03
     context: ci/prow/e2e-aws-ovn-windows
     decorate: true
     labels:
@@ -1249,7 +1249,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-e2e-aws-ovn-windows
+    name: pull-ci-openshift-cluster-network-operator-main-e2e-aws-ovn-windows
     rerun_command: /test e2e-aws-ovn-windows
     spec:
       containers:
@@ -1311,9 +1311,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build03
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/e2e-azure-ovn
     decorate: true
     labels:
@@ -1321,7 +1321,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: azure-2
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-e2e-azure-ovn
+    name: pull-ci-openshift-cluster-network-operator-main-e2e-azure-ovn
     optional: true
     rerun_command: /test e2e-azure-ovn
     spec:
@@ -1384,9 +1384,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build03
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/e2e-azure-ovn-dualstack
     decorate: true
     labels:
@@ -1394,7 +1394,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: azure-2
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-e2e-azure-ovn-dualstack
+    name: pull-ci-openshift-cluster-network-operator-main-e2e-azure-ovn-dualstack
     optional: true
     rerun_command: /test e2e-azure-ovn-dualstack
     spec:
@@ -1457,9 +1457,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build03
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/e2e-azure-ovn-manual-oidc
     decorate: true
     labels:
@@ -1467,7 +1467,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: azure-2
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-e2e-azure-ovn-manual-oidc
+    name: pull-ci-openshift-cluster-network-operator-main-e2e-azure-ovn-manual-oidc
     optional: true
     rerun_command: /test e2e-azure-ovn-manual-oidc
     spec:
@@ -1530,9 +1530,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build03
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/e2e-azure-ovn-upgrade
     decorate: true
     labels:
@@ -1540,7 +1540,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: azure-2
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-e2e-azure-ovn-upgrade
+    name: pull-ci-openshift-cluster-network-operator-main-e2e-azure-ovn-upgrade
     rerun_command: /test e2e-azure-ovn-upgrade
     spec:
       containers:
@@ -1602,9 +1602,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build02
+    - ^main$
+    - ^main-
+    cluster: build04
     context: ci/prow/e2e-gcp-ovn
     decorate: true
     labels:
@@ -1612,7 +1612,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-e2e-gcp-ovn
+    name: pull-ci-openshift-cluster-network-operator-main-e2e-gcp-ovn
     rerun_command: /test e2e-gcp-ovn
     spec:
       containers:
@@ -1674,9 +1674,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build02
+    - ^main$
+    - ^main-
+    cluster: build04
     context: ci/prow/e2e-gcp-ovn-techpreview
     decorate: true
     labels:
@@ -1684,7 +1684,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-e2e-gcp-ovn-techpreview
+    name: pull-ci-openshift-cluster-network-operator-main-e2e-gcp-ovn-techpreview
     rerun_command: /test e2e-gcp-ovn-techpreview
     spec:
       containers:
@@ -1746,9 +1746,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build02
+    - ^main$
+    - ^main-
+    cluster: build04
     context: ci/prow/e2e-gcp-ovn-upgrade
     decorate: true
     labels:
@@ -1756,7 +1756,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-e2e-gcp-ovn-upgrade
+    name: pull-ci-openshift-cluster-network-operator-main-e2e-gcp-ovn-upgrade
     rerun_command: /test e2e-gcp-ovn-upgrade
     spec:
       containers:
@@ -1818,9 +1818,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build03
     context: ci/prow/e2e-metal-ipi-ovn-dualstack-bgp
     decorate: true
     labels:
@@ -1829,7 +1829,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-e2e-metal-ipi-ovn-dualstack-bgp
+    name: pull-ci-openshift-cluster-network-operator-main-e2e-metal-ipi-ovn-dualstack-bgp
     rerun_command: /test e2e-metal-ipi-ovn-dualstack-bgp
     spec:
       containers:
@@ -1891,9 +1891,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build03
     context: ci/prow/e2e-metal-ipi-ovn-dualstack-bgp-local-gw
     decorate: true
     labels:
@@ -1902,7 +1902,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-e2e-metal-ipi-ovn-dualstack-bgp-local-gw
+    name: pull-ci-openshift-cluster-network-operator-main-e2e-metal-ipi-ovn-dualstack-bgp-local-gw
     rerun_command: /test e2e-metal-ipi-ovn-dualstack-bgp-local-gw
     spec:
       containers:
@@ -1964,9 +1964,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build03
     context: ci/prow/e2e-metal-ipi-ovn-ipv6
     decorate: true
     labels:
@@ -1975,7 +1975,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-e2e-metal-ipi-ovn-ipv6
+    name: pull-ci-openshift-cluster-network-operator-main-e2e-metal-ipi-ovn-ipv6
     rerun_command: /test e2e-metal-ipi-ovn-ipv6
     spec:
       containers:
@@ -2037,9 +2037,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build03
     context: ci/prow/e2e-metal-ipi-ovn-ipv6-ipsec
     decorate: true
     labels:
@@ -2048,7 +2048,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-e2e-metal-ipi-ovn-ipv6-ipsec
+    name: pull-ci-openshift-cluster-network-operator-main-e2e-metal-ipi-ovn-ipv6-ipsec
     rerun_command: /test e2e-metal-ipi-ovn-ipv6-ipsec
     spec:
       containers:
@@ -2110,9 +2110,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build02
+    - ^main$
+    - ^main-
+    cluster: build04
     context: ci/prow/e2e-network-mtu-migration-ovn-ipv4
     decorate: true
     labels:
@@ -2120,7 +2120,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp-3
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-e2e-network-mtu-migration-ovn-ipv4
+    name: pull-ci-openshift-cluster-network-operator-main-e2e-network-mtu-migration-ovn-ipv4
     optional: true
     rerun_command: /test e2e-network-mtu-migration-ovn-ipv4
     spec:
@@ -2183,9 +2183,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build03
     context: ci/prow/e2e-network-mtu-migration-ovn-ipv6
     decorate: true
     labels:
@@ -2194,7 +2194,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-e2e-network-mtu-migration-ovn-ipv6
+    name: pull-ci-openshift-cluster-network-operator-main-e2e-network-mtu-migration-ovn-ipv6
     optional: true
     rerun_command: /test e2e-network-mtu-migration-ovn-ipv6
     spec:
@@ -2257,9 +2257,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build03
     context: ci/prow/e2e-openstack-ovn
     decorate: true
     labels:
@@ -2267,7 +2267,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-e2e-openstack-ovn
+    name: pull-ci-openshift-cluster-network-operator-main-e2e-openstack-ovn
     optional: true
     rerun_command: /test e2e-openstack-ovn
     spec:
@@ -2330,9 +2330,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build03
     context: ci/prow/e2e-ovn-hybrid-step-registry
     decorate: true
     labels:
@@ -2340,7 +2340,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-5
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-e2e-ovn-hybrid-step-registry
+    name: pull-ci-openshift-cluster-network-operator-main-e2e-ovn-hybrid-step-registry
     optional: true
     rerun_command: /test e2e-ovn-hybrid-step-registry
     spec:
@@ -2403,9 +2403,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build03
     context: ci/prow/e2e-ovn-ipsec-step-registry
     decorate: true
     labels:
@@ -2413,7 +2413,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-5
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-e2e-ovn-ipsec-step-registry
+    name: pull-ci-openshift-cluster-network-operator-main-e2e-ovn-ipsec-step-registry
     rerun_command: /test e2e-ovn-ipsec-step-registry
     spec:
       containers:
@@ -2475,9 +2475,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build03
     context: ci/prow/e2e-ovn-step-registry
     decorate: true
     labels:
@@ -2485,7 +2485,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-4
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-e2e-ovn-step-registry
+    name: pull-ci-openshift-cluster-network-operator-main-e2e-ovn-step-registry
     optional: true
     rerun_command: /test e2e-ovn-step-registry
     spec:
@@ -2548,8 +2548,8 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: vsphere02
     context: ci/prow/e2e-vsphere-ovn
     decorate: true
@@ -2558,7 +2558,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-e2e-vsphere-ovn
+    name: pull-ci-openshift-cluster-network-operator-main-e2e-vsphere-ovn
     optional: true
     rerun_command: /test e2e-vsphere-ovn
     spec:
@@ -2621,8 +2621,8 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: vsphere02
     context: ci/prow/e2e-vsphere-ovn-dualstack
     decorate: true
@@ -2631,7 +2631,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-e2e-vsphere-ovn-dualstack
+    name: pull-ci-openshift-cluster-network-operator-main-e2e-vsphere-ovn-dualstack
     optional: true
     rerun_command: /test e2e-vsphere-ovn-dualstack
     spec:
@@ -2694,8 +2694,8 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: vsphere02
     context: ci/prow/e2e-vsphere-ovn-dualstack-primaryv6
     decorate: true
@@ -2704,7 +2704,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-e2e-vsphere-ovn-dualstack-primaryv6
+    name: pull-ci-openshift-cluster-network-operator-main-e2e-vsphere-ovn-dualstack-primaryv6
     optional: true
     rerun_command: /test e2e-vsphere-ovn-dualstack-primaryv6
     spec:
@@ -2767,8 +2767,8 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: vsphere02
     context: ci/prow/e2e-vsphere-ovn-windows
     decorate: true
@@ -2777,7 +2777,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-e2e-vsphere-ovn-windows
+    name: pull-ci-openshift-cluster-network-operator-main-e2e-vsphere-ovn-windows
     optional: true
     rerun_command: /test e2e-vsphere-ovn-windows
     spec:
@@ -2840,9 +2840,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build03
     context: ci/prow/frrk8s-e2e
     decorate: true
     labels:
@@ -2851,7 +2851,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-frrk8s-e2e
+    name: pull-ci-openshift-cluster-network-operator-main-frrk8s-e2e
     optional: true
     rerun_command: /test frrk8s-e2e
     run_if_changed: ^bindata\/network\/frr-k8s.*$
@@ -2915,9 +2915,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build03
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/hypershift-e2e-aks
     decorate: true
     labels:
@@ -2925,7 +2925,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: hypershift
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-hypershift-e2e-aks
+    name: pull-ci-openshift-cluster-network-operator-main-hypershift-e2e-aks
     rerun_command: /test hypershift-e2e-aks
     spec:
       containers:
@@ -2987,15 +2987,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build03
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/images
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-images
+    name: pull-ci-openshift-cluster-network-operator-main-images
     rerun_command: /test images
     spec:
       containers:
@@ -3041,15 +3041,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build03
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/lint
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-lint
+    name: pull-ci-openshift-cluster-network-operator-main-lint
     rerun_command: /test lint
     spec:
       containers:
@@ -3094,9 +3094,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build03
     context: ci/prow/okd-scos-e2e-aws-ovn
     decorate: true
     decoration_config:
@@ -3107,7 +3107,7 @@ presubmits:
       ci-operator.openshift.io/variant: okd-scos
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-okd-scos-e2e-aws-ovn
+    name: pull-ci-openshift-cluster-network-operator-main-okd-scos-e2e-aws-ovn
     optional: true
     rerun_command: /test okd-scos-e2e-aws-ovn
     spec:
@@ -3171,9 +3171,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build03
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/okd-scos-images
     decorate: true
     decoration_config:
@@ -3182,7 +3182,7 @@ presubmits:
       ci-operator.openshift.io/variant: okd-scos
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-okd-scos-images
+    name: pull-ci-openshift-cluster-network-operator-main-okd-scos-images
     rerun_command: /test okd-scos-images
     spec:
       containers:
@@ -3229,9 +3229,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build03
     context: ci/prow/qe-perfscale-aws-ovn-medium-cluster-density
     decorate: true
     labels:
@@ -3239,7 +3239,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-qe-perfscale-aws-ovn-medium-cluster-density
+    name: pull-ci-openshift-cluster-network-operator-main-qe-perfscale-aws-ovn-medium-cluster-density
     optional: true
     rerun_command: /test qe-perfscale-aws-ovn-medium-cluster-density
     spec:
@@ -3302,9 +3302,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build03
     context: ci/prow/qe-perfscale-aws-ovn-medium-node-density-cni
     decorate: true
     labels:
@@ -3312,7 +3312,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-qe-perfscale-aws-ovn-medium-node-density-cni
+    name: pull-ci-openshift-cluster-network-operator-main-qe-perfscale-aws-ovn-medium-node-density-cni
     optional: true
     rerun_command: /test qe-perfscale-aws-ovn-medium-node-density-cni
     spec:
@@ -3375,9 +3375,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build03
     context: ci/prow/qe-perfscale-aws-ovn-small-cluster-density
     decorate: true
     labels:
@@ -3385,7 +3385,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-qe-perfscale-aws-ovn-small-cluster-density
+    name: pull-ci-openshift-cluster-network-operator-main-qe-perfscale-aws-ovn-small-cluster-density
     optional: true
     rerun_command: /test qe-perfscale-aws-ovn-small-cluster-density
     spec:
@@ -3448,9 +3448,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build03
     context: ci/prow/qe-perfscale-aws-ovn-small-node-density-cni
     decorate: true
     labels:
@@ -3458,7 +3458,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-qe-perfscale-aws-ovn-small-node-density-cni
+    name: pull-ci-openshift-cluster-network-operator-main-qe-perfscale-aws-ovn-small-node-density-cni
     optional: true
     rerun_command: /test qe-perfscale-aws-ovn-small-node-density-cni
     spec:
@@ -3521,15 +3521,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build03
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/security
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-security
+    name: pull-ci-openshift-cluster-network-operator-main-security
     optional: true
     rerun_command: /test security
     spec:
@@ -3582,15 +3582,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build03
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/unit
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-unit
+    name: pull-ci-openshift-cluster-network-operator-main-unit
     rerun_command: /test unit
     spec:
       containers:
@@ -3635,15 +3635,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build03
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/verify
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-verify
+    name: pull-ci-openshift-cluster-network-operator-main-verify
     rerun_command: /test verify
     spec:
       containers:
@@ -3688,15 +3688,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: build03
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/verify-deps
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-verify-deps
+    name: pull-ci-openshift-cluster-network-operator-main-verify-deps
     rerun_command: /test verify-deps
     spec:
       containers:


### PR DESCRIPTION

This PR is in support of renaming the default branch for https://github.com/openshift/cluster-network-operator from 'master' to 'main'.

Unhold this PR only when:

* the default branch for https://github.com/openshift/cluster-network-operator has been renamed to 'main'
* You have verified that the CI jobs are working as expected either by running '/pj-rehearse' or by inspection.

/hold
