### PR TITLE
ci: onboard stolostron/capi-tests CAPZ e2e to OpenShift CI

### DIFF
--- a/ci-operator/config/stolostron/capi-tests/OWNERS
+++ b/ci-operator/config/stolostron/capi-tests/OWNERS
@@ -5,16 +5,11 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 approvers:
-- jnpacker
 - marek-veber
 - mzazrivec
 - radekcap
-- serngawy
 options: {}
 reviewers:
-- jnpacker
 - marek-veber
 - mzazrivec
 - radekcap
-- serngawy
-- tinaafitz

--- a/ci-operator/config/stolostron/capi-tests/stolostron-capi-tests-configure-prow.yaml
+++ b/ci-operator/config/stolostron/capi-tests/stolostron-capi-tests-configure-prow.yaml
@@ -1,0 +1,48 @@
+build_root:
+  project_image:
+    dockerfile_path: Dockerfile.prow
+releases:
+  initial:
+    integration:
+      name: "4.19"
+      namespace: ocp
+  latest:
+    integration:
+      include_built_images: true
+      name: "4.19"
+      namespace: ocp
+resources:
+  '*':
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: capz-e2e
+  steps:
+    cluster_profile: azure4
+    env:
+      DEPLOY_CHARTS: "true"
+      SIZE_VARIANT: compact
+      WORKLOAD_CLUSTER_NAMESPACE: capz-test-prow
+    post:
+    - ref: capz-test-summary
+    - ref: capz-test-teardown
+    - chain: ipi-azure-post
+    pre:
+    - chain: ipi-azure-pre
+    - ref: capz-test-check-dependencies
+    - ref: capz-test-setup
+    test:
+    - ref: capz-test-management-cluster
+    - ref: capz-test-generate-yamls
+    - ref: capz-test-cleanup-pre
+    - ref: capz-test-deploy-crs
+    - ref: capz-test-verify-workload-cluster
+    - ref: capz-test-delete-workload-cluster
+    - ref: capz-test-validate-cleanup
+    workflow: openshift-e2e-azure
+  timeout: 4h0m0s
+zz_generated_metadata:
+  branch: configure-prow
+  org: stolostron
+  repo: capi-tests

--- a/ci-operator/jobs/stolostron/capi-tests/OWNERS
+++ b/ci-operator/jobs/stolostron/capi-tests/OWNERS
@@ -5,16 +5,11 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 approvers:
-- jnpacker
 - marek-veber
 - mzazrivec
 - radekcap
-- serngawy
 options: {}
 reviewers:
-- jnpacker
 - marek-veber
 - mzazrivec
 - radekcap
-- serngawy
-- tinaafitz

--- a/ci-operator/jobs/stolostron/capi-tests/stolostron-capi-tests-configure-prow-presubmits.yaml
+++ b/ci-operator/jobs/stolostron/capi-tests/stolostron-capi-tests-configure-prow-presubmits.yaml
@@ -1,0 +1,85 @@
+presubmits:
+  stolostron/capi-tests:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^configure-prow$
+    - ^configure-prow-
+    cluster: build01
+    context: ci/prow/capz-e2e
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+      timeout: 4h0m0s
+    labels:
+      ci-operator.openshift.io/cloud: azure4
+      ci-operator.openshift.io/cloud-cluster-profile: azure4
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-stolostron-capi-tests-configure-prow-capz-e2e
+    rerun_command: /test capz-e2e
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=capz-e2e
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )capz-e2e,?($|\s.*)

--- a/ci-operator/step-registry/capz/test/check-dependencies/capz-test-check-dependencies-ref.yaml
+++ b/ci-operator/step-registry/capz/test/check-dependencies/capz-test-check-dependencies-ref.yaml
@@ -6,6 +6,10 @@ ref:
     requests:
       cpu: 100m
       memory: 200Mi
+  credentials:
+  - namespace: test-credentials
+    name: azure-capz-credentials
+    mount_path: /var/run/capz-azure-credentials
   timeout: 10m
   documentation: |-
     Runs CAPZ test suite Phase 01 (check dependencies) to validate

--- a/ci-operator/step-registry/capz/test/cleanup-pre/OWNERS
+++ b/ci-operator/step-registry/capz/test/cleanup-pre/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+- radekcap
+- marek-veber
+- mzazrivec
+reviewers:
+- radekcap
+- marek-veber
+- mzazrivec

