### PR TITLE
OCPBUGS-52386: rename 'master' to 'main' for kube-rbac-proxy

### DIFF
--- a/ci-operator/config/openshift-priv/kube-rbac-proxy/openshift-priv-kube-rbac-proxy-main.yaml
+++ b/ci-operator/config/openshift-priv/kube-rbac-proxy/openshift-priv-kube-rbac-proxy-main.yaml
@@ -1,22 +1,23 @@
 build_root:
   from_repository: true
+canonical_go_repository: github.com/openshift/kube-rbac-proxy
 images:
 - dockerfile_path: Dockerfile.ocp
   to: kube-rbac-proxy
 promotion:
   to:
-  - name: "4.22"
-    namespace: ocp
+  - name: 4.22-priv
+    namespace: ocp-private
 releases:
   initial:
     integration:
-      name: "4.22"
-      namespace: ocp
+      name: 4.22-priv
+      namespace: ocp-private
   latest:
     integration:
       include_built_images: true
-      name: "4.22"
-      namespace: ocp
+      name: 4.22-priv
+      namespace: ocp-private
 resources:
   '*':
     requests:
@@ -42,6 +43,6 @@ tests:
     test:
     - ref: go-verify-deps
 zz_generated_metadata:
-  branch: master
-  org: openshift
+  branch: main
+  org: openshift-priv
   repo: kube-rbac-proxy

--- a/ci-operator/config/openshift/kube-rbac-proxy/openshift-kube-rbac-proxy-main.yaml
+++ b/ci-operator/config/openshift/kube-rbac-proxy/openshift-kube-rbac-proxy-main.yaml
@@ -1,23 +1,22 @@
 build_root:
   from_repository: true
-canonical_go_repository: github.com/openshift/kube-rbac-proxy
 images:
 - dockerfile_path: Dockerfile.ocp
   to: kube-rbac-proxy
 promotion:
   to:
-  - name: 4.22-priv
-    namespace: ocp-private
+  - name: "4.22"
+    namespace: ocp
 releases:
   initial:
     integration:
-      name: 4.22-priv
-      namespace: ocp-private
+      name: "4.22"
+      namespace: ocp
   latest:
     integration:
       include_built_images: true
-      name: 4.22-priv
-      namespace: ocp-private
+      name: "4.22"
+      namespace: ocp
 resources:
   '*':
     requests:
@@ -43,6 +42,6 @@ tests:
     test:
     - ref: go-verify-deps
 zz_generated_metadata:
-  branch: master
-  org: openshift-priv
+  branch: main
+  org: openshift
   repo: kube-rbac-proxy

--- a/ci-operator/config/openshift/kube-rbac-proxy/openshift-kube-rbac-proxy-main__okd-scos.yaml
+++ b/ci-operator/config/openshift/kube-rbac-proxy/openshift-kube-rbac-proxy-main__okd-scos.yaml
@@ -38,7 +38,7 @@ tests:
     cluster_profile: aws
     workflow: openshift-e2e-aws
 zz_generated_metadata:
-  branch: master
+  branch: main
   org: openshift
   repo: kube-rbac-proxy
   variant: okd-scos

--- a/ci-operator/jobs/openshift-priv/kube-rbac-proxy/openshift-priv-kube-rbac-proxy-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/kube-rbac-proxy/openshift-priv-kube-rbac-proxy-main-postsubmits.yaml
@@ -3,7 +3,7 @@ postsubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
+    - ^main$
     cluster: build11
     decorate: true
     decoration_config:
@@ -15,7 +15,7 @@ postsubmits:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-openshift-priv-kube-rbac-proxy-master-images
+    name: branch-ci-openshift-priv-kube-rbac-proxy-main-images
     path_alias: github.com/openshift/kube-rbac-proxy
     spec:
       containers:

--- a/ci-operator/jobs/openshift-priv/kube-rbac-proxy/openshift-priv-kube-rbac-proxy-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/kube-rbac-proxy/openshift-priv-kube-rbac-proxy-main-presubmits.yaml
@@ -3,8 +3,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build09
     context: ci/prow/e2e-aws-ovn
     decorate: true
@@ -18,7 +18,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-3
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-kube-rbac-proxy-master-e2e-aws-ovn
+    name: pull-ci-openshift-priv-kube-rbac-proxy-main-e2e-aws-ovn
     path_alias: github.com/openshift/kube-rbac-proxy
     rerun_command: /test e2e-aws-ovn
     spec:
@@ -85,8 +85,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build10
     context: ci/prow/images
     decorate: true
@@ -98,7 +98,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-kube-rbac-proxy-master-images
+    name: pull-ci-openshift-priv-kube-rbac-proxy-main-images
     path_alias: github.com/openshift/kube-rbac-proxy
     rerun_command: /test images
     spec:
@@ -148,8 +148,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build10
     context: ci/prow/test-unit
     decorate: true
