### PR TITLE
Add rhcos10 techpreview jobs

### DIFF
--- a/ci-operator/config/openshift/insights-operator/openshift-insights-operator-release-4.22__periodics.yaml
+++ b/ci-operator/config/openshift/insights-operator/openshift-insights-operator-release-4.22__periodics.yaml
@@ -154,6 +154,71 @@ tests:
           cpu: 100m
       timeout: 3h0m0s
     workflow: ipi-gcp
+- as: e2e-gcp-rhcos10-techpreview
+  interval: 12h
+  steps:
+    cluster_profile: gcp
+    env:
+      FEATURE_SET: TechPreviewNoUpgrade
+    post:
+    - chain: gather-core-dump
+    - chain: ipi-gcp-post
+    pre:
+    - chain: ipi-conf-gcp
+    - ref: rhcos-conf-rhcos10
+    - chain: ipi-install
+    - ref: insights-live
+    test:
+    - as: api-insights-tests
+      cli: latest
+      commands: |
+        pytest.sh -m 'insights_data_gather or data_gather' --junitxml=$(pwd)/junit_report.xml --rp_enabled --rp_name=Insights_operator_e2e_tests_rhcos10_techpreview_4.22
+      credentials:
+      - collection: ""
+        mount_path: /secrets
+        name: insights-qa
+        namespace: test-credentials
+      - collection: ""
+        mount_path: /secret/aws/aws-bucket
+        name: aws-bucket
+        namespace: test-credentials
+      - collection: ""
+        mount_path: /secret/aws/aws-access-key-id
+        name: aws-access-key-id
+        namespace: test-credentials
+      - collection: ""
+        mount_path: /secret/aws/aws-region
+        name: aws-region
+        namespace: test-credentials
+      - collection: ""
+        mount_path: /secret/aws/aws-secret-access-key
+        name: aws-secret-access-key
+        namespace: test-credentials
+      - collection: ""
+        mount_path: /secret/ocm-access/
+        name: insights-ocm-token
+        namespace: test-credentials
+      - collection: ""
+        mount_path: /secret/insights-rp-access/
+        name: insights-rp-token
+        namespace: test-credentials
+      env:
+      - default: /secret/aws/aws-access-key-id/aws-access-key-id
+        name: AWS_ACCESS_KEY_ID_PATH
+      - default: /secret/aws/aws-bucket/aws-bucket
+        name: AWS_BUCKET_PATH
+      - default: /secret/aws/aws-region/aws-region
+        name: AWS_REGION_PATH
+      - default: /secret/aws/aws-secret-access-key/aws-secret-access-key
+        name: AWS_SECRET_ACCESS_KEY_PATH
+      - default: /secret/insights-rp-access/insights-rp-token
+        name: RP_API_KEY
+      from: insights-operator-tests
+      grace_period: 30s
+      resources:
+        requests:
+          cpu: 100m
+      timeout: 3h0m0s
 - as: e2e-aws-techpreview
   cron: 26 17 * * *
   steps:

--- a/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-4.22__periodics.yaml
+++ b/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-4.22__periodics.yaml
@@ -104,6 +104,15 @@ tests:
       FEATURE_SET: TechPreviewNoUpgrade
       TEST_SUITE: openshift/machine-config-operator/disruptive
     workflow: openshift-e2e-aws
+- as: e2e-aws-mco-disruptive-rhcos10-techpreview
+  interval: 12h
+  shard_count: 2
+  steps:
+    cluster_profile: aws-3
+    env:
+      FEATURE_SET: TechPreviewNoUpgrade
+      TEST_SUITE: openshift/machine-config-operator/disruptive
+    workflow: openshift-e2e-aws-rhcos10
 - as: e2e-azure-mco-disruptive-techpreview
   interval: 24h
   shard_count: 2
@@ -122,6 +131,15 @@ tests:
       FEATURE_SET: TechPreviewNoUpgrade
       TEST_SUITE: openshift/machine-config-operator/disruptive
     workflow: openshift-e2e-gcp
+- as: e2e-gcp-mco-disruptive-rhcos10-techpreview
+  interval: 12h
+  shard_count: 2
+  steps:
+    cluster_profile: gcp
+    env:
+      FEATURE_SET: TechPreviewNoUpgrade
+      TEST_SUITE: openshift/machine-config-operator/disruptive
+    workflow: openshift-e2e-gcp-rhcos10
 - as: e2e-vsphere-mco-disruptive-techpreview
   cron: 0 8 * * *
   shard_count: 2

--- a/ci-operator/config/openshift/release/openshift-release-master__ci-4.22.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-master__ci-4.22.yaml
@@ -35,6 +35,16 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-aws-ovn
+- as: e2e-aws-ovn-rhcos10-techpreview
+  interval: 12h
+  steps:
+    cluster_profile: aws
+    env:
+      FEATURE_SET: TechPreviewNoUpgrade
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: openshift-e2e-aws-ovn-rhcos10
 - as: e2e-aws-ovn-no-capabilities
   interval: 168h
   steps:
@@ -85,6 +95,17 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-aws-ovn-serial
+- as: e2e-aws-ovn-rhcos10-techpreview-serial
+  interval: 12h
+  shard_count: 3
+  steps:
+    cluster_profile: aws-5
+    env:
+      FEATURE_SET: TechPreviewNoUpgrade
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: openshift-e2e-aws-ovn-serial-rhcos10
 - as: e2e-aws-ovn-upgrade
   interval: 168h
   steps:
