### PR TITLE
Add OCP release watcher for sandboxed-containers-operator testing

### DIFF
--- a/ci-operator/config/openshift/sandboxed-containers-operator/openshift-sandboxed-containers-operator-devel__build-watcher.yaml
+++ b/ci-operator/config/openshift/sandboxed-containers-operator/openshift-sandboxed-containers-operator-devel__build-watcher.yaml
@@ -1,0 +1,16 @@
+resources:
+  '*':
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: ocp-build-watcher
+  cron: 0 0 * * *
+  steps:
+    test:
+    - ref: sandboxed-containers-operator-build-watcher
+zz_generated_metadata:
+  branch: devel
+  org: openshift
+  repo: sandboxed-containers-operator
+  variant: build-watcher

--- a/ci-operator/jobs/openshift/sandboxed-containers-operator/openshift-sandboxed-containers-operator-devel-periodics.yaml
+++ b/ci-operator/jobs/openshift/sandboxed-containers-operator/openshift-sandboxed-containers-operator-devel-periodics.yaml
@@ -1,6 +1,61 @@
 periodics:
 - agent: kubernetes
   cluster: build03
+  cron: 0 0 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: devel
+    org: openshift
+    repo: sandboxed-containers-operator
+  labels:
+    ci-operator.openshift.io/variant: build-watcher
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-sandboxed-containers-operator-devel-build-watcher-ocp-build-watcher
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --report-credentials-file=/etc/report/credentials
+      - --target=ocp-build-watcher
+      - --variant=build-watcher
+      command:
+      - ci-operator
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build03
   cron: 0 0 31 2 1
   decorate: true
   decoration_config:

--- a/ci-operator/step-registry/sandboxed-containers-operator/build-watcher/OWNERS
+++ b/ci-operator/step-registry/sandboxed-containers-operator/build-watcher/OWNERS
@@ -1,0 +1,10 @@
+reviewers:
+  - ldoktor
+  - tbuskey
+  - vvoronko
+  - wainersm
+approvers:
+  - ldoktor
+  - tbuskey
+  - vvoronko
+  - wainersm

