### PR TITLE
Limit e2e suite parallel runs to 1 given environment constraints.

### DIFF
--- a/core-services/prow/02_config/_boskos.yaml
+++ b/core-services/prow/02_config/_boskos.yaml
@@ -42,6 +42,10 @@ resources:
 - max-count: 1
   min-count: 1
   state: free
+  type: aro-hcp-int-e2e-quota-slice
+- max-count: 1
+  min-count: 1
+  state: free
   type: aro-redhat-tenant-quota-slice
 - names:
   - us-east-1--aws-1-qe-quota-slice-0

--- a/core-services/prow/02_config/generate-boskos.py
+++ b/core-services/prow/02_config/generate-boskos.py
@@ -243,6 +243,9 @@ CONFIG = {
     'azure-confidential-qe-quota-slice': {
         'eastus': 6,
     },
+    'aro-hcp-int-e2e-quota-slice': {
+        'default': 1,
+    },
     'equinix-ocp-metal-quota-slice': {
         'default': 140,
     },


### PR DESCRIPTION
The ARO-HCP integration environment is limited to 20 HCP clusters; in practice, this means only one e2e suite can run simultaneously.