--- a/ci-operator/step-registry/capz/test/cleanup-pre/capz-test-cleanup-pre-commands.sh
+++ b/ci-operator/step-registry/capz/test/cleanup-pre/capz-test-cleanup-pre-commands.sh
@@ -8,26 +8,4 @@ source openshift-ci/capz-test-env.sh
 # Pre-test cleanup: safety net for aborted previous jobs.
 # Cleans up any leftover Azure resources (resource groups, ARM resources,
 # soft-deleted Key Vaults, AD apps, SPs) before deploying new workload cluster CRs.
-#
-# Two cleanup passes are needed because the gen.sh template uses different
-# naming patterns for different resource types:
-#   - Managed identities use CAPI_USER prefix: prow-capz-tests-*
-#   - Resource group uses WORKLOAD_CLUSTER_NAME: capz-tests-resgroup
-#   - Key Vault uses WORKLOAD_CLUSTER_NAME: capz-tests-kv
-#
-# Both passes run regardless of individual failures; the overall exit code
-# reflects whether any pass failed.
-rc=0
-
-# Pass 1: Clean resources prefixed with CAPI_USER (managed identities, SPs, apps)
-FORCE=1 make clean-azure || rc=$?
-
-# Pass 2: Clean resources using WORKLOAD_CLUSTER_NAME naming (RG, Key Vault)
-# The WORKLOAD_CLUSTER_NAME defaults to capz-tests for ARO provider.
-WCN="${WORKLOAD_CLUSTER_NAME:-capz-tests}"
-./scripts/cleanup-azure-resources.sh \
-    --resource-group "${WCN}-resgroup" \
-    --prefix "${WCN}" \
-    --force || rc=$?
-
-exit $rc
+FORCE=1 make clean-azure

--- a/ci-operator/step-registry/capz/test/cleanup-pre/capz-test-cleanup-pre-commands.sh
+++ b/ci-operator/step-registry/capz/test/cleanup-pre/capz-test-cleanup-pre-commands.sh
@@ -8,4 +8,9 @@ source openshift-ci/capz-test-env.sh
 # Pre-test cleanup: safety net for aborted previous jobs.
 # Cleans up any leftover Azure resources (resource groups, ARM resources,
 # soft-deleted Key Vaults, AD apps, SPs) before deploying new workload cluster CRs.
+#
+# Two passes needed: gen.sh overrides CS_CLUSTER_NAME with WORKLOAD_CLUSTER_NAME,
+# so resources end up under a different prefix than what CS_CLUSTER_NAME defaults to.
+# See: https://github.com/stolostron/capi-tests/issues/627
 FORCE=1 make clean-azure
+FORCE=1 CS_CLUSTER_NAME="${WORKLOAD_CLUSTER_NAME:-capz-tests}" make clean-azure

--- a/ci-operator/step-registry/capz/test/cleanup-pre/capz-test-cleanup-pre-commands.sh
+++ b/ci-operator/step-registry/capz/test/cleanup-pre/capz-test-cleanup-pre-commands.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+source openshift-ci/capz-test-env.sh
+
+# Pre-test cleanup: safety net for aborted previous jobs.
+# Cleans up any leftover Azure resources (resource groups, ARM resources,
+# soft-deleted Key Vaults, AD apps, SPs) before deploying new workload cluster CRs.
+#
+# Two cleanup passes are needed because the gen.sh template uses different
+# naming patterns for different resource types:
+#   - Managed identities use CAPI_USER prefix: prow-capz-tests-*
+#   - Resource group uses WORKLOAD_CLUSTER_NAME: capz-tests-resgroup
+#   - Key Vault uses WORKLOAD_CLUSTER_NAME: capz-tests-kv
+#
+# Both passes run regardless of individual failures; the overall exit code
+# reflects whether any pass failed.
+rc=0
+
+# Pass 1: Clean resources prefixed with CAPI_USER (managed identities, SPs, apps)
+FORCE=1 make clean-azure || rc=$?
+
+# Pass 2: Clean resources using WORKLOAD_CLUSTER_NAME naming (RG, Key Vault)
+# The WORKLOAD_CLUSTER_NAME defaults to capz-tests for ARO provider.
+WCN="${WORKLOAD_CLUSTER_NAME:-capz-tests}"
+./scripts/cleanup-azure-resources.sh \
+    --resource-group "${WCN}-resgroup" \
+    --prefix "${WCN}" \
+    --force || rc=$?
+
+exit $rc

