### PR TITLE
telco: cnf-features-deploy: test tools image on PR ref

### DIFF
--- a/ci-operator/config/openshift-kni/cnf-features-deploy/openshift-kni-cnf-features-deploy-master.yaml
+++ b/ci-operator/config/openshift-kni/cnf-features-deploy/openshift-kni-cnf-features-deploy-master.yaml
@@ -3,6 +3,10 @@ base_images:
     name: "4.21"
     namespace: ocp
     tag: base-rhel9
+  fedora:
+    name: fedora
+    namespace: openshift
+    tag: latest
   os-min8:
     name: ubi-minimal
     namespace: ocp
@@ -24,6 +28,10 @@ images:
   dockerfile_path: ztp/resource-generator/Containerfile
   from: os-min8
   to: ztp-site-generator
+- context_dir: .
+  dockerfile_path: openshift-ci/Dockerfile.tools
+  from: fedora
+  to: deploy-tools
 promotion:
   to:
   - name: "4.21"

--- a/ci-operator/config/openshift-kni/cnf-features-deploy/openshift-kni-cnf-features-deploy-release-4.12.yaml
+++ b/ci-operator/config/openshift-kni/cnf-features-deploy/openshift-kni-cnf-features-deploy-release-4.12.yaml
@@ -3,6 +3,10 @@ base_images:
     name: "4.12"
     namespace: ocp
     tag: base
+  fedora:
+    name: fedora
+    namespace: openshift
+    tag: latest
   os-min8:
     name: ubi-minimal
     namespace: ocp
@@ -24,6 +28,10 @@ images:
   dockerfile_path: ztp/resource-generator/Containerfile
   from: os-min8
   to: ztp-site-generator
+- context_dir: .
+  dockerfile_path: openshift-ci/Dockerfile.tools
+  from: fedora
+  to: deploy-tools
 promotion:
   to:
   - name: "4.12"

--- a/ci-operator/config/openshift-kni/cnf-features-deploy/openshift-kni-cnf-features-deploy-release-4.14.yaml
+++ b/ci-operator/config/openshift-kni/cnf-features-deploy/openshift-kni-cnf-features-deploy-release-4.14.yaml
@@ -7,6 +7,10 @@ base_images:
     name: "4.14"
     namespace: ocp
     tag: base-rhel9
+  fedora:
+    name: fedora
+    namespace: openshift
+    tag: latest
   os-min8:
     name: ubi-minimal
     namespace: ocp
@@ -28,6 +32,10 @@ images:
   dockerfile_path: ztp/resource-generator/Containerfile
   from: os-min8
   to: ztp-site-generator
+- context_dir: .
+  dockerfile_path: openshift-ci/Dockerfile.tools
+  from: fedora
+  to: deploy-tools
 promotion:
   to:
   - name: "4.14"

--- a/ci-operator/config/openshift-kni/cnf-features-deploy/openshift-kni-cnf-features-deploy-release-4.16.yaml
+++ b/ci-operator/config/openshift-kni/cnf-features-deploy/openshift-kni-cnf-features-deploy-release-4.16.yaml
@@ -7,6 +7,10 @@ base_images:
     name: "4.16"
     namespace: ocp
     tag: base-rhel9
+  fedora:
+    name: fedora
+    namespace: openshift
+    tag: latest
   os-min8:
     name: ubi-minimal
     namespace: ocp
@@ -28,6 +32,10 @@ images:
   dockerfile_path: ztp/resource-generator/Containerfile
   from: os-min8
   to: ztp-site-generator
+- context_dir: .
+  dockerfile_path: openshift-ci/Dockerfile.tools
+  from: fedora
+  to: deploy-tools
 promotion:
   to:
   - name: "4.16"

--- a/ci-operator/config/openshift-kni/cnf-features-deploy/openshift-kni-cnf-features-deploy-release-4.17.yaml
+++ b/ci-operator/config/openshift-kni/cnf-features-deploy/openshift-kni-cnf-features-deploy-release-4.17.yaml
@@ -7,6 +7,10 @@ base_images:
     name: "4.17"
     namespace: ocp
     tag: base-rhel9
+  fedora:
+    name: fedora
+    namespace: openshift
+    tag: latest
   os-min8:
     name: ubi-minimal
     namespace: ocp
@@ -28,6 +32,10 @@ images:
   dockerfile_path: ztp/resource-generator/Containerfile
   from: os-min8
   to: ztp-site-generator
+- context_dir: .
+  dockerfile_path: openshift-ci/Dockerfile.tools
+  from: fedora
+  to: deploy-tools
 promotion:
   to:
   - name: "4.17"

--- a/ci-operator/config/openshift-kni/cnf-features-deploy/openshift-kni-cnf-features-deploy-release-4.18.yaml
+++ b/ci-operator/config/openshift-kni/cnf-features-deploy/openshift-kni-cnf-features-deploy-release-4.18.yaml
@@ -7,6 +7,10 @@ base_images:
     name: "4.18"
     namespace: ocp
     tag: base-rhel9
+  fedora:
+    name: fedora
+    namespace: openshift
+    tag: latest
   os-min8:
     name: ubi-minimal
     namespace: ocp
@@ -28,6 +32,10 @@ images:
   dockerfile_path: ztp/resource-generator/Containerfile
   from: os-min8
   to: ztp-site-generator
+- context_dir: .
+  dockerfile_path: openshift-ci/Dockerfile.tools
+  from: fedora
+  to: deploy-tools
 promotion:
   to:
   - name: "4.18"

--- a/ci-operator/config/openshift-kni/cnf-features-deploy/openshift-kni-cnf-features-deploy-release-4.19.yaml
+++ b/ci-operator/config/openshift-kni/cnf-features-deploy/openshift-kni-cnf-features-deploy-release-4.19.yaml
@@ -3,6 +3,10 @@ base_images:
     name: "4.19"
     namespace: ocp
     tag: base-rhel9
+  fedora:
+    name: fedora
+    namespace: openshift
+    tag: latest
   os-min8:
     name: ubi-minimal
     namespace: ocp
@@ -24,6 +28,10 @@ images:
   dockerfile_path: ztp/resource-generator/Containerfile
   from: os-min8
   to: ztp-site-generator
+- context_dir: .
+  dockerfile_path: openshift-ci/Dockerfile.tools
+  from: fedora
+  to: deploy-tools
 promotion:
   to:
   - name: "4.19"

--- a/ci-operator/config/openshift-kni/cnf-features-deploy/openshift-kni-cnf-features-deploy-release-4.20.yaml
+++ b/ci-operator/config/openshift-kni/cnf-features-deploy/openshift-kni-cnf-features-deploy-release-4.20.yaml
@@ -3,6 +3,10 @@ base_images:
     name: "4.20"
     namespace: ocp
     tag: base-rhel9
+  fedora:
+    name: fedora
+    namespace: openshift
+    tag: latest
   os-min8:
     name: ubi-minimal
     namespace: ocp
@@ -24,6 +28,10 @@ images:
   dockerfile_path: ztp/resource-generator/Containerfile
   from: os-min8
   to: ztp-site-generator
+- context_dir: .
+  dockerfile_path: openshift-ci/Dockerfile.tools
+  from: fedora
+  to: deploy-tools
 promotion:
   to:
   - name: "4.20"


### PR DESCRIPTION
ci-operator by design uses base image `build_root` for all the test lanes where relevant. However that root image is built from master's head not the PR's branch.
The problem is that the changes of the tools image will not be applied to the testing env even when it is part of the PR.

The best option we can do to at least minimize the impact of build-root limitation is building the image as part of `images` stanza and control the base (fedora) in prow rather than in the kni repo.