### PR TITLE
Exclude unsupported tests for ASH

### DIFF
--- a/ci-operator/config/openshift/installer/openshift-installer-main.yaml
+++ b/ci-operator/config/openshift/installer/openshift-installer-main.yaml
@@ -1114,6 +1114,9 @@ tests:
   run_if_changed: (azure|azurestack)
   steps:
     cluster_profile: azurestack-dev
+    env:
+      TEST_SKIPS: 'In-tree Volumes \[Driver: azure-file\] \| In-tree Volumes \[Driver:
+        azure-disk\]'
     workflow: openshift-e2e-azurestack
 - always_run: false
   as: e2e-azurestack-upi
@@ -1122,6 +1125,9 @@ tests:
   run_if_changed: ^(upi/(azure|azurestack)/.*)
   steps:
     cluster_profile: azurestack-dev
+    env:
+      TEST_SKIPS: 'In-tree Volumes \[Driver: azure-file\] \| In-tree Volumes \[Driver:
+        azure-disk\]'
     workflow: openshift-e2e-azurestack-upi
 - always_run: false
   as: e2e-ibmcloud-ovn

--- a/ci-operator/config/openshift/installer/openshift-installer-release-4.17.yaml
+++ b/ci-operator/config/openshift/installer/openshift-installer-release-4.17.yaml
@@ -768,6 +768,9 @@ tests:
   run_if_changed: (azure|azurestack)
   steps:
     cluster_profile: azurestack-dev
+    env:
+      TEST_SKIPS: 'In-tree Volumes \[Driver: azure-file\] \| In-tree Volumes \[Driver:
+        azure-disk\]'
     workflow: openshift-e2e-azurestack
 - always_run: false
   as: e2e-azurestack-upi
@@ -776,6 +779,9 @@ tests:
   run_if_changed: ^(upi/(azure|azurestack)/.*)
   steps:
     cluster_profile: azurestack-dev
+    env:
+      TEST_SKIPS: 'In-tree Volumes \[Driver: azure-file\] \| In-tree Volumes \[Driver:
+        azure-disk\]'
     workflow: openshift-e2e-azurestack-upi
 - always_run: false
   as: e2e-ibmcloud-ovn

--- a/ci-operator/config/openshift/installer/openshift-installer-release-4.18.yaml
+++ b/ci-operator/config/openshift/installer/openshift-installer-release-4.18.yaml
@@ -907,6 +907,9 @@ tests:
   run_if_changed: (azure|azurestack)
   steps:
     cluster_profile: azurestack-dev
+    env:
+      TEST_SKIPS: 'In-tree Volumes \[Driver: azure-file\] \| In-tree Volumes \[Driver:
+        azure-disk\]'
     workflow: openshift-e2e-azurestack
 - always_run: false
   as: e2e-azurestack-upi
@@ -915,6 +918,9 @@ tests:
   run_if_changed: ^(upi/(azure|azurestack)/.*)
   steps:
     cluster_profile: azurestack-dev
+    env:
+      TEST_SKIPS: 'In-tree Volumes \[Driver: azure-file\] \| In-tree Volumes \[Driver:
+        azure-disk\]'
     workflow: openshift-e2e-azurestack-upi
 - always_run: false
   as: e2e-ibmcloud-ovn

--- a/ci-operator/config/openshift/installer/openshift-installer-release-4.19.yaml
+++ b/ci-operator/config/openshift/installer/openshift-installer-release-4.19.yaml
@@ -999,6 +999,9 @@ tests:
   run_if_changed: (azure|azurestack)
   steps:
     cluster_profile: azurestack-dev
+    env:
+      TEST_SKIPS: 'In-tree Volumes \[Driver: azure-file\] \| In-tree Volumes \[Driver:
+        azure-disk\]'
     workflow: openshift-e2e-azurestack
 - always_run: false
   as: e2e-azurestack-upi
@@ -1007,6 +1010,9 @@ tests:
   run_if_changed: ^(upi/(azure|azurestack)/.*)
   steps:
     cluster_profile: azurestack-dev
+    env:
+      TEST_SKIPS: 'In-tree Volumes \[Driver: azure-file\] \| In-tree Volumes \[Driver:
+        azure-disk\]'
     workflow: openshift-e2e-azurestack-upi
 - always_run: false
   as: e2e-ibmcloud-ovn

--- a/ci-operator/config/openshift/installer/openshift-installer-release-4.20.yaml
+++ b/ci-operator/config/openshift/installer/openshift-installer-release-4.20.yaml
@@ -1071,6 +1071,9 @@ tests:
   run_if_changed: (azure|azurestack)
   steps:
     cluster_profile: azurestack-dev
