### PR TITLE
Add deferred Orion summary report step for consolidated regression reporting

### DIFF
--- a/ci-operator/config/cloud-bulldozer/orion/cloud-bulldozer-orion-main.yaml
+++ b/ci-operator/config/cloud-bulldozer/orion/cloud-bulldozer-orion-main.yaml
@@ -30,7 +30,7 @@ tests:
       EXTRA_FLAGS: --churn-duration=20m --pod-ready-threshold=20s --service-latency
       IGNORE_JOB_ITERATIONS: "true"
       OUTPUT_FORMAT: JUNIT
-      RUN_ORION: "true"
+      RUN_ORION: "deferred"
       UDN_ITERATION_MULTIPLIER: "12"
       VERSION: "4.21"
       ZONES_COUNT: "3"
@@ -46,7 +46,7 @@ tests:
     env:
       ES_TYPE: qe
       OUTPUT_FORMAT: JUNIT
-      RUN_ORION: "true"
+      RUN_ORION: "deferred"
       VERSION: "4.21"
     test:
     - chain: openshift-qe-orion-consolidated
@@ -55,7 +55,7 @@ tests:
   steps:
     cluster_profile: aws-perfscale-qe
     env:
-      RUN_ORION: "true"
+      RUN_ORION: "deferred"
       VERSION: "4.19"
     test:
     - chain: openshift-qe-orion-consolidated-virt

--- a/ci-operator/config/cloud-bulldozer/orion/cloud-bulldozer-orion-main.yaml
+++ b/ci-operator/config/cloud-bulldozer/orion/cloud-bulldozer-orion-main.yaml
@@ -30,7 +30,7 @@ tests:
       EXTRA_FLAGS: --churn-duration=20m --pod-ready-threshold=20s --service-latency
       IGNORE_JOB_ITERATIONS: "true"
       OUTPUT_FORMAT: JUNIT
-      RUN_ORION: "deferred"
+      RUN_ORION: deferred
       UDN_ITERATION_MULTIPLIER: "12"
       VERSION: "4.21"
       ZONES_COUNT: "3"
@@ -46,7 +46,7 @@ tests:
     env:
       ES_TYPE: qe
       OUTPUT_FORMAT: JUNIT
-      RUN_ORION: "deferred"
+      RUN_ORION: deferred
       VERSION: "4.21"
     test:
     - chain: openshift-qe-orion-consolidated
@@ -55,7 +55,7 @@ tests:
   steps:
     cluster_profile: aws-perfscale-qe
     env:
-      RUN_ORION: "deferred"
+      RUN_ORION: deferred
       VERSION: "4.19"
     test:
     - chain: openshift-qe-orion-consolidated-virt

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.21-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.21-nightly-x86.yaml
@@ -45,7 +45,7 @@ tests:
         --churn-cycles=2
       ND_EXTRA_FLAGS: --churn-mode=objects --churn-delay=1m --churn-percent=50 --churn-cycles=2
       OUTPUT_FORMAT: JUNIT
-      RUN_ORION: "true"
+      RUN_ORION: "deferred"
       UDN_ITERATION_MULTIPLIER: "12"
       VERSION: "4.21"
       ZONES_COUNT: "3"
@@ -185,6 +185,7 @@ tests:
       COMPUTE_NODE_TYPE: m5.xlarge
       ENABLE_LAYER_3: "true"
       KB_FLAGS: --local-indexing
+      RUN_ORION: "deferred"
       UDN_ITERATION_MULTIPLIER: "3"
       VERSION: "4.21"
     post:

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.21-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.21-nightly-x86.yaml
@@ -45,7 +45,7 @@ tests:
         --churn-cycles=2
       ND_EXTRA_FLAGS: --churn-mode=objects --churn-delay=1m --churn-percent=50 --churn-cycles=2
       OUTPUT_FORMAT: JUNIT
-      RUN_ORION: "deferred"
+      RUN_ORION: deferred
       UDN_ITERATION_MULTIPLIER: "12"
       VERSION: "4.21"
       ZONES_COUNT: "3"
@@ -185,7 +185,7 @@ tests:
       COMPUTE_NODE_TYPE: m5.xlarge
       ENABLE_LAYER_3: "true"
       KB_FLAGS: --local-indexing
-      RUN_ORION: "deferred"
+      RUN_ORION: deferred
       UDN_ITERATION_MULTIPLIER: "3"
       VERSION: "4.21"
     post:

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.22-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.22-nightly-x86.yaml
@@ -45,7 +45,7 @@ tests:
         --churn-cycles=2
       ND_EXTRA_FLAGS: --churn-mode=objects --churn-delay=1m --churn-percent=50 --churn-cycles=2
       OUTPUT_FORMAT: JUNIT
-      RUN_ORION: "true"
+      RUN_ORION: "deferred"
       UDN_ITERATION_MULTIPLIER: "12"
       VERSION: "4.22"
       ZONES_COUNT: "3"
@@ -296,6 +296,7 @@ tests:
       COMPUTE_NODE_TYPE: m5.xlarge
       ENABLE_LAYER_3: "true"
       KB_FLAGS: --local-indexing
+      RUN_ORION: "deferred"
       UDN_ITERATION_MULTIPLIER: "3"
       VERSION: "4.22"
     post:

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.22-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.22-nightly-x86.yaml
@@ -45,7 +45,7 @@ tests:
         --churn-cycles=2
       ND_EXTRA_FLAGS: --churn-mode=objects --churn-delay=1m --churn-percent=50 --churn-cycles=2
       OUTPUT_FORMAT: JUNIT
-      RUN_ORION: "deferred"
+      RUN_ORION: deferred
       UDN_ITERATION_MULTIPLIER: "12"
       VERSION: "4.22"
       ZONES_COUNT: "3"
