### PR TITLE
Correct must-gather image to collect ODF logs

### DIFF
--- a/ci-operator/step-registry/acm/tests/observability/acm-tests-observability-commands.sh
+++ b/ci-operator/step-registry/acm/tests/observability/acm-tests-observability-commands.sh
@@ -17,8 +17,9 @@ fi
 mkdir -p ~/.kube
 cp "${SHARED_DIR}/kubeconfig" ~/.kube/config
 
-: Remove the ACM Subscription to allow Observability interop tests full control of operators
-if oc get subscription.apps.open-cluster-management.io -n policies openshift-plus-sub -o yaml > /tmp/acm-policy-subscription-backup.yaml 2>/dev/null; then
+# Remove the ACM Subscription to allow Observability interop tests full control of operators
+if oc get subscription.apps.open-cluster-management.io -n policies openshift-plus-sub 2>/dev/null; then
+    oc get subscription.apps.open-cluster-management.io -n policies openshift-plus-sub -o yaml > /tmp/acm-policy-subscription-backup.yaml
     oc delete subscription.apps.open-cluster-management.io -n policies openshift-plus-sub
 fi
 
@@ -50,7 +51,7 @@ bash +x ./execute_obs_interop_commands.sh || :
 
 unset PARAM_AWS_SECRET_ACCESS_KEY PARAM_AWS_ACCESS_KEY_ID OC_HUB_CLUSTER_PASS MANAGED_CLUSTER_PASS
 
-: Restore the ACM subscription
+# Restore the ACM subscription
 if [[ -f /tmp/acm-policy-subscription-backup.yaml ]]; then
     oc apply -f /tmp/acm-policy-subscription-backup.yaml || :
 fi

--- a/ci-operator/step-registry/interop-tests/ocs-tests/interop-tests-ocs-tests-commands.sh
+++ b/ci-operator/step-registry/interop-tests/ocs-tests/interop-tests-ocs-tests-commands.sh
@@ -1,103 +1,73 @@
 #!/bin/bash
+set -euxo pipefail; shopt -s inherit_errexit
 
-set -o nounset
-set -o errexit
-set -o pipefail
+# --- Variables ---
+typeset logsFolder="${ARTIFACT_DIR}/ocs-tests"
+typeset logsConfig="${logsFolder}/ocs-tests-config.yaml"
+typeset clusterPath="${ARTIFACT_DIR}/ocs-tests"
+typeset binFolder="${logsFolder}/bin"
+typeset ocsVersion
+typeset ocpVersion
+typeset clusterName
+export PATH
+export OCSCI_DATA_DIR 	# Overrides OCS test framework default test data location
 
-CLUSTER_VERSION=$(oc get clusterVersion version -o jsonpath='{$.status.desired.version}')
-OCP_MAJOR_MINOR=$(echo "${CLUSTER_VERSION}" | cut -d '.' -f1,2)
-OCP_VERSION="${OCP_MAJOR_MINOR}"
+ocsVersion=$(oc get csv -n openshift-storage -o json | jq -r '.items[] | select(.metadata.name | startswith("ocs-operator")).spec.version' | cut -d. -f1,2)
+ocpVersion=$(oc get clusterVersion version -o jsonpath='{$.status.desired.version}' | cut -d '.' -f1,2)
+clusterName=$([[ -f "${SHARED_DIR}/CLUSTER_NAME" ]] && cat "${SHARED_DIR}/CLUSTER_NAME" || echo "cluster-name")
+PATH="${binFolder}:${PATH}"
+OCSCI_DATA_DIR="${ARTIFACT_DIR}"
 
-OCS_VERSION=$(oc get csv -n openshift-storage -o json | jq -r '.items[] | select(.metadata.name | startswith("ocs-operator")).spec.version' | cut -d. -f1,2)
+mkdir -p "${logsFolder}" "${clusterPath}/auth" "${clusterPath}/data" "${binFolder}"
 
-CLUSTER_NAME=$([[ -f "${SHARED_DIR}/CLUSTER_NAME" ]] && cat "${SHARED_DIR}/CLUSTER_NAME" || echo "cluster-name")
-CLUSTER_DOMAIN="${CLUSTER_DOMAIN:-release-ci.cnv-qe.rhood.us}"
-LOGS_FOLDER="${ARTIFACT_DIR}/ocs-tests"
-LOGS_CONFIG="${LOGS_FOLDER}/ocs-tests-config.yaml"
-CLUSTER_PATH="${ARTIFACT_DIR}/ocs-tests"
-
-export BIN_FOLDER="${LOGS_FOLDER}/bin"
+cp -v "${KUBECONFIG}"              "${clusterPath}/auth/kubeconfig"
+cp -v "${KUBEADMIN_PASSWORD_FILE}" "${clusterPath}/auth/kubeadmin-password"
 
 # Function to clean up folders
 cleanup() {
-    echo "Cleaning up..."
-    [[ -d "${CLUSTER_PATH}/auth" ]] && rm -fvr "${CLUSTER_PATH}/auth"
+    : "Cleaning up..."
+    [[ -d "${clusterPath}/auth" ]] && rm -fvr "${clusterPath}/auth"
 }
 # Set trap to catch EXIT and run cleanup on any exit code
 trap cleanup EXIT SIGINT
 
