### PR TITLE
Azure: subnets test coverage

### DIFF
--- a/ci-operator/config/openshift/verification-tests/openshift-verification-tests-main__installation-nightly-4.17.yaml
+++ b/ci-operator/config/openshift/verification-tests/openshift-verification-tests-main__installation-nightly-4.17.yaml
@@ -358,6 +358,9 @@ tests:
     allow_skip_on_success: true
     cluster_profile: azure-qe
     env:
+      AZURE_COMPUTE_SUBNET_PREFIX: 172.16.0.0/27
+      AZURE_CONTROL_PLANE_SUBNET_PREFIX: 172.16.0.48/28
+      AZURE_VNET_ADDRESS_PREFIXES: 172.16.0.0/26
       BASE_DOMAIN: qe.azure.devcluster.openshift.com
     test:
     - chain: cucushift-installer-check-cluster-health

--- a/ci-operator/config/openshift/verification-tests/openshift-verification-tests-main__installation-nightly-4.18.yaml
+++ b/ci-operator/config/openshift/verification-tests/openshift-verification-tests-main__installation-nightly-4.18.yaml
@@ -404,6 +404,9 @@ tests:
     allow_skip_on_success: true
     cluster_profile: azure-qe
     env:
+      AZURE_COMPUTE_SUBNET_PREFIX: 172.16.0.0/27
+      AZURE_CONTROL_PLANE_SUBNET_PREFIX: 172.16.0.48/28
+      AZURE_VNET_ADDRESS_PREFIXES: 172.16.0.0/26
       BASE_DOMAIN: qe.azure.devcluster.openshift.com
     test:
     - chain: cucushift-installer-check-cluster-health

--- a/ci-operator/config/openshift/verification-tests/openshift-verification-tests-main__installation-nightly-4.19.yaml
+++ b/ci-operator/config/openshift/verification-tests/openshift-verification-tests-main__installation-nightly-4.19.yaml
@@ -515,7 +515,10 @@ tests:
     allow_skip_on_success: true
     cluster_profile: azure-qe
     env:
+      AZURE_COMPUTE_SUBNET_PREFIX: 172.16.0.0/27
+      AZURE_CONTROL_PLANE_SUBNET_PREFIX: 172.16.0.48/28
       AZURE_INSTALL_USE_MINIMAL_PERMISSIONS: "yes"
+      AZURE_VNET_ADDRESS_PREFIXES: 172.16.0.0/26
       BASE_DOMAIN: qe.azure.devcluster.openshift.com
     test:
     - chain: cucushift-installer-check-cluster-health

--- a/ci-operator/config/openshift/verification-tests/openshift-verification-tests-main__installation-nightly-4.20.yaml
+++ b/ci-operator/config/openshift/verification-tests/openshift-verification-tests-main__installation-nightly-4.20.yaml
@@ -566,7 +566,10 @@ tests:
     allow_skip_on_success: true
     cluster_profile: azure-qe
     env:
+      AZURE_COMPUTE_SUBNET_PREFIX: 172.16.0.0/27
+      AZURE_CONTROL_PLANE_SUBNET_PREFIX: 172.16.0.48/28
       AZURE_INSTALL_USE_MINIMAL_PERMISSIONS: "yes"
+      AZURE_VNET_ADDRESS_PREFIXES: 172.16.0.0/26
       BASE_DOMAIN: qe.azure.devcluster.openshift.com
     test:
     - chain: cucushift-installer-check-cluster-health

--- a/ci-operator/config/openshift/verification-tests/openshift-verification-tests-main__installation-nightly-4.21.yaml
+++ b/ci-operator/config/openshift/verification-tests/openshift-verification-tests-main__installation-nightly-4.21.yaml
@@ -653,7 +653,10 @@ tests:
     allow_skip_on_success: true
     cluster_profile: azure-qe
     env:
+      AZURE_COMPUTE_SUBNET_PREFIX: 172.16.0.0/27
+      AZURE_CONTROL_PLANE_SUBNET_PREFIX: 172.16.0.48/28
       AZURE_INSTALL_USE_MINIMAL_PERMISSIONS: "yes"
+      AZURE_VNET_ADDRESS_PREFIXES: 172.16.0.0/26
       BASE_DOMAIN: qe.azure.devcluster.openshift.com
     test:
     - chain: cucushift-installer-check-cluster-health

--- a/ci-operator/config/openshift/verification-tests/openshift-verification-tests-main__installation-nightly-4.22.yaml
+++ b/ci-operator/config/openshift/verification-tests/openshift-verification-tests-main__installation-nightly-4.22.yaml
@@ -653,7 +653,10 @@ tests:
     allow_skip_on_success: true
     cluster_profile: azure-qe
     env:
+      AZURE_COMPUTE_SUBNET_PREFIX: 172.16.0.0/27
+      AZURE_CONTROL_PLANE_SUBNET_PREFIX: 172.16.0.48/28
       AZURE_INSTALL_USE_MINIMAL_PERMISSIONS: "yes"
+      AZURE_VNET_ADDRESS_PREFIXES: 172.16.0.0/26
       BASE_DOMAIN: qe.azure.devcluster.openshift.com
     test:
     - chain: cucushift-installer-check-cluster-health


### PR DESCRIPTION
1. To cover the test coverage for bug https://issues.redhat.com/browse/OCPBUGS-59105
2. Update step `azure-provision-bastionhost`, bastion subnet cidr is calculated from existing vnet and subnets instead of hardcoding to xx.xx.99.0/24, and range is /29