### PR TITLE
Adding OLS mcp server test

### DIFF
--- a/ci-operator/config/openshift/ols-load-generator/openshift-ols-load-generator-main__mcp.yaml
+++ b/ci-operator/config/openshift/ols-load-generator/openshift-ols-load-generator-main__mcp.yaml
@@ -1,0 +1,177 @@
+build_root:
+  image_stream_tag:
+    name: release
+    namespace: openshift
+    tag: rhel-8-release-golang-1.21-openshift-4.15
+releases:
+  latest:
+    candidate:
+      product: ocp
+      stream: nightly
+      version: "4.15"
+resources:
+  '*':
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: ols-load-test-10workers-mcp
+  cron: 0 0 * * *
+  steps:
+    allow_best_effort_post_steps: true
+    allow_skip_on_success: true
+    cluster_profile: aws-perfscale-qe
+    env:
+      ACK_FILE: ols-load-generator-10w_ack.yaml
+      BASE_DOMAIN: qe.devcluster.openshift.com
+      COLLAPSE: "true"
+      COMPUTE_NODE_REPLICAS: "3"
+      COMPUTE_NODE_TYPE: m6i.xlarge
+      ENABLE_MCP: "true"
+      ES_BENCHMARK_INDEX: ols-load-test-results*
+      ES_METADATA_INDEX: perf_scale_ci*
+      ES_TYPE: qe
+      LOOKBACK: "180"
+      LOOKBACK_SIZE: "15"
+      OLS_TEST_DURATIONS: 5m,10m,20m
+      OLS_TEST_WORKERS: "10"
+      OPENSHIFT_INFRA_NODE_INSTANCE_TYPE: r5.xlarge
+      ORION_CONFIG: examples/ols-load-generator.yaml
+      ORION_ENVS: ols_test_workers=10
+      OUTPUT_FORMAT: JUNIT
+      RUN_ORION: "true"
+      VERSION: "4.15"
+      ZONES_COUNT: "3"
+    test:
+    - ref: openshift-ols-load-generator-tests
+    - ref: openshift-qe-orion
+    workflow: openshift-qe-installer-aws
+- as: ols-load-test-25workers-mcp
+  cron: 0 6 * * *
+  steps:
+    allow_best_effort_post_steps: true
+    allow_skip_on_success: true
+    cluster_profile: aws-perfscale-qe
+    env:
+      ACK_FILE: ols-load-generator-25w_ack.yaml
+      BASE_DOMAIN: qe.devcluster.openshift.com
+      COLLAPSE: "true"
+      COMPUTE_NODE_REPLICAS: "3"
+      COMPUTE_NODE_TYPE: m6i.xlarge
+      ENABLE_MCP: "true"
+      ES_BENCHMARK_INDEX: ols-load-test-results*
+      ES_METADATA_INDEX: perf_scale_ci*
+      ES_TYPE: qe
+      LOOKBACK: "180"
+      LOOKBACK_SIZE: "15"
+      OLS_TEST_DURATIONS: 5m,10m,20m
+      OLS_TEST_WORKERS: "25"
+      OPENSHIFT_INFRA_NODE_INSTANCE_TYPE: r5.xlarge
+      ORION_CONFIG: examples/ols-load-generator.yaml
+      ORION_ENVS: ols_test_workers=25
+      OUTPUT_FORMAT: JUNIT
+      RUN_ORION: "true"
+      VERSION: "4.15"
+      ZONES_COUNT: "3"
+    test:
+    - ref: openshift-ols-load-generator-tests
+    - ref: openshift-qe-orion
+    workflow: openshift-qe-installer-aws
+- as: ols-load-test-50workers-mcp
+  cron: 0 12 * * *
+  steps:
+    allow_best_effort_post_steps: true
+    allow_skip_on_success: true
+    cluster_profile: aws-perfscale-qe
+    env:
+      ACK_FILE: ols-load-generator-50w_ack.yaml
+      BASE_DOMAIN: qe.devcluster.openshift.com
+      COLLAPSE: "true"
+      COMPUTE_NODE_REPLICAS: "3"
+      COMPUTE_NODE_TYPE: m6i.xlarge
+      ENABLE_MCP: "true"
+      ES_BENCHMARK_INDEX: ols-load-test-results*
+      ES_METADATA_INDEX: perf_scale_ci*
+      ES_TYPE: qe
+      LOOKBACK: "180"
+      LOOKBACK_SIZE: "15"
+      OLS_TEST_DURATIONS: 5m,10m,20m
+      OLS_TEST_WORKERS: "50"
+      OPENSHIFT_INFRA_NODE_INSTANCE_TYPE: r5.xlarge
+      ORION_CONFIG: examples/ols-load-generator.yaml
+      ORION_ENVS: ols_test_workers=50
+      OUTPUT_FORMAT: JUNIT
+      RUN_ORION: "true"
+      VERSION: "4.15"
+      ZONES_COUNT: "3"
+    test:
+    - ref: openshift-ols-load-generator-tests
+    - ref: openshift-qe-orion
+    workflow: openshift-qe-installer-aws
+- as: ols-load-test-100workers-mcp
+  cron: 0 18 * * *
+  steps:
+    allow_best_effort_post_steps: true
+    allow_skip_on_success: true
+    cluster_profile: aws-perfscale-qe
+    env:
+      ACK_FILE: ols-load-generator-100w_ack.yaml
+      BASE_DOMAIN: qe.devcluster.openshift.com
+      COLLAPSE: "true"
+      COMPUTE_NODE_REPLICAS: "3"
+      COMPUTE_NODE_TYPE: m6i.xlarge
+      ENABLE_MCP: "true"
+      ES_BENCHMARK_INDEX: ols-load-test-results*
+      ES_METADATA_INDEX: perf_scale_ci*
+      ES_TYPE: qe
+      LOOKBACK: "180"
+      LOOKBACK_SIZE: "15"
+      OLS_TEST_DURATIONS: 5m,10m,20m
+      OLS_TEST_WORKERS: "100"
+      OPENSHIFT_INFRA_NODE_INSTANCE_TYPE: r5.xlarge
+      ORION_CONFIG: examples/ols-load-generator.yaml
+      ORION_ENVS: ols_test_workers=100
+      OUTPUT_FORMAT: JUNIT
+      RUN_ORION: "true"
+      VERSION: "4.15"
+      ZONES_COUNT: "3"
+    test:
+    - ref: openshift-ols-load-generator-tests
+    - ref: openshift-qe-orion
+    workflow: openshift-qe-installer-aws
+- as: ols-load-test-1000workers-mcp
+  cron: 0 0 * * *
+  steps:
+    allow_best_effort_post_steps: true
+    allow_skip_on_success: true
+    cluster_profile: aws-perfscale-qe
+    env:
+      ACK_FILE: ols-load-generator-1000w_ack.yaml
+      BASE_DOMAIN: qe.devcluster.openshift.com
+      COLLAPSE: "true"
+      COMPUTE_NODE_REPLICAS: "3"
+      COMPUTE_NODE_TYPE: m6i.xlarge
+      ENABLE_MCP: "true"
+      ES_BENCHMARK_INDEX: ols-load-test-results*
+      ES_METADATA_INDEX: perf_scale_ci*
+      ES_TYPE: qe
+      LOOKBACK: "180"
+      LOOKBACK_SIZE: "15"
+      OLS_TEST_DURATIONS: 5m
+      OLS_TEST_WORKERS: "1000"
+      OPENSHIFT_INFRA_NODE_INSTANCE_TYPE: r5.xlarge
+      ORION_CONFIG: examples/ols-load-generator.yaml
+      ORION_ENVS: ols_test_workers=1000
+      OUTPUT_FORMAT: JUNIT
+      RUN_ORION: "true"
+      VERSION: "4.15"
+      ZONES_COUNT: "3"
+    test:
+    - ref: openshift-ols-load-generator-tests
+    - ref: openshift-qe-orion
+    workflow: openshift-qe-installer-aws
+zz_generated_metadata:
+  branch: main
+  org: openshift
+  repo: ols-load-generator
+  variant: mcp

