### PR TITLE
Drop cluster profiles, switch to manual vault and lease management

### DIFF
--- a/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main.yaml
+++ b/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main.yaml
@@ -200,6 +200,7 @@ tests:
       ARO_HCP_DEPLOY_ENV: int
       ARO_HCP_SUITE_NAME: integration/parallel
       LOCATION: uksouth
+      VAULT_SECRET_PROFILE: int
     leases:
     - count: 20
       env: LEASED_MSI_CONTAINERS
@@ -214,6 +215,7 @@ tests:
       ARO_HCP_DEPLOY_ENV: stg
       ARO_HCP_SUITE_NAME: stage/parallel
       LOCATION: uksouth
+      VAULT_SECRET_PROFILE: stg
     leases:
     - count: 30
       env: LEASED_MSI_CONTAINERS
@@ -228,6 +230,7 @@ tests:
       ARO_HCP_DEPLOY_ENV: prod
       ARO_HCP_SUITE_NAME: prod/parallel
       LOCATION: uksouth
+      VAULT_SECRET_PROFILE: prod
     leases:
     - count: 15
       env: LEASED_MSI_CONTAINERS

--- a/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main.yaml
+++ b/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main.yaml
@@ -124,11 +124,6 @@ promotion:
     namespace: aro-hcp
     tag: latest
     tag_by_commit: true
-releases:
-  latest:
-    release:
-      channel: stable
-      version: "4.20"
 resources:
   '*':
     limits:
@@ -152,7 +147,6 @@ tests:
 - as: secrets-validation
   run_if_changed: ^(tooling/secret-sync|dev-infrastructure/data)/
   steps:
-    cluster_profile: aro-hcp-dev
     test:
     - ref: aro-hcp-secrets-validation
 - as: verify
@@ -201,7 +195,6 @@ tests:
   as: integration-e2e-parallel
   optional: true
   steps:
-    cluster_profile: aro-hcp-int
     env:
       ARO_HCP_CLOUD: public
       ARO_HCP_DEPLOY_ENV: int
@@ -216,7 +209,6 @@ tests:
   as: stage-e2e-parallel
   optional: true
   steps:
-    cluster_profile: aro-hcp-stg
     env:
       ARO_HCP_CLOUD: public
       ARO_HCP_DEPLOY_ENV: stg
@@ -231,7 +223,6 @@ tests:
   as: prod-e2e-parallel
   optional: true
   steps:
-    cluster_profile: aro-hcp-prod
     env:
       ARO_HCP_CLOUD: public
       ARO_HCP_DEPLOY_ENV: prod
@@ -246,7 +237,6 @@ tests:
   as: e2e-parallel
   skip_if_only_changed: ^(?:action\.yml|(CODE)?OWNERS(_ALIASES)?|LICENSE|(?:demo|docs)/|(?:generate-repo|generate-tag|get-digest|get-tag-sha|svc-deploy)\.sh|\.(?:bingo|cursor|devcontainer|github|vscode)/|\.(?:ci-operator\.yaml|editorconfig|gitattributes|gitignore|gitguardian\.yaml|gitleaks\.toml|golangci\.yml|mega-linter\.yml|yamlfmt\.yaml|yamllint\.yml)$|.*\.md$)$
   steps:
-    cluster_profile: aro-hcp-dev
     env:
       ARO_HCP_CLOUD: dev
       ARO_HCP_DEPLOY_ENV: prow
@@ -257,7 +247,6 @@ tests:
   postsubmit: true
   run_if_changed: ^(?:config/config\.yaml|observability/observability\.yaml|dev-infrastructure/.*)$
   steps:
-    cluster_profile: aro-hcp-dev
     env:
       LOCATION: westus3
     leases:

--- a/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main.yaml
+++ b/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main.yaml
@@ -202,6 +202,9 @@ tests:
       LOCATION: uksouth
       VAULT_SECRET_PROFILE: int
     leases:
+    - count: 1
+      env: ENV_QUOTA_LEASED_RESOURCE
+      resource_type: aro-hcp-int-quota-slice
     - count: 20
       env: LEASED_MSI_CONTAINERS
       resource_type: aro-hcp-test-msi-containers-int
@@ -217,6 +220,9 @@ tests:
       LOCATION: uksouth
       VAULT_SECRET_PROFILE: stg
     leases:
+    - count: 1
+      env: ENV_QUOTA_LEASED_RESOURCE
+      resource_type: aro-hcp-stg-quota-slice
     - count: 30
       env: LEASED_MSI_CONTAINERS
       resource_type: aro-hcp-test-msi-containers-stg
@@ -232,6 +238,9 @@ tests:
       LOCATION: uksouth
       VAULT_SECRET_PROFILE: prod
     leases:
+    - count: 1
+      env: ENV_QUOTA_LEASED_RESOURCE
+      resource_type: aro-hcp-prod-quota-slice
     - count: 15
       env: LEASED_MSI_CONTAINERS
       resource_type: aro-hcp-test-msi-containers-prod
@@ -244,6 +253,10 @@ tests:
       ARO_HCP_CLOUD: dev
       ARO_HCP_DEPLOY_ENV: prow
       LOCATION: westus3
+    leases:
+    - count: 1
+      env: ENV_QUOTA_LEASED_RESOURCE
+      resource_type: aro-hcp-dev-quota-slice
     workflow: aro-hcp-local-e2e
   timeout: 10h0m0s
 - as: global-pipeline-postsubmit

--- a/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__baseimage-generator.yaml
+++ b/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__baseimage-generator.yaml
@@ -13,11 +13,6 @@ promotion:
   to:
   - name: aro-hcp-ci-images
     namespace: aro-hcp
-releases:
-  latest:
-    release:
-      channel: stable
-      version: "4.20"
 resources:
   '*':
     limits:

--- a/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__e2e.yaml
+++ b/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__e2e.yaml
@@ -31,11 +31,6 @@ images:
         - destination_dir: src
           source_path: /go/src/github.com/Azure/ARO-HCP
     to: aro-hcp-e2e-tools
-releases:
-  latest:
-    release:
-      channel: stable
-      version: "4.20"
 resources:
   '*':
     requests:
@@ -53,7 +48,6 @@ tests:
   postsubmit: true
   run_if_changed: ^$
   steps:
-    cluster_profile: aro-hcp-int
     env:
       ARO_HCP_CLOUD: public
       ARO_HCP_DEPLOY_ENV: int
@@ -68,7 +62,6 @@ tests:
   postsubmit: true
   run_if_changed: ^$
   steps:
-    cluster_profile: aro-hcp-stg
     env:
       ARO_HCP_CLOUD: public
       ARO_HCP_DEPLOY_ENV: stg
