### PR TITLE
CNTRLPLANE-2635: Add guest node kernel isolation CI test with version skew for HyperShift KubeVirt

### DIFF
--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.21__periodics.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.21__periodics.yaml
@@ -39,6 +39,16 @@ releases:
       product: ocp
       stream: ci
       version: "4.21"
+  latest-4-18:
+    candidate:
+      product: ocp
+      stream: nightly
+      version: "4.18"
+  latest-4-19:
+    candidate:
+      product: ocp
+      stream: nightly
+      version: "4.19"
   latest-4-20:
     candidate:
       product: ocp
@@ -251,6 +261,60 @@ tests:
       MIRROR_OLM_REMOTE_INDEX: registry.redhat.io/redhat/redhat-operator-index:v4.15
       ODF_OPERATOR_SUB_CHANNEL: stable-4.15
     workflow: hypershift-kubevirt-baremetalds-disconnected-conformance
+- as: e2e-kubevirt-metal-conformance-calico-version-skew-y1
+  capabilities:
+  - intranet
+  minimum_interval: 168h
+  steps:
+    cluster_profile: equinix-ocp-hcp
+    dependencies:
+      HOSTEDCLUSTER_RELEASE_IMAGE_LATEST: release:latest-4-20
+      RELEASE_IMAGE_LATEST: release:latest-4-20
+    env:
+      LVM_OPERATOR_SUB_CHANNEL: stable-4.21
+      ODF_OPERATOR_SUB_CHANNEL: stable-4.19
+      ODF_OPERATOR_SUB_SOURCE: redhat-operators-v4-19
+      REDHAT_OPERATORS_INDEX_TAG: v4.19
+    test:
+    - ref: hypershift-kubevirt-check-kernel-isolation
+    - chain: hypershift-conformance
+    workflow: hypershift-kubevirt-baremetalds-conformance-calico
+- as: e2e-kubevirt-metal-conformance-calico-version-skew-y2
+  capabilities:
+  - intranet
+  minimum_interval: 168h
+  steps:
+    cluster_profile: equinix-ocp-hcp
+    dependencies:
+      HOSTEDCLUSTER_RELEASE_IMAGE_LATEST: release:latest-4-19
+      RELEASE_IMAGE_LATEST: release:latest-4-19
+    env:
+      LVM_OPERATOR_SUB_CHANNEL: stable-4.21
+      ODF_OPERATOR_SUB_CHANNEL: stable-4.19
+      ODF_OPERATOR_SUB_SOURCE: redhat-operators-v4-19
+      REDHAT_OPERATORS_INDEX_TAG: v4.19
+    test:
+    - ref: hypershift-kubevirt-check-kernel-isolation
+    - chain: hypershift-conformance
+    workflow: hypershift-kubevirt-baremetalds-conformance-calico
+- as: e2e-kubevirt-metal-conformance-calico-version-skew-y3
+  capabilities:
+  - intranet
+  minimum_interval: 168h
+  steps:
+    cluster_profile: equinix-ocp-hcp
+    dependencies:
+      HOSTEDCLUSTER_RELEASE_IMAGE_LATEST: release:latest-4-18
+      RELEASE_IMAGE_LATEST: release:latest-4-18
+    env:
+      LVM_OPERATOR_SUB_CHANNEL: stable-4.21
+      ODF_OPERATOR_SUB_CHANNEL: stable-4.19
+      ODF_OPERATOR_SUB_SOURCE: redhat-operators-v4-19
+      REDHAT_OPERATORS_INDEX_TAG: v4.19
+    test:
+    - ref: hypershift-kubevirt-check-kernel-isolation
+    - chain: hypershift-conformance
+    workflow: hypershift-kubevirt-baremetalds-conformance-calico
 - as: e2e-kubevirt-aws-ovn-csi
   cron: 0 4 * * *
   steps:

--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.22__periodics.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.22__periodics.yaml
@@ -39,7 +39,22 @@ releases:
       product: ocp
       stream: ci
       version: "4.22"
+  latest-4-19:
+    candidate:
+      product: ocp
+      stream: nightly
+      version: "4.19"
   latest-4-20:
+    candidate:
+      product: ocp
+      stream: nightly
+      version: "4.21"
+  latest-4-20-skew:
+    candidate:
+      product: ocp
+      stream: nightly
+      version: "4.20"
+  latest-4-21:
     candidate:
       product: ocp
       stream: nightly
