### PR TITLE
Implement an openshift-pqc-compliance workflow for testing

### DIFF
--- a/ci-operator/step-registry/pqc/OWNERS
+++ b/ci-operator/step-registry/pqc/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+  - richardsonnick
+  - rhmdnd
+  - smith-xyz
+reviewers:
+  - richardsonnick
+  - rhmdnd
+  - smith-xyz

--- a/ci-operator/step-registry/pqc/compliance/OWNERS
+++ b/ci-operator/step-registry/pqc/compliance/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+  - richardsonnick
+  - rhmdnd
+  - smith-xyz
+reviewers:
+  - richardsonnick
+  - rhmdnd
+  - smith-xyz

--- a/ci-operator/step-registry/pqc/compliance/pqc-compliance-workflow.metadata.json
+++ b/ci-operator/step-registry/pqc/compliance/pqc-compliance-workflow.metadata.json
@@ -1,0 +1,15 @@
+{
+	"path": "pqc/compliance/pqc-compliance-workflow.yaml",
+	"owners": {
+		"approvers": [
+			"richardsonnick",
+			"rhmdnd",
+			"smith-xyz"
+		],
+		"reviewers": [
+			"richardsonnick",
+			"rhmdnd",
+			"smith-xyz"
+		]
+	}
+}

--- a/ci-operator/step-registry/pqc/compliance/pqc-compliance-workflow.yaml
+++ b/ci-operator/step-registry/pqc/compliance/pqc-compliance-workflow.yaml
@@ -1,0 +1,33 @@
+workflow:
+  as: pqc-compliance
+  steps:
+    allow_best_effort_post_steps: true
+    env:
+      PQC_CIPHER: "X25519MLKEM768"
+      PQC_MIN_TLS_VERSION: "VersionTLS13"
+    pre:
+      - chain: ipi-conf-aws
+      - chain: ipi-install
+      - chain: pqc-conf
+    test:
+      - ref: tls-scanner-run
+    post:
+      - chain: gather-core-dump
+      - chain: ipi-deprovision
+  documentation: |-
+    The OpenShift PQC Compliance workflow provisions an AWS cluster, configures it with
+    post-quantum cryptography (PQC) cipher suites across all major TLS endpoints (API
+    Server, Ingress Controller, and Kubelet), and validates compliance using the tls-scanner
+    tool.
+
+    The workflow performs the following steps:
+    1. Provision an AWS cluster using standard IPI
+    2. Configure API Server with X25519MLKEM768 cipher suite
+    3. Configure Ingress Controller with X25519MLKEM768 cipher suite
+    4. Configure Kubelet with X25519MLKEM768 cipher suite (targets worker MCP)
+    5. Run tls-scanner to validate all open ports use PQC-compliant ciphers
+    6. Gather diagnostics and deprovision cluster
+
+    The workflow fails if tls-scanner detects any non-PQC-compliant ports, providing
+    visibility into which OpenShift components are not yet compliant with post-quantum
+    cryptography requirements.

--- a/ci-operator/step-registry/pqc/conf/OWNERS
+++ b/ci-operator/step-registry/pqc/conf/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+  - richardsonnick
+  - rhmdnd
+  - smith-xyz
+reviewers:
+  - richardsonnick
+  - rhmdnd
+  - smith-xyz

--- a/ci-operator/step-registry/pqc/conf/apiserver/OWNERS
+++ b/ci-operator/step-registry/pqc/conf/apiserver/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+  - richardsonnick
+  - rhmdnd
+  - smith-xyz
+reviewers:
+  - richardsonnick
+  - rhmdnd
+  - smith-xyz

