### PR TITLE
Added oc binary for openshift installer release 4.14

### DIFF
--- a/ci-operator/config/openshift/installer/openshift-installer-release-4.13.yaml
+++ b/ci-operator/config/openshift/installer/openshift-installer-release-4.13.yaml
@@ -66,6 +66,11 @@ images:
     # Cache dir must be accessible when running the integration tests
     RUN mkdir /.cache -m 0777
   from: src
+  inputs:
+    ocp_4.10_cli:
+      paths:
+      - destination_dir: .
+        source_path: /usr/bin/oc
   to: src-oc
 promotion:
   to:

--- a/ci-operator/config/openshift/installer/openshift-installer-release-4.14.yaml
+++ b/ci-operator/config/openshift/installer/openshift-installer-release-4.14.yaml
@@ -67,6 +67,11 @@ images:
     # Cache dir must be accessible when running the integration tests
     RUN mkdir /.cache -m 0777
   from: src
+  inputs:
+    ocp_4.10_cli:
+      paths:
+      - destination_dir: .
+        source_path: /usr/bin/oc
   to: src-oc
 promotion:
   to:


### PR DESCRIPTION
This piece, according to @Prucek should not be removed, we are adding it back:

```bash
git diff 40aa6431fef^1 -- ci-operator/config/openshift/installer/openshift-installer-release-4.14.yaml

#@@ -113,11 +67,6 @@ images:
#     # Cache dir must be accessible when running the integration tests
#     RUN mkdir /.cache -m 0777
#   from: src
#-  inputs:
#-    ocp_4.10_cli:
#-      paths:
#-      - destination_dir: .
#-        source_path: /usr/bin/oc
#   to: src-oc
# promotion:
#   to:
```