@@ -158,6 +179,16 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-azure-serial
+- as: e2e-azure-ovn-rhcos10-techpreview-serial
+  interval: 12h
+  steps:
+    cluster_profile: azure-2
+    env:
+      FEATURE_SET: TechPreviewNoUpgrade
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: openshift-e2e-azure-serial-rhcos10
 - as: e2e-azure-ovn-upgrade
   interval: 168h
   steps:
@@ -223,6 +254,16 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-gcp-ovn
+- as: e2e-gcp-ovn-rhcos10-techpreview
+  interval: 12h
+  steps:
+    cluster_profile: gcp-3
+    env:
+      FEATURE_SET: TechPreviewNoUpgrade
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: openshift-e2e-gcp-ovn-rhcos10
 - as: e2e-gcp-ovn
   interval: 168h
   steps:
@@ -263,6 +304,16 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-gcp-serial
+- as: e2e-gcp-ovn-rhcos10-techpreview-serial
+  interval: 12h
+  steps:
+    cluster_profile: gcp-3
+    env:
+      FEATURE_SET: TechPreviewNoUpgrade
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: openshift-e2e-gcp-serial-rhcos10
 - as: e2e-gcp-ovn-usernamespace
   cron: '@daily'
   steps:

--- a/ci-operator/config/openshift/release/openshift-release-master__nightly-4.22.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-master__nightly-4.22.yaml
@@ -193,6 +193,17 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-aws-single-node
+- as: e2e-aws-ovn-single-node-rhcos10-techpreview-serial
+  interval: 12h
+  steps:
+    cluster_profile: aws
+    env:
+      FEATURE_SET: TechPreviewNoUpgrade
+      TEST_SUITE: openshift/conformance/serial
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: openshift-e2e-aws-single-node-rhcos10
 - as: e2e-metal-ovn-single-node-live-iso
   interval: 168h
   steps:
@@ -347,6 +358,20 @@ tests:
       enable:
       - observers-resource-watch
     workflow: baremetalds-e2e-ovn-ipv6
+- as: e2e-metal-ipi-ovn-ipv6-rhcos10-techpreview
+  capabilities:
+  - intranet
+  interval: 12h
+  steps:
+    cluster_profile: equinix-ocp-metal
+    env:
+      DEVSCRIPTS_CONFIG: |
+        IP_STACK=v6
+        FEATURE_SET=TechPreviewNoUpgrade
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: baremetalds-e2e-ovn-ipv6-rhcos10
 - as: e2e-metal-ipi-serial-ovn-ipv6-techpreview
   capabilities:
   - intranet
@@ -392,6 +417,20 @@ tests:
       enable:
       - observers-resource-watch
     workflow: baremetalds-e2e-ovn-dualstack
+- as: e2e-metal-ipi-ovn-dualstack-rhcos10-techpreview
+  capabilities:
+  - intranet
+  interval: 12h
+  steps:
+    cluster_profile: equinix-ocp-metal
+    env:
+      DEVSCRIPTS_CONFIG: |
+        IP_STACK=v4v6
+        FEATURE_SET=TechPreviewNoUpgrade
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: baremetalds-e2e-ovn-dualstack-rhcos10
 - as: e2e-metal-ipi-serial-ovn-dualstack-techpreview
   capabilities:
   - intranet
@@ -534,6 +573,22 @@ tests:
         FEATURE_SET="TechPreviewNoUpgrade"
         BMC_DRIVER=redfish
     workflow: baremetalds-two-node-fencing-techpreview
+- as: e2e-metal-ovn-two-node-fencing-ipv6-rhcos10-techpreview
+  capabilities:
+  - intranet
+  interval: 12h
+  steps:
+    cluster_profile: equinix-edge-enablement
+    env:
+      DEVSCRIPTS_CONFIG: |
+        IP_STACK=v6
+        MASTER_DISK=100
+        MASTER_MEMORY=32768
+        NUM_MASTERS=2
+        NUM_WORKERS=0
+        FEATURE_SET="TechPreviewNoUpgrade"
+        BMC_DRIVER=redfish
+    workflow: baremetalds-two-node-fencing-rhcos10
 - as: e2e-metal-ovn-two-node-fencing-etcd-certrotation-techpreview
   capabilities:
   - intranet
@@ -708,6 +763,16 @@ tests:
       TEST_SUITE: openshift/conformance/serial
     workflow: baremetalds-two-node-fencing
   timeout: 5h0m0s
+- as: e2e-metal-ovn-two-node-fencing-serial-rhcos10-techpreview
+  capabilities:
+  - intranet
+  interval: 12h
+  steps:
+    cluster_profile: equinix-edge-enablement
+    env:
+      TEST_SUITE: openshift/conformance/serial
+    workflow: baremetalds-two-node-fencing-rhcos10
+  timeout: 5h0m0s
 - as: e2e-metal-ovn-two-node-fencing-upgrade-techpreview
   capabilities:
   - intranet
