### PR TITLE
Add PQC readiness CI step

### DIFF
--- a/ci-operator/config/openshift/tls-scanner/openshift-tls-scanner-main.yaml
+++ b/ci-operator/config/openshift/tls-scanner/openshift-tls-scanner-main.yaml
@@ -68,6 +68,7 @@ tests:
   steps:
     cluster_profile: openshift-org-aws
     env:
+      COMPUTE_NODE_TYPE: m5.4xlarge
       PQC_CHECK: "true"
     test:
     - ref: tls-scanner-run

--- a/ci-operator/config/openshift/tls-scanner/openshift-tls-scanner-main.yaml
+++ b/ci-operator/config/openshift/tls-scanner/openshift-tls-scanner-main.yaml
@@ -64,20 +64,14 @@ tests:
     - ref: tls-scanner-run
     workflow: generic-claim
 - as: default-pqc-readiness
-  cluster_claim:
-    architecture: amd64
-    cloud: aws
-    owner: openshift-ci
-    product: ocp
-    timeout: 5h0m0s
-    version: "4.22"
   optional: true
   steps:
+    cluster_profile: openshift-org-aws
     env:
       PQC_CHECK: "true"
     test:
     - ref: tls-scanner-run
-    workflow: generic-claim
+    workflow: ipi-aws
 - as: tls13-conformance
   optional: true
   steps:

--- a/ci-operator/config/openshift/tls-scanner/openshift-tls-scanner-main.yaml
+++ b/ci-operator/config/openshift/tls-scanner/openshift-tls-scanner-main.yaml
@@ -51,14 +51,33 @@ tests:
   container:
     from: src
 - as: default-tls
+  cluster_claim:
+    architecture: amd64
+    cloud: aws
+    owner: openshift-ci
+    product: ocp
+    timeout: 5h0m0s
+    version: "4.22"
   optional: true
   steps:
-    cluster_profile: openshift-org-aws
-    env:
-      COMPUTE_NODE_TYPE: m5.4xlarge
     test:
     - ref: tls-scanner-run
-    workflow: ipi-aws
+    workflow: generic-claim
+- as: default-pqc-readiness
+  cluster_claim:
+    architecture: amd64
+    cloud: aws
+    owner: openshift-ci
+    product: ocp
+    timeout: 5h0m0s
+    version: "4.22"
+  optional: true
+  steps:
+    env:
+      PQC_CHECK: "true"
+    test:
+    - ref: tls-scanner-run
+    workflow: generic-claim
 - as: tls13-conformance
   optional: true
   steps:
@@ -84,6 +103,16 @@ tests:
     cluster_profile: openshift-org-aws
     env:
       COMPUTE_NODE_TYPE: m5.4xlarge
+    test:
+    - ref: tls-scanner-run
+    - ref: openshift-e2e-test
+    workflow: openshift-e2e-aws-ovn-tls-13
+- as: tls13-pqc-readiness
+  optional: true
+  steps:
+    cluster_profile: openshift-org-aws
+    env:
+      PQC_CHECK: "true"
     test:
     - ref: tls-scanner-run
     - ref: openshift-e2e-test

--- a/ci-operator/jobs/openshift/tls-scanner/openshift-tls-scanner-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/tls-scanner/openshift-tls-scanner-main-presubmits.yaml
@@ -5,7 +5,85 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build05
+    cluster: build11
+    context: ci/prow/default-pqc-readiness
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-tls-scanner-main-default-pqc-readiness
+    optional: true
+    rerun_command: /test default-pqc-readiness
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --hive-kubeconfig=/secrets/hive-hive-credentials/kubeconfig
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=default-pqc-readiness
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/hive-hive-credentials
+          name: hive-hive-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: hive-hive-credentials
+        secret:
+          secretName: hive-hive-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )default-pqc-readiness,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build11
     context: ci/prow/default-tls
     decorate: true
     decoration_config:
@@ -88,7 +166,7 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build05
+    cluster: build01
     context: ci/prow/images
     decorate: true
     decoration_config:
@@ -144,7 +222,7 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build05
+    cluster: build01
     context: ci/prow/tls13-conformance
     decorate: true
     decoration_config:
@@ -227,7 +305,90 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build05
+    cluster: build01
+    context: ci/prow/tls13-pqc-readiness
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: aws-5
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-tls-scanner-main-tls13-pqc-readiness
+    optional: true
+    rerun_command: /test tls13-pqc-readiness
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=tls13-pqc-readiness
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )tls13-pqc-readiness,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/unit
     decorate: true
     decoration_config:

--- a/ci-operator/jobs/openshift/tls-scanner/openshift-tls-scanner-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/tls-scanner/openshift-tls-scanner-main-presubmits.yaml
@@ -11,6 +11,8 @@ presubmits:
     decoration_config:
       skip_cloning: true
     labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-tls-scanner-main-default-pqc-readiness
@@ -20,7 +22,6 @@ presubmits:
       containers:
       - args:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --hive-kubeconfig=/secrets/hive-hive-credentials/kubeconfig
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
@@ -52,9 +53,6 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
-        - mountPath: /secrets/hive-hive-credentials
-          name: hive-hive-credentials
-          readOnly: true
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
@@ -75,9 +73,6 @@ presubmits:
       - name: ci-pull-credentials
         secret:
           secretName: ci-pull-credentials
-      - name: hive-hive-credentials
-        secret:
-          secretName: hive-hive-credentials
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher

--- a/ci-operator/jobs/openshift/tls-scanner/openshift-tls-scanner-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/tls-scanner/openshift-tls-scanner-main-presubmits.yaml
@@ -22,6 +22,7 @@ presubmits:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
         - --hive-kubeconfig=/secrets/hive-hive-credentials/kubeconfig
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
         - --target=default-pqc-readiness
@@ -42,6 +43,9 @@ presubmits:
           requests:
             cpu: 10m
         volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
         - mountPath: /secrets/ci-pull-credentials
           name: ci-pull-credentials
           readOnly: true
@@ -62,6 +66,12 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
       - name: ci-pull-credentials
         secret:
           secretName: ci-pull-credentials
@@ -89,8 +99,6 @@ presubmits:
     decoration_config:
       skip_cloning: true
     labels:
-      ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-tls-scanner-main-default-tls
@@ -100,6 +108,7 @@ presubmits:
       containers:
       - args:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --hive-kubeconfig=/secrets/hive-hive-credentials/kubeconfig
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
@@ -131,6 +140,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/hive-hive-credentials
+          name: hive-hive-credentials
+          readOnly: true
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
@@ -151,6 +163,9 @@ presubmits:
       - name: ci-pull-credentials
         secret:
           secretName: ci-pull-credentials
+      - name: hive-hive-credentials
+        secret:
+          secretName: hive-hive-credentials
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
@@ -312,7 +327,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws-5
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-tls-scanner-main-tls13-pqc-readiness

--- a/ci-operator/step-registry/tls/scanner/run/tls-scanner-run-commands.sh
+++ b/ci-operator/step-registry/tls/scanner/run/tls-scanner-run-commands.sh
@@ -16,6 +16,12 @@ else
     SCANNER_ARGS="--all-pods"
 fi
 
+# Enable post-quantum cryptography checks when requested by the step ref.
+if [[ "${PQC_CHECK:-false}" == "true" ]]; then
+    SCANNER_ARGS="${SCANNER_ARGS} --pqc-check"
+    echo "PQC readiness mode enabled: checks TLS 1.3 support and mlkem or mlkem25519 support per target."
+fi
+
 mkdir -p "${SCANNER_ARTIFACT_DIR}"
 
 echo "=== TLS Scanner ==="

--- a/ci-operator/step-registry/tls/scanner/run/tls-scanner-run-ref.yaml
+++ b/ci-operator/step-registry/tls/scanner/run/tls-scanner-run-ref.yaml
@@ -7,6 +7,9 @@ ref:
   - name: SCAN_NAMESPACE
     default: ""
     documentation: "Comma-separated list of namespaces to scan. Empty means scan all namespaces."
+  - name: PQC_CHECK
+    default: "false"
+    documentation: "Set to 'true' to enable post-quantum cryptography readiness checks (TLS 1.3 and mlkem/mlkem25519 support)."
   dependencies:
   - env: RELEASE_IMAGE_LATEST
     name: release:latest
@@ -25,3 +28,4 @@ ref:
   documentation: |-
     Runs the TLS scanner against all pods in the target cluster.
     The scanner runs with cluster-admin privileges and full host access.
+    Set PQC_CHECK=true to enable post-quantum cryptography readiness checks.


### PR DESCRIPTION
Adds a new job for checking PQC readiness:
This job checks that:
  - minversion TLS 1.3 is supported
  - X25519Kyber768 or MLKEM768 is supported


Utilizes the new pqc-check mode in tls-scanner: https://github.com/openshift/tls-scanner/pull/10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional TLS 1.3 post-quantum cryptography (PQC) readiness test
  * Introduced PQC readiness checking capability in TLS scanner with environment variable configuration

* **Tests**
  * Added new PQC-focused test entry to default test suite
  * Enhanced existing test with PQC readiness verification option

<!-- end of auto-generated comment: release notes by coderabbit.ai -->