-function install_yq_if_not_exists() {
-    # Install yq manually if not found in image
-    echo "Checking if yq exists"
-    cmd_yq="$(yq --version 2>/dev/null || true)"
-    if [ -n "$cmd_yq" ]; then
-        echo "yq version: $cmd_yq"
-    else
-        echo "Installing yq"
-        mkdir -p /tmp/bin
-        export PATH=$PATH:/tmp/bin/
-        curl -L "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_$(uname -m | sed 's/aarch64/arm64/;s/x86_64/amd64/')" \
-         -o /tmp/bin/yq && chmod +x /tmp/bin/yq
-    fi
-}
-
 function mapTestsForComponentReadiness() {
     if [[ $MAP_TESTS == "true" ]]; then
-        results_file="${1}"
-        echo "Patching Tests Result File: ${results_file}"
+        typeset results_file="${1}"
+        : "Patching Tests Result File: ${results_file}"
         if [ -f "${results_file}" ]; then
-            install_yq_if_not_exists
             export REPORTPORTAL_CMP
-            echo "Mapping Test Suite Name To: ${REPORTPORTAL_CMP}"
+            : "Mapping Test Site Name To: ${REPORTPORTAL_CMP}"
             yq eval -px -ox -iI0 '.testsuites.testsuite.+@name=env(REPORTPORTAL_CMP)' $results_file || echo "Warning: yq failed for ${results_file}, debug manually" >&2
         fi
     fi
 }
 
-#
-# Remove the ACM Subscription to allow OCS interop tests full control of operators
-#
-OUTPUT=$(oc get subscription.apps.open-cluster-management.io -n policies openshift-plus-sub 2>/dev/null || true)
-if [[ "$OUTPUT" != "" ]]; then
-	oc get subscription.apps.open-cluster-management.io -n policies openshift-plus-sub -o yaml > /tmp/acm-policy-subscription-backup.yaml
-	oc delete subscription.apps.open-cluster-management.io -n policies openshift-plus-sub
-fi
-
-# Overwrite OCS Test data folder
-export OCSCI_DATA_DIR="${ARTIFACT_DIR}"
-
-mkdir -p "${LOGS_FOLDER}"
-mkdir -p "${CLUSTER_PATH}/auth"
-mkdir -p "${CLUSTER_PATH}/data"
-mkdir -p "${BIN_FOLDER}"
-
-export PATH="${BIN_FOLDER}:${PATH}"
-
-cp -v "${KUBECONFIG}"              "${CLUSTER_PATH}/auth/kubeconfig"
-cp -v "${KUBEADMIN_PASSWORD_FILE}" "${CLUSTER_PATH}/auth/kubeadmin-password"
-
 # Create ocs-tests config overwrite file
-cat > "${LOGS_CONFIG}" << __EOF__
+cat > "${logsConfig}" << __EOF__
 ---
 RUN:
-  bin_dir: "${BIN_FOLDER}"
-  log_dir: "${LOGS_FOLDER}"
+  bin_dir: "${binFolder}"
+  log_dir: "${logsFolder}"
 REPORTING:
-  default_ocs_must_gather_image: "quay.io/rhceph-dev/ocs-must-gather"
-  default_ocs_must_gather_latest_tag: "latest-${ODF_VERSION_MAJOR_MINOR}"
+  ocs_must_gather_image: "registry.redhat.io/odf4/odf-must-gather-rhel9"
+  ocp_must_gather_image: "registry.redhat.io/openshift4/ose-must-gather:latest"
+  tarball_mg_logs: False
+  delete_packed_mg_logs: False
 DEPLOYMENT:
   skip_download_client: True
 __EOF__
 
+set +x
 # Append ENV_DATA in ocs-tests config file for vsphere platform
 if [[ -f "${SHARED_DIR}/vsphere_context.sh" ]]; then
-    declare vsphere_datacenter
-    declare vsphere_datastore
-    declare vsphere_cluster
+    typeset vsphere_datacenter
+    typeset vsphere_cluster
+    typeset vsphere_datastore
     source "${SHARED_DIR}/vsphere_context.sh"
     source "${SHARED_DIR}/govc.sh"
 
-    cat >> "${LOGS_CONFIG}" << __APPENDED_ENV_DATA__
+    cat >> "${logsConfig}" << __APPENDED_ENV_DATA__
 ENV_DATA:
   platform: "vsphere"
   vsphere_user: "${GOVC_USERNAME}"
@@ -107,46 +77,53 @@ ENV_DATA:
   vsphere_datastore: "${vsphere_datastore}"
 __APPENDED_ENV_DATA__
 fi
-
-
 set -x