+    env:
+      TEST_SKIPS: 'In-tree Volumes \[Driver: azure-file\] \| In-tree Volumes \[Driver:
+        azure-disk\]'
     workflow: openshift-e2e-azurestack
 - always_run: false
   as: e2e-azurestack-upi
@@ -1079,6 +1082,9 @@ tests:
   run_if_changed: ^(upi/(azure|azurestack)/.*)
   steps:
     cluster_profile: azurestack-dev
+    env:
+      TEST_SKIPS: 'In-tree Volumes \[Driver: azure-file\] \| In-tree Volumes \[Driver:
+        azure-disk\]'
     workflow: openshift-e2e-azurestack-upi
 - always_run: false
   as: e2e-ibmcloud-ovn

--- a/ci-operator/config/openshift/installer/openshift-installer-release-4.21.yaml
+++ b/ci-operator/config/openshift/installer/openshift-installer-release-4.21.yaml
@@ -1114,6 +1114,9 @@ tests:
   run_if_changed: (azure|azurestack)
   steps:
     cluster_profile: azurestack-dev
+    env:
+      TEST_SKIPS: 'In-tree Volumes \[Driver: azure-file\] \| In-tree Volumes \[Driver:
+        azure-disk\]'
     workflow: openshift-e2e-azurestack
 - always_run: false
   as: e2e-azurestack-upi
@@ -1122,6 +1125,9 @@ tests:
   run_if_changed: ^(upi/(azure|azurestack)/.*)
   steps:
     cluster_profile: azurestack-dev
+    env:
+      TEST_SKIPS: 'In-tree Volumes \[Driver: azure-file\] \| In-tree Volumes \[Driver:
+        azure-disk\]'
     workflow: openshift-e2e-azurestack-upi
 - always_run: false
   as: e2e-ibmcloud-ovn

--- a/ci-operator/config/openshift/installer/openshift-installer-release-4.22.yaml
+++ b/ci-operator/config/openshift/installer/openshift-installer-release-4.22.yaml
@@ -1115,6 +1115,9 @@ tests:
   run_if_changed: (azure|azurestack)
   steps:
     cluster_profile: azurestack-dev
+    env:
+      TEST_SKIPS: 'In-tree Volumes \[Driver: azure-file\] \| In-tree Volumes \[Driver:
+        azure-disk\]'
     workflow: openshift-e2e-azurestack
 - always_run: false
   as: e2e-azurestack-upi
@@ -1123,6 +1126,9 @@ tests:
   run_if_changed: ^(upi/(azure|azurestack)/.*)
   steps:
     cluster_profile: azurestack-dev
+    env:
+      TEST_SKIPS: 'In-tree Volumes \[Driver: azure-file\] \| In-tree Volumes \[Driver:
+        azure-disk\]'
     workflow: openshift-e2e-azurestack-upi
 - always_run: false
   as: e2e-ibmcloud-ovn

--- a/ci-operator/config/openshift/installer/openshift-installer-release-4.23.yaml
+++ b/ci-operator/config/openshift/installer/openshift-installer-release-4.23.yaml
@@ -1114,6 +1114,9 @@ tests:
   run_if_changed: (azure|azurestack)
   steps:
     cluster_profile: azurestack-dev
+    env:
+      TEST_SKIPS: 'In-tree Volumes \[Driver: azure-file\] \| In-tree Volumes \[Driver:
+        azure-disk\]'
     workflow: openshift-e2e-azurestack
 - always_run: false
   as: e2e-azurestack-upi
@@ -1122,6 +1125,9 @@ tests:
   run_if_changed: ^(upi/(azure|azurestack)/.*)
   steps:
     cluster_profile: azurestack-dev
+    env:
+      TEST_SKIPS: 'In-tree Volumes \[Driver: azure-file\] \| In-tree Volumes \[Driver:
+        azure-disk\]'
     workflow: openshift-e2e-azurestack-upi
 - always_run: false
   as: e2e-ibmcloud-ovn


### PR DESCRIPTION
Checked with storage QE ([slack thread](https://redhat-internal.slack.com/archives/CF8SMALS1/p1769561167763129?thread_ts=1769474096.726129&cid=CF8SMALS1)), 
1. In-tree azure-file is not supported on Azure Stack hub
2. some failed topology cases in in-tree azure-disk because of the topology key, there is no plan to fix this in-tree for ASH, considering we are testing azure-disk CSI driver in ASH, it is safe to skip in-tree azure-disk as well 

so exclude those test cases in installer azure stack pre-submit jobs.