### PR TITLE
OCPBUGS-76549: dpu-operator fix for ci tests

### DIFF
--- a/ci-operator/step-registry/dpu-operator/e2e-tests-workflow/tests/dpu-operator-e2e-tests-workflow-tests-commands.sh
+++ b/ci-operator/step-registry/dpu-operator/e2e-tests-workflow/tests/dpu-operator-e2e-tests-workflow-tests-commands.sh
@@ -69,8 +69,8 @@ _json_get() {
 
 get_nameservers() {
     local DNS_DATA
-    local URL1="https://github.com/openshift/release/blob/master/clusters/build-clusters/common_managed/dns.yaml"
-    local URL='https://raw.githubusercontent.com/openshift/release/refs/heads/master/clusters/build-clusters/common_managed/dns.yaml'
+    local URL1="https://github.com/openshift/release/blob/main/clusters/build-clusters/common_managed/dns.yaml"
+    local URL='https://raw.githubusercontent.com/openshift/release/refs/heads/main/clusters/build-clusters/common_managed/dns.yaml'
 
     DNS_DATA="$(curl --fail -s -L "$URL")" || die "get_nameservers: cannot download $URL1"
 


### PR DESCRIPTION
in https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_dpu-operator/629/pull-ci-openshift-dpu-operator-main-make-e2e-test/2026288442979127296

```
get_nameservers: cannot download https://github.com/openshift/release/blob/master/clusters/build-clusters/common_managed/dns.yaml
```