### PR TITLE
OCPBUGS-52245: rename 'master' to 'main' for cluster-authentication-operator

### DIFF
--- a/ci-operator/config/openshift-priv/cluster-authentication-operator/openshift-priv-cluster-authentication-operator-main.yaml
+++ b/ci-operator/config/openshift-priv/cluster-authentication-operator/openshift-priv-cluster-authentication-operator-main.yaml
@@ -305,6 +305,6 @@ tests:
     workflow: ipi-aws
   timeout: 4h0m0s
 zz_generated_metadata:
-  branch: master
+  branch: main
   org: openshift-priv
   repo: cluster-authentication-operator

--- a/ci-operator/config/openshift/cluster-authentication-operator/openshift-cluster-authentication-operator-main.yaml
+++ b/ci-operator/config/openshift/cluster-authentication-operator/openshift-cluster-authentication-operator-main.yaml
@@ -304,6 +304,6 @@ tests:
     workflow: ipi-aws
   timeout: 4h0m0s
 zz_generated_metadata:
-  branch: master
+  branch: main
   org: openshift
   repo: cluster-authentication-operator

--- a/ci-operator/config/openshift/cluster-authentication-operator/openshift-cluster-authentication-operator-main__okd-scos.yaml
+++ b/ci-operator/config/openshift/cluster-authentication-operator/openshift-cluster-authentication-operator-main__okd-scos.yaml
@@ -38,7 +38,7 @@ tests:
     cluster_profile: aws
     workflow: openshift-e2e-aws
 zz_generated_metadata:
-  branch: master
+  branch: main
   org: openshift
   repo: cluster-authentication-operator
   variant: okd-scos

--- a/ci-operator/jobs/openshift-priv/cluster-authentication-operator/openshift-priv-cluster-authentication-operator-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/cluster-authentication-operator/openshift-priv-cluster-authentication-operator-main-postsubmits.yaml
@@ -3,7 +3,7 @@ postsubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
+    - ^main$
     cluster: build11
     decorate: true
     decoration_config:
@@ -15,7 +15,7 @@ postsubmits:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-openshift-priv-cluster-authentication-operator-master-images
+    name: branch-ci-openshift-priv-cluster-authentication-operator-main-images
     path_alias: github.com/openshift/cluster-authentication-operator
     spec:
       containers:

--- a/ci-operator/jobs/openshift-priv/cluster-authentication-operator/openshift-priv-cluster-authentication-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/cluster-authentication-operator/openshift-priv-cluster-authentication-operator-main-presubmits.yaml
@@ -3,8 +3,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build04
     context: ci/prow/e2e-agnostic
     decorate: true
@@ -18,7 +18,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: azure4
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-authentication-operator-master-e2e-agnostic
+    name: pull-ci-openshift-priv-cluster-authentication-operator-main-e2e-agnostic
     path_alias: github.com/openshift/cluster-authentication-operator
     rerun_command: /test e2e-agnostic
     spec:
@@ -85,8 +85,8 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build09
     context: ci/prow/e2e-agnostic-ipv6
     decorate: true
@@ -101,7 +101,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-authentication-operator-master-e2e-agnostic-ipv6
+    name: pull-ci-openshift-priv-cluster-authentication-operator-main-e2e-agnostic-ipv6
     optional: true
     path_alias: github.com/openshift/cluster-authentication-operator
     rerun_command: /test e2e-agnostic-ipv6
@@ -169,8 +169,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build04
     context: ci/prow/e2e-agnostic-upgrade
     decorate: true
@@ -184,7 +184,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: azure4
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-authentication-operator-master-e2e-agnostic-upgrade
+    name: pull-ci-openshift-priv-cluster-authentication-operator-main-e2e-agnostic-upgrade
     path_alias: github.com/openshift/cluster-authentication-operator
     rerun_command: /test e2e-agnostic-upgrade
     spec:
@@ -251,8 +251,8 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build11
     context: ci/prow/e2e-aws-external-oidc-conformance-parallel
     decorate: true