-START_TIME=$(date "+%s")
+
+# Remove the ACM Subscription to allow OCS interop tests full control of operators
+if oc get subscription.apps.open-cluster-management.io -n policies openshift-plus-sub 2>/dev/null; then
+    oc get subscription.apps.open-cluster-management.io -n policies openshift-plus-sub -o yaml > /tmp/acm-policy-subscription-backup.yaml
+    oc delete subscription.apps.open-cluster-management.io -n policies openshift-plus-sub
+fi
+
+# Record start time for test duration check
+typeset START_TIME END_TIME DIFF_TIME
+START_TIME=$(date +%s)
 
 run-ci --color=yes -o cache_dir=/tmp tests/ -m 'acceptance and not ui' -k '' \
-  --ocsci-conf "${LOGS_CONFIG}" \
-  --collect-logs \
-  --ocs-version  "${OCS_VERSION}"                    \
-  --ocp-version  "${OCP_VERSION}"                    \
-  --cluster-path "${CLUSTER_PATH}"                   \
-  --cluster-name "${CLUSTER_NAME}"                   \
-  --html         "${CLUSTER_PATH}/test-results.html" \
-  --junit-xml    "${CLUSTER_PATH}/junit.xml"         \
+  --ocsci-conf "${logsConfig}" \
+  --collect-logs-on-success-run \
+  --ocs-version  "${ocsVersion}"                    \
+  --ocp-version  "${ocpVersion}"                    \
+  --cluster-path "${clusterPath}"                   \
+  --cluster-name "${clusterName}"                   \
+  --html         "${clusterPath}/test-results.html" \
+  --junit-xml    "${clusterPath}/junit.xml"         \
   || /bin/true
 
+# Calculate test duration
+END_TIME=$(date +%s)
+DIFF_TIME=$((END_TIME - START_TIME))
 
-FINISH_TIME=$(date "+%s")
-DIFF_TIME=$((FINISH_TIME-START_TIME))
-set +x
-
-# Map tests if needed for related use cases
-mapTestsForComponentReadiness "${CLUSTER_PATH}/junit.xml"
-
-# Send junit file to shared dir for Data Router Reporter step
-cp "${CLUSTER_PATH}/junit.xml" "${SHARED_DIR}"
-
+# Check if tests finished too quickly (might indicate a problem)
 if [[ ${DIFF_TIME} -le 1800 ]]; then
-    echo ""
-    echo " 🚨  The tests finished too quickly (took only: ${DIFF_TIME} sec), pausing here to give us time to debug"
-    echo "  😴 😴 😴"
+    : ""
+    : " 🚨  The tests finished too quickly (took only: ${DIFF_TIME} sec), pausing here to give us time to debug"
+    : "  😴 😴 😴"
     sleep 7200
     exit 1
 else
     echo "Finished in: ${DIFF_TIME} sec"
 fi
 
-#
+# Map tests if needed for related use cases
+mapTestsForComponentReadiness "${clusterPath}/junit.xml"
+
+# Send junit file to shared dir for Data Router Reporter step
+cp "${clusterPath}/junit.xml" "${SHARED_DIR}"
+
 # Restore the ACM subscription
-#
 if [[ -f /tmp/acm-policy-subscription-backup.yaml ]]; then
-	oc apply -f /tmp/acm-policy-subscription-backup.yaml
+    oc apply -f /tmp/acm-policy-subscription-backup.yaml
 fi
+
+true


### PR DESCRIPTION
Fix ODF must-gather configuration and improve OCS test scripts

  This commit addresses issues with ODF must-gather image configuration and refactors the OCS interop test scripts for better reliability and maintainability.

Updates for must-gather result getting:
  - Fix must-gather image source: use official registry.redhat.io images instead of quay.io/rhceph-dev
  - Use ocs_must_gather_image instead of default_ocs_must_gather_image in ocs-tests config
  - Use --collect-logs-on-success-run instead of --collect-logs to collect log when PASS and FAIL
  - Add OCP must-gather image configuration, since --collect-logs-on-success-run will collect OCP data too
  - Add "tarball_mg_logs: False" and "delete_packed_mg_logs: False" to keep the must-gather result after job

Best Practices and improvements: 
  - Refactor variable declarations using typeset for better scoping 
  - Optimize ACM subscription check logic
  - Remove unnecessary yq installation function
  - Improve code readability and consistency


The must result has been saved:
- https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_release/76131/rehearse-76131-periodic-ci-stolostron-policy-collection-main-ocp4.21-interop-opp-vsphere/2033532437081886720/artifacts/interop-opp-vsphere/interop-tests-ocs-tests/artifacts/ocs-tests/testcases_1773672697610/cluster-name/
- https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_release/76131/rehearse-76131-periodic-ci-red-hat-storage-ocs-ci-master-odf-ocp-4.21-lp-interop-cr-odf-interop-aws/2033532437241270272/artifacts/odf-interop-aws/interop-tests-ocs-tests/artifacts/ocs-tests/testcases_1773670607588/cluster-name/