@@ -83,7 +76,6 @@ tests:
   postsubmit: true
   run_if_changed: ^$
   steps:
-    cluster_profile: aro-hcp-prod
     env:
       ARO_HCP_CLOUD: public
       ARO_HCP_DEPLOY_ENV: prod

--- a/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__e2e.yaml
+++ b/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__e2e.yaml
@@ -53,6 +53,7 @@ tests:
       ARO_HCP_DEPLOY_ENV: int
       ARO_HCP_SUITE_NAME: integration/parallel
       LOCATION: uksouth
+      VAULT_SECRET_PROFILE: int
     leases:
     - count: 20
       env: LEASED_MSI_CONTAINERS
@@ -67,6 +68,7 @@ tests:
       ARO_HCP_DEPLOY_ENV: stg
       ARO_HCP_SUITE_NAME: stage/parallel
       LOCATION: uksouth
+      VAULT_SECRET_PROFILE: stg
     leases:
     - count: 30
       env: LEASED_MSI_CONTAINERS
@@ -81,6 +83,7 @@ tests:
       ARO_HCP_DEPLOY_ENV: prod
       ARO_HCP_SUITE_NAME: prod/parallel
       LOCATION: uksouth
+      VAULT_SECRET_PROFILE: prod
     leases:
     - count: 15
       env: LEASED_MSI_CONTAINERS

--- a/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__e2e.yaml
+++ b/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__e2e.yaml
@@ -55,6 +55,9 @@ tests:
       LOCATION: uksouth
       VAULT_SECRET_PROFILE: int
     leases:
+    - count: 1
+      env: ENV_QUOTA_LEASED_RESOURCE
+      resource_type: aro-hcp-int-quota-slice
     - count: 20
       env: LEASED_MSI_CONTAINERS
       resource_type: aro-hcp-test-msi-containers-int
@@ -70,6 +73,9 @@ tests:
       LOCATION: uksouth
       VAULT_SECRET_PROFILE: stg
     leases:
+    - count: 1
+      env: ENV_QUOTA_LEASED_RESOURCE
+      resource_type: aro-hcp-stg-quota-slice
     - count: 30
       env: LEASED_MSI_CONTAINERS
       resource_type: aro-hcp-test-msi-containers-stg
@@ -85,6 +91,9 @@ tests:
       LOCATION: uksouth
       VAULT_SECRET_PROFILE: prod
     leases:
+    - count: 1
+      env: ENV_QUOTA_LEASED_RESOURCE
+      resource_type: aro-hcp-prod-quota-slice
     - count: 15
       env: LEASED_MSI_CONTAINERS
       resource_type: aro-hcp-test-msi-containers-prod

--- a/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__periodic.yaml
+++ b/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__periodic.yaml
@@ -3,11 +3,6 @@ base_images:
     name: aro-hcp-e2e-tools
     namespace: aro-hcp
     tag: latest
-releases:
-  latest:
-    release:
-      channel: stable
-      version: "4.20"
 resources:
   '*':
     requests:
@@ -21,13 +16,11 @@ tests:
 - as: delete-expired-kusto-role-assignments
   cron: 0 4 * * *
   steps:
-    cluster_profile: aro-hcp-dev
     test:
     - ref: aro-hcp-deprovision-kusto-role-assignments
 - as: delete-expired-development-resource-groups
   cron: 7,37 * * * *
   steps:
-    cluster_profile: aro-hcp-dev
     env:
       CLEANUP_MODE: no-rp
     test:
@@ -35,25 +28,21 @@ tests:
 - as: delete-expired-integration-resource-groups
   cron: 7,37 * * * *
   steps:
-    cluster_profile: aro-hcp-int
     test:
     - ref: aro-hcp-deprovision-expired-resource-groups
 - as: delete-expired-stage-resource-groups
   cron: 7,37 * * * *
   steps:
-    cluster_profile: aro-hcp-stg
     test:
     - ref: aro-hcp-deprovision-expired-resource-groups
 - as: delete-expired-prod-resource-groups
   cron: 7,37 * * * *
   steps:
-    cluster_profile: aro-hcp-prod
     test:
     - ref: aro-hcp-deprovision-expired-resource-groups
 - as: integration-e2e-parallel
   cron: 0 0 1 1 *
   steps:
-    cluster_profile: aro-hcp-int
     env:
       ARO_HCP_CLOUD: public
       ARO_HCP_DEPLOY_ENV: int
@@ -67,7 +56,6 @@ tests:
 - as: stage-e2e-parallel
   cron: 0 2 * * *
   steps:
-    cluster_profile: aro-hcp-stg
     env:
       ARO_HCP_CLOUD: public
       ARO_HCP_DEPLOY_ENV: stg
@@ -81,7 +69,6 @@ tests:
 - as: prod-e2e-parallel
   cron: 0 2 * * *
   steps:
-    cluster_profile: aro-hcp-prod
     env:
       ARO_HCP_CLOUD: public
       ARO_HCP_DEPLOY_ENV: prod

--- a/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__periodic.yaml
+++ b/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__periodic.yaml
@@ -28,16 +28,22 @@ tests:
 - as: delete-expired-integration-resource-groups
   cron: 7,37 * * * *
   steps:
+    env:
+      VAULT_SECRET_PROFILE: int
     test:
     - ref: aro-hcp-deprovision-expired-resource-groups
 - as: delete-expired-stage-resource-groups
   cron: 7,37 * * * *
   steps:
+    env:
+      VAULT_SECRET_PROFILE: stg
     test:
     - ref: aro-hcp-deprovision-expired-resource-groups
 - as: delete-expired-prod-resource-groups
   cron: 7,37 * * * *
   steps:
+    env:
+      VAULT_SECRET_PROFILE: prod
     test:
     - ref: aro-hcp-deprovision-expired-resource-groups
 - as: integration-e2e-parallel
@@ -48,6 +54,7 @@ tests:
       ARO_HCP_DEPLOY_ENV: int
       ARO_HCP_SUITE_NAME: integration/parallel
       LOCATION: uksouth
+      VAULT_SECRET_PROFILE: int
     leases:
     - count: 20
       env: LEASED_MSI_CONTAINERS
@@ -61,6 +68,7 @@ tests:
       ARO_HCP_DEPLOY_ENV: stg
       ARO_HCP_SUITE_NAME: stage/parallel
       LOCATION: uksouth
+      VAULT_SECRET_PROFILE: stg
     leases:
     - count: 30
       env: LEASED_MSI_CONTAINERS
@@ -74,6 +82,7 @@ tests:
       ARO_HCP_DEPLOY_ENV: prod
       ARO_HCP_SUITE_NAME: prod/parallel
       LOCATION: uksouth
