### PR TITLE
Add GitHub App authentication for cross-fork PR creation

### DIFF
--- a/ci-operator/step-registry/aro-hcp/automation/image-update/aro-hcp-automation-image-update-commands.sh
+++ b/ci-operator/step-registry/aro-hcp/automation/image-update/aro-hcp-automation-image-update-commands.sh
@@ -134,6 +134,17 @@ export AZURE_TENANT_ID
 
 debug "azure: authentication configured successfully (credentials redacted)"
 
+# GitHub App: Load App credentials for PR creation
+# The GitHub App is used to create cross-fork PRs against Azure org repos
+debug "cfg: loading GitHub App credentials"
+if [[ ! -f "${GITHUB_APP_ID_PATH}" ]]; then
+  error "github-app: app ID file not found at ${GITHUB_APP_ID_PATH}"
+fi
+if [[ ! -f "${GITHUB_APP_KEY_PATH}" ]]; then
+  error "github-app: private key file not found at ${GITHUB_APP_KEY_PATH}"
+fi
+debug "cfg: GitHub App credentials loaded successfully (content redacted)"
+
 # Image Updater: Build and run the image-updater tool
 info "image: fetching the latest image digests for all components"
 make image-updater OUTPUT_FILE="${IMAGE_UPDATER_OUTPUT}" OUTPUT_FORMAT="${IMAGE_UPDATER_OUTPUT_FORMAT}"
@@ -187,6 +198,8 @@ info "git: creating the pull request"
 set +o errexit
 run /usr/bin/prcreator \
   -github-token-path="${GITHUB_TOKEN_PATH}" \
+  -pr-app-id="$(cat "${GITHUB_APP_ID_PATH}")" \
+  -pr-app-private-key-path="${GITHUB_APP_KEY_PATH}" \
   -organization="${GITHUB_REPO_ORG}" \
   -repo="${GITHUB_REPO_NAME}" \
   -branch="${GITHUB_REPO_BRANCH}" \

--- a/ci-operator/step-registry/aro-hcp/automation/image-update/aro-hcp-automation-image-update-ref.yaml
+++ b/ci-operator/step-registry/aro-hcp/automation/image-update/aro-hcp-automation-image-update-ref.yaml
@@ -45,6 +45,16 @@ ref:
     default: https://prow.ci.openshift.org/?job=periodic-ci-Azure-ARO-HCP-main-image-updater-image-updater-tooling
     documentation: |-
       The URL of the Prow job.
+  - name: GITHUB_APP_ID_PATH
+    default: /var/run/github-app/appid
+    documentation: |-
+      Path to the file containing the GitHub App ID for PR creation.
+      The App (aro-hcp-image-bumper) is used to create cross-fork PRs
+      against Azure org repos.
+  - name: GITHUB_APP_KEY_PATH
+    default: /var/run/github-app/cert
+    documentation: |-
+      Path to the GitHub App private key PEM file for PR creation.
   - name: VERBOSITY
     default: "0"
     documentation: |-
@@ -61,6 +71,10 @@ ref:
   - collection: ""
     mount_path: /var/run/slack-webhook
     name: aro-hcp-image-bump-slack-webhook
+    namespace: test-credentials
+  - collection: ""
+    mount_path: /var/run/github-app
+    name: aro-hcp-image-bumper
     namespace: test-credentials
   resources:
     requests:


### PR DESCRIPTION
Wait for https://github.com/openshift/ci-tools/pull/4963 to merge.

## Add GitHub App authentication for cross-fork PR creation

### Problem
The `periodic-ci-Azure-ARO-HCP-main-image-updater-image-updater-tooling` job fails to create PRs against `Azure/ARO-HCP` because Microsoft enterprise policy blocks GitHub REST API calls from PATs with >90-day lifetime.

### Solution
Use a GitHub App (`aro-hcp-image-bumper`) to create cross-fork PRs via prcreator's new `--pr-app-id` and `--pr-app-private-key-path` flags. The PAT is still used for fork detection and `git push`; the App token handles PR creation with `maintainer_can_modify: false` to avoid `fork_collab` errors.

### Changes
- **commands.sh**: Add GitHub App credential validation and pass App flags to prcreator
- **ref.yaml**: Add `GITHUB_APP_ID_PATH` / `GITHUB_APP_KEY_PATH` env vars and mount `aro-hcp-image-bumper` secret

### JIRA
[AROSLSRE-452](https://issues.redhat.com/browse/AROSLSRE-452)

[AROSLSRE-452]: https://redhat.atlassian.net/browse/AROSLSRE-452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