### PR TITLE
Update make target for image updater

### DIFF
--- a/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__image-updater.yaml
+++ b/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__image-updater.yaml
@@ -26,7 +26,7 @@ images:
     ENV GOCACHE=/opt/app-root/.cache
     RUN mkdir -p $GOPATH/bin && \
         make install-tools && \
-        make -C tooling/image-updater build && \
+        make image-updater-build && \
         make -C tooling/templatize templatize && \
         make -C tooling/yamlwrap && \
         make all-tidy && \

--- a/ci-operator/step-registry/aro-hcp/automation/image-update/aro-hcp-automation-image-update-commands.sh
+++ b/ci-operator/step-registry/aro-hcp/automation/image-update/aro-hcp-automation-image-update-commands.sh
@@ -134,9 +134,9 @@ export AZURE_TENANT_ID
 
 debug "azure: authentication configured successfully (credentials redacted)"
 
-# Image Updater: Build and run the image-updater tool
+# Image Updater: Run the image-updater tool
 info "image: fetching the latest image digests for all components"
-make image-updater OUTPUT_FILE="${IMAGE_UPDATER_OUTPUT}" OUTPUT_FORMAT="${IMAGE_UPDATER_OUTPUT_FORMAT}"
+make image-updater-update OUTPUT_FILE="${IMAGE_UPDATER_OUTPUT}" OUTPUT_FORMAT="${IMAGE_UPDATER_OUTPUT_FORMAT}"
 
 # Check if there are any changes from image updates
 if [[ $(git status --porcelain) == "" ]]; then


### PR DESCRIPTION
Update make target for image updater. 
New make targets were added here - https://github.com/Azure/ARO-HCP/pull/3864/changes. 
Fixes image updater error - `make: *** No rule to make target 'image-updater'.  Stop.`