### PR TITLE
OSASINFRA-4129: Move openstack-singlestackv6 jobs from hwofflowad to vexxhost cloud

### DIFF
--- a/ci-operator/config/openshift-priv/installer/openshift-priv-installer-main.yaml
+++ b/ci-operator/config/openshift-priv/installer/openshift-priv-installer-main.yaml
@@ -876,7 +876,7 @@ tests:
   as: e2e-openstack-singlestackv6
   optional: true
   steps:
-    cluster_profile: openstack-hwoffload
+    cluster_profile: openstack-vexxhost
     workflow: openshift-e2e-openstack-singlestackv6
 - always_run: false
   as: e2e-openstack-proxy

--- a/ci-operator/config/openshift-priv/installer/openshift-priv-installer-release-4.18.yaml
+++ b/ci-operator/config/openshift-priv/installer/openshift-priv-installer-release-4.18.yaml
@@ -560,7 +560,7 @@ tests:
   as: e2e-openstack-singlestackv6
   optional: true
   steps:
-    cluster_profile: openstack-hwoffload
+    cluster_profile: openstack-vexxhost
     workflow: openshift-e2e-openstack-singlestackv6
 - always_run: false
   as: e2e-openstack-proxy

--- a/ci-operator/config/openshift-priv/installer/openshift-priv-installer-release-4.19.yaml
+++ b/ci-operator/config/openshift-priv/installer/openshift-priv-installer-release-4.19.yaml
@@ -664,7 +664,7 @@ tests:
   as: e2e-openstack-singlestackv6
   optional: true
   steps:
-    cluster_profile: openstack-hwoffload
+    cluster_profile: openstack-vexxhost
     workflow: openshift-e2e-openstack-singlestackv6
 - always_run: false
   as: e2e-openstack-proxy

--- a/ci-operator/config/openshift-priv/installer/openshift-priv-installer-release-4.20.yaml
+++ b/ci-operator/config/openshift-priv/installer/openshift-priv-installer-release-4.20.yaml
@@ -715,7 +715,7 @@ tests:
   as: e2e-openstack-singlestackv6
   optional: true
   steps:
-    cluster_profile: openstack-hwoffload
+    cluster_profile: openstack-vexxhost
     workflow: openshift-e2e-openstack-singlestackv6
 - always_run: false
   as: e2e-openstack-proxy

--- a/ci-operator/config/openshift-priv/installer/openshift-priv-installer-release-4.21.yaml
+++ b/ci-operator/config/openshift-priv/installer/openshift-priv-installer-release-4.21.yaml
@@ -752,7 +752,7 @@ tests:
   as: e2e-openstack-singlestackv6
   optional: true
   steps:
-    cluster_profile: openstack-hwoffload
+    cluster_profile: openstack-vexxhost
     workflow: openshift-e2e-openstack-singlestackv6
 - always_run: false
   as: e2e-openstack-proxy

--- a/ci-operator/config/openshift-priv/installer/openshift-priv-installer-release-4.22.yaml
+++ b/ci-operator/config/openshift-priv/installer/openshift-priv-installer-release-4.22.yaml
@@ -876,7 +876,7 @@ tests:
   as: e2e-openstack-singlestackv6
   optional: true
   steps:
-    cluster_profile: openstack-hwoffload
+    cluster_profile: openstack-vexxhost
     workflow: openshift-e2e-openstack-singlestackv6
 - always_run: false
   as: e2e-openstack-proxy

--- a/ci-operator/config/openshift-priv/installer/openshift-priv-installer-release-4.23.yaml
+++ b/ci-operator/config/openshift-priv/installer/openshift-priv-installer-release-4.23.yaml
@@ -876,7 +876,7 @@ tests:
   as: e2e-openstack-singlestackv6
   optional: true
   steps:
-    cluster_profile: openstack-hwoffload
+    cluster_profile: openstack-vexxhost
     workflow: openshift-e2e-openstack-singlestackv6
 - always_run: false
   as: e2e-openstack-proxy

--- a/ci-operator/config/openshift-priv/installer/openshift-priv-installer-release-5.0.yaml
+++ b/ci-operator/config/openshift-priv/installer/openshift-priv-installer-release-5.0.yaml
@@ -877,7 +877,7 @@ tests:
   as: e2e-openstack-singlestackv6
   optional: true
   steps:
-    cluster_profile: openstack-hwoffload
+    cluster_profile: openstack-vexxhost
     workflow: openshift-e2e-openstack-singlestackv6
 - always_run: false
   as: e2e-openstack-proxy

--- a/ci-operator/config/openshift-priv/installer/openshift-priv-installer-release-5.1.yaml
+++ b/ci-operator/config/openshift-priv/installer/openshift-priv-installer-release-5.1.yaml
@@ -876,7 +876,7 @@ tests:
   as: e2e-openstack-singlestackv6
   optional: true
   steps:
-    cluster_profile: openstack-hwoffload
+    cluster_profile: openstack-vexxhost
     workflow: openshift-e2e-openstack-singlestackv6
 - always_run: false
   as: e2e-openstack-proxy

--- a/ci-operator/config/openshift-priv/machine-config-operator/openshift-priv-machine-config-operator-main.yaml
+++ b/ci-operator/config/openshift-priv/machine-config-operator/openshift-priv-machine-config-operator-main.yaml
@@ -564,7 +564,7 @@ tests:
   as: e2e-openstack-singlestackv6
   optional: true
   steps:
-    cluster_profile: openstack-hwoffload
+    cluster_profile: openstack-vexxhost
     workflow: openshift-e2e-openstack-singlestackv6
 - always_run: false
   as: e2e-openstack-hypershift

--- a/ci-operator/config/openshift-priv/machine-config-operator/openshift-priv-machine-config-operator-release-4.18.yaml
+++ b/ci-operator/config/openshift-priv/machine-config-operator/openshift-priv-machine-config-operator-release-4.18.yaml
@@ -454,7 +454,7 @@ tests:
   as: e2e-openstack-singlestackv6
   optional: true
   steps:
-    cluster_profile: openstack-hwoffload
+    cluster_profile: openstack-vexxhost
     workflow: openshift-e2e-openstack-singlestackv6
 - always_run: false
   as: e2e-openstack-hypershift

--- a/ci-operator/config/openshift-priv/machine-config-operator/openshift-priv-machine-config-operator-release-4.19.yaml
+++ b/ci-operator/config/openshift-priv/machine-config-operator/openshift-priv-machine-config-operator-release-4.19.yaml
@@ -482,7 +482,7 @@ tests:
   as: e2e-openstack-singlestackv6
   optional: true
   steps:
-    cluster_profile: openstack-hwoffload
+    cluster_profile: openstack-vexxhost
     workflow: openshift-e2e-openstack-singlestackv6
 - always_run: false
   as: e2e-openstack-hypershift

--- a/ci-operator/config/openshift-priv/machine-config-operator/openshift-priv-machine-config-operator-release-4.20.yaml
+++ b/ci-operator/config/openshift-priv/machine-config-operator/openshift-priv-machine-config-operator-release-4.20.yaml
@@ -536,7 +536,7 @@ tests:
   as: e2e-openstack-singlestackv6
   optional: true
   steps:
-    cluster_profile: openstack-hwoffload
+    cluster_profile: openstack-vexxhost
     workflow: openshift-e2e-openstack-singlestackv6
 - always_run: false
   as: e2e-openstack-hypershift

--- a/ci-operator/config/openshift-priv/machine-config-operator/openshift-priv-machine-config-operator-release-4.21.yaml
+++ b/ci-operator/config/openshift-priv/machine-config-operator/openshift-priv-machine-config-operator-release-4.21.yaml
@@ -551,7 +551,7 @@ tests:
   as: e2e-openstack-singlestackv6
   optional: true
   steps:
-    cluster_profile: openstack-hwoffload
+    cluster_profile: openstack-vexxhost
     workflow: openshift-e2e-openstack-singlestackv6
 - always_run: false
   as: e2e-openstack-hypershift

--- a/ci-operator/config/openshift-priv/machine-config-operator/openshift-priv-machine-config-operator-release-4.22.yaml
+++ b/ci-operator/config/openshift-priv/machine-config-operator/openshift-priv-machine-config-operator-release-4.22.yaml
@@ -581,7 +581,7 @@ tests:
   as: e2e-openstack-singlestackv6
   optional: true
   steps:
-    cluster_profile: openstack-hwoffload
+    cluster_profile: openstack-vexxhost
     workflow: openshift-e2e-openstack-singlestackv6
 - always_run: false
   as: e2e-openstack-hypershift

--- a/ci-operator/config/openshift-priv/machine-config-operator/openshift-priv-machine-config-operator-release-4.23.yaml
+++ b/ci-operator/config/openshift-priv/machine-config-operator/openshift-priv-machine-config-operator-release-4.23.yaml
@@ -564,7 +564,7 @@ tests:
   as: e2e-openstack-singlestackv6
   optional: true
   steps:
-    cluster_profile: openstack-hwoffload
+    cluster_profile: openstack-vexxhost
     workflow: openshift-e2e-openstack-singlestackv6
 - always_run: false
   as: e2e-openstack-hypershift

--- a/ci-operator/config/openshift-priv/machine-config-operator/openshift-priv-machine-config-operator-release-5.0.yaml
+++ b/ci-operator/config/openshift-priv/machine-config-operator/openshift-priv-machine-config-operator-release-5.0.yaml
@@ -565,7 +565,7 @@ tests:
   as: e2e-openstack-singlestackv6
   optional: true
   steps:
-    cluster_profile: openstack-hwoffload
+    cluster_profile: openstack-vexxhost
     workflow: openshift-e2e-openstack-singlestackv6
 - always_run: false
   as: e2e-openstack-hypershift

--- a/ci-operator/config/openshift-priv/machine-config-operator/openshift-priv-machine-config-operator-release-5.1.yaml
+++ b/ci-operator/config/openshift-priv/machine-config-operator/openshift-priv-machine-config-operator-release-5.1.yaml
@@ -564,7 +564,7 @@ tests:
   as: e2e-openstack-singlestackv6
   optional: true
   steps:
-    cluster_profile: openstack-hwoffload
+    cluster_profile: openstack-vexxhost
     workflow: openshift-e2e-openstack-singlestackv6
 - always_run: false
   as: e2e-openstack-hypershift

--- a/ci-operator/config/openshift/installer/openshift-installer-main.yaml
+++ b/ci-operator/config/openshift/installer/openshift-installer-main.yaml
@@ -873,7 +873,7 @@ tests:
   as: e2e-openstack-singlestackv6
   optional: true
   steps:
-    cluster_profile: openstack-hwoffload
+    cluster_profile: openstack-vexxhost
     workflow: openshift-e2e-openstack-singlestackv6
 - always_run: false
   as: e2e-openstack-proxy

--- a/ci-operator/config/openshift/installer/openshift-installer-release-4.18.yaml
+++ b/ci-operator/config/openshift/installer/openshift-installer-release-4.18.yaml
@@ -557,7 +557,7 @@ tests:
   as: e2e-openstack-singlestackv6
   optional: true
   steps:
-    cluster_profile: openstack-hwoffload
+    cluster_profile: openstack-vexxhost
     workflow: openshift-e2e-openstack-singlestackv6
 - always_run: false
   as: e2e-openstack-proxy

--- a/ci-operator/config/openshift/installer/openshift-installer-release-4.19.yaml
+++ b/ci-operator/config/openshift/installer/openshift-installer-release-4.19.yaml
@@ -661,7 +661,7 @@ tests:
   as: e2e-openstack-singlestackv6
   optional: true
   steps:
-    cluster_profile: openstack-hwoffload
+    cluster_profile: openstack-vexxhost
     workflow: openshift-e2e-openstack-singlestackv6
 - always_run: false
   as: e2e-openstack-proxy

--- a/ci-operator/config/openshift/installer/openshift-installer-release-4.20.yaml
+++ b/ci-operator/config/openshift/installer/openshift-installer-release-4.20.yaml
@@ -712,7 +712,7 @@ tests:
   as: e2e-openstack-singlestackv6
   optional: true
   steps:
-    cluster_profile: openstack-hwoffload
+    cluster_profile: openstack-vexxhost
     workflow: openshift-e2e-openstack-singlestackv6
 - always_run: false
   as: e2e-openstack-proxy

--- a/ci-operator/config/openshift/installer/openshift-installer-release-4.21.yaml
+++ b/ci-operator/config/openshift/installer/openshift-installer-release-4.21.yaml
@@ -749,7 +749,7 @@ tests:
   as: e2e-openstack-singlestackv6
   optional: true
   steps:
-    cluster_profile: openstack-hwoffload
+    cluster_profile: openstack-vexxhost
     workflow: openshift-e2e-openstack-singlestackv6
 - always_run: false
   as: e2e-openstack-proxy

--- a/ci-operator/config/openshift/installer/openshift-installer-release-4.22.yaml
+++ b/ci-operator/config/openshift/installer/openshift-installer-release-4.22.yaml
@@ -873,7 +873,7 @@ tests:
   as: e2e-openstack-singlestackv6
   optional: true
   steps:
-    cluster_profile: openstack-hwoffload
+    cluster_profile: openstack-vexxhost
     workflow: openshift-e2e-openstack-singlestackv6
 - always_run: false
   as: e2e-openstack-proxy

--- a/ci-operator/config/openshift/installer/openshift-installer-release-4.23.yaml
+++ b/ci-operator/config/openshift/installer/openshift-installer-release-4.23.yaml
@@ -873,7 +873,7 @@ tests:
   as: e2e-openstack-singlestackv6
   optional: true
   steps:
-    cluster_profile: openstack-hwoffload
+    cluster_profile: openstack-vexxhost
     workflow: openshift-e2e-openstack-singlestackv6
 - always_run: false
   as: e2e-openstack-proxy

--- a/ci-operator/config/openshift/installer/openshift-installer-release-5.0.yaml
+++ b/ci-operator/config/openshift/installer/openshift-installer-release-5.0.yaml
@@ -874,7 +874,7 @@ tests:
   as: e2e-openstack-singlestackv6
   optional: true
   steps:
-    cluster_profile: openstack-hwoffload
+    cluster_profile: openstack-vexxhost
     workflow: openshift-e2e-openstack-singlestackv6
 - always_run: false
   as: e2e-openstack-proxy

--- a/ci-operator/config/openshift/installer/openshift-installer-release-5.1.yaml
+++ b/ci-operator/config/openshift/installer/openshift-installer-release-5.1.yaml
@@ -873,7 +873,7 @@ tests:
   as: e2e-openstack-singlestackv6
   optional: true
   steps:
-    cluster_profile: openstack-hwoffload
+    cluster_profile: openstack-vexxhost
     workflow: openshift-e2e-openstack-singlestackv6
 - always_run: false
   as: e2e-openstack-proxy

--- a/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-main.yaml
+++ b/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-main.yaml
@@ -561,7 +561,7 @@ tests:
   as: e2e-openstack-singlestackv6
   optional: true
   steps:
-    cluster_profile: openstack-hwoffload
+    cluster_profile: openstack-vexxhost
     workflow: openshift-e2e-openstack-singlestackv6
 - always_run: false
   as: e2e-openstack-hypershift

--- a/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-4.18.yaml
+++ b/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-4.18.yaml
@@ -451,7 +451,7 @@ tests:
   as: e2e-openstack-singlestackv6
   optional: true
   steps:
-    cluster_profile: openstack-hwoffload
+    cluster_profile: openstack-vexxhost
     workflow: openshift-e2e-openstack-singlestackv6
 - always_run: false
   as: e2e-openstack-hypershift

--- a/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-4.19.yaml
+++ b/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-4.19.yaml
@@ -479,7 +479,7 @@ tests:
   as: e2e-openstack-singlestackv6
   optional: true
   steps:
-    cluster_profile: openstack-hwoffload
+    cluster_profile: openstack-vexxhost
     workflow: openshift-e2e-openstack-singlestackv6
 - always_run: false
   as: e2e-openstack-hypershift

--- a/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-4.20.yaml
+++ b/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-4.20.yaml
@@ -533,7 +533,7 @@ tests:
   as: e2e-openstack-singlestackv6
   optional: true
   steps:
-    cluster_profile: openstack-hwoffload
+    cluster_profile: openstack-vexxhost
     workflow: openshift-e2e-openstack-singlestackv6
 - always_run: false
   as: e2e-openstack-hypershift

--- a/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-4.21.yaml
+++ b/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-4.21.yaml
@@ -548,7 +548,7 @@ tests:
   as: e2e-openstack-singlestackv6
   optional: true
   steps:
-    cluster_profile: openstack-hwoffload
+    cluster_profile: openstack-vexxhost
     workflow: openshift-e2e-openstack-singlestackv6
 - always_run: false
   as: e2e-openstack-hypershift

--- a/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-4.22.yaml
+++ b/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-4.22.yaml
@@ -578,7 +578,7 @@ tests:
   as: e2e-openstack-singlestackv6
   optional: true
   steps:
-    cluster_profile: openstack-hwoffload
+    cluster_profile: openstack-vexxhost
     workflow: openshift-e2e-openstack-singlestackv6
 - always_run: false
   as: e2e-openstack-hypershift

--- a/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-4.23.yaml
+++ b/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-4.23.yaml
@@ -561,7 +561,7 @@ tests:
   as: e2e-openstack-singlestackv6
   optional: true
   steps:
-    cluster_profile: openstack-hwoffload
+    cluster_profile: openstack-vexxhost
     workflow: openshift-e2e-openstack-singlestackv6
 - always_run: false
   as: e2e-openstack-hypershift

--- a/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-5.0.yaml
+++ b/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-5.0.yaml
@@ -562,7 +562,7 @@ tests:
   as: e2e-openstack-singlestackv6
   optional: true
   steps:
-    cluster_profile: openstack-hwoffload
+    cluster_profile: openstack-vexxhost
     workflow: openshift-e2e-openstack-singlestackv6
 - always_run: false
   as: e2e-openstack-hypershift

--- a/ci-operator/jobs/openshift-priv/installer/openshift-priv-installer-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/installer/openshift-priv-installer-main-presubmits.yaml
@@ -8983,8 +8983,8 @@ presubmits:
         name: github-credentials-openshift-ci-robot-private-git-cloner
     hidden: true
     labels:
-      ci-operator.openshift.io/cloud: openstack-hwoffload
-      ci-operator.openshift.io/cloud-cluster-profile: openstack-hwoffload
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-priv-installer-main-e2e-openstack-singlestackv6

--- a/ci-operator/jobs/openshift-priv/installer/openshift-priv-installer-release-4.18-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/installer/openshift-priv-installer-release-4.18-presubmits.yaml
@@ -9346,8 +9346,8 @@ presubmits:
         name: github-credentials-openshift-ci-robot-private-git-cloner
     hidden: true
     labels:
-      ci-operator.openshift.io/cloud: openstack-hwoffload
-      ci-operator.openshift.io/cloud-cluster-profile: openstack-hwoffload
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-priv-installer-release-4.18-e2e-openstack-singlestackv6

--- a/ci-operator/jobs/openshift-priv/installer/openshift-priv-installer-release-4.19-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/installer/openshift-priv-installer-release-4.19-presubmits.yaml
@@ -6768,8 +6768,8 @@ presubmits:
         name: github-credentials-openshift-ci-robot-private-git-cloner
     hidden: true
     labels:
-      ci-operator.openshift.io/cloud: openstack-hwoffload
-      ci-operator.openshift.io/cloud-cluster-profile: openstack-hwoffload
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-priv-installer-release-4.19-e2e-openstack-singlestackv6

--- a/ci-operator/jobs/openshift-priv/installer/openshift-priv-installer-release-4.20-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/installer/openshift-priv-installer-release-4.20-presubmits.yaml
@@ -7336,8 +7336,8 @@ presubmits:
         name: github-credentials-openshift-ci-robot-private-git-cloner
     hidden: true
     labels:
-      ci-operator.openshift.io/cloud: openstack-hwoffload
-      ci-operator.openshift.io/cloud-cluster-profile: openstack-hwoffload
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-priv-installer-release-4.20-e2e-openstack-singlestackv6

--- a/ci-operator/jobs/openshift-priv/installer/openshift-priv-installer-release-4.21-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/installer/openshift-priv-installer-release-4.21-presubmits.yaml
@@ -7518,8 +7518,8 @@ presubmits:
         name: github-credentials-openshift-ci-robot-private-git-cloner
     hidden: true
     labels:
-      ci-operator.openshift.io/cloud: openstack-hwoffload
-      ci-operator.openshift.io/cloud-cluster-profile: openstack-hwoffload
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-priv-installer-release-4.21-e2e-openstack-singlestackv6

--- a/ci-operator/jobs/openshift-priv/installer/openshift-priv-installer-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/installer/openshift-priv-installer-release-4.22-presubmits.yaml
@@ -8704,8 +8704,8 @@ presubmits:
         name: github-credentials-openshift-ci-robot-private-git-cloner
     hidden: true
     labels:
-      ci-operator.openshift.io/cloud: openstack-hwoffload
-      ci-operator.openshift.io/cloud-cluster-profile: openstack-hwoffload
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-priv-installer-release-4.22-e2e-openstack-singlestackv6

--- a/ci-operator/jobs/openshift-priv/installer/openshift-priv-installer-release-4.23-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/installer/openshift-priv-installer-release-4.23-presubmits.yaml
@@ -8983,8 +8983,8 @@ presubmits:
         name: github-credentials-openshift-ci-robot-private-git-cloner
     hidden: true
     labels:
-      ci-operator.openshift.io/cloud: openstack-hwoffload
-      ci-operator.openshift.io/cloud-cluster-profile: openstack-hwoffload
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-priv-installer-release-4.23-e2e-openstack-singlestackv6

--- a/ci-operator/jobs/openshift-priv/installer/openshift-priv-installer-release-5.0-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/installer/openshift-priv-installer-release-5.0-presubmits.yaml
@@ -8983,8 +8983,8 @@ presubmits:
         name: github-credentials-openshift-ci-robot-private-git-cloner
     hidden: true
     labels:
-      ci-operator.openshift.io/cloud: openstack-hwoffload
-      ci-operator.openshift.io/cloud-cluster-profile: openstack-hwoffload
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-priv-installer-release-5.0-e2e-openstack-singlestackv6

--- a/ci-operator/jobs/openshift-priv/installer/openshift-priv-installer-release-5.1-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/installer/openshift-priv-installer-release-5.1-presubmits.yaml
@@ -8983,8 +8983,8 @@ presubmits:
         name: github-credentials-openshift-ci-robot-private-git-cloner
     hidden: true
     labels:
-      ci-operator.openshift.io/cloud: openstack-hwoffload
-      ci-operator.openshift.io/cloud-cluster-profile: openstack-hwoffload
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-priv-installer-release-5.1-e2e-openstack-singlestackv6

--- a/ci-operator/jobs/openshift-priv/machine-config-operator/openshift-priv-machine-config-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/machine-config-operator/openshift-priv-machine-config-operator-main-presubmits.yaml
@@ -4649,8 +4649,8 @@ presubmits:
         name: github-credentials-openshift-ci-robot-private-git-cloner
     hidden: true
     labels:
-      ci-operator.openshift.io/cloud: openstack-hwoffload
-      ci-operator.openshift.io/cloud-cluster-profile: openstack-hwoffload
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-priv-machine-config-operator-main-e2e-openstack-singlestackv6

--- a/ci-operator/jobs/openshift-priv/machine-config-operator/openshift-priv-machine-config-operator-release-4.18-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/machine-config-operator/openshift-priv-machine-config-operator-release-4.18-presubmits.yaml
@@ -3190,8 +3190,8 @@ presubmits:
         name: github-credentials-openshift-ci-robot-private-git-cloner
     hidden: true
     labels:
-      ci-operator.openshift.io/cloud: openstack-hwoffload
-      ci-operator.openshift.io/cloud-cluster-profile: openstack-hwoffload
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-priv-machine-config-operator-release-4.18-e2e-openstack-singlestackv6

--- a/ci-operator/jobs/openshift-priv/machine-config-operator/openshift-priv-machine-config-operator-release-4.19-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/machine-config-operator/openshift-priv-machine-config-operator-release-4.19-presubmits.yaml
@@ -3828,8 +3828,8 @@ presubmits:
         name: github-credentials-openshift-ci-robot-private-git-cloner
     hidden: true
     labels:
-      ci-operator.openshift.io/cloud: openstack-hwoffload
-      ci-operator.openshift.io/cloud-cluster-profile: openstack-hwoffload
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-priv-machine-config-operator-release-4.19-e2e-openstack-singlestackv6

--- a/ci-operator/jobs/openshift-priv/machine-config-operator/openshift-priv-machine-config-operator-release-4.20-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/machine-config-operator/openshift-priv-machine-config-operator-release-4.20-presubmits.yaml
@@ -4377,8 +4377,8 @@ presubmits:
         name: github-credentials-openshift-ci-robot-private-git-cloner
     hidden: true
     labels:
-      ci-operator.openshift.io/cloud: openstack-hwoffload
-      ci-operator.openshift.io/cloud-cluster-profile: openstack-hwoffload
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-priv-machine-config-operator-release-4.20-e2e-openstack-singlestackv6

--- a/ci-operator/jobs/openshift-priv/machine-config-operator/openshift-priv-machine-config-operator-release-4.21-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/machine-config-operator/openshift-priv-machine-config-operator-release-4.21-presubmits.yaml
@@ -4559,8 +4559,8 @@ presubmits:
         name: github-credentials-openshift-ci-robot-private-git-cloner
     hidden: true
     labels:
-      ci-operator.openshift.io/cloud: openstack-hwoffload
-      ci-operator.openshift.io/cloud-cluster-profile: openstack-hwoffload
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-priv-machine-config-operator-release-4.21-e2e-openstack-singlestackv6

--- a/ci-operator/jobs/openshift-priv/machine-config-operator/openshift-priv-machine-config-operator-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/machine-config-operator/openshift-priv-machine-config-operator-release-4.22-presubmits.yaml
@@ -4743,8 +4743,8 @@ presubmits:
         name: github-credentials-openshift-ci-robot-private-git-cloner
     hidden: true
     labels:
-      ci-operator.openshift.io/cloud: openstack-hwoffload
-      ci-operator.openshift.io/cloud-cluster-profile: openstack-hwoffload
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-priv-machine-config-operator-release-4.22-e2e-openstack-singlestackv6

