### PR TITLE
services/image-mirroring: Add rhel-coreos-base 10.2

### DIFF
--- a/core-services/image-mirroring/_config.yaml
+++ b/core-services/image-mirroring/_config.yaml
@@ -753,6 +753,10 @@ supplementalCIImages:
     namespace: coreos
     name: rhel-coreos-base
     tag: "10.1"
+  coreos/rhel-coreos-base:10.2:
+    namespace: coreos
+    name: rhel-coreos-base
+    tag: "10.2"
   coreos/rhel-coreos-base:9.6:
     namespace: coreos
     name: rhel-coreos-base


### PR DESCRIPTION
 -  Add rhel-coreos-base version 10.2 to the mirroring service.