@@ -267,7 +267,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-3
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-authentication-operator-master-e2e-aws-external-oidc-conformance-parallel
+    name: pull-ci-openshift-priv-cluster-authentication-operator-main-e2e-aws-external-oidc-conformance-parallel
     optional: true
     path_alias: github.com/openshift/cluster-authentication-operator
     rerun_command: /test e2e-aws-external-oidc-conformance-parallel
@@ -335,8 +335,8 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build11
     context: ci/prow/e2e-aws-external-oidc-conformance-serial
     decorate: true
@@ -351,7 +351,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-3
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-authentication-operator-master-e2e-aws-external-oidc-conformance-serial
+    name: pull-ci-openshift-priv-cluster-authentication-operator-main-e2e-aws-external-oidc-conformance-serial
     optional: true
     path_alias: github.com/openshift/cluster-authentication-operator
     rerun_command: /test e2e-aws-external-oidc-conformance-serial
@@ -419,8 +419,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build11
     context: ci/prow/e2e-aws-operator-encryption-kms-serial-ote-1of2
     decorate: true
@@ -435,7 +435,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-authentication-operator-master-e2e-aws-operator-encryption-kms-serial-ote-1of2
+    name: pull-ci-openshift-priv-cluster-authentication-operator-main-e2e-aws-operator-encryption-kms-serial-ote-1of2
     optional: true
     path_alias: github.com/openshift/cluster-authentication-operator
     rerun_command: /test e2e-aws-operator-encryption-kms-serial-ote-1of2
@@ -504,8 +504,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build11
     context: ci/prow/e2e-aws-operator-encryption-kms-serial-ote-2of2
     decorate: true
@@ -520,7 +520,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-authentication-operator-master-e2e-aws-operator-encryption-kms-serial-ote-2of2
+    name: pull-ci-openshift-priv-cluster-authentication-operator-main-e2e-aws-operator-encryption-kms-serial-ote-2of2
     optional: true
     path_alias: github.com/openshift/cluster-authentication-operator
     rerun_command: /test e2e-aws-operator-encryption-kms-serial-ote-2of2
@@ -589,8 +589,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build11
     context: ci/prow/e2e-aws-operator-encryption-perf-serial-ote-1of2
     decorate: true
@@ -605,7 +605,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-authentication-operator-master-e2e-aws-operator-encryption-perf-serial-ote-1of2
+    name: pull-ci-openshift-priv-cluster-authentication-operator-main-e2e-aws-operator-encryption-perf-serial-ote-1of2
     optional: true
     path_alias: github.com/openshift/cluster-authentication-operator
     rerun_command: /test e2e-aws-operator-encryption-perf-serial-ote-1of2
@@ -674,8 +674,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build11
     context: ci/prow/e2e-aws-operator-encryption-perf-serial-ote-2of2
     decorate: true
@@ -690,7 +690,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-authentication-operator-master-e2e-aws-operator-encryption-perf-serial-ote-2of2
+    name: pull-ci-openshift-priv-cluster-authentication-operator-main-e2e-aws-operator-encryption-perf-serial-ote-2of2
     optional: true
     path_alias: github.com/openshift/cluster-authentication-operator
     rerun_command: /test e2e-aws-operator-encryption-perf-serial-ote-2of2
@@ -759,8 +759,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build11
     context: ci/prow/e2e-aws-operator-encryption-rotation-serial-ote-1of2
     decorate: true
@@ -775,7 +775,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-authentication-operator-master-e2e-aws-operator-encryption-rotation-serial-ote-1of2
+    name: pull-ci-openshift-priv-cluster-authentication-operator-main-e2e-aws-operator-encryption-rotation-serial-ote-1of2
     optional: true
     path_alias: github.com/openshift/cluster-authentication-operator
     rerun_command: /test e2e-aws-operator-encryption-rotation-serial-ote-1of2
@@ -844,8 +844,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build11
     context: ci/prow/e2e-aws-operator-encryption-rotation-serial-ote-2of2
     decorate: true