@@ -296,7 +296,7 @@ tests:
       COMPUTE_NODE_TYPE: m5.xlarge
       ENABLE_LAYER_3: "true"
       KB_FLAGS: --local-indexing
-      RUN_ORION: "deferred"
+      RUN_ORION: deferred
       UDN_ITERATION_MULTIPLIER: "3"
       VERSION: "4.22"
     post:

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-5.0-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-5.0-nightly-x86.yaml
@@ -46,7 +46,7 @@ tests:
         --churn-cycles=2
       ND_EXTRA_FLAGS: --churn-mode=objects --churn-delay=1m --churn-percent=50 --churn-cycles=2
       OUTPUT_FORMAT: JUNIT
-      RUN_ORION: "deferred"
+      RUN_ORION: deferred
       UDN_ITERATION_MULTIPLIER: "12"
       VERSION: "5.0"
       ZONES_COUNT: "3"
@@ -172,7 +172,7 @@ tests:
       COMPUTE_NODE_TYPE: m5.xlarge
       ENABLE_LAYER_3: "true"
       KB_FLAGS: --local-indexing
-      RUN_ORION: "deferred"
+      RUN_ORION: deferred
       UDN_ITERATION_MULTIPLIER: "3"
       VERSION: "5.0"
     post:

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-5.0-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-5.0-nightly-x86.yaml
@@ -46,7 +46,7 @@ tests:
         --churn-cycles=2
       ND_EXTRA_FLAGS: --churn-mode=objects --churn-delay=1m --churn-percent=50 --churn-cycles=2
       OUTPUT_FORMAT: JUNIT
-      RUN_ORION: "true"
+      RUN_ORION: "deferred"
       UDN_ITERATION_MULTIPLIER: "12"
       VERSION: "5.0"
       ZONES_COUNT: "3"
@@ -172,6 +172,7 @@ tests:
       COMPUTE_NODE_TYPE: m5.xlarge
       ENABLE_LAYER_3: "true"
       KB_FLAGS: --local-indexing
+      RUN_ORION: "deferred"
       UDN_ITERATION_MULTIPLIER: "3"
       VERSION: "5.0"
     post:

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__metal-4.19-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__metal-4.19-nightly-x86.yaml
@@ -38,7 +38,7 @@ tests:
       CONFIG: config/standard-scalelab.yml
       INFRA: "true"
       PUBLIC_VLAN: "false"
-      RUN_ORION: "true"
+      RUN_ORION: "deferred"
       VERSION: "4.19"
       VM: "true"
     post:

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__metal-4.19-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__metal-4.19-nightly-x86.yaml
@@ -38,7 +38,7 @@ tests:
       CONFIG: config/standard-scalelab.yml
       INFRA: "true"
       PUBLIC_VLAN: "false"
-      RUN_ORION: "deferred"
+      RUN_ORION: deferred
       VERSION: "4.19"
       VM: "true"
     post:

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__metal-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__metal-x86.yaml
@@ -281,7 +281,7 @@ tests:
   steps:
     cluster_profile: metal-perfscale-cpt
     env:
-      RUN_ORION: "true"
+      RUN_ORION: "deferred"
       VERSION: "4.19"
     test:
     - chain: openshift-qe-orion-consolidated-virt

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__metal-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__metal-x86.yaml
@@ -281,7 +281,7 @@ tests:
   steps:
     cluster_profile: metal-perfscale-cpt
     env:
-      RUN_ORION: "deferred"
+      RUN_ORION: deferred
       VERSION: "4.19"
     test:
     - chain: openshift-qe-orion-consolidated-virt

--- a/ci-operator/config/openshift-priv/ovn-kubernetes/openshift-priv-ovn-kubernetes-release-4.18.yaml
+++ b/ci-operator/config/openshift-priv/ovn-kubernetes/openshift-priv-ovn-kubernetes-release-4.18.yaml
@@ -409,7 +409,7 @@ tests:
       COMPUTE_NODE_REPLICAS: "24"
       COMPUTE_NODE_TYPE: m5.xlarge
       EXTRA_MG_ARGS: --host-network
-      RUN_ORION: "deferred"
+      RUN_ORION: deferred
       UDN_ITERATION_MULTIPLIER: "3"
       VERSION: "4.18"
     post:
@@ -430,7 +430,7 @@ tests:
       ENABLE_LAYER_3: "false"
       EXTRA_MG_ARGS: --host-network
       KUBE_BURNER_VERSION: 1.5.0
-      RUN_ORION: "deferred"
+      RUN_ORION: deferred
       UDN_ITERATION_MULTIPLIER: "3"
     post:
     - chain: ipi-aws-post

--- a/ci-operator/config/openshift-priv/ovn-kubernetes/openshift-priv-ovn-kubernetes-release-4.18.yaml
+++ b/ci-operator/config/openshift-priv/ovn-kubernetes/openshift-priv-ovn-kubernetes-release-4.18.yaml
@@ -409,7 +409,6 @@ tests:
       COMPUTE_NODE_REPLICAS: "24"
       COMPUTE_NODE_TYPE: m5.xlarge
       EXTRA_MG_ARGS: --host-network
-      RUN_ORION: deferred
       UDN_ITERATION_MULTIPLIER: "3"
       VERSION: "4.18"
     post:
@@ -430,7 +429,6 @@ tests:
       ENABLE_LAYER_3: "false"
       EXTRA_MG_ARGS: --host-network
       KUBE_BURNER_VERSION: 1.5.0
-      RUN_ORION: deferred
       UDN_ITERATION_MULTIPLIER: "3"
     post:
     - chain: ipi-aws-post

--- a/ci-operator/config/openshift-priv/ovn-kubernetes/openshift-priv-ovn-kubernetes-release-4.18.yaml
+++ b/ci-operator/config/openshift-priv/ovn-kubernetes/openshift-priv-ovn-kubernetes-release-4.18.yaml
@@ -409,6 +409,7 @@ tests:
       COMPUTE_NODE_REPLICAS: "24"
       COMPUTE_NODE_TYPE: m5.xlarge
       EXTRA_MG_ARGS: --host-network