--- a/ci-operator/jobs/openshift/ols-load-generator/openshift-ols-load-generator-main-periodics.yaml
+++ b/ci-operator/jobs/openshift/ols-load-generator/openshift-ols-load-generator-main-periodics.yaml
@@ -12,6 +12,476 @@ periodics:
   labels:
     ci-operator.openshift.io/cloud: aws
     ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+    ci-operator.openshift.io/variant: mcp
+    ci.openshift.io/generator: prowgen
+    job-release: "4.15"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-ols-load-generator-main-mcp-ols-load-test-1000workers-mcp
+  reporter_config:
+    slack:
+      channel: '#ols-perf-scale-ci-results'
+      job_states_to_report:
+      - success
+      - failure
+      - error
+      report_template: '{{if eq .Status.State "success"}} :white_check_mark: Job *{{.Spec.Job}}*
+        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :white_check_mark:
+        {{else}} :warning:  Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+        logs> :warning: {{end}}'
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=ols-load-test-1000workers-mcp
+      - --variant=mcp
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build11
+  cron: 0 18 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: ols-load-generator
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+    ci-operator.openshift.io/variant: mcp
+    ci.openshift.io/generator: prowgen
+    job-release: "4.15"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-ols-load-generator-main-mcp-ols-load-test-100workers-mcp
+  reporter_config:
+    slack:
+      channel: '#ols-perf-scale-ci-results'
+      job_states_to_report:
+      - success
+      - failure
+      - error
+      report_template: '{{if eq .Status.State "success"}} :white_check_mark: Job *{{.Spec.Job}}*
+        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :white_check_mark:
+        {{else}} :warning:  Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+        logs> :warning: {{end}}'
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=ols-load-test-100workers-mcp
+      - --variant=mcp
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build11
+  cron: 0 0 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: ols-load-generator
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+    ci-operator.openshift.io/variant: mcp
+    ci.openshift.io/generator: prowgen
+    job-release: "4.15"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-ols-load-generator-main-mcp-ols-load-test-10workers-mcp
+  reporter_config:
+    slack:
+      channel: '#ols-perf-scale-ci-results'
+      job_states_to_report:
+      - success
+      - failure
+      - error
+      report_template: '{{if eq .Status.State "success"}} :white_check_mark: Job *{{.Spec.Job}}*
+        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :white_check_mark:
+        {{else}} :warning:  Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+        logs> :warning: {{end}}'
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=ols-load-test-10workers-mcp
+      - --variant=mcp
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build11
+  cron: 0 6 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: ols-load-generator
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+    ci-operator.openshift.io/variant: mcp
+    ci.openshift.io/generator: prowgen
+    job-release: "4.15"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-ols-load-generator-main-mcp-ols-load-test-25workers-mcp
+  reporter_config:
+    slack:
+      channel: '#ols-perf-scale-ci-results'
+      job_states_to_report:
+      - success
+      - failure
+      - error
+      report_template: '{{if eq .Status.State "success"}} :white_check_mark: Job *{{.Spec.Job}}*
+        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :white_check_mark:
+        {{else}} :warning:  Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+        logs> :warning: {{end}}'
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=ols-load-test-25workers-mcp
+      - --variant=mcp
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build11
+  cron: 0 12 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: ols-load-generator
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+    ci-operator.openshift.io/variant: mcp
+    ci.openshift.io/generator: prowgen
+    job-release: "4.15"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-ols-load-generator-main-mcp-ols-load-test-50workers-mcp
+  reporter_config:
+    slack:
+      channel: '#ols-perf-scale-ci-results'
+      job_states_to_report:
+      - success
+      - failure
+      - error
+      report_template: '{{if eq .Status.State "success"}} :white_check_mark: Job *{{.Spec.Job}}*
+        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :white_check_mark:
+        {{else}} :warning:  Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+        logs> :warning: {{end}}'
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=ols-load-test-50workers-mcp
+      - --variant=mcp
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build11
+  cron: 0 0 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: ols-load-generator
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"

