### PR TITLE
OpenShift Pipelines 1.21 vs 1.20 - Added new jobs for testing 1.21 Pipelines Controller for regression

### DIFF
--- a/ci-operator/config/openshift-pipelines/performance/openshift-pipelines-performance-main.yaml
+++ b/ci-operator/config/openshift-pipelines/performance/openshift-pipelines-performance-main.yaml
@@ -760,21 +760,6 @@ tests:
       TEST_SCENARIOS: 200/12 200/14 200/16 200/18 200/20
     workflow: openshift-pipelines-max-concurrency
 - always_run: false
-  as: max-concurrency-downstream-1-20-1000-x-math-cb
-  optional: true
-  steps:
-    cluster_profile: aws-pipelines-performance
-    env:
-      CUSTOM_BUILD: "true"
-      CUSTOM_BUILD_TAG: “1.20"
-      DEPLOYMENT_TYPE: downstream
-      OCP_VERSION: ”4.19"
-      TEST_NAMESPACE: "5"
-      TEST_SCENARIO: math
-      TEST_SCENARIOS: 200/12 200/14 200/16 200/18 200/20
-    workflow: openshift-pipelines-max-concurrency
-  timeout: 8h0m0s
-- always_run: false
   as: max-concurrency-downstream-1-19-1000-x-math
   optional: true
   steps:
@@ -793,6 +778,18 @@ tests:
     cluster_profile: aws-pipelines-performance
     env:
       DEPLOYMENT_VERSION: “1.20”
+      TEST_NAMESPACE: "5"
+      TEST_SCENARIO: math
+      TEST_SCENARIOS: 200/12 200/14 200/16 200/18 200/20
+    workflow: openshift-pipelines-max-concurrency
+  timeout: 8h0m0s
+- always_run: false
+  as: max-concurrency-downstream-1-21-1000-x-math
+  optional: true
+  steps:
+    cluster_profile: aws-pipelines-performance
+    env:
+      DEPLOYMENT_VERSION: “1.21”
       TEST_NAMESPACE: "5"
       TEST_SCENARIO: math
       TEST_SCENARIOS: 200/12 200/14 200/16 200/18 200/20
@@ -837,23 +834,6 @@ tests:
       TEST_SCENARIOS: 200/10 200/20 200/30 200/40
     workflow: openshift-pipelines-max-concurrency
 - always_run: false
-  as: max-concurrency-downstream-1-20-1000-x-math-ha-10-cb
-  optional: true
-  steps:
-    cluster_profile: aws-pipelines-performance
-    env:
-      CUSTOM_BUILD: "true"
-      CUSTOM_BUILD_TAG: “1.20"
-      DEPLOYMENT_PIPELINES_CONTROLLER_HA_REPLICAS: "10"
-      DEPLOYMENT_TYPE: downstream
-      MUST_GATHER_TIMEOUT: 35m
-      OCP_VERSION: ”4.19"
-      TEST_NAMESPACE: "5"
-      TEST_SCENARIO: math
-      TEST_SCENARIOS: 200/10 200/20 200/30 200/40
-    workflow: openshift-pipelines-max-concurrency
-  timeout: 8h0m0s
-- always_run: false
   as: max-concurrency-downstream-1-19-1000-x-math-ha-10
   optional: true
   steps:
@@ -876,6 +856,21 @@ tests:
       DEPLOYMENT_PIPELINES_CONTROLLER_HA_REPLICAS: "10"
       DEPLOYMENT_PIPELINES_CONTROLLER_TYPE: statefulSets
       DEPLOYMENT_VERSION: "1.20"
+      MUST_GATHER_TIMEOUT: 35m
+      TEST_NAMESPACE: "5"
+      TEST_SCENARIO: math
+      TEST_SCENARIOS: 200/10 200/20 200/30 200/40
+    workflow: openshift-pipelines-max-concurrency
+  timeout: 8h0m0s
+- always_run: false
+  as: max-concurrency-downstream-state-1-21-1000-x-math-ha-10
+  optional: true
+  steps:
+    cluster_profile: aws-pipelines-performance
+    env:
+      DEPLOYMENT_PIPELINES_CONTROLLER_HA_REPLICAS: "10"
+      DEPLOYMENT_PIPELINES_CONTROLLER_TYPE: statefulSets
+      DEPLOYMENT_VERSION: "1.21"
       MUST_GATHER_TIMEOUT: 35m
       TEST_NAMESPACE: "5"
       TEST_SCENARIO: math