+      RUN_ORION: "deferred"
       UDN_ITERATION_MULTIPLIER: "3"
       VERSION: "4.18"
     post:
@@ -429,6 +430,7 @@ tests:
       ENABLE_LAYER_3: "false"
       EXTRA_MG_ARGS: --host-network
       KUBE_BURNER_VERSION: 1.5.0
+      RUN_ORION: "deferred"
       UDN_ITERATION_MULTIPLIER: "3"
     post:
     - chain: ipi-aws-post

--- a/ci-operator/config/openshift-priv/ovn-kubernetes/openshift-priv-ovn-kubernetes-release-4.19.yaml
+++ b/ci-operator/config/openshift-priv/ovn-kubernetes/openshift-priv-ovn-kubernetes-release-4.19.yaml
@@ -334,7 +334,7 @@ tests:
       ES_TYPE: qe
       EXTRA_FLAGS: --churn-duration=20m --pod-ready-threshold=20s
       OUTPUT_FORMAT: JUNIT
-      RUN_ORION: "true"
+      RUN_ORION: "deferred"
       UDN_ITERATION_MULTIPLIER: "12"
       VERSION: "4.19"
       ZONES_COUNT: "3"
@@ -351,7 +351,7 @@ tests:
       BASE_DOMAIN: qe.devcluster.openshift.com
       COMPUTE_NODE_REPLICAS: "24"
       COMPUTE_NODE_TYPE: m5.xlarge
-      RUN_ORION: "true"
+      RUN_ORION: "deferred"
       UDN_ITERATION_MULTIPLIER: "3"
       VERSION: "4.19"
     post:
@@ -370,7 +370,7 @@ tests:
       COMPUTE_NODE_REPLICAS: "24"
       COMPUTE_NODE_TYPE: m5.xlarge
       ENABLE_LAYER_3: "false"
-      RUN_ORION: "true"
+      RUN_ORION: "deferred"
       UDN_ITERATION_MULTIPLIER: "3"
       VERSION: "4.19"
     post:

--- a/ci-operator/config/openshift-priv/ovn-kubernetes/openshift-priv-ovn-kubernetes-release-4.19.yaml
+++ b/ci-operator/config/openshift-priv/ovn-kubernetes/openshift-priv-ovn-kubernetes-release-4.19.yaml
@@ -334,7 +334,7 @@ tests:
       ES_TYPE: qe
       EXTRA_FLAGS: --churn-duration=20m --pod-ready-threshold=20s
       OUTPUT_FORMAT: JUNIT
-      RUN_ORION: "deferred"
+      RUN_ORION: deferred
       UDN_ITERATION_MULTIPLIER: "12"
       VERSION: "4.19"
       ZONES_COUNT: "3"
@@ -351,7 +351,7 @@ tests:
       BASE_DOMAIN: qe.devcluster.openshift.com
       COMPUTE_NODE_REPLICAS: "24"
       COMPUTE_NODE_TYPE: m5.xlarge
-      RUN_ORION: "deferred"
+      RUN_ORION: deferred
       UDN_ITERATION_MULTIPLIER: "3"
       VERSION: "4.19"
     post:
@@ -370,7 +370,7 @@ tests:
       COMPUTE_NODE_REPLICAS: "24"
       COMPUTE_NODE_TYPE: m5.xlarge
       ENABLE_LAYER_3: "false"
-      RUN_ORION: "deferred"
+      RUN_ORION: deferred
       UDN_ITERATION_MULTIPLIER: "3"
       VERSION: "4.19"
     post:

--- a/ci-operator/config/openshift-priv/ovn-kubernetes/openshift-priv-ovn-kubernetes-release-4.19.yaml
+++ b/ci-operator/config/openshift-priv/ovn-kubernetes/openshift-priv-ovn-kubernetes-release-4.19.yaml
@@ -334,7 +334,7 @@ tests:
       ES_TYPE: qe
       EXTRA_FLAGS: --churn-duration=20m --pod-ready-threshold=20s
       OUTPUT_FORMAT: JUNIT
-      RUN_ORION: deferred
+      RUN_ORION: "true"
       UDN_ITERATION_MULTIPLIER: "12"
       VERSION: "4.19"
       ZONES_COUNT: "3"
@@ -351,7 +351,7 @@ tests:
       BASE_DOMAIN: qe.devcluster.openshift.com
       COMPUTE_NODE_REPLICAS: "24"
       COMPUTE_NODE_TYPE: m5.xlarge
-      RUN_ORION: deferred
+      RUN_ORION: "true"
       UDN_ITERATION_MULTIPLIER: "3"
       VERSION: "4.19"
     post:
@@ -370,7 +370,7 @@ tests:
       COMPUTE_NODE_REPLICAS: "24"
       COMPUTE_NODE_TYPE: m5.xlarge
       ENABLE_LAYER_3: "false"
-      RUN_ORION: deferred
+      RUN_ORION: "true"
       UDN_ITERATION_MULTIPLIER: "3"
       VERSION: "4.19"
     post:

--- a/ci-operator/config/openshift-priv/ovn-kubernetes/openshift-priv-ovn-kubernetes-release-4.20.yaml
+++ b/ci-operator/config/openshift-priv/ovn-kubernetes/openshift-priv-ovn-kubernetes-release-4.20.yaml
@@ -335,7 +335,7 @@ tests:
       ES_TYPE: qe
       EXTRA_FLAGS: --churn-duration=20m --pod-ready-threshold=20s
       OUTPUT_FORMAT: JUNIT
-      RUN_ORION: deferred
+      RUN_ORION: "true"
       UDN_ITERATION_MULTIPLIER: "12"
       VERSION: "4.20"
       ZONES_COUNT: "3"
