### PR TITLE
Fix image-updater job

### DIFF
--- a/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__image-updater.yaml
+++ b/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__image-updater.yaml
@@ -11,13 +11,13 @@ build_root:
 images:
 - dockerfile_literal: |
     FROM src
-    RUN curl -L https://github.com/lework/skopeo-binary/releases/latest/download/skopeo-linux-amd64 -o /usr/local/bin/skopeo
-    RUN chmod +x /usr/local/bin/skopeo
-    RUN curl -L https://github.com/jqlang/jq/releases/latest/download/jq-linux-amd64 -o /usr/local/bin/jq
-    RUN chmod +x /usr/local/bin/jq
-    RUN curl -L https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -o /usr/local/bin/yq
-    RUN chmod +x /usr/local/bin/yq
-    RUN mkdir -p /etc/containers && echo '{"default":[{"type":"insecureAcceptAnything"}]}' > /etc/containers/policy.json
+    # Note: skopeo policy.json is configured at runtime in step-registry/aro-hcp/automation/image-update/aro-hcp-automation-image-update-commands.sh
+    RUN curl -L https://github.com/lework/skopeo-binary/releases/latest/download/skopeo-linux-amd64 -o /usr/local/bin/skopeo && \
+        chmod +x /usr/local/bin/skopeo
+    RUN curl -L https://github.com/jqlang/jq/releases/latest/download/jq-linux-amd64 -o /usr/local/bin/jq && \
+        chmod +x /usr/local/bin/jq
+    RUN curl -L https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -o /usr/local/bin/yq && \
+        chmod +x /usr/local/bin/yq
     ADD prcreator /usr/bin/prcreator
     COPY /src /opt/app-root/src/github.com/Azure
     WORKDIR /opt/app-root/src/github.com/Azure/ARO-HCP

--- a/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__image-updater.yaml
+++ b/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__image-updater.yaml
@@ -1,27 +1,23 @@
 base_images:
-  aro-hcp-e2e-base-image:
-    name: aro-hcp-e2e-base
-    namespace: rh_ee_ves
-    tag: v1.0
   prcreator:
     name: prcreator
     namespace: ci
     tag: latest
 build_root:
   image_stream_tag:
-    name: builder
-    namespace: ocp
-    tag: rhel-9-golang-1.24-openshift-4.20
+    name: aro-hcp-ci-images
+    namespace: aro-hcp
+    tag: aro-hcp-e2e-base-ci
 images:
 - dockerfile_literal: |
-    FROM aro-hcp-e2e-base-image
+    FROM src
     RUN dnf install -y skopeo jq
     RUN curl -L https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -o /usr/local/bin/yq &&\
         chmod +x /usr/local/bin/yq
     ADD prcreator /usr/bin/prcreator
     COPY /src /opt/app-root/src/github.com/Azure
     WORKDIR /opt/app-root/src/github.com/Azure/ARO-HCP
-  from: aro-hcp-e2e-base-image
+  from: src
   inputs:
     prcreator:
       paths:

--- a/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__image-updater.yaml
+++ b/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__image-updater.yaml
@@ -11,9 +11,12 @@ build_root:
 images:
 - dockerfile_literal: |
     FROM src
-    RUN dnf install -y skopeo jq
-    RUN curl -L https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -o /usr/local/bin/yq &&\
-        chmod +x /usr/local/bin/yq
+    RUN curl -L https://github.com/lework/skopeo-binary/releases/latest/download/skopeo-linux-amd64 -o /usr/local/bin/skopeo
+    RUN chmod +x /usr/local/bin/skopeo
+    RUN curl -L https://github.com/jqlang/jq/releases/latest/download/jq-linux-amd64 -o /usr/local/bin/jq
+    RUN chmod +x /usr/local/bin/jq
+    RUN curl -L https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -o /usr/local/bin/yq
+    RUN chmod +x /usr/local/bin/yq
     ADD prcreator /usr/bin/prcreator
     COPY /src /opt/app-root/src/github.com/Azure
     WORKDIR /opt/app-root/src/github.com/Azure/ARO-HCP

--- a/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__image-updater.yaml
+++ b/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__image-updater.yaml
@@ -17,6 +17,7 @@ images:
     RUN chmod +x /usr/local/bin/jq
     RUN curl -L https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -o /usr/local/bin/yq
     RUN chmod +x /usr/local/bin/yq