@@ -860,7 +860,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-authentication-operator-master-e2e-aws-operator-encryption-rotation-serial-ote-2of2
+    name: pull-ci-openshift-priv-cluster-authentication-operator-main-e2e-aws-operator-encryption-rotation-serial-ote-2of2
     optional: true
     path_alias: github.com/openshift/cluster-authentication-operator
     rerun_command: /test e2e-aws-operator-encryption-rotation-serial-ote-2of2
@@ -929,8 +929,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build11
     context: ci/prow/e2e-aws-operator-encryption-serial-ote-1of2
     decorate: true
@@ -945,7 +945,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-authentication-operator-master-e2e-aws-operator-encryption-serial-ote-1of2
+    name: pull-ci-openshift-priv-cluster-authentication-operator-main-e2e-aws-operator-encryption-serial-ote-1of2
     optional: true
     path_alias: github.com/openshift/cluster-authentication-operator
     rerun_command: /test e2e-aws-operator-encryption-serial-ote-1of2
@@ -1014,8 +1014,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build11
     context: ci/prow/e2e-aws-operator-encryption-serial-ote-2of2
     decorate: true
@@ -1030,7 +1030,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-authentication-operator-master-e2e-aws-operator-encryption-serial-ote-2of2
+    name: pull-ci-openshift-priv-cluster-authentication-operator-main-e2e-aws-operator-encryption-serial-ote-2of2
     optional: true
     path_alias: github.com/openshift/cluster-authentication-operator
     rerun_command: /test e2e-aws-operator-encryption-serial-ote-2of2
@@ -1099,8 +1099,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build11
     context: ci/prow/e2e-aws-operator-parallel-ote
     decorate: true
@@ -1114,7 +1114,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-authentication-operator-master-e2e-aws-operator-parallel-ote
+    name: pull-ci-openshift-priv-cluster-authentication-operator-main-e2e-aws-operator-parallel-ote
     optional: true
     path_alias: github.com/openshift/cluster-authentication-operator
     rerun_command: /test e2e-aws-operator-parallel-ote
@@ -1182,8 +1182,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build11
     context: ci/prow/e2e-aws-operator-serial-ote
     decorate: true
@@ -1197,7 +1197,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-authentication-operator-master-e2e-aws-operator-serial-ote
+    name: pull-ci-openshift-priv-cluster-authentication-operator-main-e2e-aws-operator-serial-ote
     optional: true
     path_alias: github.com/openshift/cluster-authentication-operator
     rerun_command: /test e2e-aws-operator-serial-ote
@@ -1265,8 +1265,8 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build11
     context: ci/prow/e2e-aws-single-node
     decorate: true
@@ -1280,7 +1280,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-3
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-authentication-operator-master-e2e-aws-single-node
+    name: pull-ci-openshift-priv-cluster-authentication-operator-main-e2e-aws-single-node
     optional: true
     path_alias: github.com/openshift/cluster-authentication-operator
     rerun_command: /test e2e-aws-single-node
@@ -1348,8 +1348,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build02
     context: ci/prow/e2e-console-login
     decorate: true
@@ -1363,7 +1363,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-authentication-operator-master-e2e-console-login
+    name: pull-ci-openshift-priv-cluster-authentication-operator-main-e2e-console-login
     path_alias: github.com/openshift/cluster-authentication-operator
     rerun_command: /test e2e-console-login
     spec:
@@ -1430,8 +1430,8 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build02
     context: ci/prow/e2e-gcp-operator-encryption-kms
     decorate: true
@@ -1445,7 +1445,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-authentication-operator-master-e2e-gcp-operator-encryption-kms
+    name: pull-ci-openshift-priv-cluster-authentication-operator-main-e2e-gcp-operator-encryption-kms
     optional: true
     path_alias: github.com/openshift/cluster-authentication-operator
     rerun_command: /test e2e-gcp-operator-encryption-kms
@@ -1514,8 +1514,8 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build02
     context: ci/prow/e2e-gcp-operator-encryption-perf
     decorate: true
