### PR TITLE
Run cinder-csi-operator e2e-openstack jobs on managed OpenStack

### DIFF
--- a/ci-operator/config/openshift/csi-operator/openshift-csi-operator-main.yaml
+++ b/ci-operator/config/openshift/csi-operator/openshift-csi-operator-main.yaml
@@ -304,7 +304,7 @@ tests:
   optional: true
   run_if_changed: ^(Dockerfile\.openstack-cinder|assets\/overlays\/openstack-cinder\/.*|pkg\/driver\/openstack-cinder\/.*|pkg\/openstack-cinder\/.*|Dockerfile\.openstack-manila|assets\/overlays\/openstack-manila\/.*|pkg\/driver\/openstack-manila\/.*|pkg\/openstack-manila\/.*)
   steps:
-    cluster_profile: openstack-vh-mecha-central
+    cluster_profile: openstack-vexxhost
     env:
       BASE_DOMAIN: shiftstack.devcluster.openshift.com
       CONFIG_TYPE: minimal
@@ -312,7 +312,7 @@ tests:
 - as: e2e-openstack-cinder-csi
   run_if_changed: ^(Dockerfile\.openstack-cinder|assets\/overlays\/openstack-cinder\/.*|pkg\/driver\/openstack-cinder\/.*|pkg\/openstack-cinder\/.*)
   steps:
-    cluster_profile: openstack-vh-mecha-central
+    cluster_profile: openstack-vexxhost
     env:
       TEST_SKIPS: should concurrently access the volume and restored snapshot from
         pods on the same node
@@ -331,13 +331,13 @@ tests:
   steps:
     cluster_profile: hypershift-aws
     env:
-      CLUSTER_TYPE_OVERRIDE: openstack-vh-mecha-central
+      CLUSTER_TYPE_OVERRIDE: openstack-vexxhost
       TECH_PREVIEW_NO_UPGRADE: "true"
       TEST_CSI_DRIVER_MANIFEST: manifest-openstack-cinder.yaml
       TEST_SUITE: openshift/csi
     leases:
     - env: OPENSTACK_CLOUD
-      resource_type: openstack-vh-mecha-central-quota-slice
+      resource_type: openstack-vexxhost-quota-slice
     workflow: hypershift-openstack-aws-conformance
 - as: hypershift-e2e-openstack-aws-csi-manila
   run_if_changed: ^(Dockerfile\.openstack-manila|assets\/overlays\/openstack-manila\/.*|pkg\/driver\/openstack-manila\/.*|pkg\/openstack-manila\/.*)

--- a/ci-operator/config/openshift/csi-operator/openshift-csi-operator-release-4.18.yaml
+++ b/ci-operator/config/openshift/csi-operator/openshift-csi-operator-release-4.18.yaml
@@ -239,7 +239,7 @@ tests:
   optional: true
   run_if_changed: ^(Dockerfile\.openstack-cinder|assets\/overlays\/openstack-cinder\/.*|pkg\/driver\/openstack-cinder\/.*|pkg\/openstack-cinder\/.*|Dockerfile\.openstack-manila|assets\/overlays\/openstack-manila\/.*|pkg\/driver\/openstack-manila\/.*|pkg\/openstack-manila\/.*)
   steps:
-    cluster_profile: openstack-vh-mecha-central
+    cluster_profile: openstack-vexxhost
     env:
       BASE_DOMAIN: shiftstack.devcluster.openshift.com
       CONFIG_TYPE: minimal
@@ -248,7 +248,7 @@ tests:
 - as: e2e-openstack-cinder-csi
   run_if_changed: ^(Dockerfile\.openstack-cinder|assets\/overlays\/openstack-cinder\/.*|pkg\/driver\/openstack-cinder\/.*|pkg\/openstack-cinder\/.*)
   steps:
-    cluster_profile: openstack-vh-mecha-central
+    cluster_profile: openstack-vexxhost
     env:
       TEST_SKIPS: should concurrently access the volume and restored snapshot from
         pods on the same node
@@ -267,14 +267,14 @@ tests:
   steps:
     cluster_profile: hypershift-aws
     env:
-      CLUSTER_TYPE_OVERRIDE: openstack-vh-mecha-central
+      CLUSTER_TYPE_OVERRIDE: openstack-vexxhost
       RHCOS_IMAGE_NAME: rhcos-4.18-hcp-nodepool
       TECH_PREVIEW_NO_UPGRADE: "true"
       TEST_CSI_DRIVER_MANIFEST: manifest-openstack-cinder.yaml
       TEST_SUITE: openshift/csi
     leases:
     - env: OPENSTACK_CLOUD