+    RUN mkdir -p /etc/containers && echo '{"default":[{"type":"insecureAcceptAnything"}]}' > /etc/containers/policy.json
     ADD prcreator /usr/bin/prcreator
     COPY /src /opt/app-root/src/github.com/Azure
     WORKDIR /opt/app-root/src/github.com/Azure/ARO-HCP

--- a/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__image-updater.yaml
+++ b/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__image-updater.yaml
@@ -11,7 +11,7 @@ build_root:
 images:
 - dockerfile_literal: |
     FROM src
-    # Note: skopeo policy.json is configured at runtime in step-registry/aro-hcp/automation/image-update/aro-hcp-automation-image-update-commands.sh
+    # Note: skopeo policy.json is configured at runtime in aro-hcp-automation-image-update-commands.sh
     RUN curl -L https://github.com/lework/skopeo-binary/releases/latest/download/skopeo-linux-amd64 -o /usr/local/bin/skopeo && \
         chmod +x /usr/local/bin/skopeo
     RUN curl -L https://github.com/jqlang/jq/releases/latest/download/jq-linux-amd64 -o /usr/local/bin/jq && \

--- a/ci-operator/step-registry/aro-hcp/automation/image-update/aro-hcp-automation-image-update-commands.sh
+++ b/ci-operator/step-registry/aro-hcp/automation/image-update/aro-hcp-automation-image-update-commands.sh
@@ -134,6 +134,11 @@ export AZURE_TENANT_ID
 
 debug "azure: authentication configured successfully (credentials redacted)"
 
+# Go: Sync vendor directory to resolve module inconsistencies
+info "go: syncing vendor directory with go.work modules"
+run go work vendor
+debug "go: vendor directory synchronized successfully"
+
 # Image Updater: Build and run the image-updater tool
 info "image: fetching the latest image digests for all components"
 if [[ ${VERBOSITY-0} -ge 2 ]]; then

--- a/ci-operator/step-registry/aro-hcp/automation/image-update/aro-hcp-automation-image-update-commands.sh
+++ b/ci-operator/step-registry/aro-hcp/automation/image-update/aro-hcp-automation-image-update-commands.sh
@@ -93,10 +93,11 @@ for cmd in "${required_tools[@]}"; do
 done
 debug "precheck: all required tools are present"
 
-# Skopeo: Configure container policy
+# Skopeo: Configure container policy (must be before any skopeo usage)
 debug "skopeo: configuring container policy"