--- a/ci-operator/step-registry/sandboxed-containers-operator/build-watcher/README.md
+++ b/ci-operator/step-registry/sandboxed-containers-operator/build-watcher/README.md
@@ -1,0 +1,161 @@
+# sandboxed-containers-operator-build-watcher
+
+## Purpose
+
+This step automatically watches for new accepted OpenShift Container Platform (OCP) releases and triggers OpenShift Sandboxed Containers (OSC) testing jobs to ensure continuous validation against the latest OCP builds.
+
+This replaces the previous Jenkins-based build watcher that monitored https://amd64.ocp.releases.ci.openshift.org/ and triggered jobs based on Google Spreadsheet state.
+
+## How It Works
+
+The build watcher:
+
+1. **Queries Cincinnati API** for latest accepted releases across multiple OCP versions (4.17-4.22)
+2. **Checks Prow Deck API** to see if the version was already tested in the last 24 hours
+3. **Triggers jobs via Gangway API** for untested versions
+4. **Reports results** in the job logs
+
+## OCP Versions Monitored
+
+- 4.17.0-0.nightly
+- 4.18.0-0.nightly
+- 4.19.0-0.nightly
+- 4.20.0-0.nightly
+- 4.21.0-0.nightly
+- 4.22.0-0.nightly
+
+## Jobs Triggered
+
+For each new OCP version, the following downstream-release jobs are triggered:
+
+- `periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-release-azure-ipi-kata`
+- `periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-release-azure-ipi-peerpods`
+- `periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-release-azure-ipi-coco`
+- `periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-release-aws-ipi-peerpods`
+- `periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-release-aws-ipi-coco`
+
+## Requirements
+
+### Gangway API Token
+
+This step requires a Gangway API token to trigger jobs. The token must be:
+
+1. **Requested from DPTP team** - Open a ticket with the Test Platform team requesting Gangway API access
+2. **Stored in Vault** with the following configuration:
+   - **Namespace**: `test-credentials`
+   - **Secret name**: `osc-build-watcher-secrets`
+   - **Key**: `gangway-api-token`
+   - **Value**: The token provided by DPTP
+
+### Vault Configuration
+
+To add the secret to Vault:
+
+1. Sign into https://vault.ci.openshift.org
+2. Navigate to your secret collection (e.g., `kv/sandboxed-containers-operator`)
+3. Create a new secret named `osc-build-watcher-secrets`
+4. Add keys:
+   - `secretsync/target-namespace` → `test-credentials`
+   - `gangway-api-token` → `<your-token-from-DPTP>`
+
+## Configuration
+
+The watcher is configured to run daily at 00:00 UTC as a periodic job. See the periodic job configuration in:
+`ci-operator/config/openshift/sandboxed-containers-operator/openshift-sandboxed-containers-operator-devel__build-watcher.yaml`
+
+## Deduplication Logic
+
+The watcher prevents duplicate testing by:
+
+1. Querying Prow Deck API (`/prowjobs.js`) for recent job runs
+2. Checking if the specific job succeeded in the last 24 hours
+3. Skipping jobs that were recently tested successfully
+
+**Note**: The current implementation checks for recent successful runs of the job, not the exact OCP version. This is a reasonable heuristic since the jobs run against nightly builds that change frequently.
+
+## Behavior
+
+- **Rehearsal Mode**: Automatically skips execution when `JOB_NAME` contains "rehearse"
+- **Error Handling**:
+  - Reports failures but continues processing other versions
+  - Exits with error code if any job triggers fail
+- **Logging**: Provides detailed output of all operations and decisions
+
+## Example Output
+
+```
+=========================================
+OpenShift Sandboxed Containers Build Watcher
+=========================================
+Date: Mon Jan 20 00:00:00 UTC 2026
+
+✓ Gangway API token loaded
+
+Checking OCP versions for new releases...
+
+----------------------------------------
+Processing OCP 4.21
+----------------------------------------
+Querying Cincinnati API for 4.21.0-0.nightly...
+  ✓ Latest accepted release: 4.21.0-0.nightly-2026-01-19-132300
+
+Job: periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-release-azure-ipi-kata
+  Checking if job was tested with 4.21.0-0.nightly-2026-01-19-132300 in last 24 hours...
+    ✗ No recent successful run found
+  Triggering job: periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-release-azure-ipi-kata
+    ✓ Successfully triggered (HTTP 201)
+    → Triggered for OCP 4.21.0-0.nightly-2026-01-19-132300
+
+=========================================
+Summary
+=========================================
+Jobs triggered: 5
+Jobs skipped:   30
+Jobs failed:    0
+
+✓ Build watcher completed successfully
+```
+
+## Troubleshooting
+
+### Token Not Found Error
+
+```
+ERROR: Gangway API token not found at /var/run/osc-secrets/gangway-api-token
+```
+
+**Solution**: Verify the secret is properly configured in Vault with `secretsync/target-namespace` set to `test-credentials`.
+
+### Failed to Query Cincinnati API
+
+```
+⚠ Failed to query Cincinnati API for 4.21.0-0.nightly
+```
+
+**Solution**: Check network connectivity and verify the Cincinnati API endpoint is accessible.
+
+### Failed to Trigger (HTTP 403)
+
+```
+✗ Failed to trigger (HTTP 403)
+```
+
+**Solution**: The Gangway API token may be invalid or expired. Request a new token from DPTP.
+
+### Failed to Query Deck API
+
+```
+⚠ Failed to query Deck API
+```
+
+**Solution**: Temporary network issue. The watcher will retry on the next scheduled run.
+
+## Related Documentation
+
+- [Prow Gangway API](https://docs.prow.k8s.io/)
+- [OpenShift Release Controllers](https://amd64.ocp.releases.ci.openshift.org/)
+- [OpenShift CI Secrets Guide](https://cspi.gitbook.io/ocp-ci-onboarding/tutorials/secrets_guide)
+
+## JIRA Reference
+
+This implementation addresses [KATA-3819](https://issues.redhat.com/browse/KATA-3819) - Automated triggering of OSC tests for new OCP releases.

--- a/ci-operator/step-registry/sandboxed-containers-operator/build-watcher/sandboxed-containers-operator-build-watcher-commands.sh
+++ b/ci-operator/step-registry/sandboxed-containers-operator/build-watcher/sandboxed-containers-operator-build-watcher-commands.sh
@@ -1,0 +1,203 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+# Skip in rehearsal mode
+if [[ "${JOB_NAME:-}" == *"rehearse"* ]]; then
+  echo "Running in rehearsal mode, skipping build watcher execution"
+  exit 0
+fi
+
+# Configuration
+GANGWAY_URL="https://gangway-ci.apps.ci.l2s4.p1.openshiftapps.com"
+DECK_URL="https://prow.ci.openshift.org"
+CINCINNATI_BASE_URL="https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream"
+SECRETS_DIR="${SECRETS_DIR:-/var/run/osc-secrets}"
+JOB_PREFIX="periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-release"
+
+# OCP versions to watch (major.minor format)
+OCP_VERSIONS=("4.17" "4.18" "4.19" "4.20" "4.21" "4.22")
+
+# Jobs to trigger for each OCP version
+JOBS_TO_TRIGGER=(
+  "azure-ipi-kata"
+  "azure-ipi-peerpods"
+  "azure-ipi-coco"
+  "aws-ipi-peerpods"
+  "aws-ipi-coco"
+)
+
+# Time window to check for recent runs (in days)
+DAYS_TO_CHECK=1
+
+echo "========================================="
+echo "OpenShift Sandboxed Containers Build Watcher"
+echo "========================================="
+echo "Date: $(date)"
+echo ""
+
+# Read Gangway API token
+if [ ! -f "${SECRETS_DIR}/gangway-api-token" ]; then
+  echo "ERROR: Gangway API token not found at ${SECRETS_DIR}/gangway-api-token"
+  exit 1
+fi
+
+GANGWAY_API_TOKEN=$(cat "${SECRETS_DIR}/gangway-api-token")
+echo "✓ Gangway API token loaded"
+echo ""
+
+# Function to get latest accepted release for an OCP version
+get_latest_release() {
+  local ocp_version=$1
+  local release_stream="${ocp_version}.0-0.nightly"
+
+  echo "Querying Cincinnati API for ${release_stream}..."
+  local response
+  response=$(curl -s "${CINCINNATI_BASE_URL}/${release_stream}/latest" || echo "")
+
+  if [ -z "$response" ]; then
+    echo "  ⚠ Failed to query Cincinnati API for ${release_stream}"
+    return 1
+  fi
+
+  local name phase
+  name=$(echo "$response" | jq -r '.name // empty')
+  phase=$(echo "$response" | jq -r '.phase // empty')
+
+  if [ -z "$name" ] || [ "$phase" != "Accepted" ]; then
+    echo "  ⚠ No accepted release found for ${release_stream}"
+    return 1
+  fi
+
+  echo "  ✓ Latest accepted release: ${name}"
+  echo "$name"
+  return 0
+}
+
+# Function to check if OCP version was recently tested
+check_recent_test() {
+  local job_name=$1
+  local ocp_version=$2
+
+  echo "  Checking if ${job_name} was tested with ${ocp_version} in last ${DAYS_TO_CHECK} days..."
+
+  # Query Deck API for recent ProwJobs
+  local prowjobs_response
+  prowjobs_response=$(curl -s "${DECK_URL}/prowjobs.js?var=allBuilds" || echo "")
+
+  if [ -z "$prowjobs_response" ]; then
+    echo "    ⚠ Failed to query Deck API"
+    return 1
+  fi
+
+  # Calculate timestamp for N days ago (in seconds since epoch)
+  local cutoff_time
+  cutoff_time=$(date -d "${DAYS_TO_CHECK} days ago" +%s)
+
+  # Check if job was run recently with success
+  # Note: This is a simplified check - in production you might want to parse job artifacts
+  # to verify the exact OCP version tested
+  local recent_success
+  recent_success=$(echo "$prowjobs_response" | \
+    jq -r --arg job "${job_name}" --arg cutoff "${cutoff_time}" \
+    '.items[]? | select(.spec.job == $job and .status.state == "success") |
+    select((.metadata.creationTimestamp | fromdateiso8601) > ($cutoff | tonumber)) |
+    .metadata.creationTimestamp' | head -1)
+
+  if [ -n "$recent_success" ]; then
+    echo "    ✓ Recent successful run found: ${recent_success}"
+    return 0
+  fi
+
+  echo "    ✗ No recent successful run found"
+  return 1
+}
+
+# Function to trigger a job via Gangway API
+trigger_job() {
+  local job_name=$1
+
+  echo "  Triggering job: ${job_name}"
+
+  local response http_code
+  response=$(curl -s -w "\n%{http_code}" -X POST \
+    -H "Authorization: Bearer ${GANGWAY_API_TOKEN}" \
+    -d '{"job_execution_type": "1"}' \
+    "${GANGWAY_URL}/v1/executions/${job_name}" || echo -e "\n000")
+
+  http_code=$(echo "$response" | tail -1)
+
+  if [ "$http_code" = "200" ] || [ "$http_code" = "201" ]; then
+    echo "    ✓ Successfully triggered (HTTP ${http_code})"
+    return 0
+  else
+    echo "    ✗ Failed to trigger (HTTP ${http_code})"
+    echo "$response" | head -n -1
+    return 1
+  fi
+}
+
+# Main logic
+echo "Checking OCP versions for new releases..."
+echo ""
+
+triggered_count=0
+skipped_count=0
+failed_count=0
+
+for ocp_version in "${OCP_VERSIONS[@]}"; do
+  echo "----------------------------------------"
+  echo "Processing OCP ${ocp_version}"
+  echo "----------------------------------------"
+
+  # Get latest accepted release
+  latest_release=$(get_latest_release "$ocp_version") || {
+    echo "  Skipping ${ocp_version} - no release available"
+    echo ""
+    continue
+  }
+
+  # Check each job
+  for job_suffix in "${JOBS_TO_TRIGGER[@]}"; do
+    full_job_name="${JOB_PREFIX}-${job_suffix}"
+
+    echo ""
+    echo "Job: ${full_job_name}"
+
+    # Check if recently tested
+    if check_recent_test "$full_job_name" "$latest_release"; then
+      echo "    → Skipping (already tested recently)"
+      ((skipped_count++))
+      continue
+    fi
+
+    # Trigger the job
+    if trigger_job "$full_job_name"; then
+      echo "    → Triggered for OCP ${latest_release}"
+      ((triggered_count++))
+    else
+      echo "    → Failed to trigger"
+      ((failed_count++))
+    fi
+  done
+
+  echo ""
+done
+
+echo "========================================="
+echo "Summary"
+echo "========================================="
+echo "Jobs triggered: ${triggered_count}"
+echo "Jobs skipped:   ${skipped_count}"
+echo "Jobs failed:    ${failed_count}"
+echo ""
+
+if [ $failed_count -gt 0 ]; then
+  echo "⚠ Some jobs failed to trigger"
+  exit 1
+fi
+
+echo "✓ Build watcher completed successfully"
+exit 0

--- a/ci-operator/step-registry/sandboxed-containers-operator/build-watcher/sandboxed-containers-operator-build-watcher-ref.metadata.json
+++ b/ci-operator/step-registry/sandboxed-containers-operator/build-watcher/sandboxed-containers-operator-build-watcher-ref.metadata.json
@@ -1,0 +1,17 @@
+{
+	"path": "sandboxed-containers-operator/build-watcher/sandboxed-containers-operator-build-watcher-ref.yaml",
+	"owners": {
+		"approvers": [
+			"ldoktor",
+			"tbuskey",
+			"vvoronko",
+			"wainersm"
+		],
+		"reviewers": [
+			"ldoktor",
+			"tbuskey",
+			"vvoronko",
+			"wainersm"
+		]
+	}
+}

--- a/ci-operator/step-registry/sandboxed-containers-operator/build-watcher/sandboxed-containers-operator-build-watcher-ref.yaml
+++ b/ci-operator/step-registry/sandboxed-containers-operator/build-watcher/sandboxed-containers-operator-build-watcher-ref.yaml
@@ -1,0 +1,30 @@
+ref:
+  as: sandboxed-containers-operator-build-watcher
+  from: cli
+  commands: sandboxed-containers-operator-build-watcher-commands.sh
+  credentials:
+    - namespace: test-credentials
+      name: osc-build-watcher-secrets
+      mount_path: /var/run/osc-secrets
+  resources:
+    requests:
+      cpu: 100m
+      memory: 200Mi
+  documentation: |-
+    Watches for new accepted OCP releases via Cincinnati API and triggers
+    OpenShift Sandboxed Containers test jobs via Gangway API.
+
+    This step:
+    - Queries Cincinnati API for latest accepted releases (4.17-4.22)
+    - Checks Prow Deck API to avoid duplicate testing within 7 days
+    - Triggers downstream-release jobs via Gangway API for new versions
+
+    Required secrets in Vault (namespace: test-credentials, name: osc-build-watcher-secrets):
+    - gangway-api-token: Token obtained from DPTP team for Gangway API access
+
+    Jobs triggered (per OCP version):
+    - periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-release-azure-ipi-kata
+    - periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-release-azure-ipi-peerpods
+    - periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-release-azure-ipi-coco
+    - periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-release-aws-ipi-peerpods
+    - periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-release-aws-ipi-coco


### PR DESCRIPTION
Introduces automated monitoring of new OCP releases (4.17-4.22) via Cincinnati API and triggers downstream sandboxed-containers-operator test jobs through Gangway API.

- New variant periodic configuration (__build-watcher.yaml) runs daily at 00:00 UTC
- New step-registry component checks for accepted releases and triggers jobs
- Prevents duplicate testing by checking recent job runs via Prow Deck API
- Replaces previous Jenkins-based build watcher ([KATA-3819](https://issues.redhat.com/browse/KATA-3819))

Assisted-by: Claude

[KATA-3819]: https://redhat.atlassian.net/browse/KATA-3819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