### PR TITLE
add retries to git clone command to avoid transient failures

### DIFF
--- a/ci-operator/config/cloud-bulldozer/orion/cloud-bulldozer-orion-main.yaml
+++ b/ci-operator/config/cloud-bulldozer/orion/cloud-bulldozer-orion-main.yaml
@@ -33,6 +33,7 @@ tests:
       VERSION: "4.21"
       ZONES_COUNT: "3"
     test:
+    - ref: openshift-qe-shared-post-install
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-control-plane
     - chain: openshift-qe-orion-consolidated

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.20-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.20-nightly-x86.yaml
@@ -25,6 +25,7 @@ tests:
       BASE_DOMAIN: qe.devcluster.openshift.com
       ZONES_COUNT: "3"
     test:
+    - ref: openshift-qe-shared-post-install
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-netpol-v2
     workflow: openshift-qe-installer-aws
@@ -45,6 +46,7 @@ tests:
       VERSION: "4.20"
       ZONES_COUNT: "3"
     test:
+    - ref: openshift-qe-shared-post-install
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-control-plane
     - chain: openshift-qe-orion-consolidated
@@ -68,6 +70,7 @@ tests:
         TicketId 532
       ZONES_COUNT: "3"
     test:
+    - ref: openshift-qe-shared-post-install
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-control-plane
     - chain: cucushift-installer-check-cluster-health
@@ -85,6 +88,7 @@ tests:
       ES_SECRETS_PATH: /prod-secret
       ZONES_COUNT: "3"
     test:
+    - ref: openshift-qe-shared-post-install
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-control-plane
     workflow: openshift-qe-installer-aws
@@ -98,6 +102,7 @@ tests:
       COMPUTE_NODE_REPLICAS: "3"
       ZONES_COUNT: "3"
     test:
+    - ref: openshift-qe-shared-post-install
     - chain: openshift-qe-conc-builds
     - chain: openshift-qe-run-api-apf-customized-flowcontrol
     workflow: openshift-qe-installer-aws
@@ -110,6 +115,7 @@ tests:
       BASE_DOMAIN: qe.devcluster.openshift.com
       ZONES_COUNT: "3"
     test:
+    - ref: openshift-qe-shared-post-install
     - chain: openshift-qe-cluster-density-v2
     workflow: openshift-qe-installer-aws-compact
 - always_run: false
@@ -122,6 +128,7 @@ tests:
       BASE_DOMAIN: qe.devcluster.openshift.com
       ZONES_COUNT: "3"
     test:
+    - ref: openshift-qe-shared-post-install
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-router-perf
     workflow: openshift-qe-installer-aws
@@ -136,6 +143,7 @@ tests:
       POD_READY_THRESHOLD: 4s
       ZONES_COUNT: "3"
     test:
+    - ref: openshift-qe-shared-post-install
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-node-density-cni
     workflow: openshift-qe-installer-aws
@@ -153,6 +161,7 @@ tests:
       SET_ENV_BY_PLATFORM: custom
       ZONES_COUNT: "3"
     test:
+    - ref: openshift-qe-shared-post-install
     - ref: openshift-qe-workers-scale
     - ref: openshift-qe-perfscale-aws-data-path-sg
     - chain: openshift-qe-data-path-tests
@@ -166,6 +175,7 @@ tests:
       BASE_DOMAIN: qe.devcluster.openshift.com
       COMPUTE_NODE_REPLICAS: "3"
     test:
+    - ref: openshift-qe-shared-post-install
     - chain: openshift-qe-control-plane
     - chain: cucushift-installer-check-cluster-health
     - ref: capi-conf-apply-feature-gate
@@ -180,6 +190,7 @@ tests:
       BASE_DOMAIN: qe.devcluster.openshift.com
       COMPUTE_NODE_REPLICAS: "3"
     test:
+    - ref: openshift-qe-shared-post-install
     - chain: openshift-qe-node-density-cni
     workflow: openshift-qe-installer-aws
 - as: udn-density-l3-24nodes
@@ -197,6 +208,7 @@ tests:
     pre:
     - chain: ipi-aws-pre
     - chain: create-infra-move-ingress-monitoring-registry
+    - ref: openshift-qe-shared-post-install
     - ref: openshift-qe-workers-scale
     workflow: openshift-qe-udn-density-pods
 zz_generated_metadata:

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.21-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.21-nightly-x86.yaml
@@ -25,6 +25,7 @@ tests:
       BASE_DOMAIN: qe.devcluster.openshift.com
       ZONES_COUNT: "3"
     test:
+    - ref: openshift-qe-shared-post-install
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-netpol-v2
     workflow: openshift-qe-installer-aws
@@ -45,6 +46,7 @@ tests:
       VERSION: "4.21"
       ZONES_COUNT: "3"
     test:
+    - ref: openshift-qe-shared-post-install
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-control-plane
     - chain: openshift-qe-orion-consolidated
@@ -68,6 +70,7 @@ tests:
         TicketId 532
       ZONES_COUNT: "3"
     test:
+    - ref: openshift-qe-shared-post-install
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-control-plane
     workflow: openshift-qe-installer-aws
@@ -90,6 +93,7 @@ tests:
         TicketId 532
       ZONES_COUNT: "3"
     test:
+    - ref: openshift-qe-shared-post-install
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-control-plane
     workflow: openshift-qe-installer-aws
@@ -104,6 +108,7 @@ tests:
       ES_SECRETS_PATH: /prod-secret
       ZONES_COUNT: "3"
     test:
+    - ref: openshift-qe-shared-post-install
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-control-plane
     workflow: openshift-qe-installer-aws
@@ -117,6 +122,7 @@ tests:
       COMPUTE_NODE_REPLICAS: "3"
       ZONES_COUNT: "3"
     test:
+    - ref: openshift-qe-shared-post-install
     - chain: openshift-qe-conc-builds
     - chain: openshift-qe-run-api-apf-customized-flowcontrol
     workflow: openshift-qe-installer-aws
@@ -129,6 +135,7 @@ tests:
       BASE_DOMAIN: qe.devcluster.openshift.com
       ZONES_COUNT: "3"
     test:
+    - ref: openshift-qe-shared-post-install
     - chain: openshift-qe-cluster-density-v2
     workflow: openshift-qe-installer-aws-compact
 - always_run: false
@@ -141,6 +148,7 @@ tests:
       BASE_DOMAIN: qe.devcluster.openshift.com
       ZONES_COUNT: "3"
     test:
+    - ref: openshift-qe-shared-post-install
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-router-perf
     workflow: openshift-qe-installer-aws
@@ -155,6 +163,7 @@ tests:
       POD_READY_THRESHOLD: 4s
       ZONES_COUNT: "3"
     test:
+    - ref: openshift-qe-shared-post-install
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-node-density-cni
     workflow: openshift-qe-installer-aws
@@ -172,6 +181,7 @@ tests:
       SET_ENV_BY_PLATFORM: custom
       ZONES_COUNT: "3"
     test:
+    - ref: openshift-qe-shared-post-install
     - ref: openshift-qe-workers-scale
     - ref: openshift-qe-perfscale-aws-data-path-sg
     - chain: openshift-qe-data-path-tests
@@ -185,6 +195,7 @@ tests:
       BASE_DOMAIN: qe.devcluster.openshift.com
       COMPUTE_NODE_REPLICAS: "3"
     test:
+    - ref: openshift-qe-shared-post-install
     - chain: openshift-qe-control-plane
     workflow: openshift-qe-installer-aws
 - always_run: false
@@ -196,6 +207,7 @@ tests:
       BASE_DOMAIN: qe.devcluster.openshift.com
       COMPUTE_NODE_REPLICAS: "3"
     test:
+    - ref: openshift-qe-shared-post-install
     - chain: openshift-qe-node-density-cni
     workflow: openshift-qe-installer-aws
 - as: udn-density-l3-24nodes
@@ -213,6 +225,7 @@ tests:
     pre:
     - chain: ipi-aws-pre
     - chain: create-infra-move-ingress-monitoring-registry
+    - ref: openshift-qe-shared-post-install
     - ref: openshift-qe-workers-scale
     workflow: openshift-qe-udn-density-pods
 zz_generated_metadata:

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.22-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.22-nightly-x86.yaml
@@ -25,6 +25,7 @@ tests:
       BASE_DOMAIN: qe.devcluster.openshift.com
       ZONES_COUNT: "3"
     test:
+    - ref: openshift-qe-shared-post-install
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-netpol-v2
     workflow: openshift-qe-installer-aws
@@ -45,6 +46,7 @@ tests:
       VERSION: "4.22"
       ZONES_COUNT: "3"
     test:
+    - ref: openshift-qe-shared-post-install
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-control-plane
     - chain: openshift-qe-orion-consolidated
@@ -68,6 +70,7 @@ tests:
         TicketId 532
       ZONES_COUNT: "3"
     test:
+    - ref: openshift-qe-shared-post-install
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-control-plane
     workflow: openshift-qe-installer-aws
@@ -90,6 +93,7 @@ tests:
         TicketId 532
       ZONES_COUNT: "3"
     test:
+    - ref: openshift-qe-shared-post-install
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-control-plane
     workflow: openshift-qe-installer-aws
@@ -104,6 +108,7 @@ tests:
       ES_SECRETS_PATH: /prod-secret
       ZONES_COUNT: "3"
     test:
+    - ref: openshift-qe-shared-post-install
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-control-plane
     workflow: openshift-qe-installer-aws
@@ -117,6 +122,7 @@ tests:
       ES_SECRETS_PATH: /prod-secret
       ZONES_COUNT: "3"
     test:
+    - ref: openshift-qe-shared-post-install
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-control-plane
     workflow: openshift-qe-installer-aws-etcd-encryption
@@ -130,6 +136,7 @@ tests:
       COMPUTE_NODE_REPLICAS: "3"
       ZONES_COUNT: "3"
     test:
+    - ref: openshift-qe-shared-post-install
     - chain: openshift-qe-conc-builds
     - chain: openshift-qe-run-api-apf-customized-flowcontrol
     workflow: openshift-qe-installer-aws
@@ -142,6 +149,7 @@ tests:
       BASE_DOMAIN: qe.devcluster.openshift.com
       ZONES_COUNT: "3"
     test:
+    - ref: openshift-qe-shared-post-install
     - chain: openshift-qe-cluster-density-v2
     workflow: openshift-qe-installer-aws-compact
 - always_run: false
@@ -154,6 +162,7 @@ tests:
       BASE_DOMAIN: qe.devcluster.openshift.com
       ZONES_COUNT: "3"
     test:
+    - ref: openshift-qe-shared-post-install
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-router-perf
     workflow: openshift-qe-installer-aws
@@ -167,6 +176,7 @@ tests:
       BASE_DOMAIN: qe.devcluster.openshift.com
       ZONES_COUNT: "3"
     test:
+    - ref: openshift-qe-shared-post-install
     - ref: openshift-qe-workers-scale
     - ref: openshift-qe-node-density-heavy
     workflow: openshift-qe-installer-aws
@@ -182,6 +192,7 @@ tests:
       NDH_EXTRA_FLAGS: --pod-ready-threshold=43s
       ZONES_COUNT: "3"
     test:
+    - ref: openshift-qe-shared-post-install
     - ref: openshift-qe-workers-scale
     - ref: openshift-qe-node-density-heavy
     workflow: openshift-qe-installer-aws
@@ -196,6 +207,7 @@ tests:
       POD_READY_THRESHOLD: 4s
       ZONES_COUNT: "3"
     test:
+    - ref: openshift-qe-shared-post-install
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-node-density-cni
     workflow: openshift-qe-installer-aws
@@ -213,6 +225,7 @@ tests:
       SET_ENV_BY_PLATFORM: custom
       ZONES_COUNT: "3"
     test:
+    - ref: openshift-qe-shared-post-install
     - ref: openshift-qe-workers-scale
     - ref: openshift-qe-perfscale-aws-data-path-sg
     - chain: openshift-qe-data-path-tests
@@ -226,6 +239,7 @@ tests:
       BASE_DOMAIN: qe.devcluster.openshift.com
       COMPUTE_NODE_REPLICAS: "3"
     test:
+    - ref: openshift-qe-shared-post-install
     - chain: openshift-qe-control-plane
     workflow: openshift-qe-installer-aws
 - always_run: false
@@ -248,6 +262,7 @@ tests:
       BASE_DOMAIN: qe.devcluster.openshift.com
       COMPUTE_NODE_REPLICAS: "3"
     test:
+    - ref: openshift-qe-shared-post-install
     - chain: openshift-qe-node-density-cni
     workflow: openshift-qe-installer-aws
 - as: control-plane-ipsec-120nodes
@@ -269,6 +284,7 @@ tests:
         TicketId 532
       ZONES_COUNT: "3"
     test:
+    - ref: openshift-qe-shared-post-install
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-control-plane
     workflow: openshift-qe-installer-aws-ovn-ipsec
@@ -291,6 +307,7 @@ tests:
         TicketId 532
       ZONES_COUNT: "3"
     test:
+    - ref: openshift-qe-shared-post-install
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-control-plane
     workflow: openshift-qe-installer-aws-ovn-ipsec
@@ -309,6 +326,7 @@ tests:
       TOLERANCE: "200"
       ZONES_COUNT: "3"
     test:
