### PR TITLE
Switch hypershift e2e-v2-aws to use standard CI AWS account

### DIFF
--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-main.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-main.yaml
@@ -224,7 +224,9 @@ tests:
   as: e2e-v2-aws
   pipeline_skip_if_only_changed: (^(\.tekton|\.github|\.claude|docs|examples|enhancements|contrib|\.cursor)/)|(^[A-Z]+\.md$)|((^|/)OWNERS$)|(/overrides\.yaml$)|(^renovate\.json$)|(/\.testcoverage\.yml$)|(^\.gitlint$)|(^\.gitignore$)|(^\.coderabbit\.yaml$)
   steps:
-    cluster_profile: hypershift-aws
+    cluster_profile: aws
+    env:
+      HYPERSHIFT_GUEST_INFRA_OCP_ACCOUNT: "true"
     workflow: hypershift-aws-e2e-v2
 - always_run: false
   as: e2e-azure-self-managed

--- a/ci-operator/jobs/openshift/hypershift/openshift-hypershift-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/hypershift/openshift-hypershift-main-presubmits.yaml
@@ -2107,8 +2107,8 @@ presubmits:
     context: ci/prow/e2e-v2-aws
     decorate: true
     labels:
-      ci-operator.openshift.io/cloud: hypershift-aws
-      ci-operator.openshift.io/cloud-cluster-profile: hypershift-aws
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-hypershift-main-e2e-v2-aws


### PR DESCRIPTION
## Summary
- Changes the `e2e-v2-aws` presubmit job for `openshift/hypershift` to use `cluster_profile: aws` instead of `cluster_profile: hypershift-aws`
- Sets `HYPERSHIFT_GUEST_INFRA_OCP_ACCOUNT=true` so infrastructure (VPCs, EC2 instances, DNS) is created in the shared OCP CI AWS account
- OIDC issuer and SA token signing key remain in the hypershift account (unchanged)

## Test plan
- [ ] Trigger `/test e2e-v2-aws` on this PR to verify the job runs successfully with the new cluster profile
- [ ] Verify management cluster and guest clusters are created using standard CI AWS credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)