### PR TITLE
AGENT-1454: export APPLIANCE_IMAGE config var for OVE builds in devscripts-setup step

### DIFF
--- a/ci-operator/step-registry/baremetalds/devscripts/setup/baremetalds-devscripts-setup-commands.sh
+++ b/ci-operator/step-registry/baremetalds/devscripts/setup/baremetalds-devscripts-setup-commands.sh
@@ -400,6 +400,7 @@ fi
 if [ "${AGENT_E2E_TEST_BOOT_MODE}" == "ISO_NO_REGISTRY" ];
 then
   echo "export AGENT_ISO_BUILDER_IMAGE=${AGENT_ISO_BUILDER_IMAGE}" >> /root/dev-scripts/config_root.sh
+  echo "export APPLIANCE_IMAGE=${APPLIANCE_IMAGE}" >> /root/dev-scripts/config_root.sh
 fi
 
 # If any extra manifests, then set ASSETS_EXTRA_FOLDER


### PR DESCRIPTION
This config var will be set as a dependency only in the release Appliance repo, to allow testing the current appliance image.

Required by https://github.com/openshift/release/pull/75449