### PR TITLE
add regression tests for descheduler

### DIFF
--- a/ci-operator/config/openshift/svt/openshift-svt-master__regression-aws-4.21-nightly-x86.yaml
+++ b/ci-operator/config/openshift/svt/openshift-svt-master__regression-aws-4.21-nightly-x86.yaml
@@ -1,0 +1,96 @@
+base_images:
+  upi-installer:
+    name: "4.21"
+    namespace: ocp
+    tag: upi-installer
+build_root:
+  image_stream_tag:
+    name: ci-tools-build-root
+    namespace: ci
+    tag: latest
+releases:
+  initial:
+    prerelease:
+      architecture: amd64
+      product: ocp
+      version_bounds:
+        lower: 4.21.0-0
+        upper: 4.22.0-0
+  latest:
+    candidate:
+      product: ocp
+      stream: nightly
+      version: "4.21"
+  target:
+    candidate:
+      architecture: amd64
+      product: ocp
+      stream: nightly
+      version: "4.22"
+resources:
+  '*':
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- always_run: false
+  as: desch-duplicates-profile-ocp-66355
+  steps:
+    allow_skip_on_success: true
+    cluster_profile: aws-perfscale-qe
+    env:
+      BASE_DOMAIN: qe.devcluster.openshift.com
+      COMPUTE_NODE_REPLICAS: "3"
+      COMPUTE_NODE_TYPE: m6i.large
+      CONTROL_PLANE_INSTANCE_TYPE: m5.2xlarge
+      KUBE_BURNER_VERSION: default
+      PARAMETERS: aws
+      SCRIPT: perfscale_regression_ci/scripts/scalability/descheduler/duplicates_profile.sh
+    pre:
+    - ref: openshift-qe-install-kube-descheduler-operator
+    test:
+    - ref: openshift-svt-regression
+    workflow: openshift-qe-installer-aws
+- always_run: false
+  as: desch-node-mem-util-ocp-67198
+  steps:
+    allow_skip_on_success: true
+    cluster_profile: aws-perfscale-qe
+    env:
+      BASE_DOMAIN: qe.devcluster.openshift.com
+      COMPUTE_NODE_REPLICAS: "8"
+      COMPUTE_NODE_TYPE: m6i.large
+      CONTROL_PLANE_INSTANCE_TYPE: m5.2xlarge
+      KUBE_BURNER_VERSION: default
+      PARAMETERS: aws
+      SCRIPT: perfscale_regression_ci/scripts/scalability/descheduler/node_mem_utilization_large.sh
+    pre:
+    - ref: openshift-qe-install-kube-descheduler-operator
+    test:
+    - ref: openshift-svt-regression
+    workflow: openshift-qe-installer-aws
+- always_run: false
+  as: desch-affinity-taint-ocp-66655
+  steps:
+    allow_skip_on_success: true
+    cluster_profile: aws-perfscale-qe
+    env:
+      BASE_DOMAIN: qe.devcluster.openshift.com
+      COMPUTE_NODE_REPLICAS: "3"
+      COMPUTE_NODE_TYPE: m6i.large
+      CONTROL_PLANE_INSTANCE_TYPE: m5.2xlarge
+      KUBE_BURNER_VERSION: default
+      PARAMETERS: aws
+      SCRIPT: perfscale_regression_ci/scripts/scalability/descheduler/affinity_taint.sh
+    pre:
+    - ref: openshift-qe-install-kube-descheduler-operator
+    test:
+    - ref: openshift-svt-regression
+    workflow: openshift-qe-installer-aws
+zz_generated_metadata:
+  branch: master
+  org: openshift
+  repo: svt
+  variant: regression-aws-4.21-nightly-x86

--- a/ci-operator/jobs/openshift/svt/openshift-svt-master-presubmits.yaml
+++ b/ci-operator/jobs/openshift/svt/openshift-svt-master-presubmits.yaml
@@ -2866,6 +2866,261 @@ presubmits:
     - ^master$
     - ^master-
     cluster: build05
+    context: ci/prow/regression-aws-4.21-nightly-x86-desch-affinity-taint-ocp-66655
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+      ci-operator.openshift.io/variant: regression-aws-4.21-nightly-x86
+      ci.openshift.io/generator: prowgen
+      job-release: "4.21"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-svt-master-regression-aws-4.21-nightly-x86-desch-affinity-taint-ocp-66655
+    rerun_command: /test regression-aws-4.21-nightly-x86-desch-affinity-taint-ocp-66655
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=desch-affinity-taint-ocp-66655
+        - --variant=regression-aws-4.21-nightly-x86
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )(regression-aws-4.21-nightly-x86-desch-affinity-taint-ocp-66655|remaining-required),?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^master$
+    - ^master-
+    cluster: build05
+    context: ci/prow/regression-aws-4.21-nightly-x86-desch-duplicates-profile-ocp-66355
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+      ci-operator.openshift.io/variant: regression-aws-4.21-nightly-x86
+      ci.openshift.io/generator: prowgen
+      job-release: "4.21"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-svt-master-regression-aws-4.21-nightly-x86-desch-duplicates-profile-ocp-66355
+    rerun_command: /test regression-aws-4.21-nightly-x86-desch-duplicates-profile-ocp-66355
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=desch-duplicates-profile-ocp-66355
+        - --variant=regression-aws-4.21-nightly-x86
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )(regression-aws-4.21-nightly-x86-desch-duplicates-profile-ocp-66355|remaining-required),?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^master$
+    - ^master-
+    cluster: build05
+    context: ci/prow/regression-aws-4.21-nightly-x86-desch-node-mem-util-ocp-67198
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+      ci-operator.openshift.io/variant: regression-aws-4.21-nightly-x86
+      ci.openshift.io/generator: prowgen
+      job-release: "4.21"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-svt-master-regression-aws-4.21-nightly-x86-desch-node-mem-util-ocp-67198
+    rerun_command: /test regression-aws-4.21-nightly-x86-desch-node-mem-util-ocp-67198
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=desch-node-mem-util-ocp-67198
+        - --variant=regression-aws-4.21-nightly-x86
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )(regression-aws-4.21-nightly-x86-desch-node-mem-util-ocp-67198|remaining-required),?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^master$
+    - ^master-
+    cluster: build05
     context: ci/prow/reliability-v2-aws-4.17-nightly-x86-reliability-v2-1h
     decorate: true
     decoration_config:

--- a/ci-operator/step-registry/openshift-qe/install-kube-descheduler-operator/OWNERS
+++ b/ci-operator/step-registry/openshift-qe/install-kube-descheduler-operator/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- perfscale-ocp-approvers
+reviewers:
+- perfscale-ocp-reviewers

--- a/ci-operator/step-registry/openshift-qe/install-kube-descheduler-operator/openshift-qe-install-kube-descheduler-operator-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/install-kube-descheduler-operator/openshift-qe-install-kube-descheduler-operator-commands.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NAMESPACE="openshift-cluster-kube-descheduler-operator"
+PACKAGE="cluster-kube-descheduler-operator"
+
+echo "Installing ${PACKAGE} via OLM..."
+
+oc create namespace ${NAMESPACE} --dry-run=client -o yaml | oc apply -f -
+
+echo "Checking for ${PACKAGE} in redhat-operators catalog..."
+if ! oc get packagemanifest ${PACKAGE} -n openshift-marketplace >/dev/null 2>&1; then
+  echo "ERROR: ${PACKAGE} package not found in redhat-operators catalog."
+  exit 1
+fi
+
+CHANNEL=$(oc get packagemanifest ${PACKAGE} \
+  -n openshift-marketplace \
+  -o jsonpath='{.status.defaultChannel}')
+
+echo "Using channel: ${CHANNEL}"
+
+cat <<EOF | oc apply -f -
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: ${PACKAGE}
+  namespace: ${NAMESPACE}
+spec:
+  targetNamespaces:
+  - ${NAMESPACE}
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: ${PACKAGE}
+  namespace: ${NAMESPACE}
+spec:
+  channel: ${CHANNEL}
+  name: ${PACKAGE}
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Automatic
+EOF
+
+echo "Waiting for CSV to succeed..."
+oc wait csv \
+  -n ${NAMESPACE} \
+  --all \
+  --for=condition=Succeeded \
+  --timeout=5m
+
+echo "Waiting for operator deployment..."
+DEPLOY_NAME=$(oc get deploy -n ${NAMESPACE} -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+if [[ -z "${DEPLOY_NAME}" ]]; then
+  echo "ERROR: No deployment found in ${NAMESPACE}"
+  exit 1
+fi
+
+oc rollout status deployment/${DEPLOY_NAME} \
+  -n ${NAMESPACE} \
+  --timeout=5m
+
+echo "Verifying descheduler-operator pod exists..."
+oc project ${NAMESPACE}
+
+POD_NAME=$(oc get pods -n ${NAMESPACE} -o jsonpath='{.items[?(@.metadata.name=~"descheduler.*operator")].metadata.name}' 2>/dev/null || echo "")
+if [[ -z "${POD_NAME}" ]]; then
+  echo "WARNING: No pod matching 'descheduler.*operator' pattern found"
+  echo "Available pods:"
+  oc get pods -n ${NAMESPACE}
+  exit 1
+fi
+
+echo "Found pod: ${POD_NAME}"
+oc wait pod/${POD_NAME} \
+  -n ${NAMESPACE} \
+  --for=condition=Ready \
+  --timeout=5m
+
+echo "✅ cluster-kube-descheduler-operator installed successfully"
+echo "✅ Pod ${POD_NAME} is running in namespace ${NAMESPACE}"

--- a/ci-operator/step-registry/openshift-qe/install-kube-descheduler-operator/openshift-qe-install-kube-descheduler-operator-ref.metadata.json
+++ b/ci-operator/step-registry/openshift-qe/install-kube-descheduler-operator/openshift-qe-install-kube-descheduler-operator-ref.metadata.json
@@ -1,0 +1,11 @@
+{
+	"path": "openshift-qe/install-kube-descheduler-operator/openshift-qe-install-kube-descheduler-operator-ref.yaml",
+	"owners": {
+		"approvers": [
+			"perfscale-ocp-approvers"
+		],
+		"reviewers": [
+			"perfscale-ocp-reviewers"
+		]
+	}
+}

--- a/ci-operator/step-registry/openshift-qe/install-kube-descheduler-operator/openshift-qe-install-kube-descheduler-operator-ref.yaml
+++ b/ci-operator/step-registry/openshift-qe/install-kube-descheduler-operator/openshift-qe-install-kube-descheduler-operator-ref.yaml
@@ -1,0 +1,12 @@
+ref:
+  as: openshift-qe-install-kube-descheduler-operator
+  from: cli
+  commands: openshift-qe-install-kube-descheduler-operator-commands.sh
+  resources:
+    requests:
+      cpu: 100m
+      memory: 200Mi
+  timeout: 15m
+  documentation: |-
+    Install the kube-descheduler operator (namespace, operatorgroup, subscription)
+    so that KubeDescheduler CRD and instances can be created before descheduler SVT tests run.


### PR DESCRIPTION
Add prow job to run the below regression tests:
- OCP-66656 Descheduler - Monitor Mem and CPU with AffinityAndTaints Profile Descheduling Pods at scale 
- OCP-67198 Descheduler - Validate Mem and CPU Usage using LifecycleAndUtilization profile 