### PR TITLE
ci-operator.kata-containers: Bump pp to 4.22

### DIFF
--- a/ci-operator/config/kata-containers/kata-containers/kata-containers-kata-containers-main.yaml
+++ b/ci-operator/config/kata-containers/kata-containers/kata-containers-kata-containers-main.yaml
@@ -66,7 +66,11 @@ tests:
         create pingable pods with vlan interface on an in-container master\|\[sig-network\].*should
         create a pod with bond interface\|\[sig-node\] Variable Expansion should succeed
         create a pod with bond interface\|\[sig-node\] Variable Expansion should succeed
-        in writing subpaths in container\|\[sig-node\].*\[DRA\]
+        in writing subpaths in container\|\[sig-node\].*\[DRA\]\|\[sig-node\].*User
+        Namespaces.*\|\[sig-node\].*HostUsers.*\|\[sig-node\].*UserNamespacesSupport.*\|\[sig-node\].*FileKeyRef.*\|\[sig-node\].*HostnameOverride.*\|\[sig-node\].*SupplementalGroupsPolicy.*Strict.*\|\[sig-node\].*Pod
+        Generation.*increment.*\|\[sig-node\].*Container Restart Rules.*\|\[sig-node\].*ImageVolume.*\|\[sig-node\].*Downward
+        API.*PodLevelResources.*\|\[sig-node\].*Pod InPlace Resize.*\|\[sig-node\].*Allow
+        dev fuse by default.*
     pre:
     - chain: ipi-azure-pre
     - as: kata-containers-e2e-pre

--- a/ci-operator/config/kata-containers/kata-containers/kata-containers-kata-containers-main.yaml
+++ b/ci-operator/config/kata-containers/kata-containers/kata-containers-kata-containers-main.yaml
@@ -1,6 +1,6 @@
 base_images:
   tests-base:
-    name: "4.19"
+    name: "4.22"
     namespace: ocp
     tag: tests
 binary_build_commands: |
@@ -30,12 +30,12 @@ images:
 releases:
   initial:
     integration:
-      name: "4.19"
+      name: "4.22"
       namespace: ocp
   latest:
     integration:
       include_built_images: true
-      name: "4.19"
+      name: "4.22"
       namespace: ocp
 resources:
   '*':

--- a/ci-operator/config/kata-containers/kata-containers/kata-containers-kata-containers-main.yaml
+++ b/ci-operator/config/kata-containers/kata-containers/kata-containers-kata-containers-main.yaml
@@ -66,7 +66,7 @@ tests:
         create pingable pods with vlan interface on an in-container master\|\[sig-network\].*should
         create a pod with bond interface\|\[sig-node\] Variable Expansion should succeed
         create a pod with bond interface\|\[sig-node\] Variable Expansion should succeed
-        in writing subpaths in container
+        in writing subpaths in container\|\[sig-node\].*\[DRA\]
     pre:
     - chain: ipi-azure-pre
     - as: kata-containers-e2e-pre

--- a/ci-operator/config/kata-containers/kata-containers/kata-containers-kata-containers-main.yaml
+++ b/ci-operator/config/kata-containers/kata-containers/kata-containers-kata-containers-main.yaml
@@ -50,7 +50,8 @@ tests:
     allow_skip_on_success: true
     cluster_profile: openshift-org-azure
     env:
-      TEST_ARGS: ' --max-parallel-tests 5 --cluster-stability Disruptive --run ^\[sig-node\].*|^\[sig-network\] '
+      TEST_ARGS: ' --max-parallel-tests 5 --cluster-stability Disruptive --retry-strategy=aggressive
+        --run ^\[sig-node\].*|^\[sig-network\] '
       TEST_SKIPS: \[sig-node\] Pods Extended Pod Container Status should never report\|\[sig-node\]
         Sysctls.*should support sysctls\|\[sig-node\] Pods Extended Pod Container
         Status should never report success for a pending container\|\[sig-node\] Security

--- a/ci-operator/config/kata-containers/kata-containers/kata-containers-kata-containers-main__minus1.yaml
+++ b/ci-operator/config/kata-containers/kata-containers/kata-containers-kata-containers-main__minus1.yaml
@@ -1,6 +1,6 @@
 base_images:
   tests-base:
-    name: "4.18"
+    name: "4.21"
     namespace: ocp
     tag: tests
 binary_build_commands: |