@@ -161,7 +161,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-kube-rbac-proxy-master-test-unit
+    name: pull-ci-openshift-priv-kube-rbac-proxy-main-test-unit
     path_alias: github.com/openshift/kube-rbac-proxy
     rerun_command: /test test-unit
     spec:
@@ -211,8 +211,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build10
     context: ci/prow/vendor
     decorate: true
@@ -224,7 +224,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-kube-rbac-proxy-master-vendor
+    name: pull-ci-openshift-priv-kube-rbac-proxy-main-vendor
     path_alias: github.com/openshift/kube-rbac-proxy
     rerun_command: /test vendor
     spec:
@@ -274,8 +274,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build10
     context: ci/prow/verify-deps
     decorate: true
@@ -287,7 +287,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-kube-rbac-proxy-master-verify-deps
+    name: pull-ci-openshift-priv-kube-rbac-proxy-main-verify-deps
     path_alias: github.com/openshift/kube-rbac-proxy
     rerun_command: /test verify-deps
     spec:

--- a/ci-operator/jobs/openshift/kube-rbac-proxy/openshift-kube-rbac-proxy-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/kube-rbac-proxy/openshift-kube-rbac-proxy-main-postsubmits.yaml
@@ -3,14 +3,14 @@ postsubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
+    - ^main$
     cluster: build04
     decorate: true
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-openshift-kube-rbac-proxy-master-images
+    name: branch-ci-openshift-kube-rbac-proxy-main-images
     spec:
       containers:
       - args:
@@ -61,7 +61,7 @@ postsubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
+    - ^main$
     cluster: build04
     decorate: true
     decoration_config:
@@ -71,7 +71,7 @@ postsubmits:
       ci-operator.openshift.io/variant: okd-scos
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-openshift-kube-rbac-proxy-master-okd-scos-images
+    name: branch-ci-openshift-kube-rbac-proxy-main-okd-scos-images
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift/kube-rbac-proxy/openshift-kube-rbac-proxy-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/kube-rbac-proxy/openshift-kube-rbac-proxy-main-presubmits.yaml
@@ -3,8 +3,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build11
     context: ci/prow/e2e-aws-ovn
     decorate: true
@@ -13,7 +13,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-3
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-kube-rbac-proxy-master-e2e-aws-ovn
+    name: pull-ci-openshift-kube-rbac-proxy-main-e2e-aws-ovn
     rerun_command: /test e2e-aws-ovn
     spec:
       containers:
@@ -75,15 +75,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build10
     context: ci/prow/images
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-kube-rbac-proxy-master-images
+    name: pull-ci-openshift-kube-rbac-proxy-main-images
     rerun_command: /test images
     spec:
       containers:
@@ -129,8 +129,8 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build11
     context: ci/prow/okd-scos-e2e-aws-ovn
     decorate: true
@@ -142,7 +142,7 @@ presubmits:
       ci-operator.openshift.io/variant: okd-scos
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-kube-rbac-proxy-master-okd-scos-e2e-aws-ovn
+    name: pull-ci-openshift-kube-rbac-proxy-main-okd-scos-e2e-aws-ovn
     optional: true
     rerun_command: /test okd-scos-e2e-aws-ovn
     spec:
@@ -206,8 +206,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build10
     context: ci/prow/okd-scos-images
     decorate: true
@@ -217,7 +217,7 @@ presubmits:
       ci-operator.openshift.io/variant: okd-scos
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-kube-rbac-proxy-master-okd-scos-images
+    name: pull-ci-openshift-kube-rbac-proxy-main-okd-scos-images
     rerun_command: /test okd-scos-images
     spec:
       containers:
@@ -264,15 +264,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build10
     context: ci/prow/test-unit
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-kube-rbac-proxy-master-test-unit
+    name: pull-ci-openshift-kube-rbac-proxy-main-test-unit
     rerun_command: /test test-unit
     spec:
       containers:
@@ -317,15 +317,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build10
     context: ci/prow/vendor
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-kube-rbac-proxy-master-vendor
+    name: pull-ci-openshift-kube-rbac-proxy-main-vendor
     rerun_command: /test vendor
     spec:
       containers:
@@ -370,15 +370,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build10
     context: ci/prow/verify-deps
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-kube-rbac-proxy-master-verify-deps
+    name: pull-ci-openshift-kube-rbac-proxy-main-verify-deps
     rerun_command: /test verify-deps
     spec:
       containers:


### PR DESCRIPTION
https://github.com/openshift/release/pull/67852 needed to be rebased.

> This PR is in support of renaming the default branch for https://github.com/openshift/kube-rbac-proxy from 'master' to 'main'.
> 
> Unhold this PR only when:
> 
> the default branch for https://github.com/openshift/kube-rbac-proxy has been renamed to 'main'
> You have verified that the CI jobs are working as expected either by running '/pj-rehearse' or by inspection.

/hold