### PR TITLE
OCPQE-31407: Add new hypershift-mce-agent-metallb chain to install and configure MetalLB in the management cluster for KAS LoadBalancer exposure

### DIFF
--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.21__periodics-mce.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.21__periodics-mce.yaml
@@ -98,6 +98,7 @@ tests:
       LVM_OPERATOR_SUB_SOURCE: lvm-catalogsource
       MCE_VERSION: "2.11"
       METALLB_OPERATOR_SUB_SOURCE: metallb-konflux
+      USE_LOADBALANCER_FOR_KAS: "true"
     workflow: hypershift-mce-agent-metal3-conformance
 - as: e2e-agent-connected-ovn-dualstack-metal-conformance
   capabilities:

--- a/ci-operator/step-registry/hypershift/mce/agent/create/hostedcluster/hypershift-mce-agent-create-hostedcluster-ref.yaml
+++ b/ci-operator/step-registry/hypershift/mce/agent/create/hostedcluster/hypershift-mce-agent-create-hostedcluster-ref.yaml
@@ -32,6 +32,9 @@ ref:
     - name: EXTRA_ARGS
       default: ""
       documentation: "Extra args to pass to the create cluster agent command"
+    - name: USE_LOADBALANCER_FOR_KAS
+      default: "false"
+      documentation: "Use LoadBalancer instead of NodePort for KAS (Kubernetes API Server) service publishing strategy. Requires MetalLB or similar LoadBalancer provider in the management cluster."
   commands: hypershift-mce-agent-create-hostedcluster-commands.sh
   grace_period: 5m0s
   resources:

--- a/ci-operator/step-registry/hypershift/mce/agent/metal3/conformance/hypershift-mce-agent-metal3-conformance-workflow.yaml
+++ b/ci-operator/step-registry/hypershift/mce/agent/metal3/conformance/hypershift-mce-agent-metal3-conformance-workflow.yaml
@@ -19,6 +19,7 @@ workflow:
     - ref: enable-qe-catalogsource
     - ref: deploy-konflux-operator
     - chain: hypershift-mce-agent-lvm
+    - chain: hypershift-mce-agent-metallb
     - ref: hypershift-mce-install
     - chain: hypershift-mce-agent-metal3-create
     env:

--- a/ci-operator/step-registry/hypershift/mce/agent/metallb/OWNERS
+++ b/ci-operator/step-registry/hypershift/mce/agent/metallb/OWNERS
@@ -1,0 +1,21 @@
+approvers:
+- csrwng
+- enxebre
+- sjenning
+- LiangquanLi930
+- rokej
+- jparrill
+- bryan-cox
+- zhfeng
+- heliubj18
+options: {}
+reviewers:
+- csrwng
+- enxebre
+- sjenning
+- LiangquanLi930
+- rokej
+- jparrill
+- bryan-cox
+- zhfeng
+- heliubj18

--- a/ci-operator/step-registry/hypershift/mce/agent/metallb/hypershift-mce-agent-metallb-chain.metadata.json
+++ b/ci-operator/step-registry/hypershift/mce/agent/metallb/hypershift-mce-agent-metallb-chain.metadata.json
@@ -1,0 +1,27 @@
+{
+	"path": "hypershift/mce/agent/metallb/hypershift-mce-agent-metallb-chain.yaml",
+	"owners": {
+		"approvers": [
+			"csrwng",
+			"enxebre",
+			"sjenning",
+			"LiangquanLi930",
+			"rokej",
+			"jparrill",
+			"bryan-cox",
+			"zhfeng",
+			"heliubj18"
+		],
+		"reviewers": [
+			"csrwng",
+			"enxebre",
+			"sjenning",
+			"LiangquanLi930",
+			"rokej",
+			"jparrill",
+			"bryan-cox",
+			"zhfeng",
+			"heliubj18"
+		]
+	}
+}

--- a/ci-operator/step-registry/hypershift/mce/agent/metallb/hypershift-mce-agent-metallb-chain.yaml
+++ b/ci-operator/step-registry/hypershift/mce/agent/metallb/hypershift-mce-agent-metallb-chain.yaml
@@ -1,0 +1,8 @@
+chain:
+  as: hypershift-mce-agent-metallb
+  steps:
+  - ref: operatorhub-subscribe-metallb-operator
+  - ref: hypershift-mce-agent-metallb
+  documentation: |-
+    This chain sets up MetalLB in the management cluster to expose HyperShift KAS as LoadBalancer.
+    Installs MetalLB operator and configures IPAddressPool (192.168.111.20-29) with L2 advertisement.

