### PR TITLE
kubevirt: vm-console-proxy: update golang version

### DIFF
--- a/ci-operator/config/kubevirt/vm-console-proxy/kubevirt-vm-console-proxy-main.yaml
+++ b/ci-operator/config/kubevirt/vm-console-proxy/kubevirt-vm-console-proxy-main.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: builder
     namespace: ocp
-    tag: rhel-9-golang-1.23-openshift-4.19
+    tag: rhel-9-golang-1.24-openshift-4.21
 images:
 - dockerfile_path: Dockerfile
   to: vm-console-proxy-container


### PR DESCRIPTION
Updated build root container to use golang 1.24