### PR TITLE
aro-hcp: fix missing 'release' field in jobs

### DIFF
--- a/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__image-updater.yaml
+++ b/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__image-updater.yaml
@@ -24,6 +24,11 @@ images:
       - destination_dir: .
         source_path: /usr/bin/prcreator
   to: image-updater-base
+releases:
+  latest:
+    release:
+      channel: stable
+      version: "4.20"
 resources:
   '*':
     requests:

--- a/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__periodic.yaml
+++ b/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__periodic.yaml
@@ -33,6 +33,11 @@ images:
       - destination_dir: src
         source_path: /go/src/github.com/Azure/ARO-HCP
   to: aro-hcp-e2e-tools
+releases:
+  latest:
+    release:
+      channel: stable
+      version: "4.20"
 resources:
   '*':
     requests:

--- a/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__periodic.yaml
+++ b/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__periodic.yaml
@@ -51,19 +51,16 @@ tests:
 - as: delete-expired-integration-resource-groups
   cron: 7,37 * * * *
   steps:
-    cluster_profile: aro-hcp-int
     test:
     - ref: aro-hcp-deprovision-expired-resource-groups
 - as: delete-expired-stage-resource-groups
   cron: 7,37 * * * *
   steps:
-    cluster_profile: aro-hcp-stg
     test:
     - ref: aro-hcp-deprovision-expired-resource-groups
 - as: delete-expired-prod-resource-groups
   cron: 7,37 * * * *
   steps:
-    cluster_profile: aro-hcp-prod
     test:
     - ref: aro-hcp-deprovision-expired-resource-groups
 zz_generated_metadata:

--- a/ci-operator/jobs/Azure/ARO-HCP/Azure-ARO-HCP-main-periodics.yaml
+++ b/ci-operator/jobs/Azure/ARO-HCP/Azure-ARO-HCP-main-periodics.yaml
@@ -72,8 +72,6 @@ periodics:
     org: Azure
     repo: ARO-HCP
   labels:
-    ci-operator.openshift.io/cloud: aro-hcp-int
-    ci-operator.openshift.io/cloud-cluster-profile: aro-hcp-int
     ci-operator.openshift.io/variant: periodic
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -83,7 +81,6 @@ periodics:
     - args:
       - --gcs-upload-secret=/secrets/gcs/service-account.json
       - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-      - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
       - --target=delete-expired-integration-resource-groups
@@ -97,9 +94,6 @@ periodics:
         requests:
           cpu: 10m
       volumeMounts:
-      - mountPath: /etc/boskos
-        name: boskos
-        readOnly: true
       - mountPath: /secrets/ci-pull-credentials
         name: ci-pull-credentials
         readOnly: true
@@ -117,12 +111,6 @@ periodics:
         readOnly: true
     serviceAccountName: ci-operator
     volumes:
-    - name: boskos
-      secret:
-        items:
-        - key: credentials
-          path: credentials
-        secretName: boskos-credentials
     - name: ci-pull-credentials
       secret:
         secretName: ci-pull-credentials
@@ -146,8 +134,6 @@ periodics:
     org: Azure
     repo: ARO-HCP
   labels:
-    ci-operator.openshift.io/cloud: aro-hcp-prod
-    ci-operator.openshift.io/cloud-cluster-profile: aro-hcp-prod
     ci-operator.openshift.io/variant: periodic
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -157,7 +143,6 @@ periodics:
     - args:
       - --gcs-upload-secret=/secrets/gcs/service-account.json
       - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-      - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
       - --target=delete-expired-prod-resource-groups
@@ -171,9 +156,6 @@ periodics:
         requests:
           cpu: 10m
       volumeMounts:
-      - mountPath: /etc/boskos
-        name: boskos
-        readOnly: true
       - mountPath: /secrets/ci-pull-credentials
         name: ci-pull-credentials
         readOnly: true
@@ -191,12 +173,6 @@ periodics:
         readOnly: true
     serviceAccountName: ci-operator
     volumes:
-    - name: boskos
-      secret:
-        items:
-        - key: credentials
-          path: credentials
-        secretName: boskos-credentials
     - name: ci-pull-credentials
       secret:
         secretName: ci-pull-credentials
@@ -220,8 +196,6 @@ periodics:
     org: Azure
     repo: ARO-HCP
   labels:
-    ci-operator.openshift.io/cloud: aro-hcp-stg
-    ci-operator.openshift.io/cloud-cluster-profile: aro-hcp-stg
     ci-operator.openshift.io/variant: periodic
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -231,7 +205,6 @@ periodics:
     - args:
       - --gcs-upload-secret=/secrets/gcs/service-account.json
       - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-      - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
       - --target=delete-expired-stage-resource-groups
@@ -245,9 +218,6 @@ periodics:
         requests:
           cpu: 10m
       volumeMounts:
-      - mountPath: /etc/boskos
-        name: boskos
-        readOnly: true
       - mountPath: /secrets/ci-pull-credentials
         name: ci-pull-credentials
         readOnly: true
@@ -265,12 +235,6 @@ periodics:
         readOnly: true
     serviceAccountName: ci-operator
     volumes:
-    - name: boskos
-      secret:
-        items:
-        - key: credentials
-          path: credentials
-        secretName: boskos-credentials
     - name: ci-pull-credentials
       secret:
         secretName: ci-pull-credentials

