### PR TITLE
Remove UUID variable references from orion steps

### DIFF
--- a/ci-operator/step-registry/openshift-qe/orion/cluster-density/openshift-qe-orion-cluster-density-ref.yaml
+++ b/ci-operator/step-registry/openshift-qe/orion/cluster-density/openshift-qe-orion-cluster-density-ref.yaml
@@ -42,6 +42,10 @@ ref:
     default: "false"
     documentation:
       Set orion's --node-count argument
+  - name: ORION_EXTRA_FLAGS
+    default: ""
+    documentation:
+      Flags to append to the orion command
   - name: OUTPUT_FORMAT
     default: "TEXT"
     documentation:

--- a/ci-operator/step-registry/openshift-qe/orion/cluster-density/openshift-qe-orion-cluster-density-ref.yaml
+++ b/ci-operator/step-registry/openshift-qe/orion/cluster-density/openshift-qe-orion-cluster-density-ref.yaml
@@ -30,10 +30,10 @@ ref:
     default: "qe"
     documentation: |-
       Set es type to internal or qe for getting data
-  - name: UUID
-    default: ""
+  - name: CONFIG
+    default: "examples/payload-scale-415.yaml"
     documentation: |-
-      Default is blank, which means the uuid will not be applied to the command line args
+      Configuration file to run orion on
   - name: VERSION
     default: ""
     documentation:

--- a/ci-operator/step-registry/openshift-qe/orion/cluster-density/openshift-qe-orion-cluster-density-ref.yaml
+++ b/ci-operator/step-registry/openshift-qe/orion/cluster-density/openshift-qe-orion-cluster-density-ref.yaml
@@ -30,10 +30,6 @@ ref:
     default: "qe"
     documentation: |-
       Set es type to internal or qe for getting data
-  - name: CONFIG
-    default: "examples/payload-scale-415.yaml"
-    documentation: |-
-      Configuration file to run orion on
   - name: VERSION
     default: ""
     documentation:

--- a/ci-operator/step-registry/openshift-qe/orion/crd-scale/openshift-qe-orion-crd-scale-ref.yaml
+++ b/ci-operator/step-registry/openshift-qe/orion/crd-scale/openshift-qe-orion-crd-scale-ref.yaml
@@ -42,6 +42,10 @@ ref:
     default: "false"
     documentation:
       Set orion's --node-count argument
+  - name: ORION_EXTRA_FLAGS
+    default: ""
+    documentation:
+      Flags to append to the orion command
   - name: OUTPUT_FORMAT
     default: "TEXT"
     documentation:

--- a/ci-operator/step-registry/openshift-qe/orion/crd-scale/openshift-qe-orion-crd-scale-ref.yaml
+++ b/ci-operator/step-registry/openshift-qe/orion/crd-scale/openshift-qe-orion-crd-scale-ref.yaml
@@ -30,10 +30,10 @@ ref:
     default: "qe"
     documentation: |-
       Set es type to internal or qe for getting data
-  - name: UUID
-    default: ""
+  - name: CONFIG
+    default: "examples/payload-scale-415.yaml"
     documentation: |-
-      Default is blank, which means the uuid will not be applied to the command line args
+      Configuration file to run orion on
   - name: VERSION
     default: ""
     documentation:

--- a/ci-operator/step-registry/openshift-qe/orion/crd-scale/openshift-qe-orion-crd-scale-ref.yaml
+++ b/ci-operator/step-registry/openshift-qe/orion/crd-scale/openshift-qe-orion-crd-scale-ref.yaml
@@ -30,10 +30,6 @@ ref:
     default: "qe"
     documentation: |-
       Set es type to internal or qe for getting data
-  - name: CONFIG
-    default: "examples/payload-scale-415.yaml"
-    documentation: |-
-      Configuration file to run orion on
   - name: VERSION
     default: ""
     documentation:

--- a/ci-operator/step-registry/openshift-qe/orion/data-path/openshift-qe-orion-data-path-ref.yaml
+++ b/ci-operator/step-registry/openshift-qe/orion/data-path/openshift-qe-orion-data-path-ref.yaml
@@ -42,6 +42,10 @@ ref:
     default: "false"
     documentation:
       Set orion's --node-count argument
+  - name: ORION_EXTRA_FLAGS
+    default: ""
+    documentation:
+      Flags to append to the orion command
   - name: OUTPUT_FORMAT
     default: "TEXT"
     documentation:

--- a/ci-operator/step-registry/openshift-qe/orion/data-path/openshift-qe-orion-data-path-ref.yaml
+++ b/ci-operator/step-registry/openshift-qe/orion/data-path/openshift-qe-orion-data-path-ref.yaml
@@ -30,10 +30,6 @@ ref:
     default: "qe"
     documentation: |-
       Set es type to internal or qe for getting data
-  - name: CONFIG
-    default: "examples/metal-perfscale-cpt-data-path.yaml"
-    documentation: |-
-      Configuration file to run orion on
   - name: VERSION
     default: ""
     documentation:

--- a/ci-operator/step-registry/openshift-qe/orion/data-path/openshift-qe-orion-data-path-ref.yaml
+++ b/ci-operator/step-registry/openshift-qe/orion/data-path/openshift-qe-orion-data-path-ref.yaml
@@ -30,10 +30,10 @@ ref:
     default: "qe"
     documentation: |-
       Set es type to internal or qe for getting data
-  - name: UUID
-    default: ""
+  - name: CONFIG
+    default: "examples/metal-perfscale-cpt-data-path.yaml"
     documentation: |-
-      Default is blank, which means the uuid will not be applied to the command line args
+      Configuration file to run orion on
   - name: VERSION
     default: ""
     documentation:

--- a/ci-operator/step-registry/openshift-qe/orion/udn-l3/openshift-qe-orion-udn-l3-ref.yaml
+++ b/ci-operator/step-registry/openshift-qe/orion/udn-l3/openshift-qe-orion-udn-l3-ref.yaml
@@ -30,10 +30,10 @@ ref:
     default: "qe"
     documentation: |-
       Set es type to internal or qe for getting data
-  - name: UUID
-    default: ""
+  - name: CONFIG
+    default: "examples/small-scale-udn-l3.yaml"
     documentation: |-
-      Default is blank, which means the uuid will not be applied to the command line args
+      Configuration file to run orion on
   - name: VERSION
     default: ""
     documentation:

--- a/ci-operator/step-registry/openshift-qe/orion/udn-l3/openshift-qe-orion-udn-l3-ref.yaml
+++ b/ci-operator/step-registry/openshift-qe/orion/udn-l3/openshift-qe-orion-udn-l3-ref.yaml
@@ -42,6 +42,10 @@ ref:
     default: "false"
     documentation:
       Set orion's --node-count argument
+  - name: ORION_EXTRA_FLAGS
+    default: ""
+    documentation:
+      Flags to append to the orion command
   - name: OUTPUT_FORMAT
     default: "TEXT"
     documentation:

--- a/ci-operator/step-registry/openshift-qe/orion/udn-l3/openshift-qe-orion-udn-l3-ref.yaml
+++ b/ci-operator/step-registry/openshift-qe/orion/udn-l3/openshift-qe-orion-udn-l3-ref.yaml
@@ -30,10 +30,6 @@ ref:
     default: "qe"
     documentation: |-
       Set es type to internal or qe for getting data
-  - name: CONFIG
-    default: "examples/small-scale-udn-l3.yaml"
-    documentation: |-
-      Configuration file to run orion on
   - name: VERSION
     default: ""
     documentation:

--- a/ci-operator/step-registry/openshift-qe/orion/virt-density/openshift-qe-orion-virt-density-ref.yaml
+++ b/ci-operator/step-registry/openshift-qe/orion/virt-density/openshift-qe-orion-virt-density-ref.yaml
@@ -30,10 +30,6 @@ ref:
     default: "qe"
     documentation: |-
       Set es type to internal or qe for getting data
-  - name: CONFIG
-    default: "examples/metal-perfscale-cpt-virt-density.yaml"
-    documentation: |-
-      Configuration file to run orion on
   - name: VERSION
     default: ""
     documentation:

--- a/ci-operator/step-registry/openshift-qe/orion/virt-density/openshift-qe-orion-virt-density-ref.yaml
+++ b/ci-operator/step-registry/openshift-qe/orion/virt-density/openshift-qe-orion-virt-density-ref.yaml
@@ -42,6 +42,10 @@ ref:
     default: "false"
     documentation:
       Set orion's --node-count argument
+  - name: ORION_EXTRA_FLAGS
+    default: ""
+    documentation:
+      Flags to append to the orion command
   - name: OUTPUT_FORMAT
     default: "TEXT"
     documentation:

--- a/ci-operator/step-registry/openshift-qe/orion/virt-density/openshift-qe-orion-virt-density-ref.yaml
+++ b/ci-operator/step-registry/openshift-qe/orion/virt-density/openshift-qe-orion-virt-density-ref.yaml
@@ -30,10 +30,10 @@ ref:
     default: "qe"
     documentation: |-
       Set es type to internal or qe for getting data
-  - name: UUID
-    default: ""
+  - name: CONFIG
+    default: "examples/metal-perfscale-cpt-virt-density.yaml"
     documentation: |-
-      Default is blank, which means the uuid will not be applied to the command line args
+      Configuration file to run orion on
   - name: VERSION
     default: ""
     documentation:

--- a/ci-operator/step-registry/openshift-qe/orion/virt-udn-density/openshift-qe-orion-virt-udn-density-ref.yaml
+++ b/ci-operator/step-registry/openshift-qe/orion/virt-udn-density/openshift-qe-orion-virt-udn-density-ref.yaml
@@ -42,6 +42,10 @@ ref:
     default: "false"
     documentation:
       Set orion's --node-count argument
+  - name: ORION_EXTRA_FLAGS
+    default: ""
+    documentation:
+      Flags to append to the orion command
   - name: OUTPUT_FORMAT
     default: "TEXT"
     documentation:

--- a/ci-operator/step-registry/openshift-qe/orion/virt-udn-density/openshift-qe-orion-virt-udn-density-ref.yaml
+++ b/ci-operator/step-registry/openshift-qe/orion/virt-udn-density/openshift-qe-orion-virt-udn-density-ref.yaml
@@ -30,10 +30,10 @@ ref:
     default: "qe"
     documentation: |-
       Set es type to internal or qe for getting data
-  - name: UUID
-    default: ""
+  - name: CONFIG
+    default: "examples/metal-perfscale-cpt-virt-udn-density.yaml"
     documentation: |-
-      Default is blank, which means the uuid will not be applied to the command line args
+      Configuration file to run orion on
   - name: VERSION
     default: ""
     documentation:

--- a/ci-operator/step-registry/openshift-qe/orion/virt-udn-density/openshift-qe-orion-virt-udn-density-ref.yaml
+++ b/ci-operator/step-registry/openshift-qe/orion/virt-udn-density/openshift-qe-orion-virt-udn-density-ref.yaml
@@ -30,10 +30,6 @@ ref:
     default: "qe"
     documentation: |-
       Set es type to internal or qe for getting data
-  - name: CONFIG
-    default: "examples/metal-perfscale-cpt-virt-udn-density.yaml"
-    documentation: |-
-      Configuration file to run orion on
   - name: VERSION
     default: ""
     documentation:


### PR DESCRIPTION
The uuid variable is not necessary anymore as it can be specified via ORION_EXTRA_FLAGS