-mkdir -p /etc/containers
-cat > /etc/containers/policy.json <<'EOF'
+readonly POLICY_DIR="${HOME:-/tmp}/.config/containers"
+mkdir -p "${POLICY_DIR}"
+cat > "${POLICY_DIR}/policy.json" <<'EOF'
 {
     "default": [
         {
@@ -130,7 +131,7 @@ cat > /etc/containers/policy.json <<'EOF'
     }
 }
 EOF
-debug "skopeo: container policy configured"
+debug "skopeo: policy configured at ${POLICY_DIR}/policy.json"
 
 # Configuration: Load GitHub token from file
 debug "cfg: loading GitHub token"

--- a/ci-operator/step-registry/aro-hcp/automation/image-update/aro-hcp-automation-image-update-commands.sh
+++ b/ci-operator/step-registry/aro-hcp/automation/image-update/aro-hcp-automation-image-update-commands.sh
@@ -141,13 +141,14 @@ debug "go: vendor directory synchronized successfully"
 
 # Image Updater: Build and run the image-updater tool
 info "image: fetching the latest image digests for all components"
+cd tooling/image-updater/
+run make build
 if [[ ${VERBOSITY-0} -ge 2 ]]; then
-  run make yamlfmt
-  VERBOSITY=1 make image-updater OUTPUT_FILE="${IMAGE_UPDATER_OUTPUT}" OUTPUT_FORMAT="${IMAGE_UPDATER_OUTPUT_FORMAT}"
+  VERBOSITY=1 make update OUTPUT_FILE="${IMAGE_UPDATER_OUTPUT}" OUTPUT_FORMAT="${IMAGE_UPDATER_OUTPUT_FORMAT}"
 else
-  run make yamlfmt
-  VERBOSITY=0 make image-updater OUTPUT_FILE="${IMAGE_UPDATER_OUTPUT}" OUTPUT_FORMAT="${IMAGE_UPDATER_OUTPUT_FORMAT}"
+  VERBOSITY=0 make update OUTPUT_FILE="${IMAGE_UPDATER_OUTPUT}" OUTPUT_FORMAT="${IMAGE_UPDATER_OUTPUT_FORMAT}"
 fi
+cd ../..
 
 # Check if there are any changes from image updates
 if [[ $(git status --porcelain) == "" ]]; then

--- a/ci-operator/step-registry/aro-hcp/automation/image-update/aro-hcp-automation-image-update-commands.sh
+++ b/ci-operator/step-registry/aro-hcp/automation/image-update/aro-hcp-automation-image-update-commands.sh
@@ -93,6 +93,45 @@ for cmd in "${required_tools[@]}"; do
 done
 debug "precheck: all required tools are present"
 
+# Skopeo: Configure container policy
+debug "skopeo: configuring container policy"
+mkdir -p /etc/containers
+cat > /etc/containers/policy.json <<'EOF'
+{
+    "default": [
+        {
+            "type": "insecureAcceptAnything"
+        }
+    ],
+    "transports": {
+        "docker": {
+            "registry.access.redhat.com": [
+                {
+                    "type": "signedBy",
+                    "keyType": "GPGKeys",
+                    "keyPaths": ["/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release", "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta"]
+                }
+            ],
+            "registry.redhat.io": [
+                {
+                    "type": "signedBy",
+                    "keyType": "GPGKeys",
+                    "keyPaths": ["/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release", "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta"]
+                }
+            ]
+        },
+        "docker-daemon": {
+            "": [
+                {
+                    "type": "insecureAcceptAnything"
+                }
+            ]
+        }
+    }
+}
+EOF
+debug "skopeo: container policy configured"
+
 # Configuration: Load GitHub token from file
 debug "cfg: loading GitHub token"
 if [[ ! -f "${GITHUB_TOKEN_PATH}" ]]; then

--- a/ci-operator/step-registry/aro-hcp/automation/image-update/aro-hcp-automation-image-update-commands.sh
+++ b/ci-operator/step-registry/aro-hcp/automation/image-update/aro-hcp-automation-image-update-commands.sh
@@ -142,8 +142,10 @@ debug "go: vendor directory synchronized successfully"
 # Image Updater: Build and run the image-updater tool
 info "image: fetching the latest image digests for all components"
 if [[ ${VERBOSITY-0} -ge 2 ]]; then
+  run make yamlfmt
   VERBOSITY=1 make image-updater OUTPUT_FILE="${IMAGE_UPDATER_OUTPUT}" OUTPUT_FORMAT="${IMAGE_UPDATER_OUTPUT_FORMAT}"
 else
+  run make yamlfmt
   VERBOSITY=0 make image-updater OUTPUT_FILE="${IMAGE_UPDATER_OUTPUT}" OUTPUT_FORMAT="${IMAGE_UPDATER_OUTPUT_FORMAT}"
 fi
 

--- a/ci-operator/step-registry/aro-hcp/automation/image-update/aro-hcp-automation-image-update-ref.yaml
+++ b/ci-operator/step-registry/aro-hcp/automation/image-update/aro-hcp-automation-image-update-ref.yaml
@@ -46,7 +46,7 @@ ref:
     documentation: |-
       The URL of the Prow job.
   - name: VERBOSITY
-    default: "3"
+    default: "0"
     documentation: |-
       The debug level. 0 for no debug, 1 for debug, 2 for debug with verbose output.
   credentials:

--- a/ci-operator/step-registry/aro-hcp/automation/image-update/aro-hcp-automation-image-update-ref.yaml
+++ b/ci-operator/step-registry/aro-hcp/automation/image-update/aro-hcp-automation-image-update-ref.yaml
@@ -46,7 +46,7 @@ ref:
     documentation: |-
       The URL of the Prow job.
   - name: VERBOSITY
-    default: "0"
+    default: "3"
     documentation: |-
       The debug level. 0 for no debug, 1 for debug, 2 for debug with verbose output.
   credentials:


### PR DESCRIPTION
 Updated `build_root` to use `aro-hcp-ci-images/aro-hcp-e2e-base-ci` (promoted image with Go 1.24.11)

Fixes Image updater Prow Job Error:
https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/73808/rehearse-73808-periodic-ci-Azure-ARO-HCP-main-image-updater-image-updater-tooling/2014108537902338048

`go: yamlfmt.mod requires go >= 1.24.11 (running go 1.24.4)`

Skopeo policy is needed to run skopeo commands for rendering acm helm charts.