### PR TITLE
openshift-logging: Update cluster-logging-operator to Go 1.25

### DIFF
--- a/ci-operator/config/openshift/cluster-logging-operator/openshift-cluster-logging-operator-master.yaml
+++ b/ci-operator/config/openshift/cluster-logging-operator/openshift-cluster-logging-operator-master.yaml
@@ -1,8 +1,4 @@
 base_images:
-  go_builder:
-    name: builder
-    namespace: ocp
-    tag: rhel-9-golang-1.24-openshift-4.21
   log-file-metric-exporter:
     name: 6.y
     namespace: logging
@@ -31,25 +27,17 @@ build_root:
   image_stream_tag:
     name: builder
     namespace: ocp
-    tag: rhel-9-golang-1.24-openshift-4.21
+    tag: rhel-9-golang-1.25-openshift-4.21
 images:
   items:
   - from: ubi9-minimal
-    inputs:
-      go_builder:
-        as:
-        - registry.redhat.io/ubi9/go-toolset:latest
     to: cluster-logging-operator
   - dockerfile_path: olm_deploy/operatorregistry/Dockerfile
     from: ubi9-minimal
     to: cluster-logging-operator-registry
   - dockerfile_literal: |
-      FROM loki-operator-src AS lo-src
-      FROM registry.redhat.io/ubi9/go-toolset:latest
-      ADD . /go/src/github.com/openshift/cluster-logging-operator
-      COPY --from=lo-src /go/src/github.com/openshift/loki/operator /go/src/github.com/openshift/loki/operator
-      WORKDIR /go/src/github.com/openshift/cluster-logging-operator
-      USER 0
+      FROM src
+      COPY --from=loki-operator-src /go/src/github.com/openshift/loki/operator /go/src/github.com/openshift/loki/operator
       RUN dnf install gettext -y
       RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" \
         && chmod 755 kubectl && mv kubectl /go/bin
@@ -58,10 +46,8 @@ images:
       RUN make tools
       RUN chmod -R 777 /go
       RUN make bin/functional-benchmarker
+    from: src
     inputs:
-      go_builder:
-        as:
-        - registry.redhat.io/ubi9/go-toolset:latest
       loki-operator-src:
         as:
         - loki-operator-src


### PR DESCRIPTION
- [x] Updates cluster-logging-operator in `master` to build with Go 1.25
- [x] Trying out a different way of getting the builder image into the build (was reminded of this by the LO configuration)
- [x] e2e tests successful

/cc @jcantrill 
/assign @xperimental 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD build configuration for improved maintainability
  * Upgraded Go toolchain version from 1.24 to 1.25
  * Optimized container image build process with streamlined dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->