--- a/ci-operator/step-registry/capz/test/cleanup-pre/capz-test-cleanup-pre-ref.metadata.json
+++ b/ci-operator/step-registry/capz/test/cleanup-pre/capz-test-cleanup-pre-ref.metadata.json
@@ -1,0 +1,15 @@
+{
+	"path": "capz/test/cleanup-pre/capz-test-cleanup-pre-ref.yaml",
+	"owners": {
+		"approvers": [
+			"radekcap",
+			"marek-veber",
+			"mzazrivec"
+		],
+		"reviewers": [
+			"radekcap",
+			"marek-veber",
+			"mzazrivec"
+		]
+	}
+}

--- a/ci-operator/step-registry/capz/test/cleanup-pre/capz-test-cleanup-pre-ref.yaml
+++ b/ci-operator/step-registry/capz/test/cleanup-pre/capz-test-cleanup-pre-ref.yaml
@@ -1,0 +1,13 @@
+ref:
+  as: capz-test-cleanup-pre
+  from: src
+  commands: capz-test-cleanup-pre-commands.sh
+  resources:
+    requests:
+      cpu: 100m
+      memory: 200Mi
+  timeout: 30m
+  documentation: |-
+    Pre-test cleanup safety net for CAPZ test suite. Runs before deploying
+    workload cluster CRs to clean up leftovers from previously aborted jobs
+    (resource groups, ARM resources, soft-deleted Key Vaults, AD apps, SPs).

--- a/ci-operator/step-registry/capz/test/cleanup-pre/capz-test-cleanup-pre-ref.yaml
+++ b/ci-operator/step-registry/capz/test/cleanup-pre/capz-test-cleanup-pre-ref.yaml
@@ -6,6 +6,10 @@ ref:
     requests:
       cpu: 100m
       memory: 200Mi
+  credentials:
+  - namespace: test-credentials
+    name: azure-capz-credentials
+    mount_path: /var/run/capz-azure-credentials
   timeout: 30m
   documentation: |-
     Pre-test cleanup safety net for CAPZ test suite. Runs before deploying

--- a/ci-operator/step-registry/capz/test/delete-workload-cluster/OWNERS
+++ b/ci-operator/step-registry/capz/test/delete-workload-cluster/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+- radekcap
+- marek-veber
+- mzazrivec
+reviewers:
+- radekcap
+- marek-veber
+- mzazrivec

--- a/ci-operator/step-registry/capz/test/delete-workload-cluster/capz-test-delete-workload-cluster-commands.sh
+++ b/ci-operator/step-registry/capz/test/delete-workload-cluster/capz-test-delete-workload-cluster-commands.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+source openshift-ci/capz-test-env.sh
+
+# Phase 07: Delete Workload Cluster
+# Deletes the workload cluster and verifies resource cleanup.
+# Produces JUnit XML in ${ARTIFACT_DIR} for Prow to collect.
+# Restore generated YAMLs from SHARED_DIR (copied by generate-yamls step).
+OUTPUT_DIR="${ARO_REPO_DIR}/${WORKLOAD_CLUSTER_NAME:-capz-tests}-${DEPLOYMENT_ENV}"
+if ls "${SHARED_DIR}"/generated-*.yaml 1>/dev/null 2>&1; then
+  mkdir -p "${OUTPUT_DIR}"
+  for f in "${SHARED_DIR}"/generated-*.yaml; do
+    cp "${f}" "${OUTPUT_DIR}/$(basename "${f}" | sed 's/^generated-//')"
+  done
+fi
+
+export TEST_RESULTS_DIR="${ARTIFACT_DIR}"
+script -e -q -c "make _delete-workload-cluster RESULTS_DIR=\"${ARTIFACT_DIR}\"" /dev/null
+
+# Copy JUnit XMLs to SHARED_DIR for cross-step summary aggregation
+cp "${ARTIFACT_DIR}"/junit-*.xml "${SHARED_DIR}/" 2>/dev/null || true

