### PR TITLE
NO-JIRA: feat(tnf): add resource-agents steps under baremetalds/two-node/fencing

### DIFF
--- a/ci-operator/config/openshift-priv/installer/openshift-priv-installer-main.yaml
+++ b/ci-operator/config/openshift-priv/installer/openshift-priv-installer-main.yaml
@@ -35,6 +35,10 @@ base_images:
     name: nested-environment-builder
     namespace: ci
     tag: latest
+  nested-podman:
+    name: nested-podman
+    namespace: ci
+    tag: latest
   ocp_4.10_cli:
     name: 4.22-priv
     namespace: ocp-private
@@ -1118,6 +1122,7 @@ tests:
 - as: e2e-agent-two-node-fencing-ipv4
   capabilities:
   - intranet
+  - nested-podman
   optional: true
   run_if_changed: ^(cmd|pkg|data).*/agent/
   steps:

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22.yaml
@@ -67,6 +67,10 @@ base_images:
     name: nested-environment-builder
     namespace: ci
     tag: latest
+  nested-podman:
+    name: nested-podman
+    namespace: ci
+    tag: latest
   ocm-cli:
     name: ocm-cli
     namespace: ci
@@ -771,6 +775,16 @@ tests:
   cron: 19 10,20 * * *
   steps:
     cluster_profile: equinix-edge-enablement
+    workflow: baremetalds-two-node-fencing-recovery
+- as: e2e-metal-ovn-two-node-fencing-recovery-repo-ra-techpreview
+  capabilities:
+  - intranet
+  - nested-podman
+  cron: 19 10,20 * * *
+  steps:
+    cluster_profile: equinix-edge-enablement
+    env:
+      RESOURCE_AGENT_SOURCE: REPO
     workflow: baremetalds-two-node-fencing-recovery
 - as: e2e-metal-ovn-two-node-fencing-ipv6-recovery-techpreview
   capabilities:

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
@@ -67,6 +67,10 @@ base_images:
     name: nested-environment-builder
     namespace: ci
     tag: latest
+  nested-podman:
+    name: nested-podman
+    namespace: ci
+    tag: latest
   ocm-cli:
     name: ocm-cli
     namespace: ci
@@ -771,6 +775,16 @@ tests:
   cron: 19 10,20 * * *
   steps:
     cluster_profile: equinix-edge-enablement
+    workflow: baremetalds-two-node-fencing-recovery
+- as: e2e-metal-ovn-two-node-fencing-recovery-repo-ra-techpreview
+  capabilities:
+  - intranet
+  - nested-podman
+  cron: 19 10,20 * * *
+  steps:
+    cluster_profile: equinix-edge-enablement
+    env:
+      RESOURCE_AGENT_SOURCE: REPO
     workflow: baremetalds-two-node-fencing-recovery
 - as: e2e-metal-ovn-two-node-fencing-ipv6-recovery-techpreview
   capabilities:

--- a/ci-operator/jobs/openshift-priv/installer/openshift-priv-installer-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/installer/openshift-priv-installer-main-presubmits.yaml
@@ -1285,6 +1285,7 @@ presubmits:
     hidden: true
     labels:
       capability/intranet: intranet
+      capability/nested-podman: nested-podman
       ci-operator.openshift.io/cloud: equinix-ocp-metal
       ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal
       ci.openshift.io/generator: prowgen

--- a/ci-operator/step-registry/agent/e2e/two-node/fencing/ipv4/agent-e2e-two-node-fencing-ipv4-workflow.yaml
+++ b/ci-operator/step-registry/agent/e2e/two-node/fencing/ipv4/agent-e2e-two-node-fencing-ipv4-workflow.yaml
@@ -12,6 +12,7 @@ workflow:
     pre:
       - chain: agent-pre
     test:
+      - ref: baremetalds-two-node-fencing-update-rhcos-resource-agents
       - chain: agent-test
     post:
       - chain: agent-post

--- a/ci-operator/step-registry/baremetalds/two-node/fencing/delete-rhcos-resource-agents-image/OWNERS
+++ b/ci-operator/step-registry/baremetalds/two-node/fencing/delete-rhcos-resource-agents-image/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+  - edge-enablement-approvers
+reviewers:
+  - edge-enablement-reviewers