-      resource_type: openstack-vh-mecha-central-quota-slice
+      resource_type: openstack-vexxhost-quota-slice
     workflow: hypershift-openstack-aws-conformance
 - as: hypershift-e2e-openstack-aws-csi-manila
   run_if_changed: ^(Dockerfile\.openstack-manila|assets\/overlays\/openstack-manila\/.*|pkg\/driver\/openstack-manila\/.*|pkg\/openstack-manila\/.*)

--- a/ci-operator/config/openshift/csi-operator/openshift-csi-operator-release-4.19.yaml
+++ b/ci-operator/config/openshift/csi-operator/openshift-csi-operator-release-4.19.yaml
@@ -239,7 +239,7 @@ tests:
   optional: true
   run_if_changed: ^(Dockerfile\.openstack-cinder|assets\/overlays\/openstack-cinder\/.*|pkg\/driver\/openstack-cinder\/.*|pkg\/openstack-cinder\/.*|Dockerfile\.openstack-manila|assets\/overlays\/openstack-manila\/.*|pkg\/driver\/openstack-manila\/.*|pkg\/openstack-manila\/.*)
   steps:
-    cluster_profile: openstack-vh-mecha-central
+    cluster_profile: openstack-vexxhost
     env:
       BASE_DOMAIN: shiftstack.devcluster.openshift.com
       CONFIG_TYPE: minimal
@@ -248,7 +248,7 @@ tests:
 - as: e2e-openstack-cinder-csi
   run_if_changed: ^(Dockerfile\.openstack-cinder|assets\/overlays\/openstack-cinder\/.*|pkg\/driver\/openstack-cinder\/.*|pkg\/openstack-cinder\/.*)
   steps:
-    cluster_profile: openstack-vh-mecha-central
+    cluster_profile: openstack-vexxhost
     env:
       TEST_SKIPS: should concurrently access the volume and restored snapshot from
         pods on the same node
@@ -267,13 +267,13 @@ tests:
   steps:
     cluster_profile: hypershift-aws
     env:
-      CLUSTER_TYPE_OVERRIDE: openstack-vh-mecha-central
+      CLUSTER_TYPE_OVERRIDE: openstack-vexxhost
       TECH_PREVIEW_NO_UPGRADE: "true"
       TEST_CSI_DRIVER_MANIFEST: manifest-openstack-cinder.yaml
       TEST_SUITE: openshift/csi
     leases:
     - env: OPENSTACK_CLOUD
-      resource_type: openstack-vh-mecha-central-quota-slice
+      resource_type: openstack-vexxhost-quota-slice
     workflow: hypershift-openstack-aws-conformance
 - as: hypershift-e2e-openstack-aws-csi-manila
   run_if_changed: ^(Dockerfile\.openstack-manila|assets\/overlays\/openstack-manila\/.*|pkg\/driver\/openstack-manila\/.*|pkg\/openstack-manila\/.*)

--- a/ci-operator/config/openshift/csi-operator/openshift-csi-operator-release-4.20.yaml
+++ b/ci-operator/config/openshift/csi-operator/openshift-csi-operator-release-4.20.yaml
@@ -304,7 +304,7 @@ tests:
   optional: true
   run_if_changed: ^(Dockerfile\.openstack-cinder|assets\/overlays\/openstack-cinder\/.*|pkg\/driver\/openstack-cinder\/.*|pkg\/openstack-cinder\/.*|Dockerfile\.openstack-manila|assets\/overlays\/openstack-manila\/.*|pkg\/driver\/openstack-manila\/.*|pkg\/openstack-manila\/.*)
   steps:
-    cluster_profile: openstack-vh-mecha-central
+    cluster_profile: openstack-vexxhost
     env:
       BASE_DOMAIN: shiftstack.devcluster.openshift.com
       CONFIG_TYPE: minimal
@@ -312,7 +312,7 @@ tests:
 - as: e2e-openstack-cinder-csi
   run_if_changed: ^(Dockerfile\.openstack-cinder|assets\/overlays\/openstack-cinder\/.*|pkg\/driver\/openstack-cinder\/.*|pkg\/openstack-cinder\/.*)
   steps:
-    cluster_profile: openstack-vh-mecha-central
+    cluster_profile: openstack-vexxhost
     env:
       TEST_SKIPS: should concurrently access the volume and restored snapshot from
         pods on the same node
