### PR TITLE
Starting with the first 128 modified configs

### DIFF
--- a/ci-operator/config/3scale-qe/3scale-deploy/3scale-qe-3scale-deploy-main__3scale-amp-ocp4.13-lp-interop.yaml
+++ b/ci-operator/config/3scale-qe/3scale-deploy/3scale-qe-3scale-deploy-main__3scale-amp-ocp4.13-lp-interop.yaml
@@ -11,7 +11,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-8-release-golang-1.19-openshift-4.13
 images:
 - context_dir: .
   dockerfile_path: Dockerfile

--- a/ci-operator/config/3scale-qe/3scale-deploy/3scale-qe-3scale-deploy-main__3scale-amp-ocp4.14-lp-interop.yaml
+++ b/ci-operator/config/3scale-qe/3scale-deploy/3scale-qe-3scale-deploy-main__3scale-amp-ocp4.14-lp-interop.yaml
@@ -11,7 +11,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-8-release-golang-1.19-openshift-4.14
 images:
 - context_dir: .
   dockerfile_path: Dockerfile

--- a/ci-operator/config/3scale-qe/3scale-deploy/3scale-qe-3scale-deploy-main__3scale-amp-ocp4.14-lp-rosa-classic.yaml
+++ b/ci-operator/config/3scale-qe/3scale-deploy/3scale-qe-3scale-deploy-main__3scale-amp-ocp4.14-lp-rosa-classic.yaml
@@ -19,7 +19,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-8-release-golang-1.19-openshift-4.14
 images:
 - context_dir: .
   dockerfile_path: Dockerfile

--- a/ci-operator/config/3scale-qe/3scale-deploy/3scale-qe-3scale-deploy-main__3scale-amp-ocp4.15-lp-interop.yaml
+++ b/ci-operator/config/3scale-qe/3scale-deploy/3scale-qe-3scale-deploy-main__3scale-amp-ocp4.15-lp-interop.yaml
@@ -11,7 +11,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-8-release-golang-1.19-openshift-4.15
 images:
 - context_dir: .
   dockerfile_path: Dockerfile

--- a/ci-operator/config/3scale-qe/3scale-deploy/3scale-qe-3scale-deploy-main__3scale-amp-ocp4.16-lp-interop.yaml
+++ b/ci-operator/config/3scale-qe/3scale-deploy/3scale-qe-3scale-deploy-main__3scale-amp-ocp4.16-lp-interop.yaml
@@ -11,7 +11,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-9-release-golang-1.19-openshift-4.15
 images:
 - context_dir: .
   dockerfile_path: Dockerfile

--- a/ci-operator/config/3scale-qe/3scale-deploy/3scale-qe-3scale-deploy-main__3scale-amp-ocp4.16-lp-rosa-classic.yaml
+++ b/ci-operator/config/3scale-qe/3scale-deploy/3scale-qe-3scale-deploy-main__3scale-amp-ocp4.16-lp-rosa-classic.yaml
@@ -19,7 +19,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-9-release-golang-1.19-openshift-4.15
 images:
 - context_dir: .
   dockerfile_path: Dockerfile

--- a/ci-operator/config/3scale-qe/3scale-deploy/3scale-qe-3scale-deploy-main__3scale-amp-ocp4.17-lp-interop.yaml
+++ b/ci-operator/config/3scale-qe/3scale-deploy/3scale-qe-3scale-deploy-main__3scale-amp-ocp4.17-lp-interop.yaml
@@ -11,7 +11,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-9-release-golang-1.19-openshift-4.15
 images:
 - context_dir: .
   dockerfile_path: Dockerfile

--- a/ci-operator/config/3scale-qe/3scale-deploy/3scale-qe-3scale-deploy-main__3scale-amp-ocp4.17-lp-rosa-classic.yaml
+++ b/ci-operator/config/3scale-qe/3scale-deploy/3scale-qe-3scale-deploy-main__3scale-amp-ocp4.17-lp-rosa-classic.yaml
@@ -19,7 +19,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-9-release-golang-1.19-openshift-4.15
 images:
 - context_dir: .
   dockerfile_path: Dockerfile

--- a/ci-operator/config/3scale/3scale-operator/3scale-3scale-operator-3scale-2.11-candidate.yaml
+++ b/ci-operator/config/3scale/3scale-operator/3scale-3scale-operator-3scale-2.11-candidate.yaml
@@ -3,7 +3,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.13
+    tag: rhel-8-release-golang-1.25-openshift-4.23
 releases:
   latest:
     release:

--- a/ci-operator/config/3scale/3scale-operator/3scale-3scale-operator-3scale-2.11-stable.yaml
+++ b/ci-operator/config/3scale/3scale-operator/3scale-3scale-operator-3scale-2.11-stable.yaml
@@ -3,7 +3,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.13
+    tag: rhel-8-release-golang-1.25-openshift-4.23
 releases:
   latest:
     release:

--- a/ci-operator/config/3scale/3scale-operator/3scale-3scale-operator-3scale-2.12-candidate.yaml
+++ b/ci-operator/config/3scale/3scale-operator/3scale-3scale-operator-3scale-2.12-candidate.yaml
@@ -3,7 +3,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-9-release-golang-1.19-openshift-4.15
 releases:
   latest:
     release:

--- a/ci-operator/config/3scale/3scale-operator/3scale-3scale-operator-3scale-2.12-stable.yaml
+++ b/ci-operator/config/3scale/3scale-operator/3scale-3scale-operator-3scale-2.12-stable.yaml
@@ -3,7 +3,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-9-release-golang-1.19-openshift-4.15
 releases:
   latest:
     release:

--- a/ci-operator/config/3scale/3scale-operator/3scale-3scale-operator-3scale-2.14-stable.yaml
+++ b/ci-operator/config/3scale/3scale-operator/3scale-3scale-operator-3scale-2.14-stable.yaml
@@ -3,7 +3,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-8-release-golang-1.19-openshift-4.12
 releases:
   latest:
     release:

--- a/ci-operator/config/3scale/3scale-operator/3scale-3scale-operator-master.yaml
+++ b/ci-operator/config/3scale/3scale-operator/3scale-3scale-operator-master.yaml
@@ -3,7 +3,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.22
+    tag: rhel-9-release-golang-1.22-openshift-4.19
 releases:
   latest:
     release:

--- a/ci-operator/config/CSPI-QE/MSI/CSPI-QE-MSI-rhods-rhoam__v4.14-production.yaml
+++ b/ci-operator/config/CSPI-QE/MSI/CSPI-QE-MSI-rhods-rhoam__v4.14-production.yaml
@@ -23,7 +23,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.17
+    tag: rhel-8-release-golang-1.17-openshift-4.11
 releases:
   latest:
     candidate:

--- a/ci-operator/config/CSPI-QE/MSI/CSPI-QE-MSI-rhods-rhoam__v4.14-stage.yaml
+++ b/ci-operator/config/CSPI-QE/MSI/CSPI-QE-MSI-rhods-rhoam__v4.14-stage.yaml
@@ -23,7 +23,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-8-release-golang-1.19-openshift-4.14
 releases:
   latest:
     candidate:

--- a/ci-operator/config/CSPI-QE/MSI/CSPI-QE-MSI-rhods-rhoam__v4.15-stage.yaml
+++ b/ci-operator/config/CSPI-QE/MSI/CSPI-QE-MSI-rhods-rhoam__v4.15-stage.yaml
@@ -23,7 +23,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-8-release-golang-1.19-openshift-4.15
 releases:
   latest:
     candidate:

--- a/ci-operator/config/CSPI-QE/interop-aws-reporter/CSPI-QE-interop-aws-reporter-main__image.yaml
+++ b/ci-operator/config/CSPI-QE/interop-aws-reporter/CSPI-QE-interop-aws-reporter-main__image.yaml
@@ -2,7 +2,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-9-release-golang-1.19-openshift-4.15
 images:
 - context_dir: .
   dockerfile_path: Dockerfile

--- a/ci-operator/config/CSPI-QE/interop-aws-reporter/CSPI-QE-interop-aws-reporter-main__weekly_trigger.yaml
+++ b/ci-operator/config/CSPI-QE/interop-aws-reporter/CSPI-QE-interop-aws-reporter-main__weekly_trigger.yaml
@@ -2,7 +2,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-9-release-golang-1.19-openshift-4.15
 images:
 - context_dir: .
   dockerfile_path: Dockerfile

--- a/ci-operator/config/CSPI-QE/interop-ocp-watcher-bot/CSPI-QE-interop-ocp-watcher-bot-main__image.yaml
+++ b/ci-operator/config/CSPI-QE/interop-ocp-watcher-bot/CSPI-QE-interop-ocp-watcher-bot-main__image.yaml
@@ -2,7 +2,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-9-release-golang-1.19-openshift-4.15
 images:
 - context_dir: .
   dockerfile_path: Dockerfile

--- a/ci-operator/config/ComplianceAsCode/ocp4e2e/ComplianceAsCode-ocp4e2e-main.yaml
+++ b/ci-operator/config/ComplianceAsCode/ocp4e2e/ComplianceAsCode-ocp4e2e-main.yaml
@@ -2,7 +2,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.23
+    tag: rhel-9-release-golang-1.23-openshift-4.20
 releases:
   initial:
     integration:

--- a/ci-operator/config/RedHatQE/firewatch/RedHatQE-firewatch-main__image.yaml
+++ b/ci-operator/config/RedHatQE/firewatch/RedHatQE-firewatch-main__image.yaml
@@ -2,7 +2,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-9-release-golang-1.19-openshift-4.15
 images:
 - context_dir: .
   dockerfile_path: Dockerfile

--- a/ci-operator/config/RedHatQE/interop-testing/RedHatQE-interop-testing-cnv-4.18__cnv-odf-ocp4.18-lp-interop.yaml
+++ b/ci-operator/config/RedHatQE/interop-testing/RedHatQE-interop-testing-cnv-4.18__cnv-odf-ocp4.18-lp-interop.yaml
@@ -15,7 +15,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.21
+    tag: rhel-8-release-golang-1.21-openshift-4.18
 images:
 - build_args:
   - name: OCP_VERSION

--- a/ci-operator/config/RedHatQE/interop-testing/RedHatQE-interop-testing-master__acm-cnv-ocp4.19-p2p-interop.yaml
+++ b/ci-operator/config/RedHatQE/interop-testing/RedHatQE-interop-testing-master__acm-cnv-ocp4.19-p2p-interop.yaml
@@ -27,7 +27,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.22
+    tag: rhel-8-release-golang-1.22-openshift-4.19
 images:
 - dockerfile_literal: |
     FROM this-is-ignored

--- a/ci-operator/config/RedHatQE/interop-testing/RedHatQE-interop-testing-master__cnv-odf-ocp-4.20-lp-interop-cr.yaml
+++ b/ci-operator/config/RedHatQE/interop-testing/RedHatQE-interop-testing-master__cnv-odf-ocp-4.20-lp-interop-cr.yaml
@@ -15,7 +15,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.21
+    tag: rhel-9-release-golang-1.21-openshift-4.18
 images:
 - build_args:
   - name: OCP_VERSION

--- a/ci-operator/config/RedHatQE/interop-testing/RedHatQE-interop-testing-master__cnv-odf-ocp-4.20-lp-interop.yaml
+++ b/ci-operator/config/RedHatQE/interop-testing/RedHatQE-interop-testing-master__cnv-odf-ocp-4.20-lp-interop.yaml
@@ -15,7 +15,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.21
+    tag: rhel-9-release-golang-1.21-openshift-4.18
 images:
 - build_args:
   - name: OCP_VERSION

--- a/ci-operator/config/RedHatQE/interop-testing/RedHatQE-interop-testing-master__cnv-odf-ocp-4.21-lp-interop-cr.yaml
+++ b/ci-operator/config/RedHatQE/interop-testing/RedHatQE-interop-testing-master__cnv-odf-ocp-4.21-lp-interop-cr.yaml
@@ -15,7 +15,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.21
+    tag: rhel-9-release-golang-1.21-openshift-4.18
 images:
 - build_args:
   - name: OCP_VERSION

--- a/ci-operator/config/RedHatQE/interop-testing/RedHatQE-interop-testing-master__cnv-odf-ocp4.19-lp-interop.yaml
+++ b/ci-operator/config/RedHatQE/interop-testing/RedHatQE-interop-testing-master__cnv-odf-ocp4.19-lp-interop.yaml
@@ -15,7 +15,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.21
+    tag: rhel-9-release-golang-1.21-openshift-4.18
 images:
 - build_args:
   - name: OCP_VERSION

--- a/ci-operator/config/RedHatQE/interop-testing/RedHatQE-interop-testing-master__cnv-odf-ocp4.20-konflux.yaml
+++ b/ci-operator/config/RedHatQE/interop-testing/RedHatQE-interop-testing-master__cnv-odf-ocp4.20-konflux.yaml
@@ -11,7 +11,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.21
+    tag: rhel-9-release-golang-1.21-openshift-4.18
 images:
 - build_args:
   - name: OCP_VERSION

--- a/ci-operator/config/RedHatQE/interop-testing/RedHatQE-interop-testing-master__ibm-fusion-access-operator-ocp4.20-lp-interop-cr.yaml
+++ b/ci-operator/config/RedHatQE/interop-testing/RedHatQE-interop-testing-master__ibm-fusion-access-operator-ocp4.20-lp-interop-cr.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.23
+    tag: rhel-8-release-golang-1.23-openshift-4.20
 images:
 - dockerfile_literal: |
     FROM icr.io/cpopen/ibm-spectrum-scale-must-gather:v5.2.3.1

--- a/ci-operator/config/RedHatQE/interop-testing/RedHatQE-interop-testing-master__ibm-fusion-access-operator-ocp4.20-lp-interop.yaml
+++ b/ci-operator/config/RedHatQE/interop-testing/RedHatQE-interop-testing-master__ibm-fusion-access-operator-ocp4.20-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.23
+    tag: rhel-8-release-golang-1.23-openshift-4.20
 images:
 - dockerfile_literal: |
     FROM icr.io/cpopen/ibm-spectrum-scale-must-gather:v5.2.3.1