--- a/ci-operator/step-registry/capz/test/delete-workload-cluster/capz-test-delete-workload-cluster-ref.metadata.json
+++ b/ci-operator/step-registry/capz/test/delete-workload-cluster/capz-test-delete-workload-cluster-ref.metadata.json
@@ -1,0 +1,15 @@
+{
+	"path": "capz/test/delete-workload-cluster/capz-test-delete-workload-cluster-ref.yaml",
+	"owners": {
+		"approvers": [
+			"radekcap",
+			"marek-veber",
+			"mzazrivec"
+		],
+		"reviewers": [
+			"radekcap",
+			"marek-veber",
+			"mzazrivec"
+		]
+	}
+}

--- a/ci-operator/step-registry/capz/test/delete-workload-cluster/capz-test-delete-workload-cluster-ref.yaml
+++ b/ci-operator/step-registry/capz/test/delete-workload-cluster/capz-test-delete-workload-cluster-ref.yaml
@@ -12,6 +12,10 @@ ref:
     documentation: |-
       Fixed namespace for workload cluster resources. When set, all steps
       use this value instead of generating a timestamp-based namespace.
+  credentials:
+  - namespace: test-credentials
+    name: azure-capz-credentials
+    mount_path: /var/run/capz-azure-credentials
   timeout: 60m
   documentation: |-
     Runs CAPZ test suite Phase 07 (delete workload cluster) to delete

--- a/ci-operator/step-registry/capz/test/delete-workload-cluster/capz-test-delete-workload-cluster-ref.yaml
+++ b/ci-operator/step-registry/capz/test/delete-workload-cluster/capz-test-delete-workload-cluster-ref.yaml
@@ -1,0 +1,18 @@
+ref:
+  as: capz-test-delete-workload-cluster
+  from: src
+  commands: capz-test-delete-workload-cluster-commands.sh
+  resources:
+    requests:
+      cpu: 100m
+      memory: 200Mi
+  env:
+  - name: WORKLOAD_CLUSTER_NAMESPACE
+    default: ""
+    documentation: |-
+      Fixed namespace for workload cluster resources. When set, all steps
+      use this value instead of generating a timestamp-based namespace.
+  timeout: 60m
+  documentation: |-
+    Runs CAPZ test suite Phase 07 (delete workload cluster) to delete
+    the workload cluster and verify all Kubernetes and Azure resources are cleaned up.

--- a/ci-operator/step-registry/capz/test/deploy-crs/OWNERS
+++ b/ci-operator/step-registry/capz/test/deploy-crs/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+- radekcap
+- marek-veber
+- mzazrivec
+reviewers:
+- radekcap
+- marek-veber
+- mzazrivec

--- a/ci-operator/step-registry/capz/test/deploy-crs/capz-test-deploy-crs-commands.sh
+++ b/ci-operator/step-registry/capz/test/deploy-crs/capz-test-deploy-crs-commands.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+source openshift-ci/capz-test-env.sh
+
+# Phase 05: Deploy CRs
+# Applies cluster resources and waits for control plane deployment.
+# Produces JUnit XML in ${ARTIFACT_DIR} for Prow to collect.
+# Restore generated YAMLs from SHARED_DIR (copied by generate-yamls step).
+# Each Prow step runs in a separate container; /tmp is not shared between them.
+OUTPUT_DIR="${ARO_REPO_DIR}/${WORKLOAD_CLUSTER_NAME:-capz-tests}-${DEPLOYMENT_ENV}"
+if ls "${SHARED_DIR}"/generated-*.yaml 1>/dev/null 2>&1; then
+  mkdir -p "${OUTPUT_DIR}"
+  for f in "${SHARED_DIR}"/generated-*.yaml; do
+    cp "${f}" "${OUTPUT_DIR}/$(basename "${f}" | sed 's/^generated-//')"
+  done
+  echo "Restored generated YAMLs to ${OUTPUT_DIR}"
+  ls -la "${OUTPUT_DIR}/"
+fi
+
+export TEST_RESULTS_DIR="${ARTIFACT_DIR}"
+script -e -q -c "make _deploy-crs RESULTS_DIR=\"${ARTIFACT_DIR}\"" /dev/null
+
+# Copy JUnit XMLs to SHARED_DIR for cross-step summary aggregation
+cp "${ARTIFACT_DIR}"/junit-*.xml "${SHARED_DIR}/" 2>/dev/null || true

