### PR TITLE
MCO RHEL-10 based periodic jobs for 4.22 nightly

### DIFF
--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22__amd64-nightly.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22__amd64-nightly.yaml
@@ -612,7 +612,7 @@ tests:
     test:
     - chain: openshift-e2e-test-mco-qe-longrun
     workflow: cucushift-installer-rehearse-aws-ipi
-- as: aws-ipi-longduration-mco-rhcos10-tp-p1-f7
+- as: aws-ipi-disruptive-mco-rhcos10-tp-p1-f7
   cron: 12 14 2,9,16,23 * *
   steps:
     allow_skip_on_success: true
@@ -622,13 +622,13 @@ tests:
       COMPUTE_NODE_REPLICAS: "2"
       FEATURE_SET: TechPreviewNoUpgrade
       OSSTREAM: rhel-10
-      TEST_FILTERS: ~ChkUpgrade&;~DisconnectedOnly&;~MicroShiftOnly&;~Layering&;~ocb&;P1&;~HyperShiftMGMT&
+      TEST_FILTERS: ~ChkUpgrade&;~DisconnectedOnly&;~MicroShiftOnly&;~Layering&;~ocb&;P1&;Disruptive&;~HyperShiftMGMT&
       TEST_SCENARIOS: MCO
       TEST_TIMEOUT: "140"
     test:
-    - chain: openshift-e2e-test-mco-qe-longrun
+    - chain: openshift-e2e-test-qe-destructive
     workflow: cucushift-installer-rehearse-aws-ipi
-- as: aws-ipi-longduration-mco-rhcos10-tp-p2-f7
+- as: aws-ipi-disruptive-mco-rhcos10-tp-p2-f7
   cron: 23 16 4,11,18,25 * *
   steps:
     allow_skip_on_success: true
@@ -638,13 +638,13 @@ tests:
       COMPUTE_NODE_REPLICAS: "2"
       FEATURE_SET: TechPreviewNoUpgrade
       OSSTREAM: rhel-10
-      TEST_FILTERS: ~ChkUpgrade&;~DisconnectedOnly&;~MicroShiftOnly&;~Layering&;~ocb&;P2&;~HyperShiftMGMT&
+      TEST_FILTERS: ~ChkUpgrade&;~DisconnectedOnly&;~MicroShiftOnly&;~Layering&;~ocb&;P2&;Disruptive&;~HyperShiftMGMT&
       TEST_SCENARIOS: MCO
       TEST_TIMEOUT: "140"
     test:
-    - chain: openshift-e2e-test-mco-qe-longrun
+    - chain: openshift-e2e-test-qe-destructive
     workflow: cucushift-installer-rehearse-aws-ipi
-- as: aws-ipi-longduration-mco-rhcos10-tp-p3-f7
+- as: aws-ipi-disruptive-mco-rhcos10-tp-p3-f7
   cron: 34 18 7,14,21,28 * *
   steps:
     allow_skip_on_success: true
@@ -654,11 +654,11 @@ tests:
       COMPUTE_NODE_REPLICAS: "2"
       FEATURE_SET: TechPreviewNoUpgrade
       OSSTREAM: rhel-10
-      TEST_FILTERS: ~ChkUpgrade&;~DisconnectedOnly&;~MicroShiftOnly&;~Layering&;~ocb&;~P1&;~P2&;~HyperShiftMGMT&
+      TEST_FILTERS: ~ChkUpgrade&;~DisconnectedOnly&;~MicroShiftOnly&;~Layering&;~ocb&;~P1&;~P2&;Disruptive&;~HyperShiftMGMT&
       TEST_SCENARIOS: MCO
       TEST_TIMEOUT: "140"
     test:
-    - chain: openshift-e2e-test-mco-qe-longrun
+    - chain: openshift-e2e-test-qe-destructive
     workflow: cucushift-installer-rehearse-aws-ipi
 - as: aws-ipi-localzone-byo-subnet-ovn-day2-f7
   cron: 26 14 6,15,22,29 * *

--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22__amd64-nightly.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22__amd64-nightly.yaml
@@ -625,8 +625,10 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~DisconnectedOnly&;~MicroShiftOnly&;~Layering&;~ocb&;P1&;Disruptive&;~HyperShiftMGMT&
       TEST_SCENARIOS: MCO
       TEST_TIMEOUT: "140"
+    pre:
+    - ref: rhcos-conf-osstream
     test:
-    - chain: openshift-e2e-test-qe-destructive
+    - chain: openshift-e2e-test-mco-qe-disruptive
     workflow: cucushift-installer-rehearse-aws-ipi
 - as: aws-ipi-disruptive-mco-rhcos10-tp-p2-f7
   cron: 23 16 4,11,18,25 * *
@@ -641,8 +643,10 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~DisconnectedOnly&;~MicroShiftOnly&;~Layering&;~ocb&;P2&;Disruptive&;~HyperShiftMGMT&
       TEST_SCENARIOS: MCO
       TEST_TIMEOUT: "140"
+    pre:
+    - ref: rhcos-conf-osstream
     test:
-    - chain: openshift-e2e-test-qe-destructive
+    - chain: openshift-e2e-test-mco-qe-disruptive
     workflow: cucushift-installer-rehearse-aws-ipi
 - as: aws-ipi-disruptive-mco-rhcos10-tp-p3-f7
   cron: 34 18 7,14,21,28 * *
@@ -657,8 +661,10 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~DisconnectedOnly&;~MicroShiftOnly&;~Layering&;~ocb&;~P1&;~P2&;Disruptive&;~HyperShiftMGMT&
       TEST_SCENARIOS: MCO
       TEST_TIMEOUT: "140"
+    pre:
+    - ref: rhcos-conf-osstream
     test:
-    - chain: openshift-e2e-test-qe-destructive
+    - chain: openshift-e2e-test-mco-qe-disruptive
     workflow: cucushift-installer-rehearse-aws-ipi
 - as: aws-ipi-localzone-byo-subnet-ovn-day2-f7
   cron: 26 14 6,15,22,29 * *

--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22__amd64-nightly.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22__amd64-nightly.yaml
@@ -612,6 +612,54 @@ tests:
     test:
     - chain: openshift-e2e-test-mco-qe-longrun
     workflow: cucushift-installer-rehearse-aws-ipi