@@ -30,12 +30,12 @@ images:
 releases:
   initial:
     integration:
-      name: "4.18"
+      name: "4.21"
       namespace: ocp
   latest:
     integration:
       include_built_images: true
-      name: "4.18"
+      name: "4.21"
       namespace: ocp
 resources:
   '*':
@@ -64,7 +64,9 @@ tests:
         sysctl on whitelist\|\[sig-network\].*sysctls should not affect\|\[sig-network\]
         pods should successfully create sandboxes by adding pod to network\|\[sig-network\].*should
         create pingable pods with vlan interface on an in-container master\|\[sig-network\].*should
-        create a pod with bond interface
+        create a pod with bond interface\|\[sig-node\] Variable Expansion should succeed
+        create a pod with bond interface\|\[sig-node\] Variable Expansion should succeed
+        in writing subpaths in container
     pre:
     - chain: ipi-azure-pre
     - as: kata-containers-e2e-pre

--- a/ci-operator/config/kata-containers/kata-containers/kata-containers-kata-containers-main__minus1.yaml
+++ b/ci-operator/config/kata-containers/kata-containers/kata-containers-kata-containers-main__minus1.yaml
@@ -66,7 +66,10 @@ tests:
         create pingable pods with vlan interface on an in-container master\|\[sig-network\].*should
         create a pod with bond interface\|\[sig-node\] Variable Expansion should succeed
         create a pod with bond interface\|\[sig-node\] Variable Expansion should succeed
-        in writing subpaths in container\|\[sig-node\].*\[DRA\]
+        in writing subpaths in container\|\[sig-node\].*\[DRA\]\|\[sig-node\].*User
+        Namespaces.*\|\[sig-node\].*HostUsers.*\|\[sig-node\].*UserNamespacesSupport.*\|\[sig-node\].*SupplementalGroupsPolicy.*Strict.*\|\[sig-node\].*Pod
+        Generation.*increment.*\|\[sig-node\].*ImageVolume.*\|\[sig-node\].*Downward
+        API.*PodLevelResources.*\|\[sig-node\].*Pod InPlace Resize.*
     pre:
     - chain: ipi-azure-pre
     - as: kata-containers-e2e-pre

--- a/ci-operator/config/kata-containers/kata-containers/kata-containers-kata-containers-main__minus1.yaml
+++ b/ci-operator/config/kata-containers/kata-containers/kata-containers-kata-containers-main__minus1.yaml
@@ -66,7 +66,7 @@ tests:
         create pingable pods with vlan interface on an in-container master\|\[sig-network\].*should
         create a pod with bond interface\|\[sig-node\] Variable Expansion should succeed
         create a pod with bond interface\|\[sig-node\] Variable Expansion should succeed
-        in writing subpaths in container
+        in writing subpaths in container\|\[sig-node\].*\[DRA\]
     pre:
     - chain: ipi-azure-pre
     - as: kata-containers-e2e-pre

--- a/ci-operator/config/kata-containers/kata-containers/kata-containers-kata-containers-main__minus1.yaml
+++ b/ci-operator/config/kata-containers/kata-containers/kata-containers-kata-containers-main__minus1.yaml
@@ -50,7 +50,8 @@ tests:
     allow_skip_on_success: true
     cluster_profile: openshift-org-azure
     env:
-      TEST_ARGS: ' --max-parallel-tests 5 --cluster-stability Disruptive --run ^\[sig-node\].*|^\[sig-network\] '
+      TEST_ARGS: ' --max-parallel-tests 5 --cluster-stability Disruptive --retry-strategy=aggressive
+        --run ^\[sig-node\].*|^\[sig-network\] '
       TEST_SKIPS: \[sig-node\] Pods Extended Pod Container Status should never report\|\[sig-node\]
         Sysctls.*should support sysctls\|\[sig-node\] Pods Extended Pod Container
         Status should never report success for a pending container\|\[sig-node\] Security

--- a/ci-operator/config/kata-containers/kata-containers/kata-containers-kata-containers-main__minus2.yaml
+++ b/ci-operator/config/kata-containers/kata-containers/kata-containers-kata-containers-main__minus2.yaml
@@ -1,6 +1,6 @@
 base_images:
   tests-base:
-    name: "4.17"
+    name: "4.20"
     namespace: ocp
     tag: tests
 binary_build_commands: |