@@ -331,13 +331,13 @@ tests:
   steps:
     cluster_profile: hypershift-aws
     env:
-      CLUSTER_TYPE_OVERRIDE: openstack-vh-mecha-central
+      CLUSTER_TYPE_OVERRIDE: openstack-vexxhost
       TECH_PREVIEW_NO_UPGRADE: "true"
       TEST_CSI_DRIVER_MANIFEST: manifest-openstack-cinder.yaml
       TEST_SUITE: openshift/csi
     leases:
     - env: OPENSTACK_CLOUD
-      resource_type: openstack-vh-mecha-central-quota-slice
+      resource_type: openstack-vexxhost-quota-slice
     workflow: hypershift-openstack-aws-conformance
 - as: hypershift-e2e-openstack-aws-csi-manila
   run_if_changed: ^(Dockerfile\.openstack-manila|assets\/overlays\/openstack-manila\/.*|pkg\/driver\/openstack-manila\/.*|pkg\/openstack-manila\/.*)

--- a/ci-operator/config/openshift/csi-operator/openshift-csi-operator-release-4.21.yaml
+++ b/ci-operator/config/openshift/csi-operator/openshift-csi-operator-release-4.21.yaml
@@ -304,7 +304,7 @@ tests:
   optional: true
   run_if_changed: ^(Dockerfile\.openstack-cinder|assets\/overlays\/openstack-cinder\/.*|pkg\/driver\/openstack-cinder\/.*|pkg\/openstack-cinder\/.*|Dockerfile\.openstack-manila|assets\/overlays\/openstack-manila\/.*|pkg\/driver\/openstack-manila\/.*|pkg\/openstack-manila\/.*)
   steps:
-    cluster_profile: openstack-vh-mecha-central
+    cluster_profile: openstack-vexxhost
     env:
       BASE_DOMAIN: shiftstack.devcluster.openshift.com
       CONFIG_TYPE: minimal
@@ -312,7 +312,7 @@ tests:
 - as: e2e-openstack-cinder-csi
   run_if_changed: ^(Dockerfile\.openstack-cinder|assets\/overlays\/openstack-cinder\/.*|pkg\/driver\/openstack-cinder\/.*|pkg\/openstack-cinder\/.*)
   steps:
-    cluster_profile: openstack-vh-mecha-central
+    cluster_profile: openstack-vexxhost
     env:
       TEST_SKIPS: should concurrently access the volume and restored snapshot from
         pods on the same node
@@ -331,13 +331,13 @@ tests:
   steps:
     cluster_profile: hypershift-aws
     env:
-      CLUSTER_TYPE_OVERRIDE: openstack-vh-mecha-central
+      CLUSTER_TYPE_OVERRIDE: openstack-vexxhost
       TECH_PREVIEW_NO_UPGRADE: "true"
       TEST_CSI_DRIVER_MANIFEST: manifest-openstack-cinder.yaml
       TEST_SUITE: openshift/csi
     leases:
     - env: OPENSTACK_CLOUD
-      resource_type: openstack-vh-mecha-central-quota-slice
+      resource_type: openstack-vexxhost-quota-slice
     workflow: hypershift-openstack-aws-conformance
 - as: hypershift-e2e-openstack-aws-csi-manila
   run_if_changed: ^(Dockerfile\.openstack-manila|assets\/overlays\/openstack-manila\/.*|pkg\/driver\/openstack-manila\/.*|pkg\/openstack-manila\/.*)

--- a/ci-operator/config/openshift/csi-operator/openshift-csi-operator-release-4.22.yaml
+++ b/ci-operator/config/openshift/csi-operator/openshift-csi-operator-release-4.22.yaml
@@ -305,7 +305,7 @@ tests:
   optional: true
   run_if_changed: ^(Dockerfile\.openstack-cinder|assets\/overlays\/openstack-cinder\/.*|pkg\/driver\/openstack-cinder\/.*|pkg\/openstack-cinder\/.*|Dockerfile\.openstack-manila|assets\/overlays\/openstack-manila\/.*|pkg\/driver\/openstack-manila\/.*|pkg\/openstack-manila\/.*)
   steps:
-    cluster_profile: openstack-vh-mecha-central
+    cluster_profile: openstack-vexxhost
     env:
       BASE_DOMAIN: shiftstack.devcluster.openshift.com
       CONFIG_TYPE: minimal