--- a/ci-operator/jobs/Azure/ARO-HCP/Azure-ARO-HCP-main-periodics.yaml
+++ b/ci-operator/jobs/Azure/ARO-HCP/Azure-ARO-HCP-main-periodics.yaml
@@ -20,6 +20,7 @@ periodics:
       - --gcs-upload-secret=/secrets/gcs/service-account.json
       - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
       - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
       - --target=image-updater-tooling
       - --variant=image-updater
       command:
@@ -31,6 +32,9 @@ periodics:
         requests:
           cpu: 10m
       volumeMounts:
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
       - mountPath: /secrets/gcs
         name: gcs-credentials
         readOnly: true
@@ -45,6 +49,9 @@ periodics:
         readOnly: true
     serviceAccountName: ci-operator
     volumes:
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
     - name: manifest-tool-local-pusher
       secret:
         secretName: manifest-tool-local-pusher
@@ -78,6 +85,7 @@ periodics:
       - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
       - --target=delete-expired-integration-resource-groups
       - --variant=periodic
       command:
@@ -91,6 +99,9 @@ periodics:
       volumeMounts:
       - mountPath: /etc/boskos
         name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
         readOnly: true
       - mountPath: /secrets/gcs
         name: gcs-credentials
@@ -112,6 +123,9 @@ periodics:
         - key: credentials
           path: credentials
         secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
     - name: manifest-tool-local-pusher
       secret:
         secretName: manifest-tool-local-pusher
@@ -145,6 +159,7 @@ periodics:
       - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
       - --target=delete-expired-prod-resource-groups
       - --variant=periodic
       command:
@@ -158,6 +173,9 @@ periodics:
       volumeMounts:
       - mountPath: /etc/boskos
         name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
         readOnly: true
       - mountPath: /secrets/gcs
         name: gcs-credentials
@@ -179,6 +197,9 @@ periodics:
         - key: credentials
           path: credentials
         secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
     - name: manifest-tool-local-pusher
       secret:
         secretName: manifest-tool-local-pusher
@@ -212,6 +233,7 @@ periodics:
       - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
       - --target=delete-expired-stage-resource-groups
       - --variant=periodic
       command:
@@ -225,6 +247,9 @@ periodics:
       volumeMounts:
       - mountPath: /etc/boskos
         name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
         readOnly: true
       - mountPath: /secrets/gcs
         name: gcs-credentials
@@ -246,6 +271,9 @@ periodics:
         - key: credentials
           path: credentials
         secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
     - name: manifest-tool-local-pusher
       secret:
         secretName: manifest-tool-local-pusher

--- a/ci-operator/step-registry/aro-hcp/deprovision/expired-resource-groups/aro-hcp-deprovision-expired-resource-groups-commands.sh
+++ b/ci-operator/step-registry/aro-hcp/deprovision/expired-resource-groups/aro-hcp-deprovision-expired-resource-groups-commands.sh
@@ -12,4 +12,4 @@ export SUBSCRIPTION_ID; SUBSCRIPTION_ID=$(cat "${CLUSTER_PROFILE_DIR}/subscripti
 az login --service-principal -u "${AZURE_CLIENT_ID}" -p "${AZURE_CLIENT_SECRET}" --tenant "${AZURE_TENANT_ID}"
 az account set --subscription "${SUBSCRIPTION_ID}"
 
-./test/aro-hcp-tests cleanup resource-groups --delete-expired
+./test/aro-hcp-tests cleanup resource-groups --expired


### PR DESCRIPTION
Jobs fail without this.

```
[36mINFO[0m[2025-11-21T11:07:56Z] ci-operator version v20251120-9c2192371      
[36mINFO[0m[2025-11-21T11:07:56Z] Loading configuration from https://config.ci.openshift.org for Azure/ARO-HCP@main [periodic] 
[36mINFO[0m[2025-11-21T11:07:56Z] Resolved SHA missing for main in https://github.com/Azure/ARO-HCP (will prevent caching) 
[36mINFO[0m[2025-11-21T11:07:56Z] Using namespace https://console.build02.ci.openshift.org/k8s/cluster/projects/ci-op-533wwc2q 
[36mINFO[0m[2025-11-21T11:07:56Z] Setting arch for src                          [36march[0m=amd64 [36mreasons[0m=aro-hcp-e2e-tools
[36mINFO[0m[2025-11-21T11:07:56Z] Ran for 0s                                   
[31mERRO[0m[2025-11-21T11:07:56Z] Some steps failed:                           
[31mERRO[0m[2025-11-21T11:07:56Z] 
  * could not sort nodes
  * steps are missing dependencies
  * step delete-expired-integration-resource-groups is missing dependencies: <&api.internalImageStreamTagLink{name:"release", tag:"latest", unsatisfiableError:""}> 
[36mINFO[0m[2025-11-21T11:07:56Z] Reporting job state 'failed' with reason 'building_graph' 
[36mINFO[0m[2025-11-21T11:07:56Z] Reporting job state 'failed' with reason 'unknown' 
[36mINFO[0m[2025-11-21T11:07:56Z] Reporting job state 'failed' with reason 'unknown' 
```