### PR TITLE
Added new tests for 1.21 Results testing

### DIFF
--- a/ci-operator/config/openshift-pipelines/performance/openshift-pipelines-performance-main.yaml
+++ b/ci-operator/config/openshift-pipelines/performance/openshift-pipelines-performance-main.yaml
@@ -14,15 +14,16 @@ images:
       RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
       RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
 
-      # Install tools
-      RUN yum install -y httpd-tools parallel
-      RUN curl -Lso /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.7.1/jq-linux64 && chmod +x /usr/local/bin/jq
-      RUN curl -Lso /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.42.1/yq_linux_amd64 && chmod +x /usr/local/bin/yq
-      RUN curl -Lso /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && chmod +x /usr/local/bin/kubectl
-      RUN curl -L https://github.com/sigstore/cosign/releases/download/v2.2.3/cosign-linux-amd64 -o /usr/local/bin/cosign && chmod +x /usr/local/bin/cosign
-      RUN python3 -m pip install kubernetes
-    from: src
-    to: openshift-pipelines-performance-runner
+    # Install tools
+    RUN yum install -y httpd-tools parallel
+    RUN curl -Lso /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.7.1/jq-linux64 && chmod +x /usr/local/bin/jq
+    RUN curl -Lso /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.42.1/yq_linux_amd64 && chmod +x /usr/local/bin/yq
+    RUN curl -Lso /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && chmod +x /usr/local/bin/kubectl
+    RUN curl -L https://github.com/sigstore/cosign/releases/download/v2.2.3/cosign-linux-amd64 -o /usr/local/bin/cosign && chmod +x /usr/local/bin/cosign
+    RUN python3 -m pip install kubernetes
+    RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && chmod 700 get_helm.sh && ./get_helm.sh && helm version
+  from: src
+  to: openshift-pipelines-performance-runner
 releases:
   latest:
     release:
@@ -2237,6 +2238,60 @@ tests:
       TEST_SCENARIO: cluster-resolver
       TEST_TOTAL: "200"
     workflow: openshift-pipelines-scaling-pipelines
+- always_run: false
+  as: tkn-res-downstream-1-20-s3-locust-2-lsr
+  optional: true
+  steps:
+    cluster_profile: aws-pipelines-performance
+    env:
+      CHAINS_WAIT_TIME: "0"
+      DEPLOYMENT_VERSION: "1.20"
+      INSTALL_RESULTS: "true"
+      LOCUST_DURATION: 8m
+      LOCUST_SPAWN_RATE: "2"
+      LOCUST_USERS: "500"
+      LOCUST_WAIT_TIME: "1800"
+      LOCUST_WORKERS: "30"
+      MUST_GATHER_TIMEOUT: 35m
+      PRUNER_WAIT_TIME: "0"
+      RUN_LOCUST: "true"
+      STORE_LOGS_IN_S3: "true"
+      TEST_BIGBANG_MULTI_STEP__LINE_COUNT: "10"
+      TEST_BIGBANG_MULTI_STEP__STEP_COUNT: "1"
+      TEST_BIGBANG_MULTI_STEP__TASK_COUNT: "1"
+      TEST_CONCURRENT: "30"
+      TEST_NAMESPACE: "5"
+      TEST_SCENARIO: timebased-sign-pruner
+      TOTAL_TIMEOUT: "2700"
+    workflow: openshift-pipelines-scaling-pipelines
+  timeout: 8h0m0s
+- always_run: false
+  as: tkn-res-downstream-1-21-s3-locust-2-lsr
+  optional: true
+  steps:
+    cluster_profile: aws-pipelines-performance
+    env:
+      CHAINS_WAIT_TIME: "0"
+      DEPLOYMENT_VERSION: "1.21"
+      INSTALL_RESULTS: "true"
+      LOCUST_DURATION: 8m
+      LOCUST_SPAWN_RATE: "2"
+      LOCUST_USERS: "500"
+      LOCUST_WAIT_TIME: "1800"
+      LOCUST_WORKERS: "30"
+      MUST_GATHER_TIMEOUT: 35m
+      PRUNER_WAIT_TIME: "0"
+      RUN_LOCUST: "true"
+      STORE_LOGS_IN_S3: "true"
+      TEST_BIGBANG_MULTI_STEP__LINE_COUNT: "10"
+      TEST_BIGBANG_MULTI_STEP__STEP_COUNT: "1"
+      TEST_BIGBANG_MULTI_STEP__TASK_COUNT: "1"
+      TEST_CONCURRENT: "30"
+      TEST_NAMESPACE: "5"
+      TEST_SCENARIO: timebased-sign-pruner
+      TOTAL_TIMEOUT: "2700"
+    workflow: openshift-pipelines-scaling-pipelines
+  timeout: 8h0m0s
 zz_generated_metadata:
   branch: main
   org: openshift-pipelines