@@ -353,7 +353,7 @@ tests:
       COMPUTE_NODE_REPLICAS: "24"
       COMPUTE_NODE_TYPE: m5.xlarge
       ENABLE_LAYER_3: "true"
-      RUN_ORION: deferred
+      RUN_ORION: "true"
       UDN_ITERATION_MULTIPLIER: "3"
       VERSION: "4.20"
     post:
@@ -372,7 +372,7 @@ tests:
       COMPUTE_NODE_REPLICAS: "24"
       COMPUTE_NODE_TYPE: m5.xlarge
       ENABLE_LAYER_3: "false"
-      RUN_ORION: deferred
+      RUN_ORION: "true"
       UDN_ITERATION_MULTIPLIER: "3"
       VERSION: "4.20"
     post:

--- a/ci-operator/config/openshift-priv/ovn-kubernetes/openshift-priv-ovn-kubernetes-release-4.20.yaml
+++ b/ci-operator/config/openshift-priv/ovn-kubernetes/openshift-priv-ovn-kubernetes-release-4.20.yaml
@@ -335,7 +335,7 @@ tests:
       ES_TYPE: qe
       EXTRA_FLAGS: --churn-duration=20m --pod-ready-threshold=20s
       OUTPUT_FORMAT: JUNIT
-      RUN_ORION: "deferred"
+      RUN_ORION: deferred
       UDN_ITERATION_MULTIPLIER: "12"
       VERSION: "4.20"
       ZONES_COUNT: "3"
@@ -353,7 +353,7 @@ tests:
       COMPUTE_NODE_REPLICAS: "24"
       COMPUTE_NODE_TYPE: m5.xlarge
       ENABLE_LAYER_3: "true"
-      RUN_ORION: "deferred"
+      RUN_ORION: deferred
       UDN_ITERATION_MULTIPLIER: "3"
       VERSION: "4.20"
     post:
@@ -372,7 +372,7 @@ tests:
       COMPUTE_NODE_REPLICAS: "24"
       COMPUTE_NODE_TYPE: m5.xlarge
       ENABLE_LAYER_3: "false"
-      RUN_ORION: "deferred"
+      RUN_ORION: deferred
       UDN_ITERATION_MULTIPLIER: "3"
       VERSION: "4.20"
     post:

--- a/ci-operator/config/openshift-priv/ovn-kubernetes/openshift-priv-ovn-kubernetes-release-4.20.yaml
+++ b/ci-operator/config/openshift-priv/ovn-kubernetes/openshift-priv-ovn-kubernetes-release-4.20.yaml
@@ -335,7 +335,7 @@ tests:
       ES_TYPE: qe
       EXTRA_FLAGS: --churn-duration=20m --pod-ready-threshold=20s
       OUTPUT_FORMAT: JUNIT
-      RUN_ORION: "true"
+      RUN_ORION: "deferred"
       UDN_ITERATION_MULTIPLIER: "12"
       VERSION: "4.20"
       ZONES_COUNT: "3"
@@ -353,7 +353,7 @@ tests:
       COMPUTE_NODE_REPLICAS: "24"
       COMPUTE_NODE_TYPE: m5.xlarge
       ENABLE_LAYER_3: "true"
-      RUN_ORION: "true"
+      RUN_ORION: "deferred"
       UDN_ITERATION_MULTIPLIER: "3"
       VERSION: "4.20"
     post:
@@ -372,7 +372,7 @@ tests:
       COMPUTE_NODE_REPLICAS: "24"
       COMPUTE_NODE_TYPE: m5.xlarge
       ENABLE_LAYER_3: "false"
-      RUN_ORION: "true"
+      RUN_ORION: "deferred"
       UDN_ITERATION_MULTIPLIER: "3"
       VERSION: "4.20"
     post:

--- a/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.18.yaml
+++ b/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.18.yaml
@@ -425,7 +425,6 @@ tests:
       COMPUTE_NODE_REPLICAS: "24"
       COMPUTE_NODE_TYPE: m5.xlarge
       EXTRA_MG_ARGS: --host-network
-      RUN_ORION: deferred
       UDN_ITERATION_MULTIPLIER: "3"
       VERSION: "4.18"
     post:
@@ -446,7 +445,6 @@ tests:
       ENABLE_LAYER_3: "false"
       EXTRA_MG_ARGS: --host-network
       KUBE_BURNER_VERSION: 1.5.0
-      RUN_ORION: deferred
       UDN_ITERATION_MULTIPLIER: "3"
     post:
     - chain: ipi-aws-post

--- a/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.18.yaml
+++ b/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.18.yaml
@@ -425,7 +425,7 @@ tests:
       COMPUTE_NODE_REPLICAS: "24"
       COMPUTE_NODE_TYPE: m5.xlarge
       EXTRA_MG_ARGS: --host-network
-      RUN_ORION: "deferred"
+      RUN_ORION: deferred
       UDN_ITERATION_MULTIPLIER: "3"
       VERSION: "4.18"
     post:
@@ -446,7 +446,7 @@ tests:
       ENABLE_LAYER_3: "false"
       EXTRA_MG_ARGS: --host-network
       KUBE_BURNER_VERSION: 1.5.0
-      RUN_ORION: "deferred"
+      RUN_ORION: deferred
       UDN_ITERATION_MULTIPLIER: "3"
     post:
     - chain: ipi-aws-post

--- a/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.18.yaml
+++ b/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.18.yaml
@@ -425,6 +425,7 @@ tests:
       COMPUTE_NODE_REPLICAS: "24"
       COMPUTE_NODE_TYPE: m5.xlarge
       EXTRA_MG_ARGS: --host-network
+      RUN_ORION: "deferred"
       UDN_ITERATION_MULTIPLIER: "3"
       VERSION: "4.18"
     post:
@@ -445,6 +446,7 @@ tests:
       ENABLE_LAYER_3: "false"
       EXTRA_MG_ARGS: --host-network
       KUBE_BURNER_VERSION: 1.5.0
+      RUN_ORION: "deferred"
       UDN_ITERATION_MULTIPLIER: "3"
     post:
     - chain: ipi-aws-post

--- a/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.19.yaml
+++ b/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.19.yaml
@@ -355,7 +355,7 @@ tests:
       ES_TYPE: qe
       EXTRA_FLAGS: --churn-duration=20m --pod-ready-threshold=20s
       OUTPUT_FORMAT: JUNIT
-      RUN_ORION: "true"
+      RUN_ORION: "deferred"
       UDN_ITERATION_MULTIPLIER: "12"
       VERSION: "4.19"
       ZONES_COUNT: "3"
@@ -372,7 +372,7 @@ tests:
       BASE_DOMAIN: qe.devcluster.openshift.com
       COMPUTE_NODE_REPLICAS: "24"
       COMPUTE_NODE_TYPE: m5.xlarge
-      RUN_ORION: "true"
+      RUN_ORION: "deferred"
       UDN_ITERATION_MULTIPLIER: "3"
       VERSION: "4.19"
     post:
@@ -391,7 +391,7 @@ tests:
       COMPUTE_NODE_REPLICAS: "24"
       COMPUTE_NODE_TYPE: m5.xlarge
       ENABLE_LAYER_3: "false"
-      RUN_ORION: "true"
+      RUN_ORION: "deferred"
       UDN_ITERATION_MULTIPLIER: "3"
       VERSION: "4.19"
     post:

--- a/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.19.yaml
+++ b/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.19.yaml
@@ -355,7 +355,7 @@ tests:
       ES_TYPE: qe
       EXTRA_FLAGS: --churn-duration=20m --pod-ready-threshold=20s
       OUTPUT_FORMAT: JUNIT
-      RUN_ORION: "deferred"
+      RUN_ORION: deferred
       UDN_ITERATION_MULTIPLIER: "12"
       VERSION: "4.19"
       ZONES_COUNT: "3"
@@ -372,7 +372,7 @@ tests:
       BASE_DOMAIN: qe.devcluster.openshift.com
       COMPUTE_NODE_REPLICAS: "24"
       COMPUTE_NODE_TYPE: m5.xlarge
-      RUN_ORION: "deferred"
+      RUN_ORION: deferred
       UDN_ITERATION_MULTIPLIER: "3"
       VERSION: "4.19"
     post:
@@ -391,7 +391,7 @@ tests:
       COMPUTE_NODE_REPLICAS: "24"
       COMPUTE_NODE_TYPE: m5.xlarge
       ENABLE_LAYER_3: "false"
-      RUN_ORION: "deferred"
+      RUN_ORION: deferred
       UDN_ITERATION_MULTIPLIER: "3"
       VERSION: "4.19"
     post:

--- a/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.19.yaml
+++ b/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.19.yaml
@@ -355,7 +355,7 @@ tests:
       ES_TYPE: qe
       EXTRA_FLAGS: --churn-duration=20m --pod-ready-threshold=20s
       OUTPUT_FORMAT: JUNIT
-      RUN_ORION: deferred
+      RUN_ORION: "true"
       UDN_ITERATION_MULTIPLIER: "12"
       VERSION: "4.19"
       ZONES_COUNT: "3"
@@ -372,7 +372,7 @@ tests:
       BASE_DOMAIN: qe.devcluster.openshift.com
       COMPUTE_NODE_REPLICAS: "24"
       COMPUTE_NODE_TYPE: m5.xlarge
-      RUN_ORION: deferred
+      RUN_ORION: "true"
       UDN_ITERATION_MULTIPLIER: "3"
       VERSION: "4.19"
     post:
@@ -391,7 +391,7 @@ tests:
       COMPUTE_NODE_REPLICAS: "24"
       COMPUTE_NODE_TYPE: m5.xlarge
       ENABLE_LAYER_3: "false"
-      RUN_ORION: deferred
+      RUN_ORION: "true"
       UDN_ITERATION_MULTIPLIER: "3"
       VERSION: "4.19"
     post:

--- a/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.20.yaml
+++ b/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.20.yaml
@@ -356,7 +356,7 @@ tests:
       ES_TYPE: qe
       EXTRA_FLAGS: --churn-duration=20m --pod-ready-threshold=20s
       OUTPUT_FORMAT: JUNIT
-      RUN_ORION: deferred
+      RUN_ORION: "true"
       UDN_ITERATION_MULTIPLIER: "12"
       VERSION: "4.20"
       ZONES_COUNT: "3"
@@ -374,7 +374,7 @@ tests:
       COMPUTE_NODE_REPLICAS: "24"
       COMPUTE_NODE_TYPE: m5.xlarge
       ENABLE_LAYER_3: "true"
-      RUN_ORION: deferred
+      RUN_ORION: "true"
       UDN_ITERATION_MULTIPLIER: "3"
       VERSION: "4.20"
     post:
@@ -393,7 +393,7 @@ tests:
       COMPUTE_NODE_REPLICAS: "24"
       COMPUTE_NODE_TYPE: m5.xlarge
       ENABLE_LAYER_3: "false"
-      RUN_ORION: deferred
+      RUN_ORION: "true"
       UDN_ITERATION_MULTIPLIER: "3"
       VERSION: "4.20"
     post:

--- a/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.20.yaml
+++ b/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.20.yaml
@@ -356,7 +356,7 @@ tests:
       ES_TYPE: qe
       EXTRA_FLAGS: --churn-duration=20m --pod-ready-threshold=20s
       OUTPUT_FORMAT: JUNIT
-      RUN_ORION: "true"
+      RUN_ORION: "deferred"
       UDN_ITERATION_MULTIPLIER: "12"
       VERSION: "4.20"
       ZONES_COUNT: "3"