--- a/ci-operator/step-registry/pqc/conf/apiserver/pqc-conf-apiserver-commands.sh
+++ b/ci-operator/step-registry/pqc/conf/apiserver/pqc-conf-apiserver-commands.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -euo pipefail
+
+export KUBECONFIG="${SHARED_DIR}/kubeconfig"
+
+# Set proxy if configured
+if test -s "${SHARED_DIR}/proxy-conf.sh"; then
+    echo "[INFO] Setting proxy configuration"
+    source "${SHARED_DIR}/proxy-conf.sh"
+fi
+
+# Build TLS security profile configuration
+tls_config=$(jq -nc \
+  --arg cipher "${PQC_CIPHER}" \
+  --arg minVersion "${PQC_MIN_TLS_VERSION}" \
+  '{
+    "type": "Custom",
+    "custom": {
+      "ciphers": [$cipher],
+      "minTLSVersion": $minVersion
+    }
+  }')
+
+echo "[INFO] Configuring API server with PQC TLS profile:"
+echo "${tls_config}" | jq .
+
+# Apply the configuration
+echo "[INFO] Patching apiserver/cluster..."
+oc patch apiserver/cluster --type=merge -p "{\"spec\": {\"tlsSecurityProfile\": ${tls_config}}}"
+
+# Wait for cluster to stabilize
+echo "[INFO] Waiting for cluster to stabilize (minimum 1 minute, timeout 15 minutes)..."
+oc adm wait-for-stable-cluster --minimum-stable-period=1m --timeout=15m
+
+# Verify configuration was applied correctly
+echo "[INFO] Verifying configuration..."
+current_config=$(oc get apiserver/cluster -o json | jq -cS '.spec.tlsSecurityProfile')
+desired_config=$(echo "${tls_config}" | jq -cS '.')
+
+if [[ "${current_config}" != "${desired_config}" ]]; then
+    echo "[ERROR] API server tlsSecurityProfile does not match desired configuration"
+    echo "---- Desired:"
+    echo "${desired_config}" | jq .
+    echo "---- Current:"
+    echo "${current_config}" | jq .
+    exit 1
+fi
+
+echo "[INFO] API server successfully configured with PQC cipher: ${PQC_CIPHER}"
+
+# Save cipher configuration for reference by other steps
+echo "${PQC_CIPHER}" > "${SHARED_DIR}/pqc-cipher.txt"
+echo "[INFO] Saved cipher configuration to ${SHARED_DIR}/pqc-cipher.txt"

--- a/ci-operator/step-registry/pqc/conf/apiserver/pqc-conf-apiserver-ref.metadata.json
+++ b/ci-operator/step-registry/pqc/conf/apiserver/pqc-conf-apiserver-ref.metadata.json
@@ -1,0 +1,15 @@
+{
+	"path": "pqc/conf/apiserver/pqc-conf-apiserver-ref.yaml",
+	"owners": {
+		"approvers": [
+			"richardsonnick",
+			"rhmdnd",
+			"smith-xyz"
+		],
+		"reviewers": [
+			"richardsonnick",
+			"rhmdnd",
+			"smith-xyz"
+		]
+	}
+}

--- a/ci-operator/step-registry/pqc/conf/apiserver/pqc-conf-apiserver-ref.yaml
+++ b/ci-operator/step-registry/pqc/conf/apiserver/pqc-conf-apiserver-ref.yaml
@@ -1,0 +1,26 @@
+ref:
+  as: pqc-conf-apiserver
+  from_image:
+    namespace: ocp
+    name: cli-jq
+    tag: latest
+  commands: pqc-conf-apiserver-commands.sh
+  resources:
+    requests:
+      cpu: 10m
+      memory: 100Mi
+  env:
+    - name: PQC_CIPHER
+      default: "X25519MLKEM768"
+      documentation: |-
+        Post-quantum cryptography cipher suite to configure for the API server.
+    - name: PQC_MIN_TLS_VERSION
+      default: "VersionTLS13"
+      documentation: |-
+        Minimum TLS version to configure for the API server.
+  documentation: |-
+    Configures the cluster's API server with a Custom TLS Security Profile using
+    post-quantum cryptography (PQC) cipher suites. This step patches the API server
+    configuration to use the specified PQC cipher (default: X25519MLKEM768) with
+    TLS 1.3, then waits for cluster stabilization and validates the configuration
+    was applied correctly.

--- a/ci-operator/step-registry/pqc/conf/ingress/OWNERS
+++ b/ci-operator/step-registry/pqc/conf/ingress/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+  - richardsonnick
+  - rhmdnd
+  - smith-xyz
+reviewers:
+  - richardsonnick
+  - rhmdnd
+  - smith-xyz