--- a/ci-operator/step-registry/capz/test/deploy-crs/capz-test-deploy-crs-ref.metadata.json
+++ b/ci-operator/step-registry/capz/test/deploy-crs/capz-test-deploy-crs-ref.metadata.json
@@ -1,0 +1,15 @@
+{
+	"path": "capz/test/deploy-crs/capz-test-deploy-crs-ref.yaml",
+	"owners": {
+		"approvers": [
+			"radekcap",
+			"marek-veber",
+			"mzazrivec"
+		],
+		"reviewers": [
+			"radekcap",
+			"marek-veber",
+			"mzazrivec"
+		]
+	}
+}

--- a/ci-operator/step-registry/capz/test/deploy-crs/capz-test-deploy-crs-ref.yaml
+++ b/ci-operator/step-registry/capz/test/deploy-crs/capz-test-deploy-crs-ref.yaml
@@ -12,6 +12,10 @@ ref:
     documentation: |-
       Fixed namespace for workload cluster resources. When set, all steps
       use this value instead of generating a timestamp-based namespace.
+  credentials:
+  - namespace: test-credentials
+    name: azure-capz-credentials
+    mount_path: /var/run/capz-azure-credentials
   timeout: 120m
   documentation: |-
     Runs CAPZ test suite Phase 05 (deploy CRs) to apply cluster

--- a/ci-operator/step-registry/capz/test/deploy-crs/capz-test-deploy-crs-ref.yaml
+++ b/ci-operator/step-registry/capz/test/deploy-crs/capz-test-deploy-crs-ref.yaml
@@ -1,0 +1,18 @@
+ref:
+  as: capz-test-deploy-crs
+  from: src
+  commands: capz-test-deploy-crs-commands.sh
+  resources:
+    requests:
+      cpu: 100m
+      memory: 200Mi
+  env:
+  - name: WORKLOAD_CLUSTER_NAMESPACE
+    default: ""
+    documentation: |-
+      Fixed namespace for workload cluster resources. When set, all steps
+      use this value instead of generating a timestamp-based namespace.
+  timeout: 120m
+  documentation: |-
+    Runs CAPZ test suite Phase 05 (deploy CRs) to apply cluster
+    resources, monitor deployment, and wait for control plane readiness.

--- a/ci-operator/step-registry/capz/test/generate-yamls/capz-test-generate-yamls-ref.yaml
+++ b/ci-operator/step-registry/capz/test/generate-yamls/capz-test-generate-yamls-ref.yaml
@@ -12,6 +12,10 @@ ref:
     documentation: |-
       Fixed namespace for workload cluster resources. When set, all steps
       use this value instead of generating a timestamp-based namespace.
+  credentials:
+  - namespace: test-credentials
+    name: azure-capz-credentials
+    mount_path: /var/run/capz-azure-credentials
   timeout: 20m
   documentation: |-
     Runs CAPZ test suite Phase 04 (generate YAMLs) to produce

--- a/ci-operator/step-registry/capz/test/teardown/OWNERS
+++ b/ci-operator/step-registry/capz/test/teardown/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+- radekcap
+- marek-veber
+- mzazrivec
+reviewers:
+- radekcap
+- marek-veber
+- mzazrivec

--- a/ci-operator/step-registry/capz/test/teardown/capz-test-teardown-commands.sh
+++ b/ci-operator/step-registry/capz/test/teardown/capz-test-teardown-commands.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -o nounset
-set -o errexit
 set -o pipefail
 set -o xtrace
 
@@ -10,11 +9,4 @@ source openshift-ci/capz-test-env.sh
 # Cleans up Azure resources created by the test suite (workload cluster, resource groups).
 # The management cluster itself is deprovisioned by the ipi-azure-post chain.
 # Cleanup failures should fail the job so we notice orphaned resources.
-#
-# Single cleanup pass targeting the workload cluster resource group.
-# RG deletion is synchronous — all resources inside are deleted with the RG.
-WCN="${WORKLOAD_CLUSTER_NAME:-capz-tests}"
-./scripts/cleanup-azure-resources.sh \
-    --resource-group "${WCN}-resgroup" \
-    --prefix "${WCN}" \
-    --force
+FORCE=1 make clean-azure

--- a/ci-operator/step-registry/capz/test/teardown/capz-test-teardown-commands.sh
+++ b/ci-operator/step-registry/capz/test/teardown/capz-test-teardown-commands.sh
@@ -9,4 +9,9 @@ source openshift-ci/capz-test-env.sh
 # Cleans up Azure resources created by the test suite (workload cluster, resource groups).
 # The management cluster itself is deprovisioned by the ipi-azure-post chain.
 # Cleanup failures should fail the job so we notice orphaned resources.