@@ -30,12 +30,12 @@ images:
 releases:
   initial:
     integration:
-      name: "4.17"
+      name: "4.20"
       namespace: ocp
   latest:
     integration:
       include_built_images: true
-      name: "4.17"
+      name: "4.20"
       namespace: ocp
 resources:
   '*':
@@ -64,6 +64,7 @@ tests:
         sysctl on whitelist\|\[sig-network\].*sysctls should not affect\|\[sig-network\]
         pods should successfully create sandboxes by adding pod to network\|\[sig-network\].*should
         create pingable pods with vlan interface on an in-container master\|\[sig-network\].*should
+        create a pod with bond interface\|\[sig-node\] Variable Expansion should succeed
         create a pod with bond interface\|\[sig-node\] Variable Expansion should succeed
         in writing subpaths in container
     pre:

--- a/ci-operator/config/kata-containers/kata-containers/kata-containers-kata-containers-main__minus2.yaml
+++ b/ci-operator/config/kata-containers/kata-containers/kata-containers-kata-containers-main__minus2.yaml
@@ -66,7 +66,9 @@ tests:
         create pingable pods with vlan interface on an in-container master\|\[sig-network\].*should
         create a pod with bond interface\|\[sig-node\] Variable Expansion should succeed
         create a pod with bond interface\|\[sig-node\] Variable Expansion should succeed
-        in writing subpaths in container\|\[sig-node\].*\[DRA\]
+        in writing subpaths in container\|\[sig-node\].*\[DRA\]\|\[sig-node\].*User
+        Namespaces.*\|\[sig-node\].*HostUsers.*\|\[sig-node\].*UserNamespacesSupport.*\|\[sig-node\].*SupplementalGroupsPolicy.*Strict.*\|\[sig-node\].*ImageVolume.*\|\[sig-node\].*Pod
+        InPlace Resize.*
     pre:
     - chain: ipi-azure-pre
     - as: kata-containers-e2e-pre

--- a/ci-operator/config/kata-containers/kata-containers/kata-containers-kata-containers-main__minus2.yaml
+++ b/ci-operator/config/kata-containers/kata-containers/kata-containers-kata-containers-main__minus2.yaml
@@ -66,7 +66,7 @@ tests:
         create pingable pods with vlan interface on an in-container master\|\[sig-network\].*should
         create a pod with bond interface\|\[sig-node\] Variable Expansion should succeed
         create a pod with bond interface\|\[sig-node\] Variable Expansion should succeed
-        in writing subpaths in container
+        in writing subpaths in container\|\[sig-node\].*\[DRA\]
     pre:
     - chain: ipi-azure-pre
     - as: kata-containers-e2e-pre

--- a/ci-operator/config/kata-containers/kata-containers/kata-containers-kata-containers-main__minus3.yaml
+++ b/ci-operator/config/kata-containers/kata-containers/kata-containers-kata-containers-main__minus3.yaml
@@ -1,6 +1,6 @@
 base_images:
   tests-base:
-    name: "4.16"
+    name: "4.19"
     namespace: ocp
     tag: tests
 binary_build_commands: |
@@ -30,12 +30,12 @@ images:
 releases:
   initial:
     integration:
-      name: "4.16"
+      name: "4.19"
       namespace: ocp
   latest:
     integration:
       include_built_images: true
-      name: "4.16"
+      name: "4.19"
       namespace: ocp
 resources:
   '*':
@@ -64,6 +64,7 @@ tests:
         sysctl on whitelist\|\[sig-network\].*sysctls should not affect\|\[sig-network\]
         pods should successfully create sandboxes by adding pod to network\|\[sig-network\].*should
         create pingable pods with vlan interface on an in-container master\|\[sig-network\].*should
+        create a pod with bond interface\|\[sig-node\] Variable Expansion should succeed
         create a pod with bond interface\|\[sig-node\] Variable Expansion should succeed
         in writing subpaths in container
     pre:

--- a/ci-operator/config/kata-containers/kata-containers/kata-containers-kata-containers-main__peer-pods.yaml
+++ b/ci-operator/config/kata-containers/kata-containers/kata-containers-kata-containers-main__peer-pods.yaml
@@ -74,7 +74,12 @@ tests:
         is set\|\[sig-node\].*TerminationMessagePath\|\[sig-node\].*CPU Partitioning\|\[sig-node\].*supplemental
         groups Ensure supplemental groups propagate to docker should propagate requested
         groups to the container\|\[sig-node\].*should override timeoutGracePeriodSeconds
