### PR TITLE
Added codecov.io token secret to upload gitops unit-test coverage.

### DIFF
--- a/ci-operator/config/redhat-developer/gitops-operator/redhat-developer-gitops-operator-master.yaml
+++ b/ci-operator/config/redhat-developer/gitops-operator/redhat-developer-gitops-operator-master.yaml
@@ -12,6 +12,10 @@ tests:
     test:
     - as: unit-steps
       commands: scripts/openshiftci-presubmit-unittests.sh
+      credentials:
+      - mount_path: /var/run/codecov-token
+        name: gitops-operator-codecov-token
+        namespace: test-credentials
       from: src
       resources:
         requests:


### PR DESCRIPTION
We want to track unit-test coverage and for better or worse we run our tests in openshift-ci.

This should allow us to have the token present when running the test.