### PR TITLE
ARO-HCP: Bump the number of identity containers

### DIFF
--- a/core-services/prow/02_config/_boskos.yaml
+++ b/core-services/prow/02_config/_boskos.yaml
@@ -39,8 +39,8 @@ resources:
   - us-east-1--alibabacloud-quota-slice-9
   state: free
   type: alibabacloud-quota-slice
-- max-count: 10
-  min-count: 10
+- max-count: 15
+  min-count: 15
   state: free
   type: aro-hcp-dev-quota-slice
 - max-count: 1
@@ -59,10 +59,60 @@ resources:
   - aro-hcp-test-msi-containers-dev-0
   - aro-hcp-test-msi-containers-dev-1
   - aro-hcp-test-msi-containers-dev-10
+  - aro-hcp-test-msi-containers-dev-100
+  - aro-hcp-test-msi-containers-dev-101
+  - aro-hcp-test-msi-containers-dev-102
+  - aro-hcp-test-msi-containers-dev-103
+  - aro-hcp-test-msi-containers-dev-104
+  - aro-hcp-test-msi-containers-dev-105
+  - aro-hcp-test-msi-containers-dev-106
+  - aro-hcp-test-msi-containers-dev-107
+  - aro-hcp-test-msi-containers-dev-108
+  - aro-hcp-test-msi-containers-dev-109
   - aro-hcp-test-msi-containers-dev-11
+  - aro-hcp-test-msi-containers-dev-110
+  - aro-hcp-test-msi-containers-dev-111
+  - aro-hcp-test-msi-containers-dev-112
+  - aro-hcp-test-msi-containers-dev-113
+  - aro-hcp-test-msi-containers-dev-114
+  - aro-hcp-test-msi-containers-dev-115
+  - aro-hcp-test-msi-containers-dev-116
+  - aro-hcp-test-msi-containers-dev-117
+  - aro-hcp-test-msi-containers-dev-118
+  - aro-hcp-test-msi-containers-dev-119
   - aro-hcp-test-msi-containers-dev-12
+  - aro-hcp-test-msi-containers-dev-120
+  - aro-hcp-test-msi-containers-dev-121
+  - aro-hcp-test-msi-containers-dev-122
+  - aro-hcp-test-msi-containers-dev-123
+  - aro-hcp-test-msi-containers-dev-124
+  - aro-hcp-test-msi-containers-dev-125
+  - aro-hcp-test-msi-containers-dev-126
+  - aro-hcp-test-msi-containers-dev-127
+  - aro-hcp-test-msi-containers-dev-128
+  - aro-hcp-test-msi-containers-dev-129
   - aro-hcp-test-msi-containers-dev-13
+  - aro-hcp-test-msi-containers-dev-130
+  - aro-hcp-test-msi-containers-dev-131
+  - aro-hcp-test-msi-containers-dev-132
+  - aro-hcp-test-msi-containers-dev-133
+  - aro-hcp-test-msi-containers-dev-134
+  - aro-hcp-test-msi-containers-dev-135
+  - aro-hcp-test-msi-containers-dev-136
+  - aro-hcp-test-msi-containers-dev-137
+  - aro-hcp-test-msi-containers-dev-138
+  - aro-hcp-test-msi-containers-dev-139
   - aro-hcp-test-msi-containers-dev-14
+  - aro-hcp-test-msi-containers-dev-140
+  - aro-hcp-test-msi-containers-dev-141
+  - aro-hcp-test-msi-containers-dev-142
+  - aro-hcp-test-msi-containers-dev-143
+  - aro-hcp-test-msi-containers-dev-144
+  - aro-hcp-test-msi-containers-dev-145
+  - aro-hcp-test-msi-containers-dev-146
+  - aro-hcp-test-msi-containers-dev-147
+  - aro-hcp-test-msi-containers-dev-148
+  - aro-hcp-test-msi-containers-dev-149
   - aro-hcp-test-msi-containers-dev-15
   - aro-hcp-test-msi-containers-dev-16
   - aro-hcp-test-msi-containers-dev-17
@@ -146,16 +196,76 @@ resources:
   - aro-hcp-test-msi-containers-dev-88
   - aro-hcp-test-msi-containers-dev-89
   - aro-hcp-test-msi-containers-dev-9
+  - aro-hcp-test-msi-containers-dev-90
+  - aro-hcp-test-msi-containers-dev-91
+  - aro-hcp-test-msi-containers-dev-92
+  - aro-hcp-test-msi-containers-dev-93
+  - aro-hcp-test-msi-containers-dev-94
+  - aro-hcp-test-msi-containers-dev-95
+  - aro-hcp-test-msi-containers-dev-96
+  - aro-hcp-test-msi-containers-dev-97
+  - aro-hcp-test-msi-containers-dev-98
+  - aro-hcp-test-msi-containers-dev-99
   state: free
   type: aro-hcp-test-msi-containers-dev
 - names:
   - aro-hcp-test-msi-containers-int-0
   - aro-hcp-test-msi-containers-int-1
   - aro-hcp-test-msi-containers-int-10
