### PR TITLE
[WIP] - Add periodic Codecov coverage job for kueue-operator

### DIFF
--- a/ci-operator/config/openshift/kueue-operator/openshift-kueue-operator-main.yaml
+++ b/ci-operator/config/openshift/kueue-operator/openshift-kueue-operator-main.yaml
@@ -86,6 +86,16 @@ tests:
   skip_if_only_changed: ^\.tekton/|\.md$|^(LICENSE|OWNERS)$
   steps:
     workflow: openshift-ci-security
+- as: coverage
+  commands: |
+    export CODECOV_TOKEN=$(cat /tmp/secret/CODECOV_TOKEN)
+    make coverage
+  container:
+    from: src
+  minimum_interval: 96h
+  secret:
+    mount_path: /tmp/secret
+    name: kueue-operator-codecov-token
 - as: test-e2e-4-18
   cluster_claim:
     architecture: amd64

--- a/ci-operator/jobs/openshift/kueue-operator/openshift-kueue-operator-main-periodics.yaml
+++ b/ci-operator/jobs/openshift/kueue-operator/openshift-kueue-operator-main-periodics.yaml
@@ -1,5 +1,63 @@
 periodics:
 - agent: kubernetes
+  cluster: build04
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: kueue-operator
+  labels:
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  minimum_interval: 96h
+  name: periodic-ci-openshift-kueue-operator-main-coverage
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/kueue-operator-codecov-token
+      - --target=coverage
+      command:
+      - ci-operator
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/kueue-operator-codecov-token
+        name: kueue-operator-codecov-token
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: kueue-operator-codecov-token
+      secret:
+        secretName: kueue-operator-codecov-token
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
   cluster: build06
   cron: 0 1 1,15 * *
   decorate: true


### PR DESCRIPTION
Following the initial Codecov onboarding [#1446](https://github.com/openshift/kueue-operator/pull/1446), this PR implements the second phase of the integration. The goal is to establish a consistent baseline of coverage data for the main branch.

Proposed Changes
- Periodic Job: Configures a new CI job to run coverage tests every 96 hours (4 days).
- Codecov Sync: Automates the upload of these periodic results to Codecov to track coverage trends over time.

Dependencies
- This PR requires the creation of the kueue-operator-codecov-token secret in the openshift-ci vault.
    - Ref: [Adding a new secret to CI](https://docs.ci.openshift.org/docs/how-tos/adding-a-new-secret-to-ci/)

Related PRs:
- Part 1 (Initial Config): [#1446](https://github.com/openshift/kueue-operator/pull/1446)