### PR TITLE
OCPBUGS-52395: rename 'master' to 'main' for oauth-proxy

### DIFF
--- a/ci-operator/config/openshift-priv/oauth-proxy/openshift-priv-oauth-proxy-main.yaml
+++ b/ci-operator/config/openshift-priv/oauth-proxy/openshift-priv-oauth-proxy-main.yaml
@@ -57,6 +57,6 @@ tests:
           cpu: 100m
     workflow: ipi-gcp
 zz_generated_metadata:
-  branch: master
+  branch: main
   org: openshift-priv
   repo: oauth-proxy

--- a/ci-operator/config/openshift/oauth-proxy/openshift-oauth-proxy-main.yaml
+++ b/ci-operator/config/openshift/oauth-proxy/openshift-oauth-proxy-main.yaml
@@ -56,6 +56,6 @@ tests:
           cpu: 100m
     workflow: ipi-gcp
 zz_generated_metadata:
-  branch: master
+  branch: main
   org: openshift
   repo: oauth-proxy

--- a/ci-operator/config/openshift/oauth-proxy/openshift-oauth-proxy-main__okd-scos.yaml
+++ b/ci-operator/config/openshift/oauth-proxy/openshift-oauth-proxy-main__okd-scos.yaml
@@ -38,7 +38,7 @@ tests:
     cluster_profile: aws
     workflow: openshift-e2e-aws
 zz_generated_metadata:
-  branch: master
+  branch: main
   org: openshift
   repo: oauth-proxy
   variant: okd-scos

--- a/ci-operator/jobs/openshift-priv/oauth-proxy/openshift-priv-oauth-proxy-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/oauth-proxy/openshift-priv-oauth-proxy-main-postsubmits.yaml
@@ -3,7 +3,7 @@ postsubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
+    - ^main$
     cluster: build11
     decorate: true
     decoration_config:
@@ -15,7 +15,7 @@ postsubmits:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-openshift-priv-oauth-proxy-master-images
+    name: branch-ci-openshift-priv-oauth-proxy-main-images
     path_alias: github.com/openshift/oauth-proxy
     spec:
       containers:

--- a/ci-operator/jobs/openshift-priv/oauth-proxy/openshift-priv-oauth-proxy-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/oauth-proxy/openshift-priv-oauth-proxy-main-presubmits.yaml
@@ -3,8 +3,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build01
     context: ci/prow/e2e-aws
     decorate: true
@@ -18,7 +18,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-3
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-oauth-proxy-master-e2e-aws
+    name: pull-ci-openshift-priv-oauth-proxy-main-e2e-aws
     path_alias: github.com/openshift/oauth-proxy
     rerun_command: /test e2e-aws
     spec:
@@ -85,8 +85,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build04
     context: ci/prow/e2e-component
     decorate: true
@@ -100,7 +100,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-oauth-proxy-master-e2e-component
+    name: pull-ci-openshift-priv-oauth-proxy-main-e2e-component
     path_alias: github.com/openshift/oauth-proxy
     rerun_command: /test e2e-component
     spec:
@@ -167,8 +167,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build10
     context: ci/prow/images
     decorate: true
@@ -180,7 +180,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-oauth-proxy-master-images
+    name: pull-ci-openshift-priv-oauth-proxy-main-images
     path_alias: github.com/openshift/oauth-proxy
     rerun_command: /test images
     spec:
@@ -230,8 +230,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build10
     context: ci/prow/unit
     decorate: true
@@ -243,7 +243,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-oauth-proxy-master-unit
+    name: pull-ci-openshift-priv-oauth-proxy-main-unit
     path_alias: github.com/openshift/oauth-proxy
     rerun_command: /test unit
     spec:
@@ -293,8 +293,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build10
     context: ci/prow/verify
     decorate: true
@@ -306,7 +306,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-oauth-proxy-master-verify
+    name: pull-ci-openshift-priv-oauth-proxy-main-verify
     path_alias: github.com/openshift/oauth-proxy
     rerun_command: /test verify
     spec:
@@ -356,8 +356,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build10
     context: ci/prow/verify-deps
     decorate: true