@@ -374,7 +374,7 @@ tests:
       COMPUTE_NODE_REPLICAS: "24"
       COMPUTE_NODE_TYPE: m5.xlarge
       ENABLE_LAYER_3: "true"
-      RUN_ORION: "true"
+      RUN_ORION: "deferred"
       UDN_ITERATION_MULTIPLIER: "3"
       VERSION: "4.20"
     post:
@@ -393,7 +393,7 @@ tests:
       COMPUTE_NODE_REPLICAS: "24"
       COMPUTE_NODE_TYPE: m5.xlarge
       ENABLE_LAYER_3: "false"
-      RUN_ORION: "true"
+      RUN_ORION: "deferred"
       UDN_ITERATION_MULTIPLIER: "3"
       VERSION: "4.20"
     post:

--- a/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.20.yaml
+++ b/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.20.yaml
@@ -356,7 +356,7 @@ tests:
       ES_TYPE: qe
       EXTRA_FLAGS: --churn-duration=20m --pod-ready-threshold=20s
       OUTPUT_FORMAT: JUNIT
-      RUN_ORION: "deferred"
+      RUN_ORION: deferred
       UDN_ITERATION_MULTIPLIER: "12"
       VERSION: "4.20"
       ZONES_COUNT: "3"
@@ -374,7 +374,7 @@ tests:
       COMPUTE_NODE_REPLICAS: "24"
       COMPUTE_NODE_TYPE: m5.xlarge
       ENABLE_LAYER_3: "true"
-      RUN_ORION: "deferred"
+      RUN_ORION: deferred
       UDN_ITERATION_MULTIPLIER: "3"
       VERSION: "4.20"
     post:
@@ -393,7 +393,7 @@ tests:
       COMPUTE_NODE_REPLICAS: "24"
       COMPUTE_NODE_TYPE: m5.xlarge
       ENABLE_LAYER_3: "false"
-      RUN_ORION: "deferred"
+      RUN_ORION: deferred
       UDN_ITERATION_MULTIPLIER: "3"
       VERSION: "4.20"
     post:

--- a/ci-operator/step-registry/openshift-qe/control-plane/openshift-qe-control-plane-chain.yaml
+++ b/ci-operator/step-registry/openshift-qe/control-plane/openshift-qe-control-plane-chain.yaml
@@ -9,3 +9,4 @@ chain:
   - chain: openshift-qe-udn-density-pods
   documentation: |-
     This chain executes cluster density v2, node density-cni, crd-scale, node-density, and udn density workloads.
+

--- a/ci-operator/step-registry/openshift-qe/orion/consolidated-virt/openshift-qe-orion-consolidated-virt-chain.yaml
+++ b/ci-operator/step-registry/openshift-qe/orion/consolidated-virt/openshift-qe-orion-consolidated-virt-chain.yaml
@@ -5,5 +5,6 @@ chain:
   - ref: openshift-qe-orion-virt-data-path
   - ref: openshift-qe-orion-virt-density
   - ref: openshift-qe-orion-virt-udn-density
+  - ref: openshift-qe-orion-report
   documentation: |-
-    Chain of all orion virtualization workloads. 
+    Chain of all orion virt workloads with aggregated summary reporting.

--- a/ci-operator/step-registry/openshift-qe/orion/consolidated/openshift-qe-orion-consolidated-chain.yaml
+++ b/ci-operator/step-registry/openshift-qe/orion/consolidated/openshift-qe-orion-consolidated-chain.yaml
@@ -5,5 +5,6 @@ chain:
   - ref: openshift-qe-orion-node-density
   - ref: openshift-qe-orion-node-density-cni
   - ref: openshift-qe-orion-crd-scale
+  - ref: openshift-qe-orion-report
   documentation: |-
-    Chain of all orion workloads. 
+    Chain of all orion workloads with aggregated summary reporting.

--- a/ci-operator/step-registry/openshift-qe/orion/openshift-qe-orion-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/orion/openshift-qe-orion-commands.sh
@@ -299,14 +299,6 @@ process_change_point
 
 cp *.csv *.xml *.json *.txt *.html "${ARTIFACT_DIR}/" 2>/dev/null || true
 
-# Write deferred JSON results to SHARED_DIR for report step aggregation
-if [ "${RUN_ORION}" == "deferred" ]; then
-    for f in junit*.json; do
-        [ -e "$f" ] || continue
-        cp "$f" "${SHARED_DIR}/" 2>/dev/null || true
-    done
-fi
-
 if [ $orion_exit_status -eq 3 ]; then
   echo "Orion returned exit code 3, which means there are no results to analyze."
   echo "Exiting zero since there were no regressions found."

--- a/ci-operator/step-registry/openshift-qe/orion/openshift-qe-orion-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/orion/openshift-qe-orion-commands.sh
@@ -302,7 +302,8 @@ cp *.csv *.xml *.json *.txt *.html "${ARTIFACT_DIR}/" 2>/dev/null || true
 # Write deferred JSON results to SHARED_DIR for report step aggregation
 if [ "${RUN_ORION}" == "deferred" ]; then
     for f in junit*.json; do
-        [ -e "$f" ] && cp "$f" "${SHARED_DIR}/orion-${FILENAME}-$(basename "$f")" 2>/dev/null || true
+        [ -e "$f" ] || continue
+        cp "$f" "${SHARED_DIR}/" 2>/dev/null || true
     done
 fi
 

--- a/ci-operator/step-registry/openshift-qe/orion/openshift-qe-orion-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/orion/openshift-qe-orion-commands.sh
@@ -299,9 +299,21 @@ process_change_point
 
 cp *.csv *.xml *.json *.txt *.html "${ARTIFACT_DIR}/" 2>/dev/null || true
 