--- a/ci-operator/jobs/openshift-priv/machine-config-operator/openshift-priv-machine-config-operator-release-4.23-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/machine-config-operator/openshift-priv-machine-config-operator-release-4.23-presubmits.yaml
@@ -4649,8 +4649,8 @@ presubmits:
         name: github-credentials-openshift-ci-robot-private-git-cloner
     hidden: true
     labels:
-      ci-operator.openshift.io/cloud: openstack-hwoffload
-      ci-operator.openshift.io/cloud-cluster-profile: openstack-hwoffload
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-priv-machine-config-operator-release-4.23-e2e-openstack-singlestackv6

--- a/ci-operator/jobs/openshift-priv/machine-config-operator/openshift-priv-machine-config-operator-release-5.0-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/machine-config-operator/openshift-priv-machine-config-operator-release-5.0-presubmits.yaml
@@ -4649,8 +4649,8 @@ presubmits:
         name: github-credentials-openshift-ci-robot-private-git-cloner
     hidden: true
     labels:
-      ci-operator.openshift.io/cloud: openstack-hwoffload
-      ci-operator.openshift.io/cloud-cluster-profile: openstack-hwoffload
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-priv-machine-config-operator-release-5.0-e2e-openstack-singlestackv6

--- a/ci-operator/jobs/openshift-priv/machine-config-operator/openshift-priv-machine-config-operator-release-5.1-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/machine-config-operator/openshift-priv-machine-config-operator-release-5.1-presubmits.yaml
@@ -4649,8 +4649,8 @@ presubmits:
         name: github-credentials-openshift-ci-robot-private-git-cloner
     hidden: true
     labels:
-      ci-operator.openshift.io/cloud: openstack-hwoffload
-      ci-operator.openshift.io/cloud-cluster-profile: openstack-hwoffload
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-priv-machine-config-operator-release-5.1-e2e-openstack-singlestackv6

--- a/ci-operator/jobs/openshift/installer/openshift-installer-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/installer/openshift-installer-main-presubmits.yaml
@@ -7999,8 +7999,8 @@ presubmits:
     context: ci/prow/e2e-openstack-singlestackv6
     decorate: true
     labels:
-      ci-operator.openshift.io/cloud: openstack-hwoffload
-      ci-operator.openshift.io/cloud-cluster-profile: openstack-hwoffload
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-installer-main-e2e-openstack-singlestackv6

--- a/ci-operator/jobs/openshift/installer/openshift-installer-release-4.18-presubmits.yaml
+++ b/ci-operator/jobs/openshift/installer/openshift-installer-release-4.18-presubmits.yaml
@@ -8323,8 +8323,8 @@ presubmits:
     context: ci/prow/e2e-openstack-singlestackv6
     decorate: true
     labels:
-      ci-operator.openshift.io/cloud: openstack-hwoffload
-      ci-operator.openshift.io/cloud-cluster-profile: openstack-hwoffload
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-installer-release-4.18-e2e-openstack-singlestackv6

--- a/ci-operator/jobs/openshift/installer/openshift-installer-release-4.19-presubmits.yaml
+++ b/ci-operator/jobs/openshift/installer/openshift-installer-release-4.19-presubmits.yaml
@@ -6024,8 +6024,8 @@ presubmits:
     context: ci/prow/e2e-openstack-singlestackv6
     decorate: true
     labels:
-      ci-operator.openshift.io/cloud: openstack-hwoffload
-      ci-operator.openshift.io/cloud-cluster-profile: openstack-hwoffload
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-installer-release-4.19-e2e-openstack-singlestackv6

--- a/ci-operator/jobs/openshift/installer/openshift-installer-release-4.20-presubmits.yaml
+++ b/ci-operator/jobs/openshift/installer/openshift-installer-release-4.20-presubmits.yaml
@@ -6532,8 +6532,8 @@ presubmits:
     context: ci/prow/e2e-openstack-singlestackv6
     decorate: true
     labels:
-      ci-operator.openshift.io/cloud: openstack-hwoffload
-      ci-operator.openshift.io/cloud-cluster-profile: openstack-hwoffload
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-installer-release-4.20-e2e-openstack-singlestackv6

--- a/ci-operator/jobs/openshift/installer/openshift-installer-release-4.21-presubmits.yaml
+++ b/ci-operator/jobs/openshift/installer/openshift-installer-release-4.21-presubmits.yaml
@@ -6694,8 +6694,8 @@ presubmits:
     context: ci/prow/e2e-openstack-singlestackv6
     decorate: true
     labels:
-      ci-operator.openshift.io/cloud: openstack-hwoffload
-      ci-operator.openshift.io/cloud-cluster-profile: openstack-hwoffload
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-installer-release-4.21-e2e-openstack-singlestackv6

--- a/ci-operator/jobs/openshift/installer/openshift-installer-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift/installer/openshift-installer-release-4.22-presubmits.yaml
@@ -7750,8 +7750,8 @@ presubmits:
     context: ci/prow/e2e-openstack-singlestackv6
     decorate: true
     labels:
-      ci-operator.openshift.io/cloud: openstack-hwoffload
-      ci-operator.openshift.io/cloud-cluster-profile: openstack-hwoffload
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-installer-release-4.22-e2e-openstack-singlestackv6

--- a/ci-operator/jobs/openshift/installer/openshift-installer-release-4.23-presubmits.yaml
+++ b/ci-operator/jobs/openshift/installer/openshift-installer-release-4.23-presubmits.yaml
@@ -7999,8 +7999,8 @@ presubmits:
     context: ci/prow/e2e-openstack-singlestackv6
     decorate: true
     labels:
-      ci-operator.openshift.io/cloud: openstack-hwoffload
-      ci-operator.openshift.io/cloud-cluster-profile: openstack-hwoffload
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-installer-release-4.23-e2e-openstack-singlestackv6

--- a/ci-operator/jobs/openshift/installer/openshift-installer-release-5.0-presubmits.yaml
+++ b/ci-operator/jobs/openshift/installer/openshift-installer-release-5.0-presubmits.yaml
@@ -7998,8 +7998,8 @@ presubmits:
     context: ci/prow/e2e-openstack-singlestackv6
     decorate: true
     labels:
-      ci-operator.openshift.io/cloud: openstack-hwoffload
-      ci-operator.openshift.io/cloud-cluster-profile: openstack-hwoffload
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-installer-release-5.0-e2e-openstack-singlestackv6

--- a/ci-operator/jobs/openshift/installer/openshift-installer-release-5.1-presubmits.yaml
+++ b/ci-operator/jobs/openshift/installer/openshift-installer-release-5.1-presubmits.yaml
@@ -7999,8 +7999,8 @@ presubmits:
     context: ci/prow/e2e-openstack-singlestackv6
     decorate: true
     labels:
-      ci-operator.openshift.io/cloud: openstack-hwoffload
-      ci-operator.openshift.io/cloud-cluster-profile: openstack-hwoffload
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-installer-release-5.1-e2e-openstack-singlestackv6

--- a/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-main-presubmits.yaml
@@ -4151,8 +4151,8 @@ presubmits:
     context: ci/prow/e2e-openstack-singlestackv6
     decorate: true
     labels:
-      ci-operator.openshift.io/cloud: openstack-hwoffload
-      ci-operator.openshift.io/cloud-cluster-profile: openstack-hwoffload
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-machine-config-operator-main-e2e-openstack-singlestackv6

--- a/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-release-4.18-presubmits.yaml
+++ b/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-release-4.18-presubmits.yaml
@@ -2835,8 +2835,8 @@ presubmits:
     context: ci/prow/e2e-openstack-singlestackv6
     decorate: true
     labels:
-      ci-operator.openshift.io/cloud: openstack-hwoffload
-      ci-operator.openshift.io/cloud-cluster-profile: openstack-hwoffload
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-machine-config-operator-release-4.18-e2e-openstack-singlestackv6

--- a/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-release-4.19-presubmits.yaml
+++ b/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-release-4.19-presubmits.yaml
@@ -3419,8 +3419,8 @@ presubmits:
     context: ci/prow/e2e-openstack-singlestackv6
     decorate: true
     labels:
-      ci-operator.openshift.io/cloud: openstack-hwoffload
-      ci-operator.openshift.io/cloud-cluster-profile: openstack-hwoffload
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-machine-config-operator-release-4.19-e2e-openstack-singlestackv6

--- a/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-release-4.20-presubmits.yaml
+++ b/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-release-4.20-presubmits.yaml
@@ -3909,8 +3909,8 @@ presubmits:
     context: ci/prow/e2e-openstack-singlestackv6
     decorate: true
     labels:
-      ci-operator.openshift.io/cloud: openstack-hwoffload
-      ci-operator.openshift.io/cloud-cluster-profile: openstack-hwoffload
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-machine-config-operator-release-4.20-e2e-openstack-singlestackv6

--- a/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-release-4.21-presubmits.yaml
+++ b/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-release-4.21-presubmits.yaml
@@ -4071,8 +4071,8 @@ presubmits:
     context: ci/prow/e2e-openstack-singlestackv6
     decorate: true
     labels:
-      ci-operator.openshift.io/cloud: openstack-hwoffload
-      ci-operator.openshift.io/cloud-cluster-profile: openstack-hwoffload
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-machine-config-operator-release-4.21-e2e-openstack-singlestackv6

--- a/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-release-4.22-presubmits.yaml
@@ -4291,8 +4291,8 @@ presubmits:
     context: ci/prow/e2e-openstack-singlestackv6
     decorate: true
     labels:
-      ci-operator.openshift.io/cloud: openstack-hwoffload
-      ci-operator.openshift.io/cloud-cluster-profile: openstack-hwoffload
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-machine-config-operator-release-4.22-e2e-openstack-singlestackv6

--- a/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-release-4.23-presubmits.yaml
+++ b/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-release-4.23-presubmits.yaml
@@ -4207,8 +4207,8 @@ presubmits:
     context: ci/prow/e2e-openstack-singlestackv6
     decorate: true
     labels:
-      ci-operator.openshift.io/cloud: openstack-hwoffload
-      ci-operator.openshift.io/cloud-cluster-profile: openstack-hwoffload
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-machine-config-operator-release-4.23-e2e-openstack-singlestackv6

--- a/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-release-5.0-presubmits.yaml
+++ b/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-release-5.0-presubmits.yaml
@@ -4207,8 +4207,8 @@ presubmits:
     context: ci/prow/e2e-openstack-singlestackv6
     decorate: true
     labels:
-      ci-operator.openshift.io/cloud: openstack-hwoffload
-      ci-operator.openshift.io/cloud-cluster-profile: openstack-hwoffload
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-machine-config-operator-release-5.0-e2e-openstack-singlestackv6

--- a/ci-operator/step-registry/ipi/conf/openstack/ipi-conf-openstack-chain.yaml
+++ b/ci-operator/step-registry/ipi/conf/openstack/ipi-conf-openstack-chain.yaml
@@ -6,6 +6,7 @@ chain:
   - ref: openstack-provision-machinesubnet
   - ref: openstack-provision-bastionproxy
   - ref: openstack-provision-mirror
+  - ref: openstack-conf-clouds-ipv6
   - ref: openstack-conf-proxy
   - ref: openstack-conf-externalnetworkid
   - ref: openstack-provision-vips-ports

--- a/ci-operator/step-registry/openshift/e2e/openstack/singlestackv6/openshift-e2e-openstack-singlestackv6-workflow.yaml
+++ b/ci-operator/step-registry/openshift/e2e/openstack/singlestackv6/openshift-e2e-openstack-singlestackv6-workflow.yaml
@@ -10,9 +10,12 @@ workflow:
       - chain: ipi-openstack-post
     env:
       BASE_DOMAIN: shiftstack.devcluster.openshift.com
+      BASTION_FLAVOR: "1vcpu_2gb"
       CONFIG_TYPE: "singlestackv6"
-      CONTROL_PLANE_NETWORK: "external"
-      CONTROL_PLANE_SUBNET_V6: "external-subnet-v6"
+      CONTROL_PLANE_NETWORK: "public-ipv6"
+      CONTROL_PLANE_SUBNET_V6: "public-ipv6"
+      MACHINES_SUBNET_v6_RANGE: "2604:e100:4::/64"
+      MIRROR_IPV4_NETWORK: "public"
       WORKER_REPLICAS: 1
       # https://issues.redhat.com/browse/OCPBUGS-48173
       OPENSTACK_TEST_SKIPS: The OpenStack platform on volume creation

--- a/ci-operator/step-registry/openstack/conf/clouds-ipv6/OWNERS
+++ b/ci-operator/step-registry/openstack/conf/clouds-ipv6/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- openstack-approvers
+reviewers:
+- openstack-reviewers

--- a/ci-operator/step-registry/openstack/conf/clouds-ipv6/openstack-conf-clouds-ipv6-commands.sh
+++ b/ci-operator/step-registry/openstack/conf/clouds-ipv6/openstack-conf-clouds-ipv6-commands.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+info() {
+	>&2 printf '%s: %s\n' "$(date --utc +%Y-%m-%dT%H:%M:%SZ)" "$*"
+}
+
+# Only run for singlestackv6 config
+if [[ "$CONFIG_TYPE" != *"singlestackv6"* ]]; then
+    info "Skipping IPv6 clouds.yaml configuration (CONFIG_TYPE=${CONFIG_TYPE})"
+    exit 0
+fi
+
+# Create openstack-ipv6 cloud entry (required by install-config for singlestackv6)
+# This is just a copy of the original cloud - the squid proxy handles the routing
+yq --yml-output ".clouds[\"${OS_CLOUD}-ipv6\"] = .clouds[\"${OS_CLOUD}\"]" "${SHARED_DIR}/clouds.yaml" > "${SHARED_DIR}/clouds-ipv6.yaml"
+mv "${SHARED_DIR}/clouds-ipv6.yaml" "${SHARED_DIR}/clouds.yaml"
+info "Created ${OS_CLOUD}-ipv6 cloud entry in clouds.yaml"
+
+# Get the mirror VM's IP for the squid proxy
+if [[ -f "${SHARED_DIR}/OPENSTACK_MITM_PROXY_IP" ]]; then
+	MITM_PROXY_IP=$(<"${SHARED_DIR}/OPENSTACK_MITM_PROXY_IP")
+	info "Using squid proxy on mirror VM: ${MITM_PROXY_IP}"
+else
+	info "ERROR: OPENSTACK_MITM_PROXY_IP file not found"
+	info "The mirror VM should have been provisioned before this step"
+	exit 1
+fi
+
+# Configure HTTP/HTTPS proxy environment variables
+# Squid is running on port 13001 and will tunnel all OpenStack API traffic
+info "Configuring HTTP proxy: http://${MITM_PROXY_IP}:13001"
+
+cat > "${SHARED_DIR}/proxy-conf.sh" << PROXY_CONF
+# Squid proxy configuration for OpenStack API access
+export HTTP_PROXY="http://${MITM_PROXY_IP}:13001"
+export HTTPS_PROXY="http://${MITM_PROXY_IP}:13001"
+export NO_PROXY="localhost,127.0.0.1"
+PROXY_CONF
+
+info "Proxy configuration written to ${SHARED_DIR}/proxy-conf.sh"

--- a/ci-operator/step-registry/openstack/conf/clouds-ipv6/openstack-conf-clouds-ipv6-ref.metadata.json
+++ b/ci-operator/step-registry/openstack/conf/clouds-ipv6/openstack-conf-clouds-ipv6-ref.metadata.json
@@ -1,0 +1,11 @@
+{
+	"path": "openstack/conf/clouds-ipv6/openstack-conf-clouds-ipv6-ref.yaml",
+	"owners": {
+		"approvers": [
+			"openstack-approvers"
+		],
+		"reviewers": [
+			"openstack-reviewers"
+		]
+	}
+}

--- a/ci-operator/step-registry/openstack/conf/clouds-ipv6/openstack-conf-clouds-ipv6-ref.yaml
+++ b/ci-operator/step-registry/openstack/conf/clouds-ipv6/openstack-conf-clouds-ipv6-ref.yaml
@@ -1,0 +1,21 @@
+ref:
+  as: openstack-conf-clouds-ipv6
+  from: openstack-installer
+  commands: openstack-conf-clouds-ipv6-commands.sh
+  resources:
+    requests:
+      cpu: 10m
+      memory: 100Mi
+  env:
+    - name: OS_CLOUD
+      default: 'openstack'
+      documentation: Name of cloud to use from ${SHARED_DIR}/clouds.yaml file
+    - name: CONFIG_TYPE
+      documentation: |
+        The type of config for the environment to deploy.
+
+        * 'singlestackv6' - Configure clouds.yaml to use IPv6 proxy endpoint
+  documentation: |-
+    This step configures clouds.yaml with an IPv6-compatible endpoint
+    using the openstack-mitm proxy deployed on the mirror VM.
+    Only runs for CONFIG_TYPE=singlestackv6.

--- a/ci-operator/step-registry/openstack/conf/clouds/openstack-conf-clouds-commands.sh
+++ b/ci-operator/step-registry/openstack/conf/clouds/openstack-conf-clouds-commands.sh
@@ -127,26 +127,3 @@ case "$OPENSTACK_AUTHENTICATION_METHOD" in
 	*)
 		info "Unknown authentication method '${OPENSTACK_AUTHENTICATION_METHOD}'."; exit 1 ;;
 esac