--- a/ci-operator/step-registry/openshift/ols-load-generator/tests/openshift-ols-load-generator-tests-commands.sh
+++ b/ci-operator/step-registry/openshift/ols-load-generator/tests/openshift-ols-load-generator-tests-commands.sh
@@ -58,7 +58,7 @@ for OLS_TEST_DURATION in "${test_durations[@]}"; do
   job_status="success"
   job_start=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
   job_end=""
-  additional_attributes='{"olsTestWorkers": '"${OLS_TEST_WORKERS}"', "olsTestDuration": "'"$OLS_TEST_DURATION"'"}'
+  additional_attributes='{"olsTestWorkers": '"${OLS_TEST_WORKERS}"', "olsTestDuration": "'"$OLS_TEST_DURATION"'", "mcpEnabled": "'"$ENABLE_MCP"'"}'
 
   # Create namespace and set monitoring labels
   run_or_fail oc create namespace openshift-lightspeed
@@ -95,6 +95,14 @@ for OLS_TEST_DURATION in "${test_durations[@]}"; do
   popd
 
   # Deploy olsconfig with fake values
+  PROVIDER_EXTRA=""
+  OLS_EXTRA=""
+
+  if [[ "${ENABLE_MCP:-false}" == "true" ]]; then
+    PROVIDER_EXTRA="      fakeProviderMCPToolCall: true"
+    OLS_EXTRA="    introspectionEnabled: true"
+  fi
+
   run_or_fail cat <<EOF | oc apply -f - -n openshift-lightspeed
 apiVersion: ols.openshift.io/v1alpha1
 kind: OLSConfig