@@ -1529,7 +1529,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-authentication-operator-master-e2e-gcp-operator-encryption-perf
+    name: pull-ci-openshift-priv-cluster-authentication-operator-main-e2e-gcp-operator-encryption-perf
     path_alias: github.com/openshift/cluster-authentication-operator
     rerun_command: /test e2e-gcp-operator-encryption-perf
     run_if_changed: ^(vendor/github.com/openshift/library-go/pkg/operator/encryption)|^(test/e2e-encryption-perf)|^(test/library/encryption)
@@ -1597,8 +1597,8 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build02
     context: ci/prow/e2e-gcp-operator-encryption-rotation
     decorate: true
@@ -1612,7 +1612,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-authentication-operator-master-e2e-gcp-operator-encryption-rotation
+    name: pull-ci-openshift-priv-cluster-authentication-operator-main-e2e-gcp-operator-encryption-rotation
     path_alias: github.com/openshift/cluster-authentication-operator
     rerun_command: /test e2e-gcp-operator-encryption-rotation
     run_if_changed: ^(vendor/github.com/openshift/library-go/pkg/operator/encryption)|^(test/e2e-encryption-rotation)|^(test/library/encryption)
@@ -1680,8 +1680,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build02
     context: ci/prow/e2e-oidc
     decorate: true
@@ -1695,7 +1695,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-authentication-operator-master-e2e-oidc
+    name: pull-ci-openshift-priv-cluster-authentication-operator-main-e2e-oidc
     path_alias: github.com/openshift/cluster-authentication-operator
     rerun_command: /test e2e-oidc
     spec:
@@ -1762,8 +1762,8 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build02
     context: ci/prow/e2e-oidc-techpreview
     decorate: true
@@ -1777,7 +1777,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-authentication-operator-master-e2e-oidc-techpreview
+    name: pull-ci-openshift-priv-cluster-authentication-operator-main-e2e-oidc-techpreview
     path_alias: github.com/openshift/cluster-authentication-operator
     rerun_command: /test e2e-oidc-techpreview
     run_if_changed: ^(pkg/controllers/externaloidc)|^(test/e2e-oidc)
@@ -1845,8 +1845,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build02
     context: ci/prow/e2e-operator
     decorate: true
@@ -1860,7 +1860,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-authentication-operator-master-e2e-operator
+    name: pull-ci-openshift-priv-cluster-authentication-operator-main-e2e-operator
     path_alias: github.com/openshift/cluster-authentication-operator
     rerun_command: /test e2e-operator
     spec:
@@ -1927,8 +1927,8 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build02
     context: ci/prow/e2e-operator-encryption
     decorate: true
@@ -1942,7 +1942,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-authentication-operator-master-e2e-operator-encryption
+    name: pull-ci-openshift-priv-cluster-authentication-operator-main-e2e-operator-encryption
     path_alias: github.com/openshift/cluster-authentication-operator
     rerun_command: /test e2e-operator-encryption
     run_if_changed: ^(vendor/github.com/openshift/library-go/pkg/operator/encryption)|^(test/e2e-encryption)|^(test/library/encryption)
@@ -2010,8 +2010,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build04
     context: ci/prow/images
     decorate: true
@@ -2023,7 +2023,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-authentication-operator-master-images
+    name: pull-ci-openshift-priv-cluster-authentication-operator-main-images
     path_alias: github.com/openshift/cluster-authentication-operator
     rerun_command: /test images
     spec:
@@ -2073,8 +2073,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build04
     context: ci/prow/test-operator-integration
     decorate: true
@@ -2086,7 +2086,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-authentication-operator-master-test-operator-integration
+    name: pull-ci-openshift-priv-cluster-authentication-operator-main-test-operator-integration
     path_alias: github.com/openshift/cluster-authentication-operator
     rerun_command: /test test-operator-integration
     spec:
@@ -2136,8 +2136,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build04
     context: ci/prow/unit
     decorate: true
@@ -2149,7 +2149,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-authentication-operator-master-unit
+    name: pull-ci-openshift-priv-cluster-authentication-operator-main-unit
     path_alias: github.com/openshift/cluster-authentication-operator
     rerun_command: /test unit
     spec:
@@ -2199,8 +2199,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build04
     context: ci/prow/verify
     decorate: true