+# Write deferred JSON results to SHARED_DIR for report step aggregation
+if [ "${RUN_ORION}" == "deferred" ]; then
+    for f in junit*.json; do
+        [ -e "$f" ] && cp "$f" "${SHARED_DIR}/orion-${FILENAME}-$(basename "$f")" 2>/dev/null || true
+    done
+fi
+
 if [ $orion_exit_status -eq 3 ]; then
   echo "Orion returned exit code 3, which means there are no results to analyze."
   echo "Exiting zero since there were no regressions found."
+  exit 0
+fi
+
+if [ "${RUN_ORION}" == "deferred" ]; then
+  echo "RUN_ORION=deferred. Exit status $orion_exit_status deferred to report step."
   exit 0
 fi
 

--- a/ci-operator/step-registry/openshift-qe/orion/openshift-qe-orion-ref.yaml
+++ b/ci-operator/step-registry/openshift-qe/orion/openshift-qe-orion-ref.yaml
@@ -80,6 +80,7 @@ ref:
     default: ""
     documentation:
       Comma separated list of repositories to monitor before and after change points.
+
   commands: openshift-qe-orion-commands.sh
   timeout: 6h
   credentials:

--- a/ci-operator/step-registry/openshift-qe/orion/report/OWNERS
+++ b/ci-operator/step-registry/openshift-qe/orion/report/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- perfscale-ocp-approvers
+reviewers:
+- perfscale-ocp-reviewers

--- a/ci-operator/step-registry/openshift-qe/orion/report/openshift-qe-orion-report-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/orion/report/openshift-qe-orion-report-commands.sh
@@ -9,7 +9,7 @@ fi
 
 # Check for deferred JSON results
 shopt -s nullglob
