### PR TITLE
Update ACM Observability cluster pools

### DIFF
--- a/ci-operator/config/stolostron/multicluster-observability-operator/stolostron-multicluster-observability-operator-release-2.13.yaml
+++ b/ci-operator/config/stolostron/multicluster-observability-operator/stolostron-multicluster-observability-operator-release-2.13.yaml
@@ -107,9 +107,9 @@ tests:
       CLUSTERPOOL_GROUP_NAME: Core-Services
       CLUSTERPOOL_HOST_NAMESPACE: acm-observability-usa
       CLUSTERPOOL_HOST_PROW_KUBE_SECRET: ocm-obs-usa-clusterpool
-      CLUSTERPOOL_HUB_FILTER: sno-4xlarge-418
+      CLUSTERPOOL_HUB_FILTER: sno-4xlarge-420
       CLUSTERPOOL_LIFETIME: 1h
-      CLUSTERPOOL_MANAGED_FILTER: sno-418
+      CLUSTERPOOL_MANAGED_FILTER: sno-420
       COMPONENT_NAME: multicluster-observability-operator
       DEPLOY_HUB_ADDITIONAL_YAML: |
         LS0tCmFwaVZlcnNpb246IHJiYWMuYXV0aG9yaXphdGlvbi5rOHMuaW8vdjEKa2luZDogQ2x1c3Rl
@@ -136,7 +136,7 @@ tests:
         bHVzdGVyLW9ic2VydmFiaWxpdHktb3BlcmF0b3ItZTJlLXRlc3RpbmcKc3ViamVjdHM6Ci0ga2lu
         ZDogU2VydmljZUFjY291bnQKICBuYW1lOiBtdWx0aWNsdXN0ZXItb2JzZXJ2YWJpbGl0eS1vcGVy
         YXRvcgogIG5hbWVzcGFjZTogb3Blbi1jbHVzdGVyLW1hbmFnZW1lbnQKLS0tCg==
-      PIPELINE_STAGE: dev
+      PIPELINE_STAGE: integration
     test:
     - as: e2e
       commands: |

--- a/ci-operator/config/stolostron/multicluster-observability-operator/stolostron-multicluster-observability-operator-release-2.14.yaml
+++ b/ci-operator/config/stolostron/multicluster-observability-operator/stolostron-multicluster-observability-operator-release-2.14.yaml
@@ -96,9 +96,9 @@ tests:
       CLUSTERPOOL_GROUP_NAME: Core-Services
       CLUSTERPOOL_HOST_NAMESPACE: acm-observability-usa
       CLUSTERPOOL_HOST_PROW_KUBE_SECRET: ocm-obs-usa-clusterpool
-      CLUSTERPOOL_HUB_FILTER: sno-4xlarge-419
+      CLUSTERPOOL_HUB_FILTER: sno-4xlarge-421
       CLUSTERPOOL_LIFETIME: 1h
-      CLUSTERPOOL_MANAGED_FILTER: sno-419
+      CLUSTERPOOL_MANAGED_FILTER: sno-421
       COMPONENT_NAME: multicluster-observability-operator
       DEPLOY_HUB_ADDITIONAL_YAML: |
         LS0tCmFwaVZlcnNpb246IHJiYWMuYXV0aG9yaXphdGlvbi5rOHMuaW8vdjEKa2luZDogQ2x1c3Rl
@@ -125,7 +125,7 @@ tests:
         bHVzdGVyLW9ic2VydmFiaWxpdHktb3BlcmF0b3ItZTJlLXRlc3RpbmcKc3ViamVjdHM6Ci0ga2lu
         ZDogU2VydmljZUFjY291bnQKICBuYW1lOiBtdWx0aWNsdXN0ZXItb2JzZXJ2YWJpbGl0eS1vcGVy
         YXRvcgogIG5hbWVzcGFjZTogb3Blbi1jbHVzdGVyLW1hbmFnZW1lbnQKLS0tCg==
-      PIPELINE_STAGE: dev
+      PIPELINE_STAGE: integration
     test:
     - as: e2e
       commands: |

--- a/ci-operator/config/stolostron/multicluster-observability-operator/stolostron-multicluster-observability-operator-release-2.16.yaml
+++ b/ci-operator/config/stolostron/multicluster-observability-operator/stolostron-multicluster-observability-operator-release-2.16.yaml
@@ -96,9 +96,9 @@ tests:
       CLUSTERPOOL_GROUP_NAME: Core-Services
       CLUSTERPOOL_HOST_NAMESPACE: acm-observability-usa
       CLUSTERPOOL_HOST_PROW_KUBE_SECRET: ocm-obs-usa-clusterpool
-      CLUSTERPOOL_HUB_FILTER: sno-4xlarge-420
+      CLUSTERPOOL_HUB_FILTER: sno-4xlarge-421
       CLUSTERPOOL_LIFETIME: 1h
-      CLUSTERPOOL_MANAGED_FILTER: sno-420
+      CLUSTERPOOL_MANAGED_FILTER: sno-421
       COMPONENT_NAME: multicluster-observability-operator
       DEPLOY_HUB_ADDITIONAL_YAML: |
         LS0tCmFwaVZlcnNpb246IHJiYWMuYXV0aG9yaXphdGlvbi5rOHMuaW8vdjEKa2luZDogQ2x1c3Rl


### PR DESCRIPTION
For e2e testing: Change pools to use sno-4xlarge-421 and sno-421 (latest OCP)