+  - aro-hcp-test-msi-containers-int-100
+  - aro-hcp-test-msi-containers-int-101
+  - aro-hcp-test-msi-containers-int-102
+  - aro-hcp-test-msi-containers-int-103
+  - aro-hcp-test-msi-containers-int-104
+  - aro-hcp-test-msi-containers-int-105
+  - aro-hcp-test-msi-containers-int-106
+  - aro-hcp-test-msi-containers-int-107
+  - aro-hcp-test-msi-containers-int-108
+  - aro-hcp-test-msi-containers-int-109
   - aro-hcp-test-msi-containers-int-11
+  - aro-hcp-test-msi-containers-int-110
+  - aro-hcp-test-msi-containers-int-111
+  - aro-hcp-test-msi-containers-int-112
+  - aro-hcp-test-msi-containers-int-113
+  - aro-hcp-test-msi-containers-int-114
+  - aro-hcp-test-msi-containers-int-115
+  - aro-hcp-test-msi-containers-int-116
+  - aro-hcp-test-msi-containers-int-117
+  - aro-hcp-test-msi-containers-int-118
+  - aro-hcp-test-msi-containers-int-119
   - aro-hcp-test-msi-containers-int-12
+  - aro-hcp-test-msi-containers-int-120
+  - aro-hcp-test-msi-containers-int-121
+  - aro-hcp-test-msi-containers-int-122
+  - aro-hcp-test-msi-containers-int-123
+  - aro-hcp-test-msi-containers-int-124
+  - aro-hcp-test-msi-containers-int-125
+  - aro-hcp-test-msi-containers-int-126
+  - aro-hcp-test-msi-containers-int-127
+  - aro-hcp-test-msi-containers-int-128
+  - aro-hcp-test-msi-containers-int-129
   - aro-hcp-test-msi-containers-int-13
+  - aro-hcp-test-msi-containers-int-130
+  - aro-hcp-test-msi-containers-int-131
+  - aro-hcp-test-msi-containers-int-132
+  - aro-hcp-test-msi-containers-int-133
+  - aro-hcp-test-msi-containers-int-134
+  - aro-hcp-test-msi-containers-int-135
+  - aro-hcp-test-msi-containers-int-136
+  - aro-hcp-test-msi-containers-int-137
+  - aro-hcp-test-msi-containers-int-138
+  - aro-hcp-test-msi-containers-int-139
   - aro-hcp-test-msi-containers-int-14
+  - aro-hcp-test-msi-containers-int-140
+  - aro-hcp-test-msi-containers-int-141
+  - aro-hcp-test-msi-containers-int-142
+  - aro-hcp-test-msi-containers-int-143
+  - aro-hcp-test-msi-containers-int-144
+  - aro-hcp-test-msi-containers-int-145
+  - aro-hcp-test-msi-containers-int-146
+  - aro-hcp-test-msi-containers-int-147
+  - aro-hcp-test-msi-containers-int-148
+  - aro-hcp-test-msi-containers-int-149
   - aro-hcp-test-msi-containers-int-15
   - aro-hcp-test-msi-containers-int-16
   - aro-hcp-test-msi-containers-int-17
@@ -239,16 +349,76 @@ resources:
   - aro-hcp-test-msi-containers-int-88
   - aro-hcp-test-msi-containers-int-89
   - aro-hcp-test-msi-containers-int-9
+  - aro-hcp-test-msi-containers-int-90
+  - aro-hcp-test-msi-containers-int-91
+  - aro-hcp-test-msi-containers-int-92
+  - aro-hcp-test-msi-containers-int-93
+  - aro-hcp-test-msi-containers-int-94
+  - aro-hcp-test-msi-containers-int-95
+  - aro-hcp-test-msi-containers-int-96
+  - aro-hcp-test-msi-containers-int-97
+  - aro-hcp-test-msi-containers-int-98
+  - aro-hcp-test-msi-containers-int-99
   state: free
   type: aro-hcp-test-msi-containers-int
 - names:
   - aro-hcp-test-msi-containers-prod-0
   - aro-hcp-test-msi-containers-prod-1
   - aro-hcp-test-msi-containers-prod-10