--- a/ci-operator/step-registry/pqc/conf/ingress/pqc-conf-ingress-commands.sh
+++ b/ci-operator/step-registry/pqc/conf/ingress/pqc-conf-ingress-commands.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+set -euo pipefail
+
+export KUBECONFIG="${SHARED_DIR}/kubeconfig"
+
+# Set proxy if configured
+if test -s "${SHARED_DIR}/proxy-conf.sh"; then
+    echo "[INFO] Setting proxy configuration"
+    source "${SHARED_DIR}/proxy-conf.sh"
+fi
+
+# Build TLS security profile configuration
+tls_config=$(jq -nc \
+  --arg cipher "${PQC_CIPHER}" \
+  --arg minVersion "${PQC_MIN_TLS_VERSION}" \
+  '{
+    "type": "Custom",
+    "custom": {
+      "ciphers": [$cipher],
+      "minTLSVersion": $minVersion
+    }
+  }')
+
+echo "[INFO] Configuring Ingress Controller with PQC TLS profile:"
+echo "${tls_config}" | jq .
+
+# Apply the configuration
+echo "[INFO] Patching ingresscontroller/default in openshift-ingress-operator namespace..."
+oc patch ingresscontroller/default \
+  -n openshift-ingress-operator \
+  --type=merge \
+  -p "{\"spec\": {\"tlsSecurityProfile\": ${tls_config}}}"
+
+# Wait for ingress operator to start reconciling
+echo "[INFO] Waiting for Ingress Operator to start reconciling..."
+sleep 5
+
+# Wait for ingress operator to finish reconciliation (max 10 minutes)
+echo "[INFO] Waiting for Ingress Operator to complete reconciliation..."
+timeout=600
+interval=10
+elapsed=0
+
+while [ ${elapsed} -lt ${timeout} ]; do
+    # Check if operator is available, not progressing, and not degraded
+    available=$(oc get co ingress -o jsonpath='{.status.conditions[?(@.type=="Available")].status}')
+    progressing=$(oc get co ingress -o jsonpath='{.status.conditions[?(@.type=="Progressing")].status}')
+    degraded=$(oc get co ingress -o jsonpath='{.status.conditions[?(@.type=="Degraded")].status}')
+
+    if [[ "${available}" == "True" && "${progressing}" == "False" && "${degraded}" == "False" ]]; then
+        echo "[INFO] Ingress Operator reconciliation complete"
+        break
+    fi
+
+    echo "[INFO] Waiting for operator (Available=${available}, Progressing=${progressing}, Degraded=${degraded})..."
+    sleep ${interval}
+    elapsed=$((elapsed + interval))
+done
+
+if [ ${elapsed} -ge ${timeout} ]; then
+    echo "[ERROR] Timed out waiting for Ingress Operator to reconcile"
+    echo "[INFO] Current cluster operator status:"
+    oc get co ingress -o yaml
+    exit 1
+fi
+
+# Verify configuration was applied correctly
+echo "[INFO] Verifying configuration..."
+current_config=$(oc get ingresscontroller/default -n openshift-ingress-operator -o json | jq -cS '.spec.tlsSecurityProfile')
+desired_config=$(echo "${tls_config}" | jq -cS '.')
+
+if [[ "${current_config}" != "${desired_config}" ]]; then
+    echo "[ERROR] Ingress Controller tlsSecurityProfile does not match desired configuration"
+    echo "---- Desired:"
+    echo "${desired_config}" | jq .
+    echo "---- Current:"
+    echo "${current_config}" | jq .
+    exit 1
+fi
+
+echo "[INFO] Ingress Controller successfully configured with PQC cipher: ${PQC_CIPHER}"

--- a/ci-operator/step-registry/pqc/conf/ingress/pqc-conf-ingress-ref.metadata.json
+++ b/ci-operator/step-registry/pqc/conf/ingress/pqc-conf-ingress-ref.metadata.json
@@ -1,0 +1,15 @@
+{
+	"path": "pqc/conf/ingress/pqc-conf-ingress-ref.yaml",
+	"owners": {
+		"approvers": [
+			"richardsonnick",
+			"rhmdnd",
+			"smith-xyz"
+		],
+		"reviewers": [
+			"richardsonnick",
+			"rhmdnd",
+			"smith-xyz"
+		]
+	}
+}