--- a/ci-operator/step-registry/hypershift/mce/agent/metallb/hypershift-mce-agent-metallb-commands.sh
+++ b/ci-operator/step-registry/hypershift/mce/agent/metallb/hypershift-mce-agent-metallb-commands.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+set -x
+
+oc create -f - <<EOF
+apiVersion: metallb.io/v1beta1
+kind: MetalLB
+metadata:
+  name: metallb
+  namespace: metallb-system
+EOF
+
+oc create -f - <<EOF
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: metallb
+  namespace: metallb-system
+spec:
+  addresses:
+  - 192.168.111.20-192.168.111.29
+EOF
+
+oc create -f - <<EOF
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: l2advertisement
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+   - metallb
+EOF

--- a/ci-operator/step-registry/hypershift/mce/agent/metallb/hypershift-mce-agent-metallb-ref.metadata.json
+++ b/ci-operator/step-registry/hypershift/mce/agent/metallb/hypershift-mce-agent-metallb-ref.metadata.json
@@ -1,0 +1,27 @@
+{
+	"path": "hypershift/mce/agent/metallb/hypershift-mce-agent-metallb-ref.yaml",
+	"owners": {
+		"approvers": [
+			"csrwng",
+			"enxebre",
+			"sjenning",
+			"LiangquanLi930",
+			"rokej",
+			"jparrill",
+			"bryan-cox",
+			"zhfeng",
+			"heliubj18"
+		],
+		"reviewers": [
+			"csrwng",
+			"enxebre",
+			"sjenning",
+			"LiangquanLi930",
+			"rokej",
+			"jparrill",
+			"bryan-cox",
+			"zhfeng",
+			"heliubj18"
+		]
+	}
+}

--- a/ci-operator/step-registry/hypershift/mce/agent/metallb/hypershift-mce-agent-metallb-ref.yaml
+++ b/ci-operator/step-registry/hypershift/mce/agent/metallb/hypershift-mce-agent-metallb-ref.yaml
@@ -1,0 +1,13 @@
+ref:
+  as: hypershift-mce-agent-metallb
+  from: cli
+  grace_period: 10m
+  commands: hypershift-mce-agent-metallb-commands.sh
+  resources:
+    requests:
+      cpu: 1000m
+      memory: 500Mi
+  timeout: 10m0s
+  documentation: |-
+    This step to setup MetalLB in the management cluster for KAS LoadBalancer exposure.
+    Creates MetalLB CR, IPAddressPool (192.168.111.20-29), and L2Advertisement in metallb-system namespace.


### PR DESCRIPTION
This PR adds a new step registry component `hypershift-mce-agent-metallb` to install and configure MetalLB in the management cluster for HyperShift KAS LoadBalancer exposure.

## Changes

### New Step Registry Component: `hypershift-mce-agent-metallb`
- **Location**: `ci-operator/step-registry/hypershift/mce/agent/metallb/`
- **Type**: Chain (step + chain definition)
- **Purpose**: Set up MetalLB in the management cluster to expose HyperShift KAS as LoadBalancer

### Component Details:
- Subscribes to `metallb-operator` from `qe-app-registry` catalog source
- Creates MetalLB CR in `metallb-system` namespace
- Configures IPAddressPool with range **192.168.111.20-29**
- Creates L2Advertisement for Layer 2 address advertisement

### IP Range Selection:
The IP range (192.168.111.20-29) avoids conflicts with the hosted cluster MetalLB instance which uses 192.168.111.30 for ingress LoadBalancer services.

### Workflow Integration:
Updated `hypershift-mce-agent-metal3-conformance` workflow to include the new chain:
- Runs after `hypershift-mce-agent-lvm` setup
- Runs before `hypershift-mce-install`
- Targets management cluster (not hosted cluster)

## Testing
- The chain uses existing, tested components (`operatorhub-subscribe-metallb-operator`)
- IP range validated to avoid Layer 2 ARP conflicts with hosted cluster MetalLB
- Catalog source (`qe-app-registry`) confirmed to exist in management cluster