--- a/ci-operator/config/RedHatQE/interop-testing/RedHatQE-interop-testing-master__ibm-fusion-access-operator-ocp4.21-lp-interop-cr.yaml
+++ b/ci-operator/config/RedHatQE/interop-testing/RedHatQE-interop-testing-master__ibm-fusion-access-operator-ocp4.21-lp-interop-cr.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.23
+    tag: rhel-9-release-golang-1.23-openshift-4.20
 images:
 - dockerfile_literal: |
     FROM icr.io/cpopen/ibm-spectrum-scale-must-gather:v5.2.3.1

--- a/ci-operator/config/RedHatQE/interop-testing/RedHatQE-interop-testing-master__ibm-fusion-access-operator-ocp4.21-lp-interop.yaml
+++ b/ci-operator/config/RedHatQE/interop-testing/RedHatQE-interop-testing-master__ibm-fusion-access-operator-ocp4.21-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.23
+    tag: rhel-9-release-golang-1.23-openshift-4.20
 images:
 - dockerfile_literal: |
     FROM icr.io/cpopen/ibm-spectrum-scale-must-gather:v5.2.3.1

--- a/ci-operator/config/ViaQ/log-file-metric-exporter/ViaQ-log-file-metric-exporter-release-v1.0.yaml
+++ b/ci-operator/config/ViaQ/log-file-metric-exporter/ViaQ-log-file-metric-exporter-release-v1.0.yaml
@@ -2,7 +2,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.16
+    tag: rhel-8-release-golang-1.16-openshift-4.9
 images:
 - dockerfile_path: Dockerfile
   to: log-file-metric-exporter

--- a/ci-operator/config/ViaQ/log-file-metric-exporter/ViaQ-log-file-metric-exporter-release-v1.1.yaml
+++ b/ci-operator/config/ViaQ/log-file-metric-exporter/ViaQ-log-file-metric-exporter-release-v1.1.yaml
@@ -2,7 +2,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.18
+    tag: rhel-8-release-golang-1.18-openshift-4.12
 images:
 - dockerfile_path: Dockerfile
   to: log-file-metric-exporter

--- a/ci-operator/config/ViaQ/vector/ViaQ-vector-release-5.8.yaml
+++ b/ci-operator/config/ViaQ/vector/ViaQ-vector-release-5.8.yaml
@@ -59,7 +59,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.23
+    tag: rhel-9-release-golang-1.23-openshift-4.20
 images:
 - dockerfile_path: Dockerfile
   from: ubi9-minimal

--- a/ci-operator/config/ViaQ/vector/ViaQ-vector-release-5.9.yaml
+++ b/ci-operator/config/ViaQ/vector/ViaQ-vector-release-5.9.yaml
@@ -59,7 +59,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.23
+    tag: rhel-9-release-golang-1.23-openshift-4.20
 images:
 - dockerfile_path: Dockerfile
   from: ubi9-minimal

--- a/ci-operator/config/ViaQ/vector/ViaQ-vector-release-6.0.yaml
+++ b/ci-operator/config/ViaQ/vector/ViaQ-vector-release-6.0.yaml
@@ -59,7 +59,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.23
+    tag: rhel-9-release-golang-1.23-openshift-4.20
 images:
 - dockerfile_path: Dockerfile
   from: ubi9-minimal

--- a/ci-operator/config/ViaQ/vector/ViaQ-vector-v0.37.1-rh.yaml
+++ b/ci-operator/config/ViaQ/vector/ViaQ-vector-v0.37.1-rh.yaml
@@ -51,7 +51,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.23
+    tag: rhel-9-release-golang-1.23-openshift-4.20
 images:
 - dockerfile_path: Dockerfile
   from: ubi9-minimal

--- a/ci-operator/config/ViaQ/vector/ViaQ-vector-v0.43.1-rh.yaml
+++ b/ci-operator/config/ViaQ/vector/ViaQ-vector-v0.43.1-rh.yaml
@@ -51,7 +51,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.23
+    tag: rhel-9-release-golang-1.23-openshift-4.20
 images:
 - dockerfile_path: Dockerfile
   from: ubi9-minimal

--- a/ci-operator/config/ViaQ/vector/ViaQ-vector-v0.46.1-rh.yaml
+++ b/ci-operator/config/ViaQ/vector/ViaQ-vector-v0.46.1-rh.yaml
@@ -51,7 +51,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.23
+    tag: rhel-9-release-golang-1.23-openshift-4.20
 images:
 - dockerfile_path: Dockerfile
   from: ubi9-minimal

--- a/ci-operator/config/ViaQ/vector/ViaQ-vector-v0.47.0-rh.yaml
+++ b/ci-operator/config/ViaQ/vector/ViaQ-vector-v0.47.0-rh.yaml
@@ -35,7 +35,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.23
+    tag: rhel-9-release-golang-1.23-openshift-4.20
 images:
 - dockerfile_path: Dockerfile
   from: ubi9-minimal

--- a/ci-operator/config/ViaQ/vector/ViaQ-vector-v0.50.0-rh.yaml
+++ b/ci-operator/config/ViaQ/vector/ViaQ-vector-v0.50.0-rh.yaml
@@ -35,7 +35,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.23
+    tag: rhel-9-release-golang-1.23-openshift-4.20
 images:
 - dockerfile_path: Dockerfile
   from: ubi9-minimal

--- a/ci-operator/config/crc-org/snc/crc-org-snc-4.7.yaml
+++ b/ci-operator/config/crc-org/snc/crc-org-snc-4.7.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.15
+    tag: rhel-8-release-golang-1.15-openshift-4.7
 images:
 - dockerfile_path: images/openshift-ci/Dockerfile
   from: base

--- a/ci-operator/config/crc-org/snc/crc-org-snc-4.8.yaml
+++ b/ci-operator/config/crc-org/snc/crc-org-snc-4.8.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.15
+    tag: rhel-8-release-golang-1.15-openshift-4.8
 images:
 - dockerfile_path: images/openshift-ci/Dockerfile
   from: base

--- a/ci-operator/config/crc-org/snc/crc-org-snc-4.9.yaml
+++ b/ci-operator/config/crc-org/snc/crc-org-snc-4.9.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.16
+    tag: rhel-8-release-golang-1.16-openshift-4.9
 images:
 - dockerfile_path: images/openshift-ci/Dockerfile
   from: base

--- a/ci-operator/config/crc-org/snc/crc-org-snc-release-4.14.yaml
+++ b/ci-operator/config/crc-org/snc/crc-org-snc-release-4.14.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-8-release-golang-1.19-openshift-4.14
 images:
 - dockerfile_path: images/openshift-ci/Dockerfile
   from: base

--- a/ci-operator/config/crc-org/snc/crc-org-snc-release-4.15.yaml
+++ b/ci-operator/config/crc-org/snc/crc-org-snc-release-4.15.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.15
+    tag: rhel-8-release-golang-1.15-openshift-4.8
 images:
 - dockerfile_path: images/openshift-ci/Dockerfile
   from: base

--- a/ci-operator/config/crc-org/snc/crc-org-snc-release-4.16.yaml
+++ b/ci-operator/config/crc-org/snc/crc-org-snc-release-4.16.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.15
+    tag: rhel-8-release-golang-1.15-openshift-4.8
 images:
 - dockerfile_path: images/openshift-ci/Dockerfile
   from: base

