### PR TITLE
[Debug] Add wait step to aws-ipi-disc-priv-f28-longrun-ota for OCP 4.21

### DIFF
--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.21__amd64-nightly.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.21__amd64-nightly.yaml
@@ -229,6 +229,7 @@ tests:
       TEST_FILTERS: DisconnectedOnly&
       TEST_SCENARIOS: OTA
     test:
+    - ref: wait
     - chain: openshift-e2e-test-qe-longrun
     workflow: cucushift-installer-rehearse-aws-ipi-disconnected-private
 - as: aws-ipi-disc-priv-localzone-fips-f7-nokubeadmin


### PR DESCRIPTION
This adds a wait step to enable debugging of test failures in OCP 4.21.

The wait step pauses the workflow before tests run, allowing QE to:
- SSH into the test environment
- Inspect system state and logs
- Debug configuration issues
- Investigate test failures

OCP Version: 4.21
Job: aws-ipi-disc-priv-f28-longrun-ota
Workflow: cucushift-installer-rehearse-aws-ipi-disconnected-private