### PR TITLE
Scale Konflux OCP 4.20 cluster pools to size 2

### DIFF
--- a/clusters/hosted-mgmt/hive/pools/konflux/konflux-ocp-4-20-0-amd64-aws-us-west-2_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/konflux/konflux-ocp-4-20-0-amd64-aws-us-west-2_clusterpool.yaml
@@ -32,7 +32,7 @@ spec:
       region: us-west-2
   pullSecretRef:
     name: pull-secret
-  size: 1
+  size: 2
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/konflux/konflux-ocp-4-20-0-arm64-aws-us-west-2_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/konflux/konflux-ocp-4-20-0-arm64-aws-us-west-2_clusterpool.yaml
@@ -32,7 +32,7 @@ spec:
       region: us-west-2
   pullSecretRef:
     name: pull-secret
-  size: 1
+  size: 2
   skipMachinePools: true
 status:
   ready: 0


### PR DESCRIPTION
keep 2 clusters on standby to prevent clusterclaim timeouts