+    - ref: openshift-qe-shared-post-install
     - ref: openshift-qe-workers-scale
     - ref: openshift-qe-perfscale-aws-data-path-sg
     - chain: openshift-qe-data-path-tests
@@ -328,6 +346,7 @@ tests:
     pre:
     - chain: ipi-aws-pre
     - chain: create-infra-move-ingress-monitoring-registry
+    - ref: openshift-qe-shared-post-install
     - ref: openshift-qe-workers-scale
     workflow: openshift-qe-udn-density-pods
 zz_generated_metadata:

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__gcp-4.22-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__gcp-4.22-nightly-x86.yaml
@@ -35,6 +35,7 @@ tests:
       COMPUTE_NODE_REPLICAS: "24"
       PROFILE_TYPE: reporting
     test:
+    - ref: openshift-qe-shared-post-install
     - chain: openshift-qe-control-plane
     workflow: openshift-qe-installer-gcp-ipi-ovn-etcd-encryption-fips
 - always_run: false
@@ -57,6 +58,7 @@ tests:
       COMPUTE_NODE_REPLICAS: "24"
       PROFILE_TYPE: reporting
     test:
+    - ref: openshift-qe-shared-post-install
     - chain: openshift-qe-control-plane
     workflow: openshift-qe-installer-gcp
 - always_run: false
@@ -90,6 +92,7 @@ tests:
       COMPUTE_NODE_REPLICAS: "24"
       PROFILE_TYPE: reporting
     test:
+    - ref: openshift-qe-shared-post-install
     - chain: openshift-qe-node-density-cni
     workflow: openshift-qe-installer-gcp
 - always_run: false
@@ -101,6 +104,7 @@ tests:
       COMPUTE_NODE_REPLICAS: "3"
       PROFILE_TYPE: reporting
     test:
+    - ref: openshift-qe-shared-post-install
     - chain: openshift-qe-control-plane
     workflow: openshift-qe-installer-gcp-ipi-ovn-ipsec
 - always_run: false
@@ -114,6 +118,7 @@ tests:
       PROFILE_TYPE: reporting
       SIZE_VARIANT: large
     test:
+    - ref: openshift-qe-shared-post-install
     - chain: openshift-qe-control-plane
     workflow: openshift-qe-installer-gcp-ipi-ovn-etcd-encryption-fips
 zz_generated_metadata:

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__metal-selfsched-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__metal-selfsched-x86.yaml
@@ -53,6 +53,7 @@ tests:
       PRE_PXE_LOADER: "false"
       TYPE: sno
     test:
+    - ref: openshift-qe-shared-post-install
     - chain: openshift-qe-node-density
     workflow: openshift-qe-installer-bm-self-sched-deploy
 zz_generated_metadata:

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__rosa-4.21-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__rosa-4.21-nightly-x86.yaml
@@ -42,6 +42,7 @@ tests:
       PROFILE_TYPE: reporting
       REPLICAS: "249"
     test:
+    - ref: openshift-qe-shared-post-install
     - chain: openshift-qe-cluster-density-v2
     workflow: rosa-aws-sts
 - always_run: false
@@ -60,6 +61,7 @@ tests:
       PROFILE_TYPE: reporting
       REPLICAS: "120"
     test:
+    - ref: openshift-qe-shared-post-install
     - chain: openshift-qe-control-plane
     workflow: rosa-aws-sts
 - always_run: false
@@ -78,6 +80,7 @@ tests:
       OPENSHIFT_VERSION: "4.21"
       READY_WAIT_TIMEOUT: 30m
     test:
+    - ref: openshift-qe-shared-post-install
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-control-plane
     workflow: rosa-aws-sts
@@ -95,6 +98,7 @@ tests:
       MULTI_AZ: "true"
       OPENSHIFT_VERSION: "4.21"
     test:
+    - ref: openshift-qe-shared-post-install
     - ref: openshift-qe-workers-scale
     - ref: openshift-qe-perfscale-aws-data-path-sg
     - chain: openshift-qe-data-path-tests
@@ -114,6 +118,7 @@ tests:
       OPENSHIFT_VERSION: "4.21"
       READY_WAIT_TIMEOUT: 30m
     test:
+    - ref: openshift-qe-shared-post-install
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-node-density-heavy
     workflow: rosa-aws-sts
@@ -132,6 +137,7 @@ tests:
       OPENSHIFT_VERSION: "4.21"
       READY_WAIT_TIMEOUT: 30m
     test:
+    - ref: openshift-qe-shared-post-install
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-node-density-cni
     workflow: rosa-aws-sts
@@ -172,6 +178,7 @@ tests:
       READY_WAIT_TIMEOUT: 30m
       REPLICAS: "3"
     test:
+    - ref: openshift-qe-shared-post-install
     - chain: openshift-qe-control-plane
     workflow: rosa-aws-sts
 zz_generated_metadata:

--- a/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/cluster-density-ms/cloud-bulldozer-e2e-benchmarking-cluster-density-ms-commands.sh
+++ b/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/cluster-density-ms/cloud-bulldozer-e2e-benchmarking-cluster-density-ms-commands.sh
@@ -7,6 +7,14 @@ set -x
 # Source shared retry library if available
 if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
     source "${SHARED_DIR}/retry-lib.sh"
+else
+    echo "retry-lib.sh not found in ${SHARED_DIR}"
+fi
+
+# Guarantee fallback
+if ! declare -F retry_git_clone >/dev/null; then
+    echo "retry_git_clone not defined; falling back to plain git clone (no retries)"
+    retry_git_clone() { git clone "$@"; }
 fi
 
 cat /etc/os-release

--- a/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/cluster-density-ms/cloud-bulldozer-e2e-benchmarking-cluster-density-ms-commands.sh
+++ b/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/cluster-density-ms/cloud-bulldozer-e2e-benchmarking-cluster-density-ms-commands.sh
@@ -3,6 +3,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 set -x
+
+# Source shared retry library if available
+if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
+    source "${SHARED_DIR}/retry-lib.sh"
+fi
+
 cat /etc/os-release
 oc config view
 oc projects
@@ -10,7 +16,7 @@ pushd /tmp
 
 
 if [[ "$JOB_TYPE" == "presubmit" ]] && [[ "$REPO_OWNER" = "cloud-bulldozer" ]] && [[ "$REPO_NAME" = "e2e-benchmarking" ]]; then
-    git clone https://github.com/${REPO_OWNER}/${REPO_NAME}
+    retry_git_clone https://github.com/${REPO_OWNER}/${REPO_NAME}
     pushd ${REPO_NAME}
     git config --global user.email "ocp-perfscale@redhat.com"
     git config --global user.name "ocp-perfscale"

--- a/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/cluster-density-v2/cloud-bulldozer-e2e-benchmarking-cluster-density-v2-commands.sh
+++ b/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/cluster-density-v2/cloud-bulldozer-e2e-benchmarking-cluster-density-v2-commands.sh
@@ -7,6 +7,14 @@ set -x
 # Source shared retry library if available
 if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
     source "${SHARED_DIR}/retry-lib.sh"
+else
+    echo "retry-lib.sh not found in ${SHARED_DIR}"
+fi
+
+# Guarantee fallback
+if ! declare -F retry_git_clone >/dev/null; then
+    echo "retry_git_clone not defined; falling back to plain git clone (no retries)"
+    retry_git_clone() { git clone "$@"; }
 fi
 
 cat /etc/os-release

--- a/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/cluster-density-v2/cloud-bulldozer-e2e-benchmarking-cluster-density-v2-commands.sh
+++ b/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/cluster-density-v2/cloud-bulldozer-e2e-benchmarking-cluster-density-v2-commands.sh
@@ -3,6 +3,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 set -x
+
+# Source shared retry library if available
+if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
+    source "${SHARED_DIR}/retry-lib.sh"
+fi
+
 cat /etc/os-release
 oc config view
 oc projects
@@ -10,7 +16,7 @@ pushd /tmp
 
 
 if [[ "$JOB_TYPE" == "presubmit" ]] && [[ "$REPO_OWNER" = "cloud-bulldozer" ]] && [[ "$REPO_NAME" = "e2e-benchmarking" ]]; then
-    git clone https://github.com/${REPO_OWNER}/${REPO_NAME}
+    retry_git_clone https://github.com/${REPO_OWNER}/${REPO_NAME}
     pushd ${REPO_NAME}
     git config --global user.email "ocp-perfscale@redhat.com"
     git config --global user.name "ocp-perfscale"

--- a/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/conc-builds/cloud-bulldozer-e2e-benchmarking-conc-builds-commands.sh
+++ b/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/conc-builds/cloud-bulldozer-e2e-benchmarking-conc-builds-commands.sh
@@ -7,6 +7,14 @@ set -x
 # Source shared retry library if available
 if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
     source "${SHARED_DIR}/retry-lib.sh"
+else
+    echo "retry-lib.sh not found in ${SHARED_DIR}"
+fi
+
+# Guarantee fallback
+if ! declare -F retry_git_clone >/dev/null; then
+    echo "retry_git_clone not defined; falling back to plain git clone (no retries)"
+    retry_git_clone() { git clone "$@"; }
 fi
 
 cat /etc/os-release

--- a/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/conc-builds/cloud-bulldozer-e2e-benchmarking-conc-builds-commands.sh
+++ b/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/conc-builds/cloud-bulldozer-e2e-benchmarking-conc-builds-commands.sh
@@ -3,6 +3,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 set -x
+
+# Source shared retry library if available
+if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
+    source "${SHARED_DIR}/retry-lib.sh"
+fi
+
 cat /etc/os-release
 oc config view
 oc projects
@@ -10,7 +16,7 @@ pushd /tmp
 
 
 if [[ "$JOB_TYPE" == "presubmit" ]] && [[ "$REPO_OWNER" = "cloud-bulldozer" ]] && [[ "$REPO_NAME" = "e2e-benchmarking" ]]; then
-    git clone https://github.com/${REPO_OWNER}/${REPO_NAME}
+    retry_git_clone https://github.com/${REPO_OWNER}/${REPO_NAME}
     pushd ${REPO_NAME}
     git config --global user.email "ocp-perfscale@redhat.com"
     git config --global user.name "ocp-perfscale"

--- a/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/crd-scale/cloud-bulldozer-e2e-benchmarking-crd-scale-commands.sh
+++ b/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/crd-scale/cloud-bulldozer-e2e-benchmarking-crd-scale-commands.sh
@@ -7,6 +7,14 @@ set -x
 # Source shared retry library if available
 if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
     source "${SHARED_DIR}/retry-lib.sh"
+else
+    echo "retry-lib.sh not found in ${SHARED_DIR}"
+fi
+
+# Guarantee fallback
+if ! declare -F retry_git_clone >/dev/null; then
+    echo "retry_git_clone not defined; falling back to plain git clone (no retries)"
+    retry_git_clone() { git clone "$@"; }
 fi
 
 cat /etc/os-release

--- a/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/crd-scale/cloud-bulldozer-e2e-benchmarking-crd-scale-commands.sh
+++ b/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/crd-scale/cloud-bulldozer-e2e-benchmarking-crd-scale-commands.sh
@@ -3,6 +3,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 set -x
+
+# Source shared retry library if available
+if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
+    source "${SHARED_DIR}/retry-lib.sh"
+fi
+
 cat /etc/os-release
 oc config view
 oc projects
@@ -10,7 +16,7 @@ pushd /tmp
 
 
 if [[ "$JOB_TYPE" == "presubmit" ]] && [[ "$REPO_OWNER" = "cloud-bulldozer" ]] && [[ "$REPO_NAME" = "e2e-benchmarking" ]]; then
-    git clone https://github.com/${REPO_OWNER}/${REPO_NAME}
+    retry_git_clone https://github.com/${REPO_OWNER}/${REPO_NAME}
     pushd ${REPO_NAME}
     git config --global user.email "ocp-perfscale@redhat.com"
     git config --global user.name "ocp-perfscale"

--- a/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/egressip/cloud-bulldozer-e2e-benchmarking-egressip-commands.sh
+++ b/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/egressip/cloud-bulldozer-e2e-benchmarking-egressip-commands.sh
@@ -3,13 +3,19 @@ set -o errexit
 set -o nounset
 set -o pipefail
 set -x
+
+# Source shared retry library if available
+if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
+    source "${SHARED_DIR}/retry-lib.sh"
+fi
+
 cat /etc/os-release
 oc config view
 oc projects
 pushd /tmp
 
 if [[ "$JOB_TYPE" == "presubmit" ]] && [[ "$REPO_OWNER" = "cloud-bulldozer" ]] && [[ "$REPO_NAME" = "e2e-benchmarking" ]]; then
-    git clone https://github.com/${REPO_OWNER}/${REPO_NAME}
+    retry_git_clone https://github.com/${REPO_OWNER}/${REPO_NAME}
     pushd ${REPO_NAME}
     git config --global user.email "ocp-perfscale@redhat.com"
     git config --global user.name "ocp-perfscale"

--- a/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/egressip/cloud-bulldozer-e2e-benchmarking-egressip-commands.sh
+++ b/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/egressip/cloud-bulldozer-e2e-benchmarking-egressip-commands.sh
@@ -7,6 +7,14 @@ set -x
 # Source shared retry library if available
 if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
     source "${SHARED_DIR}/retry-lib.sh"
