### PR TITLE
DPTP-4707: Add ci/severity-critical label for openshift and openshift-eng with Tide priority and restricted access

### DIFF
--- a/core-services/prow/02_config/_config.yaml
+++ b/core-services/prow/02_config/_config.yaml
@@ -762,6 +762,8 @@ tide:
   - labels:
     - priority/ci-critical
   - labels:
+    - ci/severity-critical
+  - labels:
     - jira/severity-critical
   - labels:
     - bugzilla/severity-urgent

--- a/core-services/prow/02_config/_config.yaml
+++ b/core-services/prow/02_config/_config.yaml
@@ -982,6 +982,8 @@ tide:
   - labels:
     - priority/ci-critical
   - labels:
+    - ci/severity-critical
+  - labels:
     - jira/severity-critical
   - labels:
     - bugzilla/severity-urgent

--- a/core-services/prow/02_config/_labels.yaml
+++ b/core-services/prow/02_config/_labels.yaml
@@ -515,6 +515,20 @@ orgs:
         name: 'rebase/manual'
         target: prs
         addedBy: label
+      - color: ff0000
+        description: Critical CI severity - infrastructure broken or severely impacted
+        name: ci/severity-critical
+        target: prs
+        prowPlugin: label
+        addedBy: label
+  openshift-eng:
+    labels:
+      - color: ff0000
+        description: Critical CI severity - infrastructure broken or severely impacted
+        name: ci/severity-critical
+        target: prs
+        prowPlugin: label
+        addedBy: label
   cri-o:
     labels:
       - color: e11d21

--- a/core-services/prow/02_config/_labels.yaml
+++ b/core-services/prow/02_config/_labels.yaml
@@ -526,12 +526,24 @@ orgs:
         name: 'rebase/manual'
         target: prs
         addedBy: label
+      - color: ff0000
+        description: Critical CI severity - infrastructure broken or severely impacted
+        name: ci/severity-critical
+        target: prs
+        prowPlugin: label
+        addedBy: label
   openshift-eng:
     labels:
       - color: c3f7c5
         description: Indicates a PR has been reviewed by automated tools and is ready for human review
         name: ready-for-human-review
         target: prs
+        addedBy: label
+      - color: ff0000
+        description: Critical CI severity - infrastructure broken or severely impacted
+        name: ci/severity-critical
+        target: prs
+        prowPlugin: label
         addedBy: label
   cri-o:
     labels:

--- a/core-services/prow/02_config/_plugins.yaml
+++ b/core-services/prow/02_config/_plugins.yaml
@@ -658,6 +658,11 @@ label:
       - openshift-team-leads
       - openshift-staff-engineers
       label: stability-fix-approved
+    - allowed_teams:
+      - openshift-release-oversight
+      - openshift-staff-engineers
+      - technical-release-team
+      label: ci/severity-critical
 override:
   allow_top_level_owners: true
   allowed_github_teams:

--- a/core-services/prow/02_config/_plugins.yaml
+++ b/core-services/prow/02_config/_plugins.yaml
@@ -696,6 +696,11 @@ label:
       - openshift-team-leads
       - openshift-staff-engineers
       label: stability-fix-approved
+    - allowed_teams:
+      - openshift-release-oversight
+      - openshift-staff-engineers
+      - technical-release-team
+      label: ci/severity-critical
 override:
   allow_top_level_owners: true
   allowed_github_teams:


### PR DESCRIPTION
Introduce a` ci/severity-critical` label (same semantics as priority/ci-critical) on all openshift and openshift-eng repos, with Tide priority, so OpenShift Release Oversight, OpenShift Staff Engineers, and the Technical Release Team (openshift-eng) can mark CI-critical issues across these orgs instead of only on openshift/release.

/cc @openshift/test-platform 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Adds the `ci/severity-critical` label to `openshift` and `openshift-eng` repositories.
- Restricts label application to OpenShift Release Oversight, OpenShift Staff Engineers, and the Technical Release Team.
- Assigns the label the same Tide priority as `priority/ci-critical`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->