### PR TITLE
Replaced golang build images to the ones maintained by ART

### DIFF
--- a/ci-operator/config/rh-ecosystem-edge/nvidia-ci/rh-ecosystem-edge-nvidia-ci-main.yaml
+++ b/ci-operator/config/rh-ecosystem-edge/nvidia-ci/rh-ecosystem-edge-nvidia-ci-main.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.17
+    tag: rhel-8-release-golang-1.17-openshift-4.11
 images:
 - dockerfile_path: Containerfile
   to: nvidia-ci


### PR DESCRIPTION
We are trying to use the golang build images that are created by ART, avoiding obscure images with no standard procedure.