+else
+    echo "retry-lib.sh not found in ${SHARED_DIR}"
+fi
+
+# Guarantee fallback
+if ! declare -F retry_git_clone >/dev/null; then
+    echo "retry_git_clone not defined; falling back to plain git clone (no retries)"
+    retry_git_clone() { git clone "$@"; }
 fi
 
 cat /etc/os-release

--- a/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/ingress-perf/cloud-bulldozer-e2e-benchmarking-ingress-perf-commands.sh
+++ b/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/ingress-perf/cloud-bulldozer-e2e-benchmarking-ingress-perf-commands.sh
@@ -7,6 +7,14 @@ set -x
 # Source shared retry library if available
 if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
     source "${SHARED_DIR}/retry-lib.sh"
+else
+    echo "retry-lib.sh not found in ${SHARED_DIR}"
+fi
+
+# Guarantee fallback
+if ! declare -F retry_git_clone >/dev/null; then
+    echo "retry_git_clone not defined; falling back to plain git clone (no retries)"
+    retry_git_clone() { git clone "$@"; }
 fi
 
 cat /etc/os-release

--- a/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/ingress-perf/cloud-bulldozer-e2e-benchmarking-ingress-perf-commands.sh
+++ b/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/ingress-perf/cloud-bulldozer-e2e-benchmarking-ingress-perf-commands.sh
@@ -3,6 +3,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 set -x
+
+# Source shared retry library if available
+if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
+    source "${SHARED_DIR}/retry-lib.sh"
+fi
+
 cat /etc/os-release
 oc config view
 oc projects
@@ -10,7 +16,7 @@ pushd /tmp
 
 
 if [[ "$JOB_TYPE" == "presubmit" ]] && [[ "$REPO_OWNER" = "cloud-bulldozer" ]] && [[ "$REPO_NAME" = "e2e-benchmarking" ]]; then
-    git clone https://github.com/${REPO_OWNER}/${REPO_NAME}
+    retry_git_clone https://github.com/${REPO_OWNER}/${REPO_NAME}
     pushd ${REPO_NAME}
     git config --global user.email "ocp-perfscale@redhat.com"
     git config --global user.name "ocp-perfscale"

--- a/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/network-policy/cloud-bulldozer-e2e-benchmarking-network-policy-commands.sh
+++ b/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/network-policy/cloud-bulldozer-e2e-benchmarking-network-policy-commands.sh
@@ -7,6 +7,14 @@ set -x
 # Source shared retry library if available
 if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
     source "${SHARED_DIR}/retry-lib.sh"
+else
+    echo "retry-lib.sh not found in ${SHARED_DIR}"
+fi
+
+# Guarantee fallback
+if ! declare -F retry_git_clone >/dev/null; then
+    echo "retry_git_clone not defined; falling back to plain git clone (no retries)"
+    retry_git_clone() { git clone "$@"; }
 fi
 
 cat /etc/os-release

--- a/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/network-policy/cloud-bulldozer-e2e-benchmarking-network-policy-commands.sh
+++ b/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/network-policy/cloud-bulldozer-e2e-benchmarking-network-policy-commands.sh
@@ -3,6 +3,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 set -x
+
+# Source shared retry library if available
+if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
+    source "${SHARED_DIR}/retry-lib.sh"
+fi
+
 cat /etc/os-release
 oc config view
 oc projects
@@ -10,7 +16,7 @@ pushd /tmp
 
 
 if [[ "$JOB_TYPE" == "presubmit" ]] && [[ "$REPO_OWNER" = "cloud-bulldozer" ]] && [[ "$REPO_NAME" = "e2e-benchmarking" ]]; then
-    git clone https://github.com/${REPO_OWNER}/${REPO_NAME}
+    retry_git_clone https://github.com/${REPO_OWNER}/${REPO_NAME}
     pushd ${REPO_NAME}
     git config --global user.email "ocp-perfscale@redhat.com"
     git config --global user.name "ocp-perfscale"

--- a/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/network-smoke/cloud-bulldozer-e2e-benchmarking-network-smoke-commands.sh
+++ b/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/network-smoke/cloud-bulldozer-e2e-benchmarking-network-smoke-commands.sh
@@ -7,6 +7,14 @@ set -x
 # Source shared retry library if available
 if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
     source "${SHARED_DIR}/retry-lib.sh"
+else
+    echo "retry-lib.sh not found in ${SHARED_DIR}"
+fi
+
+# Guarantee fallback
+if ! declare -F retry_git_clone >/dev/null; then
+    echo "retry_git_clone not defined; falling back to plain git clone (no retries)"
+    retry_git_clone() { git clone "$@"; }
 fi
 
 cat /etc/os-release

--- a/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/network-smoke/cloud-bulldozer-e2e-benchmarking-network-smoke-commands.sh
+++ b/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/network-smoke/cloud-bulldozer-e2e-benchmarking-network-smoke-commands.sh
@@ -3,6 +3,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 set -x
+
+# Source shared retry library if available
+if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
+    source "${SHARED_DIR}/retry-lib.sh"
+fi
+
 cat /etc/os-release
 oc config view
 oc projects
@@ -10,7 +16,7 @@ pushd /tmp
 
 
 if [[ "$JOB_TYPE" == "presubmit" ]] && [[ "$REPO_OWNER" = "cloud-bulldozer" ]] && [[ "$REPO_NAME" = "e2e-benchmarking" ]]; then
-    git clone https://github.com/${REPO_OWNER}/${REPO_NAME}
+    retry_git_clone https://github.com/${REPO_OWNER}/${REPO_NAME}
     pushd ${REPO_NAME}
     git config --global user.email "ocp-perfscale@redhat.com"
     git config --global user.name "ocp-perfscale"

--- a/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/networkpolicy-matchexpressions/cloud-bulldozer-e2e-benchmarking-networkpolicy-matchexpressions-commands.sh
+++ b/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/networkpolicy-matchexpressions/cloud-bulldozer-e2e-benchmarking-networkpolicy-matchexpressions-commands.sh
@@ -7,6 +7,14 @@ set -x
 # Source shared retry library if available
 if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
     source "${SHARED_DIR}/retry-lib.sh"
+else
+    echo "retry-lib.sh not found in ${SHARED_DIR}"
+fi
+
+# Guarantee fallback
+if ! declare -F retry_git_clone >/dev/null; then
+    echo "retry_git_clone not defined; falling back to plain git clone (no retries)"
+    retry_git_clone() { git clone "$@"; }
 fi
 
 cat /etc/os-release

--- a/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/networkpolicy-matchexpressions/cloud-bulldozer-e2e-benchmarking-networkpolicy-matchexpressions-commands.sh
+++ b/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/networkpolicy-matchexpressions/cloud-bulldozer-e2e-benchmarking-networkpolicy-matchexpressions-commands.sh
@@ -3,6 +3,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 set -x
+
+# Source shared retry library if available
+if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
+    source "${SHARED_DIR}/retry-lib.sh"
+fi
+
 cat /etc/os-release
 oc config view
 oc projects
@@ -10,7 +16,7 @@ pushd /tmp
 
 
 if [[ "$JOB_TYPE" == "presubmit" ]] && [[ "$REPO_OWNER" = "cloud-bulldozer" ]] && [[ "$REPO_NAME" = "e2e-benchmarking" ]]; then
-    git clone https://github.com/${REPO_OWNER}/${REPO_NAME}
+    retry_git_clone https://github.com/${REPO_OWNER}/${REPO_NAME}
     pushd ${REPO_NAME}
     git config --global user.email "ocp-perfscale@redhat.com"
     git config --global user.name "ocp-perfscale"

--- a/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/networkpolicy-matchlabels/cloud-bulldozer-e2e-benchmarking-networkpolicy-matchlabels-commands.sh
+++ b/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/networkpolicy-matchlabels/cloud-bulldozer-e2e-benchmarking-networkpolicy-matchlabels-commands.sh
@@ -7,6 +7,14 @@ set -x
 # Source shared retry library if available
 if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
     source "${SHARED_DIR}/retry-lib.sh"
+else
+    echo "retry-lib.sh not found in ${SHARED_DIR}"
+fi
+
+# Guarantee fallback
+if ! declare -F retry_git_clone >/dev/null; then
+    echo "retry_git_clone not defined; falling back to plain git clone (no retries)"
+    retry_git_clone() { git clone "$@"; }
 fi
 
 cat /etc/os-release

--- a/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/networkpolicy-matchlabels/cloud-bulldozer-e2e-benchmarking-networkpolicy-matchlabels-commands.sh
+++ b/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/networkpolicy-matchlabels/cloud-bulldozer-e2e-benchmarking-networkpolicy-matchlabels-commands.sh
@@ -3,6 +3,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 set -x
+
+# Source shared retry library if available
+if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
+    source "${SHARED_DIR}/retry-lib.sh"
+fi
+
 cat /etc/os-release
 oc config view
 oc projects
@@ -10,7 +16,7 @@ pushd /tmp
 
 
 if [[ "$JOB_TYPE" == "presubmit" ]] && [[ "$REPO_OWNER" = "cloud-bulldozer" ]] && [[ "$REPO_NAME" = "e2e-benchmarking" ]]; then
-    git clone https://github.com/${REPO_OWNER}/${REPO_NAME}
+    retry_git_clone https://github.com/${REPO_OWNER}/${REPO_NAME}
     pushd ${REPO_NAME}
     git config --global user.email "ocp-perfscale@redhat.com"
     git config --global user.name "ocp-perfscale"

--- a/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/networkpolicy-multitenant/cloud-bulldozer-e2e-benchmarking-networkpolicy-multitenant-commands.sh
+++ b/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/networkpolicy-multitenant/cloud-bulldozer-e2e-benchmarking-networkpolicy-multitenant-commands.sh
@@ -7,6 +7,14 @@ set -x
 # Source shared retry library if available
 if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
     source "${SHARED_DIR}/retry-lib.sh"
+else
+    echo "retry-lib.sh not found in ${SHARED_DIR}"
+fi
+
+# Guarantee fallback
+if ! declare -F retry_git_clone >/dev/null; then
+    echo "retry_git_clone not defined; falling back to plain git clone (no retries)"
+    retry_git_clone() { git clone "$@"; }
 fi
 
 cat /etc/os-release

--- a/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/networkpolicy-multitenant/cloud-bulldozer-e2e-benchmarking-networkpolicy-multitenant-commands.sh
+++ b/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/networkpolicy-multitenant/cloud-bulldozer-e2e-benchmarking-networkpolicy-multitenant-commands.sh
@@ -3,6 +3,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 set -x
+
+# Source shared retry library if available
+if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
+    source "${SHARED_DIR}/retry-lib.sh"
+fi
+
 cat /etc/os-release
 oc config view
 oc projects
@@ -10,7 +16,7 @@ pushd /tmp
 
 
 if [[ "$JOB_TYPE" == "presubmit" ]] && [[ "$REPO_OWNER" = "cloud-bulldozer" ]] && [[ "$REPO_NAME" = "e2e-benchmarking" ]]; then
-    git clone https://github.com/${REPO_OWNER}/${REPO_NAME}
+    retry_git_clone https://github.com/${REPO_OWNER}/${REPO_NAME}
     pushd ${REPO_NAME}
     git config --global user.email "ocp-perfscale@redhat.com"
     git config --global user.name "ocp-perfscale"

--- a/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/node-density-cni/cloud-bulldozer-e2e-benchmarking-node-density-cni-commands.sh
+++ b/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/node-density-cni/cloud-bulldozer-e2e-benchmarking-node-density-cni-commands.sh
@@ -7,6 +7,14 @@ set -x
 # Source shared retry library if available
 if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
     source "${SHARED_DIR}/retry-lib.sh"
+else
+    echo "retry-lib.sh not found in ${SHARED_DIR}"
+fi
+
+# Guarantee fallback
+if ! declare -F retry_git_clone >/dev/null; then
+    echo "retry_git_clone not defined; falling back to plain git clone (no retries)"
+    retry_git_clone() { git clone "$@"; }
 fi
 
 cat /etc/os-release

--- a/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/node-density-cni/cloud-bulldozer-e2e-benchmarking-node-density-cni-commands.sh
+++ b/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/node-density-cni/cloud-bulldozer-e2e-benchmarking-node-density-cni-commands.sh
@@ -3,6 +3,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 set -x
+
+# Source shared retry library if available
+if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
+    source "${SHARED_DIR}/retry-lib.sh"
+fi
+
 cat /etc/os-release
 oc config view
 oc projects
@@ -10,7 +16,7 @@ pushd /tmp
 
 
 if [[ "$JOB_TYPE" == "presubmit" ]] && [[ "$REPO_OWNER" = "cloud-bulldozer" ]] && [[ "$REPO_NAME" = "e2e-benchmarking" ]]; then
-    git clone https://github.com/${REPO_OWNER}/${REPO_NAME}
+    retry_git_clone https://github.com/${REPO_OWNER}/${REPO_NAME}
     pushd ${REPO_NAME}
     git config --global user.email "ocp-perfscale@redhat.com"
     git config --global user.name "ocp-perfscale"

--- a/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/node-density-heavy/cloud-bulldozer-e2e-benchmarking-node-density-heavy-commands.sh
+++ b/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/node-density-heavy/cloud-bulldozer-e2e-benchmarking-node-density-heavy-commands.sh
@@ -7,6 +7,14 @@ set -x
 # Source shared retry library if available
 if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
     source "${SHARED_DIR}/retry-lib.sh"