-
-# This creates another cloud entry when we want to use IPv6 endpoint that exists on the OpenStack cloud.
-# Requirements:
-# - control plane subnet for ipv6
-# - a proxy running and listening on that IP and port "13001" (used https://github.com/pierreprinetti/openstack-mitm)
-# - squid installed on the OpenStack cloud, it'll be used as a proxy to redirect the traffic to the real IPv6 endpoint which itselfs
-#   redirects to the actual OpenStack endpoint (IPv4).
-if [[ "${CONFIG_TYPE}" == *"singlestackv6"* ]]; then
-	yq --yml-output ".clouds[\"${OS_CLOUD}-ipv6\"] = .clouds[\"${OS_CLOUD}\"]" "${SHARED_DIR}/clouds.yaml" > "${SHARED_DIR}/clouds-ipv6.yaml"
-	CONTROL_PLANE_SUBNET_V6="${CONTROL_PLANE_SUBNET_V6:-$(<"${SHARED_DIR}/CONTROL_PLANE_SUBNET_V6")}"
-	export OS_CLIENT_CONFIG_FILE="${SHARED_DIR}/clouds.yaml"
-	GATEWAY_IP=$(openstack subnet show "${CONTROL_PLANE_SUBNET_V6}" -c gateway_ip -f value)
-	if [[ -z "${GATEWAY_IP}" ]]; then
-		info "Gateway IP for subnet ${CONTROL_PLANE_SUBNET_V6} not found."
-		exit 1
-	fi
-	# We need to add the /v3 here otherwise Gophercloud returns an error:
-	# "No supported version available from endpoint".
-	yq --yaml-output --in-place ".
-		| .clouds[\"${OS_CLOUD}-ipv6\"].auth.auth_url = \"https://[${GATEWAY_IP}]:13001/v3\"
-	" "${SHARED_DIR}/clouds-ipv6.yaml"
-	mv "${SHARED_DIR}/clouds-ipv6.yaml" "${SHARED_DIR}/clouds.yaml"
-fi

--- a/ci-operator/step-registry/openstack/deprovision/mirror/openstack-deprovision-mirror-commands.sh
+++ b/ci-operator/step-registry/openstack/deprovision/mirror/openstack-deprovision-mirror-commands.sh
@@ -22,14 +22,16 @@ fi
 if [[ -f "${SHARED_DIR}/squid-credentials.txt" ]]; then
    proxy_host=$(yq -r ".clouds.${OS_CLOUD}.auth.auth_url" "$OS_CLIENT_CONFIG_FILE" | cut -d/ -f3 | cut -d: -f1)
    proxy_credentials=$(<"${SHARED_DIR}/squid-credentials.txt")
-   echo "Using proxy $proxy_host for SSH connection"
+   echo "Using proxy $proxy_host for SSH connection to mirror"
+   USE_PROXY=true
 else
-  echo "Missing squid-credentials.txt file"
-  exit 1
+  echo "No squid-credentials.txt found, using direct SSH connection to mirror"
+  USE_PROXY=false
 fi
 
 if [[ -f ${SHARED_DIR}"/MIRROR_SSH_IP" ]]; then
     mirror_ip=$(<"${SHARED_DIR}"/MIRROR_SSH_IP)
+
     ssh_via_proxy() {
         local command=$1
         ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -i ${CLUSTER_PROFILE_DIR}/ssh-privatekey -o ProxyCommand="nc --proxy-auth ${proxy_credentials} --proxy ${proxy_host}:3128 %h %p" $BASTION_USER@$mirror_ip "$command"
@@ -40,18 +42,46 @@ if [[ -f ${SHARED_DIR}"/MIRROR_SSH_IP" ]]; then
         local dest=$2
         scp -o ConnectTimeout=10 -o StrictHostKeyChecking=no -i ${CLUSTER_PROFILE_DIR}/ssh-privatekey -o ProxyCommand="nc --proxy-auth ${proxy_credentials} --proxy ${proxy_host}:3128 %h %p" $src $dest
     }
-    ssh_via_proxy bash - <<EOF
+
+    ssh_direct() {
+        local command=$1
+        ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -i ${CLUSTER_PROFILE_DIR}/ssh-privatekey $BASTION_USER@$mirror_ip "$command"
+    }
+
+    scp_direct() {
+        local src=$1
+        local dest=$2
+        scp -o ConnectTimeout=10 -o StrictHostKeyChecking=no -i ${CLUSTER_PROFILE_DIR}/ssh-privatekey $src $dest
+    }
+
+    # Set up function aliases based on whether proxy is available
+    if [[ "$USE_PROXY" == "true" ]]; then
+        ssh_mirror() { ssh_via_proxy "$@"; }
+        scp_mirror() { scp_via_proxy "$@"; }
+    else
+        ssh_mirror() { ssh_direct "$@"; }
+        scp_mirror() { scp_direct "$@"; }
+    fi
+
+    ssh_mirror bash - <<EOF
     mkdir -p /tmp/mirror-logs
     sudo podman logs registry > /tmp/mirror-logs/registry.log || true
     sudo chown -R ${BASTION_USER}: /tmp/mirror-logs || true
     tar -czC "/tmp" -f "/tmp/mirror-logs.tar.gz" mirror-logs/
 EOF
-    scp_via_proxy ${BASTION_USER}@${mirror_ip}:/tmp/mirror-logs.tar.gz ${ARTIFACT_DIR}
+    scp_mirror ${BASTION_USER}@${mirror_ip}:/tmp/mirror-logs.tar.gz ${ARTIFACT_DIR}
     echo "Mirror logs collected in ${ARTIFACT_DIR}/mirror-logs.tar.gz"
 fi
 
 >&2 echo "Starting the server cleanup for cluster '$CLUSTER_NAME'"
 openstack server delete --wait "mirror-${CLUSTER_NAME}-${CONFIG_TYPE}" || >&2 echo "Failed to delete server mirror-${CLUSTER_NAME}-${CONFIG_TYPE}"
+
+# Delete floating IP if it was created
+if [[ -f "${SHARED_DIR}/MIRROR_FIP" ]]; then
+  mirror_fip=$(<"${SHARED_DIR}/MIRROR_FIP")
+  openstack floating ip delete "${mirror_fip}" || >&2 echo "Failed to delete floating IP ${mirror_fip}"
+fi
+
 openstack security group delete "mirror-${CLUSTER_NAME}-${CONFIG_TYPE}" || >&2 echo "Failed to delete security group mirror-${CLUSTER_NAME}-${CONFIG_TYPE}"
 openstack keypair delete "mirror-${CLUSTER_NAME}-${CONFIG_TYPE}" || >&2 echo "Failed to delete keypair mirror-${CLUSTER_NAME}-${CONFIG_TYPE}"
 >&2 echo 'Cleanup done.'

--- a/ci-operator/step-registry/openstack/provision/mirror/openstack-provision-mirror-commands.sh
+++ b/ci-operator/step-registry/openstack/provision/mirror/openstack-provision-mirror-commands.sh
@@ -50,22 +50,116 @@ openstack keypair create --public-key ${CLUSTER_PROFILE_DIR}/ssh-publickey mirro
 sg_id="$(openstack security group create -f value -c id mirror-${CLUSTER_NAME}-${CONFIG_TYPE} \
   --description "Mirror security group for $CLUSTER_NAME")"
 >&2 echo "Created mirror security group for ${CLUSTER_NAME}: ${sg_id}"
-openstack security group rule create --ingress --protocol tcp --dst-port 22 --description "${CLUSTER_NAME} SSH" "$sg_id" >/dev/null
-openstack security group rule create --ingress --protocol tcp --ethertype IPv6 --remote-ip "::/0" --dst-port 5000 --description "${CLUSTER_NAME} mirror registry" "$sg_id" >/dev/null
+openstack security group rule create --ingress --protocol tcp --ethertype IPv4 --remote-ip "0.0.0.0/0" --dst-port 22 --description "${CLUSTER_NAME} SSH IPv4" "$sg_id"
+openstack security group rule create --ingress --protocol tcp --ethertype IPv6 --remote-ip "::/0" --dst-port 22 --description "${CLUSTER_NAME} SSH IPv6" "$sg_id"
+
+# Restrict registry and mitm proxy to the cluster's IPv6 subnet
+if [[ -n "${MIRROR_IPV4_NETWORK:-}" ]]; then
+  # Get the IPv6 subnet CIDR for vexxhost
+  IPV6_SUBNET_CIDR="${MACHINES_SUBNET_v6_RANGE:-2604:e100:4::/64}"
+  openstack security group rule create --ingress --protocol tcp --ethertype IPv6 --remote-ip "${IPV6_SUBNET_CIDR}" --dst-port 5000 --description "${CLUSTER_NAME} mirror registry IPv6" "$sg_id"
+  openstack security group rule create --ingress --protocol tcp --ethertype IPv6 --remote-ip "${IPV6_SUBNET_CIDR}" --dst-port 13001 --description "${CLUSTER_NAME} openstack-mitm proxy IPv6" "$sg_id"
+  # Allow IPv4 access to mitm proxy and registry from anywhere (CI infrastructure needs to reach them)
+  openstack security group rule create --ingress --protocol tcp --ethertype IPv4 --remote-ip "0.0.0.0/0" --dst-port 13001 --description "${CLUSTER_NAME} openstack-mitm proxy IPv4" "$sg_id"
+  openstack security group rule create --ingress --protocol tcp --ethertype IPv4 --remote-ip "0.0.0.0/0" --dst-port 5000 --description "${CLUSTER_NAME} mirror registry IPv4" "$sg_id"
+else
+  # For hwoffload (dualstack network), allow from anywhere since we don't know the subnet
+  openstack security group rule create --ingress --protocol tcp --ethertype IPv6 --remote-ip "::/0" --dst-port 5000 --description "${CLUSTER_NAME} mirror registry" "$sg_id"
+fi
 >&2 echo "Created necessary security group rules in ${sg_id}"
 
-server_params="--network $CONTROL_PLANE_NETWORK --image $BASTION_IMAGE --flavor $BASTION_FLAVOR \
-  --security-group $sg_id --key-name mirror-${CLUSTER_NAME}-${CONFIG_TYPE} \
-  --block-device source_type=blank,destination_type=volume,volume_size=70,delete_on_termination=true"
+# Build network parameters based on environment
+# For dualstack networks (hwoffload): use single network with both IPv4+IPv6
+# For separate networks (vexxhost): attach to both networks to get IPv4 and IPv6
+if [[ -n "${MIRROR_IPV4_NETWORK:-}" ]]; then
+  network_params="--network ${MIRROR_IPV4_NETWORK} --network $CONTROL_PLANE_NETWORK"
+  echo "Using dual network setup: IPv4=${MIRROR_IPV4_NETWORK}, IPv6=${CONTROL_PLANE_NETWORK}"
+else
+  network_params="--network $CONTROL_PLANE_NETWORK"
+  echo "Using single dualstack network: ${CONTROL_PLANE_NETWORK}"
+fi
+
+# On vexxhost, skip block-device as it may cause server creation issues
+if [[ -n "${MIRROR_IPV4_NETWORK:-}" ]]; then
+  server_params="$network_params --image $BASTION_IMAGE --flavor $BASTION_FLAVOR \
+    --security-group $sg_id --key-name mirror-${CLUSTER_NAME}-${CONFIG_TYPE}"
+else
+  server_params="$network_params --image $BASTION_IMAGE --flavor $BASTION_FLAVOR \
+    --security-group $sg_id --key-name mirror-${CLUSTER_NAME}-${CONFIG_TYPE} \
+    --block-device source_type=blank,destination_type=volume,volume_size=70,delete_on_termination=true"
+fi
+
+echo "Creating server with command:"
+echo "  openstack server create --wait -f value -c id $server_params mirror-$CLUSTER_NAME-${CONFIG_TYPE}"
 
 server_id="$(openstack server create --wait -f value -c id $server_params \
-		"mirror-$CLUSTER_NAME-${CONFIG_TYPE}")"
+		"mirror-$CLUSTER_NAME-${CONFIG_TYPE}" | tr -d '[:space:]')"
+
+# Verify server_id is a valid UUID (not an error message)
+if [[ ! "$server_id" =~ ^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$ ]]; then
+	echo "ERROR: Server creation failed. Got invalid server ID: '$server_id'"
+	echo "This might indicate:"
+	echo "  - Quota exceeded"
+	echo "  - Flavor '$BASTION_FLAVOR' not available"
+	echo "  - Network/port creation failed"
+	echo "  - Image '$BASTION_IMAGE' not found or inaccessible"
+	exit 1
+fi
+
 >&2 echo "Created nova server mirror-${CLUSTER_NAME}-${CONFIG_TYPE}: ${server_id}"