--- a/ci-operator/config/crc-org/snc/crc-org-snc-release-4.17.yaml
+++ b/ci-operator/config/crc-org/snc/crc-org-snc-release-4.17.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.15
+    tag: rhel-8-release-golang-1.15-openshift-4.8
 images:
 - dockerfile_path: images/openshift-ci/Dockerfile
   from: base

--- a/ci-operator/config/crc-org/snc/crc-org-snc-release-4.18.yaml
+++ b/ci-operator/config/crc-org/snc/crc-org-snc-release-4.18.yaml
@@ -2,7 +2,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.20
+    tag: rhel-9-release-golang-1.20-openshift-4.17
 images:
 - dockerfile_path: images/openshift-ci/Dockerfile
   to: libvirt-installer

--- a/ci-operator/config/crc-org/snc/crc-org-snc-release-4.19.yaml
+++ b/ci-operator/config/crc-org/snc/crc-org-snc-release-4.19.yaml
@@ -2,7 +2,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.20
+    tag: rhel-9-release-golang-1.20-openshift-4.17
 images:
 - dockerfile_path: images/openshift-ci/Dockerfile
   to: libvirt-installer

--- a/ci-operator/config/crc-org/snc/crc-org-snc-release-4.20.yaml
+++ b/ci-operator/config/crc-org/snc/crc-org-snc-release-4.20.yaml
@@ -2,7 +2,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.20
+    tag: rhel-9-release-golang-1.20-openshift-4.17
 images:
 - dockerfile_path: images/openshift-ci/Dockerfile
   to: libvirt-installer

--- a/ci-operator/config/cri-o/cri-o/cri-o-cri-o-release-1.13.yaml
+++ b/ci-operator/config/cri-o/cri-o/cri-o-cri-o-release-1.13.yaml
@@ -15,7 +15,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.11
+    tag: rhel-golang-1.11
 images:
 - context_dir: images/os/
   from: base

--- a/ci-operator/config/cri-o/cri-o/cri-o-cri-o-release-1.14.yaml
+++ b/ci-operator/config/cri-o/cri-o/cri-o-cri-o-release-1.14.yaml
@@ -15,7 +15,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.11
+    tag: rhel-golang-1.11
 images:
 - context_dir: images/os/
   from: base

--- a/ci-operator/config/cri-o/cri-o/cri-o-cri-o-release-1.16.yaml
+++ b/ci-operator/config/cri-o/cri-o/cri-o-cri-o-release-1.16.yaml
@@ -15,7 +15,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.12
+    tag: rhel-golang-1.12
 images:
 - context_dir: images/os/
   from: base

--- a/ci-operator/config/cri-o/cri-o/cri-o-cri-o-release-1.17.yaml
+++ b/ci-operator/config/cri-o/cri-o/cri-o-cri-o-release-1.17.yaml
@@ -15,7 +15,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.13
+    tag: rhel-8-release-golang-1.25-openshift-4.23
 images:
 - context_dir: images/os/
   from: base

--- a/ci-operator/config/cri-o/cri-o/cri-o-cri-o-release-1.18.yaml
+++ b/ci-operator/config/cri-o/cri-o/cri-o-cri-o-release-1.18.yaml
@@ -15,7 +15,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.13
+    tag: rhel-8-release-golang-1.25-openshift-4.23
 images:
 - context_dir: images/os/
   from: base

--- a/ci-operator/config/cri-o/cri-o/cri-o-cri-o-release-1.19.yaml
+++ b/ci-operator/config/cri-o/cri-o/cri-o-cri-o-release-1.19.yaml
@@ -15,7 +15,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.13
+    tag: rhel-8-release-golang-1.25-openshift-4.23
 images:
 - context_dir: images/os/
   from: base

--- a/ci-operator/config/cri-o/cri-o/cri-o-cri-o-release-1.20.yaml
+++ b/ci-operator/config/cri-o/cri-o/cri-o-cri-o-release-1.20.yaml
@@ -15,7 +15,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.13
+    tag: rhel-8-release-golang-1.25-openshift-4.23
 images:
 - context_dir: images/os/
   from: base

--- a/ci-operator/config/cri-o/cri-o/cri-o-cri-o-release-1.21.yaml
+++ b/ci-operator/config/cri-o/cri-o/cri-o-cri-o-release-1.21.yaml
@@ -15,7 +15,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.14
+    tag: rhel-8-release-golang-1.14-openshift-4.8
 images:
 - context_dir: images/os/
   from: base

--- a/ci-operator/config/cri-o/cri-o/cri-o-cri-o-release-1.22.yaml
+++ b/ci-operator/config/cri-o/cri-o/cri-o-cri-o-release-1.22.yaml
@@ -15,7 +15,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.16
+    tag: rhel-8-release-golang-1.16-openshift-4.9
 images:
 - context_dir: images/os/
   from: base

--- a/ci-operator/config/cri-o/cri-o/cri-o-cri-o-release-1.23.yaml
+++ b/ci-operator/config/cri-o/cri-o/cri-o-cri-o-release-1.23.yaml
@@ -15,7 +15,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.20
+    tag: rhel-9-release-golang-1.20-openshift-4.17
 images:
 - context_dir: images/os/
   from: base

--- a/ci-operator/config/cri-o/cri-o/cri-o-cri-o-release-1.24.yaml
+++ b/ci-operator/config/cri-o/cri-o/cri-o-cri-o-release-1.24.yaml
@@ -15,7 +15,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.20
+    tag: rhel-9-release-golang-1.20-openshift-4.17
 images:
 - context_dir: images/os/
   from: base

--- a/ci-operator/config/cri-o/cri-o/cri-o-cri-o-release-1.25.yaml
+++ b/ci-operator/config/cri-o/cri-o/cri-o-cri-o-release-1.25.yaml
@@ -15,7 +15,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.20
+    tag: rhel-9-release-golang-1.20-openshift-4.17
 images:
 - context_dir: images/os/
   from: base

--- a/ci-operator/config/cri-o/cri-o/cri-o-cri-o-release-1.26.yaml
+++ b/ci-operator/config/cri-o/cri-o/cri-o-cri-o-release-1.26.yaml
@@ -11,7 +11,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.20
+    tag: rhel-9-release-golang-1.20-openshift-4.17
 images:
 - dockerfile_literal: |
     # This uses the new rhel-coreos-8 base image

--- a/ci-operator/config/cri-o/cri-o/cri-o-cri-o-release-1.27.yaml
+++ b/ci-operator/config/cri-o/cri-o/cri-o-cri-o-release-1.27.yaml
@@ -11,7 +11,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.20
+    tag: rhel-8-release-golang-1.20-openshift-4.14
 images:
 - dockerfile_literal: |
     # This uses the new rhel-coreos-9 base image

--- a/ci-operator/config/cri-o/cri-o/cri-o-cri-o-release-1.28.yaml
+++ b/ci-operator/config/cri-o/cri-o/cri-o-cri-o-release-1.28.yaml
@@ -11,7 +11,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.20
+    tag: rhel-8-release-golang-1.20-openshift-4.15
 images:
 - dockerfile_literal: |
     # This uses the new rhel-coreos-9 base image

