### PR TITLE
ARO-23200 | Modify the bicep-lint job to always run

### DIFF
--- a/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main.yaml
+++ b/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main.yaml
@@ -170,7 +170,6 @@ tests:
     test:
     - ref: aro-hcp-observability-grafana
 - as: bicep-lint
-  run_if_changed: ^dev-infrastructure/
   steps:
     test:
     - ref: aro-hcp-bicep-lint

--- a/ci-operator/jobs/Azure/ARO-HCP/Azure-ARO-HCP-main-presubmits.yaml
+++ b/ci-operator/jobs/Azure/ARO-HCP/Azure-ARO-HCP-main-presubmits.yaml
@@ -121,7 +121,7 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )baseimage-generator-images,?($|\s.*)
   - agent: kubernetes
-    always_run: false
+    always_run: true
     branches:
     - ^main$
     - ^main-
@@ -135,7 +135,6 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-Azure-ARO-HCP-main-bicep-lint
     rerun_command: /test bicep-lint
-    run_if_changed: ^dev-infrastructure/
     spec:
       containers:
       - args:


### PR DESCRIPTION
Running it always in case someone adds a `.bicep` file in an unexpected folder.
There is no harm in always running the job.