+
+# Wait for server to be fully available in OpenStack database
+# Vexxhost has timing issues even after --wait completes
+echo "Waiting 30 seconds for server to be fully initialized in OpenStack..."
+sleep 30
+
+# For vexxhost, create and attach additional storage volume for registry data
+# Root disk is too small (20GB) for OpenShift release images
+if [[ -n "${MIRROR_IPV4_NETWORK:-}" ]]; then
+  echo "Creating 70GB volume for registry data..."
+  volume_id="$(openstack volume create --size 70 \
+    --description "Registry data for ${CLUSTER_NAME}" \
+    --type __DEFAULT__ \
+    -f value -c id \
+    "registry-data-${CLUSTER_NAME}")"
+
+  if [[ ! "$volume_id" =~ ^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$ ]]; then
+    echo "ERROR: Volume creation failed. Got: '$volume_id'"
+    exit 1
+  fi
+
+  echo "Waiting for volume to become available..."
+  for _ in {1..30}; do
+    vol_status="$(openstack volume show -f value -c status "$volume_id")"
+    if [[ "$vol_status" == "available" ]]; then
+      echo "Volume is available"
+      break
+    fi
+    echo "Volume status: $vol_status, waiting..."
+    sleep 2
+  done
+
+  echo "Attaching volume to server..."
+  openstack server add volume "$server_id" "$volume_id"
+
+  echo "Waiting for volume attachment..."
+  sleep 10
+fi
 
 IPV4_REGEX="((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])"
 IPV6_REGEX="(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))"
+
+# Get server IPs
 mirror_ipv4="$(openstack server show -f value -c addresses mirror-$CLUSTER_NAME-${CONFIG_TYPE} | grep -oE $IPV4_REGEX)"
 mirror_ipv6="$(openstack server show -f value -c addresses mirror-$CLUSTER_NAME-${CONFIG_TYPE} | grep -oE $IPV6_REGEX)"
+
+echo "Mirror VM fixed IPv4: ${mirror_ipv4}"
+echo "Mirror VM IPv6: ${mirror_ipv6}"
+
+# Use fixed IPv4 for SSH (vexxhost public IPs are directly accessible, no floating IP needed)
+mirror_ssh_ip="${mirror_ipv4}"
+
+echo "Mirror VM SSH IP: ${mirror_ssh_ip}"
 
 # configure the local container environment to have the correct SSH configuration
 if ! whoami &> /dev/null; then
@@ -77,15 +171,16 @@ fi
 if [[ -f "${SHARED_DIR}/squid-credentials.txt" ]]; then
    proxy_host=$(yq -r ".clouds.${OS_CLOUD}.auth.auth_url" "$OS_CLIENT_CONFIG_FILE" | cut -d/ -f3 | cut -d: -f1)
    proxy_credentials=$(<"${SHARED_DIR}/squid-credentials.txt")
-   echo "Using proxy $proxy_host for SSH connection"
+   echo "Using proxy $proxy_host for SSH connection to mirror"
+   USE_PROXY=true
 else