+      VAULT_SECRET_PROFILE: prod
     leases:
     - count: 15
       env: LEASED_MSI_CONTAINERS

--- a/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__periodic.yaml
+++ b/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__periodic.yaml
@@ -56,6 +56,9 @@ tests:
       LOCATION: uksouth
       VAULT_SECRET_PROFILE: int
     leases:
+    - count: 1
+      env: ENV_QUOTA_LEASED_RESOURCE
+      resource_type: aro-hcp-int-quota-slice
     - count: 20
       env: LEASED_MSI_CONTAINERS
       resource_type: aro-hcp-test-msi-containers-int
@@ -70,6 +73,9 @@ tests:
       LOCATION: uksouth
       VAULT_SECRET_PROFILE: stg
     leases:
+    - count: 1
+      env: ENV_QUOTA_LEASED_RESOURCE
+      resource_type: aro-hcp-stg-quota-slice
     - count: 30
       env: LEASED_MSI_CONTAINERS
       resource_type: aro-hcp-test-msi-containers-stg
@@ -84,6 +90,9 @@ tests:
       LOCATION: uksouth
       VAULT_SECRET_PROFILE: prod
     leases:
+    - count: 1
+      env: ENV_QUOTA_LEASED_RESOURCE
+      resource_type: aro-hcp-prod-quota-slice
     - count: 15
       env: LEASED_MSI_CONTAINERS
       resource_type: aro-hcp-test-msi-containers-prod

--- a/ci-operator/jobs/Azure/ARO-HCP/Azure-ARO-HCP-main-periodics.yaml
+++ b/ci-operator/jobs/Azure/ARO-HCP/Azure-ARO-HCP-main-periodics.yaml
@@ -91,8 +91,6 @@ periodics:
     org: Azure
     repo: ARO-HCP
   labels:
-    ci-operator.openshift.io/cloud: aro-hcp-dev
-    ci-operator.openshift.io/cloud-cluster-profile: aro-hcp-dev
     ci-operator.openshift.io/variant: periodic
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -104,7 +102,6 @@ periodics:
       - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
-      - --secret-dir=/secrets/ci-pull-credentials
       - --target=delete-expired-development-resource-groups
       - --variant=periodic
       command:
@@ -127,9 +124,6 @@ periodics:
       - mountPath: /etc/boskos
         name: boskos
         readOnly: true
-      - mountPath: /secrets/ci-pull-credentials
-        name: ci-pull-credentials
-        readOnly: true
       - mountPath: /secrets/gcs
         name: gcs-credentials
         readOnly: true
@@ -150,9 +144,6 @@ periodics:
         - key: credentials
           path: credentials
         secretName: boskos-credentials
-    - name: ci-pull-credentials
-      secret:
-        secretName: ci-pull-credentials
     - name: manifest-tool-local-pusher
       secret:
         secretName: manifest-tool-local-pusher
@@ -173,8 +164,6 @@ periodics:
     org: Azure
     repo: ARO-HCP
   labels:
-    ci-operator.openshift.io/cloud: aro-hcp-int
-    ci-operator.openshift.io/cloud-cluster-profile: aro-hcp-int
     ci-operator.openshift.io/variant: periodic
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -194,7 +183,6 @@ periodics:
       - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
-      - --secret-dir=/secrets/ci-pull-credentials
       - --target=delete-expired-integration-resource-groups
       - --variant=periodic
       command:
@@ -217,9 +205,6 @@ periodics:
       - mountPath: /etc/boskos
         name: boskos
         readOnly: true
-      - mountPath: /secrets/ci-pull-credentials
-        name: ci-pull-credentials
-        readOnly: true
       - mountPath: /secrets/gcs
         name: gcs-credentials
         readOnly: true
@@ -240,9 +225,6 @@ periodics:
         - key: credentials
           path: credentials
         secretName: boskos-credentials
-    - name: ci-pull-credentials
-      secret:
-        secretName: ci-pull-credentials
     - name: manifest-tool-local-pusher
       secret:
         secretName: manifest-tool-local-pusher
@@ -263,8 +245,6 @@ periodics:
     org: Azure
     repo: ARO-HCP
   labels:
-    ci-operator.openshift.io/cloud: aro-hcp-dev
-    ci-operator.openshift.io/cloud-cluster-profile: aro-hcp-dev
     ci-operator.openshift.io/variant: periodic
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -276,7 +256,6 @@ periodics:
       - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
-      - --secret-dir=/secrets/ci-pull-credentials
       - --target=delete-expired-kusto-role-assignments
       - --variant=periodic
       command:
@@ -299,9 +278,6 @@ periodics:
       - mountPath: /etc/boskos
         name: boskos
         readOnly: true
-      - mountPath: /secrets/ci-pull-credentials
-        name: ci-pull-credentials
-        readOnly: true
       - mountPath: /secrets/gcs
         name: gcs-credentials
         readOnly: true
@@ -322,9 +298,6 @@ periodics:
         - key: credentials
           path: credentials
         secretName: boskos-credentials
-    - name: ci-pull-credentials
-      secret:
-        secretName: ci-pull-credentials
     - name: manifest-tool-local-pusher
       secret:
         secretName: manifest-tool-local-pusher
@@ -345,8 +318,6 @@ periodics:
     org: Azure
     repo: ARO-HCP
   labels:
-    ci-operator.openshift.io/cloud: aro-hcp-prod
-    ci-operator.openshift.io/cloud-cluster-profile: aro-hcp-prod
     ci-operator.openshift.io/variant: periodic
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -366,7 +337,6 @@ periodics:
       - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
-      - --secret-dir=/secrets/ci-pull-credentials
       - --target=delete-expired-prod-resource-groups
       - --variant=periodic
       command:
@@ -389,9 +359,6 @@ periodics:
       - mountPath: /etc/boskos
         name: boskos
         readOnly: true
-      - mountPath: /secrets/ci-pull-credentials
-        name: ci-pull-credentials
-        readOnly: true
       - mountPath: /secrets/gcs
         name: gcs-credentials
         readOnly: true
@@ -412,9 +379,6 @@ periodics:
         - key: credentials
           path: credentials
         secretName: boskos-credentials
-    - name: ci-pull-credentials
-      secret:
-        secretName: ci-pull-credentials
     - name: manifest-tool-local-pusher
       secret:
         secretName: manifest-tool-local-pusher
@@ -435,8 +399,6 @@ periodics:
     org: Azure
     repo: ARO-HCP
   labels:
-    ci-operator.openshift.io/cloud: aro-hcp-stg
-    ci-operator.openshift.io/cloud-cluster-profile: aro-hcp-stg
     ci-operator.openshift.io/variant: periodic
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -456,7 +418,6 @@ periodics:
       - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
-      - --secret-dir=/secrets/ci-pull-credentials
       - --target=delete-expired-stage-resource-groups
       - --variant=periodic
       command:
@@ -479,9 +440,6 @@ periodics:
       - mountPath: /etc/boskos
         name: boskos
         readOnly: true
-      - mountPath: /secrets/ci-pull-credentials
-        name: ci-pull-credentials
-        readOnly: true
       - mountPath: /secrets/gcs
         name: gcs-credentials
         readOnly: true
@@ -502,9 +460,6 @@ periodics:
         - key: credentials
           path: credentials
         secretName: boskos-credentials
-    - name: ci-pull-credentials
-      secret:
-        secretName: ci-pull-credentials
     - name: manifest-tool-local-pusher
       secret:
         secretName: manifest-tool-local-pusher
@@ -525,8 +480,6 @@ periodics:
     org: Azure
     repo: ARO-HCP
   labels:
-    ci-operator.openshift.io/cloud: aro-hcp-int
-    ci-operator.openshift.io/cloud-cluster-profile: aro-hcp-int
     ci-operator.openshift.io/variant: periodic
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -546,7 +499,6 @@ periodics:
       - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
-      - --secret-dir=/secrets/ci-pull-credentials
       - --target=integration-e2e-parallel
       - --variant=periodic
       command:
@@ -569,9 +521,6 @@ periodics:
       - mountPath: /etc/boskos
         name: boskos
         readOnly: true
-      - mountPath: /secrets/ci-pull-credentials
-        name: ci-pull-credentials
-        readOnly: true
       - mountPath: /secrets/gcs
         name: gcs-credentials
         readOnly: true
@@ -592,9 +541,6 @@ periodics:
         - key: credentials
           path: credentials
         secretName: boskos-credentials
-    - name: ci-pull-credentials
-      secret:
-        secretName: ci-pull-credentials
     - name: manifest-tool-local-pusher
       secret:
         secretName: manifest-tool-local-pusher
@@ -616,8 +562,6 @@ periodics:
     org: Azure
     repo: ARO-HCP
   labels:
-    ci-operator.openshift.io/cloud: aro-hcp-prod
-    ci-operator.openshift.io/cloud-cluster-profile: aro-hcp-prod
     ci-operator.openshift.io/variant: periodic
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -637,7 +581,6 @@ periodics:
       - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
-      - --secret-dir=/secrets/ci-pull-credentials
       - --target=prod-e2e-parallel
       - --variant=periodic
       command:
@@ -660,9 +603,6 @@ periodics:
       - mountPath: /etc/boskos
         name: boskos
         readOnly: true
-      - mountPath: /secrets/ci-pull-credentials
-        name: ci-pull-credentials
-        readOnly: true
       - mountPath: /secrets/gcs
         name: gcs-credentials
         readOnly: true
@@ -683,9 +623,6 @@ periodics:
         - key: credentials
           path: credentials
         secretName: boskos-credentials
-    - name: ci-pull-credentials
-      secret:
-        secretName: ci-pull-credentials
     - name: manifest-tool-local-pusher
       secret:
         secretName: manifest-tool-local-pusher
@@ -706,8 +643,6 @@ periodics:
     org: Azure
     repo: ARO-HCP
   labels:
-    ci-operator.openshift.io/cloud: aro-hcp-stg
-    ci-operator.openshift.io/cloud-cluster-profile: aro-hcp-stg
     ci-operator.openshift.io/variant: periodic
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -727,7 +662,6 @@ periodics:
       - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
-      - --secret-dir=/secrets/ci-pull-credentials
       - --target=stage-e2e-parallel
       - --variant=periodic
       command:
@@ -750,9 +684,6 @@ periodics:
       - mountPath: /etc/boskos
         name: boskos
         readOnly: true
-      - mountPath: /secrets/ci-pull-credentials
-        name: ci-pull-credentials
-        readOnly: true
       - mountPath: /secrets/gcs
         name: gcs-credentials
         readOnly: true
@@ -773,9 +704,6 @@ periodics:
         - key: credentials
           path: credentials
         secretName: boskos-credentials
-    - name: ci-pull-credentials
-      secret:
-        secretName: ci-pull-credentials
     - name: manifest-tool-local-pusher
       secret:
         secretName: manifest-tool-local-pusher

--- a/ci-operator/jobs/Azure/ARO-HCP/Azure-ARO-HCP-main-postsubmits.yaml
+++ b/ci-operator/jobs/Azure/ARO-HCP/Azure-ARO-HCP-main-postsubmits.yaml
@@ -71,8 +71,6 @@ postsubmits:
     decoration_config:
       skip_cloning: true
     labels:
-      ci-operator.openshift.io/cloud: aro-hcp-int
-      ci-operator.openshift.io/cloud-cluster-profile: aro-hcp-int
       ci-operator.openshift.io/variant: e2e
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
@@ -93,7 +91,6 @@ postsubmits:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
         - --target=integration-e2e-parallel
         - --variant=e2e
         command:
@@ -116,9 +113,6 @@ postsubmits:
         - mountPath: /etc/boskos
           name: boskos
           readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
@@ -139,9 +133,6 @@ postsubmits:
           - key: credentials
             path: credentials
           secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
@@ -160,8 +151,6 @@ postsubmits:
     decoration_config:
       skip_cloning: true
     labels:
-      ci-operator.openshift.io/cloud: aro-hcp-prod
-      ci-operator.openshift.io/cloud-cluster-profile: aro-hcp-prod
       ci-operator.openshift.io/variant: e2e
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
@@ -182,7 +171,6 @@ postsubmits:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
         - --target=prod-e2e-parallel
         - --variant=e2e
         command:
@@ -205,9 +193,6 @@ postsubmits:
         - mountPath: /etc/boskos
           name: boskos
           readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
@@ -228,9 +213,6 @@ postsubmits:
           - key: credentials
             path: credentials
           secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
@@ -249,8 +231,6 @@ postsubmits:
     decoration_config:
       skip_cloning: true
     labels:
-      ci-operator.openshift.io/cloud: aro-hcp-stg
-      ci-operator.openshift.io/cloud-cluster-profile: aro-hcp-stg
       ci-operator.openshift.io/variant: e2e
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
@@ -271,7 +251,6 @@ postsubmits:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
         - --target=stage-e2e-parallel
         - --variant=e2e
         command:
@@ -294,9 +273,6 @@ postsubmits:
         - mountPath: /etc/boskos
           name: boskos
           readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