+#
+# Two passes needed: gen.sh overrides CS_CLUSTER_NAME with WORKLOAD_CLUSTER_NAME,
+# so resources end up under a different prefix than what CS_CLUSTER_NAME defaults to.
+# See: https://github.com/stolostron/capi-tests/issues/627
 FORCE=1 make clean-azure
+FORCE=1 CS_CLUSTER_NAME="${WORKLOAD_CLUSTER_NAME:-capz-tests}" make clean-azure

--- a/ci-operator/step-registry/capz/test/teardown/capz-test-teardown-commands.sh
+++ b/ci-operator/step-registry/capz/test/teardown/capz-test-teardown-commands.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -o nounset
+set -o errexit
+set -o pipefail
+set -o xtrace
+
+source openshift-ci/capz-test-env.sh
+
+# Teardown: Safety net cleanup (post step - always runs)
+# Cleans up Azure resources created by the test suite (workload cluster, resource groups).
+# The management cluster itself is deprovisioned by the ipi-azure-post chain.
+# Cleanup failures should fail the job so we notice orphaned resources.
+#
+# Single cleanup pass targeting the workload cluster resource group.
+# RG deletion is synchronous — all resources inside are deleted with the RG.
+WCN="${WORKLOAD_CLUSTER_NAME:-capz-tests}"
+./scripts/cleanup-azure-resources.sh \
+    --resource-group "${WCN}-resgroup" \
+    --prefix "${WCN}" \
+    --force

--- a/ci-operator/step-registry/capz/test/teardown/capz-test-teardown-ref.metadata.json
+++ b/ci-operator/step-registry/capz/test/teardown/capz-test-teardown-ref.metadata.json
@@ -1,0 +1,15 @@
+{
+	"path": "capz/test/teardown/capz-test-teardown-ref.yaml",
+	"owners": {
+		"approvers": [
+			"radekcap",
+			"marek-veber",
+			"mzazrivec"
+		],
+		"reviewers": [
+			"radekcap",
+			"marek-veber",
+			"mzazrivec"
+		]
+	}
+}

--- a/ci-operator/step-registry/capz/test/teardown/capz-test-teardown-ref.yaml
+++ b/ci-operator/step-registry/capz/test/teardown/capz-test-teardown-ref.yaml
@@ -1,0 +1,14 @@
+ref:
+  as: capz-test-teardown
+  from: src
+  commands: capz-test-teardown-commands.sh
+  best_effort: true
+  resources:
+    requests:
+      cpu: 100m
+      memory: 200Mi
+  timeout: 30m
+  documentation: |-
+    Teardown safety net for CAPZ test suite. Always runs as a post step,
+    even if test steps fail. Cleans up Azure resources (workload cluster,
+    resource groups). The management cluster is deprovisioned by ipi-azure-post.

--- a/ci-operator/step-registry/capz/test/teardown/capz-test-teardown-ref.yaml
+++ b/ci-operator/step-registry/capz/test/teardown/capz-test-teardown-ref.yaml
@@ -7,6 +7,10 @@ ref:
     requests:
       cpu: 100m
       memory: 200Mi
+  credentials:
+  - namespace: test-credentials
+    name: azure-capz-credentials
+    mount_path: /var/run/capz-azure-credentials
   timeout: 30m
   documentation: |-
     Teardown safety net for CAPZ test suite. Always runs as a post step,

--- a/ci-operator/step-registry/capz/test/validate-cleanup/OWNERS
+++ b/ci-operator/step-registry/capz/test/validate-cleanup/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+- radekcap
+- marek-veber
+- mzazrivec
+reviewers:
+- radekcap
+- marek-veber
+- mzazrivec