@@ -266,6 +281,60 @@ tests:
       MIRROR_OLM_REMOTE_INDEX: registry.redhat.io/redhat/redhat-operator-index:v4.15
       ODF_OPERATOR_SUB_CHANNEL: stable-4.15
     workflow: hypershift-kubevirt-baremetalds-disconnected-conformance
+- as: e2e-kubevirt-metal-conformance-calico-version-skew-y1
+  capabilities:
+  - intranet
+  minimum_interval: 168h
+  steps:
+    cluster_profile: equinix-ocp-hcp
+    dependencies:
+      HOSTEDCLUSTER_RELEASE_IMAGE_LATEST: release:latest-4-21
+      RELEASE_IMAGE_LATEST: release:latest-4-21
+    env:
+      LVM_OPERATOR_SUB_CHANNEL: stable-4.22
+      ODF_OPERATOR_SUB_CHANNEL: stable-4.19
+      ODF_OPERATOR_SUB_SOURCE: redhat-operators-v4-19
+      REDHAT_OPERATORS_INDEX_TAG: v4.19
+    test:
+    - ref: hypershift-kubevirt-check-kernel-isolation
+    - chain: hypershift-conformance
+    workflow: hypershift-kubevirt-baremetalds-conformance-calico
+- as: e2e-kubevirt-metal-conformance-calico-version-skew-y2
+  capabilities:
+  - intranet
+  minimum_interval: 168h
+  steps:
+    cluster_profile: equinix-ocp-hcp
+    dependencies:
+      HOSTEDCLUSTER_RELEASE_IMAGE_LATEST: release:latest-4-20-skew
+      RELEASE_IMAGE_LATEST: release:latest-4-20-skew
+    env:
+      LVM_OPERATOR_SUB_CHANNEL: stable-4.22
+      ODF_OPERATOR_SUB_CHANNEL: stable-4.19
+      ODF_OPERATOR_SUB_SOURCE: redhat-operators-v4-19
+      REDHAT_OPERATORS_INDEX_TAG: v4.19
+    test:
+    - ref: hypershift-kubevirt-check-kernel-isolation
+    - chain: hypershift-conformance
+    workflow: hypershift-kubevirt-baremetalds-conformance-calico
+- as: e2e-kubevirt-metal-conformance-calico-version-skew-y3
+  capabilities:
+  - intranet
+  minimum_interval: 168h
+  steps:
+    cluster_profile: equinix-ocp-hcp
+    dependencies:
+      HOSTEDCLUSTER_RELEASE_IMAGE_LATEST: release:latest-4-19
+      RELEASE_IMAGE_LATEST: release:latest-4-19
+    env:
+      LVM_OPERATOR_SUB_CHANNEL: stable-4.22
+      ODF_OPERATOR_SUB_CHANNEL: stable-4.19
+      ODF_OPERATOR_SUB_SOURCE: redhat-operators-v4-19
+      REDHAT_OPERATORS_INDEX_TAG: v4.19
+    test:
+    - ref: hypershift-kubevirt-check-kernel-isolation
+    - chain: hypershift-conformance
+    workflow: hypershift-kubevirt-baremetalds-conformance-calico
 - as: e2e-kubevirt-aws-ovn-csi
   cron: 0 4 * * *
   steps:

--- a/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.21-periodics.yaml
+++ b/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.21-periodics.yaml
@@ -1555,6 +1555,258 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build03
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: release-4.21
+    org: openshift
+    repo: hypershift
+  labels:
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: equinix-ocp-metal
+    ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-hcp
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "4.21"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  minimum_interval: 168h
+  name: periodic-ci-openshift-hypershift-release-4.21-periodics-e2e-kubevirt-metal-conformance-calico-version-skew-y1
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-kubevirt-metal-conformance-calico-version-skew-y1
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build03
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: release-4.21
+    org: openshift
+    repo: hypershift
+  labels:
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: equinix-ocp-metal
+    ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-hcp
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "4.21"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  minimum_interval: 168h
+  name: periodic-ci-openshift-hypershift-release-4.21-periodics-e2e-kubevirt-metal-conformance-calico-version-skew-y2
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-kubevirt-metal-conformance-calico-version-skew-y2
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build03
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: release-4.21
+    org: openshift
+    repo: hypershift
+  labels:
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: equinix-ocp-metal
+    ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-hcp
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "4.21"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  minimum_interval: 168h
+  name: periodic-ci-openshift-hypershift-release-4.21-periodics-e2e-kubevirt-metal-conformance-calico-version-skew-y3
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-kubevirt-metal-conformance-calico-version-skew-y3
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build03
   cron: 0 4 * * *
   decorate: true
   decoration_config:

--- a/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.22-periodics.yaml
+++ b/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.22-periodics.yaml
@@ -1603,6 +1603,258 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
+  cluster: build03
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: release-4.22
+    org: openshift
+    repo: hypershift
+  labels:
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: equinix-ocp-metal
+    ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-hcp
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  minimum_interval: 168h
+  name: periodic-ci-openshift-hypershift-release-4.22-periodics-e2e-kubevirt-metal-conformance-calico-version-skew-y1
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-kubevirt-metal-conformance-calico-version-skew-y1
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build03
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: release-4.22
+    org: openshift
+    repo: hypershift
+  labels:
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: equinix-ocp-metal
+    ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-hcp
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  minimum_interval: 168h
+  name: periodic-ci-openshift-hypershift-release-4.22-periodics-e2e-kubevirt-metal-conformance-calico-version-skew-y2
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-kubevirt-metal-conformance-calico-version-skew-y2
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build03
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: release-4.22
+    org: openshift
+    repo: hypershift
+  labels:
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: equinix-ocp-metal
+    ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-hcp
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  minimum_interval: 168h
+  name: periodic-ci-openshift-hypershift-release-4.22-periodics-e2e-kubevirt-metal-conformance-calico-version-skew-y3
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-kubevirt-metal-conformance-calico-version-skew-y3
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
   cluster: build07
   cron: 0 23 * * 0
   decorate: true

--- a/ci-operator/step-registry/hypershift/kubevirt/check-kernel-isolation/OWNERS
+++ b/ci-operator/step-registry/hypershift/kubevirt/check-kernel-isolation/OWNERS
@@ -1,0 +1,16 @@
+approvers:
+- csrwng
+- enxebre
+- sjenning
+- imain
+- davidvossel
+- LiangquanLi930
+- bryan-cox
+- jparrill
+reviewers:
+- csrwng
+- enxebre
+- sjenning
+- imain
+- bryan-cox
+- jparrill