@@ -110,11 +118,13 @@ spec:
       - name: fake_model
       name: fake_provider
       type: fake_provider
+${PROVIDER_EXTRA}
   ols:
     defaultModel: fake_model
     defaultProvider: fake_provider
     enableDeveloperUI: false
     logLevel: INFO
+${OLS_EXTRA}
     deployment:
       replicas: 1
     userDataCollection:

--- a/ci-operator/step-registry/openshift/ols-load-generator/tests/openshift-ols-load-generator-tests-commands.sh
+++ b/ci-operator/step-registry/openshift/ols-load-generator/tests/openshift-ols-load-generator-tests-commands.sh
@@ -2,7 +2,11 @@
 set -o errexit
 set -o nounset
 set -o pipefail
+
+# Add timestamps to xtrace output for easier CI debugging
+export PS4='+ $(date -Is) '
 set -x
+
 cat /etc/os-release
 oc config view
 oc projects

--- a/ci-operator/step-registry/openshift/ols-load-generator/tests/openshift-ols-load-generator-tests-ref.yaml
+++ b/ci-operator/step-registry/openshift/ols-load-generator/tests/openshift-ols-load-generator-tests-ref.yaml
@@ -40,5 +40,9 @@ ref:
     default: "false"
     documentation: |-
       Flag to only perform load test on /query api endpoint
+  - name: ENABLE_MCP
+    default: "false"
+    documentation: |-
+      Flag to enable deployment with MCP enabled
   documentation: >-
     This step runs the ols load testing workload in the deployed cluster


### PR DESCRIPTION
## Intro
This PR is cherry-picked from https://github.com/openshift/release/pull/75188 for ownership transfer.

## Changes & Goal

1. ci-operator/jobs/openshift/ols-load-generator/openshift-ols-load-generator-main-periodics.yaml 
This file defines what tests exist and how they run for openshift/ols-load-generator in OpenShift CI with the mcp variant. 
2. ci-operator/jobs/openshift/ols-load-generator/openshift-ols-load-generator-main-periodics.yaml
This file defines Prow jobs (the CI system’s job runner) that will be scheduled/triggered, including periodic (cron) jobs for the above CI-operator targets.
3. ci-operator/step-registry/openshift/ols-load-generator/tests/openshift-ols-load-generator-tests-commands.sh
Parsing mcpEnabled option and log metadata.
4. ci-operator/step-registry/openshift/ols-load-generator/tests/openshift-ols-load-generator-tests-ref.yaml
Increasing the timeout limit for jobs and adds env var ENABLE_MCP

## Testing
Will test via rehearsal