--- a/ci-operator/config/infinispan/infinispan-operator/infinispan-infinispan-operator-stable__data-grid-ocp4.13-lp-interop.yaml
+++ b/ci-operator/config/infinispan/infinispan-operator/infinispan-infinispan-operator-stable__data-grid-ocp4.13-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-8-release-golang-1.19-openshift-4.13
 images:
 - context_dir: .
   dockerfile_path: test-integration/Dockerfile

--- a/ci-operator/config/infinispan/infinispan-operator/infinispan-infinispan-operator-stable__data-grid-ocp4.14-lp-interop.yaml
+++ b/ci-operator/config/infinispan/infinispan-operator/infinispan-infinispan-operator-stable__data-grid-ocp4.14-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-8-release-golang-1.19-openshift-4.14
 images:
 - context_dir: .
   dockerfile_path: test-integration/Dockerfile

--- a/ci-operator/config/infinispan/infinispan-operator/infinispan-infinispan-operator-stable__data-grid-ocp4.15-lp-interop.yaml
+++ b/ci-operator/config/infinispan/infinispan-operator/infinispan-infinispan-operator-stable__data-grid-ocp4.15-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-8-release-golang-1.19-openshift-4.15
 images:
 - context_dir: .
   dockerfile_path: test-integration/Dockerfile

--- a/ci-operator/config/infinispan/infinispan-operator/infinispan-infinispan-operator-stable__data-grid-ocp4.16-lp-interop.yaml
+++ b/ci-operator/config/infinispan/infinispan-operator/infinispan-infinispan-operator-stable__data-grid-ocp4.16-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-9-release-golang-1.19-openshift-4.15
 images:
 - context_dir: .
   dockerfile_path: test-integration/Dockerfile

--- a/ci-operator/config/infinispan/infinispan-operator/infinispan-infinispan-operator-stable__data-grid-ocp4.17-lp-interop.yaml
+++ b/ci-operator/config/infinispan/infinispan-operator/infinispan-infinispan-operator-stable__data-grid-ocp4.17-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-9-release-golang-1.19-openshift-4.15
 images:
 - context_dir: .
   dockerfile_path: test-integration/Dockerfile

--- a/ci-operator/config/infinispan/infinispan-operator/infinispan-infinispan-operator-stable__data-grid-ocp4.18-lp-interop.yaml
+++ b/ci-operator/config/infinispan/infinispan-operator/infinispan-infinispan-operator-stable__data-grid-ocp4.18-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-9-release-golang-1.19-openshift-4.15
 images:
 - context_dir: .
   dockerfile_path: test-integration/Dockerfile

--- a/ci-operator/config/infinispan/infinispan-operator/infinispan-infinispan-operator-stable__data-grid-ocp4.19-lp-interop.yaml
+++ b/ci-operator/config/infinispan/infinispan-operator/infinispan-infinispan-operator-stable__data-grid-ocp4.19-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-9-release-golang-1.19-openshift-4.15
 images:
 - context_dir: .
   dockerfile_path: test-integration/Dockerfile

--- a/ci-operator/config/integr8ly/workload-web-app/integr8ly-workload-web-app-master.yaml
+++ b/ci-operator/config/integr8ly/workload-web-app/integr8ly-workload-web-app-master.yaml
@@ -2,7 +2,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.13
+    tag: rhel-8-release-golang-1.25-openshift-4.23
 images:
 - dockerfile_path: Dockerfile
   to: workload-web-app

--- a/ci-operator/config/jboss-eap-qe/openshift-eap-tests/jboss-eap-qe-openshift-eap-tests-pit-7.4.x__eap-ocp4.14-lp-interop.yaml
+++ b/ci-operator/config/jboss-eap-qe/openshift-eap-tests/jboss-eap-qe-openshift-eap-tests-pit-7.4.x__eap-ocp4.14-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-8-release-golang-1.19-openshift-4.14
 images:
 - context_dir: .
   dockerfile_path: .ci/openshift-ci/build-root/Dockerfile

--- a/ci-operator/config/jboss-eap-qe/openshift-eap-tests/jboss-eap-qe-openshift-eap-tests-pit-7.4.x__eap-ocp4.15-lp-interop.yaml
+++ b/ci-operator/config/jboss-eap-qe/openshift-eap-tests/jboss-eap-qe-openshift-eap-tests-pit-7.4.x__eap-ocp4.15-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-8-release-golang-1.19-openshift-4.15
 images:
 - context_dir: .
   dockerfile_path: .ci/openshift-ci/build-root/Dockerfile

--- a/ci-operator/config/jboss-eap-qe/openshift-eap-tests/jboss-eap-qe-openshift-eap-tests-pit-7.4.x__eap-ocp4.16-lp-interop.yaml
+++ b/ci-operator/config/jboss-eap-qe/openshift-eap-tests/jboss-eap-qe-openshift-eap-tests-pit-7.4.x__eap-ocp4.16-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-9-release-golang-1.19-openshift-4.15
 images:
 - context_dir: .
   dockerfile_path: .ci/openshift-ci/build-root/Dockerfile

--- a/ci-operator/config/jboss-eap-qe/openshift-eap-tests/jboss-eap-qe-openshift-eap-tests-pit-7.4.x__eap-ocp4.17-lp-interop.yaml
+++ b/ci-operator/config/jboss-eap-qe/openshift-eap-tests/jboss-eap-qe-openshift-eap-tests-pit-7.4.x__eap-ocp4.17-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-9-release-golang-1.19-openshift-4.15
 images:
 - context_dir: .
   dockerfile_path: .ci/openshift-ci/build-root/Dockerfile

--- a/ci-operator/config/jboss-eap-qe/openshift-eap-tests/jboss-eap-qe-openshift-eap-tests-pit-7.4.x__eap-ocp4.18-lp-interop.yaml
+++ b/ci-operator/config/jboss-eap-qe/openshift-eap-tests/jboss-eap-qe-openshift-eap-tests-pit-7.4.x__eap-ocp4.18-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-9-release-golang-1.19-openshift-4.15
 images:
 - context_dir: .
   dockerfile_path: .ci/openshift-ci/build-root/Dockerfile

--- a/ci-operator/config/jboss-eap-qe/openshift-eap-tests/jboss-eap-qe-openshift-eap-tests-pit-7.4.x__eap-ocp4.19-lp-interop.yaml
+++ b/ci-operator/config/jboss-eap-qe/openshift-eap-tests/jboss-eap-qe-openshift-eap-tests-pit-7.4.x__eap-ocp4.19-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-9-release-golang-1.19-openshift-4.15
 images:
 - context_dir: .
   dockerfile_path: .ci/openshift-ci/build-root/Dockerfile

--- a/ci-operator/config/jboss-fuse/camel-k-test-container/jboss-fuse-camel-k-test-container-main__camel-k-ocp4.14-lp-interop.yaml
+++ b/ci-operator/config/jboss-fuse/camel-k-test-container/jboss-fuse-camel-k-test-container-main__camel-k-ocp4.14-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-8-release-golang-1.19-openshift-4.14
 images:
 - context_dir: .
   dockerfile_path: Dockerfile