--- a/ci-operator/step-registry/hypershift/kubevirt/check-kernel-isolation/hypershift-kubevirt-check-kernel-isolation-commands.sh
+++ b/ci-operator/step-registry/hypershift/kubevirt/check-kernel-isolation/hypershift-kubevirt-check-kernel-isolation-commands.sh
@@ -1,0 +1,231 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "=========================================="
+echo "Checking Kernel Isolation Between Management and Hosted Clusters"
+echo "=========================================="
+echo ""
+
+# Install oc CLI if not available
+if ! command -v oc &> /dev/null; then
+    echo "Installing oc CLI..."
+    cd /tmp
+    curl -sL https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest/openshift-client-linux.tar.gz | tar xzf -
+    chmod +x oc kubectl
+    export PATH="/tmp:${PATH}"
+    echo "oc CLI installed successfully"
+    oc version --client || true
+    echo ""
+fi
+
+CLUSTER_NAME=$(echo -n "${PROW_JOB_ID}"|sha256sum|cut -c-20)
+MGMT_KUBECONFIG="${KUBECONFIG}"
+
+# Function to get kernel info from a node using node status (no oc debug needed)
+get_kernel_info() {
+  local KUBECONFIG_PATH=$1
+  local LABEL_SELECTOR=$2
+  local CONTEXT_NAME=$3
+
+  echo "--- Getting kernel info for $CONTEXT_NAME ---"
+
+  export KUBECONFIG="$KUBECONFIG_PATH"
+
+  # Wait for at least one node to be ready
+  echo "Waiting for nodes to be ready..."
+  timeout 300 bash -c "until oc get nodes -l \"$LABEL_SELECTOR\" 2>/dev/null | grep -q Ready; do sleep 5; done" || {
+    echo "ERROR: No ready nodes found for $CONTEXT_NAME"
+    oc get nodes || true
+    return 1
+  }
+
+  # Get the first ready node
+  local NODE
+  NODE=$(oc get nodes -l "$LABEL_SELECTOR" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+  if [[ -z "$NODE" ]]; then
+    echo "ERROR: Could not find node for $CONTEXT_NAME"
+    return 1
+  fi
+
+  echo "Using node: $NODE"
+
+  # Get kernel version from node status
+  local KERNEL
+  KERNEL=$(oc get node "$NODE" -o jsonpath='{.status.nodeInfo.kernelVersion}' 2>/dev/null)
+  echo "Kernel version: $KERNEL"
+
+  # Get boot ID from node status (unique per kernel instance)
+  local BOOT_ID
+  BOOT_ID=$(oc get node "$NODE" -o jsonpath='{.status.nodeInfo.bootID}' 2>/dev/null)
+  echo "Boot ID: $BOOT_ID"
+
+  # Get OS image from node status
+  local OS_IMAGE
+  OS_IMAGE=$(oc get node "$NODE" -o jsonpath='{.status.nodeInfo.osImage}' 2>/dev/null)
+  echo "OS Image: $OS_IMAGE"
+
+  # Return values via global variables
+  eval "${CONTEXT_NAME}_KERNEL='$KERNEL'"
+  eval "${CONTEXT_NAME}_BOOT_ID='$BOOT_ID'"
+  eval "${CONTEXT_NAME}_OS_IMAGE='$OS_IMAGE'"
+
+  echo ""
+}
+
+# Get management cluster kernel info
+echo "=== Management Cluster Kernel Info ==="
+# Try worker nodes first, then master nodes if no workers found
+get_kernel_info "$KUBECONFIG" "node-role.kubernetes.io/worker=" "MGMT" || \
+get_kernel_info "$KUBECONFIG" "node-role.kubernetes.io/master=" "MGMT" || \
+get_kernel_info "$KUBECONFIG" "node-role.kubernetes.io/control-plane=" "MGMT" || {
+  echo "ERROR: Failed to get management cluster kernel info"
+  exit 1
+}
+
+# Use nested_kubeconfig from SHARED_DIR (created by previous steps)
+echo "=== Hosted Cluster Kernel Info (Guest VM) ==="
+HOSTED_KUBECONFIG="${SHARED_DIR}/nested_kubeconfig"
+
+if [[ ! -f "$HOSTED_KUBECONFIG" ]]; then
+  echo "ERROR: Hosted cluster kubeconfig not found at $HOSTED_KUBECONFIG"
+  echo "Expected location: ${SHARED_DIR}/nested_kubeconfig"
+  echo "Files in ${SHARED_DIR}:"
+  ls -la "${SHARED_DIR}" || true
+  exit 1
+fi
+
+echo "Using hosted cluster kubeconfig: $HOSTED_KUBECONFIG"
+get_kernel_info "$HOSTED_KUBECONFIG" "node-role.kubernetes.io/worker=" "HOSTED" || {
+  echo "ERROR: Failed to get hosted cluster kernel info"
+  exit 1
+}
+
+# Verify VM boundaries - switch back to management cluster kubeconfig
+echo "=== Verifying VM Boundaries ==="
+export KUBECONFIG="${MGMT_KUBECONFIG}"
+
+# Find the control plane namespace (VirtLauncher pods run there, not in the hosted cluster namespace)
+echo "Looking for VirtLauncher pods in namespaces matching ${CLUSTER_NAME}..."
+
+# Wait for VirtLauncher pods to appear (they may take time to start)
+CONTROL_PLANE_NS=""
+for i in {1..60}; do
+  CONTROL_PLANE_NS=$(oc get pods -A --no-headers 2>/dev/null | grep virt-launcher | grep "${CLUSTER_NAME}" | head -1 | awk '{print $1}' || echo "")
+  if [[ -n "$CONTROL_PLANE_NS" ]]; then
+    break
+  fi
+  echo "Waiting for VirtLauncher pods to appear (attempt $i/60)..."
+  sleep 5
+done
+
+if [[ -z "$CONTROL_PLANE_NS" ]]; then
+  echo "ERROR: Could not find control plane namespace with VirtLauncher pods after 5 minutes!"
+  echo "Searching for namespaces containing ${CLUSTER_NAME}:"
+  oc get namespaces | grep "${CLUSTER_NAME}" || true
+  echo ""
+  echo "Searching for any VirtLauncher pods:"
+  oc get pods -A | grep virt-launcher || true
+  echo ""
+  echo "All namespaces:"
+  oc get namespaces || true
+  exit 1
+fi
+
+echo "Found control plane namespace: ${CONTROL_PLANE_NS}"
+
+echo "Checking for VirtLauncher pods..."
+VIRT_LAUNCHER_COUNT=$(oc get pods -n "${CONTROL_PLANE_NS}" --no-headers 2>/dev/null | grep -c virt-launcher || echo "0")
+VIRT_LAUNCHER_COUNT=$(echo "$VIRT_LAUNCHER_COUNT" | tr -d '\r\n' | head -1)
+if [[ "$VIRT_LAUNCHER_COUNT" -eq 0 ]]; then
+  echo "ERROR: No VirtLauncher pods found in namespace ${CONTROL_PLANE_NS}!"
+  echo "Available pods:"
+  oc get pods -n "${CONTROL_PLANE_NS}" || true
+  exit 1
+fi
+echo "PASS: Found $VIRT_LAUNCHER_COUNT VirtLauncher pod(s)"
+
+echo "Checking for VirtualMachineInstance resources..."
+VMI_COUNT=$(oc get vmi -n "${CONTROL_PLANE_NS}" --no-headers 2>/dev/null | wc -l || echo "0")
+VMI_COUNT=$(echo "$VMI_COUNT" | tr -d '\r\n' | head -1)
+if [[ "$VMI_COUNT" -eq 0 ]]; then
+  echo "ERROR: No VirtualMachineInstance resources found in namespace ${CONTROL_PLANE_NS}!"
+  echo "Available VMIs:"
+  oc get vmi -A || true
+  exit 1
+fi
+echo "PASS: Found $VMI_COUNT VirtualMachineInstance resource(s)"
+
+# Verify NetworkPolicy
+echo ""
+echo "=== Verifying VirtLauncher NetworkPolicy ==="
+if oc get networkpolicy -n "${CONTROL_PLANE_NS}" -o yaml 2>/dev/null | grep -q virt-launcher; then
+  echo "PASS: VirtLauncher NetworkPolicy found"
+else
+  echo "WARNING: VirtLauncher NetworkPolicy not found"
+  echo "Available NetworkPolicies:"
+  oc get networkpolicy -n "${CONTROL_PLANE_NS}" || true
+fi
+
+# Compare kernel isolation
+echo ""
+echo "=========================================="
+echo "Kernel Isolation Analysis"
+echo "=========================================="
+
+echo ""
+echo "Management Cluster:"
+echo "  Kernel:   $MGMT_KERNEL"
+echo "  Boot ID:  $MGMT_BOOT_ID"
+echo "  OS Image: $MGMT_OS_IMAGE"
+
+echo ""
+echo "Hosted Cluster (Guest VM):"
+echo "  Kernel:   $HOSTED_KERNEL"
+echo "  Boot ID:  $HOSTED_BOOT_ID"
+echo "  OS Image: $HOSTED_OS_IMAGE"
+
+echo ""
+echo "--- Boot ID Comparison (Critical Test) ---"
+if [[ "$MGMT_BOOT_ID" == "$HOSTED_BOOT_ID" ]]; then
+  echo "FAIL: Management and hosted clusters have the SAME boot ID!"
+  echo "   Management Boot ID: $MGMT_BOOT_ID"
+  echo "   Hosted Boot ID:     $HOSTED_BOOT_ID"
+  echo ""
+  echo "This indicates they may be sharing the same kernel (NO TRUE VM ISOLATION)"
+  echo "This violates ANSSI BP-028 requirements for kernel-level isolation."
+  exit 1
+fi
+
+echo "PASS: Different boot IDs confirm separate kernel instances"
+echo "   Management Boot ID: $MGMT_BOOT_ID"
+echo "   Hosted Boot ID:     $HOSTED_BOOT_ID"
+
+echo ""
+echo "--- Kernel Version Comparison (Informational) ---"
+if [[ "$MGMT_KERNEL" == "$HOSTED_KERNEL" ]]; then
+  echo "NOTICE: Same kernel version string detected"
+  echo "   Management: $MGMT_KERNEL"
+  echo "   Hosted:     $HOSTED_KERNEL"
+  echo "   This is acceptable - both may use the same RHCOS release"
+  echo "   VM isolation is still confirmed by different boot IDs"
+else
+  echo "PASS: Different kernel versions detected"
+  echo "   Management: $MGMT_KERNEL"
+  echo "   Hosted:     $HOSTED_KERNEL"
+  echo "   This provides additional evidence of version skew working correctly"
+fi
+
+echo ""
+echo "=========================================="
+echo "Kernel Isolation Check: PASSED"
+echo "=========================================="
+echo ""
+echo "Summary:"
+echo "  VM Isolation:     Confirmed (VirtLauncher pods: $VIRT_LAUNCHER_COUNT, VMIs: $VMI_COUNT)"
+echo "  Kernel Isolation: Confirmed (different boot IDs)"
+echo "  ANSSI BP-028:     Validated (kernel-level isolation)"
+echo ""
+echo "Management Kernel: $MGMT_KERNEL (Boot ID: ${MGMT_BOOT_ID:0:8}...)"
+echo "Hosted Kernel:     $HOSTED_KERNEL (Boot ID: ${HOSTED_BOOT_ID:0:8}...)"
+echo ""

--- a/ci-operator/step-registry/hypershift/kubevirt/check-kernel-isolation/hypershift-kubevirt-check-kernel-isolation-ref.metadata.json
+++ b/ci-operator/step-registry/hypershift/kubevirt/check-kernel-isolation/hypershift-kubevirt-check-kernel-isolation-ref.metadata.json
@@ -1,0 +1,23 @@
+{
+	"path": "hypershift/kubevirt/check-kernel-isolation/hypershift-kubevirt-check-kernel-isolation-ref.yaml",
+	"owners": {
+		"approvers": [
+			"csrwng",
+			"enxebre",
+			"sjenning",
+			"imain",
+			"davidvossel",
+			"LiangquanLi930",
+			"bryan-cox",
+			"jparrill"
+		],
+		"reviewers": [
+			"csrwng",
+			"enxebre",
+			"sjenning",
+			"imain",
+			"bryan-cox",
+			"jparrill"
+		]
+	}
+}

--- a/ci-operator/step-registry/hypershift/kubevirt/check-kernel-isolation/hypershift-kubevirt-check-kernel-isolation-ref.yaml
+++ b/ci-operator/step-registry/hypershift/kubevirt/check-kernel-isolation/hypershift-kubevirt-check-kernel-isolation-ref.yaml
@@ -1,0 +1,52 @@
+ref:
+  as: hypershift-kubevirt-check-kernel-isolation
+  from: hypershift-tests
+  grace_period: 5m0s
+  commands: hypershift-kubevirt-check-kernel-isolation-commands.sh
+  resources:
+    requests:
+      cpu: 100m
+      memory: 100Mi
+  documentation: |-
+    Validates kernel-level isolation between management cluster and hosted cluster
+    running in KubeVirt VMs. This step verifies ANSSI BP-028 compliance requirements
+    for multi-tenant hosted control planes.
+
+    The validation checks:
+
+    1. **Different kernel boot IDs** (Critical): Proves that management and guest
+       clusters are running separate kernel instances, not sharing the same kernel.
+       This is the definitive test for VM-level isolation.
+
+    2. **VirtLauncher pods exist and are running**: Confirms that the hosted cluster
+       control plane is running inside KubeVirt VMs, not just containers.
+
+    3. **VirtualMachineInstance resources are present**: Validates that KubeVirt
+       virtualization layer is active and managing the guest VMs.
+
+    4. **NetworkPolicy is applied to VirtLauncher pods**: Verifies network isolation
+       between management and guest clusters.
+
+    5. **/proc/version differences** (Informational): When kernel versions differ,
+       this provides additional evidence of version skew working correctly. When
+       kernel versions are the same, compilation timestamps are checked.
+
+    **Why Boot ID Matters:**
+    The boot ID (`/proc/sys/kernel/random/boot_id`) is a randomly generated UUID
+    created when the kernel boots. It is unique per kernel instance and cannot be
+    shared between different kernel boots. If management and guest have different
+    boot IDs, they MUST be running separate kernel instances, which proves true
+    VM-level isolation.
+
+    **ANSSI BP-028 Compliance:**
+    This validation demonstrates that OpenShift Hosted Control Planes provide
+    kernel-level isolation when running on KubeVirt, meeting the highest security
+    requirements for multi-tenant environments as specified in ANSSI BP-028.
+
+    **Related Jira:**
+    - OCPSTRAT-2217: VM-level and Hosted Cluster Isolation levels for HCP
+    - OCPSTRAT-1707: Align HCP NodePool minor-version skew limits
+
+    **Exit Codes:**
+    - 0: Kernel isolation confirmed (different boot IDs)
+    - 1: Kernel isolation failed (same boot ID or missing VMs)


### PR DESCRIPTION
# [CNTRLPLANE-2635](https://issues.redhat.com/browse/CNTRLPLANE-2635): Add guest node kernel isolation CI test with version skew for HyperShift KubeVirt

## Summary

This PR adds periodic CI jobs that verify **KubeVirt guest worker nodes run in a separate kernel instance from the management cluster's bare-metal host**, across N-1, N-2, and N-3 version skew configurations (6 weekly jobs for OCP 4.21 and 4.22).

## Scope & What This Proves

**Topology:** Shared Everything (default — no dedicated node assignment per hosted cluster).

The test compares:
- **Management cluster node** — bare-metal Equinix host running OCP 4.21/4.22
- **Hosted cluster worker node** — a KubeVirt VM running inside that bare-metal host

Different boot IDs confirm these are separate kernel instances, proving that KubeVirt guest nodes are VM-isolated from the management host. This is a meaningful correctness check: if KubeVirt were misconfigured and guest workloads shared the host kernel, the boot IDs would match.

**What this does NOT prove:**
- Kernel isolation *between the control planes of two different hosted clusters* — that requires Shared Nothing topology (dedicated nodes per cluster, labeled `hypershift.openshift.io/cluster=clusters-<name>`) and is tracked in [CNTRLPLANE-2636](https://issues.redhat.com/browse/CNTRLPLANE-2636)
- Cross-cluster network isolation between co-located control planes — tracked in [CNTRLPLANE-2637](https://issues.redhat.com/browse/CNTRLPLANE-2637)

## Test Results ✅

All rehearsal jobs **PASSED**:

| Job | Mgmt | Guest | Skew | Status | Build Log |
|-----|------|-------|------|--------|-----------|
| **Y-1 Skew** | 4.21 | 4.20 | N-1 | ✅ PASSED | [build-log](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_release/74326/rehearse-74326-periodic-ci-openshift-hypershift-release-4.21-periodics-e2e-kubevirt-metal-conformance-calico-version-skew-y1/2021420140238737408/artifacts/e2e-kubevirt-metal-conformance-calico-version-skew-y1/hypershift-kubevirt-check-kernel-isolation/build-log.txt) |
| **Y-2 Skew** | 4.21 | 4.19 | N-2 | ✅ PASSED | [build-log](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_release/74326/rehearse-74326-periodic-ci-openshift-hypershift-release-4.21-periodics-e2e-kubevirt-metal-conformance-calico-version-skew-y2/2021772960271962112/artifacts/e2e-kubevirt-metal-conformance-calico-version-skew-y2/hypershift-kubevirt-check-kernel-isolation/build-log.txt) |
| **Y-3 Skew** | 4.21 | 4.18 | N-3 | ✅ PASSED | [build-log](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_release/74326/rehearse-74326-periodic-ci-openshift-hypershift-release-4.21-periodics-e2e-kubevirt-metal-conformance-calico-version-skew-y3/2021950983591956480/artifacts/e2e-kubevirt-metal-conformance-calico-version-skew-y3/hypershift-kubevirt-check-kernel-isolation/build-log.txt) |

Sample result (Y-3 skew, management 4.21 → hosted 4.18):
```
Management Cluster (bare-metal):
  Kernel:  5.14.0-570.88.1.el9_6.x86_64
  Boot ID: d5f271d8-...

Hosted Cluster (KubeVirt guest VM worker node):
  Kernel:  5.14.0-427.110.1.el9_4.x86_64
  Boot ID: 5ed4a70f-...

PASS: Different boot IDs confirm separate kernel instances
```

## Changes

### 1. New CI Step: `hypershift-kubevirt-check-kernel-isolation`

**Location:** `ci-operator/step-registry/hypershift/kubevirt/check-kernel-isolation/`

Compares kernel boot IDs between a management cluster worker node and a hosted cluster guest VM worker node. A different boot ID is definitive proof of a separate kernel instance — it is a UUID generated at kernel boot time, unique and immutable per kernel lifetime.

**Checks performed:**
- Boot ID comparison between management bare-metal node and hosted guest VM node (critical)
- VirtLauncher pods running in the control plane namespace
- VirtualMachineInstance resources present
- VirtLauncher NetworkPolicy exists
- Kernel version comparison (informational — version skew evidence)

**Exit codes:** `0` = separate kernel instances confirmed, `1` = same boot ID or missing VMs

### 2. New Weekly Periodic Jobs

The kernel isolation check is added as an **inline `test:` override** in the version skew jobs only, using the existing `hypershift-kubevirt-baremetalds-conformance-calico` workflow.

**6 new weekly jobs (`minimum_interval: 168h`):**

| Release | Job | Management | Hosted | Skew |
|---------|-----|-----------|--------|------|
| 4.21 | `e2e-kubevirt-metal-conformance-calico-version-skew-y1` | 4.21 | 4.20 | N-1 |
| 4.21 | `e2e-kubevirt-metal-conformance-calico-version-skew-y2` | 4.21 | 4.19 | N-2 |
| 4.21 | `e2e-kubevirt-metal-conformance-calico-version-skew-y3` | 4.21 | 4.18 | N-3 |
| 4.22 | `e2e-kubevirt-metal-conformance-calico-version-skew-y1` | 4.22 | 4.21 | N-1 |
| 4.22 | `e2e-kubevirt-metal-conformance-calico-version-skew-y2` | 4.22 | 4.20 | N-2 |
| 4.22 | `e2e-kubevirt-metal-conformance-calico-version-skew-y3` | 4.22 | 4.19 | N-3 |

**Platform:** Equinix bare metal (KubeVirt) | **CNI:** Calico | **Profile:** `equinix-ocp-hcp`

### 3. Release Definitions

Added `latest-4-18` and `latest-4-19` candidate release definitions to `openshift-hypershift-release-4.21__periodics.yaml` for N-2 and N-3 skew dependencies.

## Files Changed

### Commit 1: Infrastructure Code
```
ci-operator/step-registry/hypershift/kubevirt/check-kernel-isolation/
  hypershift-kubevirt-check-kernel-isolation-commands.sh    (new)
  hypershift-kubevirt-check-kernel-isolation-ref.yaml       (new)
  hypershift-kubevirt-check-kernel-isolation-ref.metadata.json  (new)
  OWNERS                                                     (new)

ci-operator/config/openshift/hypershift/
  openshift-hypershift-release-4.21__periodics.yaml         (modified)
  openshift-hypershift-release-4.22__periodics.yaml         (modified)
```

### Commit 2: Generated Artifacts
```
ci-operator/jobs/openshift/hypershift/
  openshift-hypershift-release-4.21-periodics.yaml          (generated)
  openshift-hypershift-release-4.22-periodics.yaml          (generated)
```

## Related Issues

- **[CNTRLPLANE-2635](https://issues.redhat.com/browse/CNTRLPLANE-2635)**: CI test for guest node kernel isolation (this PR)
- **[CNTRLPLANE-2636](https://issues.redhat.com/browse/CNTRLPLANE-2636)**: Next step — Shared Nothing topology kernel isolation between two hosted control planes
- **[CNTRLPLANE-2637](https://issues.redhat.com/browse/CNTRLPLANE-2637)**: Next step — Cross-cluster network isolation verification
- **[OCPSTRAT-2217](https://issues.redhat.com/browse/OCPSTRAT-2217)**: VM-level and Hosted Cluster Isolation levels for HCP
- **[OCPSTRAT-1707](https://issues.redhat.com/browse/OCPSTRAT-1707)**: Align HCP NodePool minor-version skew limits

## References

- [HyperShift Versioning Support](https://hypershift-docs.netlify.app/reference/versioning-support/)
- [Distribute Hosted Cluster Workloads (Shared Nothing topology)](https://hypershift-docs.netlify.app/how-to/distribute-hosted-cluster-workloads/)
- [ANSSI BP-028 Security Recommendations](https://www.redhat.com/en/blog/anssi-bp-028-security-recommendations-updated-version-2.0)

/cc @csrwng @enxebre @sjenning @imain @davidvossel @LiangquanLi930 @bryan-cox @jparrill

[CNTRLPLANE-2635]: https://redhat.atlassian.net/browse/CNTRLPLANE-2635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CNTRLPLANE-2636]: https://redhat.atlassian.net/browse/CNTRLPLANE-2636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