### PR TITLE
registry-access/osd-images: remove OWNERS file

### DIFF
--- a/clusters/app.ci/registry-access/osd-images/OWNERS
+++ b/clusters/app.ci/registry-access/osd-images/OWNERS
@@ -1,2 +1,0 @@
-approvers:
-- dsimansk


### PR DESCRIPTION
Solves: [DPTP-4625](https://issues.redhat.com/browse/DPTP-4625)
Follow up of: https://github.com/openshift/release/pull/60887/changes

/cc dsimansk

[DPTP-4625]: https://redhat.atlassian.net/browse/DPTP-4625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