--- a/ci-operator/config/jboss-fuse/camel-k-test-container/jboss-fuse-camel-k-test-container-main__camel-k-ocp4.14-lp-rosa-classic.yaml
+++ b/ci-operator/config/jboss-fuse/camel-k-test-container/jboss-fuse-camel-k-test-container-main__camel-k-ocp4.14-lp-rosa-classic.yaml
@@ -15,7 +15,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-8-release-golang-1.19-openshift-4.14
 images:
 - context_dir: .
   dockerfile_path: Dockerfile

--- a/ci-operator/config/jboss-fuse/camel-k-test-container/jboss-fuse-camel-k-test-container-main__camel-k-ocp4.15-lp-interop.yaml
+++ b/ci-operator/config/jboss-fuse/camel-k-test-container/jboss-fuse-camel-k-test-container-main__camel-k-ocp4.15-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-8-release-golang-1.19-openshift-4.15
 images:
 - context_dir: .
   dockerfile_path: Dockerfile

--- a/ci-operator/config/jboss-fuse/camel-k-test-container/jboss-fuse-camel-k-test-container-main__camel-k-ocp4.16-lp-interop.yaml
+++ b/ci-operator/config/jboss-fuse/camel-k-test-container/jboss-fuse-camel-k-test-container-main__camel-k-ocp4.16-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-9-release-golang-1.19-openshift-4.15
 images:
 - context_dir: .
   dockerfile_path: Dockerfile

--- a/ci-operator/config/jboss-fuse/camel-k-test-container/jboss-fuse-camel-k-test-container-main__camel-k-ocp4.16-lp-rosa-classic.yaml
+++ b/ci-operator/config/jboss-fuse/camel-k-test-container/jboss-fuse-camel-k-test-container-main__camel-k-ocp4.16-lp-rosa-classic.yaml
@@ -15,7 +15,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-9-release-golang-1.19-openshift-4.15
 images:
 - context_dir: .
   dockerfile_path: Dockerfile

--- a/ci-operator/config/jboss-fuse/camel-k-test-container/jboss-fuse-camel-k-test-container-main__camel-k-ocp4.17-lp-interop.yaml
+++ b/ci-operator/config/jboss-fuse/camel-k-test-container/jboss-fuse-camel-k-test-container-main__camel-k-ocp4.17-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-9-release-golang-1.19-openshift-4.15
 images:
 - context_dir: .
   dockerfile_path: Dockerfile

--- a/ci-operator/config/jboss-fuse/camel-k-test-container/jboss-fuse-camel-k-test-container-main__camel-k-ocp4.17-lp-rosa-classic.yaml
+++ b/ci-operator/config/jboss-fuse/camel-k-test-container/jboss-fuse-camel-k-test-container-main__camel-k-ocp4.17-lp-rosa-classic.yaml
@@ -15,7 +15,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-9-release-golang-1.19-openshift-4.15
 images:
 - context_dir: .
   dockerfile_path: Dockerfile

--- a/ci-operator/config/jboss-fuse/camel-k-test-container/jboss-fuse-camel-k-test-container-main__camel-k-ocp4.18-lp-interop.yaml
+++ b/ci-operator/config/jboss-fuse/camel-k-test-container/jboss-fuse-camel-k-test-container-main__camel-k-ocp4.18-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-9-release-golang-1.19-openshift-4.15
 images:
 - context_dir: .
   dockerfile_path: Dockerfile

--- a/ci-operator/config/jboss-fuse/camel-k-test-container/jboss-fuse-camel-k-test-container-main__camel-k-ocp4.19-lp-interop.yaml
+++ b/ci-operator/config/jboss-fuse/camel-k-test-container/jboss-fuse-camel-k-test-container-main__camel-k-ocp4.19-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-9-release-golang-1.19-openshift-4.15
 images:
 - context_dir: .
   dockerfile_path: Dockerfile

--- a/ci-operator/config/jboss-fuse/camel-k-test-container/jboss-fuse-camel-k-test-container-main__camel-k-ocp4.20-lp-interop.yaml
+++ b/ci-operator/config/jboss-fuse/camel-k-test-container/jboss-fuse-camel-k-test-container-main__camel-k-ocp4.20-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-9-release-golang-1.19-openshift-4.15
 images:
 - context_dir: .
   dockerfile_path: Dockerfile

--- a/ci-operator/config/jboss-fuse/camel-quarkus-openshift-interop/jboss-fuse-camel-quarkus-openshift-interop-main__camel-quarkus-ocp4.14-lp-interop.yaml
+++ b/ci-operator/config/jboss-fuse/camel-quarkus-openshift-interop/jboss-fuse-camel-quarkus-openshift-interop-main__camel-quarkus-ocp4.14-lp-interop.yaml
@@ -11,7 +11,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-8-release-golang-1.19-openshift-4.14
 releases:
   latest:
     prerelease:

--- a/ci-operator/config/jboss-fuse/camel-quarkus-openshift-interop/jboss-fuse-camel-quarkus-openshift-interop-main__camel-quarkus-ocp4.15-lp-interop.yaml
+++ b/ci-operator/config/jboss-fuse/camel-quarkus-openshift-interop/jboss-fuse-camel-quarkus-openshift-interop-main__camel-quarkus-ocp4.15-lp-interop.yaml
@@ -11,7 +11,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-8-release-golang-1.19-openshift-4.15
 releases:
   latest:
     prerelease:

--- a/ci-operator/config/jboss-fuse/camel-quarkus-openshift-interop/jboss-fuse-camel-quarkus-openshift-interop-main__camel-quarkus-ocp4.16-lp-interop.yaml
+++ b/ci-operator/config/jboss-fuse/camel-quarkus-openshift-interop/jboss-fuse-camel-quarkus-openshift-interop-main__camel-quarkus-ocp4.16-lp-interop.yaml
@@ -11,7 +11,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-9-release-golang-1.19-openshift-4.15
 releases:
   latest:
     prerelease:

--- a/ci-operator/config/jboss-fuse/camel-quarkus-openshift-interop/jboss-fuse-camel-quarkus-openshift-interop-main__camel-quarkus-ocp4.17-lp-interop.yaml
+++ b/ci-operator/config/jboss-fuse/camel-quarkus-openshift-interop/jboss-fuse-camel-quarkus-openshift-interop-main__camel-quarkus-ocp4.17-lp-interop.yaml
@@ -11,7 +11,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-9-release-golang-1.19-openshift-4.15
 releases:
   latest:
     prerelease:

--- a/ci-operator/config/jboss-fuse/camel-quarkus-openshift-interop/jboss-fuse-camel-quarkus-openshift-interop-main__camel-quarkus-ocp4.18-lp-interop.yaml
+++ b/ci-operator/config/jboss-fuse/camel-quarkus-openshift-interop/jboss-fuse-camel-quarkus-openshift-interop-main__camel-quarkus-ocp4.18-lp-interop.yaml
@@ -11,7 +11,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-9-release-golang-1.19-openshift-4.15
 releases:
   latest:
     prerelease:

--- a/ci-operator/config/jboss-fuse/camel-quarkus-openshift-interop/jboss-fuse-camel-quarkus-openshift-interop-main__camel-quarkus-ocp4.19-lp-interop.yaml
+++ b/ci-operator/config/jboss-fuse/camel-quarkus-openshift-interop/jboss-fuse-camel-quarkus-openshift-interop-main__camel-quarkus-ocp4.19-lp-interop.yaml
@@ -11,7 +11,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-9-release-golang-1.19-openshift-4.15
 releases:
   latest:
     candidate:

--- a/ci-operator/config/jianzhangbjz/learn-operator/jianzhangbjz-learn-operator-master.yaml
+++ b/ci-operator/config/jianzhangbjz/learn-operator/jianzhangbjz-learn-operator-master.yaml
@@ -8,7 +8,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.14
+    tag: rhel-8-release-golang-1.14-openshift-4.7
 images:
 - dockerfile_path: build/Dockerfile.ci
   from: base

--- a/ci-operator/config/jws-qe/interop-ocp-ci/jws-qe-interop-ocp-ci-main__ocp-4.14-lp-interop.yaml
+++ b/ci-operator/config/jws-qe/interop-ocp-ci/jws-qe-interop-ocp-ci-main__ocp-4.14-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.21
+    tag: rhel-8-release-golang-1.21-openshift-4.14
 releases:
   latest:
     prerelease:

--- a/ci-operator/config/jws-qe/interop-ocp-ci/jws-qe-interop-ocp-ci-main__ocp-4.15-lp-interop.yaml
+++ b/ci-operator/config/jws-qe/interop-ocp-ci/jws-qe-interop-ocp-ci-main__ocp-4.15-lp-interop.yaml
@@ -11,7 +11,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.21
+    tag: rhel-8-release-golang-1.21-openshift-4.15
 releases:
   latest:
     prerelease:

--- a/ci-operator/config/jws-qe/interop-ocp-ci/jws-qe-interop-ocp-ci-main__ocp-4.16-lp-interop.yaml
+++ b/ci-operator/config/jws-qe/interop-ocp-ci/jws-qe-interop-ocp-ci-main__ocp-4.16-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.21
+    tag: rhel-8-release-golang-1.21-openshift-4.16
 releases:
   latest:
     prerelease:

--- a/ci-operator/config/jws-qe/interop-ocp-ci/jws-qe-interop-ocp-ci-main__ocp-4.17-lp-interop.yaml
+++ b/ci-operator/config/jws-qe/interop-ocp-ci/jws-qe-interop-ocp-ci-main__ocp-4.17-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.21
+    tag: rhel-8-release-golang-1.21-openshift-4.17
 releases:
   latest:
     candidate:

--- a/ci-operator/config/jws-qe/interop-ocp-ci/jws-qe-interop-ocp-ci-main__ocp-4.18-lp-interop.yaml
+++ b/ci-operator/config/jws-qe/interop-ocp-ci/jws-qe-interop-ocp-ci-main__ocp-4.18-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.21
+    tag: rhel-8-release-golang-1.21-openshift-4.18
 releases:
   latest:
     candidate:

--- a/ci-operator/config/jws-qe/interop-ocp-ci/jws-qe-interop-ocp-ci-main__ocp-4.19-lp-interop.yaml
+++ b/ci-operator/config/jws-qe/interop-ocp-ci/jws-qe-interop-ocp-ci-main__ocp-4.19-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.21
+    tag: rhel-9-release-golang-1.21-openshift-4.18
 releases:
   latest:
     candidate:

--- a/ci-operator/config/kiegroup/kie-cloud-operator/kiegroup-kie-cloud-operator-release-v1.0.x.yaml
+++ b/ci-operator/config/kiegroup/kie-cloud-operator/kiegroup-kie-cloud-operator-release-v1.0.x.yaml
@@ -8,7 +8,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.10
+    tag: rhel-8-release-golang-1.25-openshift-4.23
 images:
 - dockerfile_path: build/Dockerfile
   from: os

--- a/ci-operator/config/kiegroup/kie-cloud-operator/kiegroup-kie-cloud-operator-release-v1.1.x.yaml
+++ b/ci-operator/config/kiegroup/kie-cloud-operator/kiegroup-kie-cloud-operator-release-v1.1.x.yaml
@@ -8,7 +8,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.11
+    tag: rhel-golang-1.11
 images:
 - dockerfile_path: build/Dockerfile
   from: os

--- a/ci-operator/config/kiegroup/kie-cloud-operator/kiegroup-kie-cloud-operator-release-v1.2.x.yaml
+++ b/ci-operator/config/kiegroup/kie-cloud-operator/kiegroup-kie-cloud-operator-release-v1.2.x.yaml
@@ -8,7 +8,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.11
+    tag: rhel-golang-1.11
 images:
 - dockerfile_path: build/Dockerfile
   from: os

--- a/ci-operator/config/kiegroup/kie-cloud-operator/kiegroup-kie-cloud-operator-release-v1.3.x.yaml
+++ b/ci-operator/config/kiegroup/kie-cloud-operator/kiegroup-kie-cloud-operator-release-v1.3.x.yaml
@@ -8,7 +8,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.11
+    tag: rhel-golang-1.11
 images:
 - dockerfile_path: build/Dockerfile
   from: os

--- a/ci-operator/config/kiegroup/kie-cloud-operator/kiegroup-kie-cloud-operator-release-v1.4.x.yaml
+++ b/ci-operator/config/kiegroup/kie-cloud-operator/kiegroup-kie-cloud-operator-release-v1.4.x.yaml
@@ -8,7 +8,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.12
+    tag: rhel-golang-1.12
 images:
 - dockerfile_path: build/Dockerfile
   from: os

--- a/ci-operator/config/kiegroup/kie-cloud-operator/kiegroup-kie-cloud-operator-release-v7.10.x.yaml
+++ b/ci-operator/config/kiegroup/kie-cloud-operator/kiegroup-kie-cloud-operator-release-v7.10.x.yaml
@@ -8,7 +8,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.13
+    tag: rhel-8-release-golang-1.25-openshift-4.23
 images:
 - dockerfile_path: build/Dockerfile
   from: os

--- a/ci-operator/config/kiegroup/kie-cloud-operator/kiegroup-kie-cloud-operator-release-v7.11.x.yaml
+++ b/ci-operator/config/kiegroup/kie-cloud-operator/kiegroup-kie-cloud-operator-release-v7.11.x.yaml
@@ -8,7 +8,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.13
+    tag: rhel-8-release-golang-1.25-openshift-4.23
 images:
 - dockerfile_path: build/Dockerfile
   from: os

--- a/ci-operator/config/kiegroup/kie-cloud-operator/kiegroup-kie-cloud-operator-release-v7.12.x.yaml
+++ b/ci-operator/config/kiegroup/kie-cloud-operator/kiegroup-kie-cloud-operator-release-v7.12.x.yaml
@@ -8,7 +8,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.16
+    tag: rhel-8-release-golang-1.16-openshift-4.9
 images:
 - dockerfile_path: build/Dockerfile
   from: os