@@ -2212,7 +2212,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-authentication-operator-master-verify
+    name: pull-ci-openshift-priv-cluster-authentication-operator-main-verify
     path_alias: github.com/openshift/cluster-authentication-operator
     rerun_command: /test verify
     spec:
@@ -2262,8 +2262,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build04
     context: ci/prow/verify-bindata
     decorate: true
@@ -2275,7 +2275,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-authentication-operator-master-verify-bindata
+    name: pull-ci-openshift-priv-cluster-authentication-operator-main-verify-bindata
     path_alias: github.com/openshift/cluster-authentication-operator
     rerun_command: /test verify-bindata
     spec:
@@ -2325,8 +2325,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build04
     context: ci/prow/verify-deps
     decorate: true
@@ -2338,7 +2338,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-authentication-operator-master-verify-deps
+    name: pull-ci-openshift-priv-cluster-authentication-operator-main-verify-deps
     path_alias: github.com/openshift/cluster-authentication-operator
     rerun_command: /test verify-deps
     spec:

--- a/ci-operator/jobs/openshift/cluster-authentication-operator/openshift-cluster-authentication-operator-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-authentication-operator/openshift-cluster-authentication-operator-main-postsubmits.yaml
@@ -3,14 +3,14 @@ postsubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
+    - ^main$
     cluster: build04
     decorate: true
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-openshift-cluster-authentication-operator-master-images
+    name: branch-ci-openshift-cluster-authentication-operator-main-images
     spec:
       containers:
       - args:
@@ -61,7 +61,7 @@ postsubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
+    - ^main$
     cluster: build04
     decorate: true
     decoration_config:
@@ -71,7 +71,7 @@ postsubmits:
       ci-operator.openshift.io/variant: okd-scos
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-openshift-cluster-authentication-operator-master-okd-scos-images
+    name: branch-ci-openshift-cluster-authentication-operator-main-okd-scos-images
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift/cluster-authentication-operator/openshift-cluster-authentication-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-authentication-operator/openshift-cluster-authentication-operator-main-presubmits.yaml
@@ -3,8 +3,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build05
     context: ci/prow/e2e-agnostic
     decorate: true
@@ -13,7 +13,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: azure4
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-authentication-operator-master-e2e-agnostic
+    name: pull-ci-openshift-cluster-authentication-operator-main-e2e-agnostic
     rerun_command: /test e2e-agnostic
     spec:
       containers:
@@ -75,8 +75,8 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build10
     context: ci/prow/e2e-agnostic-ipv6
     decorate: true
@@ -86,7 +86,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-authentication-operator-master-e2e-agnostic-ipv6
+    name: pull-ci-openshift-cluster-authentication-operator-main-e2e-agnostic-ipv6
     optional: true
     rerun_command: /test e2e-agnostic-ipv6
     spec:
@@ -149,8 +149,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build05
     context: ci/prow/e2e-agnostic-upgrade
     decorate: true
@@ -159,7 +159,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: azure4
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-authentication-operator-master-e2e-agnostic-upgrade
+    name: pull-ci-openshift-cluster-authentication-operator-main-e2e-agnostic-upgrade
     rerun_command: /test e2e-agnostic-upgrade
     spec:
       containers:
@@ -221,8 +221,8 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build05
     context: ci/prow/e2e-aws-external-oidc-conformance-parallel
     decorate: true
@@ -233,7 +233,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-3
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-authentication-operator-master-e2e-aws-external-oidc-conformance-parallel
+    name: pull-ci-openshift-cluster-authentication-operator-main-e2e-aws-external-oidc-conformance-parallel
     optional: true
     rerun_command: /test e2e-aws-external-oidc-conformance-parallel
     spec:
@@ -296,8 +296,8 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build05
     context: ci/prow/e2e-aws-external-oidc-conformance-serial
     decorate: true
@@ -308,7 +308,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-3
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-authentication-operator-master-e2e-aws-external-oidc-conformance-serial
+    name: pull-ci-openshift-cluster-authentication-operator-main-e2e-aws-external-oidc-conformance-serial
     optional: true
     rerun_command: /test e2e-aws-external-oidc-conformance-serial
     spec:
@@ -371,8 +371,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build05
     context: ci/prow/e2e-aws-operator-encryption-kms-serial-ote-1of2
     decorate: true
@@ -383,7 +383,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-authentication-operator-master-e2e-aws-operator-encryption-kms-serial-ote-1of2
+    name: pull-ci-openshift-cluster-authentication-operator-main-e2e-aws-operator-encryption-kms-serial-ote-1of2
     optional: true
     rerun_command: /test e2e-aws-operator-encryption-kms-serial-ote-1of2
     spec:
@@ -447,8 +447,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build05
     context: ci/prow/e2e-aws-operator-encryption-kms-serial-ote-2of2
     decorate: true
@@ -459,7 +459,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-authentication-operator-master-e2e-aws-operator-encryption-kms-serial-ote-2of2
+    name: pull-ci-openshift-cluster-authentication-operator-main-e2e-aws-operator-encryption-kms-serial-ote-2of2
     optional: true
     rerun_command: /test e2e-aws-operator-encryption-kms-serial-ote-2of2
     spec:
@@ -523,8 +523,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build05
     context: ci/prow/e2e-aws-operator-encryption-perf-serial-ote-1of2
     decorate: true
@@ -535,7 +535,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-authentication-operator-master-e2e-aws-operator-encryption-perf-serial-ote-1of2
+    name: pull-ci-openshift-cluster-authentication-operator-main-e2e-aws-operator-encryption-perf-serial-ote-1of2
     optional: true
     rerun_command: /test e2e-aws-operator-encryption-perf-serial-ote-1of2
     spec:
@@ -599,8 +599,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build05
     context: ci/prow/e2e-aws-operator-encryption-perf-serial-ote-2of2
     decorate: true
@@ -611,7 +611,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-authentication-operator-master-e2e-aws-operator-encryption-perf-serial-ote-2of2
+    name: pull-ci-openshift-cluster-authentication-operator-main-e2e-aws-operator-encryption-perf-serial-ote-2of2
     optional: true
     rerun_command: /test e2e-aws-operator-encryption-perf-serial-ote-2of2
     spec:
@@ -675,8 +675,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build05
     context: ci/prow/e2e-aws-operator-encryption-rotation-serial-ote-1of2
     decorate: true
@@ -687,7 +687,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-authentication-operator-master-e2e-aws-operator-encryption-rotation-serial-ote-1of2
+    name: pull-ci-openshift-cluster-authentication-operator-main-e2e-aws-operator-encryption-rotation-serial-ote-1of2
     optional: true
     rerun_command: /test e2e-aws-operator-encryption-rotation-serial-ote-1of2
     spec:
@@ -751,8 +751,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build05
     context: ci/prow/e2e-aws-operator-encryption-rotation-serial-ote-2of2
     decorate: true
@@ -763,7 +763,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-authentication-operator-master-e2e-aws-operator-encryption-rotation-serial-ote-2of2
+    name: pull-ci-openshift-cluster-authentication-operator-main-e2e-aws-operator-encryption-rotation-serial-ote-2of2
     optional: true
     rerun_command: /test e2e-aws-operator-encryption-rotation-serial-ote-2of2
     spec:
@@ -827,8 +827,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build05
     context: ci/prow/e2e-aws-operator-encryption-serial-ote-1of2
     decorate: true
@@ -839,7 +839,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-authentication-operator-master-e2e-aws-operator-encryption-serial-ote-1of2
+    name: pull-ci-openshift-cluster-authentication-operator-main-e2e-aws-operator-encryption-serial-ote-1of2
     optional: true
     rerun_command: /test e2e-aws-operator-encryption-serial-ote-1of2
     spec:
@@ -903,8 +903,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build05
     context: ci/prow/e2e-aws-operator-encryption-serial-ote-2of2
     decorate: true
@@ -915,7 +915,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-authentication-operator-master-e2e-aws-operator-encryption-serial-ote-2of2
+    name: pull-ci-openshift-cluster-authentication-operator-main-e2e-aws-operator-encryption-serial-ote-2of2
     optional: true
     rerun_command: /test e2e-aws-operator-encryption-serial-ote-2of2
     spec:
@@ -979,8 +979,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build05
     context: ci/prow/e2e-aws-operator-parallel-ote
     decorate: true
@@ -989,7 +989,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-authentication-operator-master-e2e-aws-operator-parallel-ote
+    name: pull-ci-openshift-cluster-authentication-operator-main-e2e-aws-operator-parallel-ote
     optional: true
     rerun_command: /test e2e-aws-operator-parallel-ote
     spec:
@@ -1052,8 +1052,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build05
     context: ci/prow/e2e-aws-operator-serial-ote
     decorate: true
@@ -1062,7 +1062,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-authentication-operator-master-e2e-aws-operator-serial-ote
+    name: pull-ci-openshift-cluster-authentication-operator-main-e2e-aws-operator-serial-ote
     optional: true
     rerun_command: /test e2e-aws-operator-serial-ote
     spec:
@@ -1125,8 +1125,8 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build05
     context: ci/prow/e2e-aws-single-node
     decorate: true
@@ -1135,7 +1135,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-3
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-authentication-operator-master-e2e-aws-single-node
+    name: pull-ci-openshift-cluster-authentication-operator-main-e2e-aws-single-node
     optional: true
     rerun_command: /test e2e-aws-single-node
     spec:
@@ -1198,8 +1198,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build04
     context: ci/prow/e2e-console-login
     decorate: true
@@ -1208,7 +1208,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-authentication-operator-master-e2e-console-login
+    name: pull-ci-openshift-cluster-authentication-operator-main-e2e-console-login
     rerun_command: /test e2e-console-login
     spec:
       containers:
@@ -1270,8 +1270,8 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build04
     context: ci/prow/e2e-gcp-operator-encryption-kms
     decorate: true
@@ -1280,7 +1280,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-authentication-operator-master-e2e-gcp-operator-encryption-kms
+    name: pull-ci-openshift-cluster-authentication-operator-main-e2e-gcp-operator-encryption-kms
     optional: true
     rerun_command: /test e2e-gcp-operator-encryption-kms
     run_if_changed: ^(vendor/github.com/openshift/library-go/pkg/operator/encryption)|^(test/e2e-encryption-kms)|^(test/library/encryption)
@@ -1344,8 +1344,8 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build04
     context: ci/prow/e2e-gcp-operator-encryption-perf
     decorate: true
@@ -1354,7 +1354,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-authentication-operator-master-e2e-gcp-operator-encryption-perf
+    name: pull-ci-openshift-cluster-authentication-operator-main-e2e-gcp-operator-encryption-perf
     rerun_command: /test e2e-gcp-operator-encryption-perf
     run_if_changed: ^(vendor/github.com/openshift/library-go/pkg/operator/encryption)|^(test/e2e-encryption-perf)|^(test/library/encryption)
     spec:
@@ -1417,8 +1417,8 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build04
     context: ci/prow/e2e-gcp-operator-encryption-rotation
     decorate: true
@@ -1427,7 +1427,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-authentication-operator-master-e2e-gcp-operator-encryption-rotation
+    name: pull-ci-openshift-cluster-authentication-operator-main-e2e-gcp-operator-encryption-rotation
     rerun_command: /test e2e-gcp-operator-encryption-rotation
     run_if_changed: ^(vendor/github.com/openshift/library-go/pkg/operator/encryption)|^(test/e2e-encryption-rotation)|^(test/library/encryption)
     spec:
@@ -1490,8 +1490,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build04
     context: ci/prow/e2e-oidc
     decorate: true
@@ -1500,7 +1500,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-authentication-operator-master-e2e-oidc
+    name: pull-ci-openshift-cluster-authentication-operator-main-e2e-oidc
     rerun_command: /test e2e-oidc
     spec:
       containers:
@@ -1562,8 +1562,8 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build04
     context: ci/prow/e2e-oidc-techpreview
     decorate: true