--- a/ci-operator/step-registry/capz/test/validate-cleanup/capz-test-validate-cleanup-commands.sh
+++ b/ci-operator/step-registry/capz/test/validate-cleanup/capz-test-validate-cleanup-commands.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+source openshift-ci/capz-test-env.sh
+
+# Phase 08: Validate Cleanup
+# Validates cleanup operations for local and Azure resources.
+# Produces JUnit XML in ${ARTIFACT_DIR} for Prow to collect.
+export TEST_RESULTS_DIR="${ARTIFACT_DIR}"
+script -e -q -c "make _validate-cleanup RESULTS_DIR=\"${ARTIFACT_DIR}\"" /dev/null
+
+# Copy JUnit XMLs to SHARED_DIR for cross-step summary aggregation
+cp "${ARTIFACT_DIR}"/junit-*.xml "${SHARED_DIR}/" 2>/dev/null || true

--- a/ci-operator/step-registry/capz/test/validate-cleanup/capz-test-validate-cleanup-ref.metadata.json
+++ b/ci-operator/step-registry/capz/test/validate-cleanup/capz-test-validate-cleanup-ref.metadata.json
@@ -1,0 +1,15 @@
+{
+	"path": "capz/test/validate-cleanup/capz-test-validate-cleanup-ref.yaml",
+	"owners": {
+		"approvers": [
+			"radekcap",
+			"marek-veber",
+			"mzazrivec"
+		],
+		"reviewers": [
+			"radekcap",
+			"marek-veber",
+			"mzazrivec"
+		]
+	}
+}

--- a/ci-operator/step-registry/capz/test/validate-cleanup/capz-test-validate-cleanup-ref.yaml
+++ b/ci-operator/step-registry/capz/test/validate-cleanup/capz-test-validate-cleanup-ref.yaml
@@ -12,6 +12,10 @@ ref:
     documentation: |-
       Fixed namespace for workload cluster resources. When set, all steps
       use this value instead of generating a timestamp-based namespace.
+  credentials:
+  - namespace: test-credentials
+    name: azure-capz-credentials
+    mount_path: /var/run/capz-azure-credentials
   timeout: 20m
   documentation: |-
     Runs CAPZ test suite Phase 08 (validate cleanup) to verify cleanup

--- a/ci-operator/step-registry/capz/test/validate-cleanup/capz-test-validate-cleanup-ref.yaml
+++ b/ci-operator/step-registry/capz/test/validate-cleanup/capz-test-validate-cleanup-ref.yaml
@@ -1,0 +1,19 @@
+ref:
+  as: capz-test-validate-cleanup
+  from: src
+  commands: capz-test-validate-cleanup-commands.sh
+  resources:
+    requests:
+      cpu: 100m
+      memory: 200Mi
+  env:
+  - name: WORKLOAD_CLUSTER_NAMESPACE
+    default: ""
+    documentation: |-
+      Fixed namespace for workload cluster resources. When set, all steps
+      use this value instead of generating a timestamp-based namespace.
+  timeout: 20m
+  documentation: |-
+    Runs CAPZ test suite Phase 08 (validate cleanup) to verify cleanup
+    operations for local resources and Azure resources. This phase is
+    informational and does not delete any resources.

--- a/ci-operator/step-registry/capz/test/verify-workload-cluster/OWNERS
+++ b/ci-operator/step-registry/capz/test/verify-workload-cluster/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+- radekcap
+- marek-veber
+- mzazrivec
+reviewers:
+- radekcap
+- marek-veber
+- mzazrivec

--- a/ci-operator/step-registry/capz/test/verify-workload-cluster/capz-test-verify-workload-cluster-commands.sh
+++ b/ci-operator/step-registry/capz/test/verify-workload-cluster/capz-test-verify-workload-cluster-commands.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+source openshift-ci/capz-test-env.sh
+
+# Phase 06: Verify Workload Cluster
+# Validates the deployed workload cluster is accessible and healthy.
+# Produces JUnit XML in ${ARTIFACT_DIR} for Prow to collect.
+# Restore generated YAMLs from SHARED_DIR (copied by generate-yamls step).
+OUTPUT_DIR="${ARO_REPO_DIR}/${WORKLOAD_CLUSTER_NAME:-capz-tests}-${DEPLOYMENT_ENV}"
+if ls "${SHARED_DIR}"/generated-*.yaml 1>/dev/null 2>&1; then
+  mkdir -p "${OUTPUT_DIR}"
+  for f in "${SHARED_DIR}"/generated-*.yaml; do
+    cp "${f}" "${OUTPUT_DIR}/$(basename "${f}" | sed 's/^generated-//')"
+  done
+fi
+
+export TEST_RESULTS_DIR="${ARTIFACT_DIR}"
+script -e -q -c "make _verify-workload-cluster RESULTS_DIR=\"${ARTIFACT_DIR}\"" /dev/null
+
+# Copy JUnit XMLs to SHARED_DIR for cross-step summary aggregation
+cp "${ARTIFACT_DIR}"/junit-*.xml "${SHARED_DIR}/" 2>/dev/null || true