--- a/ci-operator/config/openshift-pipelines/performance/openshift-pipelines-performance-main.yaml
+++ b/ci-operator/config/openshift-pipelines/performance/openshift-pipelines-performance-main.yaml
@@ -14,16 +14,16 @@ images:
       RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
       RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
 
-    # Install tools
-    RUN yum install -y httpd-tools parallel
-    RUN curl -Lso /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.7.1/jq-linux64 && chmod +x /usr/local/bin/jq
-    RUN curl -Lso /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.42.1/yq_linux_amd64 && chmod +x /usr/local/bin/yq
-    RUN curl -Lso /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && chmod +x /usr/local/bin/kubectl
-    RUN curl -L https://github.com/sigstore/cosign/releases/download/v2.2.3/cosign-linux-amd64 -o /usr/local/bin/cosign && chmod +x /usr/local/bin/cosign
-    RUN python3 -m pip install kubernetes
-    RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && chmod 700 get_helm.sh && ./get_helm.sh && helm version
-  from: src
-  to: openshift-pipelines-performance-runner
+      # Install tools
+      RUN yum install -y httpd-tools parallel
+      RUN curl -Lso /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.7.1/jq-linux64 && chmod +x /usr/local/bin/jq
+      RUN curl -Lso /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.42.1/yq_linux_amd64 && chmod +x /usr/local/bin/yq
+      RUN curl -Lso /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && chmod +x /usr/local/bin/kubectl
+      RUN curl -L https://github.com/sigstore/cosign/releases/download/v2.2.3/cosign-linux-amd64 -o /usr/local/bin/cosign && chmod +x /usr/local/bin/cosign
+      RUN python3 -m pip install kubernetes
+      RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && chmod 700 get_helm.sh && ./get_helm.sh && helm version
+    from: src
+    to: openshift-pipelines-performance-runner
 releases:
   latest:
     release:
@@ -2245,6 +2245,10 @@ tests:
     cluster_profile: aws-pipelines-performance
     env:
       CHAINS_WAIT_TIME: "0"
+      DEPLOYMENT_RESULTS_WATCHER_DISABLE_STORING_INCOMPLETE_RUNS: "true"
+      DEPLOYMENT_RESULTS_WATCHER_KUBE_API_BURST: "100"
+      DEPLOYMENT_RESULTS_WATCHER_KUBE_API_QPS: "50.0"
+      DEPLOYMENT_RESULTS_WATCHER_THREADINESS: "16"
       DEPLOYMENT_VERSION: "1.20"
       INSTALL_RESULTS: "true"
       LOCUST_DURATION: 8m
@@ -2272,6 +2276,10 @@ tests:
     cluster_profile: aws-pipelines-performance
     env:
       CHAINS_WAIT_TIME: "0"
