### PR TITLE
New jobs to run ARO-HCP tests against OCP candidate builds

### DIFF
--- a/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__periodic.yaml
+++ b/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__periodic.yaml
@@ -78,6 +78,54 @@ tests:
       env: LEASED_MSI_CONTAINERS
       resource_type: aro-hcp-test-msi-containers-stg
     workflow: aro-hcp-e2e
+- as: stage-e2e-parallel-ocp-candidate-4-19
+  cron: 0 4 * * 1
+  steps:
+    cluster_profile: aro-hcp-stg
+    env:
+      ARO_HCP_CLOUD: public
+      ARO_HCP_DEPLOY_ENV: stg
+      ARO_HCP_OPENSHIFT_CHANNEL_GROUP: candidate-4.19
+      ARO_HCP_OPENSHIFT_NODEPOOL_CHANNEL_GROUP: candidate-4.19
+      ARO_HCP_SUITE_NAME: stage/parallel
+      LOCATION: uksouth
+    leases:
+    - count: 30
+      env: LEASED_MSI_CONTAINERS
+      resource_type: aro-hcp-test-msi-containers-stg
+    workflow: aro-hcp-e2e
+- as: stage-e2e-parallel-ocp-candidate-4-20
+  cron: 0 5 * * 1
+  steps:
+    cluster_profile: aro-hcp-stg
+    env:
+      ARO_HCP_CLOUD: public
+      ARO_HCP_DEPLOY_ENV: stg
+      ARO_HCP_OPENSHIFT_CHANNEL_GROUP: candidate-4.20
+      ARO_HCP_OPENSHIFT_NODEPOOL_CHANNEL_GROUP: candidate-4.20
+      ARO_HCP_SUITE_NAME: stage/parallel
+      LOCATION: uksouth
+    leases:
+    - count: 30
+      env: LEASED_MSI_CONTAINERS
+      resource_type: aro-hcp-test-msi-containers-stg
+    workflow: aro-hcp-e2e
+- as: stage-e2e-parallel-ocp-candidate-4-21
+  cron: 0 6 * * 1
+  steps:
+    cluster_profile: aro-hcp-stg
+    env:
+      ARO_HCP_CLOUD: public
+      ARO_HCP_DEPLOY_ENV: stg
+      ARO_HCP_OPENSHIFT_CHANNEL_GROUP: candidate-4.21
+      ARO_HCP_OPENSHIFT_NODEPOOL_CHANNEL_GROUP: candidate-4.21
+      ARO_HCP_SUITE_NAME: stage/parallel
+      LOCATION: uksouth
+    leases:
+    - count: 30
+      env: LEASED_MSI_CONTAINERS
+      resource_type: aro-hcp-test-msi-containers-stg
+    workflow: aro-hcp-e2e
 - as: prod-e2e-parallel
   cron: 0 2 * * *
   steps:

--- a/ci-operator/jobs/Azure/ARO-HCP/Azure-ARO-HCP-main-periodics.yaml
+++ b/ci-operator/jobs/Azure/ARO-HCP/Azure-ARO-HCP-main-periodics.yaml
@@ -774,3 +774,249 @@ periodics:
     - name: result-aggregator
       secret:
         secretName: result-aggregator
+- agent: kubernetes
+  cluster: build10
+  cron: 0 4 * * 1
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: Azure
+    repo: ARO-HCP
+  labels:
+    ci-operator.openshift.io/cloud: aro-hcp-stg
+    ci-operator.openshift.io/cloud-cluster-profile: aro-hcp-stg
+    ci-operator.openshift.io/variant: periodic
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-Azure-ARO-HCP-main-periodic-stage-e2e-parallel-ocp-candidate-4-19
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=stage-e2e-parallel-ocp-candidate-4-19
+      - --variant=periodic
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build10
+  cron: 0 5 * * 1
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: Azure
+    repo: ARO-HCP
+  labels:
+    ci-operator.openshift.io/cloud: aro-hcp-stg
+    ci-operator.openshift.io/cloud-cluster-profile: aro-hcp-stg
+    ci-operator.openshift.io/variant: periodic
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-Azure-ARO-HCP-main-periodic-stage-e2e-parallel-ocp-candidate-4-20
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=stage-e2e-parallel-ocp-candidate-4-20
+      - --variant=periodic
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build10
+  cron: 0 6 * * 1
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: Azure
+    repo: ARO-HCP
+  labels:
+    ci-operator.openshift.io/cloud: aro-hcp-stg
+    ci-operator.openshift.io/cloud-cluster-profile: aro-hcp-stg
+    ci-operator.openshift.io/variant: periodic
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-Azure-ARO-HCP-main-periodic-stage-e2e-parallel-ocp-candidate-4-21
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=stage-e2e-parallel-ocp-candidate-4-21
+      - --variant=periodic
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator

--- a/ci-operator/step-registry/aro-hcp/test/persistent/aro-hcp-test-persistent-commands.sh
+++ b/ci-operator/step-registry/aro-hcp/test/persistent/aro-hcp-test-persistent-commands.sh
@@ -18,4 +18,24 @@ if [[ -n "${MULTISTAGE_PARAM_OVERRIDE_LOCATION:-}" ]]; then
   export LOCATION="${MULTISTAGE_PARAM_OVERRIDE_LOCATION}"
 fi
 
+if [[ "${ARO_HCP_OPENSHIFT_CHANNEL_GROUP:-}"  =~ "candidate-" ]]; then
+  candidate_version="$(
+    curl -s "https://api.openshift.com/api/upgrades_info/v1/graph?channel=${ARO_HCP_OPENSHIFT_CHANNEL_GROUP}" \
+      | jq -r '.nodes[].version' \
+      | sort -V \
+      | tail -n1
+  )"
+
+  if [[ -z "${candidate_version}" || "${candidate_version}" == "null" ]]; then
+    echo "Failed to resolve ${ARO_HCP_OPENSHIFT_CHANNEL_GROUP} version from upgrades info graph." >&2
+    exit 1
+  fi
+
+  export ARO_HCP_OPENSHIFT_CONTROLPLANE_VERSION="${candidate_version}"
+  export ARO_HCP_OPENSHIFT_NODEPOOL_VERSION="${candidate_version}"
+  # Channel group name is just "candidate", with no version number, so we need to set it back to "candidate"
+  export ARO_HCP_OPENSHIFT_CHANNEL_GROUP="candidate"
+  export ARO_HCP_OPENSHIFT_NODEPOOL_CHANNEL_GROUP="candidate"
+fi
+
 ./test/aro-hcp-tests run-suite "${ARO_HCP_SUITE_NAME}" --junit-path="${ARTIFACT_DIR}/junit.xml" --html-path="${ARTIFACT_DIR}/extension-test-result-summary.html" --max-concurrency 100

--- a/ci-operator/step-registry/aro-hcp/test/persistent/aro-hcp-test-persistent-ref.yaml
+++ b/ci-operator/step-registry/aro-hcp/test/persistent/aro-hcp-test-persistent-ref.yaml
@@ -32,6 +32,12 @@ ref:
     - name: ARO_E2E_SKIP_CLEANUP
       default: ""
       documentation: Set to true to skip cleanup.  This can leave lot of cruft, so be responsible.
+    - name: ARO_HCP_OPENSHIFT_CHANNEL_GROUP 
+      default: ""
+      documentation: Set to "candidate" to resolve the latest candidate version for ARO HCP tests.
+    - name: ARO_HCP_OPENSHIFT_NODEPOOL_CHANNEL_GROUP
+      default: ""
+      documentation: Set to "candidate" to resolve the latest candidate version for ARO HCP nodepool tests.
     - name: POOLED_IDENTITIES
       default: "true"
       documentation: Whether to use pooled identities for the test.


### PR DESCRIPTION
These jobs will run the ARO-HCP E2E test suite using the latest candidate build of OCP in the Y stream. Currently: 4.19, 4.20 and 4.21.

Thes job are scheduled to run once a week.