--- a/ci-operator/step-registry/capz/test/verify-workload-cluster/capz-test-verify-workload-cluster-ref.metadata.json
+++ b/ci-operator/step-registry/capz/test/verify-workload-cluster/capz-test-verify-workload-cluster-ref.metadata.json
@@ -1,0 +1,15 @@
+{
+	"path": "capz/test/verify-workload-cluster/capz-test-verify-workload-cluster-ref.yaml",
+	"owners": {
+		"approvers": [
+			"radekcap",
+			"marek-veber",
+			"mzazrivec"
+		],
+		"reviewers": [
+			"radekcap",
+			"marek-veber",
+			"mzazrivec"
+		]
+	}
+}

--- a/ci-operator/step-registry/capz/test/verify-workload-cluster/capz-test-verify-workload-cluster-ref.yaml
+++ b/ci-operator/step-registry/capz/test/verify-workload-cluster/capz-test-verify-workload-cluster-ref.yaml
@@ -12,6 +12,10 @@ ref:
     documentation: |-
       Fixed namespace for workload cluster resources. When set, all steps
       use this value instead of generating a timestamp-based namespace.
+  credentials:
+  - namespace: test-credentials
+    name: azure-capz-credentials
+    mount_path: /var/run/capz-azure-credentials
   timeout: 20m
   documentation: |-
     Runs CAPZ test suite Phase 06 (verify workload cluster) to validate

--- a/ci-operator/step-registry/capz/test/verify-workload-cluster/capz-test-verify-workload-cluster-ref.yaml
+++ b/ci-operator/step-registry/capz/test/verify-workload-cluster/capz-test-verify-workload-cluster-ref.yaml
@@ -1,0 +1,18 @@
+ref:
+  as: capz-test-verify-workload-cluster
+  from: src
+  commands: capz-test-verify-workload-cluster-commands.sh
+  resources:
+    requests:
+      cpu: 100m
+      memory: 200Mi
+  env:
+  - name: WORKLOAD_CLUSTER_NAMESPACE
+    default: ""
+    documentation: |-
+      Fixed namespace for workload cluster resources. When set, all steps
+      use this value instead of generating a timestamp-based namespace.
+  timeout: 20m
+  documentation: |-
+    Runs CAPZ test suite Phase 06 (verify workload cluster) to validate
+    nodes, cluster operators, and overall health of the deployed cluster.


### PR DESCRIPTION
## Summary
- Add CAPZ step registry with 10 steps for full e2e test lifecycle (pre/test/post)
- Add ci-operator config for `stolostron/capi-tests` using IPI-provisioned Azure cluster as management cluster
- Uses `project_image` build root with custom `Dockerfile.prow` for tooling (kubectl, helm, clusterctl)

### Step Registry Layout

| Step | Lifecycle | Description |
|------|-----------|-------------|
| `capz-test-check-dependencies` | pre | Validate tools, auth, naming |
| `capz-test-setup` | pre | Clone repository, verify scripts |
| `capz-test-management-cluster` | test | Deploy controllers (`DEPLOY_CHARTS=true`) and validate cluster |
| `capz-test-generate-yamls` | test | Generate YAML manifests |
| `capz-test-deploy-crs` | test | Apply CRs, wait for deployment |
| `capz-test-verify-workload-cluster` | test | Validate workload cluster |
| `capz-test-delete-workload-cluster` | test | Delete workload cluster |
| `capz-test-validate-cleanup` | test | Validate cleanup operations |
| `capz-test-summary` | post | Aggregate JUnit XMLs and generate summary.txt |
| `capz-test-teardown` | post | Safety net cleanup (always runs) |

Each step delegates to a Makefile target and writes JUnit XML to `${ARTIFACT_DIR}` for Prow artifact collection. The teardown and summary steps use `best_effort: true` so failures don't mask test results.

Jira: [ARO-24304](https://issues.redhat.com/browse/ARO-24304)

[ARO-24304]: https://redhat.atlassian.net/browse/ARO-24304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