+  - aro-hcp-test-msi-containers-prod-100
+  - aro-hcp-test-msi-containers-prod-101
+  - aro-hcp-test-msi-containers-prod-102
+  - aro-hcp-test-msi-containers-prod-103
+  - aro-hcp-test-msi-containers-prod-104
+  - aro-hcp-test-msi-containers-prod-105
+  - aro-hcp-test-msi-containers-prod-106
+  - aro-hcp-test-msi-containers-prod-107
+  - aro-hcp-test-msi-containers-prod-108
+  - aro-hcp-test-msi-containers-prod-109
   - aro-hcp-test-msi-containers-prod-11
+  - aro-hcp-test-msi-containers-prod-110
+  - aro-hcp-test-msi-containers-prod-111
+  - aro-hcp-test-msi-containers-prod-112
+  - aro-hcp-test-msi-containers-prod-113
+  - aro-hcp-test-msi-containers-prod-114
+  - aro-hcp-test-msi-containers-prod-115
+  - aro-hcp-test-msi-containers-prod-116
+  - aro-hcp-test-msi-containers-prod-117
+  - aro-hcp-test-msi-containers-prod-118
+  - aro-hcp-test-msi-containers-prod-119
   - aro-hcp-test-msi-containers-prod-12
+  - aro-hcp-test-msi-containers-prod-120
+  - aro-hcp-test-msi-containers-prod-121
+  - aro-hcp-test-msi-containers-prod-122
+  - aro-hcp-test-msi-containers-prod-123
+  - aro-hcp-test-msi-containers-prod-124
+  - aro-hcp-test-msi-containers-prod-125
+  - aro-hcp-test-msi-containers-prod-126
+  - aro-hcp-test-msi-containers-prod-127
+  - aro-hcp-test-msi-containers-prod-128
+  - aro-hcp-test-msi-containers-prod-129
   - aro-hcp-test-msi-containers-prod-13
+  - aro-hcp-test-msi-containers-prod-130
+  - aro-hcp-test-msi-containers-prod-131
+  - aro-hcp-test-msi-containers-prod-132
+  - aro-hcp-test-msi-containers-prod-133
+  - aro-hcp-test-msi-containers-prod-134
+  - aro-hcp-test-msi-containers-prod-135
+  - aro-hcp-test-msi-containers-prod-136
+  - aro-hcp-test-msi-containers-prod-137
+  - aro-hcp-test-msi-containers-prod-138
+  - aro-hcp-test-msi-containers-prod-139
   - aro-hcp-test-msi-containers-prod-14
+  - aro-hcp-test-msi-containers-prod-140
+  - aro-hcp-test-msi-containers-prod-141
+  - aro-hcp-test-msi-containers-prod-142
+  - aro-hcp-test-msi-containers-prod-143
+  - aro-hcp-test-msi-containers-prod-144
+  - aro-hcp-test-msi-containers-prod-145
+  - aro-hcp-test-msi-containers-prod-146
+  - aro-hcp-test-msi-containers-prod-147
+  - aro-hcp-test-msi-containers-prod-148
+  - aro-hcp-test-msi-containers-prod-149
   - aro-hcp-test-msi-containers-prod-15
   - aro-hcp-test-msi-containers-prod-16
   - aro-hcp-test-msi-containers-prod-17
@@ -332,16 +502,76 @@ resources:
   - aro-hcp-test-msi-containers-prod-88
   - aro-hcp-test-msi-containers-prod-89
   - aro-hcp-test-msi-containers-prod-9
+  - aro-hcp-test-msi-containers-prod-90
+  - aro-hcp-test-msi-containers-prod-91
+  - aro-hcp-test-msi-containers-prod-92
+  - aro-hcp-test-msi-containers-prod-93
+  - aro-hcp-test-msi-containers-prod-94
+  - aro-hcp-test-msi-containers-prod-95
+  - aro-hcp-test-msi-containers-prod-96
+  - aro-hcp-test-msi-containers-prod-97
+  - aro-hcp-test-msi-containers-prod-98
+  - aro-hcp-test-msi-containers-prod-99
   state: free
   type: aro-hcp-test-msi-containers-prod
 - names:
   - aro-hcp-test-msi-containers-stg-0
   - aro-hcp-test-msi-containers-stg-1
   - aro-hcp-test-msi-containers-stg-10
+  - aro-hcp-test-msi-containers-stg-100
+  - aro-hcp-test-msi-containers-stg-101
+  - aro-hcp-test-msi-containers-stg-102
+  - aro-hcp-test-msi-containers-stg-103
+  - aro-hcp-test-msi-containers-stg-104
+  - aro-hcp-test-msi-containers-stg-105
+  - aro-hcp-test-msi-containers-stg-106
+  - aro-hcp-test-msi-containers-stg-107
+  - aro-hcp-test-msi-containers-stg-108
+  - aro-hcp-test-msi-containers-stg-109
   - aro-hcp-test-msi-containers-stg-11