--- a/ci-operator/config/kiegroup/kie-cloud-operator/kiegroup-kie-cloud-operator-release-v7.13.x.yaml
+++ b/ci-operator/config/kiegroup/kie-cloud-operator/kiegroup-kie-cloud-operator-release-v7.13.x.yaml
@@ -8,7 +8,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.18
+    tag: rhel-8-release-golang-1.18-openshift-4.12
 images:
 - dockerfile_path: build/Dockerfile
   from: os

--- a/ci-operator/config/kiegroup/kie-cloud-operator/kiegroup-kie-cloud-operator-release-v7.8.x.yaml
+++ b/ci-operator/config/kiegroup/kie-cloud-operator/kiegroup-kie-cloud-operator-release-v7.8.x.yaml
@@ -8,7 +8,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.13
+    tag: rhel-8-release-golang-1.25-openshift-4.23
 images:
 - dockerfile_path: build/Dockerfile
   from: os

--- a/ci-operator/config/kiegroup/kie-cloud-operator/kiegroup-kie-cloud-operator-release-v7.9.x.yaml
+++ b/ci-operator/config/kiegroup/kie-cloud-operator/kiegroup-kie-cloud-operator-release-v7.9.x.yaml
@@ -8,7 +8,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.13
+    tag: rhel-8-release-golang-1.25-openshift-4.23
 images:
 - dockerfile_path: build/Dockerfile
   from: os

--- a/ci-operator/config/kiegroup/kie-cloud-tests-container/kiegroup-kie-cloud-tests-container-main__rhba-ocp4.14-lp-interop.yaml
+++ b/ci-operator/config/kiegroup/kie-cloud-tests-container/kiegroup-kie-cloud-tests-container-main__rhba-ocp4.14-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-8-release-golang-1.19-openshift-4.14
 images:
 - context_dir: .
   dockerfile_path: Dockerfile

--- a/ci-operator/config/kiegroup/kie-cloud-tests-container/kiegroup-kie-cloud-tests-container-main__rhba-ocp4.15-lp-interop.yaml
+++ b/ci-operator/config/kiegroup/kie-cloud-tests-container/kiegroup-kie-cloud-tests-container-main__rhba-ocp4.15-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-8-release-golang-1.19-openshift-4.15
 images:
 - context_dir: .
   dockerfile_path: Dockerfile

--- a/ci-operator/config/kiegroup/kie-cloud-tests-container/kiegroup-kie-cloud-tests-container-main__rhba-ocp4.16-lp-interop.yaml
+++ b/ci-operator/config/kiegroup/kie-cloud-tests-container/kiegroup-kie-cloud-tests-container-main__rhba-ocp4.16-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-9-release-golang-1.19-openshift-4.15
 images:
 - context_dir: .
   dockerfile_path: Dockerfile

--- a/ci-operator/config/konveyor/tackle-ui-tests/konveyor-tackle-ui-tests-mta_7.2.0__mta-ocp4.16-lp-interop.yaml
+++ b/ci-operator/config/konveyor/tackle-ui-tests/konveyor-tackle-ui-tests-mta_7.2.0__mta-ocp4.16-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-9-release-golang-1.19-openshift-4.15
 images:
 - context_dir: .
   dockerfile_path: dockerfiles/interop/Dockerfile

--- a/ci-operator/config/konveyor/tackle-ui-tests/konveyor-tackle-ui-tests-mta_7.2.0__mta-ocp4.17-lp-interop.yaml
+++ b/ci-operator/config/konveyor/tackle-ui-tests/konveyor-tackle-ui-tests-mta_7.2.0__mta-ocp4.17-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-9-release-golang-1.19-openshift-4.15
 images:
 - context_dir: .
   dockerfile_path: dockerfiles/interop/Dockerfile

--- a/ci-operator/config/konveyor/tackle-ui-tests/konveyor-tackle-ui-tests-mta_7.2.0__mta-ocp4.18-lp-interop.yaml
+++ b/ci-operator/config/konveyor/tackle-ui-tests/konveyor-tackle-ui-tests-mta_7.2.0__mta-ocp4.18-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-9-release-golang-1.19-openshift-4.15
 images:
 - context_dir: .
   dockerfile_path: dockerfiles/interop/Dockerfile

--- a/ci-operator/config/konveyor/tackle-ui-tests/konveyor-tackle-ui-tests-mta_8.0.0__mta-ocp-4.21-lp-interop-cr.yaml
+++ b/ci-operator/config/konveyor/tackle-ui-tests/konveyor-tackle-ui-tests-mta_8.0.0__mta-ocp-4.21-lp-interop-cr.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.20
+    tag: rhel-9-release-golang-1.20-openshift-4.17
 images:
 - context_dir: .
   dockerfile_path: dockerfiles/interop/Dockerfile

--- a/ci-operator/config/konveyor/tackle-ui-tests/konveyor-tackle-ui-tests-release-0.6__mta-ocp4.19-lp-interop.yaml
+++ b/ci-operator/config/konveyor/tackle-ui-tests/konveyor-tackle-ui-tests-release-0.6__mta-ocp4.19-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-9-release-golang-1.19-openshift-4.15
 images:
 - context_dir: .
   dockerfile_path: dockerfiles/interop/Dockerfile

--- a/ci-operator/config/konveyor/tackle-ui-tests/konveyor-tackle-ui-tests-release-0.7__mta-ocp4.20-lp-interop.yaml
+++ b/ci-operator/config/konveyor/tackle-ui-tests/konveyor-tackle-ui-tests-release-0.7__mta-ocp4.20-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.19
+    tag: rhel-9-release-golang-1.19-openshift-4.15
 images:
 - context_dir: .
   dockerfile_path: dockerfiles/interop/Dockerfile

--- a/ci-operator/config/kube-reporting/ghostunnel/kube-reporting-ghostunnel-release-4.5.yaml
+++ b/ci-operator/config/kube-reporting/ghostunnel/kube-reporting-ghostunnel-release-4.5.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.13
+    tag: rhel-8-release-golang-1.25-openshift-4.23
 canonical_go_repository: github.com/square/ghostunnel
 images:
 - from: base

--- a/ci-operator/config/kube-reporting/ghostunnel/kube-reporting-ghostunnel-release-4.6.yaml
+++ b/ci-operator/config/kube-reporting/ghostunnel/kube-reporting-ghostunnel-release-4.6.yaml
@@ -11,7 +11,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.13
+    tag: rhel-8-release-golang-1.25-openshift-4.23
 canonical_go_repository: github.com/square/ghostunnel
 images:
 - dockerfile_path: Dockerfile.rhel

--- a/ci-operator/config/kube-reporting/ghostunnel/kube-reporting-ghostunnel-release-4.7.yaml
+++ b/ci-operator/config/kube-reporting/ghostunnel/kube-reporting-ghostunnel-release-4.7.yaml
@@ -11,7 +11,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.13
+    tag: rhel-8-release-golang-1.25-openshift-4.23
 canonical_go_repository: github.com/square/ghostunnel
 images:
 - dockerfile_path: Dockerfile.rhel


### PR DESCRIPTION
This is an effort do standardize the golang build images used in our CI environment to the ones created by ART.

The modified images are the `build_root` ones, these images are not promoted but used to build artifacts to be transfered to other images.