--- a/ci-operator/step-registry/pqc/conf/ingress/pqc-conf-ingress-ref.yaml
+++ b/ci-operator/step-registry/pqc/conf/ingress/pqc-conf-ingress-ref.yaml
@@ -1,0 +1,27 @@
+ref:
+  as: pqc-conf-ingress
+  from_image:
+    namespace: ocp
+    name: cli-jq
+    tag: latest
+  commands: pqc-conf-ingress-commands.sh
+  resources:
+    requests:
+      cpu: 10m
+      memory: 100Mi
+  env:
+    - name: PQC_CIPHER
+      default: "X25519MLKEM768"
+      documentation: |-
+        Post-quantum cryptography cipher suite to configure for the Ingress Controller.
+    - name: PQC_MIN_TLS_VERSION
+      default: "VersionTLS13"
+      documentation: |-
+        Minimum TLS version to configure for the Ingress Controller.
+  documentation: |-
+    Configures the cluster's default Ingress Controller with a Custom TLS Security
+    Profile using post-quantum cryptography (PQC) cipher suites. This step patches
+    the default ingress controller in the openshift-ingress-operator namespace to
+    use the specified PQC cipher (default: X25519MLKEM768) with TLS 1.3, then waits
+    for the ingress operator to reconcile and validates the configuration was applied
+    correctly.

--- a/ci-operator/step-registry/pqc/conf/kubelet/OWNERS
+++ b/ci-operator/step-registry/pqc/conf/kubelet/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+  - richardsonnick
+  - rhmdnd
+  - smith-xyz
+reviewers:
+  - richardsonnick
+  - rhmdnd
+  - smith-xyz

--- a/ci-operator/step-registry/pqc/conf/kubelet/pqc-conf-kubelet-commands.sh
+++ b/ci-operator/step-registry/pqc/conf/kubelet/pqc-conf-kubelet-commands.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+set -euo pipefail
+
+export KUBECONFIG="${SHARED_DIR}/kubeconfig"
+
+# Set proxy if configured
+if test -s "${SHARED_DIR}/proxy-conf.sh"; then
+    echo "[INFO] Setting proxy configuration"
+    source "${SHARED_DIR}/proxy-conf.sh"
+fi
+
+# Build TLS security profile configuration
+tls_config=$(jq -nc \
+  --arg cipher "${PQC_CIPHER}" \
+  --arg minVersion "${PQC_MIN_TLS_VERSION}" \
+  '{
+    "type": "Custom",
+    "custom": {
+      "ciphers": [$cipher],
+      "minTLSVersion": $minVersion
+    }
+  }')
+
+echo "[INFO] Configuring Kubelet with PQC TLS profile:"
+echo "${tls_config}" | jq .
+
+# Create KubeletConfig resource
+echo "[INFO] Creating KubeletConfig resource targeting MCP: ${PQC_KUBELET_MCP}..."
+cat <<EOF | oc apply -f -
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  name: pqc-tls-config
+spec:
+  machineConfigPoolSelector:
+    matchLabels:
+      pools.operator.machineconfiguration.openshift.io/${PQC_KUBELET_MCP}: ""
+  tlsSecurityProfile: ${tls_config}
+EOF
+
+# Verify the MCP exists
+if ! oc get mcp "${PQC_KUBELET_MCP}" &>/dev/null; then
+    echo "[ERROR] Machine Config Pool '${PQC_KUBELET_MCP}' not found"
+    echo "[INFO] Available Machine Config Pools:"
+    oc get mcp
+    exit 1
+fi
+
+# Wait for MCP to start updating
+echo "[INFO] Waiting for Machine Config Pool '${PQC_KUBELET_MCP}' to start updating (max 5 minutes)..."
+if ! oc wait mcp/${PQC_KUBELET_MCP} --for condition=Updating=True --timeout=5m; then
+    echo "[WARN] MCP did not enter Updating state within 5 minutes, checking current state..."
+    oc get mcp/${PQC_KUBELET_MCP} -o yaml
+fi
+
+# Wait for MCP to complete update
+echo "[INFO] Waiting for Machine Config Pool '${PQC_KUBELET_MCP}' to complete update (max 20 minutes)..."
+oc wait mcp/${PQC_KUBELET_MCP} --for condition=Updated=True --timeout=20m
+
+echo "[INFO] Machine Config Pool '${PQC_KUBELET_MCP}' update complete"
+
+# Verify configuration was applied correctly
+echo "[INFO] Verifying KubeletConfig..."
+current_config=$(oc get kubeletconfig/pqc-tls-config -o json | jq -cS '.spec.tlsSecurityProfile')
+desired_config=$(echo "${tls_config}" | jq -cS '.')
+
+if [[ "${current_config}" != "${desired_config}" ]]; then
+    echo "[ERROR] KubeletConfig tlsSecurityProfile does not match desired configuration"
+    echo "---- Desired:"
+    echo "${desired_config}" | jq .
+    echo "---- Current:"
+    echo "${current_config}" | jq .
+    exit 1
+fi
+
+echo "[INFO] Kubelet successfully configured with PQC cipher: ${PQC_CIPHER}"
+echo "[INFO] Configuration applied to Machine Config Pool: ${PQC_KUBELET_MCP}"