-  echo "Missing squid-credentials.txt file"
-  exit 1
+  echo "No squid-credentials.txt found, using direct SSH connection to mirror"
+  USE_PROXY=false
 fi
 
 ssh_via_proxy() {
     local command=$1
-    ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -i ${CLUSTER_PROFILE_DIR}/ssh-privatekey -o ProxyCommand="nc --proxy-auth ${proxy_credentials} --proxy ${proxy_host}:3128 %h %p" $BASTION_USER@$mirror_ipv4 "$command"
+    ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -i ${CLUSTER_PROFILE_DIR}/ssh-privatekey -o ProxyCommand="nc --proxy-auth ${proxy_credentials} --proxy ${proxy_host}:3128 %h %p" $BASTION_USER@$mirror_ssh_ip "$command"
 }
 
 scp_via_proxy() {
@@ -94,23 +189,58 @@ scp_via_proxy() {
     scp -o ConnectTimeout=10 -o StrictHostKeyChecking=no -i ${CLUSTER_PROFILE_DIR}/ssh-privatekey -o ProxyCommand="nc --proxy-auth ${proxy_credentials} --proxy ${proxy_host}:3128 %h %p" $src $dest
 }
 
-if ! retry 60 5 ssh_via_proxy "uname -a"; then
-		echo "ERROR: Bastion proxy is not reachable via $mirror_ipv4 - check logs:"
+ssh_direct() {
+    local command=$1
+    ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -i ${CLUSTER_PROFILE_DIR}/ssh-privatekey $BASTION_USER@$mirror_ssh_ip "$command"
+}
+
+scp_direct() {
+    local src=$1
+    local dest=$2
+    scp -o ConnectTimeout=10 -o StrictHostKeyChecking=no -i ${CLUSTER_PROFILE_DIR}/ssh-privatekey $src $dest
+}
+
+# Set up function aliases based on whether proxy is available
+if [[ "$USE_PROXY" == "true" ]]; then
+    ssh_mirror() { ssh_via_proxy "$@"; }
+    scp_mirror() { scp_via_proxy "$@"; }
+else
+    ssh_mirror() { ssh_direct "$@"; }
+    scp_mirror() { scp_direct "$@"; }
+fi
+
+if ! retry 60 5 ssh_mirror "uname -a"; then
+		echo "ERROR: Mirror VM is not reachable via $mirror_ssh_ip - check logs:"
     openstack console log show ${server_id}
 		exit 1
 fi
 
 MIRROR_REGISTRY_DNS_NAME="mirror-registry.${CLUSTER_NAME}.${BASE_DOMAIN}"
 MIRROR_REGISTRY_CREDENTIALS=$(<"/var/run/vault/mirror-registry/registry_creds")
-scp_via_proxy "/var/run/vault/mirror-registry/registry_creds_encrypted_htpasswd" $BASTION_USER@$mirror_ipv4:/tmp/htpasswd
+scp_mirror "/var/run/vault/mirror-registry/registry_creds_encrypted_htpasswd" $BASTION_USER@$mirror_ssh_ip:/tmp/htpasswd
 
 echo "Deploying the mirror registry"
+# Both vexxhost and hwoffload now use separate block device
 >&2 cat << EOF > $WORK_DIR/deploy_mirror.sh
 #!/usr/bin/env bash
 set -e
-sudo mkfs.xfs /dev/vdc
+# Find the additional block device (not the root device)
+# Get the root device and exclude it, then find first unused disk
+ROOT_DEVICE=\$(lsblk -no PKNAME \$(findmnt -n -o SOURCE /))
+DEVICE=\$(lsblk -dn -o NAME,TYPE | awk -v root="\$ROOT_DEVICE" '\$2=="disk" && \$1!=root {print "/dev/" \$1; exit}')
+if [[ -z "\$DEVICE" ]]; then
+    echo "ERROR: Could not find additional block device for registry data"
+    echo "Root device: \$ROOT_DEVICE"
+    lsblk -a
+    exit 1
+fi
+echo "Using block device: \$DEVICE (root device: \$ROOT_DEVICE)"
+sudo mkfs.xfs \$DEVICE
 sudo mkdir -p /opt/registry/{auth,certs,data}
-sudo mount /dev/vdc /opt/registry/data
+sudo mount \$DEVICE /opt/registry/data
+EOF
+
+>&2 cat << EOF >> $WORK_DIR/deploy_mirror.sh
 sudo openssl req -newkey rsa:4096 -nodes -sha256 -keyout /opt/registry/certs/domain.key -x509 -days 1 -subj "/CN=mirror-$CLUSTER_NAME-${CONFIG_TYPE}" -addext "subjectAltName=DNS:$MIRROR_REGISTRY_DNS_NAME,DNS:mirror-$CLUSTER_NAME-${CONFIG_TYPE}" -out /opt/registry/certs/domain.crt
 sudo cp /opt/registry/certs/domain.crt /etc/pki/ca-trust/source/anchors/domain.crt   
 sudo mv /tmp/htpasswd /opt/registry/auth/htpasswd
@@ -127,16 +257,75 @@ sudo podman create --name registry -p 5000:5000 --net host \
     -e REGISTRY_HTTP_TLS_KEY=/certs/domain.key \
     quay.io/libpod/registry:2.8.2
 sudo podman start registry
-curl -u "$MIRROR_REGISTRY_CREDENTIALS" --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 40 https://mirror-$CLUSTER_NAME-${CONFIG_TYPE}:5000/v2/_catalog
+curl -u "$MIRROR_REGISTRY_CREDENTIALS" --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 40 -k https://localhost:5000/v2/_catalog
 EOF
 
-scp_via_proxy $WORK_DIR/deploy_mirror.sh $BASTION_USER@$mirror_ipv4:/tmp
-ssh_via_proxy "chmod +x /tmp/deploy_mirror.sh"
-ssh_via_proxy "bash -c /tmp/deploy_mirror.sh"
+scp_mirror $WORK_DIR/deploy_mirror.sh $BASTION_USER@$mirror_ssh_ip:/tmp
+ssh_mirror "chmod +x /tmp/deploy_mirror.sh"
+ssh_mirror "bash -c /tmp/deploy_mirror.sh"
 
-echo "${MIRROR_REGISTRY_DNS_NAME}:5000" >"${SHARED_DIR}/mirror_registry_url"
-scp_via_proxy $BASTION_USER@$mirror_ipv4:/opt/registry/certs/domain.crt ${SHARED_DIR}/additional_trust_bundle
-echo $mirror_ipv4 > "${SHARED_DIR}/MIRROR_SSH_IP"
+# Use IPv4 for CI image push (CI infrastructure is IPv4-only)
+# Cluster pods will pull via IPv6 using DNS name from MIRROR_REGISTRY_IP
+echo "${mirror_ipv4}:5000" >"${SHARED_DIR}/mirror_registry_url"
+scp_mirror $BASTION_USER@$mirror_ssh_ip:/opt/registry/certs/domain.crt ${SHARED_DIR}/additional_trust_bundle
+echo $mirror_ssh_ip > "${SHARED_DIR}/MIRROR_SSH_IP"
 echo $mirror_ipv6 > "${SHARED_DIR}/MIRROR_REGISTRY_IP"
+
+# Deploy openstack-mitm proxy for IPv6-to-IPv4 API translation (vexxhost)
+if [[ -n "${MIRROR_IPV4_NETWORK:-}" ]]; then
+	echo "Deploying openstack-mitm proxy on mirror VM for OpenStack API access"
+	REAL_AUTH_URL=$(yq -r ".clouds.${OS_CLOUD}.auth.auth_url" "$OS_CLIENT_CONFIG_FILE")
+	echo "Real OpenStack API URL: ${REAL_AUTH_URL}"
+
+	>&2 cat << EOF > $WORK_DIR/deploy_mitm.sh
+#!/usr/bin/env bash
+set -e
+
+# Install squid
+sudo dnf install -y squid
+
+# Configure squid as a simple HTTPS proxy (CONNECT tunnel, no SSL bumping)
+sudo bash -c 'cat > /etc/squid/squid.conf << SQUID_CONF
+# Listen on port 13001
+http_port 13001
+
+# Allow CONNECT for HTTPS
+acl SSL_ports port 443
+acl CONNECT method CONNECT
+http_access allow CONNECT SSL_ports
+
+# Allow all HTTP
+http_access allow all
+
+# Disable caching
+cache deny all
+
+# Access logging
+access_log /var/log/squid/access.log squid
+cache_log /var/log/squid/cache.log
+
+# Misc
+coredump_dir /var/spool/squid
+SQUID_CONF'
+
+# Create log directory
+sudo mkdir -p /var/log/squid
+sudo chown squid:squid /var/log/squid
+
+# Start squid
+sudo systemctl enable --now squid
+sleep 3
+sudo systemctl status squid
+EOF
+
+	scp_mirror $WORK_DIR/deploy_mitm.sh $BASTION_USER@$mirror_ssh_ip:/tmp/deploy_mitm.sh
+
+	scp_mirror $WORK_DIR/deploy_mitm.sh $BASTION_USER@$mirror_ssh_ip:/tmp/deploy_mitm.sh
+	ssh_mirror "chmod +x /tmp/deploy_mitm.sh"
+	ssh_mirror "bash -c /tmp/deploy_mitm.sh"
+	echo "openstack-mitm proxy is running on ${mirror_ipv4}:13001 and [${mirror_ipv6}]:13001"
+	# Use IPv4 for the proxy so CI infrastructure can reach it
+	echo $mirror_ipv4 > "${SHARED_DIR}/OPENSTACK_MITM_PROXY_IP"
+fi
 
 echo "Mirror is ready!"

--- a/ci-operator/step-registry/openstack/provision/mirror/openstack-provision-mirror-ref.yaml
+++ b/ci-operator/step-registry/openstack/provision/mirror/openstack-provision-mirror-ref.yaml
@@ -25,8 +25,20 @@ ref:
     - name: CONTROL_PLANE_NETWORK
       default: ''
       documentation: |-
-        Name of the OpenStack dualstack network. Defaults to the value in
+        Name of the OpenStack network for IPv6 connectivity (or dualstack if
+        MIRROR_IPV4_NETWORK is not set). Defaults to the value in
         "${SHARED_DIR}/CONTROL_PLANE_NETWORK"
+    - name: MIRROR_IPV4_NETWORK
+      default: ''
+      documentation: |-
+        Optional: Name of the OpenStack network for IPv4 connectivity.
+        If set, the mirror VM will be attached to both this network (for IPv4)
+        and CONTROL_PLANE_NETWORK (for IPv6). This is needed for environments
+        without dualstack networks (e.g., vexxhost with separate 'public' and
+        'public-ipv6' networks). If not set, only CONTROL_PLANE_NETWORK is used
+        (assumes it's a dualstack network).
+        When using dual networks, a floating IP will be automatically allocated
+        from OPENSTACK_EXTERNAL_NETWORK for SSH access to the mirror VM.
     - name: CONFIG_TYPE
       documentation: |
         The type of config for the environment to deploy.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Retargeted e2e-openstack-singlestackv6 tests to run on the Vexxhost cloud provider across main and release branches.
  * Enhanced IPv6 single‑stack networking and mirror VM provisioning, adding optional dual‑network (IPv4+IPv6) support and flexible proxy or direct connectivity.
  * Added resilient IPv6 endpoint handling with fallback mechanisms for OpenStack configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->