+- as: aws-ipi-longduration-mco-rhcos10-tp-p1-f7
+  cron: 12 14 2,9,16,23 * *
+  steps:
+    allow_skip_on_success: true
+    cluster_profile: aws-qe
+    env:
+      BASE_DOMAIN: qe.devcluster.openshift.com
+      COMPUTE_NODE_REPLICAS: "2"
+      FEATURE_SET: TechPreviewNoUpgrade
+      OSSTREAM: rhel-10
+      TEST_FILTERS: ~ChkUpgrade&;~DisconnectedOnly&;~MicroShiftOnly&;~Layering&;~ocb&;P1&;~HyperShiftMGMT&
+      TEST_SCENARIOS: MCO
+      TEST_TIMEOUT: "140"
+    test:
+    - chain: openshift-e2e-test-mco-qe-longrun
+    workflow: cucushift-installer-rehearse-aws-ipi
+- as: aws-ipi-longduration-mco-rhcos10-tp-p2-f7
+  cron: 23 16 4,11,18,25 * *
+  steps:
+    allow_skip_on_success: true
+    cluster_profile: aws-qe
+    env:
+      BASE_DOMAIN: qe.devcluster.openshift.com
+      COMPUTE_NODE_REPLICAS: "2"
+      FEATURE_SET: TechPreviewNoUpgrade
+      OSSTREAM: rhel-10
+      TEST_FILTERS: ~ChkUpgrade&;~DisconnectedOnly&;~MicroShiftOnly&;~Layering&;~ocb&;P2&;~HyperShiftMGMT&
+      TEST_SCENARIOS: MCO
+      TEST_TIMEOUT: "140"
+    test:
+    - chain: openshift-e2e-test-mco-qe-longrun
+    workflow: cucushift-installer-rehearse-aws-ipi
+- as: aws-ipi-longduration-mco-rhcos10-tp-p3-f7
+  cron: 34 18 7,14,21,28 * *
+  steps:
+    allow_skip_on_success: true
+    cluster_profile: aws-qe
+    env:
+      BASE_DOMAIN: qe.devcluster.openshift.com
+      COMPUTE_NODE_REPLICAS: "2"
+      FEATURE_SET: TechPreviewNoUpgrade
+      OSSTREAM: rhel-10
+      TEST_FILTERS: ~ChkUpgrade&;~DisconnectedOnly&;~MicroShiftOnly&;~Layering&;~ocb&;~P1&;~P2&;~HyperShiftMGMT&
+      TEST_SCENARIOS: MCO
+      TEST_TIMEOUT: "140"
+    test:
+    - chain: openshift-e2e-test-mco-qe-longrun
+    workflow: cucushift-installer-rehearse-aws-ipi
 - as: aws-ipi-localzone-byo-subnet-ovn-day2-f7
   cron: 26 14 6,15,22,29 * *
   steps:

--- a/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22-periodics.yaml
+++ b/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22-periodics.yaml
@@ -625,7 +625,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 31 1 8 * *
   decorate: true
   decoration_config:
@@ -2232,7 +2232,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 14 1 29 * *
   decorate: true
   decoration_config:
@@ -2321,7 +2321,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 14 5 7 * *
   decorate: true
   decoration_config:
@@ -2410,7 +2410,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 43 4 6 * *
   decorate: true
   decoration_config:
@@ -2588,7 +2588,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 2 23 4 * *
   decorate: true
   decoration_config:
@@ -2677,7 +2677,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 28 4 17 * *
   decorate: true
   decoration_config:
@@ -2766,7 +2766,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 24 2 26 * *
   decorate: true
   decoration_config:
@@ -2855,7 +2855,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 19 10 25 * *
   decorate: true
   decoration_config:
@@ -2944,7 +2944,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 6 7 30 * *
   decorate: true
   decoration_config:
@@ -3033,7 +3033,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 13 12 7,16,23,30 * *
   decorate: true
   decoration_config:
@@ -3122,7 +3122,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 45 2 6,13,20,27 * *
   decorate: true
   decoration_config:
@@ -3211,7 +3211,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 8 14 18 * *
   decorate: true
   decoration_config:
@@ -3300,7 +3300,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 20 12 11 * *
   decorate: true
   decoration_config:
@@ -3389,7 +3389,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 7 12 3 * *
   decorate: true
   decoration_config:
@@ -3478,7 +3478,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 3 18 19 * *
   decorate: true
   decoration_config:
@@ -3567,7 +3567,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 21 12 13 * *
   decorate: true
   decoration_config:
@@ -3656,7 +3656,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 53 3 22 * *
   decorate: true
   decoration_config:
@@ -3745,7 +3745,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 1 9 11 * *
   decorate: true
   decoration_config:
@@ -10393,7 +10393,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 44 22 5 2,4,6,8,10,12 *
   decorate: true
   decoration_config:
@@ -10571,7 +10571,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 10 6 4 1,3,5,7,9,11 *
   decorate: true
   decoration_config:
@@ -10660,7 +10660,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 7 0 13 2,4,6,8,10,12 *
   decorate: true
   decoration_config:
@@ -10749,7 +10749,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 0 9 13 1,3,5,7,9,11 *
   decorate: true
   decoration_config:
@@ -10838,7 +10838,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 29 19 14 2,4,6,8,10,12 *
   decorate: true
   decoration_config:
@@ -10927,7 +10927,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 4 8 24 2,4,6,8,10,12 *
   decorate: true
   decoration_config:
@@ -11016,7 +11016,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 15 16 2 2,4,6,8,10,12 *
   decorate: true
   decoration_config:
@@ -11105,7 +11105,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 22 18 29 2,4,6,8,10,12 *
   decorate: true
   decoration_config:
@@ -11205,7 +11205,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 24 11 16 1,3,5,7,9,11 *
   decorate: true
   decoration_config:
@@ -11305,7 +11305,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 23 3 13 1,3,5,7,9,11 *
   decorate: true
   decoration_config:
@@ -11394,7 +11394,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 6 13 14 2,4,6,8,10,12 *
   decorate: true
   decoration_config:
@@ -11483,7 +11483,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 24 19 14 2,4,6,8,10,12 *
   decorate: true
   decoration_config:
@@ -11572,7 +11572,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 47 18 6 1,3,5,7,9,11 *
   decorate: true
   decoration_config:
@@ -11661,7 +11661,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 3 10 27 1,3,5,7,9,11 *
   decorate: true
   decoration_config:
@@ -11750,7 +11750,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 53 21 23 1,3,5,7,9,11 *
   decorate: true
   decoration_config:
@@ -11839,7 +11839,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 52 21 27 2,4,6,8,10,12 *
   decorate: true
   decoration_config:
@@ -11928,7 +11928,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 46 15 6 2,4,6,8,10,12 *
   decorate: true
   decoration_config:
@@ -18940,7 +18940,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 3 3 1,8,17,24 * *
   decorate: true
   decoration_config:
@@ -19041,7 +19041,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 8 19 12 * *
   decorate: true
   decoration_config:
@@ -19131,7 +19131,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 45 6 1,8,15,24 * *
   decorate: true
   decoration_config:
@@ -19221,7 +19221,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 37 13 27 * *
   decorate: true
   decoration_config:
@@ -19311,7 +19311,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 20 16 20 * *
   decorate: true
   decoration_config:
@@ -19401,7 +19401,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 9 13 3,12,19,26 * *
   decorate: true
   decoration_config:
@@ -19491,7 +19491,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 46 2 8,22 * *
   decorate: true
   decoration_config:
@@ -19671,7 +19671,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 15 13 6 * *
   decorate: true
   decoration_config:
@@ -19851,7 +19851,277 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
+  cron: 12 14 2,9,16,23 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: release-4.22
+    org: openshift
+    repo: openshift-tests-private
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-qe
+    ci-operator.openshift.io/variant: amd64-nightly
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-openshift-tests-private-release-4.22-amd64-nightly-aws-ipi-disruptive-mco-rhcos10-tp-p1-f7
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --oauth-token-path=/usr/local/github-credentials/oauth
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=aws-ipi-disruptive-mco-rhcos10-tp-p1-f7
+      - --variant=amd64-nightly
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /usr/local/github-credentials
+        name: github-credentials-openshift-ci-robot-private-git-cloner
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: github-credentials-openshift-ci-robot-private-git-cloner
+      secret:
+        secretName: github-credentials-openshift-ci-robot-private-git-cloner
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build09
+  cron: 23 16 4,11,18,25 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: release-4.22
+    org: openshift
+    repo: openshift-tests-private
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-qe
+    ci-operator.openshift.io/variant: amd64-nightly
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-openshift-tests-private-release-4.22-amd64-nightly-aws-ipi-disruptive-mco-rhcos10-tp-p2-f7
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --oauth-token-path=/usr/local/github-credentials/oauth
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=aws-ipi-disruptive-mco-rhcos10-tp-p2-f7
+      - --variant=amd64-nightly
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /usr/local/github-credentials
+        name: github-credentials-openshift-ci-robot-private-git-cloner
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: github-credentials-openshift-ci-robot-private-git-cloner
+      secret:
+        secretName: github-credentials-openshift-ci-robot-private-git-cloner
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build09
+  cron: 34 18 7,14,21,28 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: release-4.22
+    org: openshift
+    repo: openshift-tests-private
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-qe
+    ci-operator.openshift.io/variant: amd64-nightly
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-openshift-tests-private-release-4.22-amd64-nightly-aws-ipi-disruptive-mco-rhcos10-tp-p3-f7
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --oauth-token-path=/usr/local/github-credentials/oauth
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=aws-ipi-disruptive-mco-rhcos10-tp-p3-f7
+      - --variant=amd64-nightly
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /usr/local/github-credentials
+        name: github-credentials-openshift-ci-robot-private-git-cloner
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: github-credentials-openshift-ci-robot-private-git-cloner
+      secret:
+        secretName: github-credentials-openshift-ci-robot-private-git-cloner
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build09
   cron: 30 14 5 * *
   decorate: true
   decoration_config:
@@ -19941,7 +20211,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 6 5 5,14,21,28 * *
   decorate: true
   decoration_config:
@@ -20031,7 +20301,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 24 12 10,24 * *
   decorate: true
   decoration_config:
@@ -20121,7 +20391,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 26 16 6,22 * *
   decorate: true
   decoration_config:
@@ -20211,7 +20481,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 35 1 7,16,23,30 * *
   decorate: true
   decoration_config:
@@ -20312,7 +20582,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 55 7 2,11,18,25 * *
   decorate: true
   decoration_config:
@@ -20413,7 +20683,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 5 8 7,16,23,30 * *
   decorate: true
   decoration_config:
@@ -20514,7 +20784,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 46 11 9,16,23,30 * *
   decorate: true
   decoration_config:
@@ -20604,7 +20874,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 1 18 12 * *
   decorate: true
   decoration_config:
@@ -20694,7 +20964,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 26 14 6,15,22,29 * *
   decorate: true
   decoration_config:
@@ -20784,7 +21054,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 53 14 9,25 * *
   decorate: true
   decoration_config:
@@ -20874,7 +21144,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 29 13 19 * *
   decorate: true
   decoration_config:
@@ -20964,7 +21234,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 6 4 23 * *
   decorate: true
   decoration_config:
@@ -21054,7 +21324,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 53 23 11,25 * *
   decorate: true
   decoration_config:
@@ -21144,7 +21414,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 32 22 7,21 * *
   decorate: true
   decoration_config:
@@ -21234,7 +21504,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 28 7 21 * *
   decorate: true
   decoration_config:
@@ -21324,7 +21594,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 31 21 15,29 * *
   decorate: true
   decoration_config:
@@ -21414,7 +21684,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 10 19 27 * *
   decorate: true
   decoration_config:
@@ -21504,7 +21774,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 52 11 7,14,21,28 * *
   decorate: true
   decoration_config:
@@ -21605,7 +21875,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 58 13 1,8,15,22 * *
   decorate: true
   decoration_config:
@@ -21706,7 +21976,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 42 5 7,14,21,28 * *
   decorate: true
   decoration_config:
@@ -21807,7 +22077,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 54 13 6,13,22,29 * *
   decorate: true
   decoration_config:
@@ -21908,7 +22178,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 41 11 5,12,19,28 * *
   decorate: true
   decoration_config:
@@ -21998,7 +22268,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 43 14 1,8,15,24 * *
   decorate: true
   decoration_config:
@@ -22088,7 +22358,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 13 1 1,8,15,24 * *
   decorate: true
   decoration_config:
@@ -22178,7 +22448,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 44 22 10,26 * *
   decorate: true
   decoration_config:
@@ -22279,7 +22549,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 2 16 6,13,22,29 * *
   decorate: true
   decoration_config:
@@ -22380,7 +22650,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 51 19 6,13,22,29 * *
   decorate: true
   decoration_config:
@@ -22481,7 +22751,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 8 8 29 2 *
   decorate: true
   decoration_config:
@@ -22582,7 +22852,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 46 12 23 * *
   decorate: true
   decoration_config:
@@ -22683,7 +22953,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 42 21 1,17 * *
   decorate: true
   decoration_config:
@@ -22784,7 +23054,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 42 1 7,21 * *
   decorate: true
   decoration_config:
@@ -22987,7 +23257,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 6 22 7,16,23,30 * *
   decorate: true
   decoration_config:
@@ -23088,7 +23358,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 11 23 6,20 * *
   decorate: true
   decoration_config:
@@ -23189,7 +23459,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 26 20 8,22 * *
   decorate: true
   decoration_config:
@@ -23290,7 +23560,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 22 18 12,26 * *
   decorate: true
   decoration_config:
@@ -23391,7 +23661,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 29 10 7,23 * *
   decorate: true
   decoration_config:
@@ -23492,7 +23762,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 4 23 4,13,20,27 * *
   decorate: true
   decoration_config:
@@ -23593,7 +23863,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 25 21 3,10,17,26 * *
   decorate: true
   decoration_config:
@@ -23694,7 +23964,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 25 0 4,11,18,27 * *
   decorate: true
   decoration_config:
@@ -23795,7 +24065,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 29 3 2,16 * *
   decorate: true
   decoration_config:
@@ -23896,7 +24166,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 21 6 1,17 * *
   decorate: true
   decoration_config:
@@ -23997,7 +24267,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 12 11 3 * *
   decorate: true
   decoration_config:
@@ -24098,7 +24368,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 30 19 7,21 * *
   decorate: true
   decoration_config:
@@ -24199,7 +24469,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 37 19 4 * *
   decorate: true
   decoration_config:
@@ -24300,7 +24570,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 17 5 12,28 * *
   decorate: true
   decoration_config:
@@ -24401,7 +24671,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 36 14 27 * *
   decorate: true
   decoration_config:
@@ -24502,7 +24772,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 53 11 2,9,16,25 * *
   decorate: true
   decoration_config:
@@ -24603,7 +24873,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 11 14 5,12,19,28 * *
   decorate: true
   decoration_config:
@@ -24704,7 +24974,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 17 15 6,13,20,27 * *
   decorate: true
   decoration_config:
@@ -24805,7 +25075,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 43 2 5,12,19,28 * *
   decorate: true
   decoration_config:
@@ -24906,7 +25176,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 37 12 4,11,18,25 * *
   decorate: true
   decoration_config:
@@ -24996,7 +25266,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 33 12 4,11,18,25 * *
   decorate: true
   decoration_config:
@@ -25086,7 +25356,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 19 17 7 * *
   decorate: true
   decoration_config:
@@ -25176,7 +25446,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 14 11 7,14,21,28 * *
   decorate: true
   decoration_config:
@@ -25266,7 +25536,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 55 12 14 * *
   decorate: true
   decoration_config:
@@ -25366,7 +25636,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 23 12 21 * *
   decorate: true
   decoration_config:
@@ -25456,7 +25726,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 35 7 10 * *
   decorate: true
   decoration_config:
@@ -25546,7 +25816,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 25 15 7,16,23,30 * *
   decorate: true
   decoration_config:
@@ -25636,7 +25906,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 8 8 29 2 *
   decorate: true
   decoration_config:
@@ -25726,7 +25996,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 24 0 11,27 * *
   decorate: true
   decoration_config:
@@ -25816,7 +26086,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 53 17 4 * *
   decorate: true
   decoration_config:
@@ -26086,7 +26356,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 1 1 12 * *
   decorate: true
   decoration_config:
@@ -26176,7 +26446,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 13 1 2,11,18,25 * *
   decorate: true
   decoration_config:
@@ -26266,7 +26536,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 4 4 4,11,20,27 * *
   decorate: true
   decoration_config:
@@ -26356,7 +26626,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 46 2 17 * *
   decorate: true
   decoration_config:
@@ -26446,7 +26716,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 36 9 3,10,17,26 * *
   decorate: true
   decoration_config:
@@ -26536,7 +26806,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 52 4 6,22 * *
   decorate: true
   decoration_config:
@@ -26626,7 +26896,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 12 20 26 * *
   decorate: true
   decoration_config:
@@ -26716,7 +26986,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 40 8 1,8,17,24 * *
   decorate: true
   decoration_config:
@@ -26806,7 +27076,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 5 6 17 * *
   decorate: true
   decoration_config:
@@ -26896,7 +27166,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 1 11 6,20 * *
   decorate: true
   decoration_config:
@@ -26986,7 +27256,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 30 16 16,30 * *
   decorate: true
   decoration_config:
@@ -27076,7 +27346,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 12 21 2 * *
   decorate: true
   decoration_config:
@@ -27166,7 +27436,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 22 16 4,18 * *
   decorate: true
   decoration_config:
@@ -27256,7 +27526,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 53 18 23 * *
   decorate: true
   decoration_config:
@@ -27346,7 +27616,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 1 13 5 * *
   decorate: true
   decoration_config:
@@ -27436,7 +27706,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 43 22 3,10,17,24 * *
   decorate: true
   decoration_config:
@@ -27526,7 +27796,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 26 15 5,12,19,26 * *
   decorate: true
   decoration_config:
@@ -27627,7 +27897,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 34 21 2,9,16,25 * *
   decorate: true
   decoration_config:
@@ -27717,7 +27987,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 6 4 4,11,18,25 * *
   decorate: true
   decoration_config:
@@ -27818,7 +28088,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 43 8 1,8,17,24 * *
   decorate: true
   decoration_config:
@@ -27919,7 +28189,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 34 6 2,9,16,23 * *
   decorate: true
   decoration_config:
@@ -28020,7 +28290,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 31 1 3,10,17,24 * *
   decorate: true
   decoration_config:
@@ -28121,7 +28391,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 35 4 3,10,19,26 * *
   decorate: true
   decoration_config:
@@ -28222,7 +28492,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 1 22 7,14,23,30 * *
   decorate: true
   decoration_config:
@@ -28323,7 +28593,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 37 2 4,11,18,25 * *
   decorate: true
   decoration_config:
@@ -28424,7 +28694,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 14 6 5,12,19,26 * *
   decorate: true
   decoration_config:
@@ -28525,7 +28795,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 51 19 3,10,17,24 * *
   decorate: true
   decoration_config:
@@ -28626,7 +28896,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 32 20 1,8,17,24 * *
   decorate: true
   decoration_config:
@@ -28727,7 +28997,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 8 8 29 2 *
   decorate: true
   decoration_config:
@@ -28828,7 +29098,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 45 14 6,13,20,27 * *
   decorate: true
   decoration_config:
@@ -28929,7 +29199,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 34 1 2,9,16,23 * *
   decorate: true
   decoration_config:
@@ -29030,7 +29300,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 9 18 3,10,19,26 * *
   decorate: true
   decoration_config:
@@ -29120,7 +29390,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 43 2 6,13,20,27 * *
   decorate: true
   decoration_config:
@@ -29210,7 +29480,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 35 8 1,8,15,22 * *
   decorate: true
   decoration_config:
@@ -29311,7 +29581,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 0 15 5,12,21,28 * *
   decorate: true
   decoration_config:
@@ -29592,7 +29862,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 0 23 4,11,18,27 * *
   decorate: true
   decoration_config:
@@ -33644,17 +33914,6 @@ periodics:
     job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-amd64-nightly-azure-ipi-ovn-hypershift-arm-nodepool-guest-f7
-  reporter_config:
-    slack:
-      channel: '#forum-prow-hypershift-qe-ci'
-      job_states_to_report:
-      - error
-      - failure
-      - success
-      report_template: '{{if eq .Status.State "success"}} :rainbow: Job *{{.Spec.Job}}*
-        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :rainbow: {{else}}
-        :volcano: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
-        logs> :volcano: {{end}}'
   spec:
     containers:
     - args:
@@ -33745,17 +34004,6 @@ periodics:
     job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-amd64-nightly-azure-ipi-ovn-hypershift-arm-nodepool-mgmt-f7
-  reporter_config:
-    slack:
-      channel: '#forum-prow-hypershift-qe-ci'
-      job_states_to_report:
-      - error
-      - failure
-      - success
-      report_template: '{{if eq .Status.State "success"}} :rainbow: Job *{{.Spec.Job}}*
-        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :rainbow: {{else}}
-        :volcano: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
-        logs> :volcano: {{end}}'
   spec:
     containers:
     - args:
@@ -57358,7 +57606,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 14 0 4 * *
   decorate: true
   decoration_config:
@@ -57447,7 +57695,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 3 9 29 * *
   decorate: true
   decoration_config:
@@ -58172,7 +58420,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 15 8 5 * *
   decorate: true
   decoration_config:
@@ -58439,7 +58687,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 38 3 14 * *
   decorate: true
   decoration_config:
@@ -58528,7 +58776,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 11 17 5 * *
   decorate: true
   decoration_config:
@@ -58617,7 +58865,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 50 5 27 * *
   decorate: true
   decoration_config:
@@ -59687,7 +59935,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 50 6 6 * *
   decorate: true
   decoration_config:
@@ -59776,7 +60024,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 36 12 2 * *
   decorate: true
   decoration_config:
@@ -59865,7 +60113,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 49 5 11 * *
   decorate: true
   decoration_config:
@@ -59954,7 +60202,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 40 5 14,30 * *
   decorate: true
   decoration_config:
@@ -60043,7 +60291,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 46 0 7,14,23,30 * *
   decorate: true
   decoration_config:
@@ -60143,7 +60391,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 33 16 4,11,18,27 * *
   decorate: true
   decoration_config:
@@ -60232,7 +60480,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 18 18 3,12,19,26 * *
   decorate: true
   decoration_config:
@@ -60332,7 +60580,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 36 17 3,10,17,26 * *
   decorate: true
   decoration_config:
@@ -60432,7 +60680,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 46 2 5,12,19,28 * *
   decorate: true
   decoration_config:
@@ -60532,7 +60780,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 42 18 7,16,23,30 * *
   decorate: true
   decoration_config:
@@ -60632,7 +60880,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 30 3 6,13,22,29 * *
   decorate: true
   decoration_config:
@@ -60732,7 +60980,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 34 4 1,10,17,24 * *
   decorate: true
   decoration_config:
@@ -60832,7 +61080,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 22 15 23 * *
   decorate: true
   decoration_config:
@@ -60932,7 +61180,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 15 12 7,14,23,30 * *
   decorate: true
   decoration_config:
@@ -61032,7 +61280,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 36 18 2,9,16,25 * *
   decorate: true
   decoration_config:
@@ -61132,7 +61380,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 46 4 1,8,17,24 * *
   decorate: true
   decoration_config:
@@ -61232,7 +61480,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 31 3 1,8,15,24 * *
   decorate: true
   decoration_config:
@@ -61332,7 +61580,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 53 7 5,12,19,26 * *
   decorate: true
   decoration_config:
@@ -61432,7 +61680,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 8 8 29 2 *
   decorate: true
   decoration_config:
@@ -61532,7 +61780,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 27 4 4,11,18,25 * *
   decorate: true
   decoration_config:
@@ -61632,7 +61880,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 3 12 7,16,23,30 * *
   decorate: true
   decoration_config:
@@ -61732,7 +61980,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 27 10 5,12,19,28 * *
   decorate: true
   decoration_config:
@@ -61821,7 +62069,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 7 14 5,12,21,28 * *
   decorate: true
   decoration_config:
@@ -61910,7 +62158,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 34 15 4,11,18,25 * *
   decorate: true
   decoration_config:
@@ -62010,7 +62258,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 5 2 5,12,19,26 * *
   decorate: true
   decoration_config:
@@ -64345,7 +64593,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 2 17 5 * *
   decorate: true
   decoration_config:
@@ -64434,7 +64682,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 56 11 28 * *
   decorate: true
   decoration_config:
@@ -64523,7 +64771,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 2 11 13 * *
   decorate: true
   decoration_config:
@@ -65059,7 +65307,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 11 11 7 1,3,5,7,9,11 *
   decorate: true
   decoration_config:
@@ -65148,7 +65396,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 11 19 23 2,4,6,8,10,12 *
   decorate: true
   decoration_config:
@@ -65595,7 +65843,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 24 4 7,23 * *
   decorate: true
   decoration_config:
@@ -65775,7 +66023,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 13 2 7 * *
   decorate: true
   decoration_config:
@@ -65955,7 +66203,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 43 7 14,28 * *
   decorate: true
   decoration_config:
@@ -66045,7 +66293,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 5 1 4 * *
   decorate: true
   decoration_config:
@@ -66135,7 +66383,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 30 9 8,24 * *
   decorate: true
   decoration_config:
@@ -66225,7 +66473,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 12 2 13,27 * *
   decorate: true
   decoration_config:
@@ -66315,7 +66563,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 48 12 4,13,20,27 * *
   decorate: true
   decoration_config:
@@ -66405,7 +66653,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 14 8 3,10,19,26 * *
   decorate: true
   decoration_config:
@@ -66495,7 +66743,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 36 16 4 * *
   decorate: true
   decoration_config:
@@ -66585,7 +66833,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 52 0 6 * *
   decorate: true
   decoration_config:
@@ -66675,7 +66923,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 9 14 1 * *
   decorate: true
   decoration_config:
@@ -66765,7 +67013,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 52 22 3,10,17,26 * *
   decorate: true
   decoration_config:
@@ -66855,7 +67103,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 27 12 23 * *
   decorate: true
   decoration_config:
@@ -66945,7 +67193,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 31 14 5,12,19,26 * *
   decorate: true
   decoration_config:
@@ -69023,7 +69271,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 34 8 11 * *
   decorate: true
   decoration_config:
@@ -69201,7 +69449,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 57 7 2 * *
   decorate: true
   decoration_config:
@@ -69290,7 +69538,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 1 1 16 * *
   decorate: true
   decoration_config:
@@ -70719,7 +70967,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 57 19 7 * *
   decorate: true
   decoration_config:
@@ -70897,7 +71145,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 33 9 24 * *
   decorate: true
   decoration_config:
@@ -71521,7 +71769,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 30 0 17 * *
   decorate: true
   decoration_config:
@@ -71610,7 +71858,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 6 7 6 * *
   decorate: true
   decoration_config:
@@ -71877,7 +72125,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 16 10 25 * *
   decorate: true
   decoration_config:
@@ -71966,7 +72214,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 3 19 12 * *
   decorate: true
   decoration_config:
@@ -72413,7 +72661,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 4 16 26 * *
   decorate: true
   decoration_config:
@@ -72947,7 +73195,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 16 2 5 * *
   decorate: true
   decoration_config:
@@ -73036,7 +73284,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 46 20 12 * *
   decorate: true
   decoration_config:
@@ -73303,7 +73551,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 43 2 14 * *
   decorate: true
   decoration_config:
@@ -73392,7 +73640,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 23 7 19 * *
   decorate: true
   decoration_config:
@@ -73481,7 +73729,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 50 17 29 * *
   decorate: true
   decoration_config:
@@ -73570,7 +73818,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 54 21 24 * *
   decorate: true
   decoration_config:
@@ -73659,7 +73907,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 23 18 18 * *
   decorate: true
   decoration_config:
@@ -73748,7 +73996,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 34 18 10 * *
   decorate: true
   decoration_config:
@@ -73837,7 +74085,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 4 12 22 * *
   decorate: true
   decoration_config:
@@ -73926,7 +74174,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 43 11 24 * *
   decorate: true
   decoration_config:
@@ -74015,7 +74263,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 46 2 6 * *
   decorate: true
   decoration_config:
@@ -74104,7 +74352,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 33 11 5 * *
   decorate: true
   decoration_config:
@@ -74193,7 +74441,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 38 20 16,30 * *
   decorate: true
   decoration_config:
@@ -74282,7 +74530,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 54 2 14 * *
   decorate: true
   decoration_config:
@@ -74371,7 +74619,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 25 13 21 * *
   decorate: true
   decoration_config:
@@ -74460,7 +74708,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 45 18 5 * *
   decorate: true
   decoration_config:
@@ -74549,7 +74797,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 51 2 29 * *
   decorate: true
   decoration_config:
@@ -74638,7 +74886,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 24 21 28 * *
   decorate: true
   decoration_config:
@@ -78741,7 +78989,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 16 3 27 1,3,5,7,9,11 *
   decorate: true
   decoration_config:
@@ -78830,7 +79078,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 22 17 15 1,3,5,7,9,11 *
   decorate: true
   decoration_config:
@@ -78919,7 +79167,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 21 1 18 1,3,5,7,9,11 *
   decorate: true
   decoration_config:
@@ -79008,7 +79256,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 25 22 2 1,3,5,7,9,11 *
   decorate: true
   decoration_config:
@@ -79097,7 +79345,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 22 1 7 2,4,6,8,10,12 *
   decorate: true
   decoration_config:
@@ -79186,7 +79434,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 2 5 26 2,4,6,8,10,12 *
   decorate: true
   decoration_config:
@@ -79275,7 +79523,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 7 13 16 * *
   decorate: true
   decoration_config:
@@ -79364,7 +79612,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 22 16 16 2,4,6,8,10,12 *
   decorate: true
   decoration_config:
@@ -79453,7 +79701,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 43 23 13 1,3,5,7,9,11 *
   decorate: true
   decoration_config:
@@ -79542,7 +79790,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 26 7 2 1,3,5,7,9,11 *
   decorate: true
   decoration_config:
@@ -79631,7 +79879,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 7 18 17 2,4,6,8,10,12 *
   decorate: true
   decoration_config:
@@ -79720,7 +79968,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 13 10 20 * *
   decorate: true
   decoration_config:
@@ -79809,7 +80057,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 58 23 3 1,3,5,7,9,11 *
   decorate: true
   decoration_config:
@@ -79898,7 +80146,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 9 1 2 2,4,6,8,10,12 *
   decorate: true
   decoration_config:
@@ -79987,7 +80235,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 2 12 23 1,3,5,7,9,11 *
   decorate: true
   decoration_config:
@@ -80076,7 +80324,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 38 22 24 1,3,5,7,9,11 *
   decorate: true
   decoration_config:
@@ -80165,7 +80413,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 36 2 7 1,3,5,7,9,11 *
   decorate: true
   decoration_config:
@@ -83819,7 +84067,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 7 19 5,12,19,26 * *
   decorate: true
   decoration_config:
@@ -83920,7 +84168,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 2 13 19 * *
   decorate: true
   decoration_config:
@@ -84021,7 +84269,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 6 11 9,16,23,30 * *
   decorate: true
   decoration_config:
@@ -84111,7 +84359,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 54 15 5 * *
   decorate: true
   decoration_config:
@@ -84201,7 +84449,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 5 12 6,13,20,29 * *
   decorate: true
   decoration_config:
@@ -84291,7 +84539,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 23 12 8,24 * *
   decorate: true
   decoration_config:
@@ -84381,7 +84629,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 25 12 28 * *
   decorate: true
   decoration_config:
@@ -84561,7 +84809,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 42 21 7,16,23,30 * *
   decorate: true
   decoration_config:
@@ -84831,7 +85079,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 42 3 19 * *
   decorate: true
   decoration_config:
@@ -84921,7 +85169,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 20 12 4,13,20,27 * *
   decorate: true
   decoration_config:
@@ -85011,7 +85259,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 55 3 6 * *
   decorate: true
   decoration_config:
@@ -85101,7 +85349,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 1 10 7,14,21,30 * *
   decorate: true
   decoration_config:
@@ -85191,7 +85439,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 29 11 27 * *
   decorate: true
   decoration_config:
@@ -85281,7 +85529,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 24 3 8,22 * *
   decorate: true
   decoration_config:
@@ -85371,7 +85619,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 24 9 16 * *
   decorate: true
   decoration_config:
@@ -85461,7 +85709,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 1 12 9,25 * *
   decorate: true
   decoration_config:
@@ -85551,7 +85799,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 47 16 9 * *
   decorate: true
   decoration_config:
@@ -85641,7 +85889,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 15 17 8,15,22,29 * *
   decorate: true
   decoration_config:
@@ -85731,7 +85979,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 2 5 17 * *
   decorate: true
   decoration_config:
@@ -85821,7 +86069,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 3 6 7,14,23,30 * *
   decorate: true
   decoration_config:
@@ -85911,7 +86159,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 35 1 12 * *
   decorate: true
   decoration_config:
@@ -86001,7 +86249,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 6 13 16 * *
   decorate: true
   decoration_config:
@@ -86091,7 +86339,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 13 3 2 * *
   decorate: true
   decoration_config:
@@ -86181,7 +86429,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 5 7 8,15,22,29 * *
   decorate: true
   decoration_config:
@@ -86271,7 +86519,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 51 18 15 * *
   decorate: true
   decoration_config:
@@ -86361,7 +86609,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 33 11 1,8,15,24 * *
   decorate: true
   decoration_config:
@@ -86631,7 +86879,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 35 11 2,11,18,25 * *
   decorate: true
   decoration_config:
@@ -86721,7 +86969,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 25 18 24 * *
   decorate: true
   decoration_config:
@@ -86811,7 +87059,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 54 6 7 * *
   decorate: true
   decoration_config:
@@ -86901,7 +87149,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 29 8 6,13,22,29 * *
   decorate: true
   decoration_config:
@@ -86991,7 +87239,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 19 11 6,20 * *
   decorate: true
   decoration_config:
@@ -87081,7 +87329,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 21 16 4 * *
   decorate: true
   decoration_config:
@@ -87171,7 +87419,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 17 21 27 * *
   decorate: true
   decoration_config:
@@ -87261,7 +87509,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 33 8 7,16,23,30 * *
   decorate: true
   decoration_config:
@@ -87531,7 +87779,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 11 21 16 * *
   decorate: true
   decoration_config:
@@ -87621,7 +87869,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 50 3 1,8,15,24 * *
   decorate: true
   decoration_config:
@@ -87711,7 +87959,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 25 11 2,11,18,25 * *
   decorate: true
   decoration_config:
@@ -87812,7 +88060,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 12 8 2,11,18,25 * *
   decorate: true
   decoration_config:
@@ -87913,7 +88161,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 46 18 6,13,20,27 * *
   decorate: true
   decoration_config:
@@ -88003,7 +88251,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 16 2 11,25 * *
   decorate: true
   decoration_config:
@@ -88104,7 +88352,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 36 0 7,23 * *
   decorate: true
   decoration_config:
@@ -88205,7 +88453,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 55 8 6,13,20,27 * *
   decorate: true
   decoration_config:
@@ -88295,7 +88543,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 53 14 26 * *
   decorate: true
   decoration_config:
@@ -88385,7 +88633,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 11 3 25 * *
   decorate: true
   decoration_config:
@@ -88475,7 +88723,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 30 13 5,12,19,26 * *
   decorate: true
   decoration_config:
@@ -88745,7 +88993,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 42 12 11,25 * *
   decorate: true
   decoration_config:
@@ -88835,7 +89083,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 5 17 27 * *
   decorate: true
   decoration_config:
@@ -88925,7 +89173,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 36 12 17 * *
   decorate: true
   decoration_config:
@@ -89015,7 +89263,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 51 0 6,22 * *
   decorate: true
   decoration_config:
@@ -89105,7 +89353,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 54 8 16,30 * *
   decorate: true
   decoration_config:
@@ -89195,7 +89443,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 55 1 22 * *
   decorate: true
   decoration_config:
@@ -89285,7 +89533,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 57 18 26 * *
   decorate: true
   decoration_config:
@@ -89375,7 +89623,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 11 22 6,22 * *
   decorate: true
   decoration_config:
@@ -89465,7 +89713,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 13 13 4 * *
   decorate: true
   decoration_config:
@@ -89555,7 +89803,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 33 8 4,18 * *
   decorate: true
   decoration_config:
@@ -89645,7 +89893,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 6 22 30 * *
   decorate: true
   decoration_config:
@@ -89735,7 +89983,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 57 17 12,26 * *
   decorate: true
   decoration_config:
@@ -89825,7 +90073,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 20 16 1 * *
   decorate: true
   decoration_config:
@@ -89915,7 +90163,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 41 14 22 * *
   decorate: true
   decoration_config:
@@ -90005,7 +90253,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 3 10 2 * *
   decorate: true
   decoration_config:
@@ -90095,7 +90343,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 15 23 2,9,16,23 * *
   decorate: true
   decoration_config:
@@ -90185,7 +90433,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 37 19 2,11,18,25 * *
   decorate: true
   decoration_config:
@@ -90286,7 +90534,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 14 16 2,11,18,25 * *
   decorate: true
   decoration_config:
@@ -90488,7 +90736,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 31 21 3,10,17,24 * *
   decorate: true
   decoration_config:
@@ -90578,7 +90826,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 51 21 16 * *
   decorate: true
   decoration_config:
@@ -90668,7 +90916,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 3 12 1,8,15,24 * *
   decorate: true
   decoration_config:
@@ -106059,7 +106307,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 0 9 * * 1
   decorate: true
   decoration_config:
@@ -106160,7 +106408,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 16 23 7 * *
   decorate: true
   decoration_config:
@@ -106338,7 +106586,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 3 12 17 * *
   decorate: true
   decoration_config:
@@ -106427,7 +106675,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 20 9 16 * *
   decorate: true
   decoration_config:
@@ -106605,7 +106853,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 56 0 16 * *
   decorate: true
   decoration_config:
@@ -106694,7 +106942,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 47 13 29 * *
   decorate: true
   decoration_config:
@@ -106783,7 +107031,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 0 6 30 * *
   decorate: true
   decoration_config:
@@ -107317,7 +107565,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 2 1 9 * *
   decorate: true
   decoration_config:
@@ -107406,7 +107654,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 38 12 2 * *
   decorate: true
   decoration_config:
@@ -107495,7 +107743,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 49 22 30 * *
   decorate: true
   decoration_config:
@@ -107584,7 +107832,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 5 1 30 * *
   decorate: true
   decoration_config:
@@ -108567,7 +108815,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build09
   cron: 1 * 31 2 *
   decorate: true
   decoration_config:

--- a/ci-operator/step-registry/cucushift/installer/rehearse/aws/ipi/provision/cucushift-installer-rehearse-aws-ipi-provision-chain.yaml
+++ b/ci-operator/step-registry/cucushift/installer/rehearse/aws/ipi/provision/cucushift-installer-rehearse-aws-ipi-provision-chain.yaml
@@ -4,8 +4,9 @@ chain:
   - chain: ipi-conf-aws
   - ref: ipi-conf-aws-usage-info
   - chain: aws-provision-iam-user-minimal-permission
+  - ref: rhcos-conf-osstream
   - chain: ipi-install
   - ref: enable-qe-catalogsource
   - chain: cucushift-installer-check
   documentation: |-
-    Create an IPI cluster on AWS for QE e2e tests.
+    Create an IPI cluster on AWS for QE e2e tests. Supports RHEL 9 and RHEL 10 based RHCOS via OSSTREAM env var.

--- a/ci-operator/step-registry/openshift/e2e/test/mco-qe/disruptive/OWNERS
+++ b/ci-operator/step-registry/openshift/e2e/test/mco-qe/disruptive/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+  - sergiordlr
+  - rioliu-rh
+  - ptalgulk01
+reviewers:
+  - sergiordlr
+  - rioliu-rh
+  - ptalgulk01

--- a/ci-operator/step-registry/openshift/e2e/test/mco-qe/disruptive/openshift-e2e-test-mco-qe-disruptive-chain.metadata.json
+++ b/ci-operator/step-registry/openshift/e2e/test/mco-qe/disruptive/openshift-e2e-test-mco-qe-disruptive-chain.metadata.json
@@ -1,0 +1,15 @@
+{
+	"path": "openshift/e2e/test/mco-qe/disruptive/openshift-e2e-test-mco-qe-disruptive-chain.yaml",
+	"owners": {
+		"approvers": [
+			"sergiordlr",
+			"rioliu-rh",
+			"ptalgulk01"
+		],
+		"reviewers": [
+			"sergiordlr",
+			"rioliu-rh",
+			"ptalgulk01"
+		]
+	}
+}

--- a/ci-operator/step-registry/openshift/e2e/test/mco-qe/disruptive/openshift-e2e-test-mco-qe-disruptive-chain.yaml
+++ b/ci-operator/step-registry/openshift/e2e/test/mco-qe/disruptive/openshift-e2e-test-mco-qe-disruptive-chain.yaml
@@ -1,0 +1,11 @@
+chain:
+  as: openshift-e2e-test-mco-qe-disruptive
+  steps:
+  - chain: cucushift-installer-check-cluster-health
+  - ref: idp-htpasswd
+  - ref: mco-conf-day2-add-mcoqe-robot-to-pull-secret
+  - ref: mco-conf-day2-enable-ocl
+  - ref: openshift-extended-test-disruptive
+  - ref: openshift-e2e-test-qe-report
+  documentation: |-
+    Execute openshift extended MCO disruptive e2e tests from QE. It does not execute cucushift test cases.


### PR DESCRIPTION
  This PR adds three new periodic CI jobs to test MCO (Machine Config Operator) on RHEL 10 based RHCOS nodes in Tech Preview mode on AWS IPI clusters for OpenShift 4.22.

  Jobs added:
  - aws-ipi-longduration-mco-rhcos10-tp-p1-f7 — P1 priority MCO tests
  - aws-ipi-longduration-mco-rhcos10-tp-p2-f7 — P2 priority MCO tests
  - aws-ipi-longduration-mco-rhcos10-tp-p3-f7 — P3 priority MCO tests

  All jobs set OSSTREAM: rhel-10 to provision RHEL 10 based RHCOS nodes and use FEATURE_SET: TechPreviewNoUpgrade. Each job runs on a staggered weekly cron schedule using the
  cucushift-installer-rehearse-aws-ipi workflow with the openshift-e2e-test-mco-qe-longrun test chain.

  Also updates cucushift-installer-rehearse-aws-ipi-provision-chain.yaml documentation to reflect RHEL 9 and RHEL 10 RHCOS support via the OSSTREAM env var.