@@ -369,7 +369,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-oauth-proxy-master-verify-deps
+    name: pull-ci-openshift-priv-oauth-proxy-main-verify-deps
     path_alias: github.com/openshift/oauth-proxy
     rerun_command: /test verify-deps
     spec:

--- a/ci-operator/jobs/openshift/oauth-proxy/openshift-oauth-proxy-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/oauth-proxy/openshift-oauth-proxy-main-postsubmits.yaml
@@ -3,14 +3,14 @@ postsubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
+    - ^main$
     cluster: build08
     decorate: true
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-openshift-oauth-proxy-master-images
+    name: branch-ci-openshift-oauth-proxy-main-images
     spec:
       containers:
       - args:
@@ -61,7 +61,7 @@ postsubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
+    - ^main$
     cluster: build08
     decorate: true
     decoration_config:
@@ -71,7 +71,7 @@ postsubmits:
       ci-operator.openshift.io/variant: okd-scos
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-openshift-oauth-proxy-master-okd-scos-images
+    name: branch-ci-openshift-oauth-proxy-main-okd-scos-images
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift/oauth-proxy/openshift-oauth-proxy-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/oauth-proxy/openshift-oauth-proxy-main-presubmits.yaml
@@ -3,8 +3,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build06
     context: ci/prow/e2e-aws
     decorate: true
@@ -13,7 +13,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-3
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-oauth-proxy-master-e2e-aws
+    name: pull-ci-openshift-oauth-proxy-main-e2e-aws
     rerun_command: /test e2e-aws
     spec:
       containers:
@@ -75,8 +75,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build08
     context: ci/prow/e2e-component
     decorate: true
@@ -85,7 +85,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-oauth-proxy-master-e2e-component
+    name: pull-ci-openshift-oauth-proxy-main-e2e-component
     rerun_command: /test e2e-component
     spec:
       containers:
@@ -149,13 +149,15 @@ presubmits:
     branches:
     - ^master$
     - ^master-
+    - ^main$
+    - ^main-
     cluster: build04
     context: ci/prow/images
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-oauth-proxy-master-images
+    name: pull-ci-openshift-oauth-proxy-main-images
     rerun_command: /test images
     spec:
       containers:
@@ -201,8 +203,8 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build06
     context: ci/prow/okd-scos-e2e-aws-ovn
     decorate: true
@@ -214,7 +216,7 @@ presubmits:
       ci-operator.openshift.io/variant: okd-scos
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-oauth-proxy-master-okd-scos-e2e-aws-ovn
+    name: pull-ci-openshift-oauth-proxy-main-okd-scos-e2e-aws-ovn
     optional: true
     rerun_command: /test okd-scos-e2e-aws-ovn
     spec:
@@ -278,8 +280,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build04
     context: ci/prow/okd-scos-images
     decorate: true
@@ -289,7 +291,7 @@ presubmits:
       ci-operator.openshift.io/variant: okd-scos
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-oauth-proxy-master-okd-scos-images
+    name: pull-ci-openshift-oauth-proxy-main-okd-scos-images
     rerun_command: /test okd-scos-images
     spec:
       containers:
@@ -336,15 +338,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build04
     context: ci/prow/unit
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-oauth-proxy-master-unit
+    name: pull-ci-openshift-oauth-proxy-main-unit
     rerun_command: /test unit
     spec:
       containers:
@@ -389,15 +391,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build04
     context: ci/prow/verify
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-oauth-proxy-master-verify
+    name: pull-ci-openshift-oauth-proxy-main-verify
     rerun_command: /test verify
     spec:
       containers:
@@ -442,15 +444,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build04
     context: ci/prow/verify-deps
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-oauth-proxy-master-verify-deps
+    name: pull-ci-openshift-oauth-proxy-main-verify-deps
     rerun_command: /test verify-deps
     spec:
       containers:


### PR DESCRIPTION
https://github.com/openshift/release/pull/67855 needed to be rebased.

> This PR is in support of renaming the default branch for https://github.com/openshift/oauth-proxy from 'master' to 'main'.
> 
> Unhold this PR only when:
> 
> the default branch for https://github.com/openshift/oauth-proxy has been renamed to 'main'
> You have verified that the CI jobs are working as expected either by running '/pj-rehearse' or by inspection.

/hold