+      DEPLOYMENT_RESULTS_WATCHER_DISABLE_STORING_INCOMPLETE_RUNS: "true"
+      DEPLOYMENT_RESULTS_WATCHER_KUBE_API_BURST: "100"
+      DEPLOYMENT_RESULTS_WATCHER_KUBE_API_QPS: "50.0"
+      DEPLOYMENT_RESULTS_WATCHER_THREADINESS: "16"
       DEPLOYMENT_VERSION: "1.21"
       INSTALL_RESULTS: "true"
       LOCUST_DURATION: 8m

--- a/ci-operator/jobs/openshift-pipelines/performance/openshift-pipelines-performance-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-pipelines/performance/openshift-pipelines-performance-main-presubmits.yaml
@@ -12519,3 +12519,155 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )scaling-pipelines-upstream-stable,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build07
+    context: ci/prow/tkn-res-downstream-1-20-s3-locust-2-lsr
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+      timeout: 8h0m0s
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: aws-pipelines-performance
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-pipelines-performance-main-tkn-res-downstream-1-20-s3-locust-2-lsr
+    optional: true
+    rerun_command: /test tkn-res-downstream-1-20-s3-locust-2-lsr
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=tkn-res-downstream-1-20-s3-locust-2-lsr
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )tkn-res-downstream-1-20-s3-locust-2-lsr,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build07
+    context: ci/prow/tkn-res-downstream-1-21-s3-locust-2-lsr
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+      timeout: 8h0m0s
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: aws-pipelines-performance
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-pipelines-performance-main-tkn-res-downstream-1-21-s3-locust-2-lsr
+    optional: true
+    rerun_command: /test tkn-res-downstream-1-21-s3-locust-2-lsr
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=tkn-res-downstream-1-21-s3-locust-2-lsr
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )tkn-res-downstream-1-21-s3-locust-2-lsr,?($|\s.*)

--- a/ci-operator/jobs/openshift-pipelines/performance/openshift-pipelines-performance-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-pipelines/performance/openshift-pipelines-performance-main-presubmits.yaml
@@ -12549,9 +12549,17 @@ presubmits:
         - --target=tkn-res-downstream-1-20-s3-locust-2-lsr
         command:
         - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
         imagePullPolicy: Always
         name: ""
+        ports:
+        - containerPort: 8080
+          name: http
         resources:
           requests:
             cpu: 10m
@@ -12625,9 +12633,17 @@ presubmits:
         - --target=tkn-res-downstream-1-21-s3-locust-2-lsr
         command:
         - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
         imagePullPolicy: Always
         name: ""
+        ports:
+        - containerPort: 8080
+          name: http
         resources:
           requests:
             cpu: 10m

--- a/ci-operator/step-registry/openshift-pipelines/scaling-pipelines/openshift-pipelines-scaling-pipelines-commands.sh
+++ b/ci-operator/step-registry/openshift-pipelines/scaling-pipelines/openshift-pipelines-scaling-pipelines-commands.sh
@@ -47,8 +47,10 @@ else
     exit 1
 fi
 
-export AWS_ACCESS_ID AWS_BUCKET_NAME AWS_SECRET_KEY
+export AWS_ACCESS_ID AWS_BUCKET_NAME AWS_SECRET_KEY AWS_ENDPOINT AWS_REGION
 
+AWS_REGION="eu-west-1"
+AWS_ENDPOINT="https://s3.eu-west-1.amazonaws.com"
 AWS_ACCESS_ID="$( cat /usr/local/ci-secrets/openshift-pipelines-scaling-pipelines/aws-access-id )"
 AWS_BUCKET_NAME="$( cat /usr/local/ci-secrets/openshift-pipelines-scaling-pipelines/aws-bucket-name )"
 AWS_SECRET_KEY="$( cat /usr/local/ci-secrets/openshift-pipelines-scaling-pipelines/aws-secret-key )"