@@ -317,9 +293,6 @@ postsubmits:
           - key: credentials
             path: credentials
           secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
@@ -338,8 +311,6 @@ postsubmits:
     decoration_config:
       skip_cloning: true
     labels:
-      ci-operator.openshift.io/cloud: aro-hcp-dev
-      ci-operator.openshift.io/cloud-cluster-profile: aro-hcp-dev
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
     name: branch-ci-Azure-ARO-HCP-main-global-pipeline-postsubmit
@@ -351,7 +322,6 @@ postsubmits:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
         - --target=global-pipeline-postsubmit
         command:
         - ci-operator
@@ -373,9 +343,6 @@ postsubmits:
         - mountPath: /etc/boskos
           name: boskos
           readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
@@ -396,9 +363,6 @@ postsubmits:
           - key: credentials
             path: credentials
           secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher

--- a/ci-operator/jobs/Azure/ARO-HCP/Azure-ARO-HCP-main-presubmits.yaml
+++ b/ci-operator/jobs/Azure/ARO-HCP/Azure-ARO-HCP-main-presubmits.yaml
@@ -23,7 +23,6 @@ presubmits:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
         - --target=api-validation
         command:
         - ci-operator
@@ -45,9 +44,6 @@ presubmits:
         - mountPath: /etc/boskos
           name: boskos
           readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
@@ -68,9 +64,6 @@ presubmits:
           - key: credentials
             path: credentials
           secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
@@ -162,7 +155,6 @@ presubmits:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
         - --target=bicep-lint
         command:
         - ci-operator
@@ -184,9 +176,6 @@ presubmits:
         - mountPath: /etc/boskos
           name: boskos
           readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
@@ -207,9 +196,6 @@ presubmits:
           - key: credentials
             path: credentials
           secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
@@ -242,7 +228,6 @@ presubmits:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
         - --target=config-change-detection
         command:
         - ci-operator
@@ -264,9 +249,6 @@ presubmits:
         - mountPath: /etc/boskos
           name: boskos
           readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
@@ -287,9 +269,6 @@ presubmits:
           - key: credentials
             path: credentials
           secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
@@ -369,8 +348,6 @@ presubmits:
       skip_cloning: true
       timeout: 10h0m0s
     labels:
-      ci-operator.openshift.io/cloud: aro-hcp-dev
-      ci-operator.openshift.io/cloud-cluster-profile: aro-hcp-dev
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-Azure-ARO-HCP-main-e2e-parallel
@@ -383,7 +360,6 @@ presubmits:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
         - --target=e2e-parallel
         command:
         - ci-operator
@@ -405,9 +381,6 @@ presubmits:
         - mountPath: /etc/boskos
           name: boskos
           readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
@@ -428,9 +401,6 @@ presubmits:
           - key: credentials
             path: credentials
           secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
@@ -577,7 +547,6 @@ presubmits:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
         - --target=integration
         command:
         - ci-operator
@@ -599,9 +568,6 @@ presubmits:
         - mountPath: /etc/boskos
           name: boskos
           readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
@@ -622,9 +588,6 @@ presubmits:
           - key: credentials
             path: credentials
           secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
@@ -646,8 +609,6 @@ presubmits:
     decoration_config:
       skip_cloning: true
     labels:
-      ci-operator.openshift.io/cloud: aro-hcp-int
-      ci-operator.openshift.io/cloud-cluster-profile: aro-hcp-int
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-Azure-ARO-HCP-main-integration-e2e-parallel
@@ -668,7 +629,6 @@ presubmits:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
         - --target=integration-e2e-parallel
         command:
         - ci-operator
@@ -690,9 +650,6 @@ presubmits:
         - mountPath: /etc/boskos
           name: boskos
           readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
@@ -713,9 +670,6 @@ presubmits:
           - key: credentials
             path: credentials
           secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
@@ -748,7 +702,6 @@ presubmits:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
         - --target=lint
         command:
         - ci-operator
@@ -770,9 +723,6 @@ presubmits:
         - mountPath: /etc/boskos
           name: boskos
           readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
@@ -793,9 +743,6 @@ presubmits:
           - key: credentials
             path: credentials
           secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
@@ -829,7 +776,6 @@ presubmits:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
         - --target=mega-linter
         command:
         - ci-operator
@@ -851,9 +797,6 @@ presubmits:
         - mountPath: /etc/boskos
           name: boskos
           readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
@@ -874,9 +817,6 @@ presubmits:
           - key: credentials
             path: credentials
           secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
@@ -910,7 +850,6 @@ presubmits:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
         - --target=observability-prometheus
         command:
         - ci-operator
@@ -932,9 +871,6 @@ presubmits:
         - mountPath: /etc/boskos
           name: boskos
           readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
@@ -955,9 +891,6 @@ presubmits:
           - key: credentials
             path: credentials
           secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
@@ -979,8 +912,6 @@ presubmits:
     decoration_config:
       skip_cloning: true
     labels:
-      ci-operator.openshift.io/cloud: aro-hcp-prod
-      ci-operator.openshift.io/cloud-cluster-profile: aro-hcp-prod
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-Azure-ARO-HCP-main-prod-e2e-parallel
@@ -1001,7 +932,6 @@ presubmits:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
         - --target=prod-e2e-parallel
         command:
         - ci-operator
@@ -1023,9 +953,6 @@ presubmits:
         - mountPath: /etc/boskos
           name: boskos
           readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
@@ -1046,9 +973,6 @@ presubmits:
           - key: credentials
             path: credentials
           secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
@@ -1070,8 +994,6 @@ presubmits:
     decoration_config:
       skip_cloning: true
     labels:
-      ci-operator.openshift.io/cloud: aro-hcp-dev
-      ci-operator.openshift.io/cloud-cluster-profile: aro-hcp-dev
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-Azure-ARO-HCP-main-secrets-validation
@@ -1084,7 +1006,6 @@ presubmits:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
         - --target=secrets-validation
         command:
         - ci-operator
@@ -1106,9 +1027,6 @@ presubmits:
         - mountPath: /etc/boskos
           name: boskos
           readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
@@ -1129,9 +1047,6 @@ presubmits:
           - key: credentials
             path: credentials
           secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
@@ -1153,8 +1068,6 @@ presubmits:
     decoration_config:
       skip_cloning: true
     labels:
-      ci-operator.openshift.io/cloud: aro-hcp-stg
-      ci-operator.openshift.io/cloud-cluster-profile: aro-hcp-stg
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-Azure-ARO-HCP-main-stage-e2e-parallel
@@ -1175,7 +1088,6 @@ presubmits:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
         - --target=stage-e2e-parallel
         command:
         - ci-operator