-        when annotation is set\|\[sig-node\].*\[DRA\]
+        when annotation is set\|\[sig-node\].*\[DRA\]\|\[sig-node\].*User Namespaces.*\|\[sig-node\].*HostUsers.*\|\[sig-node\].*UserNamespacesSupport.*\|\[sig-node\].*FileKeyRef.*\|\[sig-node\].*HostnameOverride.*\|\[sig-node\].*SupplementalGroupsPolicy.*Strict.*\|\[sig-node\].*Pod
+        Generation.*\|\[sig-node\].*InPlace Resize.*\|\[sig-node\].*Pod InPlace Resize.*\|\[sig-node\].*limit-ranger.*\|\[sig-node\].*resource-quota.*\|\[sig-node\].*Downward
+        API.*limits.*\|\[sig-node\].*Downward API.*requests.*\|\[sig-node\].*QOS Class.*\|\[sig-node\].*PodRejectionStatus.*\|\[sig-node\].*Lifecycle
+        Sleep Hook.*\|\[sig-node\].*Lifecycle sleep action.*\|\[sig-node\].*Container
+        Restart Rules.*\|\[sig-node\].*zstd:chunked.*\|\[sig-node\].*ImageVolume.*\|\[sig-node\].*Allow
+        dev fuse by default.*
     pre:
     - chain: ipi-azure-pre
     - as: kata-containers-e2e-pre

--- a/ci-operator/config/kata-containers/kata-containers/kata-containers-kata-containers-main__peer-pods.yaml
+++ b/ci-operator/config/kata-containers/kata-containers/kata-containers-kata-containers-main__peer-pods.yaml
@@ -74,7 +74,7 @@ tests:
         is set\|\[sig-node\].*TerminationMessagePath\|\[sig-node\].*CPU Partitioning\|\[sig-node\].*supplemental
         groups Ensure supplemental groups propagate to docker should propagate requested
         groups to the container\|\[sig-node\].*should override timeoutGracePeriodSeconds
-        when annotation is set
+        when annotation is set\|\[sig-node\].*\[DRA\]
     pre:
     - chain: ipi-azure-pre
     - as: kata-containers-e2e-pre

--- a/ci-operator/config/kata-containers/kata-containers/kata-containers-kata-containers-main__peer-pods.yaml
+++ b/ci-operator/config/kata-containers/kata-containers/kata-containers-kata-containers-main__peer-pods.yaml
@@ -52,7 +52,8 @@ tests:
     allow_skip_on_success: true
     cluster_profile: openshift-org-azure
     env:
-      TEST_ARGS: ' --max-parallel-tests 10 --cluster-stability Disruptive --run ^\[sig-node\].*'
+      TEST_ARGS: ' --max-parallel-tests 10 --cluster-stability Disruptive --retry-strategy=aggressive
+        --run ^\[sig-node\].*'
       TEST_SKIPS: \[sig-node\] Pods Extended Pod Container Status should never report\|\[sig-node\]
         Sysctls.*should support sysctls\|\[sig-node\] Pods Extended Pod Container
         Status should never report success for a pending container\|\[sig-node\] Security

--- a/ci-operator/config/kata-containers/kata-containers/kata-containers-kata-containers-main__peer-pods.yaml
+++ b/ci-operator/config/kata-containers/kata-containers/kata-containers-kata-containers-main__peer-pods.yaml
@@ -1,6 +1,6 @@
 base_images:
   tests-base:
-    name: "4.19"
+    name: "4.22"
     namespace: ocp
     tag: tests
 binary_build_commands: |
@@ -32,12 +32,12 @@ images:
 releases:
   initial:
     integration:
-      name: "4.19"
+      name: "4.22"
       namespace: ocp
   latest:
     integration:
       include_built_images: true
-      name: "4.19"
+      name: "4.22"
       namespace: ocp
 resources:
   '*':


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Kata Containers CI base and integration image tags across pipeline configurations to newer releases.
  * Expanded and consolidated E2E test-skip patterns to exclude additional [sig-node], DRA, user-namespace, in-place resize, volume/Downward API, and related conformance cases; added an aggressive retry strategy while preserving test selection and parallelism.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->