### PR TITLE
CNTRLPLANE-2580 hypershift: add periodic-konflux-check for Tekton task updates

### DIFF
--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-main.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-main.yaml
@@ -545,6 +545,10 @@ tests:
       GKE_REGION: us-central1
       GKE_RELEASE_CHANNEL: stable
     workflow: hypershift-gcp-gke-e2e
+- as: periodic-konflux-check
+  cron: 0 8 * * 1
+  steps:
+    workflow: hypershift-konflux-check
 zz_generated_metadata:
   branch: main
   org: openshift

--- a/ci-operator/jobs/openshift/hypershift/openshift-hypershift-main-periodics.yaml
+++ b/ci-operator/jobs/openshift/hypershift/openshift-hypershift-main-periodics.yaml
@@ -230,7 +230,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build07
+  cluster: build06
   cron: 30 8 * * 1
   decorate: true
   extra_refs:
@@ -249,6 +249,72 @@ periodics:
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
       - --target=periodic-jira-agent
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build06
+  cron: 0 8 * * 1
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: hypershift
+  labels:
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-hypershift-main-periodic-konflux-check
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=periodic-konflux-check
       command:
       - ci-operator
       env:

--- a/ci-operator/step-registry/hypershift/konflux-check/OWNERS
+++ b/ci-operator/step-registry/hypershift/konflux-check/OWNERS
@@ -1,0 +1,12 @@
+approvers:
+- bryan-cox
+- csrwng
+- celebdor
+- enxebre
+- sjenning
+reviewers:
+- bryan-cox
+- csrwng
+- celebdor
+- enxebre
+- sjenning

--- a/ci-operator/step-registry/hypershift/konflux-check/hypershift-konflux-check-workflow.metadata.json
+++ b/ci-operator/step-registry/hypershift/konflux-check/hypershift-konflux-check-workflow.metadata.json
@@ -1,0 +1,19 @@
+{
+	"path": "hypershift/konflux-check/hypershift-konflux-check-workflow.yaml",
+	"owners": {
+		"approvers": [
+			"bryan-cox",
+			"csrwng",
+			"celebdor",
+			"enxebre",
+			"sjenning"
+		],
+		"reviewers": [
+			"bryan-cox",
+			"csrwng",
+			"celebdor",
+			"enxebre",
+			"sjenning"
+		]
+	}
+}

--- a/ci-operator/step-registry/hypershift/konflux-check/hypershift-konflux-check-workflow.yaml
+++ b/ci-operator/step-registry/hypershift/konflux-check/hypershift-konflux-check-workflow.yaml
@@ -1,0 +1,21 @@
+workflow:
+  as: hypershift-konflux-check
+  steps:
+    pre:
+      - ref: hypershift-konflux-check-setup
+    test:
+      - ref: hypershift-konflux-check-process
+    post:
+      - ref: hypershift-konflux-check-report
+  documentation: |-
+    Periodic workflow that checks HyperShift Tekton pipeline task bundles for updates.
+
+    This workflow:
+    1. Setup: Verifies Claude Code CLI is available
+    2. Process: Clones HyperShift repo from fork, configures git credentials, runs
+       Claude Code with /update-konflux-tasks skill to detect and apply updates,
+       pushes branch and creates PR if updates are found
+    3. Report: Generates HTML report with task update details, PR link, token usage,
+       and cost estimates
+
+    Schedule: Weekly on Mondays at 08:00 UTC

--- a/ci-operator/step-registry/hypershift/konflux-check/process/OWNERS
+++ b/ci-operator/step-registry/hypershift/konflux-check/process/OWNERS
@@ -1,0 +1,12 @@
+approvers:
+- bryan-cox
+- csrwng
+- celebdor
+- enxebre
+- sjenning
+reviewers:
+- bryan-cox
+- csrwng
+- celebdor
+- enxebre
+- sjenning