@@ -1197,9 +1109,6 @@ presubmits:
         - mountPath: /etc/boskos
           name: boskos
           readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
@@ -1220,9 +1129,6 @@ presubmits:
           - key: credentials
             path: credentials
           secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
@@ -1255,7 +1161,6 @@ presubmits:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
         - --target=test-unit
         command:
         - ci-operator
@@ -1277,9 +1182,6 @@ presubmits:
         - mountPath: /etc/boskos
           name: boskos
           readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
@@ -1300,9 +1202,6 @@ presubmits:
           - key: credentials
             path: credentials
           secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
@@ -1335,7 +1234,6 @@ presubmits:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
         - --target=verify
         command:
         - ci-operator
@@ -1357,9 +1255,6 @@ presubmits:
         - mountPath: /etc/boskos
           name: boskos
           readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
@@ -1380,9 +1275,6 @@ presubmits:
           - key: credentials
             path: credentials
           secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher

--- a/ci-operator/step-registry/aro-hcp/deprovision/environment/aro-hcp-deprovision-environment-commands.sh
+++ b/ci-operator/step-registry/aro-hcp/deprovision/environment/aro-hcp-deprovision-environment-commands.sh
@@ -4,6 +4,8 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
+export CLUSTER_PROFILE_DIR="/var/run/aro-hcp-${VAULT_SECRET_PROFILE}"
+
 export AZURE_CLIENT_ID; AZURE_CLIENT_ID=$(cat "${CLUSTER_PROFILE_DIR}/client-id")
 export AZURE_TENANT_ID; AZURE_TENANT_ID=$(cat "${CLUSTER_PROFILE_DIR}/tenant")
 export AZURE_CLIENT_SECRET; AZURE_CLIENT_SECRET=$(cat "${CLUSTER_PROFILE_DIR}/client-secret")

--- a/ci-operator/step-registry/aro-hcp/deprovision/environment/aro-hcp-deprovision-environment-ref.yaml
+++ b/ci-operator/step-registry/aro-hcp/deprovision/environment/aro-hcp-deprovision-environment-ref.yaml
@@ -6,5 +6,14 @@ ref:
     requests:
       cpu: 100m
       memory: 300Mi
+  credentials:
+    - namespace: test-credentials
+      name: cluster-secrets-aro-hcp-dev
+      mount_path: /var/run/aro-hcp-dev
+  env:
+    - name: VAULT_SECRET_PROFILE
+      default: "dev"
+      documentation: |-
+        Selects which environment's cluster secrets to use (dev, int, stg, prod).
   documentation: |-
     Delete an ARO HCP development environment

--- a/ci-operator/step-registry/aro-hcp/deprovision/expired-resource-groups/aro-hcp-deprovision-expired-resource-groups-commands.sh
+++ b/ci-operator/step-registry/aro-hcp/deprovision/expired-resource-groups/aro-hcp-deprovision-expired-resource-groups-commands.sh
@@ -4,6 +4,8 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
+export CLUSTER_PROFILE_DIR="/var/run/aro-hcp-${VAULT_SECRET_PROFILE}"
+
 export AZURE_CLIENT_ID; AZURE_CLIENT_ID=$(cat "${CLUSTER_PROFILE_DIR}/client-id")
 export AZURE_TENANT_ID; AZURE_TENANT_ID=$(cat "${CLUSTER_PROFILE_DIR}/tenant")
 export AZURE_CLIENT_SECRET; AZURE_CLIENT_SECRET=$(cat "${CLUSTER_PROFILE_DIR}/client-secret")

--- a/ci-operator/step-registry/aro-hcp/deprovision/expired-resource-groups/aro-hcp-deprovision-expired-resource-groups-ref.yaml
+++ b/ci-operator/step-registry/aro-hcp/deprovision/expired-resource-groups/aro-hcp-deprovision-expired-resource-groups-ref.yaml
@@ -6,7 +6,24 @@ ref:
     requests:
       cpu: 100m
       memory: 300Mi
+  credentials:
+    - namespace: test-credentials
+      name: cluster-secrets-aro-hcp-dev
+      mount_path: /var/run/aro-hcp-dev
+    - namespace: test-credentials
+      name: cluster-secrets-aro-hcp-int
+      mount_path: /var/run/aro-hcp-int
+    - namespace: test-credentials
+      name: cluster-secrets-aro-hcp-stg
+      mount_path: /var/run/aro-hcp-stg
+    - namespace: test-credentials
+      name: cluster-secrets-aro-hcp-prod
+      mount_path: /var/run/aro-hcp-prod
   env:
+  - name: VAULT_SECRET_PROFILE
+    default: "dev"
+    documentation: |-
+      Selects which environment's cluster secrets to use (dev, int, stg, prod).
   - name: CLEANUP_MODE
     default: ""
     documentation: Cleanup mode to use.

--- a/ci-operator/step-registry/aro-hcp/deprovision/kusto-role-assignments/aro-hcp-deprovision-kusto-role-assignments-commands.sh
+++ b/ci-operator/step-registry/aro-hcp/deprovision/kusto-role-assignments/aro-hcp-deprovision-kusto-role-assignments-commands.sh
@@ -4,6 +4,8 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
+export CLUSTER_PROFILE_DIR="/var/run/aro-hcp-${VAULT_SECRET_PROFILE}"
+
 export AZURE_CLIENT_ID; AZURE_CLIENT_ID=$(cat "${CLUSTER_PROFILE_DIR}/client-id")
 export AZURE_TENANT_ID; AZURE_TENANT_ID=$(cat "${CLUSTER_PROFILE_DIR}/tenant")
 export AZURE_CLIENT_SECRET; AZURE_CLIENT_SECRET=$(cat "${CLUSTER_PROFILE_DIR}/client-secret")

--- a/ci-operator/step-registry/aro-hcp/deprovision/kusto-role-assignments/aro-hcp-deprovision-kusto-role-assignments-ref.yaml
+++ b/ci-operator/step-registry/aro-hcp/deprovision/kusto-role-assignments/aro-hcp-deprovision-kusto-role-assignments-ref.yaml
@@ -6,5 +6,14 @@ ref:
     requests:
       cpu: 100m
       memory: 300Mi
+  credentials:
+    - namespace: test-credentials
+      name: cluster-secrets-aro-hcp-dev
+      mount_path: /var/run/aro-hcp-dev
+  env:
+    - name: VAULT_SECRET_PROFILE
+      default: "dev"
+      documentation: |-
+        Selects which environment's cluster secrets to use (dev, int, stg, prod).
   documentation: |-
     Clean up expired role assignments that were left by test runs. Simply deletes all stale assignments.

