### PR TITLE
fix network policy latency

### DIFF
--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.21-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.21-nightly-x86.yaml
@@ -23,6 +23,7 @@ tests:
     env:
       ADDITIONAL_WORKER_NODES: "21"
       BASE_DOMAIN: qe.devcluster.openshift.com
+      EXTRA_FLAGS: --except-rules=0
       ZONES_COUNT: "3"
     test:
     - ref: openshift-qe-workers-scale

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.22-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.22-nightly-x86.yaml
@@ -23,6 +23,7 @@ tests:
     env:
       ADDITIONAL_WORKER_NODES: "21"
       BASE_DOMAIN: qe.devcluster.openshift.com
+      EXTRA_FLAGS: --except-rules=0
       ZONES_COUNT: "3"
     test:
     - ref: openshift-qe-workers-scale

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-5.0-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-5.0-nightly-x86.yaml
@@ -23,6 +23,7 @@ tests:
     env:
       ADDITIONAL_WORKER_NODES: "21"
       BASE_DOMAIN: qe.devcluster.openshift.com
+      EXTRA_FLAGS: --except-rules=0
       ZONES_COUNT: "3"
     test:
     - ref: openshift-qe-workers-scale

--- a/ci-operator/step-registry/openshift-qe/netpol-v2/openshift-qe-netpol-v2-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/netpol-v2/openshift-qe-netpol-v2-commands.sh
@@ -38,7 +38,7 @@ export ES_SERVER="https://$ES_USERNAME:$ES_PASSWORD@$ES_HOST"
 if [[ "${ENABLE_LOCAL_INDEX}" == "true" ]]; then
     EXTRA_FLAGS+=" --local-indexing"
 fi
-EXTRA_FLAGS+=" --gc-metrics=true --profile-type=${PROFILE_TYPE} --pods-per-namespace ${PODS_PER_NAMESPACE} --netpol-per-namespace ${NETPOL_PER_NAMESPACE} --local-pods ${LOCAL_PODS} --single-ports ${SINGLE_PORTS} --port-ranges ${PORT_RANGES} --remotes-namespaces ${REMOTE_NAMESPACES} --remotes-pods ${REMOTE_PODS} --cidrs ${CIDR}"
+EXTRA_FLAGS+=" --gc-metrics=true --profile-type=${PROFILE_TYPE} --netpol-ready-threshold=$NETPOL_READY_THRESHOLD --pods-per-namespace ${PODS_PER_NAMESPACE} --netpol-per-namespace ${NETPOL_PER_NAMESPACE} --local-pods ${LOCAL_PODS} --single-ports ${SINGLE_PORTS} --port-ranges ${PORT_RANGES} --remotes-namespaces ${REMOTE_NAMESPACES} --remotes-pods ${REMOTE_PODS} --cidrs ${CIDR}"
 export EXTRA_FLAGS
 
 ./run.sh

--- a/ci-operator/step-registry/openshift-qe/netpol-v2/openshift-qe-netpol-v2-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/netpol-v2/openshift-qe-netpol-v2-commands.sh
@@ -30,16 +30,26 @@ export WORKLOAD=network-policy
 
 current_worker_count=$(oc get nodes --no-headers -l node-role.kubernetes.io/worker=,node-role.kubernetes.io/infra!=,node-role.kubernetes.io/workload!= --output jsonpath="{.items[?(@.status.conditions[-1].type=='Ready')].status.conditions[-1].type}" | wc -w | xargs)
 
-iteration_multiplier=$(($ITERATION_MULTIPLIER_ENV))
-export ITERATIONS=$(($iteration_multiplier*$current_worker_count))
+# On a freshly deployed environment, we am getting high and inconsistent latency for the first time. However the later runs giving us the consistent latency. So adding a dry run with 20 iterations to stabilize the environment before running the scale iterations to have consistent latency.
+export ITERATIONS=20
 
-export ES_SERVER="https://$ES_USERNAME:$ES_PASSWORD@$ES_HOST"
+EXTRA_FLAGS+=" --gc-metrics=true --profile-type=${PROFILE_TYPE} --pods-per-namespace ${PODS_PER_NAMESPACE} --netpol-per-namespace ${NETPOL_PER_NAMESPACE} --local-pods ${LOCAL_PODS} --single-ports ${SINGLE_PORTS} --port-ranges ${PORT_RANGES} --remotes-namespaces ${REMOTE_NAMESPACES} --remotes-pods ${REMOTE_PODS} --cidrs ${CIDR}"
+export EXTRA_FLAGS
+
+./run.sh
+
+sleep 60
 
 if [[ "${ENABLE_LOCAL_INDEX}" == "true" ]]; then
     EXTRA_FLAGS+=" --local-indexing"
 fi
-EXTRA_FLAGS+=" --gc-metrics=true --profile-type=${PROFILE_TYPE} --netpol-ready-threshold=$NETPOL_READY_THRESHOLD --pods-per-namespace ${PODS_PER_NAMESPACE} --netpol-per-namespace ${NETPOL_PER_NAMESPACE} --local-pods ${LOCAL_PODS} --single-ports ${SINGLE_PORTS} --port-ranges ${PORT_RANGES} --remotes-namespaces ${REMOTE_NAMESPACES} --remotes-pods ${REMOTE_PODS} --cidrs ${CIDR}"
-export EXTRA_FLAGS
+
+export ES_SERVER="https://$ES_USERNAME:$ES_PASSWORD@$ES_HOST"
+
+iteration_multiplier=$(($ITERATION_MULTIPLIER_ENV))
+export ITERATIONS=$(($iteration_multiplier*$current_worker_count))
+
+EXTRA_FLAGS+=" --netpol-ready-threshold=$NETPOL_READY_THRESHOLD"
 
 ./run.sh
 

--- a/ci-operator/step-registry/openshift-qe/netpol-v2/openshift-qe-netpol-v2-ref.yaml
+++ b/ci-operator/step-registry/openshift-qe/netpol-v2/openshift-qe-netpol-v2-ref.yaml
@@ -19,7 +19,7 @@ ref:
     documentation: |-
       Default is true, which means clean up the pod/resource that kube-burner ocp created, you can set it to false to keep the resource
   - name: NETPOL_READY_THRESHOLD
-    default: "6000ms"
+    default: "8000ms"
     documentation: |-
       Defines the maximum threshold for Network Policy Ready
   - name: EXTRA_FLAGS

--- a/ci-operator/step-registry/openshift-qe/netpol-v2/openshift-qe-netpol-v2-ref.yaml
+++ b/ci-operator/step-registry/openshift-qe/netpol-v2/openshift-qe-netpol-v2-ref.yaml
@@ -18,6 +18,10 @@ ref:
     default: "true"
     documentation: |-
       Default is true, which means clean up the pod/resource that kube-burner ocp created, you can set it to false to keep the resource
+  - name: NETPOL_READY_THRESHOLD
+    default: "6000ms"
+    documentation: |-
+      Defines the maximum threshold for Network Policy Ready
   - name: EXTRA_FLAGS
     default: "--timeout=5h"
     documentation: |-


### PR DESCRIPTION
We have not tested except rules with network policy. When we enabled this, netpol latency is becoming high & inconsistent. So this job disables except rules for network policies

We got netpol readiness latency to 6 sec in manaul testing, so NETPOL_READY_THRESHOLD is set to 6 sec.