### PR TITLE
Test notification for IBM z periodic job to slack

### DIFF
--- a/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.16-periodics.yaml
+++ b/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.16-periodics.yaml
@@ -1764,6 +1764,17 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.16"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  reporter_config:
+    slack:
+      channel: '#ibmz-prowci-notifier'
+      job_states_to_report:
+      - success
+      - failure
+      - error
+      report_template: '{{if eq .Status.State "success"}} :slack-green: Job *{{.Spec.Job}}*
+        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> {{else}} :failed:
+        Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+        logs> {{end}}'
   name: periodic-ci-openshift-hypershift-release-4.16-periodics-mce-e2e-ibmz-ovn-conformance
   spec:
     containers:

--- a/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.16-periodics.yaml
+++ b/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.16-periodics.yaml
@@ -1764,6 +1764,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.16"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-hypershift-release-4.16-periodics-mce-e2e-ibmz-ovn-conformance
   reporter_config:
     slack:
       channel: '#ibmz-prowci-notifier'
@@ -1775,7 +1776,6 @@ periodics:
         ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> {{else}} :failed:
         Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
         logs> {{end}}'
-  name: periodic-ci-openshift-hypershift-release-4.16-periodics-mce-e2e-ibmz-ovn-conformance
   spec:
     containers:
     - args:

--- a/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.17-periodics.yaml
+++ b/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.17-periodics.yaml
@@ -2015,6 +2015,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.17"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-hypershift-release-4.17-periodics-mce-e2e-ibmz-ovn-conformance
   reporter_config:
     slack:
       channel: '#ibmz-prowci-notifier'
@@ -2026,7 +2027,6 @@ periodics:
         ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> {{else}} :failed:
         Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
         logs> {{end}}'
-  name: periodic-ci-openshift-hypershift-release-4.17-periodics-mce-e2e-ibmz-ovn-conformance
   spec:
     containers:
     - args:

--- a/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.17-periodics.yaml
+++ b/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.17-periodics.yaml
@@ -2015,6 +2015,17 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.17"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  reporter_config:
+    slack:
+      channel: '#ibmz-prowci-notifier'
+      job_states_to_report:
+      - success
+      - failure
+      - error
+      report_template: '{{if eq .Status.State "success"}} :slack-green: Job *{{.Spec.Job}}*
+        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> {{else}} :failed:
+        Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+        logs> {{end}}'
   name: periodic-ci-openshift-hypershift-release-4.17-periodics-mce-e2e-ibmz-ovn-conformance
   spec:
     containers:

--- a/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.18-periodics.yaml
+++ b/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.18-periodics.yaml
@@ -2758,6 +2758,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.18"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-hypershift-release-4.18-periodics-mce-e2e-ibmz-ovn-conformance
   reporter_config:
     slack:
       channel: '#ibmz-prowci-notifier'
@@ -2769,7 +2770,6 @@ periodics:
         ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> {{else}} :failed:
         Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
         logs> {{end}}'
-  name: periodic-ci-openshift-hypershift-release-4.18-periodics-mce-e2e-ibmz-ovn-conformance
   spec:
     containers:
     - args:

--- a/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.18-periodics.yaml
+++ b/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.18-periodics.yaml
@@ -2758,6 +2758,17 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.18"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  reporter_config:
+    slack:
+      channel: '#ibmz-prowci-notifier'
+      job_states_to_report:
+      - success
+      - failure
+      - error
+      report_template: '{{if eq .Status.State "success"}} :slack-green: Job *{{.Spec.Job}}*
+        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> {{else}} :failed:
+        Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+        logs> {{end}}'
   name: periodic-ci-openshift-hypershift-release-4.18-periodics-mce-e2e-ibmz-ovn-conformance
   spec:
     containers:

--- a/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.19-periodics.yaml
+++ b/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.19-periodics.yaml
@@ -3759,6 +3759,7 @@ periodics:
     job-release: "4.19"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   minimum_interval: 168h
+  name: periodic-ci-openshift-hypershift-release-4.19-periodics-mce-e2e-ibmz-ovn-conformance
   reporter_config:
     slack:
       channel: '#ibmz-prowci-notifier'
@@ -3770,7 +3771,6 @@ periodics:
         ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> {{else}} :failed:
         Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
         logs> {{end}}'
-  name: periodic-ci-openshift-hypershift-release-4.19-periodics-mce-e2e-ibmz-ovn-conformance
   spec:
     containers:
     - args:

--- a/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.19-periodics.yaml
+++ b/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.19-periodics.yaml
@@ -3759,6 +3759,17 @@ periodics:
     job-release: "4.19"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   minimum_interval: 168h
+  reporter_config:
+    slack:
+      channel: '#ibmz-prowci-notifier'
+      job_states_to_report:
+      - success
+      - failure
+      - error
+      report_template: '{{if eq .Status.State "success"}} :slack-green: Job *{{.Spec.Job}}*
+        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> {{else}} :failed:
+        Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+        logs> {{end}}'
   name: periodic-ci-openshift-hypershift-release-4.19-periodics-mce-e2e-ibmz-ovn-conformance
   spec:
     containers:

--- a/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.20-periodics.yaml
+++ b/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.20-periodics.yaml
@@ -4019,6 +4019,17 @@ periodics:
     job-release: "4.20"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-hypershift-release-4.20-periodics-mce-e2e-ibmz-s390x-mgmt-ovn-conformance
+  reporter_config:
+    slack:
+      channel: '#ibmz-prowci-notifier'
+      job_states_to_report:
+      - success
+      - failure
+      - error
+      report_template: '{{if eq .Status.State "success"}} :slack-green: Job *{{.Spec.Job}}*
+        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> {{else}} :failed:
+        Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+        logs> {{end}}'
   spec:
     containers:
     - args:

--- a/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.20-periodics.yaml
+++ b/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.20-periodics.yaml
@@ -3925,6 +3925,17 @@ periodics:
     job-release: "4.20"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   minimum_interval: 168h
+  reporter_config:
+    slack:
+      channel: '#ibmz-prowci-notifier'
+      job_states_to_report:
+      - success
+      - failure
+      - error
+      report_template: '{{if eq .Status.State "success"}} :slack-green: Job *{{.Spec.Job}}*
+        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> {{else}} :failed:
+        Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+        logs> {{end}}'
   name: periodic-ci-openshift-hypershift-release-4.20-periodics-mce-e2e-ibmz-ovn-conformance
   spec:
     containers:

--- a/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.20-periodics.yaml
+++ b/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.20-periodics.yaml
@@ -3925,6 +3925,7 @@ periodics:
     job-release: "4.20"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   minimum_interval: 168h
+  name: periodic-ci-openshift-hypershift-release-4.20-periodics-mce-e2e-ibmz-ovn-conformance
   reporter_config:
     slack:
       channel: '#ibmz-prowci-notifier'
@@ -3936,7 +3937,6 @@ periodics:
         ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> {{else}} :failed:
         Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
         logs> {{end}}'
-  name: periodic-ci-openshift-hypershift-release-4.20-periodics-mce-e2e-ibmz-ovn-conformance
   spec:
     containers:
     - args:

--- a/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.21-periodics.yaml
+++ b/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.21-periodics.yaml
@@ -4185,6 +4185,17 @@ periodics:
     job-release: "4.21"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-hypershift-release-4.21-periodics-mce-e2e-ibmz-s390x-mgmt-ovn-conformance
+  reporter_config:
+    slack:
+      channel: '#ibmz-prowci-notifier'
+      job_states_to_report:
+      - success
+      - failure
+      - error
+      report_template: '{{if eq .Status.State "success"}} :slack-green: Job *{{.Spec.Job}}*
+        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> {{else}} :failed:
+        Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+        logs> {{end}}'
   spec:
     containers:
     - args:
@@ -4267,6 +4278,17 @@ periodics:
     job-release: "4.21"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-hypershift-release-4.21-periodics-mce-e2e-ibmz-s390x-mgmt-ovn-conformance-virt
+  reporter_config:
+    slack:
+      channel: '#ibmz-prowci-notifier'
+      job_states_to_report:
+      - success
+      - failure
+      - error
+      report_template: '{{if eq .Status.State "success"}} :slack-green: Job *{{.Spec.Job}}*
+        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> {{else}} :failed:
+        Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+        logs> {{end}}'
   spec:
     containers:
     - args:

--- a/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.21-periodics.yaml
+++ b/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.21-periodics.yaml
@@ -4091,6 +4091,17 @@ periodics:
     job-release: "4.21"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   minimum_interval: 168h
+  reporter_config:
+    slack:
+      channel: '#ibmz-prowci-notifier'
+      job_states_to_report:
+      - success
+      - failure
+      - error
+      report_template: '{{if eq .Status.State "success"}} :slack-green: Job *{{.Spec.Job}}*
+        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> {{else}} :failed:
+        Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+        logs> {{end}}'
   name: periodic-ci-openshift-hypershift-release-4.21-periodics-mce-e2e-ibmz-ovn-conformance
   spec:
     containers:

--- a/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.21-periodics.yaml
+++ b/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.21-periodics.yaml
@@ -4091,6 +4091,7 @@ periodics:
     job-release: "4.21"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   minimum_interval: 168h
+  name: periodic-ci-openshift-hypershift-release-4.21-periodics-mce-e2e-ibmz-ovn-conformance
   reporter_config:
     slack:
       channel: '#ibmz-prowci-notifier'
@@ -4102,7 +4103,6 @@ periodics:
         ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> {{else}} :failed:
         Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
         logs> {{end}}'
-  name: periodic-ci-openshift-hypershift-release-4.21-periodics-mce-e2e-ibmz-ovn-conformance
   spec:
     containers:
     - args:


### PR DESCRIPTION
We want to get notifications for the job running on IBM Z , and catch any failing jobs to be looked into quickly. 

Starting with these jobs. I have configured the notification to report to the channel I created on the RH slack workspace. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled Slack notifications for several periodic MCE e2e IBMZ conformance jobs across releases 4.16–4.21 (including s390x/virt variants). Notifications report success, failure, and error states, present status-dependent message formatting, and include direct links to job logs for faster troubleshooting and improved operational visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->