### PR TITLE
Add uv to hypershift custom-verify-src image

### DIFF
--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-main.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-main.yaml
@@ -34,7 +34,7 @@ images:
   to: hypershift-tests
 - dockerfile_literal: |
     FROM base
-    RUN dnf install -y python3-pip
+    RUN dnf install -y python3-pip && python3 -m pip install --no-cache-dir uv
   from: src
   to: custom-verify-src
 - dockerfile_literal: |


### PR DESCRIPTION
## Summary

- Install `uv` via `pip` in the hypershift `custom-verify-src` dockerfile_literal so that the verify job can use `uvx` for codespell and gitlint
- Unblocks [openshift/hypershift#7829](https://github.com/openshift/hypershift/pull/7829) which migrates from `pip install --target` to `uvx`
- Follows established precedent (`rosa-cora-agent`, `rebasebot`, `assisted-service-mcp` all use `pip install uv`)
- Backward-compatible: adding `uv` doesn't break the current pip-based Makefile, so this PR can be merged first

## Note on release branches

- **4.22, 4.23, 5.0**: Managed by config-brancher — will be updated automatically after merge
- **4.20, 4.21**: Not managed by config-brancher — can be updated if/when the hypershift Makefile change is backported to those branches

## Test plan

- [ ] Rehearsal jobs validate the config change
- [ ] After merge, `/test verify` on openshift/hypershift#7829 should pass (uvx will be available in the image)