@@ -912,6 +907,20 @@ tests:
     workflow: openshift-pipelines-max-concurrency
   timeout: 8h0m0s
 - always_run: false
+  as: max-concurrency-downstream-1-21-1000-x-math-ha-10
+  optional: true
+  steps:
+    cluster_profile: aws-pipelines-performance
+    env:
+      DEPLOYMENT_PIPELINES_CONTROLLER_HA_REPLICAS: "10"
+      DEPLOYMENT_VERSION: “1.21"
+      MUST_GATHER_TIMEOUT: 35m
+      TEST_NAMESPACE: "5"
+      TEST_SCENARIO: math
+      TEST_SCENARIOS: 200/10 200/20 200/30 200/40
+    workflow: openshift-pipelines-max-concurrency
+  timeout: 8h0m0s
+- always_run: false
   as: max-concurrency-downstream-1-14-1000-x-math-qbt
   optional: true
   steps:
@@ -926,25 +935,6 @@ tests:
       TEST_SCENARIO: math
       TEST_SCENARIOS: 200/10 200/20 200/30 200/40
     workflow: openshift-pipelines-max-concurrency
-- always_run: false
-  as: max-concurrency-downstream-1-20-1000-x-math-qbt-cb
-  optional: true
-  steps:
-    cluster_profile: aws-pipelines-performance
-    env:
-      CUSTOM_BUILD: "true"
-      CUSTOM_BUILD_TAG: “1.20"
-      DEPLOYMENT_PIPELINES_KUBE_API_BURST: "50"
-      DEPLOYMENT_PIPELINES_KUBE_API_QPS: "50"
-      DEPLOYMENT_PIPELINES_THREADS_PER_CONTROLLER: "32"
-      DEPLOYMENT_TYPE: downstream
-      MUST_GATHER_TIMEOUT: 35m
-      OCP_VERSION: ”4.19"
-      TEST_NAMESPACE: "5"
-      TEST_SCENARIO: math
-      TEST_SCENARIOS: 200/10 200/20 200/30 200/40
-    workflow: openshift-pipelines-max-concurrency
-  timeout: 8h0m0s
 - always_run: false
   as: max-concurrency-downstream-1-19-1000-x-math-qbt
   optional: true
@@ -971,6 +961,22 @@ tests:
       DEPLOYMENT_PIPELINES_KUBE_API_QPS: "50"
       DEPLOYMENT_PIPELINES_THREADS_PER_CONTROLLER: "32"
       DEPLOYMENT_VERSION: “1.20”
+      MUST_GATHER_TIMEOUT: 35m
+      TEST_NAMESPACE: "5"
+      TEST_SCENARIO: math
+      TEST_SCENARIOS: 200/10 200/20 200/30 200/40
+    workflow: openshift-pipelines-max-concurrency
+  timeout: 8h0m0s
+- always_run: false
+  as: max-concurrency-downstream-1-21-1000-x-math-qbt
+  optional: true
+  steps:
+    cluster_profile: aws-pipelines-performance
+    env:
+      DEPLOYMENT_PIPELINES_KUBE_API_BURST: "50"
+      DEPLOYMENT_PIPELINES_KUBE_API_QPS: "50"
+      DEPLOYMENT_PIPELINES_THREADS_PER_CONTROLLER: "32"
+      DEPLOYMENT_VERSION: “1.21”
       MUST_GATHER_TIMEOUT: 35m
       TEST_NAMESPACE: "5"
       TEST_SCENARIO: math
@@ -1025,26 +1031,6 @@ tests:
       TEST_SCENARIOS: 200/10 200/20 200/30 200/40
     workflow: openshift-pipelines-max-concurrency
 - always_run: false
-  as: max-concurrency-downstream-1-20-1000-x-math-ha10-qbt-cb
-  optional: true
-  steps:
-    cluster_profile: aws-pipelines-performance
-    env:
-      CUSTOM_BUILD: "true"
-      CUSTOM_BUILD_TAG: “1.20"
-      DEPLOYMENT_PIPELINES_CONTROLLER_HA_REPLICAS: "10"
-      DEPLOYMENT_PIPELINES_KUBE_API_BURST: "50"
-      DEPLOYMENT_PIPELINES_KUBE_API_QPS: "50"
-      DEPLOYMENT_PIPELINES_THREADS_PER_CONTROLLER: "32"
-      DEPLOYMENT_TYPE: downstream
-      MUST_GATHER_TIMEOUT: 35m
-      OCP_VERSION: ”4.19"
-      TEST_NAMESPACE: "5"
-      TEST_SCENARIO: math
-      TEST_SCENARIOS: 200/10 200/20 200/30 200/40
-    workflow: openshift-pipelines-max-concurrency
-  timeout: 8h0m0s
-- always_run: false
   as: max-concurrency-downstream-1-19-1000-x-math-ha10-qbt
   optional: true
   steps:
@@ -1072,6 +1058,23 @@ tests:
       DEPLOYMENT_PIPELINES_KUBE_API_QPS: "50"
       DEPLOYMENT_PIPELINES_THREADS_PER_CONTROLLER: "32"
       DEPLOYMENT_VERSION: “1.20”
+      MUST_GATHER_TIMEOUT: 35m
+      TEST_NAMESPACE: "5"
+      TEST_SCENARIO: math
+      TEST_SCENARIOS: 200/10 200/20 200/30 200/40
+    workflow: openshift-pipelines-max-concurrency
+  timeout: 8h0m0s
+- always_run: false
+  as: max-concurrency-downstream-1-21-1000-x-math-ha10-qbt
+  optional: true
+  steps:
+    cluster_profile: aws-pipelines-performance
+    env:
+      DEPLOYMENT_PIPELINES_CONTROLLER_HA_REPLICAS: "10"
+      DEPLOYMENT_PIPELINES_KUBE_API_BURST: "50"
+      DEPLOYMENT_PIPELINES_KUBE_API_QPS: "50"
+      DEPLOYMENT_PIPELINES_THREADS_PER_CONTROLLER: "32"
+      DEPLOYMENT_VERSION: “1.21”
       MUST_GATHER_TIMEOUT: 35m
       TEST_NAMESPACE: "5"
       TEST_SCENARIO: math

--- a/ci-operator/jobs/openshift-pipelines/performance/openshift-pipelines-performance-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-pipelines/performance/openshift-pipelines-performance-main-presubmits.yaml
@@ -7940,83 +7940,7 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build07
-    context: ci/prow/max-concurrency-downstream-1-20-1000-x-math-cb
-    decorate: true
-    decoration_config:
-      skip_cloning: true
-      timeout: 8h0m0s
-    labels:
-      ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws-pipelines-performance
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-pipelines-performance-main-max-concurrency-downstream-1-20-1000-x-math-cb
-    optional: true
-    rerun_command: /test max-concurrency-downstream-1-20-1000-x-math-cb
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=max-concurrency-downstream-1-20-1000-x-math-cb
-        command:
-        - ci-operator
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )max-concurrency-downstream-1-20-1000-x-math-cb,?($|\s.*)
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - ^main$
-    - ^main-
-    cluster: build07
+    cluster: build09
     context: ci/prow/max-concurrency-downstream-1-20-1000-x-math-ha-10
     decorate: true
     decoration_config:
@@ -8092,83 +8016,7 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build07
-    context: ci/prow/max-concurrency-downstream-1-20-1000-x-math-ha-10-cb
-    decorate: true
-    decoration_config:
-      skip_cloning: true
-      timeout: 8h0m0s
-    labels:
-      ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws-pipelines-performance
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-pipelines-performance-main-max-concurrency-downstream-1-20-1000-x-math-ha-10-cb
-    optional: true
-    rerun_command: /test max-concurrency-downstream-1-20-1000-x-math-ha-10-cb
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=max-concurrency-downstream-1-20-1000-x-math-ha-10-cb
-        command:
-        - ci-operator
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )max-concurrency-downstream-1-20-1000-x-math-ha-10-cb,?($|\s.*)
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - ^main$
-    - ^main-
-    cluster: build07
+    cluster: build09
     context: ci/prow/max-concurrency-downstream-1-20-1000-x-math-ha10-qbt
     decorate: true
     decoration_config:
@@ -8244,83 +8092,7 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build07
-    context: ci/prow/max-concurrency-downstream-1-20-1000-x-math-ha10-qbt-cb
-    decorate: true
-    decoration_config:
-      skip_cloning: true
-      timeout: 8h0m0s
-    labels:
-      ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws-pipelines-performance
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-pipelines-performance-main-max-concurrency-downstream-1-20-1000-x-math-ha10-qbt-cb
-    optional: true
-    rerun_command: /test max-concurrency-downstream-1-20-1000-x-math-ha10-qbt-cb
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=max-concurrency-downstream-1-20-1000-x-math-ha10-qbt-cb
-        command:
-        - ci-operator
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )max-concurrency-downstream-1-20-1000-x-math-ha10-qbt-cb,?($|\s.*)
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - ^main$
-    - ^main-
-    cluster: build07
+    cluster: build09
     context: ci/prow/max-concurrency-downstream-1-20-1000-x-math-qbt
     decorate: true
     decoration_config:
@@ -8397,7 +8169,7 @@ presubmits:
     - ^main$
     - ^main-
     cluster: build07
-    context: ci/prow/max-concurrency-downstream-1-20-1000-x-math-qbt-cb
+    context: ci/prow/max-concurrency-downstream-1-21-1000-x-math
     decorate: true
     decoration_config:
       skip_cloning: true
@@ -8407,9 +8179,9 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-pipelines-performance
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-pipelines-performance-main-max-concurrency-downstream-1-20-1000-x-math-qbt-cb
+    name: pull-ci-openshift-pipelines-performance-main-max-concurrency-downstream-1-21-1000-x-math
     optional: true
-    rerun_command: /test max-concurrency-downstream-1-20-1000-x-math-qbt-cb
+    rerun_command: /test max-concurrency-downstream-1-21-1000-x-math
     spec:
       containers:
       - args:
@@ -8418,7 +8190,7 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=max-concurrency-downstream-1-20-1000-x-math-qbt-cb
+        - --target=max-concurrency-downstream-1-21-1000-x-math
         command:
         - ci-operator
         image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
@@ -8466,7 +8238,235 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )max-concurrency-downstream-1-20-1000-x-math-qbt-cb,?($|\s.*)
+    trigger: (?m)^/test( | .* )max-concurrency-downstream-1-21-1000-x-math,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build07
+    context: ci/prow/max-concurrency-downstream-1-21-1000-x-math-ha-10
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+      timeout: 8h0m0s
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: aws-pipelines-performance
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-pipelines-performance-main-max-concurrency-downstream-1-21-1000-x-math-ha-10
+    optional: true
+    rerun_command: /test max-concurrency-downstream-1-21-1000-x-math-ha-10
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=max-concurrency-downstream-1-21-1000-x-math-ha-10
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )max-concurrency-downstream-1-21-1000-x-math-ha-10,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build07
+    context: ci/prow/max-concurrency-downstream-1-21-1000-x-math-ha10-qbt
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+      timeout: 8h0m0s
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: aws-pipelines-performance
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-pipelines-performance-main-max-concurrency-downstream-1-21-1000-x-math-ha10-qbt
+    optional: true
+    rerun_command: /test max-concurrency-downstream-1-21-1000-x-math-ha10-qbt
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=max-concurrency-downstream-1-21-1000-x-math-ha10-qbt
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )max-concurrency-downstream-1-21-1000-x-math-ha10-qbt,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build07
+    context: ci/prow/max-concurrency-downstream-1-21-1000-x-math-qbt
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+      timeout: 8h0m0s
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: aws-pipelines-performance
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-pipelines-performance-main-max-concurrency-downstream-1-21-1000-x-math-qbt
+    optional: true
+    rerun_command: /test max-concurrency-downstream-1-21-1000-x-math-qbt
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=max-concurrency-downstream-1-21-1000-x-math-qbt
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )max-concurrency-downstream-1-21-1000-x-math-qbt,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:
@@ -8625,6 +8625,82 @@ presubmits:
     - ^main$
     - ^main-
     cluster: build07
+    context: ci/prow/max-concurrency-downstream-state-1-21-1000-x-math-ha-10
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+      timeout: 8h0m0s
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: aws-pipelines-performance
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-pipelines-performance-main-max-concurrency-downstream-state-1-21-1000-x-math-ha-10
+    optional: true
+    rerun_command: /test max-concurrency-downstream-state-1-21-1000-x-math-ha-10
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=max-concurrency-downstream-state-1-21-1000-x-math-ha-10
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )max-concurrency-downstream-state-1-21-1000-x-math-ha-10,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build09
     context: ci/prow/scaling-pipelines-downstream-1-11
     decorate: true
     decoration_config:


### PR DESCRIPTION
This PR evaluates OpenShift Pipelines 1.21 - especially its Pipeline Controller for any regression when compared to the existing version of 1.20 