--- a/ci-operator/step-registry/openshift-pipelines/scaling-pipelines/openshift-pipelines-scaling-pipelines-ref.yaml
+++ b/ci-operator/step-registry/openshift-pipelines/scaling-pipelines/openshift-pipelines-scaling-pipelines-ref.yaml
@@ -81,6 +81,42 @@ ref:
     - name: PRUNE_PER_RESOURCE
       default: "true"
       documentation: Whether to retain the resources at each pipelinerun and taskrun separately?
+    - name: INSTALL_RESULTS
+      default: "false"
+      documentation: Boolean value which indicates whether to install Tekton Results or not
+    - name: TOTAL_TIMEOUT
+      default: ""
+      documentation: Timeout value indicating when the test should terminate
+    - name: CHAINS_WAIT_TIME
+      default: "0"
+      documentation: Timeout value which represents when to enable Chains in the test
+    - name: PRUNER_WAIT_TIME
+      default: "0"
+      documentation: Timeout value which represents when to enable Pruner in the test
+    - name: STORE_LOGS_IN_S3
+      default: "false"
+      documentation: Boolean value which suggests where to store logs either in PVC or S3
+    - name: DEPLOYMENT_RESULTS_DOWNSTREAM_VERSION
+      default: "1.16"
+      documentation: This represents the version of which Tekton Results will be installed
+    - name: LOCUST_DURATION
+      default: "15m"
+      documentation: Total duration for locust testing for Locus Test
+    - name: LOCUST_USERS
+      default: "100"
+      documentation: Total number of users to spawn for Locus Test
+    - name: LOCUST_SPAWN_RATE
+      default: "10"
+      documentation: Number of users to spawn every second for Locus Test
+    - name: LOCUST_WORKERS
+      default: "5"
+      documentation: Number of Locust worker pods for Locus Test
+    - name: RUN_LOCUST
+      default: "false"
+      documentation: Boolean value which suggests where to run locust or not
+    - name: LOCUST_WAIT_TIME
+      default: "600"
+      documentation: Wait time before starting locust test.
   credentials:
     - mount_path: /usr/local/ci-secrets/openshift-pipelines-scaling-pipelines
       name: openshift-pipelines-perfscale
@@ -90,3 +126,4 @@ ref:
     requests:
       cpu: 3000m
       memory: 6Gi
+      

--- a/ci-operator/step-registry/openshift-pipelines/scaling-pipelines/openshift-pipelines-scaling-pipelines-ref.yaml
+++ b/ci-operator/step-registry/openshift-pipelines/scaling-pipelines/openshift-pipelines-scaling-pipelines-ref.yaml
@@ -99,6 +99,18 @@ ref:
     - name: DEPLOYMENT_RESULTS_DOWNSTREAM_VERSION
       default: "1.16"
       documentation: This represents the version of which Tekton Results will be installed
+    - name: DEPLOYMENT_RESULTS_WATCHER_KUBE_API_QPS
+      default: ""
+      documentation: Set the QPS value for the Tekton Results watcher performance configuration
+    - name: DEPLOYMENT_RESULTS_WATCHER_KUBE_API_BURST
+      default: ""
+      documentation: Set the burst value for the Tekton Results watcher performance configuration
+    - name: DEPLOYMENT_RESULTS_WATCHER_THREADINESS
+      default: ""
+      documentation: Number of threads for the Tekton Results watcher
+    - name: DEPLOYMENT_RESULTS_WATCHER_DISABLE_STORING_INCOMPLETE_RUNS
+      default: ""
+      documentation: When true, disable storing incomplete runs in the Results watcher
     - name: LOCUST_DURATION
       default: "15m"
       documentation: Total duration for locust testing for Locus Test


### PR DESCRIPTION
Added Tekton Results 1.21 Regression tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Helm v3 support to the pipeline runner container image.
  * Introduced scaling performance tests for OpenShift Pipelines versions 1.20 and 1.21.
  * Enabled S3-backed result storage configuration for test pipelines.
  * Added Locust-based performance testing capabilities with configurable parameters.
  * Enhanced Tekton Results configuration options including watcher performance tuning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->