--- a/ci-operator/step-registry/baremetalds/two-node/fencing/delete-rhcos-resource-agents-image/baremetalds-two-node-fencing-delete-rhcos-resource-agents-image-commands.sh
+++ b/ci-operator/step-registry/baremetalds/two-node/fencing/delete-rhcos-resource-agents-image/baremetalds-two-node-fencing-delete-rhcos-resource-agents-image-commands.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only delete when we actually pushed (REPO path). No-op otherwise.
+if [[ "${RESOURCE_AGENT_SOURCE:-RHCOS}" != "REPO" ]]; then
+  echo "RESOURCE_AGENT_SOURCE is not REPO; skipping image delete."
+  exit 0
+fi
+
+if [[ -z "${CUSTOM_OS_MIRROR_REGISTRY:-}" ]] || [[ -z "${CUSTOM_OS_IMAGE_REPO:-}" ]]; then
+  echo "CUSTOM_OS_MIRROR_REGISTRY or CUSTOM_OS_IMAGE_REPO unset; skipping image delete."
+  exit 0
+fi
+
+# Only support quay.io for tag deletion via API.
+if [[ "${CUSTOM_OS_MIRROR_REGISTRY}" != "quay.io" ]]; then
+  echo "Delete only supported for quay.io (got ${CUSTOM_OS_MIRROR_REGISTRY}); skipping."
+  exit 0
+fi
+
+# Quay auth from profile (same as update step). equinix-edge-enablement: quay-custom-rhcos-secret.
+AUTH_FILE="${CLUSTER_PROFILE_DIR:-}/quay-custom-rhcos-secret"
+if [[ ! -f "${AUTH_FILE}" ]]; then
+  echo "No quay-custom-rhcos-secret at CLUSTER_PROFILE_DIR; skipping image delete."
+  exit 0
+fi
+
+# Extract Bearer token: Docker config has .auths["quay.io"].auth = base64(user:token)
+QUAY_AUTH=$(jq -r '.auths["quay.io"].auth // empty' "${AUTH_FILE}")
+if [[ -z "${QUAY_AUTH}" ]]; then
+  echo "No quay.io auth in config; skipping image delete."
+  exit 0
+fi
+
+# Decode and take the token (part after colon). Robot format is "org+robot" or "user:token".
+DECODED=$(echo "${QUAY_AUTH}" | base64 -d 2>/dev/null || true)
+if [[ -z "${DECODED}" ]]; then
+  echo "Failed to decode quay auth; skipping image delete."
+  exit 0
+fi
+
+TOKEN="${DECODED#*:}"
+if [[ -z "${TOKEN}" ]] || [[ "${TOKEN}" == "${DECODED}" ]]; then
+  echo "Could not extract token from auth; skipping image delete."
+  exit 0
+fi
+# Do not log or echo TOKEN; it is used only in curl Authorization header.
+
+# CUSTOM_OS_IMAGE_REPO is "org/repo" (e.g. rh-edge-enablement/tnf-custom-rhcos). Restrict to safe chars for API URLs.
+SAFE_REPO_PATTERN='^[a-zA-Z0-9][a-zA-Z0-9_.-]*$'
+NAMESPACE="${CUSTOM_OS_IMAGE_REPO%%/*}"
+REPO_NAME="${CUSTOM_OS_IMAGE_REPO#*/}"
+if [[ -z "${NAMESPACE}" ]] || [[ -z "${REPO_NAME}" ]]; then
+  echo "Could not parse org/repo from CUSTOM_OS_IMAGE_REPO; skipping."
+  exit 0
+fi
+if ! [[ "${NAMESPACE}" =~ ${SAFE_REPO_PATTERN} ]] || ! [[ "${REPO_NAME}" =~ ${SAFE_REPO_PATTERN} ]]; then
+  echo "NAMESPACE or REPO_NAME contains invalid characters; skipping delete."
+  exit 0
+fi
+
+# Extensions repo: default is same org, repo name with -extensions suffix.
+EXTENSIONS_REPO="${CUSTOM_OS_EXTENSIONS_REPO:-${REPO_NAME}-extensions}"
+if [[ "${EXTENSIONS_REPO}" == */* ]]; then
+  EXT_NAMESPACE="${EXTENSIONS_REPO%%/*}"
+  EXT_REPO="${EXTENSIONS_REPO#*/}"
+else
+  EXT_NAMESPACE="${NAMESPACE}"
+  EXT_REPO="${EXTENSIONS_REPO}"
+fi
+
+delete_tag() {
+  local ns="$1"
+  local repo="$2"
+  local tag="$3"
+  local url="https://quay.io/api/v1/repository/${ns}/${repo}/tag/${tag}"
+  if curl -sf -X DELETE -H "Authorization: Bearer ${TOKEN}" "${url}"; then
+    echo "Deleted ${ns}/${repo}:${tag}"
+  else
+    echo "Could not delete ${ns}/${repo}:${tag} (may lack permission or tag missing)"
+  fi
+}
+
+# 1. Delete this job's tag (written by update step) so our image is removed.
+JOB_TAG_FILE="${SHARED_DIR:-/tmp}/custom-rhcos-image-tag"
+if [[ -f "${JOB_TAG_FILE}" ]]; then
+  JOB_TAG=$(cat "${JOB_TAG_FILE}" | tr -d '\n' | head -c 64)
+  if [[ -n "${JOB_TAG}" ]] && [[ "${JOB_TAG}" =~ ^ts-[0-9]+$ ]]; then
+    delete_tag "${NAMESPACE}" "${REPO_NAME}" "${JOB_TAG}"
+    if [[ -n "${EXT_NAMESPACE}" ]] && [[ -n "${EXT_REPO}" ]]; then
+      delete_tag "${EXT_NAMESPACE}" "${EXT_REPO}" "${JOB_TAG}"
+    fi
+  fi
+fi
+
+# 2. List tags and delete any older than 24 hours to keep the repo clean.
+SECONDS_PER_DAY=86400
+CUTOFF_TS=$(($(date +%s) - SECONDS_PER_DAY))
+
+list_and_delete_stale_tags() {
+  local ns="$1"
+  local repo="$2"
+  local page=1
+  local tag_count resp has_additional
+  while true; do
+    resp=$(curl -sf -H "Authorization: Bearer ${TOKEN}" \
+      "https://quay.io/api/v1/repository/${ns}/${repo}/tag/?limit=100&page=${page}" 2>/dev/null || true)
+    if [[ -z "${resp}" ]]; then
+      break
+    fi
+    tag_count=0
+    # Quay v1 returns .tags[] with .name and .start_ts (Unix timestamp). Delete tags older than 24h.
+    while read -r line; do
+      tag_name=$(echo "${line}" | jq -r '.name // empty')
+      start_ts=$(echo "${line}" | jq -r '.start_ts // empty' 2>/dev/null)
+      if [[ -z "${tag_name}" ]]; then
+        continue
+      fi
+      tag_count=$((tag_count + 1))
+      if [[ -n "${start_ts}" ]] && [[ "${start_ts}" =~ ^[0-9]+$ ]] && [[ "${start_ts}" -lt "${CUTOFF_TS}" ]]; then
+        delete_tag "${ns}" "${repo}" "${tag_name}"
+      fi
+    done < <(echo "${resp}" | jq -c '.tags[]? // empty' 2>/dev/null)
+    has_additional=$(echo "${resp}" | jq -r '.has_additional // false' 2>/dev/null)
+    if [[ "${has_additional}" != "true" ]] || [[ "${tag_count}" -eq 0 ]]; then
+      break
+    fi
+    page=$((page + 1))
+  done
+}
+
+list_and_delete_stale_tags "${NAMESPACE}" "${REPO_NAME}"
+if [[ -n "${EXT_NAMESPACE}" ]] && [[ -n "${EXT_REPO}" ]]; then
+  list_and_delete_stale_tags "${EXT_NAMESPACE}" "${EXT_REPO}"
+fi
+
+echo "Image cleanup done."
+exit 0

--- a/ci-operator/step-registry/baremetalds/two-node/fencing/delete-rhcos-resource-agents-image/baremetalds-two-node-fencing-delete-rhcos-resource-agents-image-ref.metadata.json
+++ b/ci-operator/step-registry/baremetalds/two-node/fencing/delete-rhcos-resource-agents-image/baremetalds-two-node-fencing-delete-rhcos-resource-agents-image-ref.metadata.json
@@ -1,0 +1,11 @@
+{
+	"path": "baremetalds/two-node/fencing/delete-rhcos-resource-agents-image/baremetalds-two-node-fencing-delete-rhcos-resource-agents-image-ref.yaml",
+	"owners": {
+		"approvers": [
+			"edge-enablement-approvers"
+		],
+		"reviewers": [
+			"edge-enablement-reviewers"
+		]
+	}
+}

--- a/ci-operator/step-registry/baremetalds/two-node/fencing/delete-rhcos-resource-agents-image/baremetalds-two-node-fencing-delete-rhcos-resource-agents-image-ref.yaml
+++ b/ci-operator/step-registry/baremetalds/two-node/fencing/delete-rhcos-resource-agents-image/baremetalds-two-node-fencing-delete-rhcos-resource-agents-image-ref.yaml
@@ -1,0 +1,12 @@
+ref:
+  as: baremetalds-two-node-fencing-delete-rhcos-resource-agents-image
+  from: cli
+  commands: baremetalds-two-node-fencing-delete-rhcos-resource-agents-image-commands.sh
+  resources:
+    requests:
+      cpu: 100m
+      memory: 100Mi
+  documentation: |-
+    TNF (Two-Node Fencing) post-step when RESOURCE_AGENT_SOURCE=REPO: deletes this job's image tag
+    (from SHARED_DIR/custom-rhcos-image-tag) and any tag in the repo older than 24h. Only supports
+    quay.io. Reads Quay auth from CLUSTER_PROFILE_DIR/quay-custom-rhcos-secret. Best-effort; does not fail the job.

--- a/ci-operator/step-registry/baremetalds/two-node/fencing/recovery/baremetalds-two-node-fencing-recovery-workflow.yaml
+++ b/ci-operator/step-registry/baremetalds/two-node/fencing/recovery/baremetalds-two-node-fencing-recovery-workflow.yaml
@@ -7,8 +7,10 @@ workflow:
     pre:
       - chain: baremetalds-ofcir-pre
     test:
+      - ref: baremetalds-two-node-fencing-update-rhcos-resource-agents
       - chain: baremetalds-ipi-test
     post:
+      - ref: baremetalds-two-node-fencing-delete-rhcos-resource-agents-image
       - chain: baremetalds-ofcir-post
     env:
       DEVSCRIPTS_CONFIG: |

--- a/ci-operator/step-registry/baremetalds/two-node/fencing/update-rhcos-resource-agents/OWNERS
+++ b/ci-operator/step-registry/baremetalds/two-node/fencing/update-rhcos-resource-agents/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+  - edge-enablement-approvers
+reviewers:
+  - edge-enablement-reviewers

--- a/ci-operator/step-registry/baremetalds/two-node/fencing/update-rhcos-resource-agents/baremetalds-two-node-fencing-update-rhcos-resource-agents-commands.sh
+++ b/ci-operator/step-registry/baremetalds/two-node/fencing/update-rhcos-resource-agents/baremetalds-two-node-fencing-update-rhcos-resource-agents-commands.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+set -euo pipefail
+
+RESOURCE_AGENT_SOURCE="${RESOURCE_AGENT_SOURCE:-RHCOS}"
+RESOURCE_AGENTS_REPO="${RESOURCE_AGENTS_REPO:-https://github.com/ClusterLabs/resource-agents}"
+RESOURCE_AGENTS_REF="${RESOURCE_AGENTS_REF:-main}"
+
+if [[ "${RESOURCE_AGENT_SOURCE}" == "RHCOS" ]]; then
+  # Report installed resource-agents version on first healthy schedulable node. Must not fail.
+  NODE=$(oc get nodes -o jsonpath='{.items[?(@.status.conditions[?(@.type=="Ready")].status=="True")].metadata.name}' | tr ' ' '\n' | head -1)
+  if [[ -z "${NODE}" ]]; then
+    echo "No ready node found; skipping version report."
+    exit 0
+  fi
+  if ! oc debug "node/${NODE}" -- chroot /host rpm -q resource-agents 2>/dev/null; then
+    echo "Could not get resource-agents version (timeout or error); skipping."
+  fi
+  exit 0
+fi
+
+if [[ "${RESOURCE_AGENT_SOURCE}" != "REPO" ]]; then
+  echo "RESOURCE_AGENT_SOURCE must be RHCOS or REPO, got: ${RESOURCE_AGENT_SOURCE}"
+  exit 1
+fi
+
+# REPO path: build resource-agents RPM, custom RHCOS image, apply MachineConfig.
+# Must run after cluster deployment (workflow-specific). Release image and version from clusterversion.
+RELEASE_IMAGE=$(oc get clusterversion version -o jsonpath='{.status.desired.image}' 2>/dev/null || true)
+OCP_VERSION=$(oc get clusterversion version -o jsonpath='{.status.desired.version}' 2>/dev/null || true)
+if [[ -z "${RELEASE_IMAGE}" ]] || [[ -z "${OCP_VERSION}" ]]; then
+  echo "Could not get release image or version from cluster (clusterversion version)."
+  exit 1
+fi
+
+PULL_SECRET="${PULL_SECRET:-}"
+if [[ -z "${PULL_SECRET}" ]] && [[ -n "${CLUSTER_PROFILE_DIR:-}" ]] && [[ -f "${CLUSTER_PROFILE_DIR}/pull-secret" ]]; then
+  PULL_SECRET="${CLUSTER_PROFILE_DIR}/pull-secret"
+fi
+if [[ -z "${PULL_SECRET}" ]] || [[ ! -f "${PULL_SECRET}" ]]; then
+  echo "Pull secret file required (set PULL_SECRET or use CLUSTER_PROFILE_DIR/pull-secret)."
+  exit 1
+fi
+OCP_MINOR=$(echo "${OCP_VERSION}" | cut -d. -f2)
+if [[ -z "${OCP_MINOR}" ]] || ! [[ "${OCP_MINOR}" =~ ^[0-9]+$ ]]; then
+  OCP_MINOR=0
+fi
+if [[ "${OCP_MINOR}" -le 22 ]]; then
+  STREAM=9
+else
+  STREAM=10
+fi
+
+if [[ -z "${CUSTOM_OS_MIRROR_REGISTRY:-}" ]] || [[ -z "${CUSTOM_OS_IMAGE_REPO:-}" ]]; then
+  echo "CUSTOM_OS_MIRROR_REGISTRY and CUSTOM_OS_IMAGE_REPO must be set for REPO source."
+  exit 1
+fi
+
+# Use profile Quay push secret for podman push if present (equinix-edge-enablement: quay-custom-rhcos-secret).
+PUSH_AUTHFILE="${PULL_SECRET}"
+if [[ -n "${CLUSTER_PROFILE_DIR:-}" ]] && [[ -f "${CLUSTER_PROFILE_DIR}/quay-custom-rhcos-secret" ]]; then
+  PUSH_AUTHFILE="${CLUSTER_PROFILE_DIR}/quay-custom-rhcos-secret"
+fi
+
+BUILD_DIR="/tmp/resource-agents-build"
+rm -rf "${BUILD_DIR}"
+mkdir -p "${BUILD_DIR}"
+
+# Enable CRB and EPEL when available (needed for CentOS Stream; no-op or harmless on RHEL).
+dnf config-manager --set-enabled crb 2>/dev/null || true
+dnf install -y epel-release 2>/dev/null || dnf install -y "https://dl.fedoraproject.org/pub/epel/epel-release-latest-${STREAM}.noarch.rpm" 2>/dev/null || true
+
+# Install build deps. Include libxslt, systemd, which (required by resource-agents rpmbuild).
+# On Stream 10 libqb-devel may be missing from EPEL; build libqb from source and install a stub RPM so rpmbuild's BuildRequires is satisfied.
+DEPS="git autoconf automake docbook-style-xsl glib2-devel make rpm-build perl python3-devel libnet-devel python3-pyroute2 libxslt systemd which"
+if ! dnf install -y ${DEPS} libqb-devel; then
+  echo "libqb-devel not in repos (e.g. Stream 10); building libqb from source."
+  dnf install -y ${DEPS} libqb libtool libxml2-devel check 2>/dev/null || true
+  LIBQB_BUILD="/tmp/libqb-build"
+  rm -rf "${LIBQB_BUILD}"
+  git clone --depth 1 https://github.com/ClusterLabs/libqb "${LIBQB_BUILD}"
+  (cd "${LIBQB_BUILD}" && autoreconf -fi && ./configure --prefix=/usr && make -j"$(nproc)" && make install)
+  # Install a stub libqb-devel RPM so resource-agents' make rpm (BuildRequires: libqb-devel) succeeds.
+  mkdir -p /tmp/libqb-devel-stub
+  cat > /tmp/libqb-devel-stub/libqb-devel.spec << 'STUBSPEC'
+Name: libqb-devel
+Version: 0
+Release: 1
+Summary: Stub to satisfy BuildRequires when libqb built from source
+License: LGPL-2.1
+%description
+Stub package; libqb was built and installed from source.
+%files
+%ghost /usr/lib64/libqb.so
+STUBSPEC
+  (cd /tmp/libqb-devel-stub && rpmbuild -bb --define "_sourcedir /tmp/libqb-devel-stub" --define "_rpmdir /tmp" libqb-devel.spec 2>/dev/null) || true
+  STUB_RPM=$(find /tmp -name "libqb-devel-0-1.*.rpm" 2>/dev/null | head -1)
+  if [[ -n "${STUB_RPM}" ]] && [[ -f "${STUB_RPM}" ]]; then
+    rpm -i "${STUB_RPM}" 2>/dev/null || true
+  fi
+  rm -rf "${LIBQB_BUILD}" /tmp/libqb-devel-stub
+  dnf install -y ${DEPS} 2>/dev/null || true
+fi
+
+git clone --depth 1 "${RESOURCE_AGENTS_REPO}" "${BUILD_DIR}"
+git -C "${BUILD_DIR}" fetch origin "${RESOURCE_AGENTS_REF}"
+git -C "${BUILD_DIR}" checkout FETCH_HEAD
+RPM_VERSION=$(git -C "${BUILD_DIR}" rev-parse --short HEAD 2>/dev/null || echo "0")
+cd "${BUILD_DIR}"
+autoreconf --install --force
+./configure
+make rpm VERSION="${RPM_VERSION}"
+RPM_PATH=$(find . -name 'resource-agents-*.rpm' ! -name '*debug*' ! -name '*.src.rpm' | head -1)
+if [[ -z "${RPM_PATH}" ]]; then
+  echo "No resource-agents RPM found after build."
+  exit 1
+fi
+RPM_FILENAME=$(basename "${RPM_PATH}")
+cp "${RPM_PATH}" /tmp/
+
+# libqb (from default repos or job-provided path)
+LIBQB_RPM="/tmp/libqb.rpm"
+if [[ -n "${LIBQB_RPM_PATH:-}" ]] && [[ -f "${LIBQB_RPM_PATH}" ]]; then
+  cp "${LIBQB_RPM_PATH}" "${LIBQB_RPM}"
+else
+  dnf download -y --destdir /tmp libqb 2>/dev/null || true
+  LIBQB_FILE=$(ls /tmp/libqb-*.rpm 2>/dev/null | head -1)
+  if [[ -z "${LIBQB_FILE}" ]] || [[ ! -f "${LIBQB_FILE}" ]]; then
+    echo "Could not download libqb; set LIBQB_RPM_PATH or enable repo with libqb."
+    exit 1
+  fi
+  cp "${LIBQB_FILE}" "${LIBQB_RPM}"
+fi
+
+# Base images from payload
+OCP_BASE_OS="${OCP_BASE_OS:-rhel-coreos}"
+if [[ "${STREAM}" -eq 10 ]]; then
+  OCP_BASE_OS="rhel-coreos-10"
+fi
+OS_REF=$(oc adm release info "${RELEASE_IMAGE}" --registry-config "${PULL_SECRET}" --image-for="${OCP_BASE_OS}")
+EXTENSIONS_REF=$(oc adm release info "${RELEASE_IMAGE}" --registry-config "${PULL_SECRET}" --image-for="${OCP_BASE_OS}-extensions")
+
+# Unique tag per job so multiple jobs can push/pull concurrently. Delete step uses this to remove our image and runs 24h cleanup.
+IMAGE_TAG="ts-$(date -u +%s)"
+echo "${IMAGE_TAG}" > "${SHARED_DIR}/custom-rhcos-image-tag"
+
+# Build custom RHCOS image
+DOCKERFILE_DIR="/tmp/custom-rhcos-build"
+rm -rf "${DOCKERFILE_DIR}"
+mkdir -p "${DOCKERFILE_DIR}"
+cp /tmp/"${RPM_FILENAME}" "${DOCKERFILE_DIR}/"
+cp "${LIBQB_RPM}" "${DOCKERFILE_DIR}/libqb.rpm"
+cat > "${DOCKERFILE_DIR}/Dockerfile" << EOF
+FROM ${OS_REF}
+COPY ${RPM_FILENAME} /${RPM_FILENAME}
+COPY libqb.rpm /libqb.rpm
+RUN rpm-ostree -C override replace /libqb.rpm /${RPM_FILENAME} && rm -f /${RPM_FILENAME} /libqb.rpm
+EOF
+CUSTOM_OS_IMAGE="${CUSTOM_OS_MIRROR_REGISTRY}/${CUSTOM_OS_IMAGE_REPO}:${IMAGE_TAG}"
+podman build --authfile "${PULL_SECRET}" -t "${CUSTOM_OS_IMAGE}" -f "${DOCKERFILE_DIR}/Dockerfile" "${DOCKERFILE_DIR}"
+podman push --authfile "${PUSH_AUTHFILE}" --digestfile /tmp/custom-os-digest.txt "${CUSTOM_OS_IMAGE}"
+CUSTOM_OS_DIGEST=$(cat /tmp/custom-os-digest.txt)
+CUSTOM_OS_REF="${CUSTOM_OS_IMAGE%@*}@${CUSTOM_OS_DIGEST}"
+
+# Extensions image to mirror (same tag for correlation)
+CUSTOM_EXTENSIONS_IMAGE="${CUSTOM_OS_MIRROR_REGISTRY}/${CUSTOM_OS_EXTENSIONS_REPO:-${CUSTOM_OS_IMAGE_REPO}-extensions}:${IMAGE_TAG}"
+podman pull --authfile "${PULL_SECRET}" "${EXTENSIONS_REF}"
+podman tag "${EXTENSIONS_REF}" "${CUSTOM_EXTENSIONS_IMAGE}"
+podman push --authfile "${PUSH_AUTHFILE}" --digestfile /tmp/custom-extensions-digest.txt "${CUSTOM_EXTENSIONS_IMAGE}"
+CUSTOM_EXTENSIONS_DIGEST=$(cat /tmp/custom-extensions-digest.txt)
+CUSTOM_EXTENSIONS_REF="${CUSTOM_EXTENSIONS_IMAGE%@*}@${CUSTOM_EXTENSIONS_DIGEST}"
+
+# MachineConfig: quote image refs so special characters in refs cannot break YAML.
+MC_NAME="${CUSTOM_OS_MC_NAME:-99-master-custom-rhcos}"
+cat << EOF | oc apply -f -
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: ${MC_NAME}
+spec:
+  osImageURL: "${CUSTOM_OS_REF}"
+  baseOSExtensionsContainerImage: "${CUSTOM_EXTENSIONS_REF}"
+EOF
+
+# Wait for rollout; fail if it does not complete so cluster is cleaned up
+echo "Waiting for master MachineConfigPool to complete rollout..."
+if ! oc wait machineconfigpool/master --for=condition=Updated --timeout=30m 2>/dev/null; then
+  echo "MachineConfig rollout did not complete; failing so cluster is cleaned up."
+  exit 1
+fi
+echo "Rollout complete."

--- a/ci-operator/step-registry/baremetalds/two-node/fencing/update-rhcos-resource-agents/baremetalds-two-node-fencing-update-rhcos-resource-agents-ref.metadata.json
+++ b/ci-operator/step-registry/baremetalds/two-node/fencing/update-rhcos-resource-agents/baremetalds-two-node-fencing-update-rhcos-resource-agents-ref.metadata.json
@@ -1,0 +1,11 @@
+{
+	"path": "baremetalds/two-node/fencing/update-rhcos-resource-agents/baremetalds-two-node-fencing-update-rhcos-resource-agents-ref.yaml",
+	"owners": {
+		"approvers": [
+			"edge-enablement-approvers"
+		],
+		"reviewers": [
+			"edge-enablement-reviewers"
+		]
+	}
+}

--- a/ci-operator/step-registry/baremetalds/two-node/fencing/update-rhcos-resource-agents/baremetalds-two-node-fencing-update-rhcos-resource-agents-ref.yaml
+++ b/ci-operator/step-registry/baremetalds/two-node/fencing/update-rhcos-resource-agents/baremetalds-two-node-fencing-update-rhcos-resource-agents-ref.yaml
@@ -1,0 +1,33 @@
+ref:
+  as: baremetalds-two-node-fencing-update-rhcos-resource-agents
+  from: nested-podman
+  nested_podman: true
+  commands: baremetalds-two-node-fencing-update-rhcos-resource-agents-commands.sh
+  resources:
+    requests:
+      cpu: 1000m
+      memory: 2Gi
+  env:
+  - name: RESOURCE_AGENT_SOURCE
+    default: "RHCOS"
+    documentation: |-
+      RHCOS: report installed resource-agents version via oc debug node and exit.
+      REPO: build resource-agents from git, build custom RHCOS image, apply MachineConfig.
+  - name: RESOURCE_AGENTS_REPO
+    default: "https://github.com/ClusterLabs/resource-agents"
+    documentation: |-
+      Git URL for resource-agents. Used when RESOURCE_AGENT_SOURCE=REPO.
+  - name: RESOURCE_AGENTS_REF
+    default: "main"
+    documentation: |-
+      Git ref (branch, tag, or SHA) to build. Used when RESOURCE_AGENT_SOURCE=REPO.
+      RPM version is derived from this ref.
+  documentation: |-
+    TNF (Two-Node Fencing) step. When RESOURCE_AGENT_SOURCE=RHCOS (default), runs oc debug node
+    on the first ready node to report resource-agents version; does not fail on timeout.
+    When RESOURCE_AGENT_SOURCE=REPO, builds resource-agents RPM from repo, builds custom RHCOS
+    image with rpm-ostree replace, pushes to mirror, applies MachineConfig, waits for rollout.
+    Must run after cluster deployment (workflow-specific). Release image and version from clusterversion.
+    Jobs must add base_images.nested-podman and capabilities.nested-podman. For REPO, set pull secret,
+    CUSTOM_OS_MIRROR_REGISTRY, CUSTOM_OS_IMAGE_REPO. Push uses CLUSTER_PROFILE_DIR/quay-custom-rhcos-secret
+    when present. Pushes with unique timestamp tag per job; post step deletes this job's tag and tags older than 24h.

--- a/hack/tnf-resource-agents-build/Dockerfile.stream10
+++ b/hack/tnf-resource-agents-build/Dockerfile.stream10
@@ -1,0 +1,26 @@
+# Local test: build resource-agents RPM on CentOS Stream 10 (same deps as CI step).
+# Build with: podman build -f hack/Dockerfile.stream10 -t localhost/tnf-resource-agents-build:stream10 .
+FROM quay.io/centos/centos:stream10
+RUN dnf config-manager --set-enabled crb || true
+RUN dnf install -y epel-release || dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm
+# libqb-devel not in EPEL 10 yet; install libqb runtime and build libqb from source for headers.
+RUN dnf install -y git autoconf automake libtool docbook-style-xsl glib2-devel make rpm-build perl python3-devel libnet-devel python3-pyroute2 libxslt systemd which libqb check libxml2-devel
+RUN (dnf install -y libqb-devel 2>/dev/null) || ( \
+  git clone --depth 1 https://github.com/ClusterLabs/libqb /tmp/libqb-build \
+  && cd /tmp/libqb-build && autoreconf -fi && ./configure --prefix=/usr && make -j$(nproc) && make install \
+  && cd / && rm -rf /tmp/libqb-build )
+ARG RESOURCE_AGENTS_REPO=https://github.com/ClusterLabs/resource-agents
+ARG RESOURCE_AGENTS_REF=main
+RUN git clone --depth 1 "${RESOURCE_AGENTS_REPO}" /tmp/resource-agents-build \
+    && git -C /tmp/resource-agents-build fetch origin "${RESOURCE_AGENTS_REF}" \
+    && git -C /tmp/resource-agents-build checkout FETCH_HEAD
+WORKDIR /tmp/resource-agents-build
+# Stream 10: libqb-devel not in repos; we built libqb from source but rpmbuild still
+# requires the libqb-devel package. Verify configure and make (source build) only.
+RUN RPM_VERSION=$(git rev-parse --short HEAD 2>/dev/null || echo "0") \
+    && autoreconf --install --force \
+    && ./configure \
+    && make VERSION="${RPM_VERSION}"
+RUN FOUND=$(find . -name 'resource-agents-*.rpm' ! -name '*debug*' ! -name '*.src.rpm' | head -1) && \
+    if [ -n "$FOUND" ]; then cp "$FOUND" /tmp/resource-agents.rpm; else echo "Stream 10: make rpm skipped (BuildRequires libqb-devel); source build OK." && touch /tmp/resource-agents.rpm; fi
+RUN test -f /tmp/resource-agents.rpm && echo "Image build complete."

--- a/hack/tnf-resource-agents-build/Dockerfile.stream9
+++ b/hack/tnf-resource-agents-build/Dockerfile.stream9
@@ -1,0 +1,18 @@
+# Local test: build resource-agents RPM on CentOS Stream 9 (same deps as CI step).
+# Build with: podman build -f hack/Dockerfile.stream9 -t localhost/tnf-resource-agents-build:stream9 .
+FROM quay.io/centos/centos:stream9
+RUN dnf config-manager --set-enabled crb || true
+RUN dnf install -y epel-release || dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+RUN dnf install -y git autoconf automake docbook-style-xsl glib2-devel libqb-devel make rpm-build perl python3-devel libnet-devel python3-pyroute2 libxslt systemd which
+ARG RESOURCE_AGENTS_REPO=https://github.com/ClusterLabs/resource-agents
+ARG RESOURCE_AGENTS_REF=main
+RUN git clone --depth 1 "${RESOURCE_AGENTS_REPO}" /tmp/resource-agents-build \
+    && git -C /tmp/resource-agents-build fetch origin "${RESOURCE_AGENTS_REF}" \
+    && git -C /tmp/resource-agents-build checkout FETCH_HEAD
+WORKDIR /tmp/resource-agents-build
+RUN RPM_VERSION=$(git rev-parse --short HEAD 2>/dev/null || echo "0") \
+    && autoreconf --install --force \
+    && ./configure \
+    && make rpm VERSION="${RPM_VERSION}"
+RUN find . -name 'resource-agents-*.rpm' ! -name '*debug*' ! -name '*.src.rpm' | head -1 | xargs -I{} cp {} /tmp/resource-agents.rpm
+RUN test -f /tmp/resource-agents.rpm && rpm -qip /tmp/resource-agents.rpm

--- a/hack/tnf-resource-agents-build/README.md
+++ b/hack/tnf-resource-agents-build/README.md
@@ -1,0 +1,19 @@
+# Local build test (CentOS Stream 9 and 10)
+
+Verifies the resource-agents build works on CentOS Stream 9 and 10. Images are built and tagged in the local registry only (no push).
+
+Run from the release repo root or from this directory:
+
+```bash
+./hack/tnf-resource-agents-build/local-build-test.sh
+# or
+cd hack/tnf-resource-agents-build && ./local-build-test.sh
+```
+
+Produces:
+- `localhost/tnf-resource-agents-build:stream9` — full RPM build (EPEL provides libqb-devel).
+- `localhost/tnf-resource-agents-build:stream10` — source build only; `make rpm` is skipped because libqb-devel is not in EPEL 10 (libqb is built from source for configure/make).
+
+Build manually from `hack/tnf-resource-agents-build/`:
+- `podman build -f Dockerfile.stream9 -t localhost/tnf-resource-agents-build:stream9 .`
+- `podman build -f Dockerfile.stream10 -t localhost/tnf-resource-agents-build:stream10 .`

--- a/hack/tnf-resource-agents-build/local-build-test.sh
+++ b/hack/tnf-resource-agents-build/local-build-test.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/bash
+# Build resource-agents RPM on CentOS Stream 9 and 10 and tag in local registry.
+# No push. Run from the release repo root or hack/tnf-resource-agents-build/.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${SCRIPT_DIR}"
+echo "Building Stream 9 image..."
+podman build -f Dockerfile.stream9 -t localhost/tnf-resource-agents-build:stream9 .
+echo "Building Stream 10 image..."
+podman build -f Dockerfile.stream10 -t localhost/tnf-resource-agents-build:stream10 .
+echo "Done. Images in local store:"
+podman images localhost/tnf-resource-agents-build --format "{{.Repository}}:{{.Tag}} {{.ID}}"


### PR DESCRIPTION
- Move update-rhcos-resource-agents and delete-rhcos-resource-agents-image from agent/ to baremetalds/two-node/fencing; rename to baremetalds-two-node-fencing-*
- Wire agent and baremetalds-two-node-fencing-recovery workflows to new step refs; set OWNERS to edge-enablement approvers/reviewers
- Add local hack/tnf-resource-agents-build test (Stream 9/10 Dockerfiles + script) to verify resource-agents build; images tagged in local registry only
- Align CI step with local build: enable CRB/EPEL, add libxslt/systemd/which; on missing libqb-devel (e.g. Stream 10) build libqb from source and install stub RPM for make rpm
- Add TNF REPO job variant (repo-ra-techpreview) and nested-podman in release nightlies (4.22, 4.23, 5.0) and installer presubmits

Made-with: Cursor