+else
+    echo "retry-lib.sh not found in ${SHARED_DIR}"
+fi
+
+# Guarantee fallback
+if ! declare -F retry_git_clone >/dev/null; then
+    echo "retry_git_clone not defined; falling back to plain git clone (no retries)"
+    retry_git_clone() { git clone "$@"; }
 fi
 
 cat /etc/os-release

--- a/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/node-density-heavy/cloud-bulldozer-e2e-benchmarking-node-density-heavy-commands.sh
+++ b/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/node-density-heavy/cloud-bulldozer-e2e-benchmarking-node-density-heavy-commands.sh
@@ -3,6 +3,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 set -x
+
+# Source shared retry library if available
+if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
+    source "${SHARED_DIR}/retry-lib.sh"
+fi
+
 cat /etc/os-release
 oc config view
 oc projects
@@ -10,7 +16,7 @@ pushd /tmp
 
 
 if [[ "$JOB_TYPE" == "presubmit" ]] && [[ "$REPO_OWNER" = "cloud-bulldozer" ]] && [[ "$REPO_NAME" = "e2e-benchmarking" ]]; then
-    git clone https://github.com/${REPO_OWNER}/${REPO_NAME}
+    retry_git_clone https://github.com/${REPO_OWNER}/${REPO_NAME}
     pushd ${REPO_NAME}
     git config --global user.email "ocp-perfscale@redhat.com"
     git config --global user.name "ocp-perfscale"

--- a/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/node-density/cloud-bulldozer-e2e-benchmarking-node-density-commands.sh
+++ b/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/node-density/cloud-bulldozer-e2e-benchmarking-node-density-commands.sh
@@ -7,6 +7,14 @@ set -x
 # Source shared retry library if available
 if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
     source "${SHARED_DIR}/retry-lib.sh"
+else
+    echo "retry-lib.sh not found in ${SHARED_DIR}"
+fi
+
+# Guarantee fallback
+if ! declare -F retry_git_clone >/dev/null; then
+    echo "retry_git_clone not defined; falling back to plain git clone (no retries)"
+    retry_git_clone() { git clone "$@"; }
 fi
 
 cat /etc/os-release

--- a/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/node-density/cloud-bulldozer-e2e-benchmarking-node-density-commands.sh
+++ b/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/node-density/cloud-bulldozer-e2e-benchmarking-node-density-commands.sh
@@ -3,6 +3,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 set -x
+
+# Source shared retry library if available
+if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
+    source "${SHARED_DIR}/retry-lib.sh"
+fi
+
 cat /etc/os-release
 oc config view
 oc projects
@@ -10,7 +16,7 @@ pushd /tmp
 
 
 if [[ "$JOB_TYPE" == "presubmit" ]] && [[ "$REPO_OWNER" = "cloud-bulldozer" ]] && [[ "$REPO_NAME" = "e2e-benchmarking" ]]; then
-    git clone https://github.com/${REPO_OWNER}/${REPO_NAME}
+    retry_git_clone https://github.com/${REPO_OWNER}/${REPO_NAME}
     pushd ${REPO_NAME}
     git config --global user.email "ocp-perfscale@redhat.com"
     git config --global user.name "ocp-perfscale"

--- a/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/pvc-density/cloud-bulldozer-e2e-benchmarking-pvc-density-commands.sh
+++ b/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/pvc-density/cloud-bulldozer-e2e-benchmarking-pvc-density-commands.sh
@@ -7,6 +7,14 @@ set -x
 # Source shared retry library if available
 if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
     source "${SHARED_DIR}/retry-lib.sh"
+else
+    echo "retry-lib.sh not found in ${SHARED_DIR}"
+fi
+
+# Guarantee fallback
+if ! declare -F retry_git_clone >/dev/null; then
+    echo "retry_git_clone not defined; falling back to plain git clone (no retries)"
+    retry_git_clone() { git clone "$@"; }
 fi
 
 cat /etc/os-release

--- a/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/pvc-density/cloud-bulldozer-e2e-benchmarking-pvc-density-commands.sh
+++ b/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/pvc-density/cloud-bulldozer-e2e-benchmarking-pvc-density-commands.sh
@@ -3,6 +3,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 set -x
+
+# Source shared retry library if available
+if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
+    source "${SHARED_DIR}/retry-lib.sh"
+fi
+
 cat /etc/os-release
 oc config view
 oc projects
@@ -10,7 +16,7 @@ pushd /tmp
 
 
 if [[ "$JOB_TYPE" == "presubmit" ]] && [[ "$REPO_OWNER" = "cloud-bulldozer" ]] && [[ "$REPO_NAME" = "e2e-benchmarking" ]]; then
-    git clone https://github.com/${REPO_OWNER}/${REPO_NAME}
+    retry_git_clone https://github.com/${REPO_OWNER}/${REPO_NAME}
     pushd ${REPO_NAME}
     git config --global user.email "ocp-perfscale@redhat.com"
     git config --global user.name "ocp-perfscale"

--- a/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/rds-core/cloud-bulldozer-e2e-benchmarking-rds-core-commands.sh
+++ b/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/rds-core/cloud-bulldozer-e2e-benchmarking-rds-core-commands.sh
@@ -3,6 +3,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 set -x
+
+# Source shared retry library if available
+if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
+    source "${SHARED_DIR}/retry-lib.sh"
+fi
+
 cat /etc/os-release
 oc config view
 oc projects
@@ -26,7 +32,7 @@ if [[ "$JOB_TYPE" == "presubmit" ]] && [[ "$REPO_OWNER" = "cloud-bulldozer" ]] &
       export http_proxy=socks5://localhost:12345
       oc --kubeconfig="$KUBECONFIG" config set-cluster bm --proxy-url=socks5://localhost:12345
     fi
-    git clone https://github.com/${REPO_OWNER}/${REPO_NAME}
+    retry_git_clone https://github.com/${REPO_OWNER}/${REPO_NAME}
     pushd ${REPO_NAME}
     git config --global user.email "ocp-perfscale@redhat.com"
     git config --global user.name "ocp-perfscale"

--- a/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/rds-core/cloud-bulldozer-e2e-benchmarking-rds-core-commands.sh
+++ b/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/rds-core/cloud-bulldozer-e2e-benchmarking-rds-core-commands.sh
@@ -7,6 +7,14 @@ set -x
 # Source shared retry library if available
 if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
     source "${SHARED_DIR}/retry-lib.sh"
+else
+    echo "retry-lib.sh not found in ${SHARED_DIR}"
+fi
+
+# Guarantee fallback
+if ! declare -F retry_git_clone >/dev/null; then
+    echo "retry_git_clone not defined; falling back to plain git clone (no retries)"
+    retry_git_clone() { git clone "$@"; }
 fi
 
 cat /etc/os-release

--- a/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/router-perf/cloud-bulldozer-e2e-benchmarking-router-perf-commands.sh
+++ b/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/router-perf/cloud-bulldozer-e2e-benchmarking-router-perf-commands.sh
@@ -7,6 +7,14 @@ set -x
 # Source shared retry library if available
 if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
     source "${SHARED_DIR}/retry-lib.sh"
+else
+    echo "retry-lib.sh not found in ${SHARED_DIR}"
+fi
+
+# Guarantee fallback
+if ! declare -F retry_git_clone >/dev/null; then
+    echo "retry_git_clone not defined; falling back to plain git clone (no retries)"
+    retry_git_clone() { git clone "$@"; }
 fi
 
 cat /etc/os-release

--- a/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/router-perf/cloud-bulldozer-e2e-benchmarking-router-perf-commands.sh
+++ b/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/router-perf/cloud-bulldozer-e2e-benchmarking-router-perf-commands.sh
@@ -3,6 +3,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 set -x
+
+# Source shared retry library if available
+if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
+    source "${SHARED_DIR}/retry-lib.sh"
+fi
+
 cat /etc/os-release
 oc config view
 oc projects
@@ -10,7 +16,7 @@ pushd /tmp
 
 
 if [[ "$JOB_TYPE" == "presubmit" ]] && [[ "$REPO_OWNER" = "cloud-bulldozer" ]] && [[ "$REPO_NAME" = "e2e-benchmarking" ]]; then
-    git clone https://github.com/${REPO_OWNER}/${REPO_NAME}
+    retry_git_clone https://github.com/${REPO_OWNER}/${REPO_NAME}
     pushd ${REPO_NAME}
     git config --global user.email "ocp-perfscale@redhat.com"
     git config --global user.name "ocp-perfscale"

--- a/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/udn-density-pods/cloud-bulldozer-e2e-benchmarking-udn-density-pods-commands.sh
+++ b/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/udn-density-pods/cloud-bulldozer-e2e-benchmarking-udn-density-pods-commands.sh
@@ -7,6 +7,14 @@ set -x
 # Source shared retry library if available
 if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
     source "${SHARED_DIR}/retry-lib.sh"
+else
+    echo "retry-lib.sh not found in ${SHARED_DIR}"
+fi
+
+# Guarantee fallback
+if ! declare -F retry_git_clone >/dev/null; then
+    echo "retry_git_clone not defined; falling back to plain git clone (no retries)"
+    retry_git_clone() { git clone "$@"; }
 fi
 
 cat /etc/os-release

--- a/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/udn-density-pods/cloud-bulldozer-e2e-benchmarking-udn-density-pods-commands.sh
+++ b/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/udn-density-pods/cloud-bulldozer-e2e-benchmarking-udn-density-pods-commands.sh
@@ -3,6 +3,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 set -x
+
+# Source shared retry library if available
+if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
+    source "${SHARED_DIR}/retry-lib.sh"
+fi
+
 cat /etc/os-release
 oc config view
 oc projects
@@ -10,7 +16,7 @@ pushd /tmp
 
 
 if [[ "$JOB_TYPE" == "presubmit" ]] && [[ "$REPO_OWNER" = "cloud-bulldozer" ]] && [[ "$REPO_NAME" = "e2e-benchmarking" ]]; then
-    git clone https://github.com/${REPO_OWNER}/${REPO_NAME}
+    retry_git_clone https://github.com/${REPO_OWNER}/${REPO_NAME}
     pushd ${REPO_NAME}
     git config --global user.email "ocp-perfscale@redhat.com"
     git config --global user.name "ocp-perfscale"

--- a/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/virt-density/cloud-bulldozer-e2e-benchmarking-virt-density-commands.sh
+++ b/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/virt-density/cloud-bulldozer-e2e-benchmarking-virt-density-commands.sh
@@ -3,13 +3,19 @@ set -o errexit
 set -o nounset
 set -o pipefail
 set -x
+
+# Source shared retry library if available
+if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
+    source "${SHARED_DIR}/retry-lib.sh"
+fi
+
 cat /etc/os-release
 oc config view
 oc projects
 pushd /tmp
 
 if [[ "$JOB_TYPE" == "presubmit" ]] && [[ "$REPO_OWNER" = "cloud-bulldozer" ]] && [[ "$REPO_NAME" = "e2e-benchmarking" ]]; then
-    git clone https://github.com/${REPO_OWNER}/${REPO_NAME}
+    retry_git_clone https://github.com/${REPO_OWNER}/${REPO_NAME}
     pushd ${REPO_NAME}
     git config --global user.email "ocp-perfscale@redhat.com"
     git config --global user.name "ocp-perfscale"

--- a/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/virt-density/cloud-bulldozer-e2e-benchmarking-virt-density-commands.sh
+++ b/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/virt-density/cloud-bulldozer-e2e-benchmarking-virt-density-commands.sh
@@ -7,6 +7,14 @@ set -x
 # Source shared retry library if available
 if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
     source "${SHARED_DIR}/retry-lib.sh"
+else
+    echo "retry-lib.sh not found in ${SHARED_DIR}"
+fi
+
+# Guarantee fallback
+if ! declare -F retry_git_clone >/dev/null; then
+    echo "retry_git_clone not defined; falling back to plain git clone (no retries)"
+    retry_git_clone() { git clone "$@"; }
 fi
 
 cat /etc/os-release

--- a/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/whereabouts/cloud-bulldozer-e2e-benchmarking-whereabouts-commands.sh
+++ b/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/whereabouts/cloud-bulldozer-e2e-benchmarking-whereabouts-commands.sh
@@ -7,6 +7,14 @@ set -x
 # Source shared retry library if available
 if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
     source "${SHARED_DIR}/retry-lib.sh"
+else
+    echo "retry-lib.sh not found in ${SHARED_DIR}"
+fi
+
+# Guarantee fallback
+if ! declare -F retry_git_clone >/dev/null; then
+    echo "retry_git_clone not defined; falling back to plain git clone (no retries)"
+    retry_git_clone() { git clone "$@"; }
 fi
 
 cat /etc/os-release

--- a/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/whereabouts/cloud-bulldozer-e2e-benchmarking-whereabouts-commands.sh
+++ b/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking/whereabouts/cloud-bulldozer-e2e-benchmarking-whereabouts-commands.sh
@@ -3,6 +3,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 set -x
+
+# Source shared retry library if available
+if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
+    source "${SHARED_DIR}/retry-lib.sh"
+fi
+
 cat /etc/os-release
 oc config view
 oc projects
@@ -10,7 +16,7 @@ pushd /tmp
 
 
 if [[ "$JOB_TYPE" == "presubmit" ]] && [[ "$REPO_OWNER" = "cloud-bulldozer" ]] && [[ "$REPO_NAME" = "e2e-benchmarking" ]]; then