--- a/ci-operator/step-registry/pqc/conf/kubelet/pqc-conf-kubelet-ref.metadata.json
+++ b/ci-operator/step-registry/pqc/conf/kubelet/pqc-conf-kubelet-ref.metadata.json
@@ -1,0 +1,15 @@
+{
+	"path": "pqc/conf/kubelet/pqc-conf-kubelet-ref.yaml",
+	"owners": {
+		"approvers": [
+			"richardsonnick",
+			"rhmdnd",
+			"smith-xyz"
+		],
+		"reviewers": [
+			"richardsonnick",
+			"rhmdnd",
+			"smith-xyz"
+		]
+	}
+}

--- a/ci-operator/step-registry/pqc/conf/kubelet/pqc-conf-kubelet-ref.yaml
+++ b/ci-operator/step-registry/pqc/conf/kubelet/pqc-conf-kubelet-ref.yaml
@@ -1,0 +1,31 @@
+ref:
+  as: pqc-conf-kubelet
+  from_image:
+    namespace: ocp
+    name: cli-jq
+    tag: latest
+  commands: pqc-conf-kubelet-commands.sh
+  resources:
+    requests:
+      cpu: 10m
+      memory: 100Mi
+  env:
+    - name: PQC_CIPHER
+      default: "X25519MLKEM768"
+      documentation: |-
+        Post-quantum cryptography cipher suite to configure for the Kubelet.
+    - name: PQC_MIN_TLS_VERSION
+      default: "VersionTLS13"
+      documentation: |-
+        Minimum TLS version to configure for the Kubelet.
+    - name: PQC_KUBELET_MCP
+      default: "worker"
+      documentation: |-
+        Machine Config Pool to target for Kubelet configuration (default: worker).
+  documentation: |-
+    Configures the cluster's Kubelet with a Custom TLS Security Profile using
+    post-quantum cryptography (PQC) cipher suites. This step creates a KubeletConfig
+    resource targeting the specified Machine Config Pool (default: worker) to use
+    the specified PQC cipher (default: X25519MLKEM768) with TLS 1.3. The step then
+    waits for the Machine Config Pool to complete its rollout and validates the
+    configuration was applied correctly.

--- a/ci-operator/step-registry/pqc/conf/pqc-conf-chain.metadata.json
+++ b/ci-operator/step-registry/pqc/conf/pqc-conf-chain.metadata.json
@@ -1,0 +1,15 @@
+{
+	"path": "pqc/conf/pqc-conf-chain.yaml",
+	"owners": {
+		"approvers": [
+			"richardsonnick",
+			"rhmdnd",
+			"smith-xyz"
+		],
+		"reviewers": [
+			"richardsonnick",
+			"rhmdnd",
+			"smith-xyz"
+		]
+	}
+}