--- a/ci-operator/step-registry/aro-hcp/gather/custom-link-tools/aro-hcp-gather-custom-link-tools-commands.sh
+++ b/ci-operator/step-registry/aro-hcp/gather/custom-link-tools/aro-hcp-gather-custom-link-tools-commands.sh
@@ -4,6 +4,8 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
+export CLUSTER_PROFILE_DIR="/var/run/aro-hcp-${VAULT_SECRET_PROFILE}"
+
 export AZURE_TOKEN_CREDENTIALS=prod
 SUBSCRIPTION_ID=$(cat "${CLUSTER_PROFILE_DIR}/subscription-id")
 

--- a/ci-operator/step-registry/aro-hcp/gather/custom-link-tools/aro-hcp-gather-custom-link-tools-ref.yaml
+++ b/ci-operator/step-registry/aro-hcp/gather/custom-link-tools/aro-hcp-gather-custom-link-tools-ref.yaml
@@ -6,7 +6,24 @@ ref:
     requests:
       cpu: 10m
       memory: 100Mi
+  credentials:
+    - namespace: test-credentials
+      name: cluster-secrets-aro-hcp-dev
+      mount_path: /var/run/aro-hcp-dev
+    - namespace: test-credentials
+      name: cluster-secrets-aro-hcp-int
+      mount_path: /var/run/aro-hcp-int
+    - namespace: test-credentials
+      name: cluster-secrets-aro-hcp-stg
+      mount_path: /var/run/aro-hcp-stg
+    - namespace: test-credentials
+      name: cluster-secrets-aro-hcp-prod
+      mount_path: /var/run/aro-hcp-prod
   env:
+    - name: VAULT_SECRET_PROFILE
+      default: "dev"
+      documentation: |-
+        Selects which environment's cluster secrets to use (dev, int, stg, prod).
     - name: COMPRESS_TIMING_METADATA
       default: "true"
       documentation: Whether to compress timing metadata files with gzip.

--- a/ci-operator/step-registry/aro-hcp/gather/provision-failure/aro-hcp-gather-provision-failure-commands.sh
+++ b/ci-operator/step-registry/aro-hcp/gather/provision-failure/aro-hcp-gather-provision-failure-commands.sh
@@ -4,6 +4,8 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
+export CLUSTER_PROFILE_DIR="/var/run/aro-hcp-${VAULT_SECRET_PROFILE}"
+
 # Load resource group names from config.yaml
 if [[ ! -f "${SHARED_DIR}/config.yaml" ]]; then
   echo "ERROR: config.yaml not found at ${SHARED_DIR}/config.yaml"

--- a/ci-operator/step-registry/aro-hcp/gather/provision-failure/aro-hcp-gather-provision-failure-ref.yaml
+++ b/ci-operator/step-registry/aro-hcp/gather/provision-failure/aro-hcp-gather-provision-failure-ref.yaml
@@ -6,5 +6,14 @@ ref:
     requests:
       cpu: 10m
       memory: 100Mi
+  credentials:
+    - namespace: test-credentials
+      name: cluster-secrets-aro-hcp-dev
+      mount_path: /var/run/aro-hcp-dev
+  env:
+    - name: VAULT_SECRET_PROFILE
+      default: "dev"
+      documentation: |-
+        Selects which environment's cluster secrets to use (dev, int, stg, prod).
   best_effort: true
   timeout: 5m

--- a/ci-operator/step-registry/aro-hcp/provision/environment/aro-hcp-provision-environment-commands.sh
+++ b/ci-operator/step-registry/aro-hcp/provision/environment/aro-hcp-provision-environment-commands.sh
@@ -3,6 +3,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+export CLUSTER_PROFILE_DIR="/var/run/aro-hcp-${VAULT_SECRET_PROFILE}"
+
 export AZURE_CLIENT_ID; AZURE_CLIENT_ID=$(cat "${CLUSTER_PROFILE_DIR}/client-id")
 export AZURE_TENANT_ID; AZURE_TENANT_ID=$(cat "${CLUSTER_PROFILE_DIR}/tenant")
 export AZURE_CLIENT_SECRET; AZURE_CLIENT_SECRET=$(cat "${CLUSTER_PROFILE_DIR}/client-secret")

--- a/ci-operator/step-registry/aro-hcp/provision/environment/aro-hcp-provision-environment-ref.yaml
+++ b/ci-operator/step-registry/aro-hcp/provision/environment/aro-hcp-provision-environment-ref.yaml
@@ -7,7 +7,15 @@ ref:
     requests:
       cpu: 1000m
       memory: 1Gi
+  credentials:
+    - namespace: test-credentials
+      name: cluster-secrets-aro-hcp-dev
+      mount_path: /var/run/aro-hcp-dev
   env:
+    - name: VAULT_SECRET_PROFILE
+      default: "dev"
+      documentation: |-
+        Selects which environment's cluster secrets to use (dev, int, stg, prod).
     - name: LOCATION
       default: "westus3"
       documentation: Azure region to provision resources in.  For example, "westus3".

--- a/ci-operator/step-registry/aro-hcp/provision/global-pipeline/aro-hcp-provision-global-pipeline-commands.sh
+++ b/ci-operator/step-registry/aro-hcp/provision/global-pipeline/aro-hcp-provision-global-pipeline-commands.sh
@@ -3,6 +3,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+export CLUSTER_PROFILE_DIR="/var/run/aro-hcp-${VAULT_SECRET_PROFILE}"
+
 export AZURE_CLIENT_ID; AZURE_CLIENT_ID=$(cat "${CLUSTER_PROFILE_DIR}/client-id")
 export AZURE_TENANT_ID; AZURE_TENANT_ID=$(cat "${CLUSTER_PROFILE_DIR}/tenant")
 export AZURE_CLIENT_SECRET; AZURE_CLIENT_SECRET=$(cat "${CLUSTER_PROFILE_DIR}/client-secret")

--- a/ci-operator/step-registry/aro-hcp/provision/global-pipeline/aro-hcp-provision-global-pipeline-ref.yaml
+++ b/ci-operator/step-registry/aro-hcp/provision/global-pipeline/aro-hcp-provision-global-pipeline-ref.yaml
@@ -6,7 +6,15 @@ ref:
     requests:
       cpu: 1000m
       memory: 1Gi
+  credentials:
+    - namespace: test-credentials
+      name: cluster-secrets-aro-hcp-dev
+      mount_path: /var/run/aro-hcp-dev
   env:
+  - name: VAULT_SECRET_PROFILE
+    default: "dev"
+    documentation: |-
+      Selects which environment's cluster secrets to use (dev, int, stg, prod).
   - name: DEPLOY_ENV
     default: "prow"
     documentation: The ARO HCP deploy environment to target for the global pipeline.

--- a/ci-operator/step-registry/aro-hcp/secrets-validation/aro-hcp-secrets-validation-commands.sh
+++ b/ci-operator/step-registry/aro-hcp/secrets-validation/aro-hcp-secrets-validation-commands.sh
@@ -3,6 +3,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+export CLUSTER_PROFILE_DIR="/var/run/aro-hcp-${VAULT_SECRET_PROFILE}"
+
 export AZURE_CLIENT_ID; AZURE_CLIENT_ID=$(cat "${CLUSTER_PROFILE_DIR}/client-id")
 export AZURE_TENANT_ID; AZURE_TENANT_ID=$(cat "${CLUSTER_PROFILE_DIR}/tenant")
 export AZURE_CLIENT_SECRET; AZURE_CLIENT_SECRET=$(cat "${CLUSTER_PROFILE_DIR}/client-secret")

--- a/ci-operator/step-registry/aro-hcp/secrets-validation/aro-hcp-secrets-validation-ref.yaml
+++ b/ci-operator/step-registry/aro-hcp/secrets-validation/aro-hcp-secrets-validation-ref.yaml
@@ -7,5 +7,14 @@ ref:
     requests:
       cpu: 1000m
       memory: 1Gi
+  credentials:
+    - namespace: test-credentials
+      name: cluster-secrets-aro-hcp-dev
+      mount_path: /var/run/aro-hcp-dev
+  env:
+    - name: VAULT_SECRET_PROFILE
+      default: "dev"
+      documentation: |-
+        Selects which environment's cluster secrets to use (dev, int, stg, prod).
   documentation: |-
     Validate the authenticity of encrypted secrets via Azure Key Vault.

--- a/ci-operator/step-registry/aro-hcp/test/local/aro-hcp-test-local-commands.sh
+++ b/ci-operator/step-registry/aro-hcp/test/local/aro-hcp-test-local-commands.sh
@@ -3,6 +3,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+export CLUSTER_PROFILE_DIR="/var/run/aro-hcp-${VAULT_SECRET_PROFILE}"
+
 export AZURE_CLIENT_ID; AZURE_CLIENT_ID=$(cat "${CLUSTER_PROFILE_DIR}/client-id")
 export AZURE_TENANT_ID; AZURE_TENANT_ID=$(cat "${CLUSTER_PROFILE_DIR}/tenant")
 export AZURE_CLIENT_SECRET; AZURE_CLIENT_SECRET=$(cat "${CLUSTER_PROFILE_DIR}/client-secret")

--- a/ci-operator/step-registry/aro-hcp/test/local/aro-hcp-test-local-ref.yaml
+++ b/ci-operator/step-registry/aro-hcp/test/local/aro-hcp-test-local-ref.yaml
@@ -6,12 +6,19 @@ ref:
     - namespace: test-credentials
       name: aro-hcp-qe-pull-secret
       mount_path: /var/run/aro-hcp-qe-pull-secret
+    - namespace: test-credentials
+      name: cluster-secrets-aro-hcp-dev
+      mount_path: /var/run/aro-hcp-dev
   grace_period: 30s
   resources:
     requests:
       cpu: 1000m
       memory: 1Gi
   env:
+    - name: VAULT_SECRET_PROFILE
+      default: "dev"
+      documentation: |-
+        Selects which environment's cluster secrets to use (dev, int, stg, prod).
     - name: AROHCP_ENV
       default: "development"
     - name: LOCATION

--- a/ci-operator/step-registry/aro-hcp/test/persistent/aro-hcp-test-persistent-commands.sh
+++ b/ci-operator/step-registry/aro-hcp/test/persistent/aro-hcp-test-persistent-commands.sh
@@ -4,6 +4,8 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
+export CLUSTER_PROFILE_DIR="/var/run/aro-hcp-${VAULT_SECRET_PROFILE}"
+
 export AZURE_CLIENT_ID; AZURE_CLIENT_ID=$(cat "${CLUSTER_PROFILE_DIR}/client-id")
 export AZURE_TENANT_ID; AZURE_TENANT_ID=$(cat "${CLUSTER_PROFILE_DIR}/tenant")
 export AZURE_CLIENT_SECRET; AZURE_CLIENT_SECRET=$(cat "${CLUSTER_PROFILE_DIR}/client-secret")

--- a/ci-operator/step-registry/aro-hcp/test/persistent/aro-hcp-test-persistent-ref.yaml
+++ b/ci-operator/step-registry/aro-hcp/test/persistent/aro-hcp-test-persistent-ref.yaml
@@ -6,12 +6,25 @@ ref:
     - namespace: test-credentials
       name: aro-hcp-qe-pull-secret
       mount_path: /var/run/aro-hcp-qe-pull-secret
+    - namespace: test-credentials
+      name: cluster-secrets-aro-hcp-int
+      mount_path: /var/run/aro-hcp-int
+    - namespace: test-credentials
+      name: cluster-secrets-aro-hcp-stg
+      mount_path: /var/run/aro-hcp-stg
+    - namespace: test-credentials
+      name: cluster-secrets-aro-hcp-prod
+      mount_path: /var/run/aro-hcp-prod
   timeout: 4h0m0s
   resources:
     requests:
       cpu: 1000m
       memory: 1Gi
   env:
+    - name: VAULT_SECRET_PROFILE
+      default: "dev"
+      documentation: |-
+        Selects which environment's cluster secrets to use (dev, int, stg, prod).
     - name: LOCATION
       default: ""
       documentation: |-


### PR DESCRIPTION
## This PR
- drops `releases:` and `cluster_profiles:`
- replaces them with ~manual management of profile leases and vault secrets 

### Prerequisites
- https://github.com/openshift/ci-tools/pull/5058
- changing all the profile secrets so that their `secretsync/target-namespace` keys point from `ci` -> `test-credentials`

### Mounting secrets
CI Operator with cluster profiles was smart enough to get you access to the secret of the selected profile and that is how our vault is currently set up (per-profile secrets). This PR preserves that.

We might want to change our vault setup eventually, but for now the only way to work with this in a manual way is to mount all the old cluster profile secret for each job that might need them and just have the job use the one of interest.


## Reasoning
ARO-HCP periodic e2e jobs (integration, stage, prod) waste ~10 minutes importing 192 OCP component images that are never used by any test step. This is caused by ci-operator's assumption that any test using a `cluster_profile` needs the OCP release payload. But we don't consume OCP payloads.



https://issues.redhat.com/browse/AROSLSRE-555