### PR TITLE
Changed from "preview" to "openshift-4.18"

### DIFF
--- a/ci-operator/config/openshift-pipelines/manual-approval-gate/openshift-pipelines-manual-approval-gate-main.yaml
+++ b/ci-operator/config/openshift-pipelines/manual-approval-gate/openshift-pipelines-manual-approval-gate-main.yaml
@@ -3,7 +3,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: rhel-9-release-golang-1.21-openshift-preview
+    tag: rhel-9-release-golang-1.21-openshift-4.18
 releases:
   initial:
     integration:

--- a/ci-operator/config/openshift-priv/must-gather-clean/openshift-priv-must-gather-clean-main.yaml
+++ b/ci-operator/config/openshift-priv/must-gather-clean/openshift-priv-must-gather-clean-main.yaml
@@ -3,7 +3,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: rhel-9-release-golang-1.21-openshift-preview
+    tag: rhel-9-release-golang-1.21-openshift-4.18
 canonical_go_repository: github.com/openshift/must-gather-clean
 promotion:
   to:

--- a/ci-operator/config/openshift-virtualization/wasp-agent/openshift-virtualization-wasp-agent-main.yaml
+++ b/ci-operator/config/openshift-virtualization/wasp-agent/openshift-virtualization-wasp-agent-main.yaml
@@ -3,7 +3,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: rhel-9-release-golang-1.21-openshift-preview
+    tag: rhel-9-release-golang-1.21-openshift-4.18
 promotion:
   to:
   - name: "4.22"

--- a/ci-operator/config/openshift/managed-release-bundle-osd/openshift-managed-release-bundle-osd-main.yaml
+++ b/ci-operator/config/openshift/managed-release-bundle-osd/openshift-managed-release-bundle-osd-main.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: rhel-9-release-golang-1.21-openshift-preview
+    tag: rhel-9-release-golang-1.21-openshift-4.18
 resources:
   '*':
     limits:

--- a/ci-operator/config/openshift/must-gather-clean/openshift-must-gather-clean-main.yaml
+++ b/ci-operator/config/openshift/must-gather-clean/openshift-must-gather-clean-main.yaml
@@ -3,7 +3,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: rhel-9-release-golang-1.21-openshift-preview
+    tag: rhel-9-release-golang-1.21-openshift-4.18
 promotion:
   to:
   - name: "4.22"

--- a/ci-operator/config/openshift/osd-example-operator/openshift-osd-example-operator-main.yaml
+++ b/ci-operator/config/openshift/osd-example-operator/openshift-osd-example-operator-main.yaml
@@ -2,7 +2,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: rhel-9-release-golang-1.21-openshift-preview
+    tag: rhel-9-release-golang-1.21-openshift-4.18
 resources:
   '*':
     limits:

--- a/ci-operator/config/red-hat-storage/odf-cli/red-hat-storage-odf-cli-main.yaml
+++ b/ci-operator/config/red-hat-storage/odf-cli/red-hat-storage-odf-cli-main.yaml
@@ -3,7 +3,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: rhel-9-release-golang-1.21-openshift-preview
+    tag: rhel-9-release-golang-1.21-openshift-4.18
 resources:
   '*':
     limits:

--- a/ci-operator/config/rh-ecosystem-edge/openshift-dpf/rh-ecosystem-edge-openshift-dpf-main.yaml
+++ b/ci-operator/config/rh-ecosystem-edge/openshift-dpf/rh-ecosystem-edge-openshift-dpf-main.yaml
@@ -2,7 +2,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: rhel-9-release-golang-1.21-openshift-preview
+    tag: rhel-9-release-golang-1.21-openshift-4.18
 images:
 - dockerfile_path: Containerfile
   to: dpf-ci

--- a/ci-operator/config/stolostron/acm-workload/stolostron-acm-workload-main.yaml
+++ b/ci-operator/config/stolostron/acm-workload/stolostron-acm-workload-main.yaml
@@ -11,7 +11,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: rhel-9-release-golang-1.21-openshift-preview
+    tag: rhel-9-release-golang-1.21-openshift-4.18
 images:
 - dockerfile_path: Dockerfile
   from: base

--- a/ci-operator/config/validatedpatterns/patterns-operator/validatedpatterns-patterns-operator-main.yaml
+++ b/ci-operator/config/validatedpatterns/patterns-operator/validatedpatterns-patterns-operator-main.yaml
@@ -3,7 +3,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: rhel-9-release-golang-1.21-openshift-preview
+    tag: rhel-9-release-golang-1.21-openshift-4.18
 promotion:
   to:
   - name: "4.22"


### PR DESCRIPTION
These configs are using `preview` tag from previous modification https://github.com/openshift/release/pull/74222.
To avoid that I fixed a 4.18 version.

The objective here is to use build images based on the ones that are maintained by ART, avoiding obscure ones with no formal process of build.