### PR TITLE
Skip HCP-incompatible conformance tests in ROSA HCP workflow

### DIFF
--- a/ci-operator/step-registry/rosa/aws/hcp/conformance/rosa-aws-hcp-conformance-workflow.yaml
+++ b/ci-operator/step-registry/rosa/aws/hcp/conformance/rosa-aws-hcp-conformance-workflow.yaml
@@ -30,7 +30,13 @@ workflow:
         DRA.*kubelet.*DynamicResourceAllocation\|
         CSI Mock volume expansion Expansion with recovery recovery should not be possible\|
         cloud-provider-aws-e2e.*loadbalancer NLB internal should be reachable with hairpinning traffic\|
-        cloud-provider-aws-e2e.*loadbalancer NLB should be reachable with target-node-labels
+        cloud-provider-aws-e2e.*loadbalancer NLB should be reachable with target-node-labels\|
+        \[sig-apps\]\[Feature:DeploymentConfig\]\|
+        \[sig-auth\]\[Feature:RoleBindingRestrictions\]\|
+        \[sig-builds\]\[Feature:Builds\]\|
+        \[sig-devex\]\[Feature:Templates\]\|
+        HostUsers.*UserNamespacesSupport\|
+        AWSServiceLBNetworkSecurityGroup
     pre:
       - chain: rosa-aws-sts-hcp-provision
       - ref: osd-ccs-conf-idp-htpasswd-multi-users


### PR DESCRIPTION
## Summary

- Add skip patterns for 6 test categories that fail on ROSA HCP clusters because they test legacy OpenShift controllers (Builds, DeploymentConfig, Templates) or features not available on HCP (RoleBindingRestrictions, UserNamespaces HostUsers, NLB SecurityGroup)
- Uses feature tag patterns (e.g., `[sig-builds][Feature:Builds]`) for broader coverage rather than individual test names

## Problem

The ROSA HCP conformance periodic jobs (`periodic-ci-openshift-release-main-nightly-4.{19,20,21,22}-e2e-rosa-hcp-ovn`) are failing on tests that don't apply to HCP clusters. These tests exercise legacy OpenShift controllers (Builds, DeploymentConfig, Templates) that run on the control plane, which customers don't manage in HCP.

Failing tests observed on 4.22 nightly:
- `[sig-apps][Feature:DeploymentConfig] deploymentconfigs with failing hook`
- `[sig-auth][Feature:RoleBindingRestrictions] RoleBindingRestrictions`
- `[sig-builds][Feature:Builds]` (multiple: oc new-app, prune builds, s2i root user, valueFrom)
- `[sig-devex][Feature:Templates]` (templateinstance creation/readiness)
- `[sig-node] Security Context HostUsers metrics UserNamespacesSupport`
- `[cloud-provider-aws-e2e-openshift] loadbalancer NLB AWSServiceLBNetworkSecurityGroup`

Other HyperShift conformance workflows (e.g., hypershift-mce-power, hypershift-aws) already skip similar tests.

## Test plan

- [ ] `make validate-step-registry` passes
- [ ] Monitor next periodic job runs for reduced test failures

/cc @joshbranham

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ROSA AWS HCP conformance workflow test exclusion patterns to skip additional feature-specific and subsystem-specific test scenarios during conformance runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->