@@ -1572,7 +1572,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-authentication-operator-master-e2e-oidc-techpreview
+    name: pull-ci-openshift-cluster-authentication-operator-main-e2e-oidc-techpreview
     rerun_command: /test e2e-oidc-techpreview
     run_if_changed: ^(pkg/controllers/externaloidc)|^(test/e2e-oidc)
     spec:
@@ -1635,8 +1635,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build04
     context: ci/prow/e2e-operator
     decorate: true
@@ -1645,7 +1645,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-authentication-operator-master-e2e-operator
+    name: pull-ci-openshift-cluster-authentication-operator-main-e2e-operator
     rerun_command: /test e2e-operator
     spec:
       containers:
@@ -1707,8 +1707,8 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build04
     context: ci/prow/e2e-operator-encryption
     decorate: true
@@ -1717,7 +1717,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: gcp
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-authentication-operator-master-e2e-operator-encryption
+    name: pull-ci-openshift-cluster-authentication-operator-main-e2e-operator-encryption
     rerun_command: /test e2e-operator-encryption
     run_if_changed: ^(vendor/github.com/openshift/library-go/pkg/operator/encryption)|^(test/e2e-encryption)|^(test/library/encryption)
     spec:
@@ -1780,15 +1780,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build05
     context: ci/prow/images
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-authentication-operator-master-images
+    name: pull-ci-openshift-cluster-authentication-operator-main-images
     rerun_command: /test images
     spec:
       containers:
@@ -1834,8 +1834,8 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build05
     context: ci/prow/okd-scos-e2e-aws-ovn
     decorate: true
@@ -1847,7 +1847,7 @@ presubmits:
       ci-operator.openshift.io/variant: okd-scos
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-authentication-operator-master-okd-scos-e2e-aws-ovn
+    name: pull-ci-openshift-cluster-authentication-operator-main-okd-scos-e2e-aws-ovn
     optional: true
     rerun_command: /test okd-scos-e2e-aws-ovn
     spec:
@@ -1911,8 +1911,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build05
     context: ci/prow/okd-scos-images
     decorate: true
@@ -1922,7 +1922,7 @@ presubmits:
       ci-operator.openshift.io/variant: okd-scos
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-authentication-operator-master-okd-scos-images
+    name: pull-ci-openshift-cluster-authentication-operator-main-okd-scos-images
     rerun_command: /test okd-scos-images
     spec:
       containers:
@@ -1969,15 +1969,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build05
     context: ci/prow/test-operator-integration
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-authentication-operator-master-test-operator-integration
+    name: pull-ci-openshift-cluster-authentication-operator-main-test-operator-integration
     rerun_command: /test test-operator-integration
     spec:
       containers:
@@ -2022,15 +2022,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build05
     context: ci/prow/unit
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-authentication-operator-master-unit
+    name: pull-ci-openshift-cluster-authentication-operator-main-unit
     rerun_command: /test unit
     spec:
       containers:
@@ -2075,15 +2075,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build05
     context: ci/prow/verify
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-authentication-operator-master-verify
+    name: pull-ci-openshift-cluster-authentication-operator-main-verify
     rerun_command: /test verify
     spec:
       containers:
@@ -2128,15 +2128,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build05
     context: ci/prow/verify-bindata
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-authentication-operator-master-verify-bindata
+    name: pull-ci-openshift-cluster-authentication-operator-main-verify-bindata
     rerun_command: /test verify-bindata
     spec:
       containers:
@@ -2181,15 +2181,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: build05
     context: ci/prow/verify-deps
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-authentication-operator-master-verify-deps
+    name: pull-ci-openshift-cluster-authentication-operator-main-verify-deps
     rerun_command: /test verify-deps
     spec:
       containers:


### PR DESCRIPTION
https://github.com/openshift/release/pull/67843 needed to be rebased.

> This PR is in support of renaming the default branch for https://github.com/openshift/cluster-authentication-operator from 'master' to 'main'.
> 
> Unhold this PR only when:
> 
> the default branch for https://github.com/openshift/cluster-authentication-operator has been renamed to 'main'
> You have verified that the CI jobs are working as expected either by running '/pj-rehearse' or by inspection.

/hold