@@ -767,6 +832,18 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-vsphere
+- as: e2e-vsphere-ovn-rhcos10-techpreview
+  interval: 12h
+  steps:
+    cluster_profile: vsphere-elastic
+    env:
+      FEATURE_SET: TechPreviewNoUpgrade
+      TEST_SKIPS: 'In-tree Volumes \[Driver: vsphere\] \[Testpattern: Inline-volume\|
+        In-tree Volumes \[Driver: vsphere\] \[Testpattern: Pre-provisioned PV'
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: openshift-e2e-vsphere-rhcos10
 - as: e2e-vsphere-ovn-multi-network
   cron: 32 13 * * 1
   steps:
@@ -867,6 +944,16 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-vsphere-serial
+- as: e2e-vsphere-ovn-rhcos10-techpreview-serial
+  interval: 12h
+  steps:
+    cluster_profile: vsphere-elastic
+    env:
+      FEATURE_SET: TechPreviewNoUpgrade
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: openshift-e2e-vsphere-serial-rhcos10
 - as: e2e-vsphere-ovn-upi
   cron: 34 7 * * 1
   steps:

--- a/ci-operator/jobs/openshift/insights-operator/openshift-insights-operator-release-4.22-periodics.yaml
+++ b/ci-operator/jobs/openshift/insights-operator/openshift-insights-operator-release-4.22-periodics.yaml
@@ -439,6 +439,79 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
+  decorate: true
+  extra_refs:
+  - base_ref: release-4.22
+    org: openshift
+    repo: insights-operator
+  interval: 12h
+  labels:
+    ci-operator.openshift.io/cloud: gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-insights-operator-release-4.22-periodics-e2e-gcp-rhcos10-techpreview
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-gcp-rhcos10-techpreview
+      - --variant=periodics
+      command:
+      - ci-operator
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build08
   cron: 2 10 * * *
   decorate: true
   extra_refs:

--- a/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-release-4.22-periodics.yaml
+++ b/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-release-4.22-periodics.yaml
@@ -87,6 +87,154 @@ periodics:
   - base_ref: release-4.22
     org: openshift
     repo: machine-config-operator
+  interval: 12h
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-3
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-machine-config-operator-release-4.22-periodics-e2e-aws-mco-disruptive-rhcos10-techpreview-1of2
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --multi-stage-param=SHARD_ARGS="--shard-count 2 --shard-id 1"
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-aws-mco-disruptive-rhcos10-techpreview
+      - --variant=periodics
+      command:
+      - ci-operator
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build09
+  decorate: true
+  extra_refs:
+  - base_ref: release-4.22
+    org: openshift
+    repo: machine-config-operator
+  interval: 12h
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-3
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-machine-config-operator-release-4.22-periodics-e2e-aws-mco-disruptive-rhcos10-techpreview-2of2
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --multi-stage-param=SHARD_ARGS="--shard-count 2 --shard-id 2"
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-aws-mco-disruptive-rhcos10-techpreview
+      - --variant=periodics
+      command:
+      - ci-operator
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build09
+  decorate: true
+  extra_refs:
+  - base_ref: release-4.22
+    org: openshift
+    repo: machine-config-operator
   interval: 24h
   labels:
     ci-operator.openshift.io/cloud: aws
@@ -866,6 +1014,154 @@ periodics:
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
       - --target=e2e-gcp-mco-disruptive
+      - --variant=periodics
+      command:
+      - ci-operator
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build08
+  decorate: true
+  extra_refs:
+  - base_ref: release-4.22
+    org: openshift
+    repo: machine-config-operator
+  interval: 12h
+  labels:
+    ci-operator.openshift.io/cloud: gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-machine-config-operator-release-4.22-periodics-e2e-gcp-mco-disruptive-rhcos10-techpreview-1of2
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --multi-stage-param=SHARD_ARGS="--shard-count 2 --shard-id 1"
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-gcp-mco-disruptive-rhcos10-techpreview
+      - --variant=periodics
+      command:
+      - ci-operator
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build08
+  decorate: true
+  extra_refs:
+  - base_ref: release-4.22
+    org: openshift
+    repo: machine-config-operator
+  interval: 12h
+  labels:
+    ci-operator.openshift.io/cloud: gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-machine-config-operator-release-4.22-periodics-e2e-gcp-mco-disruptive-rhcos10-techpreview-2of2
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --multi-stage-param=SHARD_ARGS="--shard-count 2 --shard-id 2"
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-gcp-mco-disruptive-rhcos10-techpreview
       - --variant=periodics
       command:
       - ci-operator

--- a/ci-operator/step-registry/baremetalds/e2e/ovn/dualstack/rhcos10/OWNERS
+++ b/ci-operator/step-registry/baremetalds/e2e/ovn/dualstack/rhcos10/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+- andfasano
+- dtantsur
+- elfosardo
+- honza
+- MahnoorAsghar
+- rhjanders
+- tdomnesc

--- a/ci-operator/step-registry/baremetalds/e2e/ovn/dualstack/rhcos10/baremetalds-e2e-ovn-dualstack-rhcos10-workflow.metadata.json
+++ b/ci-operator/step-registry/baremetalds/e2e/ovn/dualstack/rhcos10/baremetalds-e2e-ovn-dualstack-rhcos10-workflow.metadata.json
@@ -1,0 +1,14 @@
+{
+	"path": "baremetalds/e2e/ovn/dualstack/rhcos10/baremetalds-e2e-ovn-dualstack-rhcos10-workflow.yaml",
+	"owners": {
+		"approvers": [
+			"andfasano",
+			"dtantsur",
+			"elfosardo",
+			"honza",
+			"MahnoorAsghar",
+			"rhjanders",
+			"tdomnesc"
+		]
+	}
+}

--- a/ci-operator/step-registry/baremetalds/e2e/ovn/dualstack/rhcos10/baremetalds-e2e-ovn-dualstack-rhcos10-workflow.yaml
+++ b/ci-operator/step-registry/baremetalds/e2e/ovn/dualstack/rhcos10/baremetalds-e2e-ovn-dualstack-rhcos10-workflow.yaml
@@ -1,0 +1,21 @@
+workflow:
+  as: baremetalds-e2e-ovn-dualstack-rhcos10
+  steps:
+    env:
+      DEVSCRIPTS_CONFIG: |
+        IP_STACK=v4v6
+    pre:
+      - ref: ofcir-acquire
+      - ref: ipi-install-rbac
+      - ref: baremetalds-devscripts-ibm
+      - ref: baremetalds-devscripts-proxy
+      - ref: ipi-install-hosted-loki
+      - ref: rhcos-conf-rhcos10
+      - ref: baremetalds-devscripts-setup
+    test:
+      - chain: baremetalds-ipi-test
+    post:
+      - chain: baremetalds-ofcir-post
+  documentation: |-
+    This workflow with RHCOS10 executes the common end-to-end test suite on a cluster provisioned by running dev-scripts
+    on a packet server with both IPv4 and IPv6 enabled.

--- a/ci-operator/step-registry/baremetalds/e2e/ovn/ipv6/rhcos10/OWNERS
+++ b/ci-operator/step-registry/baremetalds/e2e/ovn/ipv6/rhcos10/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+- andfasano
+- dtantsur
+- elfosardo
+- honza
+- MahnoorAsghar
+- rhjanders
+- tdomnesc

--- a/ci-operator/step-registry/baremetalds/e2e/ovn/ipv6/rhcos10/baremetalds-e2e-ovn-ipv6-rhcos10-workflow.metadata.json
+++ b/ci-operator/step-registry/baremetalds/e2e/ovn/ipv6/rhcos10/baremetalds-e2e-ovn-ipv6-rhcos10-workflow.metadata.json
@@ -1,0 +1,14 @@
+{
+	"path": "baremetalds/e2e/ovn/ipv6/rhcos10/baremetalds-e2e-ovn-ipv6-rhcos10-workflow.yaml",
+	"owners": {
+		"approvers": [
+			"andfasano",
+			"dtantsur",
+			"elfosardo",
+			"honza",
+			"MahnoorAsghar",
+			"rhjanders",
+			"tdomnesc"
+		]
+	}
+}

--- a/ci-operator/step-registry/baremetalds/e2e/ovn/ipv6/rhcos10/baremetalds-e2e-ovn-ipv6-rhcos10-workflow.yaml
+++ b/ci-operator/step-registry/baremetalds/e2e/ovn/ipv6/rhcos10/baremetalds-e2e-ovn-ipv6-rhcos10-workflow.yaml
@@ -1,0 +1,21 @@
+workflow:
+  as: baremetalds-e2e-ovn-ipv6-rhcos10
+  steps:
+    env:
+      DEVSCRIPTS_CONFIG: |
+        IP_STACK=v6
+    pre:
+      - ref: ofcir-acquire
+      - ref: ipi-install-rbac
+      - ref: baremetalds-devscripts-ibm
+      - ref: baremetalds-devscripts-proxy
+      - ref: ipi-install-hosted-loki
+      - ref: rhcos-conf-rhcos10
+      - ref: baremetalds-devscripts-setup
+    test:
+      - chain: baremetalds-ipi-test
+    post:
+      - chain: baremetalds-ofcir-post
+  documentation: |-
+    This workflow with RHCOS10 executes the common end-to-end test suite on a cluster provisioned by running dev-scripts
+    on a packet server with IPv6 enabled.

--- a/ci-operator/step-registry/baremetalds/two-node/fencing/rhcos10/OWNERS
+++ b/ci-operator/step-registry/baremetalds/two-node/fencing/rhcos10/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+- andfasano
+- dtantsur
+- elfosardo
+- honza
+- MahnoorAsghar
+- rhjanders
+- tdomnesc

--- a/ci-operator/step-registry/baremetalds/two-node/fencing/rhcos10/baremetalds-two-node-fencing-rhcos10-workflow.metadata.json
+++ b/ci-operator/step-registry/baremetalds/two-node/fencing/rhcos10/baremetalds-two-node-fencing-rhcos10-workflow.metadata.json
@@ -1,0 +1,14 @@
+{
+	"path": "baremetalds/two-node/fencing/rhcos10/baremetalds-two-node-fencing-rhcos10-workflow.yaml",
+	"owners": {
+		"approvers": [
+			"andfasano",
+			"dtantsur",
+			"elfosardo",
+			"honza",
+			"MahnoorAsghar",
+			"rhjanders",
+			"tdomnesc"
+		]
+	}
+}

--- a/ci-operator/step-registry/baremetalds/two-node/fencing/rhcos10/baremetalds-two-node-fencing-rhcos10-workflow.yaml
+++ b/ci-operator/step-registry/baremetalds/two-node/fencing/rhcos10/baremetalds-two-node-fencing-rhcos10-workflow.yaml
@@ -1,0 +1,31 @@
+workflow:
+  as: baremetalds-two-node-fencing-rhcos10
+  steps:
+    allow_skip_on_success: true
+    allow_best_effort_post_steps: true
+    cluster_profile: equinix-edge-enablement
+    pre:
+      - ref: ofcir-acquire
+      - ref: ipi-install-rbac
+      - ref: baremetalds-devscripts-ibm
+      - ref: baremetalds-devscripts-proxy
+      - ref: ipi-install-hosted-loki
+      - ref: rhcos-conf-rhcos10
+      - ref: baremetalds-devscripts-setup
+      - chain: baremetalds-two-node-fencing-post-install
+      - ref: openshift-cluster-bot-rbac
+    test:
+    - chain: baremetalds-ipi-test
+    post:
+      - chain: baremetalds-ofcir-post
+    env:
+      DEVSCRIPTS_CONFIG: |
+        IP_STACK=v4
+        NUM_MASTERS=2
+        MASTER_MEMORY=32768
+        NUM_WORKERS=0
+        FEATURE_SET="TechPreviewNoUpgrade"
+        BMC_DRIVER=redfish
+      ENABLE_HYPERVISOR_SSH_CONFIG: "true"
+  documentation: |-
+    This workflow with RHCOS10 executes a Two Node OpenShift with Fencing (TNF) cluster installation

--- a/ci-operator/step-registry/openshift/e2e/aws/ovn/rhcos10/OWNERS
+++ b/ci-operator/step-registry/openshift/e2e/aws/ovn/rhcos10/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- core-networking-approvers
+reviewers:
+- core-networking-reviewers

--- a/ci-operator/step-registry/openshift/e2e/aws/ovn/rhcos10/openshift-e2e-aws-ovn-rhcos10-workflow.metadata.json
+++ b/ci-operator/step-registry/openshift/e2e/aws/ovn/rhcos10/openshift-e2e-aws-ovn-rhcos10-workflow.metadata.json
@@ -1,0 +1,11 @@
+{
+	"path": "openshift/e2e/aws/ovn/rhcos10/openshift-e2e-aws-ovn-rhcos10-workflow.yaml",
+	"owners": {
+		"approvers": [
+			"core-networking-approvers"
+		],
+		"reviewers": [
+			"core-networking-reviewers"
+		]
+	}
+}

--- a/ci-operator/step-registry/openshift/e2e/aws/ovn/rhcos10/openshift-e2e-aws-ovn-rhcos10-workflow.yaml
+++ b/ci-operator/step-registry/openshift/e2e/aws/ovn/rhcos10/openshift-e2e-aws-ovn-rhcos10-workflow.yaml
@@ -1,0 +1,19 @@
+workflow:
+  as: openshift-e2e-aws-ovn-rhcos10
+  steps:
+    allow_best_effort_post_steps: true
+    pre:
+    - chain: ipi-conf-aws
+    - ref: ovn-conf
+    - ref: rhcos-conf-rhcos10
+    - chain: ipi-install
+    test:
+    - ref: openshift-e2e-test
+    post:
+    - chain: gather-network
+    - chain: gather-core-dump
+    - chain: ipi-deprovision
+    env:
+      FAIL_ON_CORE_DUMP: "false"
+  documentation: |-
+    The Openshift E2E OVN workflow with RHCOS10

--- a/ci-operator/step-registry/openshift/e2e/aws/ovn/serial/rhcos10/OWNERS
+++ b/ci-operator/step-registry/openshift/e2e/aws/ovn/serial/rhcos10/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- core-networking-approvers
+reviewers:
+- core-networking-reviewers

--- a/ci-operator/step-registry/openshift/e2e/aws/ovn/serial/rhcos10/openshift-e2e-aws-ovn-serial-rhcos10-workflow.metadata.json
+++ b/ci-operator/step-registry/openshift/e2e/aws/ovn/serial/rhcos10/openshift-e2e-aws-ovn-serial-rhcos10-workflow.metadata.json
@@ -1,0 +1,11 @@
+{
+	"path": "openshift/e2e/aws/ovn/serial/rhcos10/openshift-e2e-aws-ovn-serial-rhcos10-workflow.yaml",
+	"owners": {
+		"approvers": [
+			"core-networking-approvers"
+		],
+		"reviewers": [
+			"core-networking-reviewers"
+		]
+	}
+}

--- a/ci-operator/step-registry/openshift/e2e/aws/ovn/serial/rhcos10/openshift-e2e-aws-ovn-serial-rhcos10-workflow.yaml
+++ b/ci-operator/step-registry/openshift/e2e/aws/ovn/serial/rhcos10/openshift-e2e-aws-ovn-serial-rhcos10-workflow.yaml
@@ -1,0 +1,20 @@
+workflow:
+  as: openshift-e2e-aws-ovn-serial-rhcos10
+  steps:
+    allow_best_effort_post_steps: true
+    pre:
+    - chain: ipi-conf-aws
+    - ref: ovn-conf
+    - ref: ovn-conf-multi-network-policy-manifest
+    - ref: rhcos-conf-rhcos10
+    - chain: ipi-install
+    test:
+    - ref: openshift-e2e-test
+    post:
+      - chain: gather-network
+      - chain: gather-core-dump
+      - chain: ipi-deprovision
+    env:
+      TEST_SUITE: openshift/conformance/serial
+  documentation: |-
+    The Openshift E2E AWS `serial` workflow with RHCOS10

--- a/ci-operator/step-registry/openshift/e2e/aws/rhcos10/OWNERS
+++ b/ci-operator/step-registry/openshift/e2e/aws/rhcos10/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- deads2k
+- dgoodwin
+- stbenjam
+- vrutkovs
+- wking

--- a/ci-operator/step-registry/openshift/e2e/aws/rhcos10/openshift-e2e-aws-rhcos10-workflow.metadata.json
+++ b/ci-operator/step-registry/openshift/e2e/aws/rhcos10/openshift-e2e-aws-rhcos10-workflow.metadata.json
@@ -1,0 +1,12 @@
+{
+	"path": "openshift/e2e/aws/rhcos10/openshift-e2e-aws-rhcos10-workflow.yaml",
+	"owners": {
+		"approvers": [
+			"deads2k",
+			"dgoodwin",
+			"stbenjam",
+			"vrutkovs",
+			"wking"
+		]
+	}
+}

--- a/ci-operator/step-registry/openshift/e2e/aws/rhcos10/openshift-e2e-aws-rhcos10-workflow.yaml
+++ b/ci-operator/step-registry/openshift/e2e/aws/rhcos10/openshift-e2e-aws-rhcos10-workflow.yaml
@@ -1,0 +1,16 @@
+workflow:
+  as: openshift-e2e-aws-rhcos10
+  steps:
+    allow_best_effort_post_steps: true
+    pre:
+    - chain: ipi-conf-aws
+    - chain: aws-provision-iam-user-minimal-permission
+    - ref: rhcos-conf-rhcos10
+    - chain: ipi-install
+    test:
+    - ref: openshift-e2e-test
+    post:
+    - chain: gather-core-dump
+    - chain: ipi-aws-post
+  documentation: |-
+    The Openshift E2E AWS workflow with RHCOS10

--- a/ci-operator/step-registry/openshift/e2e/azure/serial/rhcos10/OWNERS
+++ b/ci-operator/step-registry/openshift/e2e/azure/serial/rhcos10/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+- jianlinliu
+- patrickdillon
+- yunjiang29
+- jcpowermac

--- a/ci-operator/step-registry/openshift/e2e/azure/serial/rhcos10/openshift-e2e-azure-serial-rhcos10-workflow.metadata.json
+++ b/ci-operator/step-registry/openshift/e2e/azure/serial/rhcos10/openshift-e2e-azure-serial-rhcos10-workflow.metadata.json
@@ -1,0 +1,11 @@
+{
+	"path": "openshift/e2e/azure/serial/rhcos10/openshift-e2e-azure-serial-rhcos10-workflow.yaml",
+	"owners": {
+		"approvers": [
+			"jianlinliu",
+			"patrickdillon",
+			"yunjiang29",
+			"jcpowermac"
+		]
+	}
+}

--- a/ci-operator/step-registry/openshift/e2e/azure/serial/rhcos10/openshift-e2e-azure-serial-rhcos10-workflow.yaml
+++ b/ci-operator/step-registry/openshift/e2e/azure/serial/rhcos10/openshift-e2e-azure-serial-rhcos10-workflow.yaml
@@ -1,0 +1,19 @@
+workflow:
+  as: openshift-e2e-azure-serial-rhcos10
+  steps:
+    allow_best_effort_post_steps: true
+    pre:
+    - chain: ipi-conf-azure
+    - chain: azure-provision-service-principal-minimal-permission
+    - ref: rhcos-conf-rhcos10
+    - chain: ipi-install
+    - ref: ipi-azure-rbac
+    test:
+    - ref: openshift-e2e-test
+    post:
+    - chain: gather-core-dump
+    - chain: ipi-azure-post
+    env:
+      TEST_SUITE: openshift/conformance/serial
+  documentation: |-
+    The Openshift E2E Azure `serial` workflow with RHCOS10

--- a/ci-operator/step-registry/openshift/e2e/gcp/ovn/rhcos10/OWNERS
+++ b/ci-operator/step-registry/openshift/e2e/gcp/ovn/rhcos10/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- core-networking-approvers
+reviewers:
+- core-networking-reviewers

--- a/ci-operator/step-registry/openshift/e2e/gcp/ovn/rhcos10/openshift-e2e-gcp-ovn-rhcos10-workflow.metadata.json
+++ b/ci-operator/step-registry/openshift/e2e/gcp/ovn/rhcos10/openshift-e2e-gcp-ovn-rhcos10-workflow.metadata.json
@@ -1,0 +1,11 @@
+{
+	"path": "openshift/e2e/gcp/ovn/rhcos10/openshift-e2e-gcp-ovn-rhcos10-workflow.yaml",
+	"owners": {
+		"approvers": [
+			"core-networking-approvers"
+		],
+		"reviewers": [
+			"core-networking-reviewers"
+		]
+	}
+}

--- a/ci-operator/step-registry/openshift/e2e/gcp/ovn/rhcos10/openshift-e2e-gcp-ovn-rhcos10-workflow.yaml
+++ b/ci-operator/step-registry/openshift/e2e/gcp/ovn/rhcos10/openshift-e2e-gcp-ovn-rhcos10-workflow.yaml
@@ -1,0 +1,19 @@
+workflow:
+  as: openshift-e2e-gcp-ovn-rhcos10
+  steps:
+    allow_best_effort_post_steps: true
+    pre:
+    - chain: ipi-conf-gcp
+    - ref: ovn-conf
+    - ref: rhcos-conf-rhcos10
+    - chain: ipi-install
+    test:
+    - ref: openshift-e2e-test
+    post:
+    - chain: gather-network
+    - chain: gather-core-dump
+    - chain: ipi-deprovision
+    env:
+      FAIL_ON_CORE_DUMP: "false"
+  documentation: |-
+    The Openshift E2E OVN workflow with RHCOS10

--- a/ci-operator/step-registry/openshift/e2e/gcp/rhcos10/OWNERS
+++ b/ci-operator/step-registry/openshift/e2e/gcp/rhcos10/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+- patrickdillon

--- a/ci-operator/step-registry/openshift/e2e/gcp/rhcos10/openshift-e2e-gcp-rhcos10-workflow.metadata.json
+++ b/ci-operator/step-registry/openshift/e2e/gcp/rhcos10/openshift-e2e-gcp-rhcos10-workflow.metadata.json
@@ -1,0 +1,8 @@
+{
+	"path": "openshift/e2e/gcp/rhcos10/openshift-e2e-gcp-rhcos10-workflow.yaml",
+	"owners": {
+		"approvers": [
+			"patrickdillon"
+		]
+	}
+}

--- a/ci-operator/step-registry/openshift/e2e/gcp/rhcos10/openshift-e2e-gcp-rhcos10-workflow.yaml
+++ b/ci-operator/step-registry/openshift/e2e/gcp/rhcos10/openshift-e2e-gcp-rhcos10-workflow.yaml
@@ -1,0 +1,15 @@
+workflow:
+  as: openshift-e2e-gcp-rhcos10
+  steps:
+    allow_best_effort_post_steps: true
+    pre:
+    - chain: ipi-conf-gcp
+    - ref: rhcos-conf-rhcos10
+    - chain: ipi-install
+    test:
+    - ref: openshift-e2e-test
+    post:
+    - chain: gather-core-dump
+    - chain: ipi-gcp-post
+  documentation: |-
+    The Openshift E2E GCP workflow with RHCOS10

--- a/ci-operator/step-registry/openshift/e2e/gcp/serial/rhcos10/OWNERS
+++ b/ci-operator/step-registry/openshift/e2e/gcp/serial/rhcos10/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+- patrickdillon

--- a/ci-operator/step-registry/openshift/e2e/gcp/serial/rhcos10/openshift-e2e-gcp-serial-rhcos10-workflow.metadata.json
+++ b/ci-operator/step-registry/openshift/e2e/gcp/serial/rhcos10/openshift-e2e-gcp-serial-rhcos10-workflow.metadata.json
@@ -1,0 +1,8 @@
+{
+	"path": "openshift/e2e/gcp/serial/rhcos10/openshift-e2e-gcp-serial-rhcos10-workflow.yaml",
+	"owners": {
+		"approvers": [
+			"patrickdillon"
+		]
+	}
+}

--- a/ci-operator/step-registry/openshift/e2e/gcp/serial/rhcos10/openshift-e2e-gcp-serial-rhcos10-workflow.yaml
+++ b/ci-operator/step-registry/openshift/e2e/gcp/serial/rhcos10/openshift-e2e-gcp-serial-rhcos10-workflow.yaml
@@ -1,0 +1,15 @@
+workflow:
+  as: openshift-e2e-gcp-serial-rhcos10
+  steps:
+    pre:
+    - chain: ipi-conf-gcp
+    - ref: rhcos-conf-rhcos10
+    - chain: ipi-install
+    test:
+    - ref: openshift-e2e-test
+    post:
+    - chain: ipi-gcp-post
+    env:
+      TEST_SUITE: openshift/conformance/serial
+  documentation: |-
+    The Openshift E2E GCP `serial` workflow with RHCOS10

--- a/ci-operator/step-registry/openshift/e2e/vsphere/rhcos10/OWNERS
+++ b/ci-operator/step-registry/openshift/e2e/vsphere/rhcos10/OWNERS
@@ -1,0 +1,3 @@
+approvers:
+- vsphere-approvers
+- storage-approvers

--- a/ci-operator/step-registry/openshift/e2e/vsphere/rhcos10/openshift-e2e-vsphere-rhcos10-workflow.metadata.json
+++ b/ci-operator/step-registry/openshift/e2e/vsphere/rhcos10/openshift-e2e-vsphere-rhcos10-workflow.metadata.json
@@ -1,0 +1,9 @@
+{
+	"path": "openshift/e2e/vsphere/rhcos10/openshift-e2e-vsphere-rhcos10-workflow.yaml",
+	"owners": {
+		"approvers": [
+			"vsphere-approvers",
+			"storage-approvers"
+		]
+	}
+}

--- a/ci-operator/step-registry/openshift/e2e/vsphere/rhcos10/openshift-e2e-vsphere-rhcos10-workflow.yaml
+++ b/ci-operator/step-registry/openshift/e2e/vsphere/rhcos10/openshift-e2e-vsphere-rhcos10-workflow.yaml
@@ -1,0 +1,14 @@
+workflow:
+  as: openshift-e2e-vsphere-rhcos10
+  steps:
+    pre:
+    - chain: ipi-conf-vsphere
+    - ref: rhcos-conf-rhcos10
+    - chain: ipi-install-vsphere
+    test:
+    - ref: openshift-e2e-test
+    post:
+    - chain: gather-core-dump
+    - chain: ipi-vsphere-post
+  documentation: |-
+    VSphere E2E workflow with RHCOS10

--- a/ci-operator/step-registry/openshift/e2e/vsphere/serial/rhcos10/OWNERS
+++ b/ci-operator/step-registry/openshift/e2e/vsphere/serial/rhcos10/OWNERS
@@ -1,0 +1,3 @@
+approvers:
+- vsphere-approvers
+- storage-approvers

--- a/ci-operator/step-registry/openshift/e2e/vsphere/serial/rhcos10/openshift-e2e-vsphere-serial-rhcos10-workflow.metadata.json
+++ b/ci-operator/step-registry/openshift/e2e/vsphere/serial/rhcos10/openshift-e2e-vsphere-serial-rhcos10-workflow.metadata.json
@@ -1,0 +1,9 @@
+{
+	"path": "openshift/e2e/vsphere/serial/rhcos10/openshift-e2e-vsphere-serial-rhcos10-workflow.yaml",
+	"owners": {
+		"approvers": [
+			"vsphere-approvers",
+			"storage-approvers"
+		]
+	}
+}

--- a/ci-operator/step-registry/openshift/e2e/vsphere/serial/rhcos10/openshift-e2e-vsphere-serial-rhcos10-workflow.yaml
+++ b/ci-operator/step-registry/openshift/e2e/vsphere/serial/rhcos10/openshift-e2e-vsphere-serial-rhcos10-workflow.yaml
@@ -1,0 +1,15 @@
+workflow:
+  as: openshift-e2e-vsphere-serial-rhcos10
+  steps:
+    pre:
+    - chain: ipi-conf-vsphere
+    - ref: rhcos-conf-rhcos10
+    - chain: ipi-install-vsphere
+    test:
+    - ref: openshift-e2e-test
+    post:
+    - chain: ipi-vsphere-post
+    env:
+      TEST_SUITE: openshift/conformance/serial
+  documentation: |-
+    The Openshift E2E vSphere `serial` workflow with RHCOS10


### PR DESCRIPTION
Duplicate the most frequently executed techpreview jobs so that they run using rhcos10 too.


List of rhcos jobs after these changes (23 jobs, please note that "insights" and "machine-config-operator" repositories have been impacted, not only "relase-master"):




```
  periodic-ci-openshift-insights-operator-release-4.22-periodics-e2e-gcp-rhcos10-techpreview                                                                                                                       
  periodic-ci-openshift-machine-config-operator-release-4.22-periodics-e2e-aws-mco-disruptive-rhcos10-techpreview-1of2                                                                                             
  periodic-ci-openshift-machine-config-operator-release-4.22-periodics-e2e-aws-mco-disruptive-rhcos10-techpreview-2of2                                                                                             
  periodic-ci-openshift-machine-config-operator-release-4.22-periodics-e2e-gcp-mco-disruptive-rhcos10-techpreview-1of2                                                                                             
  periodic-ci-openshift-machine-config-operator-release-4.22-periodics-e2e-gcp-mco-disruptive-rhcos10-techpreview-2of2                                                                                             
  periodic-ci-openshift-release-master-ci-4.22-e2e-aws-ovn-rhcos10-techpreview                                                                                                                                     
  periodic-ci-openshift-release-master-ci-4.22-e2e-aws-ovn-rhcos10-techpreview-serial-1of3                                                                                                                         
  periodic-ci-openshift-release-master-ci-4.22-e2e-aws-ovn-rhcos10-techpreview-serial-2of3                                                                                                                         
  periodic-ci-openshift-release-master-ci-4.22-e2e-aws-ovn-rhcos10-techpreview-serial-3of3                                                                                                                         
  periodic-ci-openshift-release-master-ci-4.22-e2e-azure-ovn-rhcos10-techpreview-serial                                                                                                                            
  periodic-ci-openshift-release-master-ci-4.22-e2e-gcp-ovn-rhcos10-techpreview                                                                                                                                     
  periodic-ci-openshift-release-master-ci-4.22-e2e-gcp-ovn-rhcos10-techpreview-serial                                                                                                                              
  periodic-ci-openshift-release-master-nightly-4.22-e2e-aws-ovn-single-node-rhcos10-techpreview    (already existing))                                                      
  periodic-ci-openshift-release-master-nightly-4.22-e2e-aws-ovn-single-node-rhcos10-techpreview-serial                                                                                         
  periodic-ci-openshift-release-master-nightly-4.22-e2e-azure-ovn-rhcos10-techpreview    (already existing)                                                                      
  periodic-ci-openshift-release-master-nightly-4.22-e2e-gcp-ovn-rt-rhcos10-techpreview        (already existing)                                                                                                                      
  periodic-ci-openshift-release-master-nightly-4.22-e2e-metal-ipi-ovn-dualstack-rhcos10-techpreview                                                                                                                
  periodic-ci-openshift-release-master-nightly-4.22-e2e-metal-ipi-ovn-ipv4-rhcos10-techpreview  (already existing)                                                                                                                    
  periodic-ci-openshift-release-master-nightly-4.22-e2e-metal-ipi-ovn-ipv6-rhcos10-techpreview                                                                                                                     
  periodic-ci-openshift-release-master-nightly-4.22-e2e-metal-ovn-two-node-fencing-ipv6-rhcos10-techpreview                                                                                                        
  periodic-ci-openshift-release-master-nightly-4.22-e2e-metal-ovn-two-node-fencing-serial-rhcos10-techpreview                                                                                                      
  periodic-ci-openshift-release-master-nightly-4.22-e2e-vsphere-ovn-rhcos10-techpreview                                                                                                                            
  periodic-ci-openshift-release-master-nightly-4.22-e2e-vsphere-ovn-rhcos10-techpreview-serial
```


We only created 19 jobs, there were other 4 rhcos10 already existing.

Out for those 19 jobs 4 of them can be considered as shards. So we actually created only 15 new job configs.