--- a/ci-operator/step-registry/hypershift/konflux-check/process/hypershift-konflux-check-process-commands.sh
+++ b/ci-operator/step-registry/hypershift/konflux-check/process/hypershift-konflux-check-process-commands.sh
@@ -1,0 +1,244 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "=== HyperShift Konflux Task Update Check ==="
+
+# Clone HyperShift fork (we push here and create PRs to upstream)
+echo "Cloning HyperShift repository..."
+git clone https://github.com/hypershift-community/hypershift /tmp/hypershift
+
+cd /tmp/hypershift
+
+# Configure git
+git config user.name "OpenShift CI Bot"
+git config user.email "ci-bot@redhat.com"
+
+# Generate GitHub App installation token
+echo "Generating GitHub App token..."
+
+GITHUB_APP_CREDS_DIR="/var/run/claude-code-service-account"
+APP_ID_FILE="${GITHUB_APP_CREDS_DIR}/app-id"
+INSTALLATION_ID_FILE="${GITHUB_APP_CREDS_DIR}/installation-id"
+PRIVATE_KEY_FILE="${GITHUB_APP_CREDS_DIR}/private-key"
+INSTALLATION_ID_UPSTREAM_FILE="${GITHUB_APP_CREDS_DIR}/o-h-installation-id"
+
+# Check if all required credentials exist
+if [ ! -f "$APP_ID_FILE" ] || [ ! -f "$INSTALLATION_ID_FILE" ] || [ ! -f "$PRIVATE_KEY_FILE" ] || [ ! -f "$INSTALLATION_ID_UPSTREAM_FILE" ]; then
+  echo "GitHub App credentials not yet available in ${GITHUB_APP_CREDS_DIR}"
+  echo "Available files:"
+  ls -la "${GITHUB_APP_CREDS_DIR}/" || echo "Directory does not exist"
+  echo ""
+  echo "Waiting for Vault secretsync to complete. The following keys are required:"
+  echo "  - app-id"
+  echo "  - installation-id (for hypershift-community fork)"
+  echo "  - o-h-installation-id (for openshift/hypershift upstream)"
+  echo "  - private-key"
+  echo ""
+  echo "Exiting gracefully. Re-run once secrets are synced."
+  echo "STATUS:NO_CREDENTIALS" > "${SHARED_DIR}/konflux-check-results.txt"
+  exit 0
+fi
+
+APP_ID=$(cat "$APP_ID_FILE")
+INSTALLATION_ID_FORK=$(cat "$INSTALLATION_ID_FILE")
+INSTALLATION_ID_UPSTREAM=$(cat "$INSTALLATION_ID_UPSTREAM_FILE")
+
+# Function to generate GitHub App token for a given installation ID
+generate_github_token() {
+  local INSTALL_ID=$1
+  local NOW
+  NOW=$(date +%s)
+  local IAT=$((NOW - 60))
+  local EXP=$((NOW + 600))
+
+  local HEADER
+  HEADER=$(echo -n '{"alg":"RS256","typ":"JWT"}' | base64 | tr -d '=' | tr '/+' '_-' | tr -d '\n')
+  local PAYLOAD
+  PAYLOAD=$(echo -n "{\"iat\":${IAT},\"exp\":${EXP},\"iss\":\"${APP_ID}\"}" | base64 | tr -d '=' | tr '/+' '_-' | tr -d '\n')
+  local SIGNATURE
+  SIGNATURE=$(echo -n "${HEADER}.${PAYLOAD}" | openssl dgst -sha256 -sign "$PRIVATE_KEY_FILE" | base64 | tr -d '=' | tr '/+' '_-' | tr -d '\n')
+  local JWT="${HEADER}.${PAYLOAD}.${SIGNATURE}"
+
+  curl -s -X POST \
+    -H "Authorization: Bearer ${JWT}" \
+    -H "Accept: application/vnd.github+json" \
+    "https://api.github.com/app/installations/${INSTALL_ID}/access_tokens" \
+    | jq -r '.token'
+}
+
+# Generate token for fork (hypershift-community/hypershift) - for pushing branches
+echo "Generating GitHub App token for fork..."
+GITHUB_TOKEN_FORK=$(generate_github_token "$INSTALLATION_ID_FORK")
+if [ -z "$GITHUB_TOKEN_FORK" ] || [ "$GITHUB_TOKEN_FORK" = "null" ]; then
+  echo "ERROR: Failed to generate GitHub App token for fork"
+  exit 1
+fi
+echo "Fork token generated successfully"
+
+# Generate token for upstream (openshift/hypershift) - for creating PRs
+echo "Generating GitHub App token for upstream..."
+GITHUB_TOKEN_UPSTREAM=$(generate_github_token "$INSTALLATION_ID_UPSTREAM")
+if [ -z "$GITHUB_TOKEN_UPSTREAM" ] || [ "$GITHUB_TOKEN_UPSTREAM" = "null" ]; then
+  echo "ERROR: Failed to generate GitHub App token for upstream"
+  exit 1
+fi
+echo "Upstream token generated successfully"
+
+# Configure git to use the fork token for push operations via credential helper
+git config --global credential.helper "!f() { echo username=x-access-token; echo password=${GITHUB_TOKEN_FORK}; }; f"
+
+# Export upstream token as GITHUB_TOKEN for gh CLI (used for PR creation)
+export GITHUB_TOKEN="$GITHUB_TOKEN_UPSTREAM"
+echo "GitHub App tokens configured successfully"
+
+# Load Jira API token for creating tickets
+JIRA_TOKEN_FILE="/var/run/claude-code-service-account/jira-pat"
+if [ -f "$JIRA_TOKEN_FILE" ]; then
+  JIRA_TOKEN=$(cat "$JIRA_TOKEN_FILE")
+  export JIRA_TOKEN
+  echo "Jira API token loaded from jira-pat"
+else
+  echo "Warning: Jira API token not found at $JIRA_TOKEN_FILE"
+  echo "Jira tickets will not be created"
+  JIRA_TOKEN=""
+fi
+
+# Create branch name with date
+BRANCH_NAME="konflux-task-update-$(date +%Y%m%d)"
+echo "Creating branch: $BRANCH_NAME"
+git checkout -b "$BRANCH_NAME"
+
+# Record the starting commit SHA so we can detect changes after Claude runs
+START_SHA=$(git rev-parse HEAD)
+
+# Additional context for fork-based workflow
+FORK_CONTEXT="IMPORTANT: You are working in a fork (hypershift-community/hypershift). Git push is pre-configured to work with the fork. CRITICAL: When running hack/tools/scripts/update_trusted_task_bundles.py, you MUST pass --upgrade-versions to detect and apply version bumps (e.g. 0.7 to 0.9), not just digest updates within the same version. CRITICAL: After applying all updates, you MUST complete these steps in order: 1) git add -A && git commit -m 'chore(ci): update Konflux Tekton tasks to latest versions' 2) git push origin $BRANCH_NAME 3) gh pr create --repo openshift/hypershift --head hypershift-community:$BRANCH_NAME --no-maintainer-edit --title 'NO-JIRA: chore(ci): update Konflux Tekton tasks to latest versions' --body '<body>'. The gh CLI is authenticated to openshift/hypershift. Do NOT skip commit, push, or PR creation - these are ALL required steps. SECURITY: Do NOT run commands that reveal git credentials like 'git remote -v' or 'git remote get-url origin'."
+
+# Run the update-konflux-tasks skill
+echo "Running /update-konflux-tasks skill..."
+
+CLAUDE_OUTPUT_FILE="/tmp/claude-konflux-output.json"
+CLAUDE_START_TIME=$(date +%s)
+
+set +e  # Don't exit on error
+echo "/update-konflux-tasks. $FORK_CONTEXT" | claude --print \
+  --allowedTools "Bash,Read,Write,Edit,Grep,Glob,WebFetch,mcp__atlassian__jira_create_issue,mcp__atlassian__jira_search,mcp__atlassian__jira_add_comment" \
+  --max-turns 100 \
+  --verbose \
+  --output-format stream-json \
+  2> "/tmp/claude-konflux-stderr.log" \
+  | tee "$CLAUDE_OUTPUT_FILE"
+CLAUDE_EXIT_CODE=$?
+set -e
+
+CLAUDE_END_TIME=$(date +%s)
+CLAUDE_DURATION=$((CLAUDE_END_TIME - CLAUDE_START_TIME))
+echo "$CLAUDE_DURATION" > "${SHARED_DIR}/claude-konflux-duration.txt"
+
+echo "Claude processing complete (exit code: $CLAUDE_EXIT_CODE, duration: ${CLAUDE_DURATION}s)"
+
+# Extract token usage from stream-json result message
+grep '"type":"result"' "$CLAUDE_OUTPUT_FILE" \
+  | head -1 \
+  | jq '{
+      total_cost_usd: (.total_cost_usd // 0),
+      duration_ms: (.duration_ms // 0),
+      num_turns: (.num_turns // 0),
+      input_tokens: (.input_tokens // 0),
+      output_tokens: (.output_tokens // 0),
+      cache_read_input_tokens: (.cache_read_input_tokens // 0),
+      cache_creation_input_tokens: (.cache_creation_input_tokens // 0),
+      model_usage: (.model_usage // {}),
+      model: (.model // "unknown")
+    }' > "${SHARED_DIR}/claude-konflux-tokens.json" 2>/dev/null \
+  || echo '{"total_cost_usd":0,"duration_ms":0,"num_turns":0,"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"model_usage":{},"model":"unknown"}' > "${SHARED_DIR}/claude-konflux-tokens.json"
+echo "Token usage: $(cat "${SHARED_DIR}/claude-konflux-tokens.json")"
+
+# Extract Claude text output and tool usage summaries
+jq -r '
+  if .type == "assistant" then
+    .message.content[]? |
+    if .type == "text" then .text
+    else empty end
+  else empty end
+' "$CLAUDE_OUTPUT_FILE" > "${SHARED_DIR}/claude-konflux-output-text.txt" 2>/dev/null || true
+
+jq -r 'select(.type == "assistant") | .message.content[]? | select(.type == "tool_use") | "\(.name): \(.input | keys | join(", "))"' "$CLAUDE_OUTPUT_FILE" 2>/dev/null \
+  | sort | uniq -c | sort -rn > "${SHARED_DIR}/claude-konflux-output-tools.txt" 2>/dev/null || true
+
+# Copy stderr log to artifacts
+cp "/tmp/claude-konflux-stderr.log" "${ARTIFACT_DIR}/claude-stderr.log" 2>/dev/null || true
+
+# Detect whether Claude actually made changes by comparing HEAD to the starting SHA
+END_SHA=$(git rev-parse HEAD)
+RESULTS_FILE="${SHARED_DIR}/konflux-check-results.txt"
+
+if [ "$START_SHA" != "$END_SHA" ]; then
+  # Claude committed changes - count the commits
+  COMMIT_COUNT=$(git rev-list "${START_SHA}..HEAD" --count)
+  echo "Detected $COMMIT_COUNT new commit(s)"
+
+  # Extract PR URL from Claude output if available
+  PR_URL=$(jq -r '
+    if .type == "assistant" then
+      .message.content[]? |
+      if .type == "text" then .text
+      else empty end
+    else empty end
+  ' "$CLAUDE_OUTPUT_FILE" 2>/dev/null | grep -oE 'https://github.com/openshift/hypershift/pull/[0-9]+' | head -1 || echo "")
+
+  # Get the list of updated tasks from git diff
+  CHANGED_FILES=$(git diff --name-only "${START_SHA}..HEAD" | sort)
+
+  {
+    echo "STATUS:UPDATED"
+    echo "COMMITS:$COMMIT_COUNT"
+    echo "PR_URL:${PR_URL:-none}"
+    echo "START_SHA:$START_SHA"
+    echo "END_SHA:$END_SHA"
+    echo "CHANGED_FILES:$CHANGED_FILES"
+  } > "$RESULTS_FILE"
+
+  # Extract the commit messages for the report
+  git log --format="%s" "${START_SHA}..HEAD" > "${SHARED_DIR}/konflux-check-commits.txt" 2>/dev/null || true
+
+  echo ""
+  echo "Konflux task updates applied successfully."
+  if [ -n "$PR_URL" ]; then
+    echo "PR: $PR_URL"
+    echo "$PR_URL" > "${SHARED_DIR}/konflux-check-pr-url.txt"
+
+    # Append report link to PR description
+    PR_NUM=$(echo "$PR_URL" | grep -o '[0-9]*$' || true)
+    if [ -n "$PR_NUM" ] && [ -n "${BUILD_ID:-}" ] && [ -n "${JOB_NAME:-}" ]; then
+      REPORT_URL=""
+      if [ "${JOB_TYPE:-}" = "periodic" ]; then
+        REPORT_URL="https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/${JOB_NAME}/${BUILD_ID}/artifacts/periodic-konflux-check/hypershift-konflux-check-report/artifacts/konflux-check-report.html"
+      else
+        REPORT_URL="https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_release/${PULL_NUMBER:-0}/${JOB_NAME}/${BUILD_ID}/artifacts/periodic-konflux-check/hypershift-konflux-check-report/artifacts/konflux-check-report.html"
+      fi
+      echo "Appending report link to PR #${PR_NUM} description..."
+      CURRENT_BODY=$(gh pr view "$PR_NUM" --repo openshift/hypershift --json body -q .body 2>/dev/null || echo "")
+      REPORT_SECTION="---
+
+> **Note:** This PR was auto-generated by the [konflux-check](https://github.com/openshift/release/tree/main/ci-operator/step-registry/hypershift/konflux-check) periodic CI job. See the [full report](${REPORT_URL}) for token usage, cost breakdown, and detailed output."
+      UPDATED_BODY="${CURRENT_BODY}
+
+${REPORT_SECTION}"
+      gh pr edit "$PR_NUM" --repo openshift/hypershift --body "$UPDATED_BODY" 2>/dev/null || echo "Warning: Failed to update PR #${PR_NUM} description"
+    fi
+  else
+    echo "Warning: No PR URL found in Claude output."
+  fi
+else
+  echo "No changes detected. Konflux tasks are up to date."
+  echo "STATUS:UP_TO_DATE" > "$RESULTS_FILE"
+fi
+
+if [ $CLAUDE_EXIT_CODE -ne 0 ]; then
+  echo "WARNING: Claude exited with non-zero status ($CLAUDE_EXIT_CODE)"
+  echo "CLAUDE_EXIT_CODE:$CLAUDE_EXIT_CODE" >> "$RESULTS_FILE"
+fi
+
+echo ""
+echo "=== Konflux Task Update Check Complete ==="

--- a/ci-operator/step-registry/hypershift/konflux-check/process/hypershift-konflux-check-process-ref.metadata.json
+++ b/ci-operator/step-registry/hypershift/konflux-check/process/hypershift-konflux-check-process-ref.metadata.json
@@ -1,0 +1,19 @@
+{
+	"path": "hypershift/konflux-check/process/hypershift-konflux-check-process-ref.yaml",
+	"owners": {
+		"approvers": [
+			"bryan-cox",
+			"csrwng",
+			"celebdor",
+			"enxebre",
+			"sjenning"
+		],
+		"reviewers": [
+			"bryan-cox",
+			"csrwng",
+			"celebdor",
+			"enxebre",
+			"sjenning"
+		]
+	}
+}

--- a/ci-operator/step-registry/hypershift/konflux-check/process/hypershift-konflux-check-process-ref.yaml
+++ b/ci-operator/step-registry/hypershift/konflux-check/process/hypershift-konflux-check-process-ref.yaml
@@ -1,0 +1,31 @@
+ref:
+  as: hypershift-konflux-check-process
+  from: claude-ai-helpers
+  commands: hypershift-konflux-check-process-commands.sh
+  env:
+  - name: CLAUDE_CODE_USE_VERTEX
+    default: "1"
+    documentation: Enable Vertex AI for Claude Code.
+  - name: CLOUD_ML_REGION
+    default: "us-east5"
+    documentation: Google Cloud region for Vertex AI.
+  - name: ANTHROPIC_VERTEX_PROJECT_ID
+    default: "itpc-gcp-hybrid-pe-eng-claude"
+    documentation: Google Cloud project ID for Vertex AI authentication.
+  - name: GOOGLE_APPLICATION_CREDENTIALS
+    default: "/var/run/claude-code-service-account/claude-prow"
+    documentation: Path to the Google Cloud service account JSON key file.
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+  credentials:
+  - namespace: test-credentials
+    name: hypershift-team-claude-prow
+    mount_path: /var/run/claude-code-service-account
+  documentation: |-
+    Process step for the HyperShift Konflux task update check.
+    Clones the HyperShift repository from the hypershift-community fork,
+    runs Claude Code with /update-konflux-tasks skill to detect and apply
+    Tekton task bundle updates, and creates a PR if updates are found.
+    Results and token usage are written to SHARED_DIR for the report step.

--- a/ci-operator/step-registry/hypershift/konflux-check/report/OWNERS
+++ b/ci-operator/step-registry/hypershift/konflux-check/report/OWNERS
@@ -1,0 +1,12 @@
+approvers:
+- bryan-cox
+- csrwng
+- celebdor
+- enxebre
+- sjenning
+reviewers:
+- bryan-cox
+- csrwng
+- celebdor
+- enxebre
+- sjenning

--- a/ci-operator/step-registry/hypershift/konflux-check/report/hypershift-konflux-check-report-commands.sh
+++ b/ci-operator/step-registry/hypershift/konflux-check/report/hypershift-konflux-check-report-commands.sh
@@ -1,0 +1,251 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "=== Konflux Check Report Generation ==="
+
+RESULTS_FILE="${SHARED_DIR}/konflux-check-results.txt"
+TOKEN_FILE="${SHARED_DIR}/claude-konflux-tokens.json"
+REPORT_FILE="${ARTIFACT_DIR}/konflux-check-report.html"
+
+if [ ! -f "$RESULTS_FILE" ]; then
+  echo "No results file found. Nothing to report."
+  exit 0
+fi
+
+# Parse results
+STATUS=$(grep '^STATUS:' "$RESULTS_FILE" | head -1 | cut -d: -f2)
+COMMIT_COUNT=$(grep '^COMMITS:' "$RESULTS_FILE" | head -1 | cut -d: -f2 || echo "0")
+PR_URL=$(grep '^PR_URL:' "$RESULTS_FILE" | head -1 | cut -d: -f2- || echo "none")
+CHANGED_FILES_RAW=$(grep '^CHANGED_FILES:' "$RESULTS_FILE" | head -1 | cut -d: -f2- || echo "")
+CLAUDE_EXIT_CODE=$(grep '^CLAUDE_EXIT_CODE:' "$RESULTS_FILE" | head -1 | cut -d: -f2 || echo "0")
+
+RUN_TIMESTAMP=$(date -u +"%Y-%m-%d %H:%M:%S UTC")
+
+# Read a pre-extracted text file, or return a placeholder
+read_extracted() {
+  local file=$1
+  if [ -f "$file" ] && [ -s "$file" ]; then
+    cat "$file"
+  else
+    echo "(no output captured)"
+  fi
+}
+
+# Read a JSON token file and extract a field, defaulting to 0
+read_token_field() {
+  local file=$1
+  local field=$2
+  if [ -f "$file" ] && [ -s "$file" ]; then
+    jq -r ".${field} // 0" "$file" 2>/dev/null || echo "0"
+  else
+    echo "0"
+  fi
+}
+
+# Format token count with comma separators
+format_number() {
+  local num=$1
+  printf "%s" "$num" | sed -e ':a' -e 's/\([0-9]\)\([0-9]\{3\}\)\(\b\)/\1,\2\3/' -e 'ta'
+}
+
+# Format a cost value for display
+format_cost() {
+  local cost=${1:-0}
+  printf '$%s' "$(awk "BEGIN {printf \"%.4f\", $cost}" 2>/dev/null || echo "0.0000")"
+}
+
+# HTML-escape a string
+html_escape() {
+  sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g; s/"/\&quot;/g'
+}
+
+# Format seconds into human-readable string
+format_duration() {
+  local secs=$1
+  if [ "$secs" -eq 0 ] 2>/dev/null; then
+    echo "-"
+    return
+  fi
+  local mins=$(( secs / 60 ))
+  local s=$(( secs % 60 ))
+  if [ "$mins" -gt 0 ]; then
+    printf "%dm %ds" "$mins" "$s"
+  else
+    printf "%ds" "$s"
+  fi
+}
+
+# Read token data
+INPUT_TOKENS=$(read_token_field "$TOKEN_FILE" "input_tokens")
+OUTPUT_TOKENS=$(read_token_field "$TOKEN_FILE" "output_tokens")
+CACHE_READ=$(read_token_field "$TOKEN_FILE" "cache_read_input_tokens")
+CACHE_CREATE=$(read_token_field "$TOKEN_FILE" "cache_creation_input_tokens")
+MODEL=$(read_token_field "$TOKEN_FILE" "model")
+TOTAL_COST_RAW=$(read_token_field "$TOKEN_FILE" "total_cost_usd")
+TOTAL_COST=$(format_cost "$TOTAL_COST_RAW")
+DURATION_MS=$(read_token_field "$TOKEN_FILE" "duration_ms")
+NUM_TURNS=$(read_token_field "$TOKEN_FILE" "num_turns")
+
+# Read duration from our own measurement
+DURATION_SECS=$(cat "${SHARED_DIR}/claude-konflux-duration.txt" 2>/dev/null || echo "0")
+DURATION_DISPLAY=$(format_duration "$DURATION_SECS")
+
+# Status display
+case "$STATUS" in
+  UPDATED)
+    STATUS_LABEL="Updates Applied"
+    STATUS_COLOR="#22863a"
+    ;;
+  UP_TO_DATE)
+    STATUS_LABEL="Up to Date"
+    STATUS_COLOR="#0366d6"
+    ;;
+  NO_CREDENTIALS)
+    STATUS_LABEL="No Credentials"
+    STATUS_COLOR="#e36209"
+    ;;
+  *)
+    STATUS_LABEL="Unknown"
+    STATUS_COLOR="#666"
+    ;;
+esac
+
+# PR banner
+PR_BANNER=""
+if [ "$PR_URL" != "none" ] && [ -n "$PR_URL" ]; then
+  PR_NUMBER="${PR_URL##*/}"
+  PR_BANNER="<div style=\"background:#dcffe4; border:2px solid #22863a; border-radius:8px; padding:1em 1.5em; margin:1em 0;\"><strong style=\"font-size:1.2em;\">Pull Request: <a href=\"${PR_URL}\">#${PR_NUMBER}</a></strong></div>"
+fi
+
+# Changed files table
+CHANGED_FILES_SECTION=""
+if [ -n "$CHANGED_FILES_RAW" ]; then
+  CHANGED_FILES_ROWS=""
+  for f in $CHANGED_FILES_RAW; do
+    CHANGED_FILES_ROWS="${CHANGED_FILES_ROWS}<tr><td><code>$(echo "$f" | html_escape)</code></td></tr>"
+  done
+  CHANGED_FILES_SECTION="
+<h2>Changed Files</h2>
+<table>
+<thead><tr><th>File</th></tr></thead>
+<tbody>
+${CHANGED_FILES_ROWS}
+</tbody>
+</table>"
+fi
+
+# Commit messages section
+COMMITS_SECTION=""
+if [ -f "${SHARED_DIR}/konflux-check-commits.txt" ] && [ -s "${SHARED_DIR}/konflux-check-commits.txt" ]; then
+  COMMIT_ROWS=""
+  while IFS= read -r msg; do
+    COMMIT_ROWS="${COMMIT_ROWS}<tr><td>$(echo "$msg" | html_escape)</td></tr>"
+  done < "${SHARED_DIR}/konflux-check-commits.txt"
+  COMMITS_SECTION="
+<h2>Commits</h2>
+<table>
+<thead><tr><th>Message</th></tr></thead>
+<tbody>
+${COMMIT_ROWS}
+</tbody>
+</table>"
+fi
+
+# Build per-model breakdown rows for the token table
+MODEL_BREAKDOWN_ROWS=""
+if [ -f "$TOKEN_FILE" ] && [ -s "$TOKEN_FILE" ]; then
+  while IFS= read -r model_line; do
+    model_name=$(echo "$model_line" | jq -r '.key')
+    model_input=$(echo "$model_line" | jq -r '.value.input_tokens // .value.inputTokens // 0')
+    model_output=$(echo "$model_line" | jq -r '.value.output_tokens // .value.outputTokens // 0')
+    MODEL_BREAKDOWN_ROWS="${MODEL_BREAKDOWN_ROWS}<tr style=\"font-size:0.85em; color:#666;\"><td>&nbsp;&nbsp;${model_name}</td><td>$(format_number "$model_input")</td><td>$(format_number "$model_output")</td><td>-</td><td>-</td><td>-</td></tr>"
+  done < <(jq -c '.model_usage // {} | to_entries[]' "$TOKEN_FILE" 2>/dev/null || true)
+fi
+
+# Claude warnings section
+WARNINGS_SECTION=""
+if [ "$CLAUDE_EXIT_CODE" != "0" ] && [ "$CLAUDE_EXIT_CODE" != "" ]; then
+  WARNINGS_SECTION="<div style=\"background:#fff5b1; border:2px solid #e36209; border-radius:8px; padding:1em 1.5em; margin:1em 0;\"><strong>Warning:</strong> Claude exited with non-zero status code: ${CLAUDE_EXIT_CODE}</div>"
+fi
+
+# Read Claude output text and tool summaries
+CLAUDE_TEXT=$(read_extracted "${SHARED_DIR}/claude-konflux-output-text.txt" | html_escape)
+CLAUDE_TOOLS=$(read_extracted "${SHARED_DIR}/claude-konflux-output-tools.txt" | html_escape)
+
+# Write the HTML report
+cat > "$REPORT_FILE" <<EOF
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Konflux Task Update Report</title>
+<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; margin: 2em; background: #f5f5f5; color: #333; }
+  h1 { border-bottom: 2px solid #333; padding-bottom: 0.3em; }
+  .summary-stats { display: flex; gap: 2em; margin: 1em 0; flex-wrap: wrap; }
+  .stat { background: #fff; padding: 1em 1.5em; border-radius: 6px; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+  .stat .value { font-size: 2em; font-weight: bold; }
+  .stat .label { color: #666; }
+  table { border-collapse: collapse; width: 100%; background: #fff; border-radius: 6px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.1); margin: 1em 0; }
+  th, td { padding: 0.75em 1em; text-align: left; border-bottom: 1px solid #eee; }
+  th { background: #f8f8f8; font-weight: 600; }
+  a { color: #0366d6; text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  code { background: #f0f0f0; padding: 0.15em 0.4em; border-radius: 3px; font-size: 0.9em; }
+  .token-table { width: auto; min-width: 600px; }
+  .token-table td, .token-table th { text-align: right; }
+  .token-table td:first-child, .token-table th:first-child { text-align: left; }
+  .total-row td { border-top: 2px solid #333; }
+  .model-info { color: #666; font-size: 0.85em; margin-top: 0.3em; }
+  .output-card { background: #fff; border-radius: 6px; padding: 1.5em; margin: 1.5em 0; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+  .output-card h3 { color: #555; margin-top: 0; }
+  .output-card pre { background: #f6f8fa; padding: 1em; border-radius: 4px; overflow-x: auto; white-space: pre-wrap; word-wrap: break-word; font-size: 0.85em; max-height: 400px; overflow-y: auto; }
+  details { margin: 0.5em 0 1em 0; }
+  details summary { cursor: pointer; color: #666; font-size: 0.9em; }
+  details pre { background: #f6f8fa; padding: 1em; border-radius: 4px; font-size: 0.8em; overflow-x: auto; }
+  .timestamp { color: #666; font-size: 0.9em; }
+</style>
+</head>
+<body>
+<h1>Konflux Task Update Report</h1>
+<p class="timestamp">Generated: ${RUN_TIMESTAMP}</p>
+
+${PR_BANNER}
+${WARNINGS_SECTION}
+
+<div class="summary-stats">
+  <div class="stat"><div class="value" style="color:${STATUS_COLOR}">${STATUS_LABEL}</div><div class="label">Status</div></div>
+  <div class="stat"><div class="value">${COMMIT_COUNT:-0}</div><div class="label">Commits</div></div>
+  <div class="stat"><div class="value">${DURATION_DISPLAY}</div><div class="label">Duration</div></div>
+  <div class="stat"><div class="value">$(format_number "$INPUT_TOKENS")</div><div class="label">Input Tokens</div></div>
+  <div class="stat"><div class="value">$(format_number "$OUTPUT_TOKENS")</div><div class="label">Output Tokens</div></div>
+  <div class="stat"><div class="value">${TOTAL_COST}</div><div class="label">Cost</div></div>
+</div>
+
+${COMMITS_SECTION}
+
+${CHANGED_FILES_SECTION}
+
+<h2>Token Usage &amp; Cost</h2>
+<table class="token-table">
+<thead><tr><th>Category</th><th>Input Tokens</th><th>Output Tokens</th><th>Cache Read</th><th>Cache Create</th><th>Cost</th></tr></thead>
+<tbody>
+<tr class="total-row"><td><strong>Total</strong></td><td><strong>$(format_number "$INPUT_TOKENS")</strong></td><td><strong>$(format_number "$OUTPUT_TOKENS")</strong></td><td><strong>$(format_number "$CACHE_READ")</strong></td><td><strong>$(format_number "$CACHE_CREATE")</strong></td><td><strong>${TOTAL_COST}</strong></td></tr>
+${MODEL_BREAKDOWN_ROWS}
+</tbody>
+</table>
+<p class="model-info">Primary model: ${MODEL} | ${NUM_TURNS} turns | $((DURATION_MS / 1000))s</p>
+
+<div class="output-card">
+  <h3>Claude Output</h3>
+  <div><pre>${CLAUDE_TEXT}</pre></div>
+  <details><summary>Tool calls</summary><pre>${CLAUDE_TOOLS}</pre></details>
+</div>
+
+</body>
+</html>
+EOF
+
+echo "Report written to ${REPORT_FILE}"
+
+echo "=== Report generation complete ==="

--- a/ci-operator/step-registry/hypershift/konflux-check/report/hypershift-konflux-check-report-ref.metadata.json
+++ b/ci-operator/step-registry/hypershift/konflux-check/report/hypershift-konflux-check-report-ref.metadata.json
@@ -1,0 +1,19 @@
+{
+	"path": "hypershift/konflux-check/report/hypershift-konflux-check-report-ref.yaml",
+	"owners": {
+		"approvers": [
+			"bryan-cox",
+			"csrwng",
+			"celebdor",
+			"enxebre",
+			"sjenning"
+		],
+		"reviewers": [
+			"bryan-cox",
+			"csrwng",
+			"celebdor",
+			"enxebre",
+			"sjenning"
+		]
+	}
+}

--- a/ci-operator/step-registry/hypershift/konflux-check/report/hypershift-konflux-check-report-ref.yaml
+++ b/ci-operator/step-registry/hypershift/konflux-check/report/hypershift-konflux-check-report-ref.yaml
@@ -1,0 +1,12 @@
+ref:
+  as: hypershift-konflux-check-report
+  from: claude-ai-helpers
+  commands: hypershift-konflux-check-report-commands.sh
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+  documentation: |-
+    Generates an HTML report from the Konflux task update check output.
+    Parses stream-json token data, task update results, and PR info
+    to produce a readable report in ${ARTIFACT_DIR}.

--- a/ci-operator/step-registry/hypershift/konflux-check/setup/OWNERS
+++ b/ci-operator/step-registry/hypershift/konflux-check/setup/OWNERS
@@ -1,0 +1,12 @@
+approvers:
+- bryan-cox
+- csrwng
+- celebdor
+- enxebre
+- sjenning
+reviewers:
+- bryan-cox
+- csrwng
+- celebdor
+- enxebre
+- sjenning

--- a/ci-operator/step-registry/hypershift/konflux-check/setup/hypershift-konflux-check-setup-commands.sh
+++ b/ci-operator/step-registry/hypershift/konflux-check/setup/hypershift-konflux-check-setup-commands.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "=== HyperShift Konflux Check Setup ==="
+
+# Verify Claude Code is available (Vertex AI authentication is handled via GOOGLE_APPLICATION_CREDENTIALS env var)
+echo "Verifying Claude Code CLI..."
+claude --version || { echo "ERROR: Claude Code CLI not found"; exit 1; }
+
+echo "Setup complete"

--- a/ci-operator/step-registry/hypershift/konflux-check/setup/hypershift-konflux-check-setup-ref.metadata.json
+++ b/ci-operator/step-registry/hypershift/konflux-check/setup/hypershift-konflux-check-setup-ref.metadata.json
@@ -1,0 +1,19 @@
+{
+	"path": "hypershift/konflux-check/setup/hypershift-konflux-check-setup-ref.yaml",
+	"owners": {
+		"approvers": [
+			"bryan-cox",
+			"csrwng",
+			"celebdor",
+			"enxebre",
+			"sjenning"
+		],
+		"reviewers": [
+			"bryan-cox",
+			"csrwng",
+			"celebdor",
+			"enxebre",
+			"sjenning"
+		]
+	}
+}

--- a/ci-operator/step-registry/hypershift/konflux-check/setup/hypershift-konflux-check-setup-ref.yaml
+++ b/ci-operator/step-registry/hypershift/konflux-check/setup/hypershift-konflux-check-setup-ref.yaml
@@ -1,0 +1,33 @@
+ref:
+  as: hypershift-konflux-check-setup
+  from: claude-ai-helpers
+  commands: hypershift-konflux-check-setup-commands.sh
+  env:
+  - name: CLAUDE_CODE_USE_VERTEX
+    default: "1"
+    documentation: |-
+      Enable Vertex AI for Claude Code.
+  - name: CLOUD_ML_REGION
+    default: "us-east5"
+    documentation: |-
+      Google Cloud region for Vertex AI.
+  - name: ANTHROPIC_VERTEX_PROJECT_ID
+    default: "itpc-gcp-hybrid-pe-eng-claude"
+    documentation: |-
+      Google Cloud project ID for Vertex AI authentication.
+  - name: GOOGLE_APPLICATION_CREDENTIALS
+    default: "/var/run/claude-code-service-account/claude-prow"
+    documentation: |-
+      Path to the Google Cloud service account JSON key file for Vertex AI authentication.
+  resources:
+    requests:
+      cpu: 100m
+      memory: 200Mi
+  credentials:
+  - namespace: test-credentials
+    name: hypershift-team-claude-prow
+    mount_path: /var/run/claude-code-service-account
+  documentation: |-
+    Setup step for the HyperShift Konflux task update check.
+    Verifies Claude Code CLI is available.
+    Vertex AI authentication is handled via GOOGLE_APPLICATION_CREDENTIALS env var.


### PR DESCRIPTION
## Summary
- Adds a new `hypershift-konflux-check` step registry ref that uses Claude Code with the `/update-konflux-tasks` skill
- Adds weekly periodic job (`periodic-konflux-check`) running Mondays at 8:00 UTC
- When Tekton pipeline task bundle updates are found, creates a PR from hypershift-community/hypershift to openshift/hypershift

## Test plan
- [ ] Verify `make jobs` completes successfully
- [ ] Verify step registry files are valid YAML
- [ ] Manual rehearsal of the periodic job once merged

JIRA: [CNTRLPLANE-2580](https://issues.redhat.com/browse/CNTRLPLANE-2580)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CNTRLPLANE-2580]: https://redhat.atlassian.net/browse/CNTRLPLANE-2580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