### PR TITLE
art update ci branches config

### DIFF
--- a/ci-operator/config/openshift-eng/ocp-build-data/openshift-eng-ocp-build-data-openshift-4.22.yaml
+++ b/ci-operator/config/openshift-eng/ocp-build-data/openshift-eng-ocp-build-data-openshift-4.22.yaml
@@ -1,0 +1,26 @@
+build_root:
+  image_stream_tag:
+    name: release
+    namespace: openshift
+    tag: rhel-9-release-golang-1.23-openshift-4.22
+resources:
+  '*':
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: art-konflux-delivery-repo-check
+  capabilities:
+  - intranet
+  restrict_network_access: false
+  run_if_changed: ^images/.*
+  steps:
+    env:
+      OCP_VERSION: "4.22"
+    workflow: ocp-art
+zz_generated_metadata:
+  branch: openshift-4.22
+  org: openshift-eng
+  repo: ocp-build-data

--- a/ci-operator/config/openshift-eng/ocp-build-data/openshift-eng-ocp-build-data-openshift-4.23.yaml
+++ b/ci-operator/config/openshift-eng/ocp-build-data/openshift-eng-ocp-build-data-openshift-4.23.yaml
@@ -1,0 +1,26 @@
+build_root:
+  image_stream_tag:
+    name: release
+    namespace: openshift
+    tag: rhel-9-release-golang-1.23-openshift-4.23
+resources:
+  '*':
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: art-konflux-delivery-repo-check
+  capabilities:
+  - intranet
+  restrict_network_access: false
+  run_if_changed: ^images/.*
+  steps:
+    env:
+      OCP_VERSION: "4.23"
+    workflow: ocp-art
+zz_generated_metadata:
+  branch: openshift-4.23
+  org: openshift-eng
+  repo: ocp-build-data

--- a/ci-operator/config/openshift-eng/ocp-build-data/openshift-eng-ocp-build-data-openshift-5.0.yaml
+++ b/ci-operator/config/openshift-eng/ocp-build-data/openshift-eng-ocp-build-data-openshift-5.0.yaml
@@ -1,0 +1,26 @@
+build_root:
+  image_stream_tag:
+    name: release
+    namespace: openshift
+    tag: rhel-9-release-golang-1.23-openshift-5.0
+resources:
+  '*':
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: art-konflux-delivery-repo-check
+  capabilities:
+  - intranet
+  restrict_network_access: false
+  run_if_changed: ^images/.*
+  steps:
+    env:
+      OCP_VERSION: "5.0"
+    workflow: ocp-art
+zz_generated_metadata:
+  branch: openshift-5.0
+  org: openshift-eng
+  repo: ocp-build-data

--- a/ci-operator/jobs/openshift-eng/ocp-build-data/openshift-eng-ocp-build-data-openshift-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift-eng/ocp-build-data/openshift-eng-ocp-build-data-openshift-4.22-presubmits.yaml
@@ -1,0 +1,59 @@
+presubmits:
+  openshift-eng/ocp-build-data:
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^openshift-4\.22$
+    - ^openshift-4\.22-
+    cluster: build11
+    context: ci/prow/art-konflux-delivery-repo-check
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      capability/intranet: intranet
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-eng-ocp-build-data-openshift-4.22-art-konflux-delivery-repo-check
+    rerun_command: /test art-konflux-delivery-repo-check
+    run_if_changed: ^images/.*
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=art-konflux-delivery-repo-check
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )art-konflux-delivery-repo-check,?($|\s.*)

--- a/ci-operator/jobs/openshift-eng/ocp-build-data/openshift-eng-ocp-build-data-openshift-4.23-presubmits.yaml
+++ b/ci-operator/jobs/openshift-eng/ocp-build-data/openshift-eng-ocp-build-data-openshift-4.23-presubmits.yaml
@@ -1,0 +1,59 @@
+presubmits:
+  openshift-eng/ocp-build-data:
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^openshift-4\.23$
+    - ^openshift-4\.23-
+    cluster: build11
+    context: ci/prow/art-konflux-delivery-repo-check
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      capability/intranet: intranet
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-eng-ocp-build-data-openshift-4.23-art-konflux-delivery-repo-check
+    rerun_command: /test art-konflux-delivery-repo-check
+    run_if_changed: ^images/.*
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=art-konflux-delivery-repo-check
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )art-konflux-delivery-repo-check,?($|\s.*)

--- a/ci-operator/jobs/openshift-eng/ocp-build-data/openshift-eng-ocp-build-data-openshift-5.0-presubmits.yaml
+++ b/ci-operator/jobs/openshift-eng/ocp-build-data/openshift-eng-ocp-build-data-openshift-5.0-presubmits.yaml
@@ -1,0 +1,59 @@
+presubmits:
+  openshift-eng/ocp-build-data:
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^openshift-5\.0$
+    - ^openshift-5\.0-
+    cluster: build10
+    context: ci/prow/art-konflux-delivery-repo-check
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      capability/intranet: intranet
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-eng-ocp-build-data-openshift-5.0-art-konflux-delivery-repo-check
+    rerun_command: /test art-konflux-delivery-repo-check
+    run_if_changed: ^images/.*
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=art-konflux-delivery-repo-check
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )art-konflux-delivery-repo-check,?($|\s.*)

--- a/core-services/prow/02_config/openshift-eng/ocp-build-data/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift-eng/ocp-build-data/_prowconfig.yaml
@@ -42,7 +42,6 @@ tide:
     - openshift-4.21
     - openshift-4.22
     - openshift-4.23
-    - openshift-5.0
     - openshift-4.7
     - openshift-4.8
     - openshift-4.9

--- a/core-services/prow/02_config/openshift-eng/ocp-build-data/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift-eng/ocp-build-data/_prowconfig.yaml
@@ -42,6 +42,7 @@ tide:
     - openshift-4.21
     - openshift-4.22
     - openshift-4.23
+    - openshift-5.0
     - openshift-4.7
     - openshift-4.8
     - openshift-4.9

--- a/core-services/prow/02_config/openshift-eng/ocp-build-data/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift-eng/ocp-build-data/_prowconfig.yaml
@@ -46,6 +46,7 @@ tide:
     - openshift-4.7
     - openshift-4.8
     - openshift-4.9
+    - openshift-5.0
     - openshift-base-nodejs
     - openshift-base-nodejs-runtime
     - openshift-base-python


### PR DESCRIPTION
This PR adds CI operator configuration files for ocp-build-data to support missing OpenShift releases.