-json_files=("${SHARED_DIR}"/orion-*.json)
+json_files=("${SHARED_DIR}"/junit*.json)
 shopt -u nullglob
 
 if [ ${#json_files[@]} -eq 0 ]; then
@@ -47,7 +47,7 @@ done
 # Run orion report on all deferred JSONs
 # orion --report exits 2 if regressions found, 0 otherwise
 set +e
-orion --report "$json_file_list"
+orion --report "$json_file_list" | tee "${ARTIFACT_DIR}/orion-report-summary.txt"
 report_exit=$?
 set -e
 

--- a/ci-operator/step-registry/openshift-qe/orion/report/openshift-qe-orion-report-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/orion/report/openshift-qe-orion-report-commands.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "${RUN_ORION}" == "false" ]; then
+  echo "RUN_ORION is false, skipping report."
+  exit 0
+fi
+
+# Check for deferred JSON results
+shopt -s nullglob
+json_files=(${SHARED_DIR}/orion-*.json)
+shopt -u nullglob
+
+if [ ${#json_files[@]} -eq 0 ]; then
+  echo "No deferred orion JSON results found in SHARED_DIR."
+  echo "This is expected when RUN_ORION is not set to deferred."
+  exit 0
+fi
+
+# Copy JSONs to ARTIFACT_DIR for archival
+cp "${json_files[@]}" "${ARTIFACT_DIR}/" 2>/dev/null || true
+
+# Set up Python environment and install orion
+python --version
+pushd /tmp
+python -m virtualenv ./venv_report
+source ./venv_report/bin/activate
+
+if [[ $TAG == "latest" ]]; then
+    LATEST_TAG=$(curl -s "https://api.github.com/repos/cloud-bulldozer/orion/releases/latest" | jq -r '.tag_name')
+else
+    LATEST_TAG=$TAG
+fi
+git clone --branch "$LATEST_TAG" "$ORION_REPO" --depth 1
+pushd orion
+pip install .
+popd && popd
+
+# Build comma-separated file list for orion --report
+json_file_list=$(IFS=,; echo "${json_files[*]}")
+
+# Run orion report on all deferred JSONs
+# orion --report exits 2 if regressions found, 0 otherwise
+set +e
+orion --report "$json_file_list"
+report_exit=$?
+set -e
+
+if [ $report_exit -eq 2 ]; then
+  echo "Orion report detected regressions."
+  exit 1
+fi
+
+exit $report_exit

--- a/ci-operator/step-registry/openshift-qe/orion/report/openshift-qe-orion-report-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/orion/report/openshift-qe-orion-report-commands.sh
@@ -7,14 +7,38 @@ if [ "${RUN_ORION}" == "false" ]; then
   exit 0
 fi
 
-# Check for deferred JSON results
+# Fetch deferred JSON results from previous steps' GCS artifacts
+GCS_BUCKET="gs://test-platform-results"
+GCS_BASE=""
+
+case "${JOB_TYPE:-}" in
+    presubmit)
+        if [[ -n "${REPO_OWNER:-}" && -n "${REPO_NAME:-}" && -n "${PULL_NUMBER:-}" && -n "${JOB_NAME:-}" && -n "${BUILD_ID:-}" ]]; then
+            GCS_BASE="${GCS_BUCKET}/pr-logs/pull/${REPO_OWNER}_${REPO_NAME}/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}/artifacts"
+        fi
+        ;;
+    periodic)
+        if [[ -n "${JOB_NAME:-}" && -n "${BUILD_ID:-}" ]]; then
+            GCS_BASE="${GCS_BUCKET}/logs/${JOB_NAME}/${BUILD_ID}/artifacts"
+        fi
+        ;;
+esac
+
+if [[ -z "$GCS_BASE" ]]; then
+    echo "Could not determine GCS artifacts path. Skipping report."
+    exit 0
+fi
+
+echo "Fetching deferred orion JSONs from GCS: ${GCS_BASE}"
+mkdir -p /tmp/orion-jsons
+gsutil -m cp "${GCS_BASE}/*/openshift-qe-orion-*/artifacts/junit_*.json" /tmp/orion-jsons/ 2>/dev/null || true
+
 shopt -s nullglob
-json_files=("${SHARED_DIR}"/junit*.json)
+json_files=(/tmp/orion-jsons/junit*.json)
 shopt -u nullglob
 
 if [ ${#json_files[@]} -eq 0 ]; then
-  echo "No deferred orion JSON results found in SHARED_DIR."
-  echo "This is expected when RUN_ORION is not set to deferred."
+  echo "No deferred orion JSON results found in GCS."
   exit 0
 fi
 

--- a/ci-operator/step-registry/openshift-qe/orion/report/openshift-qe-orion-report-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/orion/report/openshift-qe-orion-report-commands.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -x
 set -euo pipefail
 
 if [ "${RUN_ORION}" == "false" ]; then
@@ -8,7 +9,7 @@ fi
 
 # Check for deferred JSON results
 shopt -s nullglob
-json_files=(${SHARED_DIR}/orion-*.json)
+json_files=("${SHARED_DIR}"/orion-*.json)
 shopt -u nullglob
 
 if [ ${#json_files[@]} -eq 0 ]; then
@@ -33,11 +34,15 @@ else
 fi
 git clone --branch "$LATEST_TAG" "$ORION_REPO" --depth 1
 pushd orion
+pip install -r requirements.txt
 pip install .
 popd && popd
 
 # Build comma-separated file list for orion --report
-json_file_list=$(IFS=,; echo "${json_files[*]}")
+json_file_list=""
+for f in "${json_files[@]}"; do
+  json_file_list="${json_file_list:+${json_file_list},}${f}"
+done
 
 # Run orion report on all deferred JSONs
 # orion --report exits 2 if regressions found, 0 otherwise
@@ -46,9 +51,9 @@ orion --report "$json_file_list"
 report_exit=$?
 set -e
 
-if [ $report_exit -eq 2 ]; then
+if [ "$report_exit" -eq 2 ]; then
   echo "Orion report detected regressions."
   exit 1
 fi
 
-exit $report_exit
+exit "$report_exit"

--- a/ci-operator/step-registry/openshift-qe/orion/report/openshift-qe-orion-report-ref.metadata.json
+++ b/ci-operator/step-registry/openshift-qe/orion/report/openshift-qe-orion-report-ref.metadata.json
@@ -1,0 +1,11 @@
+{
+	"path": "openshift-qe/orion/report/openshift-qe-orion-report-ref.yaml",
+	"owners": {
+		"approvers": [
+			"perfscale-ocp-approvers"
+		],
+		"reviewers": [
+			"perfscale-ocp-reviewers"
+		]
+	}
+}

--- a/ci-operator/step-registry/openshift-qe/orion/report/openshift-qe-orion-report-ref.yaml
+++ b/ci-operator/step-registry/openshift-qe/orion/report/openshift-qe-orion-report-ref.yaml
@@ -1,0 +1,29 @@
+ref:
+  as: openshift-qe-orion-report
+  from_image:
+    namespace: ci
+    name: ocp-qe-perfscale-ci
+    tag: latest
+  env:
+  - name: ORION_REPO
+    default: "https://github.com/cloud-bulldozer/orion.git"
+    documentation:
+      Orion github repository to clone for report generation.
+  - name: TAG
+    default: "latest"
+    documentation:
+      Orion version/tag to clone.
+  - name: RUN_ORION
+    default: "false"
+    documentation:
+      When false, the report step is skipped. Set to deferred at test level to enable deferred failure reporting.
+  commands: openshift-qe-orion-report-commands.sh
+  timeout: 30m
+  resources:
+    requests:
+      cpu: 100m
+      memory: 100Mi
+  documentation: >-
+    Aggregates deferred orion regression results from SHARED_DIR using
+    orion --report to produce a consolidated regression report. Must be
+    used as the last step in an orion chain when RUN_ORION is set to deferred.

--- a/ci-operator/step-registry/openshift-qe/udn-density-pods/openshift-qe-udn-density-pods-workflow.yaml
+++ b/ci-operator/step-registry/openshift-qe/udn-density-pods/openshift-qe-udn-density-pods-workflow.yaml
@@ -4,5 +4,6 @@ workflow:
   steps:
     test:
       - chain: openshift-qe-udn-density-pods
+      - ref: openshift-qe-orion-report
   documentation: |-
-    This workflow executes udn-density-pods workload.
+    This workflow executes udn-density-pods workload and Orion change detection with summary reporting.


### PR DESCRIPTION
  Summary

  - Introduces a new `openshift-qe-orion-repor`t step in the step registry that aggregates deferred Orion regression results from SHARED_DIR and produces a consolidated report using orion `--report`
  - Changes RUN_ORION from "true" to deferred across all perfscale CI configs (cloud-bulldozer/orion,
  openshift-eng/ocp-qe-perfscale-ci, openshift/ovn-kubernetes, openshift-priv/ovn-kubernetes) so that individual Orion steps no  longer fail immediately on regression; instead they write JSON results to SHARED_DIR and exit 0
  - Appends the new openshift-qe-orion-report ref as the final step in the openshift-qe-orion-consolidated,
  openshift-qe-orion-consolidated-virt chains and openshift-qe-udn-density-pods workflow, which aggregates all deferred results and  fails the job if any regressions are detected
  - Adds `RUN_ORION: "deferred"` to UDN density pod tests in ovn-kubernetes (4.18, 4.19, 4.20) and perfscale-ci (4.21, 4.22, 5.0) configs that previously did not set it
  
    ## TODOs before merge                                                                                                                                                                                                                                       
  - [x] Remove `--no-default-ack` from orion command in `openshift-qe-orion-commands.sh` (added for testing)                                                                                                                                                  
  - [x] Revert orion report step to upstream repo (currently pointing to `mohit-sheth/orion` fork, `summary-analysis` branch)    
  
  Depends on:  Add --report CLI option https://github.com/cloud-bulldozer/orion/pull/300 