-    git clone https://github.com/${REPO_OWNER}/${REPO_NAME}
+    retry_git_clone https://github.com/${REPO_OWNER}/${REPO_NAME}
     pushd ${REPO_NAME}
     git config --global user.email "ocp-perfscale@redhat.com"
     git config --global user.name "ocp-perfscale"

--- a/ci-operator/step-registry/openshift-qe/cluster-density-v2/observer/openshift-qe-cluster-density-v2-observer-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/cluster-density-v2/observer/openshift-qe-cluster-density-v2-observer-commands.sh
@@ -5,6 +5,12 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 set -x
+
+# Source shared retry library if available
+if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
+    source "${SHARED_DIR}/retry-lib.sh"
+fi
+
 ls
 
 function cd_cleanup() {
@@ -25,7 +31,7 @@ pushd /tmp
 REPO_URL="https://github.com/cloud-bulldozer/e2e-benchmarking";
 LATEST_TAG=$(curl -s "https://api.github.com/repos/cloud-bulldozer/e2e-benchmarking/releases/latest" | jq -r '.tag_name');
 TAG_OPTION="--branch $(if [ "$E2E_VERSION" == "default" ]; then echo "$LATEST_TAG"; else echo "$E2E_VERSION"; fi)";
-git clone $REPO_URL $TAG_OPTION --depth 1
+retry_git_clone $REPO_URL $TAG_OPTION --depth 1
 
 python -m virtualenv ./venv_qe
 source ./venv_qe/bin/activate

--- a/ci-operator/step-registry/openshift-qe/cluster-density-v2/observer/openshift-qe-cluster-density-v2-observer-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/cluster-density-v2/observer/openshift-qe-cluster-density-v2-observer-commands.sh
@@ -9,6 +9,14 @@ set -x
 # Source shared retry library if available
 if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
     source "${SHARED_DIR}/retry-lib.sh"
+else
+    echo "retry-lib.sh not found in ${SHARED_DIR}"
+fi
+
+# Guarantee fallback
+if ! declare -F retry_git_clone >/dev/null; then
+    echo "retry_git_clone not defined; falling back to plain git clone (no retries)"
+    retry_git_clone() { git clone "$@"; }
 fi
 
 ls

--- a/ci-operator/step-registry/openshift-qe/cluster-density-v2/openshift-qe-cluster-density-v2-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/cluster-density-v2/openshift-qe-cluster-density-v2-commands.sh
@@ -3,6 +3,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 set -x
+
+# Source shared retry library if available
+if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
+    source "${SHARED_DIR}/retry-lib.sh"
+fi
+
 cat /etc/os-release
 oc config view
 oc projects
@@ -52,7 +58,7 @@ fi
 REPO_URL="https://github.com/cloud-bulldozer/e2e-benchmarking";
 LATEST_TAG=$(curl -s "https://api.github.com/repos/cloud-bulldozer/e2e-benchmarking/releases/latest" | jq -r '.tag_name');
 TAG_OPTION="--branch $(if [ "$E2E_VERSION" == "default" ]; then echo "$LATEST_TAG"; else echo "$E2E_VERSION"; fi)";
-git clone $REPO_URL $TAG_OPTION --depth 1
+retry_git_clone $REPO_URL $TAG_OPTION --depth 1
 pushd e2e-benchmarking/workloads/kube-burner-ocp-wrapper
 export WORKLOAD=cluster-density-v2
 

--- a/ci-operator/step-registry/openshift-qe/cluster-density-v2/openshift-qe-cluster-density-v2-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/cluster-density-v2/openshift-qe-cluster-density-v2-commands.sh
@@ -7,6 +7,14 @@ set -x
 # Source shared retry library if available
 if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
     source "${SHARED_DIR}/retry-lib.sh"
+else
+    echo "retry-lib.sh not found in ${SHARED_DIR}"
+fi
+
+# Guarantee fallback
+if ! declare -F retry_git_clone >/dev/null; then
+    echo "retry_git_clone not defined; falling back to plain git clone (no retries)"
+    retry_git_clone() { git clone "$@"; }
 fi
 
 cat /etc/os-release

--- a/ci-operator/step-registry/openshift-qe/conc-builds/openshift-qe-conc-builds-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/conc-builds/openshift-qe-conc-builds-commands.sh
@@ -3,6 +3,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 set -x
+
+# Source shared retry library if available
+if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
+    source "${SHARED_DIR}/retry-lib.sh"
+fi
+
 cat /etc/os-release
 oc config view
 oc projects
@@ -19,7 +25,7 @@ export KUBE_BURNER_URL="https://github.com/cloud-bulldozer/kube-burner/releases/
 REPO_URL="https://github.com/cloud-bulldozer/e2e-benchmarking";
 LATEST_TAG=$(curl -s "https://api.github.com/repos/cloud-bulldozer/e2e-benchmarking/releases/latest" | jq -r '.tag_name');
 TAG_OPTION="--branch $(if [ "$E2E_VERSION" == "default" ]; then echo "$LATEST_TAG"; else echo "$E2E_VERSION"; fi)";
-git clone $REPO_URL $TAG_OPTION --depth 1
+retry_git_clone $REPO_URL $TAG_OPTION --depth 1
 pushd e2e-benchmarking/workloads/kube-burner
 export WORKLOAD=concurrent-builds
 

--- a/ci-operator/step-registry/openshift-qe/conc-builds/openshift-qe-conc-builds-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/conc-builds/openshift-qe-conc-builds-commands.sh
@@ -7,6 +7,14 @@ set -x
 # Source shared retry library if available
 if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
     source "${SHARED_DIR}/retry-lib.sh"
+else
+    echo "retry-lib.sh not found in ${SHARED_DIR}"
+fi
+
+# Guarantee fallback
+if ! declare -F retry_git_clone >/dev/null; then
+    echo "retry_git_clone not defined; falling back to plain git clone (no retries)"
+    retry_git_clone() { git clone "$@"; }
 fi
 
 cat /etc/os-release

--- a/ci-operator/step-registry/openshift-qe/crd-scale/openshift-qe-crd-scale-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/crd-scale/openshift-qe-crd-scale-commands.sh
@@ -7,6 +7,14 @@ set -x
 # Source shared retry library if available
 if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
     source "${SHARED_DIR}/retry-lib.sh"
+else
+    echo "retry-lib.sh not found in ${SHARED_DIR}"
+fi
+
+# Guarantee fallback
+if ! declare -F retry_git_clone >/dev/null; then
+    echo "retry_git_clone not defined; falling back to plain git clone (no retries)"
+    retry_git_clone() { git clone "$@"; }
 fi
 
 cat /etc/os-release

--- a/ci-operator/step-registry/openshift-qe/crd-scale/openshift-qe-crd-scale-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/crd-scale/openshift-qe-crd-scale-commands.sh
@@ -3,6 +3,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 set -x
+
+# Source shared retry library if available
+if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
+    source "${SHARED_DIR}/retry-lib.sh"
+fi
+
 cat /etc/os-release
 oc config view
 oc projects
@@ -51,7 +57,7 @@ fi
 REPO_URL="https://github.com/cloud-bulldozer/e2e-benchmarking";
 LATEST_TAG=$(curl -s "https://api.github.com/repos/cloud-bulldozer/e2e-benchmarking/releases/latest" | jq -r '.tag_name');
 TAG_OPTION="--branch $(if [ "$E2E_VERSION" == "default" ]; then echo "$LATEST_TAG"; else echo "$E2E_VERSION"; fi)";
-git clone $REPO_URL $TAG_OPTION --depth 1
+retry_git_clone $REPO_URL $TAG_OPTION --depth 1
 pushd e2e-benchmarking/workloads/kube-burner-ocp-wrapper
 export WORKLOAD=crd-scale
 

--- a/ci-operator/step-registry/openshift-qe/ingress-perf/openshift-qe-ingress-perf-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/ingress-perf/openshift-qe-ingress-perf-commands.sh
@@ -4,6 +4,11 @@ set -o nounset
 set -o pipefail
 set -x
 
+# Source shared retry library if available
+if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
+    source "${SHARED_DIR}/retry-lib.sh"
+fi
+
 cat /etc/os-release
 
 # For disconnected or otherwise unreachable environments, we want to
@@ -30,7 +35,7 @@ ES_USERNAME=$(cat "/secret/username")
 REPO_URL="https://github.com/cloud-bulldozer/e2e-benchmarking";
 LATEST_TAG=$(curl -s "https://api.github.com/repos/cloud-bulldozer/e2e-benchmarking/releases/latest" | jq -r '.tag_name');
 TAG_OPTION="--branch $(if [ "$E2E_VERSION" == "default" ]; then echo "$LATEST_TAG"; else echo "$E2E_VERSION"; fi)";
-git clone $REPO_URL $TAG_OPTION --depth 1
+retry_git_clone $REPO_URL $TAG_OPTION --depth 1
 pushd e2e-benchmarking/workloads/ingress-perf
 
 # ES Configuration

--- a/ci-operator/step-registry/openshift-qe/ingress-perf/openshift-qe-ingress-perf-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/ingress-perf/openshift-qe-ingress-perf-commands.sh
@@ -7,6 +7,14 @@ set -x
 # Source shared retry library if available
 if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
     source "${SHARED_DIR}/retry-lib.sh"
+else
+    echo "retry-lib.sh not found in ${SHARED_DIR}"
+fi
+
+# Guarantee fallback
+if ! declare -F retry_git_clone >/dev/null; then
+    echo "retry_git_clone not defined; falling back to plain git clone (no retries)"
+    retry_git_clone() { git clone "$@"; }
 fi
 
 cat /etc/os-release

--- a/ci-operator/step-registry/openshift-qe/kube-burner-index/openshift-qe-kube-burner-index-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/kube-burner-index/openshift-qe-kube-burner-index-commands.sh
@@ -3,6 +3,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 set -x
+
+# Source shared retry library if available
+if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
+    source "${SHARED_DIR}/retry-lib.sh"
+fi
+
 cat /etc/os-release
 oc config view
 oc projects
@@ -17,7 +23,7 @@ ES_USERNAME=$(cat "/secret/username")
 REPO_URL="https://github.com/cloud-bulldozer/e2e-benchmarking";
 LATEST_TAG=$(curl -s "https://api.github.com/repos/cloud-bulldozer/e2e-benchmarking/releases/latest" | jq -r '.tag_name');
 TAG_OPTION="--branch $(if [ "$E2E_VERSION" == "default" ]; then echo "$LATEST_TAG"; else echo "$E2E_VERSION"; fi)";
-git clone $REPO_URL $TAG_OPTION --depth 1
+retry_git_clone $REPO_URL $TAG_OPTION --depth 1
 pushd e2e-benchmarking/workloads/kube-burner-ocp-wrapper
 export WORKLOAD=index
 

--- a/ci-operator/step-registry/openshift-qe/kube-burner-index/openshift-qe-kube-burner-index-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/kube-burner-index/openshift-qe-kube-burner-index-commands.sh
@@ -7,6 +7,14 @@ set -x
 # Source shared retry library if available
 if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
     source "${SHARED_DIR}/retry-lib.sh"
+else
+    echo "retry-lib.sh not found in ${SHARED_DIR}"
+fi
+
+# Guarantee fallback
+if ! declare -F retry_git_clone >/dev/null; then
+    echo "retry_git_clone not defined; falling back to plain git clone (no retries)"
+    retry_git_clone() { git clone "$@"; }
 fi
 
 cat /etc/os-release

--- a/ci-operator/step-registry/openshift-qe/kube-burner-ingress-perf/openshift-qe-kube-burner-ingress-perf-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/kube-burner-ingress-perf/openshift-qe-kube-burner-ingress-perf-commands.sh
@@ -5,6 +5,11 @@ set -o errexit
 set -o pipefail
 set -x
 
+# Source shared retry library if available
+if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
+    source "${SHARED_DIR}/retry-lib.sh"
+fi
+
 python --version
 pushd /tmp
 python -m virtualenv ./venv_qe
@@ -22,7 +27,7 @@ export GSHEET_KEY_LOCATION
 REPO_URL="https://github.com/cloud-bulldozer/e2e-benchmarking";
 LATEST_TAG=$(curl -s "https://api.github.com/repos/cloud-bulldozer/e2e-benchmarking/releases/latest" | jq -r '.tag_name');
 TAG_OPTION="--branch $(if [ "$E2E_VERSION" == "default" ]; then echo "$LATEST_TAG"; else echo "$E2E_VERSION"; fi)";
-git clone $REPO_URL $TAG_OPTION --depth 1
+retry_git_clone $REPO_URL $TAG_OPTION --depth 1
 pushd e2e-benchmarking/workloads/kube-burner-ocp-wrapper
 
 export ES_SERVER="https://$ES_USERNAME:$ES_PASSWORD@search-ocp-qe-perf-scale-test-elk-hcm7wtsqpxy7xogbu72bor4uve.us-east-1.es.amazonaws.com"

--- a/ci-operator/step-registry/openshift-qe/kube-burner-ingress-perf/openshift-qe-kube-burner-ingress-perf-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/kube-burner-ingress-perf/openshift-qe-kube-burner-ingress-perf-commands.sh
@@ -8,6 +8,14 @@ set -x
 # Source shared retry library if available
 if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
     source "${SHARED_DIR}/retry-lib.sh"
+else
+    echo "retry-lib.sh not found in ${SHARED_DIR}"
+fi
+
+# Guarantee fallback
+if ! declare -F retry_git_clone >/dev/null; then
+    echo "retry_git_clone not defined; falling back to plain git clone (no retries)"
+    retry_git_clone() { git clone "$@"; }
 fi
 
 python --version

--- a/ci-operator/step-registry/openshift-qe/kueue-operator/openshift-qe-kueue-operator-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/kueue-operator/openshift-qe-kueue-operator-commands.sh
@@ -4,6 +4,11 @@ set -o nounset
 set -o pipefail
 set -x
 
+# Source shared retry library if available
+if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
+    source "${SHARED_DIR}/retry-lib.sh"
+fi
+
 pushd /tmp
 
 ES_PASSWORD=$(cat "/secret/password")
@@ -12,7 +17,7 @@ ES_USERNAME=$(cat "/secret/username")
 REPO_URL="https://github.com/cloud-bulldozer/e2e-benchmarking";
 LATEST_TAG=$(curl -s "https://api.github.com/repos/cloud-bulldozer/e2e-benchmarking/releases/latest" | jq -r '.tag_name');
 TAG_OPTION="--branch $(if [ "$E2E_VERSION" == "default" ]; then echo "$LATEST_TAG"; else echo "$E2E_VERSION"; fi)";
-git clone $REPO_URL $TAG_OPTION --depth 1
+retry_git_clone $REPO_URL $TAG_OPTION --depth 1
 pushd e2e-benchmarking/workloads/kube-burner-ocp-wrapper
 
 export ES_SERVER="https://$ES_USERNAME:$ES_PASSWORD@search-ocp-qe-perf-scale-test-elk-hcm7wtsqpxy7xogbu72bor4uve.us-east-1.es.amazonaws.com"

--- a/ci-operator/step-registry/openshift-qe/kueue-operator/openshift-qe-kueue-operator-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/kueue-operator/openshift-qe-kueue-operator-commands.sh
@@ -7,6 +7,14 @@ set -x
 # Source shared retry library if available
 if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
     source "${SHARED_DIR}/retry-lib.sh"
+else
+    echo "retry-lib.sh not found in ${SHARED_DIR}"
+fi
+
+# Guarantee fallback
+if ! declare -F retry_git_clone >/dev/null; then
+    echo "retry_git_clone not defined; falling back to plain git clone (no retries)"
+    retry_git_clone() { git clone "$@"; }
 fi
 
 pushd /tmp

--- a/ci-operator/step-registry/openshift-qe/netpol-v2/openshift-qe-netpol-v2-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/netpol-v2/openshift-qe-netpol-v2-commands.sh
@@ -7,6 +7,14 @@ set -x
 # Source shared retry library if available
 if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
     source "${SHARED_DIR}/retry-lib.sh"
+else
+    echo "retry-lib.sh not found in ${SHARED_DIR}"
+fi
+
+# Guarantee fallback
+if ! declare -F retry_git_clone >/dev/null; then
+    echo "retry_git_clone not defined; falling back to plain git clone (no retries)"
+    retry_git_clone() { git clone "$@"; }
 fi
 
 cat /etc/os-release

--- a/ci-operator/step-registry/openshift-qe/netpol-v2/openshift-qe-netpol-v2-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/netpol-v2/openshift-qe-netpol-v2-commands.sh
@@ -3,6 +3,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 set -x
+
+# Source shared retry library if available
+if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
+    source "${SHARED_DIR}/retry-lib.sh"
+fi
+
 cat /etc/os-release
 oc config view
 oc projects
@@ -24,7 +30,7 @@ fi
 REPO_URL="https://github.com/cloud-bulldozer/e2e-benchmarking";
 LATEST_TAG=$(curl -s "https://api.github.com/repos/cloud-bulldozer/e2e-benchmarking/releases/latest" | jq -r '.tag_name');
 TAG_OPTION="--branch $(if [ "$E2E_VERSION" == "default" ]; then echo "$LATEST_TAG"; else echo "$E2E_VERSION"; fi)";
-git clone $REPO_URL $TAG_OPTION --depth 1
+retry_git_clone $REPO_URL $TAG_OPTION --depth 1
 pushd e2e-benchmarking/workloads/kube-burner-ocp-wrapper
 export WORKLOAD=network-policy
 

--- a/ci-operator/step-registry/openshift-qe/network-perf/openshift-qe-network-perf-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/network-perf/openshift-qe-network-perf-commands.sh
@@ -7,6 +7,14 @@ set -x
 # Source shared retry library if available
 if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
     source "${SHARED_DIR}/retry-lib.sh"
+else
+    echo "retry-lib.sh not found in ${SHARED_DIR}"
+fi
+
+# Guarantee fallback
+if ! declare -F retry_git_clone >/dev/null; then
+    echo "retry_git_clone not defined; falling back to plain git clone (no retries)"
+    retry_git_clone() { git clone "$@"; }
 fi
 
 cat /etc/os-release

--- a/ci-operator/step-registry/openshift-qe/network-perf/openshift-qe-network-perf-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/network-perf/openshift-qe-network-perf-commands.sh
@@ -4,6 +4,11 @@ set -o nounset
 set -o pipefail
 set -x
 
+# Source shared retry library if available
+if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
+    source "${SHARED_DIR}/retry-lib.sh"
+fi
+
 cat /etc/os-release
 
 # For disconnected or otherwise unreachable environments, we want to
@@ -29,7 +34,7 @@ ES_USERNAME=$(cat "/secret/username")
 REPO_URL="https://github.com/cloud-bulldozer/e2e-benchmarking";
 LATEST_TAG=$(curl -s "https://api.github.com/repos/cloud-bulldozer/e2e-benchmarking/releases/latest" | jq -r '.tag_name');
 TAG_OPTION="--branch $(if [ "$E2E_VERSION" == "default" ]; then echo "$LATEST_TAG"; else echo "$E2E_VERSION"; fi)";
-git clone $REPO_URL $TAG_OPTION --depth 1
+retry_git_clone $REPO_URL $TAG_OPTION --depth 1
 pushd e2e-benchmarking/workloads/network-perf-v2
 
 if [ ${CLEAN_UP} == "true" ]; then

--- a/ci-operator/step-registry/openshift-qe/network-smoke/openshift-qe-network-smoke-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/network-smoke/openshift-qe-network-smoke-commands.sh
@@ -4,6 +4,11 @@ set -o nounset
 set -o pipefail
 set -x
 
+# Source shared retry library if available
+if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
+    source "${SHARED_DIR}/retry-lib.sh"
+fi
+
 cat /etc/os-release
 
 # For disconnected or otherwise unreachable environments, we want to
@@ -26,7 +31,7 @@ source ./venv_qe/bin/activate
 REPO_URL="https://github.com/cloud-bulldozer/e2e-benchmarking";
 LATEST_TAG=$(curl -s "https://api.github.com/repos/cloud-bulldozer/e2e-benchmarking/releases/latest" | jq -r '.tag_name');
 TAG_OPTION="--branch $(if [ "$E2E_VERSION" == "default" ]; then echo "$LATEST_TAG"; else echo "$E2E_VERSION"; fi)";
-git clone $REPO_URL $TAG_OPTION --depth 1
+retry_git_clone $REPO_URL $TAG_OPTION --depth 1
 pushd e2e-benchmarking/workloads/network-perf-v2
 
 # Clean up

--- a/ci-operator/step-registry/openshift-qe/network-smoke/openshift-qe-network-smoke-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/network-smoke/openshift-qe-network-smoke-commands.sh
@@ -7,6 +7,14 @@ set -x
 # Source shared retry library if available
 if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
     source "${SHARED_DIR}/retry-lib.sh"
+else
+    echo "retry-lib.sh not found in ${SHARED_DIR}"
+fi
+
+# Guarantee fallback
+if ! declare -F retry_git_clone >/dev/null; then
+    echo "retry_git_clone not defined; falling back to plain git clone (no retries)"
+    retry_git_clone() { git clone "$@"; }
 fi
 
 cat /etc/os-release

--- a/ci-operator/step-registry/openshift-qe/network-vm-perf/openshift-qe-network-vm-perf-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/network-vm-perf/openshift-qe-network-vm-perf-commands.sh
@@ -7,6 +7,14 @@ set -x
 # Source shared retry library if available
 if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
     source "${SHARED_DIR}/retry-lib.sh"
+else
+    echo "retry-lib.sh not found in ${SHARED_DIR}"
+fi
+
+# Guarantee fallback
+if ! declare -F retry_git_clone >/dev/null; then
+    echo "retry_git_clone not defined; falling back to plain git clone (no retries)"
+    retry_git_clone() { git clone "$@"; }
 fi
 
 cat /etc/os-release

--- a/ci-operator/step-registry/openshift-qe/network-vm-perf/openshift-qe-network-vm-perf-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/network-vm-perf/openshift-qe-network-vm-perf-commands.sh
@@ -4,6 +4,11 @@ set -o nounset
 set -o pipefail
 set -x
 
+# Source shared retry library if available
+if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
+    source "${SHARED_DIR}/retry-lib.sh"
+fi
+
 cat /etc/os-release
 
 # For disconnected or otherwise unreachable environments, we want to
@@ -41,7 +46,7 @@ if [ ${BAREMETAL} == "true" ]; then
   # kill the ssh tunnel so the job completes
   pkill ssh
 else
-  git clone $REPO_URL $TAG_OPTION --depth 1
+  retry_git_clone $REPO_URL $TAG_OPTION --depth 1
   pushd e2e-benchmarking/workloads/network-perf-v2
   # Clean up resources from possible previous tests.
   oc delete ns netperf --wait=true --ignore-not-found=true

--- a/ci-operator/step-registry/openshift-qe/node-density-cni/openshift-qe-node-density-cni-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/node-density-cni/openshift-qe-node-density-cni-commands.sh
@@ -7,6 +7,14 @@ set -x
 # Source shared retry library if available
 if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
     source "${SHARED_DIR}/retry-lib.sh"
+else
+    echo "retry-lib.sh not found in ${SHARED_DIR}"
+fi
+
+# Guarantee fallback
+if ! declare -F retry_git_clone >/dev/null; then
+    echo "retry_git_clone not defined; falling back to plain git clone (no retries)"
+    retry_git_clone() { git clone "$@"; }
 fi
 
 cat /etc/os-release

--- a/ci-operator/step-registry/openshift-qe/node-density-cni/openshift-qe-node-density-cni-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/node-density-cni/openshift-qe-node-density-cni-commands.sh
@@ -3,6 +3,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 set -x
+
+# Source shared retry library if available
+if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
+    source "${SHARED_DIR}/retry-lib.sh"
+fi
+
 cat /etc/os-release
 oc config view
 oc projects
@@ -51,7 +57,7 @@ fi
 REPO_URL="https://github.com/cloud-bulldozer/e2e-benchmarking";
 LATEST_TAG=$(curl -s "https://api.github.com/repos/cloud-bulldozer/e2e-benchmarking/releases/latest" | jq -r '.tag_name');
 TAG_OPTION="--branch $(if [ "$E2E_VERSION" == "default" ]; then echo "$LATEST_TAG"; else echo "$E2E_VERSION"; fi)";
-git clone $REPO_URL $TAG_OPTION --depth 1
+retry_git_clone $REPO_URL $TAG_OPTION --depth 1
 pushd e2e-benchmarking/workloads/kube-burner-ocp-wrapper
 export WORKLOAD=node-density-cni
 EXTRA_FLAGS="${ND_CNI_EXTRA_FLAGS} --gc=$GC --gc-metrics=$GC_METRICS --pods-per-node=$PODS_PER_NODE --namespaced-iterations=$NAMESPACED_ITERATIONS --iterations-per-namespace=$ITERATIONS_PER_NAMESPACE --profile-type=${PROFILE_TYPE} --pprof=${PPROF}"

--- a/ci-operator/step-registry/openshift-qe/node-density-heavy/openshift-qe-node-density-heavy-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/node-density-heavy/openshift-qe-node-density-heavy-commands.sh
@@ -7,6 +7,14 @@ set -x
 # Source shared retry library if available
 if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
     source "${SHARED_DIR}/retry-lib.sh"
+else
+    echo "retry-lib.sh not found in ${SHARED_DIR}"
+fi
+
+# Guarantee fallback
+if ! declare -F retry_git_clone >/dev/null; then
+    echo "retry_git_clone not defined; falling back to plain git clone (no retries)"
+    retry_git_clone() { git clone "$@"; }
 fi
 
 cat /etc/os-release

--- a/ci-operator/step-registry/openshift-qe/node-density-heavy/openshift-qe-node-density-heavy-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/node-density-heavy/openshift-qe-node-density-heavy-commands.sh
@@ -3,6 +3,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 set -x
+
+# Source shared retry library if available
+if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
+    source "${SHARED_DIR}/retry-lib.sh"
+fi
+
 cat /etc/os-release
 
 # For disconnected or otherwise unreachable environments, we want to
@@ -32,7 +38,7 @@ export GSHEET_KEY_LOCATION
 REPO_URL="https://github.com/cloud-bulldozer/e2e-benchmarking";
 LATEST_TAG=$(curl -s "https://api.github.com/repos/cloud-bulldozer/e2e-benchmarking/releases/latest" | jq -r '.tag_name');
 TAG_OPTION="--branch $(if [ "$E2E_VERSION" == "default" ]; then echo "$LATEST_TAG"; else echo "$E2E_VERSION"; fi)";
-git clone $REPO_URL $TAG_OPTION --depth 1
+retry_git_clone $REPO_URL $TAG_OPTION --depth 1
 pushd e2e-benchmarking/workloads/kube-burner-ocp-wrapper
 export WORKLOAD=node-density-heavy
 

--- a/ci-operator/step-registry/openshift-qe/node-density/openshift-qe-node-density-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/node-density/openshift-qe-node-density-commands.sh
@@ -7,6 +7,14 @@ set -x
 # Source shared retry library if available
 if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
     source "${SHARED_DIR}/retry-lib.sh"
+else
+    echo "retry-lib.sh not found in ${SHARED_DIR}"
+fi
+
+# Guarantee fallback
+if ! declare -F retry_git_clone >/dev/null; then
+    echo "retry_git_clone not defined; falling back to plain git clone (no retries)"
+    retry_git_clone() { git clone "$@"; }
 fi
 
 cat /etc/os-release

--- a/ci-operator/step-registry/openshift-qe/node-density/openshift-qe-node-density-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/node-density/openshift-qe-node-density-commands.sh
@@ -3,6 +3,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 set -x
+
+# Source shared retry library if available
+if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
+    source "${SHARED_DIR}/retry-lib.sh"
+fi
+
 cat /etc/os-release
 
 # For disconnected or otherwise unreachable environments, we want to
@@ -58,7 +64,7 @@ fi
 REPO_URL="https://github.com/cloud-bulldozer/e2e-benchmarking";
 LATEST_TAG=$(curl -s "https://api.github.com/repos/cloud-bulldozer/e2e-benchmarking/releases/latest" | jq -r '.tag_name');
 TAG_OPTION="--branch $(if [ "$E2E_VERSION" == "default" ]; then echo "$LATEST_TAG"; else echo "$E2E_VERSION"; fi)";
-git clone $REPO_URL $TAG_OPTION --depth 1
+retry_git_clone $REPO_URL $TAG_OPTION --depth 1
 pushd e2e-benchmarking/workloads/kube-burner-ocp-wrapper
 export WORKLOAD=node-density
 

--- a/ci-operator/step-registry/openshift-qe/orion/olmv1/openshift-qe-orion-olmv1-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/orion/olmv1/openshift-qe-orion-olmv1-commands.sh
@@ -4,6 +4,14 @@ set -x
 # Source shared retry library if available
 if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
     source "${SHARED_DIR}/retry-lib.sh"
+else
+    echo "retry-lib.sh not found in ${SHARED_DIR}"
+fi
+
+# Guarantee fallback
+if ! declare -F retry_git_clone >/dev/null; then
+    echo "retry_git_clone not defined; falling back to plain git clone (no retries)"
+    retry_git_clone() { git clone "$@"; }
 fi
 
 if [ ${RUN_ORION} == false ]; then

--- a/ci-operator/step-registry/openshift-qe/orion/olmv1/openshift-qe-orion-olmv1-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/orion/olmv1/openshift-qe-orion-olmv1-commands.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -x
 
+# Source shared retry library if available
+if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
+    source "${SHARED_DIR}/retry-lib.sh"
+fi
+
 if [ ${RUN_ORION} == false ]; then
   exit 0
 fi
@@ -94,7 +99,7 @@ if [[ $TAG == "latest" ]]; then
 else
     LATEST_TAG=$TAG
 fi
-git clone --branch $LATEST_TAG $ORION_REPO --depth 1
+retry_git_clone --branch $LATEST_TAG $ORION_REPO --depth 1
 pushd orion
 
 pip install -r requirements.txt

--- a/ci-operator/step-registry/openshift-qe/orion/openshift-qe-orion-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/orion/openshift-qe-orion-commands.sh
@@ -4,6 +4,14 @@ set -x
 # Source shared retry library if available
 if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
     source "${SHARED_DIR}/retry-lib.sh"
+else
+    echo "retry-lib.sh not found in ${SHARED_DIR}"
+fi
+
+# Guarantee fallback
+if ! declare -F retry_git_clone >/dev/null; then
+    echo "retry_git_clone not defined; falling back to plain git clone (no retries)"
+    retry_git_clone() { git clone "$@"; }
 fi
 
 if [ ${RUN_ORION} == false ]; then

--- a/ci-operator/step-registry/openshift-qe/orion/openshift-qe-orion-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/orion/openshift-qe-orion-commands.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -x
 
+# Source shared retry library if available
+if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
+    source "${SHARED_DIR}/retry-lib.sh"
+fi
+
 if [ ${RUN_ORION} == false ]; then
   exit 0
 fi
@@ -15,7 +20,7 @@ if [[ $TAG == "latest" ]]; then
 else
     LATEST_TAG=$TAG
 fi
-git clone --branch $LATEST_TAG $ORION_REPO --depth 1
+retry_git_clone --branch $LATEST_TAG $ORION_REPO --depth 1
 pushd orion
 
 # Invoked from orion repo by the openshift-ci bot

--- a/ci-operator/step-registry/openshift-qe/rds-core/openshift-qe-rds-core-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/rds-core/openshift-qe-rds-core-commands.sh
@@ -7,6 +7,14 @@ set -x
 # Source shared retry library if available
 if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
     source "${SHARED_DIR}/retry-lib.sh"
+else
+    echo "retry-lib.sh not found in ${SHARED_DIR}"
+fi
+
+# Guarantee fallback
+if ! declare -F retry_git_clone >/dev/null; then
+    echo "retry_git_clone not defined; falling back to plain git clone (no retries)"
+    retry_git_clone() { git clone "$@"; }
 fi
 
 cat /etc/os-release

--- a/ci-operator/step-registry/openshift-qe/rds-core/openshift-qe-rds-core-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/rds-core/openshift-qe-rds-core-commands.sh
@@ -3,6 +3,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 set -x
+
+# Source shared retry library if available
+if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
+    source "${SHARED_DIR}/retry-lib.sh"
+fi
+
 cat /etc/os-release
 
 oc config view
@@ -18,7 +24,7 @@ ES_USERNAME=$(cat "/secret/username")
 REPO_URL="https://github.com/cloud-bulldozer/e2e-benchmarking";
 LATEST_TAG=$(curl -s "https://api.github.com/repos/cloud-bulldozer/e2e-benchmarking/releases/latest" | jq -r '.tag_name');
 TAG_OPTION="--branch $(if [ "$E2E_VERSION" == "default" ]; then echo "$LATEST_TAG"; else echo "$E2E_VERSION"; fi)";
-git clone $REPO_URL $TAG_OPTION --depth 1
+retry_git_clone $REPO_URL $TAG_OPTION --depth 1
 pushd e2e-benchmarking/workloads/kube-burner-ocp-wrapper
 
 export ES_SERVER="https://$ES_USERNAME:$ES_PASSWORD@search-ocp-qe-perf-scale-test-elk-hcm7wtsqpxy7xogbu72bor4uve.us-east-1.es.amazonaws.com"

--- a/ci-operator/step-registry/openshift-qe/router-perf/openshift-qe-router-perf-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/router-perf/openshift-qe-router-perf-commands.sh
@@ -3,6 +3,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 set -x
+
+# Source shared retry library if available
+if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
+    source "${SHARED_DIR}/retry-lib.sh"
+fi
+
 cat /etc/os-release
 oc config view
 oc projects
@@ -19,7 +25,7 @@ export GSHEET_KEY_LOCATION
 REPO_URL="https://github.com/cloud-bulldozer/e2e-benchmarking";
 LATEST_TAG=$(curl -s "https://api.github.com/repos/cloud-bulldozer/e2e-benchmarking/releases/latest" | jq -r '.tag_name');
 TAG_OPTION="--branch $(if [ "$E2E_VERSION" == "default" ]; then echo "$LATEST_TAG"; else echo "$E2E_VERSION"; fi)";
-git clone $REPO_URL $TAG_OPTION --depth 1
+retry_git_clone $REPO_URL $TAG_OPTION --depth 1
 pushd e2e-benchmarking/workloads/router-perf-v2
 # ES configuration
 export ES_SERVER="https://$ES_USERNAME:$ES_PASSWORD@search-ocp-qe-perf-scale-test-elk-hcm7wtsqpxy7xogbu72bor4uve.us-east-1.es.amazonaws.com"

--- a/ci-operator/step-registry/openshift-qe/router-perf/openshift-qe-router-perf-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/router-perf/openshift-qe-router-perf-commands.sh
@@ -7,6 +7,14 @@ set -x
 # Source shared retry library if available
 if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
     source "${SHARED_DIR}/retry-lib.sh"
+else
+    echo "retry-lib.sh not found in ${SHARED_DIR}"
+fi
+
+# Guarantee fallback
+if ! declare -F retry_git_clone >/dev/null; then
+    echo "retry_git_clone not defined; falling back to plain git clone (no retries)"
+    retry_git_clone() { git clone "$@"; }
 fi
 
 cat /etc/os-release

--- a/ci-operator/step-registry/openshift-qe/sdn-ovn-migration/openshift-qe-sdn-ovn-migration-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/sdn-ovn-migration/openshift-qe-sdn-ovn-migration-commands.sh
@@ -7,6 +7,14 @@ set -x
 # Source shared retry library if available
 if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
     source "${SHARED_DIR}/retry-lib.sh"
+else
+    echo "retry-lib.sh not found in ${SHARED_DIR}"
+fi
+
+# Guarantee fallback
+if ! declare -F retry_git_clone >/dev/null; then
+    echo "retry_git_clone not defined; falling back to plain git clone (no retries)"
+    retry_git_clone() { git clone "$@"; }
 fi
 
 cat /etc/os-release

--- a/ci-operator/step-registry/openshift-qe/sdn-ovn-migration/openshift-qe-sdn-ovn-migration-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/sdn-ovn-migration/openshift-qe-sdn-ovn-migration-commands.sh
@@ -3,6 +3,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 set -x
+
+# Source shared retry library if available
+if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
+    source "${SHARED_DIR}/retry-lib.sh"
+fi
+
 cat /etc/os-release
 
 python --version
@@ -20,7 +26,7 @@ GSHEET_KEY_LOCATION="/ga-gsheet/gcp-sa-account"
 export GSHEET_KEY_LOCATION
 
 REPO_URL="https://github.com/liqcui/e2e-benchmarking";
-git clone -b sdn-ovn-migration $REPO_URL --depth 1
+retry_git_clone -b sdn-ovn-migration $REPO_URL --depth 1
 pushd e2e-benchmarking/workloads/sdn-ovn-migration
 
 # The measurable run

--- a/ci-operator/step-registry/openshift-qe/shared-post-install/OWNERS
+++ b/ci-operator/step-registry/openshift-qe/shared-post-install/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- perfscale-ocp-approvers
+reviewers:
+- perfscale-ocp-reviewers

--- a/ci-operator/step-registry/openshift-qe/shared-post-install/openshift-qe-shared-post-install-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/shared-post-install/openshift-qe-shared-post-install-commands.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Create shared retry library for use by subsequent steps
+cat > ${SHARED_DIR}/retry-lib.sh << 'RETRY_EOF'
+#!/bin/bash
+
+# Retry function for git clone operations
+# Usage: retry_git_clone <repo_url> [git clone options...]
+retry_git_clone() {
+    local max_retries=3
+    local retry_delay=5
+    local attempt=1
+
+    while [ $attempt -le $max_retries ]; do
+        echo "Attempt $attempt of $max_retries: git clone $@"
+        if git clone "$@"; then
+            echo "git clone succeeded on attempt $attempt"
+            return 0
+        fi
+        echo "git clone failed on attempt $attempt"
+        if [ $attempt -lt $max_retries ]; then
+            echo "Waiting ${retry_delay} seconds before retry..."
+            sleep $retry_delay
+            retry_delay=$((retry_delay * 2))
+        fi
+        attempt=$((attempt + 1))
+    done
+
+    echo "git clone failed after $max_retries attempts"
+    return 1
+}
+RETRY_EOF
+
+echo "Created retry library at ${SHARED_DIR}/retry-lib.sh"

--- a/ci-operator/step-registry/openshift-qe/shared-post-install/openshift-qe-shared-post-install-ref.metadata.json
+++ b/ci-operator/step-registry/openshift-qe/shared-post-install/openshift-qe-shared-post-install-ref.metadata.json
@@ -1,0 +1,11 @@
+{
+	"path": "openshift-qe/shared-post-install/openshift-qe-shared-post-install-ref.yaml",
+	"owners": {
+		"approvers": [
+			"perfscale-ocp-approvers"
+		],
+		"reviewers": [
+			"perfscale-ocp-reviewers"
+		]
+	}
+}

--- a/ci-operator/step-registry/openshift-qe/shared-post-install/openshift-qe-shared-post-install-ref.yaml
+++ b/ci-operator/step-registry/openshift-qe/shared-post-install/openshift-qe-shared-post-install-ref.yaml
@@ -1,0 +1,12 @@
+ref:
+  as: openshift-qe-shared-post-install
+  from: cli
+  commands: openshift-qe-shared-post-install-commands.sh
+  resources:
+    requests:
+      cpu: 10m
+      memory: 10Mi
+  timeout: 5m
+  documentation: |-
+    This step creates shared utilities (e.g., retry library for git clone operations)
+    in SHARED_DIR for use by subsequent perfscale steps.

--- a/ci-operator/step-registry/openshift-qe/udn-bgp/openshift-qe-udn-bgp-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/udn-bgp/openshift-qe-udn-bgp-commands.sh
@@ -4,6 +4,11 @@ set -o nounset
 set -o pipefail
 set -x
 
+# Source shared retry library if available
+if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
+    source "${SHARED_DIR}/retry-lib.sh"
+fi
+
 pushd /tmp
 
 ES_SECRETS_PATH=${ES_SECRETS_PATH:-/secret}

--- a/ci-operator/step-registry/openshift-qe/udn-bgp/openshift-qe-udn-bgp-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/udn-bgp/openshift-qe-udn-bgp-commands.sh
@@ -7,6 +7,14 @@ set -x
 # Source shared retry library if available
 if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
     source "${SHARED_DIR}/retry-lib.sh"
+else
+    echo "retry-lib.sh not found in ${SHARED_DIR}"
+fi
+
+# Guarantee fallback
+if ! declare -F retry_git_clone >/dev/null; then
+    echo "retry_git_clone not defined; falling back to plain git clone (no retries)"
+    retry_git_clone() { git clone "$@"; }
 fi
 
 pushd /tmp

--- a/ci-operator/step-registry/openshift-qe/udn-density-pods/openshift-qe-udn-density-pods-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/udn-density-pods/openshift-qe-udn-density-pods-commands.sh
@@ -7,6 +7,14 @@ set -x
 # Source shared retry library if available
 if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
     source "${SHARED_DIR}/retry-lib.sh"
+else
+    echo "retry-lib.sh not found in ${SHARED_DIR}"
+fi
+
+# Guarantee fallback
+if ! declare -F retry_git_clone >/dev/null; then
+    echo "retry_git_clone not defined; falling back to plain git clone (no retries)"
+    retry_git_clone() { git clone "$@"; }
 fi
 
 cat /etc/os-release

--- a/ci-operator/step-registry/openshift-qe/udn-density-pods/openshift-qe-udn-density-pods-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/udn-density-pods/openshift-qe-udn-density-pods-commands.sh
@@ -3,6 +3,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 set -x
+
+# Source shared retry library if available
+if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
+    source "${SHARED_DIR}/retry-lib.sh"
+fi
+
 cat /etc/os-release
 
 # For disconnected or otherwise unreachable environments, we want to
@@ -36,7 +42,7 @@ fi
 REPO_URL="https://github.com/cloud-bulldozer/e2e-benchmarking";
 LATEST_TAG=$(curl -s "https://api.github.com/repos/cloud-bulldozer/e2e-benchmarking/releases/latest" | jq -r '.tag_name');
 TAG_OPTION="--branch $(if [ "$E2E_VERSION" == "default" ]; then echo "$LATEST_TAG"; else echo "$E2E_VERSION"; fi)";
-git clone $REPO_URL $TAG_OPTION --depth 1
+retry_git_clone $REPO_URL $TAG_OPTION --depth 1
 pushd e2e-benchmarking/workloads/kube-burner-ocp-wrapper
 export WORKLOAD=udn-density-pods
 

--- a/ci-operator/step-registry/openshift-qe/virt-density/observer/openshift-qe-virt-density-observer-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/virt-density/observer/openshift-qe-virt-density-observer-commands.sh
@@ -5,6 +5,12 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 set -x
+
+# Source shared retry library if available
+if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
+    source "${SHARED_DIR}/retry-lib.sh"
+fi
+
 ls
 
 function vd_cleanup() {
@@ -25,7 +31,7 @@ pushd /tmp
 REPO_URL="https://github.com/cloud-bulldozer/e2e-benchmarking";
 LATEST_TAG=$(curl -s "https://api.github.com/repos/cloud-bulldozer/e2e-benchmarking/releases/latest" | jq -r '.tag_name');
 TAG_OPTION="--branch $(if [ "$E2E_VERSION" == "default" ]; then echo "$LATEST_TAG"; else echo "$E2E_VERSION"; fi)";
-git clone $REPO_URL $TAG_OPTION --depth 1
+retry_git_clone $REPO_URL $TAG_OPTION --depth 1
 
 python -m virtualenv ./venv_qe
 source ./venv_qe/bin/activate

--- a/ci-operator/step-registry/openshift-qe/virt-density/observer/openshift-qe-virt-density-observer-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/virt-density/observer/openshift-qe-virt-density-observer-commands.sh
@@ -9,6 +9,14 @@ set -x
 # Source shared retry library if available
 if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
     source "${SHARED_DIR}/retry-lib.sh"
+else
+    echo "retry-lib.sh not found in ${SHARED_DIR}"
+fi
+
+# Guarantee fallback
+if ! declare -F retry_git_clone >/dev/null; then
+    echo "retry_git_clone not defined; falling back to plain git clone (no retries)"
+    retry_git_clone() { git clone "$@"; }
 fi
 
 ls

--- a/ci-operator/step-registry/openshift-qe/virt-density/openshift-qe-virt-density-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/virt-density/openshift-qe-virt-density-commands.sh
@@ -7,6 +7,14 @@ set -x
 # Source shared retry library if available
 if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
     source "${SHARED_DIR}/retry-lib.sh"
+else
+    echo "retry-lib.sh not found in ${SHARED_DIR}"
+fi
+
+# Guarantee fallback
+if ! declare -F retry_git_clone >/dev/null; then
+    echo "retry_git_clone not defined; falling back to plain git clone (no retries)"
+    retry_git_clone() { git clone "$@"; }
 fi
 
 cat /etc/os-release

--- a/ci-operator/step-registry/openshift-qe/virt-density/openshift-qe-virt-density-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/virt-density/openshift-qe-virt-density-commands.sh
@@ -3,6 +3,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 set -x
+
+# Source shared retry library if available
+if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
+    source "${SHARED_DIR}/retry-lib.sh"
+fi
+
 cat /etc/os-release
 
 # For disconnected or otherwise unreachable environments, we want to
@@ -34,7 +40,7 @@ fi
 REPO_URL="https://github.com/cloud-bulldozer/e2e-benchmarking";
 LATEST_TAG=$(curl -s "https://api.github.com/repos/cloud-bulldozer/e2e-benchmarking/releases/latest" | jq -r '.tag_name');
 TAG_OPTION="--branch $(if [ "$E2E_VERSION" == "default" ]; then echo "$LATEST_TAG"; else echo "$E2E_VERSION"; fi)";
-git clone $REPO_URL $TAG_OPTION --depth 1
+retry_git_clone $REPO_URL $TAG_OPTION --depth 1
 pushd e2e-benchmarking/workloads/kube-burner-ocp-wrapper
 export WORKLOAD=virt-density
 

--- a/ci-operator/step-registry/openshift-qe/virt-udn-density/openshift-qe-virt-udn-density-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/virt-udn-density/openshift-qe-virt-udn-density-commands.sh
@@ -3,6 +3,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 set -x
+
+# Source shared retry library if available
+if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
+    source "${SHARED_DIR}/retry-lib.sh"
+fi
+
 cat /etc/os-release
 
 # For disconnected or otherwise unreachable environments, we want to
@@ -31,7 +37,7 @@ fi
 REPO_URL="https://github.com/cloud-bulldozer/e2e-benchmarking";
 LATEST_TAG=$(curl -s "https://api.github.com/repos/cloud-bulldozer/e2e-benchmarking/releases/latest" | jq -r '.tag_name');
 TAG_OPTION="--branch $(if [ "$E2E_VERSION" == "default" ]; then echo "$LATEST_TAG"; else echo "$E2E_VERSION"; fi)";
-git clone $REPO_URL $TAG_OPTION --depth 1
+retry_git_clone $REPO_URL $TAG_OPTION --depth 1
 pushd e2e-benchmarking/workloads/kube-burner-ocp-wrapper
 export WORKLOAD=virt-udn-density
 

--- a/ci-operator/step-registry/openshift-qe/virt-udn-density/openshift-qe-virt-udn-density-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/virt-udn-density/openshift-qe-virt-udn-density-commands.sh
@@ -7,6 +7,14 @@ set -x
 # Source shared retry library if available
 if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
     source "${SHARED_DIR}/retry-lib.sh"
+else
+    echo "retry-lib.sh not found in ${SHARED_DIR}"
+fi
+
+# Guarantee fallback
+if ! declare -F retry_git_clone >/dev/null; then
+    echo "retry_git_clone not defined; falling back to plain git clone (no retries)"
+    retry_git_clone() { git clone "$@"; }
 fi
 
 cat /etc/os-release

--- a/ci-operator/step-registry/openshift-qe/web-burner/openshift-qe-web-burner-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/web-burner/openshift-qe-web-burner-commands.sh
@@ -7,6 +7,14 @@ set -x
 # Source shared retry library if available
 if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
     source "${SHARED_DIR}/retry-lib.sh"
+else
+    echo "retry-lib.sh not found in ${SHARED_DIR}"
+fi
+
+# Guarantee fallback
+if ! declare -F retry_git_clone >/dev/null; then
+    echo "retry_git_clone not defined; falling back to plain git clone (no retries)"
+    retry_git_clone() { git clone "$@"; }
 fi
 
 cat /etc/os-release

--- a/ci-operator/step-registry/openshift-qe/web-burner/openshift-qe-web-burner-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/web-burner/openshift-qe-web-burner-commands.sh
@@ -3,6 +3,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 set -x
+
+# Source shared retry library if available
+if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
+    source "${SHARED_DIR}/retry-lib.sh"
+fi
+
 cat /etc/os-release
 
 # For disconnected or otherwise unreachable environments, we want to
@@ -33,7 +39,7 @@ ES_USERNAME=$(cat "/secret/username")
 REPO_URL="https://github.com/cloud-bulldozer/e2e-benchmarking";
 LATEST_TAG=$(curl -s "https://api.github.com/repos/cloud-bulldozer/e2e-benchmarking/releases/latest" | jq -r '.tag_name');
 TAG_OPTION="--branch $(if [ "$E2E_VERSION" == "default" ]; then echo "$LATEST_TAG"; else echo "$E2E_VERSION"; fi)";
-git clone $REPO_URL $TAG_OPTION --depth 1
+retry_git_clone $REPO_URL $TAG_OPTION --depth 1
 pushd e2e-benchmarking/workloads/kube-burner-ocp-wrapper
 
 export ES_SERVER="https://$ES_USERNAME:$ES_PASSWORD@search-ocp-qe-perf-scale-test-elk-hcm7wtsqpxy7xogbu72bor4uve.us-east-1.es.amazonaws.com"

--- a/ci-operator/step-registry/telcov10n/orion/tests/telcov10n-orion-tests-commands.sh
+++ b/ci-operator/step-registry/telcov10n/orion/tests/telcov10n-orion-tests-commands.sh
@@ -4,6 +4,14 @@ set -x
 # Source shared retry library if available
 if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
     source "${SHARED_DIR}/retry-lib.sh"
+else
+    echo "retry-lib.sh not found in ${SHARED_DIR}"
+fi
+
+# Guarantee fallback
+if ! declare -F retry_git_clone >/dev/null; then
+    echo "retry_git_clone not defined; falling back to plain git clone (no retries)"
+    retry_git_clone() { git clone "$@"; }
 fi
 
 if [ ${RUN_ORION} == false ]; then

--- a/ci-operator/step-registry/telcov10n/orion/tests/telcov10n-orion-tests-commands.sh
+++ b/ci-operator/step-registry/telcov10n/orion/tests/telcov10n-orion-tests-commands.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -x
 
+# Source shared retry library if available
+if [[ -f "${SHARED_DIR}/retry-lib.sh" ]]; then
+    source "${SHARED_DIR}/retry-lib.sh"
+fi
+
 if [ ${RUN_ORION} == false ]; then
   exit 0
 fi
@@ -15,7 +20,7 @@ if [[ $TAG == "latest" ]]; then
 else
     LATEST_TAG=$TAG
 fi
-git clone --branch $LATEST_TAG $ORION_REPO --depth 1
+retry_git_clone --branch $LATEST_TAG $ORION_REPO --depth 1
 pushd orion
 
 pip install -r requirements.txt


### PR DESCRIPTION
                                                                                   
  ---                                                                              
  Summary                                                                          
                                                                                   
  - Add retry logic for git clone operations to prevent transient network failures 
  from causing job failures                                                        
  - Create a shared retry library (retry-lib.sh) in SHARED_DIR that can be sourced 
  by subsequent steps                                                              
  - Implements exponential backoff with 3 retry attempts (5s, 10s, 20s delays)     
                                                                                   
  Details                                                                          
                                                                                   
  The workers-scale step now creates a shared retry library at                     
  ${SHARED_DIR}/retry-lib.sh containing a retry_git_clone function. All subsequent 
  perfscale test steps source this library and use retry_git_clone instead of git  
  clone for cloning e2e-benchmarking and orion repositories.                       
                                                                                   
  This approach mirrors how proxy-conf.sh is shared across steps, making the retry 
  logic available to all steps in the chain without requiring changes to container 
  images.                                                                          
                                                                                   
  Files Modified                                                                   
                                                                                   
  - 48 step-registry command scripts updated                                       
  - Affects: openshift-qe/, cloud-bulldozer/e2e-benchmarking/, and                 
  telcov10n/orion/*      