### PR TITLE
ARO-HCP: e2e identity reuse

### DIFF
--- a/ci-operator/step-registry/aro-hcp/local-e2e/aro-hcp-local-e2e-workflow.yaml
+++ b/ci-operator/step-registry/aro-hcp/local-e2e/aro-hcp-local-e2e-workflow.yaml
@@ -2,6 +2,10 @@ workflow:
   as: aro-hcp-local-e2e
   steps:
     allow_best_effort_post_steps: true
+    leases:
+    - resource_type: aro-hcp-test-msi-containers-dev
+      env: LEASED_MSI_CONTAINERS
+      count: 20
     pre:
       - ref: aro-hcp-provision-environment
     test:

--- a/ci-operator/step-registry/aro-hcp/test/local/aro-hcp-test-local-ref.yaml
+++ b/ci-operator/step-registry/aro-hcp/test/local/aro-hcp-test-local-ref.yaml
@@ -17,5 +17,8 @@ ref:
     - name: LOCATION
       default: "westus3"
       documentation: Azure region to create resources in.  For example, "uksouth"
+    - name: POOLED_IDENTITIES
+      default: "true"
+      documentation: Whether to use pooled identities for the test.
   documentation: |-
     Run ARO HCP local e2e suite on Prow environment


### PR DESCRIPTION
Enable use of pooled identities for `pull-ci-Azure-ARO-HCP-main-e2e-parallel`.