### PR TITLE
CMP-3208: Test Compliance Operator BSI profiles on ARM64

### DIFF
--- a/ci-operator/config/ComplianceAsCode/content/ComplianceAsCode-content-master.yaml
+++ b/ci-operator/config/ComplianceAsCode/content/ComplianceAsCode-content-master.yaml
@@ -102,6 +102,36 @@ tests:
           cpu: 100m
     workflow: ipi-aws
 - always_run: false
+  as: e2e-aws-ocp4-bsi-arm
+  steps:
+    cluster_profile: quay-aws
+    dependencies:
+      OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: release:arm64-latest
+    env:
+      BASE_DOMAIN: quay.devcluster.openshift.com
+      COMPUTE_ARCH: arm64
+      CONTROL_ARCH: arm64
+      OCP_ARCH: arm64
+    test:
+    - as: test
+      cli: latest
+      commands: |
+        export PROFILE=bsi
+        export PRODUCT=ocp4
+        export CONTENT_DIRECTORY=$PWD
+        export component=ocp4-content-ds
+        git clone https://github.com/ComplianceAsCode/ocp4e2e.git ocp4e2e
+        pushd ocp4e2e; make install-jq
+        PATH=$PATH:/tmp/bin go test -v -timeout 240m . -run=^TestProfileRemediations$ -profile="$PROFILE" -product="$PRODUCT" -content-image="$CONTENT_IMAGE" -content-directory="$CONTENT_DIRECTORY"
+      dependencies:
+      - env: CONTENT_IMAGE
+        name: ocp4-content-ds
+      from: src
+      resources:
+        requests:
+          cpu: 100m
+    workflow: ipi-aws
+- always_run: false
   as: e2e-aws-ocp4-bsi-node
   steps:
     cluster_profile: quay-aws
@@ -127,11 +157,72 @@ tests:
           cpu: 100m
     workflow: ipi-aws
 - always_run: false
+  as: e2e-aws-ocp4-bsi-node-arm
+  steps:
+    cluster_profile: quay-aws
+    dependencies:
+      OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: release:arm64-latest
+    env:
+      BASE_DOMAIN: quay.devcluster.openshift.com
+      COMPUTE_ARCH: arm64
+      CONTROL_ARCH: arm64
+      OCP_ARCH: arm64
+    test:
+    - as: test
+      cli: latest
+      commands: |
+        export PROFILE=bsi-node
+        export PRODUCT=ocp4
+        export CONTENT_DIRECTORY=$PWD
+        export component=ocp4-content-ds
+        git clone https://github.com/ComplianceAsCode/ocp4e2e.git ocp4e2e
+        pushd ocp4e2e; make install-jq
+        PATH=$PATH:/tmp/bin go test -v -timeout 240m . -run=^TestProfileRemediations$ -profile="$PROFILE" -product="$PRODUCT" -content-image="$CONTENT_IMAGE" -content-directory="$CONTENT_DIRECTORY"
+      dependencies:
+      - env: CONTENT_IMAGE
+        name: ocp4-content-ds
+      from: src
+      resources:
+        requests:
+          cpu: 100m
+    workflow: ipi-aws
+- always_run: false
   as: e2e-aws-rhcos4-bsi
   steps:
     cluster_profile: quay-aws
     env:
       BASE_DOMAIN: quay.devcluster.openshift.com
+    test:
+    - as: test
+      cli: latest
+      commands: |
+        set -x
+        export PROFILE=bsi
+        export PRODUCT=rhcos4
+        export CONTENT_DIRECTORY=$PWD
+        export component=ocp4-content-ds
+        git clone https://github.com/ComplianceAsCode/ocp4e2e.git ocp4e2e
+        pushd ocp4e2e; make install-jq
+        PATH=$PATH:/tmp/bin go test -v -timeout 240m . -run=^TestProfileRemediations$ -profile="$PROFILE" -product="$PRODUCT" -content-image="$CONTENT_IMAGE" -content-directory="$CONTENT_DIRECTORY"
+      dependencies:
+      - env: CONTENT_IMAGE
+        name: ocp4-content-ds
+      from: src
+      resources:
+        requests:
+          cpu: 100m
+    workflow: ipi-aws
+- always_run: false
+  as: e2e-aws-rhcos4-bsi-arm
+  steps:
+    cluster_profile: quay-aws
+    dependencies:
+      OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: release:arm64-latest
+    env:
+      BASE_DOMAIN: quay.devcluster.openshift.com
+      COMPUTE_ARCH: arm64
+      CONTROL_ARCH: arm64
+      OCP_ARCH: arm64
     test:
     - as: test
       cli: latest

--- a/ci-operator/jobs/ComplianceAsCode/content/ComplianceAsCode-content-master-presubmits.yaml
+++ b/ci-operator/jobs/ComplianceAsCode/content/ComplianceAsCode-content-master-presubmits.yaml
@@ -13140,6 +13140,88 @@ presubmits:
     - ^master$
     - ^master-
     cluster: build11
+    context: ci/prow/e2e-aws-ocp4-bsi-arm
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: quay-aws
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-ComplianceAsCode-content-master-e2e-aws-ocp4-bsi-arm
+    rerun_command: /test e2e-aws-ocp4-bsi-arm
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-aws-ocp4-bsi-arm
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )(e2e-aws-ocp4-bsi-arm|remaining-required),?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^master$
+    - ^master-
+    cluster: build11
     context: ci/prow/e2e-aws-ocp4-bsi-node
     decorate: true
     decoration_config:
@@ -13216,6 +13298,88 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )(e2e-aws-ocp4-bsi-node|remaining-required),?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^master$
+    - ^master-
+    cluster: build11
+    context: ci/prow/e2e-aws-ocp4-bsi-node-arm
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: quay-aws
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-ComplianceAsCode-content-master-e2e-aws-ocp4-bsi-node-arm
+    rerun_command: /test e2e-aws-ocp4-bsi-node-arm
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-aws-ocp4-bsi-node-arm
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )(e2e-aws-ocp4-bsi-node-arm|remaining-required),?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:
@@ -14856,6 +15020,88 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )(e2e-aws-rhcos4-bsi|remaining-required),?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^master$
+    - ^master-
+    cluster: build11
+    context: ci/prow/e2e-aws-rhcos4-bsi-arm
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: quay-aws
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-ComplianceAsCode-content-master-e2e-aws-rhcos4-bsi-arm
+    rerun_command: /test e2e-aws-rhcos4-bsi-arm
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-aws-rhcos4-bsi-arm
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )(e2e-aws-rhcos4-bsi-arm|remaining-required),?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:


### PR DESCRIPTION
This commit adds new jobs that provision arm64 clusters and run the BSI
profiles on them so we can test the compliance posture of OpenShift on
arm64 against that benchmark.