--- a/ci-operator/step-registry/pqc/conf/pqc-conf-chain.yaml
+++ b/ci-operator/step-registry/pqc/conf/pqc-conf-chain.yaml
@@ -1,0 +1,28 @@
+chain:
+  as: pqc-conf
+  steps:
+  - ref: pqc-conf-apiserver
+  - ref: pqc-conf-ingress
+  - ref: pqc-conf-kubelet
+  env:
+  - name: PQC_CIPHER
+    default: "X25519MLKEM768"
+    documentation: |-
+      Post-quantum cryptography cipher suite to configure for API Server, Ingress Controller, and Kubelet.
+  - name: PQC_MIN_TLS_VERSION
+    default: "VersionTLS13"
+    documentation: |-
+      Minimum TLS version to configure for API Server, Ingress Controller, and Kubelet.
+  - name: PQC_KUBELET_MCP
+    default: "worker"
+    documentation: |-
+      Machine Config Pool to target for Kubelet configuration (default: worker).
+  documentation: |-
+    This chain configures an OpenShift cluster with post-quantum cryptography (PQC)
+    cipher suites across all major TLS endpoints. It sequentially configures:
+    1. API Server with Custom TLS Security Profile
+    2. Ingress Controller with Custom TLS Security Profile
+    3. Kubelet with Custom TLS Security Profile via KubeletConfig
+
+    All components are configured to use the X25519MLKEM768 cipher suite with TLS 1.3.
+    The chain waits for each component to stabilize before proceeding to the next.

--- a/ci-operator/step-registry/tls-scanner/OWNERS
+++ b/ci-operator/step-registry/tls-scanner/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+  - richardsonnick
+  - rhmdnd
+  - smith-xyz
+reviewers:
+  - richardsonnick
+  - rhmdnd
+  - smith-xyz

--- a/ci-operator/step-registry/tls-scanner/run/OWNERS
+++ b/ci-operator/step-registry/tls-scanner/run/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+  - richardsonnick
+  - rhmdnd
+  - smith-xyz
+reviewers:
+  - richardsonnick
+  - rhmdnd
+  - smith-xyz

--- a/ci-operator/step-registry/tls-scanner/run/tls-scanner-run-commands.sh
+++ b/ci-operator/step-registry/tls-scanner/run/tls-scanner-run-commands.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+# PLACEHOLDER: This is a temporary placeholder script.
+# The actual tls-scanner implementation is being added in https://github.com/openshift/release/pull/71526
+
+echo "[INFO] PLACEHOLDER: tls-scanner-run step"
+echo "[INFO] This is a temporary placeholder. The actual implementation is in PR #71526."
+echo "[INFO] When merged, this step will scan all cluster ports for PQC compliance."
+
+# For now, just pass
+exit 0

--- a/ci-operator/step-registry/tls-scanner/run/tls-scanner-run-ref.metadata.json
+++ b/ci-operator/step-registry/tls-scanner/run/tls-scanner-run-ref.metadata.json
@@ -1,0 +1,15 @@
+{
+	"path": "tls-scanner/run/tls-scanner-run-ref.yaml",
+	"owners": {
+		"approvers": [
+			"richardsonnick",
+			"rhmdnd",
+			"smith-xyz"
+		],
+		"reviewers": [
+			"richardsonnick",
+			"rhmdnd",
+			"smith-xyz"
+		]
+	}
+}

--- a/ci-operator/step-registry/tls-scanner/run/tls-scanner-run-ref.yaml
+++ b/ci-operator/step-registry/tls-scanner/run/tls-scanner-run-ref.yaml
@@ -1,0 +1,18 @@
+ref:
+  as: tls-scanner-run
+  from_image:
+    namespace: ocp
+    name: cli
+    tag: latest
+  commands: tls-scanner-run-commands.sh
+  resources:
+    requests:
+      cpu: 100m
+      memory: 200Mi
+  documentation: |-
+    PLACEHOLDER: This is a temporary placeholder for the tls-scanner-run step.
+    The actual implementation is being added in https://github.com/openshift/release/pull/71526.
+
+    This step will scan all open ports on the cluster and validate they are using
+    the configured PQC-compliant cipher suites. It will fail if any non-compliant
+    ports are found.


### PR DESCRIPTION
To ensure various components are setting TLS appropriately for
PQC-concious usage, we should have a workflow that configures the
cluster appropriately, then wires up the tls-scanner to run after and
flag any endpoints that are not using the desired configs.

This PR is meant to follow
https://github.com/openshift/release/pull/71526 where the tls-scanner
step is being introduced.