+  - aro-hcp-test-msi-containers-stg-110
+  - aro-hcp-test-msi-containers-stg-111
+  - aro-hcp-test-msi-containers-stg-112
+  - aro-hcp-test-msi-containers-stg-113
+  - aro-hcp-test-msi-containers-stg-114
+  - aro-hcp-test-msi-containers-stg-115
+  - aro-hcp-test-msi-containers-stg-116
+  - aro-hcp-test-msi-containers-stg-117
+  - aro-hcp-test-msi-containers-stg-118
+  - aro-hcp-test-msi-containers-stg-119
   - aro-hcp-test-msi-containers-stg-12
+  - aro-hcp-test-msi-containers-stg-120
+  - aro-hcp-test-msi-containers-stg-121
+  - aro-hcp-test-msi-containers-stg-122
+  - aro-hcp-test-msi-containers-stg-123
+  - aro-hcp-test-msi-containers-stg-124
+  - aro-hcp-test-msi-containers-stg-125
+  - aro-hcp-test-msi-containers-stg-126
+  - aro-hcp-test-msi-containers-stg-127
+  - aro-hcp-test-msi-containers-stg-128
+  - aro-hcp-test-msi-containers-stg-129
   - aro-hcp-test-msi-containers-stg-13
+  - aro-hcp-test-msi-containers-stg-130
+  - aro-hcp-test-msi-containers-stg-131
+  - aro-hcp-test-msi-containers-stg-132
+  - aro-hcp-test-msi-containers-stg-133
+  - aro-hcp-test-msi-containers-stg-134
+  - aro-hcp-test-msi-containers-stg-135
+  - aro-hcp-test-msi-containers-stg-136
+  - aro-hcp-test-msi-containers-stg-137
+  - aro-hcp-test-msi-containers-stg-138
+  - aro-hcp-test-msi-containers-stg-139
   - aro-hcp-test-msi-containers-stg-14
+  - aro-hcp-test-msi-containers-stg-140
+  - aro-hcp-test-msi-containers-stg-141
+  - aro-hcp-test-msi-containers-stg-142
+  - aro-hcp-test-msi-containers-stg-143
+  - aro-hcp-test-msi-containers-stg-144
+  - aro-hcp-test-msi-containers-stg-145
+  - aro-hcp-test-msi-containers-stg-146
+  - aro-hcp-test-msi-containers-stg-147
+  - aro-hcp-test-msi-containers-stg-148
+  - aro-hcp-test-msi-containers-stg-149
   - aro-hcp-test-msi-containers-stg-15
   - aro-hcp-test-msi-containers-stg-16
   - aro-hcp-test-msi-containers-stg-17
@@ -425,6 +655,16 @@ resources:
   - aro-hcp-test-msi-containers-stg-88
   - aro-hcp-test-msi-containers-stg-89
   - aro-hcp-test-msi-containers-stg-9
+  - aro-hcp-test-msi-containers-stg-90
+  - aro-hcp-test-msi-containers-stg-91
+  - aro-hcp-test-msi-containers-stg-92
+  - aro-hcp-test-msi-containers-stg-93
+  - aro-hcp-test-msi-containers-stg-94
+  - aro-hcp-test-msi-containers-stg-95
+  - aro-hcp-test-msi-containers-stg-96
+  - aro-hcp-test-msi-containers-stg-97
+  - aro-hcp-test-msi-containers-stg-98
+  - aro-hcp-test-msi-containers-stg-99
   state: free
   type: aro-hcp-test-msi-containers-stg
 - max-count: 10

--- a/core-services/prow/02_config/generate-boskos.py
+++ b/core-services/prow/02_config/generate-boskos.py
@@ -253,7 +253,7 @@ CONFIG = {
         'default': 2,
     },
     'aro-hcp-dev-quota-slice': {
-        'default': 10,
+        'default': 15,
     },
     'aro-hcp-test-tenant-quota-slice': {
         'default': 10,
@@ -695,7 +695,7 @@ for i in range(4):
 for i in range(4):
     CONFIG['powervs-8-quota-slice']['fran-powervs-8-quota-slice-{}'.format(i)] = 1
 
-for i in range(90):
+for i in range(150):
     CONFIG['aro-hcp-test-msi-containers-dev']['aro-hcp-test-msi-containers-dev-{}'.format(i)] = 1
     CONFIG['aro-hcp-test-msi-containers-int']['aro-hcp-test-msi-containers-int-{}'.format(i)] = 1
     CONFIG['aro-hcp-test-msi-containers-stg']['aro-hcp-test-msi-containers-stg-{}'.format(i)] = 1


### PR DESCRIPTION
After the role assignment consolidation done in https://github.com/Azure/ARO-HCP/pull/3919 we can safely bump the count of identity containers back up to 150 without risking hitting Azure quota limits.