### PR TITLE
NO-JIRA: match the current HyperShift dev roster

### DIFF
--- a/core-services/pr-reminder/_config.yaml
+++ b/core-services/pr-reminder/_config.yaml
@@ -156,15 +156,19 @@ teams:
   - rhobs/observability-operator
   - rhobs/obo-prometheus-operator/
 - teamMembers:
-  - sjenning
-  - asegurap
+  - aabdelre
   - agarcial
-  - jparrill
-  - cewong
-  - mraee
-  - pstefans
-  - brcox
+  - alesross
+  - asegurap
   - bclement
+  - brcox
+  - cewong
+  - jparrill
+  - liangli
+  - mraee
+  - sjenning
+  - sminonne
+  - zfeng
   teamNames:
   - openshift-team-hypershift
   repos:


### PR DESCRIPTION
Over time the list had gotten outdated. This updates it to the current developer roster. A follow-up with QEs that contribute might come.