@@ -313,7 +313,7 @@ tests:
 - as: e2e-openstack-cinder-csi
   run_if_changed: ^(Dockerfile\.openstack-cinder|assets\/overlays\/openstack-cinder\/.*|pkg\/driver\/openstack-cinder\/.*|pkg\/openstack-cinder\/.*)
   steps:
-    cluster_profile: openstack-vh-mecha-central
+    cluster_profile: openstack-vexxhost
     env:
       TEST_SKIPS: should concurrently access the volume and restored snapshot from
         pods on the same node
@@ -332,13 +332,13 @@ tests:
   steps:
     cluster_profile: hypershift-aws
     env:
-      CLUSTER_TYPE_OVERRIDE: openstack-vh-mecha-central
+      CLUSTER_TYPE_OVERRIDE: openstack-vexxhost
       TECH_PREVIEW_NO_UPGRADE: "true"
       TEST_CSI_DRIVER_MANIFEST: manifest-openstack-cinder.yaml
       TEST_SUITE: openshift/csi
     leases:
     - env: OPENSTACK_CLOUD
-      resource_type: openstack-vh-mecha-central-quota-slice
+      resource_type: openstack-vexxhost-quota-slice
     workflow: hypershift-openstack-aws-conformance
 - as: hypershift-e2e-openstack-aws-csi-manila
   run_if_changed: ^(Dockerfile\.openstack-manila|assets\/overlays\/openstack-manila\/.*|pkg\/driver\/openstack-manila\/.*|pkg\/openstack-manila\/.*)
@@ -351,7 +351,7 @@ tests:
       TEST_SUITE: openshift/csi
     leases:
     - env: OPENSTACK_CLOUD
-      resource_type: openstack-vh-mecha-central-quota-slice
+      resource_type: openstack-vexxhost-quota-slice
     workflow: hypershift-openstack-aws-conformance
 - always_run: false
   as: smb-operator-e2e

--- a/ci-operator/jobs/openshift/csi-operator/openshift-csi-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/csi-operator/openshift-csi-operator-main-presubmits.yaml
@@ -1655,8 +1655,8 @@ presubmits:
     context: ci/prow/e2e-openstack
     decorate: true
     labels:
-      ci-operator.openshift.io/cloud: openstack-vh-mecha-central
-      ci-operator.openshift.io/cloud-cluster-profile: openstack-vh-mecha-central
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-csi-operator-main-e2e-openstack
@@ -1737,8 +1737,8 @@ presubmits:
     context: ci/prow/e2e-openstack-cinder-csi
     decorate: true
     labels:
-      ci-operator.openshift.io/cloud: openstack-vh-mecha-central
-      ci-operator.openshift.io/cloud-cluster-profile: openstack-vh-mecha-central
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-csi-operator-main-e2e-openstack-cinder-csi

--- a/ci-operator/jobs/openshift/csi-operator/openshift-csi-operator-release-4.18-presubmits.yaml
+++ b/ci-operator/jobs/openshift/csi-operator/openshift-csi-operator-release-4.18-presubmits.yaml
@@ -1243,12 +1243,12 @@ presubmits:
     branches:
     - ^release-4\.18$
     - ^release-4\.18-
-    cluster: build08
+    cluster: build09
     context: ci/prow/e2e-openstack
     decorate: true
     labels:
-      ci-operator.openshift.io/cloud: openstack-vh-mecha-central
-      ci-operator.openshift.io/cloud-cluster-profile: openstack-vh-mecha-central
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-csi-operator-release-4.18-e2e-openstack
@@ -1325,12 +1325,12 @@ presubmits:
     branches:
     - ^release-4\.18$
     - ^release-4\.18-
-    cluster: build08
+    cluster: build09
     context: ci/prow/e2e-openstack-cinder-csi
     decorate: true
     labels:
-      ci-operator.openshift.io/cloud: openstack-vh-mecha-central
-      ci-operator.openshift.io/cloud-cluster-profile: openstack-vh-mecha-central
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-csi-operator-release-4.18-e2e-openstack-cinder-csi

--- a/ci-operator/jobs/openshift/csi-operator/openshift-csi-operator-release-4.19-presubmits.yaml
+++ b/ci-operator/jobs/openshift/csi-operator/openshift-csi-operator-release-4.19-presubmits.yaml
@@ -1243,12 +1243,12 @@ presubmits:
     branches:
     - ^release-4\.19$
     - ^release-4\.19-
-    cluster: build08
+    cluster: build09
     context: ci/prow/e2e-openstack
     decorate: true
     labels:
-      ci-operator.openshift.io/cloud: openstack-vh-mecha-central
-      ci-operator.openshift.io/cloud-cluster-profile: openstack-vh-mecha-central
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-csi-operator-release-4.19-e2e-openstack
@@ -1325,12 +1325,12 @@ presubmits:
     branches:
     - ^release-4\.19$
     - ^release-4\.19-
-    cluster: build08
+    cluster: build09
     context: ci/prow/e2e-openstack-cinder-csi
     decorate: true
     labels:
-      ci-operator.openshift.io/cloud: openstack-vh-mecha-central
-      ci-operator.openshift.io/cloud-cluster-profile: openstack-vh-mecha-central
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-csi-operator-release-4.19-e2e-openstack-cinder-csi

--- a/ci-operator/jobs/openshift/csi-operator/openshift-csi-operator-release-4.20-presubmits.yaml
+++ b/ci-operator/jobs/openshift/csi-operator/openshift-csi-operator-release-4.20-presubmits.yaml
@@ -1655,8 +1655,8 @@ presubmits:
     context: ci/prow/e2e-openstack
     decorate: true
     labels:
-      ci-operator.openshift.io/cloud: openstack-vh-mecha-central
-      ci-operator.openshift.io/cloud-cluster-profile: openstack-vh-mecha-central
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-csi-operator-release-4.20-e2e-openstack
@@ -1737,8 +1737,8 @@ presubmits:
     context: ci/prow/e2e-openstack-cinder-csi
     decorate: true
     labels:
-      ci-operator.openshift.io/cloud: openstack-vh-mecha-central
-      ci-operator.openshift.io/cloud-cluster-profile: openstack-vh-mecha-central
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-csi-operator-release-4.20-e2e-openstack-cinder-csi

--- a/ci-operator/jobs/openshift/csi-operator/openshift-csi-operator-release-4.21-presubmits.yaml
+++ b/ci-operator/jobs/openshift/csi-operator/openshift-csi-operator-release-4.21-presubmits.yaml
@@ -1651,12 +1651,12 @@ presubmits:
     branches:
     - ^release-4\.21$
     - ^release-4\.21-
-    cluster: build08
+    cluster: build09
     context: ci/prow/e2e-openstack
     decorate: true
     labels:
-      ci-operator.openshift.io/cloud: openstack-vh-mecha-central
-      ci-operator.openshift.io/cloud-cluster-profile: openstack-vh-mecha-central
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-csi-operator-release-4.21-e2e-openstack
@@ -1733,12 +1733,12 @@ presubmits:
     branches:
     - ^release-4\.21$
     - ^release-4\.21-
-    cluster: build08
+    cluster: build09
     context: ci/prow/e2e-openstack-cinder-csi
     decorate: true
     labels:
-      ci-operator.openshift.io/cloud: openstack-vh-mecha-central
-      ci-operator.openshift.io/cloud-cluster-profile: openstack-vh-mecha-central
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-csi-operator-release-4.21-e2e-openstack-cinder-csi

--- a/ci-operator/jobs/openshift/csi-operator/openshift-csi-operator-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift/csi-operator/openshift-csi-operator-release-4.22-presubmits.yaml
@@ -1651,12 +1651,12 @@ presubmits:
     branches:
     - ^release-4\.22$
     - ^release-4\.22-
-    cluster: build08
+    cluster: build09
     context: ci/prow/e2e-openstack
     decorate: true
     labels:
-      ci-operator.openshift.io/cloud: openstack-vh-mecha-central
-      ci-operator.openshift.io/cloud-cluster-profile: openstack-vh-mecha-central
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-csi-operator-release-4.22-e2e-openstack
@@ -1733,12 +1733,12 @@ presubmits:
     branches:
     - ^release-4\.22$
     - ^release-4\.22-
-    cluster: build08
+    cluster: build09
     context: ci/prow/e2e-openstack-cinder-csi
     decorate: true
     labels:
-      ci-operator.openshift.io/cloud: openstack-vh-mecha-central
-      ci-operator.openshift.io/cloud-cluster-profile: openstack-vh-mecha-central
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-csi-operator-release-4.22-e2e-openstack-cinder-csi


### PR DESCRIPTION
This is effectively a revert of #58548. ~The managed Vexxhost cloud now has Manila support, so we can move both the Manila and Cinder jobs to this cloud.~ This should improve reliability since we have someone managing this for us.

**EDIT:** We are only moving the Cinder jobs for now since the Manila jobs need a tweak to ensure we configure a share network ID (DHSS is `true` on the managed cloud).