### PR TITLE
Add minimal DPF CI configuration for rh-ecosystem-edge/openshift-dpf

### DIFF
--- a/ci-operator/config/rh-ecosystem-edge/openshift-dpf/OWNERS
+++ b/ci-operator/config/rh-ecosystem-edge/openshift-dpf/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+- szigmon
+- tsorya
+- wabouhamad
+reviewers:
+- szigmon
+- tsorya
+- wabouhamad

--- a/ci-operator/config/rh-ecosystem-edge/openshift-dpf/rh-ecosystem-edge-openshift-dpf-main.yaml
+++ b/ci-operator/config/rh-ecosystem-edge/openshift-dpf/rh-ecosystem-edge-openshift-dpf-main.yaml
@@ -1,0 +1,31 @@
+base_images:
+  ubi9:
+    name: ubi
+    namespace: ocp
+    tag: "9"
+
+build_root:
+  image_stream_tag:
+    name: release
+    namespace: openshift
+    tag: golang-1.21
+
+resources:
+  '*':
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+
+tests:
+- as: unit
+  commands: make verify-files
+  container:
+    from: ubi9
+  skip_if_only_changed: ^(README|OWNERS|LICENSE)$|\.(md|adoc)$|^docs/|^\.github/
+
+zz_generated_metadata:
+  branch: main
+  org: rh-ecosystem-edge
+  repo: openshift-dpf

--- a/core-services/prow/02_config/rh-ecosystem-edge/openshift-dpf/_pluginconfig.yaml
+++ b/core-services/prow/02_config/rh-ecosystem-edge/openshift-dpf/_pluginconfig.yaml
@@ -1,0 +1,26 @@
+approve:
+- repos:
+  - rh-ecosystem-edge/openshift-dpf
+  require_self_approval: false
+
+lgtm:
+- repos:
+  - rh-ecosystem-edge/openshift-dpf
+  review_acts_as_lgtm: true
+
+plugins:
+  rh-ecosystem-edge/openshift-dpf:
+    plugins:
+    - approve
+    - assign
+    - help
+    - hold
+    - label
+    - lgtm
+    - lifecycle
+    - trigger
+    - verify-owners
+
+triggers:
+- repos:
+  - rh-ecosystem-edge/openshift-dpf

--- a/core-services/prow/02_config/rh-ecosystem-edge/openshift-dpf/_prowconfig.yaml
+++ b/core-services/prow/02_config/rh-ecosystem-edge/openshift-dpf/_prowconfig.yaml
@@ -1,0 +1,13 @@
+tide:
+  merge_method:
+    rh-ecosystem-edge/openshift-dpf: rebase
+  queries:
+  - labels:
+    - approved
+    - lgtm
+    missingLabels:
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    repos:
+    - rh-ecosystem-edge/openshift-dpf


### PR DESCRIPTION
## Minimal DPF CI Configuration - 4 Files Only

This PR adds basic CI configuration for the NVIDIA DPF (DPU Platform Framework) repository with the **minimal approach**.

### ✅ **Files Added (4 total)**:

1. **`OWNERS`** - with szigmon, tsorya, wabouhamad as approvers/reviewers
2. **`ci-operator config`** - simple unit test using `make verify-files`  
3. **`prow config`** - basic tide configuration
4. **`plugin config`** - essential plugins (approve, lgtm, etc.)

### 🎯 **Scope**:
- **Unit tests only** - no complex workflows yet
- **Basic validation** - `make verify-files` command
- **Standard patterns** - following proven openshift/release patterns
- **Foundation for future** - can add workflows incrementally

### 🧪 **Testing**:
Simple unit test that validates file structure and basic repository health.

### 📋 **Next Steps** (Future PRs):
- Add step-registry workflows for hypervisor testing
- Add version-specific configs (4.20, 4.21)  
- Add comprehensive DPF validation suites

This minimal approach establishes the CI foundation without overwhelming complexity.