### PR TITLE
kubevirt-plugin: use a metal compute node

### DIFF
--- a/ci-operator/config/kubevirt-ui/kubevirt-plugin/kubevirt-ui-kubevirt-plugin-main.yaml
+++ b/ci-operator/config/kubevirt-ui/kubevirt-plugin/kubevirt-ui-kubevirt-plugin-main.yaml
@@ -31,7 +31,9 @@ tests:
       KUBEVIRT_PLUGIN_IMG_NAME: kubevirt-plugin
     env:
       BASE_DOMAIN: cnv-ci.syseng.devcluster.openshift.com
-      SPOT_INSTANCES: "true"
+      COMPUTE_NODE_REPLICAS: "1"
+      COMPUTE_NODE_TYPE: c5n.metal
+      CONTROL_PLANE_INSTANCE_TYPE: m6i.2xlarge
     test:
     - as: tests
       cli: latest


### PR DESCRIPTION
https://issues.redhat.com/browse/CNV-81348

Use the ipi-aws workflow with `c5n.metal` worker nodes to provide `/dev/kvm` access for KubeVirt testing. Metal instances enable hardware virtualization without emulation.