### PR TITLE
CORENET-6614: no skip_ config for manual jobs / add to upgrade jobs

### DIFF
--- a/ci-operator/config/openshift/cluster-network-operator/openshift-cluster-network-operator-master__4.22-upgrade-from-stable-4.21.yaml
+++ b/ci-operator/config/openshift/cluster-network-operator/openshift-cluster-network-operator-master__4.22-upgrade-from-stable-4.21.yaml
@@ -23,6 +23,7 @@ resources:
 tests:
 - as: e2e-aws-ovn-upgrade
   optional: true
+  skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
   steps:
     cluster_profile: aws-2
     env:
@@ -32,6 +33,7 @@ tests:
   timeout: 6h0m0s
 - as: e2e-azure-ovn-upgrade
   optional: true
+  skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
   steps:
     cluster_profile: openshift-org-azure
     env:
@@ -42,6 +44,7 @@ tests:
   timeout: 6h0m0s
 - as: e2e-gcp-ovn-upgrade
   optional: true
+  skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
   steps:
     cluster_profile: gcp-3
     env:

--- a/ci-operator/config/openshift/cluster-network-operator/openshift-cluster-network-operator-release-4.21.yaml
+++ b/ci-operator/config/openshift/cluster-network-operator/openshift-cluster-network-operator-release-4.21.yaml
@@ -67,7 +67,6 @@ tests:
 - always_run: false
   as: e2e-ovn-step-registry
   optional: true
-  skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
   steps:
     cluster_profile: aws-4
     env:
@@ -88,7 +87,6 @@ tests:
 - always_run: false
   as: e2e-ovn-hybrid-step-registry
   optional: true
-  skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
   steps:
     cluster_profile: aws-5
     env:
@@ -113,7 +111,6 @@ tests:
   as: e2e-aws-ovn-serial-ipsec
   optional: true
   shard_count: 2
-  skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
   steps:
     cluster_profile: aws
     env:
@@ -155,7 +152,6 @@ tests:
 - always_run: false
   as: e2e-vsphere-ovn
   optional: true
-  skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
   steps:
     cluster_profile: vsphere-elastic
     env:
@@ -164,7 +160,6 @@ tests:
 - always_run: false
   as: e2e-vsphere-ovn-dualstack
   optional: true
-  skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
   steps:
     cluster_profile: vsphere-elastic
     env:
@@ -178,7 +173,6 @@ tests:
 - always_run: false
   as: e2e-vsphere-ovn-dualstack-primaryv6
   optional: true
-  skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
   steps:
     cluster_profile: vsphere-elastic
     env:
@@ -188,7 +182,6 @@ tests:
 - always_run: false
   as: e2e-azure-ovn
   optional: true
-  skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
   steps:
     cluster_profile: openshift-org-azure
     env:
@@ -197,7 +190,6 @@ tests:
 - always_run: false
   as: e2e-azure-ovn-dualstack
   optional: true
-  skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
   steps:
     cluster_profile: openshift-org-azure
     env:
@@ -206,7 +198,6 @@ tests:
 - always_run: false
   as: e2e-azure-ovn-manual-oidc
   optional: true
-  skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
   steps:
     cluster_profile: openshift-org-azure
     env:
@@ -232,7 +223,6 @@ tests:
     workflow: openshift-e2e-gcp-ovn
 - always_run: false
   as: e2e-gcp-ovn-techpreview
-  skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
   steps:
     cluster_profile: gcp
     env:
@@ -243,7 +233,6 @@ tests:
   as: e2e-aws-ovn-techpreview-serial
   optional: true
   shard_count: 2
-  skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
   steps:
     cluster_profile: aws-3
     env:
@@ -253,7 +242,6 @@ tests:
 - always_run: false
   as: e2e-vsphere-ovn-windows
   optional: true
-  skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
   steps:
     cluster_profile: vsphere-elastic
     env:
@@ -264,7 +252,6 @@ tests:
 - always_run: false
   as: e2e-openstack-ovn
   optional: true
-  skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
   steps:
     cluster_profile: openstack-vexxhost
     env:
@@ -291,7 +278,6 @@ tests:
 - always_run: false
   as: e2e-aws-ovn-single-node
   optional: true
-  skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
   steps:
     cluster_profile: aws-3
     env:
@@ -314,7 +300,6 @@ tests:
 - always_run: false
   as: e2e-network-mtu-migration-ovn-ipv4
   optional: true
-  skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
   steps:
     cluster_profile: gcp
     env:
@@ -331,7 +316,6 @@ tests:
   capabilities:
   - intranet
   optional: true
-  skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
   steps:
     cluster_profile: equinix-ocp-metal
     env:
@@ -346,7 +330,6 @@ tests:
 - always_run: false
   as: e2e-aws-ovn-shared-to-local-gateway-mode-migration
   optional: true
-  skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
   steps:
     cluster_profile: aws-3
     env:
@@ -355,7 +338,6 @@ tests:
 - always_run: false
   as: e2e-aws-ovn-local-to-shared-gateway-mode-migration
   optional: true
-  skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
   steps:
     cluster_profile: aws-3
     env:
@@ -365,14 +347,12 @@ tests:
 - always_run: false
   as: e2e-aws-hypershift-ovn-kubevirt
   optional: true
-  skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
   steps:
     cluster_profile: aws-3
     workflow: hypershift-kubevirt-conformance
 - always_run: false
   as: qe-perfscale-aws-ovn-medium-cluster-density
   optional: true
-  skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
   steps:
     cluster_profile: aws-perfscale
     env:
@@ -390,7 +370,6 @@ tests:
 - always_run: false
   as: qe-perfscale-aws-ovn-small-cluster-density
   optional: true
-  skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
   steps:
     cluster_profile: aws-perfscale-qe
     env:
@@ -407,7 +386,6 @@ tests:
 - always_run: false
   as: qe-perfscale-aws-ovn-medium-node-density-cni
   optional: true
-  skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
   steps:
     cluster_profile: aws-perfscale
     env:
@@ -425,7 +403,6 @@ tests:
 - always_run: false
   as: qe-perfscale-aws-ovn-small-node-density-cni
   optional: true
-  skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
   steps:
     cluster_profile: aws-perfscale-qe
     env:

--- a/ci-operator/config/openshift/cluster-network-operator/openshift-cluster-network-operator-release-4.21__4.21-upgrade-from-stable-4.20.yaml
+++ b/ci-operator/config/openshift/cluster-network-operator/openshift-cluster-network-operator-release-4.21__4.21-upgrade-from-stable-4.20.yaml
@@ -23,6 +23,7 @@ resources:
 tests:
 - as: e2e-aws-ovn-upgrade
   optional: true
+  skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
   steps:
     cluster_profile: aws-2
     env:
@@ -32,6 +33,7 @@ tests:
   timeout: 6h0m0s
 - as: e2e-azure-ovn-upgrade
   optional: true
+  skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
   steps:
     cluster_profile: openshift-org-azure
     env:
@@ -42,6 +44,7 @@ tests:
   timeout: 6h0m0s
 - as: e2e-gcp-ovn-upgrade
   optional: true
+  skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
   steps:
     cluster_profile: gcp
     env:

--- a/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-master__4.22-upgrade-from-stable-4.21.yaml
+++ b/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-master__4.22-upgrade-from-stable-4.21.yaml
@@ -27,6 +27,7 @@ resources:
       memory: 200Mi
 tests:
 - as: e2e-aws-ovn-upgrade
+  skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
   steps:
     cluster_profile: aws
     env:
@@ -41,6 +42,7 @@ tests:
       EXTRA_MG_ARGS: --host-network
     workflow: openshift-e2e-aws-ovn-upgrade-ipsec
 - as: e2e-gcp-ovn-rt-upgrade
+  skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
   steps:
     cluster_profile: gcp
     env:

--- a/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.21.yaml
+++ b/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.21.yaml
@@ -45,7 +45,6 @@ tests:
 - always_run: false
   as: e2e-aws-ovn-clusternetwork-cidr-expansion
   optional: true
-  skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
   steps:
     cluster_profile: aws
     env:
@@ -56,7 +55,6 @@ tests:
   capabilities:
   - intranet
   optional: true
-  skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
   steps:
     cluster_profile: equinix-ocp-metal
     env:
@@ -80,7 +78,6 @@ tests:
   capabilities:
   - intranet
   optional: true
-  skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
   steps:
     cluster_profile: equinix-ocp-metal
     env:
@@ -107,7 +104,6 @@ tests:
 - always_run: false
   as: e2e-ovn-hybrid-step-registry
   optional: true
-  skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
   steps:
     cluster_profile: aws
     env:
@@ -123,7 +119,6 @@ tests:
 - always_run: false
   as: e2e-aws-ovn-fdp-qe
   optional: true
-  skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
   steps:
     cluster_profile: aws
     env:
@@ -136,7 +131,6 @@ tests:
 - always_run: false
   as: e2e-metal-ovn-fdp-qe-ipv6
   optional: true
-  skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
   steps:
     cluster_profile: equinix-ocp-metal
     env:
@@ -164,7 +158,6 @@ tests:
 - always_run: false
   as: e2e-vsphere-ovn
   optional: true
-  skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
   steps:
     cluster_profile: vsphere-elastic
     env:
@@ -173,7 +166,6 @@ tests:
 - always_run: false
   as: e2e-azure-ovn
   optional: true
-  skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
   steps:
     cluster_profile: openshift-org-azure
     env:
@@ -190,7 +182,6 @@ tests:
 - always_run: false
   as: e2e-aws-ovn-upgrade-ipsec
   optional: true
-  skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
   steps:
     cluster_profile: aws
     env:
@@ -199,7 +190,6 @@ tests:
 - always_run: false
   as: e2e-aws-ovn-serial-ipsec
   optional: true
-  skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
   steps:
     cluster_profile: aws
     env:
@@ -236,7 +226,6 @@ tests:
 - always_run: false
   as: e2e-vsphere-windows
   optional: true
-  skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
   steps:
     cluster_profile: vsphere-elastic
     env:
@@ -247,7 +236,6 @@ tests:
 - always_run: false
   as: e2e-openstack-ovn
   optional: true
-  skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
   steps:
     cluster_profile: openstack-vexxhost
     env:
@@ -299,7 +287,6 @@ tests:
   capabilities:
   - intranet
   optional: true
-  skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
   steps:
     cluster_profile: equinix-ocp-metal
     env:
@@ -412,7 +399,6 @@ tests:
 - always_run: false
   as: qe-perfscale-aws-ovn-small-udn-density-l2
   optional: true
-  skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
   steps:
     cluster_profile: aws-perfscale-qe
     env:
@@ -432,7 +418,6 @@ tests:
 - always_run: false
   as: e2e-aws-ovn-techpreview
   optional: true
-  skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
   steps:
     cluster_profile: aws-2
     env:
@@ -442,7 +427,6 @@ tests:
 - always_run: false
   as: e2e-aws-ovn-single-node-techpreview
   optional: true
-  skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
   steps:
     cluster_profile: aws-2
     env:
@@ -452,7 +436,6 @@ tests:
 - always_run: false
   as: e2e-azure-ovn-techpreview
   optional: true
-  skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
   steps:
     cluster_profile: openshift-org-azure
     env:
@@ -471,7 +454,6 @@ tests:
 - always_run: false
   as: openshift-e2e-gcp-ovn-techpreview-upgrade
   optional: true
-  skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
   steps:
     cluster_profile: gcp
     env:
@@ -483,7 +465,6 @@ tests:
   capabilities:
   - intranet
   optional: true
-  skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
   steps:
     cluster_profile: equinix-ocp-metal
     env:
@@ -497,7 +478,6 @@ tests:
   capabilities:
   - intranet
   optional: true
-  skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
   steps:
     cluster_profile: equinix-ocp-metal
     env:
@@ -511,7 +491,6 @@ tests:
   capabilities:
   - intranet
   optional: true
-  skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
   steps:
     cluster_profile: equinix-ocp-metal
     env:
@@ -525,7 +504,6 @@ tests:
   capabilities:
   - intranet
   optional: true
-  skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
   steps:
     cluster_profile: equinix-ocp-metal
     env:
@@ -539,7 +517,6 @@ tests:
 - always_run: false
   as: e2e-vsphere-ovn-techpreview
   optional: true
-  skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
   steps:
     cluster_profile: vsphere-elastic
     env:
@@ -551,7 +528,6 @@ tests:
   capabilities:
   - intranet
   optional: true
-  skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
   steps:
     cluster_profile: equinix-ocp-metal
     env:
@@ -562,7 +538,6 @@ tests:
   capabilities:
   - intranet
   optional: true
-  skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
   steps:
     cluster_profile: equinix-ocp-metal
     env:
@@ -572,7 +547,6 @@ tests:
 - always_run: false
   as: perfscale-aws-ovn-small-cluster-density-v2
   optional: true
-  skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
   steps:
     allow_skip_on_success: true
     cluster_profile: aws-perfscale
@@ -591,7 +565,6 @@ tests:
 - always_run: false
   as: perfscale-aws-ovn-small-node-density-cni
   optional: true
-  skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
   steps:
     allow_skip_on_success: true
     cluster_profile: aws-perfscale
@@ -608,7 +581,6 @@ tests:
 - always_run: false
   as: perfscale-aws-ovn-medium-cluster-density-v2
   optional: true
-  skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
   steps:
     allow_skip_on_success: true
     cluster_profile: aws-perfscale
@@ -630,7 +602,6 @@ tests:
 - always_run: false
   as: perfscale-aws-ovn-medium-node-density-cni
   optional: true
-  skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
   steps:
     allow_skip_on_success: true
     cluster_profile: aws-perfscale

--- a/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.21__4.21-upgrade-from-stable-4.20.yaml
+++ b/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.21__4.21-upgrade-from-stable-4.20.yaml
@@ -27,6 +27,7 @@ resources:
       memory: 200Mi
 tests:
 - as: e2e-aws-ovn-upgrade
+  skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
   steps:
     cluster_profile: aws
     env:
@@ -41,6 +42,7 @@ tests:
       EXTRA_MG_ARGS: --host-network
     workflow: openshift-e2e-aws-ovn-upgrade-ipsec
 - as: e2e-gcp-ovn-rt-upgrade
+  skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
   steps:
     cluster_profile: gcp
     env:

--- a/ci-operator/jobs/openshift/cluster-network-operator/openshift-cluster-network-operator-master-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-network-operator/openshift-cluster-network-operator-master-presubmits.yaml
@@ -1,7 +1,7 @@
 presubmits:
   openshift/cluster-network-operator:
   - agent: kubernetes
-    always_run: true
+    always_run: false
     branches:
     - ^master$
     - ^master-
@@ -19,6 +19,7 @@ presubmits:
     name: pull-ci-openshift-cluster-network-operator-master-4.22-upgrade-from-stable-4.21-e2e-aws-ovn-upgrade
     optional: true
     rerun_command: /test 4.22-upgrade-from-stable-4.21-e2e-aws-ovn-upgrade
+    skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
     spec:
       containers:
       - args:
@@ -86,7 +87,7 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )4.22-upgrade-from-stable-4.21-e2e-aws-ovn-upgrade,?($|\s.*)
   - agent: kubernetes
-    always_run: true
+    always_run: false
     branches:
     - ^master$
     - ^master-
@@ -104,6 +105,7 @@ presubmits:
     name: pull-ci-openshift-cluster-network-operator-master-4.22-upgrade-from-stable-4.21-e2e-azure-ovn-upgrade
     optional: true
     rerun_command: /test 4.22-upgrade-from-stable-4.21-e2e-azure-ovn-upgrade
+    skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
     spec:
       containers:
       - args:
@@ -171,7 +173,7 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )4.22-upgrade-from-stable-4.21-e2e-azure-ovn-upgrade,?($|\s.*)
   - agent: kubernetes
-    always_run: true
+    always_run: false
     branches:
     - ^master$
     - ^master-
@@ -189,6 +191,7 @@ presubmits:
     name: pull-ci-openshift-cluster-network-operator-master-4.22-upgrade-from-stable-4.21-e2e-gcp-ovn-upgrade
     optional: true
     rerun_command: /test 4.22-upgrade-from-stable-4.21-e2e-gcp-ovn-upgrade
+    skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift/cluster-network-operator/openshift-cluster-network-operator-release-4.21-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-network-operator/openshift-cluster-network-operator-release-4.21-presubmits.yaml
@@ -1,7 +1,7 @@
 presubmits:
   openshift/cluster-network-operator:
   - agent: kubernetes
-    always_run: true
+    always_run: false
     branches:
     - ^release-4\.21$
     - ^release-4\.21-
@@ -19,6 +19,7 @@ presubmits:
     name: pull-ci-openshift-cluster-network-operator-release-4.21-4.21-upgrade-from-stable-4.20-e2e-aws-ovn-upgrade
     optional: true
     rerun_command: /test 4.21-upgrade-from-stable-4.20-e2e-aws-ovn-upgrade
+    skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
     spec:
       containers:
       - args:
@@ -86,7 +87,7 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )4.21-upgrade-from-stable-4.20-e2e-aws-ovn-upgrade,?($|\s.*)
   - agent: kubernetes
-    always_run: true
+    always_run: false
     branches:
     - ^release-4\.21$
     - ^release-4\.21-
@@ -104,6 +105,7 @@ presubmits:
     name: pull-ci-openshift-cluster-network-operator-release-4.21-4.21-upgrade-from-stable-4.20-e2e-azure-ovn-upgrade
     optional: true
     rerun_command: /test 4.21-upgrade-from-stable-4.20-e2e-azure-ovn-upgrade
+    skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
     spec:
       containers:
       - args:
@@ -171,7 +173,7 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )4.21-upgrade-from-stable-4.20-e2e-azure-ovn-upgrade,?($|\s.*)
   - agent: kubernetes
-    always_run: true
+    always_run: false
     branches:
     - ^release-4\.21$
     - ^release-4\.21-
@@ -189,6 +191,7 @@ presubmits:
     name: pull-ci-openshift-cluster-network-operator-release-4.21-4.21-upgrade-from-stable-4.20-e2e-gcp-ovn-upgrade
     optional: true
     rerun_command: /test 4.21-upgrade-from-stable-4.20-e2e-gcp-ovn-upgrade
+    skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
     spec:
       containers:
       - args:
@@ -326,7 +329,6 @@ presubmits:
     name: pull-ci-openshift-cluster-network-operator-release-4.21-e2e-aws-hypershift-ovn-kubevirt
     optional: true
     rerun_command: /test e2e-aws-hypershift-ovn-kubevirt
-    skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
     spec:
       containers:
       - args:
@@ -489,7 +491,6 @@ presubmits:
     name: pull-ci-openshift-cluster-network-operator-release-4.21-e2e-aws-ovn-local-to-shared-gateway-mode-migration
     optional: true
     rerun_command: /test e2e-aws-ovn-local-to-shared-gateway-mode-migration
-    skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
     spec:
       containers:
       - args:
@@ -735,7 +736,6 @@ presubmits:
     name: pull-ci-openshift-cluster-network-operator-release-4.21-e2e-aws-ovn-serial-ipsec-1of2
     optional: true
     rerun_command: /test e2e-aws-ovn-serial-ipsec-1of2
-    skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
     spec:
       containers:
       - args:
@@ -818,7 +818,6 @@ presubmits:
     name: pull-ci-openshift-cluster-network-operator-release-4.21-e2e-aws-ovn-serial-ipsec-2of2
     optional: true
     rerun_command: /test e2e-aws-ovn-serial-ipsec-2of2
-    skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
     spec:
       containers:
       - args:
@@ -901,7 +900,6 @@ presubmits:
     name: pull-ci-openshift-cluster-network-operator-release-4.21-e2e-aws-ovn-shared-to-local-gateway-mode-migration
     optional: true
     rerun_command: /test e2e-aws-ovn-shared-to-local-gateway-mode-migration
-    skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
     spec:
       containers:
       - args:
@@ -983,7 +981,6 @@ presubmits:
     name: pull-ci-openshift-cluster-network-operator-release-4.21-e2e-aws-ovn-single-node
     optional: true
     rerun_command: /test e2e-aws-ovn-single-node
-    skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
     spec:
       containers:
       - args:
@@ -1065,7 +1062,6 @@ presubmits:
     name: pull-ci-openshift-cluster-network-operator-release-4.21-e2e-aws-ovn-techpreview-serial-1of2
     optional: true
     rerun_command: /test e2e-aws-ovn-techpreview-serial-1of2
-    skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
     spec:
       containers:
       - args:
@@ -1148,7 +1144,6 @@ presubmits:
     name: pull-ci-openshift-cluster-network-operator-release-4.21-e2e-aws-ovn-techpreview-serial-2of2
     optional: true
     rerun_command: /test e2e-aws-ovn-techpreview-serial-2of2
-    skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
     spec:
       containers:
       - args:
@@ -1474,7 +1469,6 @@ presubmits:
     name: pull-ci-openshift-cluster-network-operator-release-4.21-e2e-azure-ovn
     optional: true
     rerun_command: /test e2e-azure-ovn
-    skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
     spec:
       containers:
       - args:
@@ -1556,7 +1550,6 @@ presubmits:
     name: pull-ci-openshift-cluster-network-operator-release-4.21-e2e-azure-ovn-dualstack
     optional: true
     rerun_command: /test e2e-azure-ovn-dualstack
-    skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
     spec:
       containers:
       - args:
@@ -1638,7 +1631,6 @@ presubmits:
     name: pull-ci-openshift-cluster-network-operator-release-4.21-e2e-azure-ovn-manual-oidc
     optional: true
     rerun_command: /test e2e-azure-ovn-manual-oidc
-    skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
     spec:
       containers:
       - args:
@@ -1881,7 +1873,6 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-cluster-network-operator-release-4.21-e2e-gcp-ovn-techpreview
     rerun_command: /test e2e-gcp-ovn-techpreview
-    skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
     spec:
       containers:
       - args:
@@ -1946,7 +1937,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-gcp-ovn-techpreview,?($|\s.*)
+    trigger: (?m)^/test( | .* )(e2e-gcp-ovn-techpreview|remaining-required),?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:
@@ -2372,7 +2363,6 @@ presubmits:
     name: pull-ci-openshift-cluster-network-operator-release-4.21-e2e-network-mtu-migration-ovn-ipv4
     optional: true
     rerun_command: /test e2e-network-mtu-migration-ovn-ipv4
-    skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
     spec:
       containers:
       - args:
@@ -2455,7 +2445,6 @@ presubmits:
     name: pull-ci-openshift-cluster-network-operator-release-4.21-e2e-network-mtu-migration-ovn-ipv6
     optional: true
     rerun_command: /test e2e-network-mtu-migration-ovn-ipv6
-    skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
     spec:
       containers:
       - args:
@@ -2537,7 +2526,6 @@ presubmits:
     name: pull-ci-openshift-cluster-network-operator-release-4.21-e2e-openstack-ovn
     optional: true
     rerun_command: /test e2e-openstack-ovn
-    skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
     spec:
       containers:
       - args:
@@ -2619,7 +2607,6 @@ presubmits:
     name: pull-ci-openshift-cluster-network-operator-release-4.21-e2e-ovn-hybrid-step-registry
     optional: true
     rerun_command: /test e2e-ovn-hybrid-step-registry
-    skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
     spec:
       containers:
       - args:
@@ -2782,7 +2769,6 @@ presubmits:
     name: pull-ci-openshift-cluster-network-operator-release-4.21-e2e-ovn-step-registry
     optional: true
     rerun_command: /test e2e-ovn-step-registry
-    skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
     spec:
       containers:
       - args:
@@ -2864,7 +2850,6 @@ presubmits:
     name: pull-ci-openshift-cluster-network-operator-release-4.21-e2e-vsphere-ovn
     optional: true
     rerun_command: /test e2e-vsphere-ovn
-    skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
     spec:
       containers:
       - args:
@@ -2946,7 +2931,6 @@ presubmits:
     name: pull-ci-openshift-cluster-network-operator-release-4.21-e2e-vsphere-ovn-dualstack
     optional: true
     rerun_command: /test e2e-vsphere-ovn-dualstack
-    skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
     spec:
       containers:
       - args:
@@ -3028,7 +3012,6 @@ presubmits:
     name: pull-ci-openshift-cluster-network-operator-release-4.21-e2e-vsphere-ovn-dualstack-primaryv6
     optional: true
     rerun_command: /test e2e-vsphere-ovn-dualstack-primaryv6
-    skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
     spec:
       containers:
       - args:
@@ -3110,7 +3093,6 @@ presubmits:
     name: pull-ci-openshift-cluster-network-operator-release-4.21-e2e-vsphere-ovn-windows
     optional: true
     rerun_command: /test e2e-vsphere-ovn-windows
-    skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
     spec:
       containers:
       - args:
@@ -3614,7 +3596,6 @@ presubmits:
     name: pull-ci-openshift-cluster-network-operator-release-4.21-qe-perfscale-aws-ovn-medium-cluster-density
     optional: true
     rerun_command: /test qe-perfscale-aws-ovn-medium-cluster-density
-    skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
     spec:
       containers:
       - args:
@@ -3696,7 +3677,6 @@ presubmits:
     name: pull-ci-openshift-cluster-network-operator-release-4.21-qe-perfscale-aws-ovn-medium-node-density-cni
     optional: true
     rerun_command: /test qe-perfscale-aws-ovn-medium-node-density-cni
-    skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
     spec:
       containers:
       - args:
@@ -3778,7 +3758,6 @@ presubmits:
     name: pull-ci-openshift-cluster-network-operator-release-4.21-qe-perfscale-aws-ovn-small-cluster-density
     optional: true
     rerun_command: /test qe-perfscale-aws-ovn-small-cluster-density
-    skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
     spec:
       containers:
       - args:
@@ -3860,7 +3839,6 @@ presubmits:
     name: pull-ci-openshift-cluster-network-operator-release-4.21-qe-perfscale-aws-ovn-small-node-density-cni
     optional: true
     rerun_command: /test qe-perfscale-aws-ovn-small-node-density-cni
-    skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift/ovn-kubernetes/openshift-ovn-kubernetes-master-presubmits.yaml
+++ b/ci-operator/jobs/openshift/ovn-kubernetes/openshift-ovn-kubernetes-master-presubmits.yaml
@@ -1,7 +1,7 @@
 presubmits:
   openshift/ovn-kubernetes:
   - agent: kubernetes
-    always_run: true
+    always_run: false
     branches:
     - ^master$
     - ^master-
@@ -16,6 +16,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-ovn-kubernetes-master-4.22-upgrade-from-stable-4.21-e2e-aws-ovn-upgrade
     rerun_command: /test 4.22-upgrade-from-stable-4.21-e2e-aws-ovn-upgrade
+    skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
     spec:
       containers:
       - args:
@@ -166,7 +167,7 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )4.22-upgrade-from-stable-4.21-e2e-aws-ovn-upgrade-ipsec,?($|\s.*)
   - agent: kubernetes
-    always_run: true
+    always_run: false
     branches:
     - ^master$
     - ^master-
@@ -181,6 +182,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-ovn-kubernetes-master-4.22-upgrade-from-stable-4.21-e2e-gcp-ovn-rt-upgrade
     rerun_command: /test 4.22-upgrade-from-stable-4.21-e2e-gcp-ovn-rt-upgrade
+    skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.21-presubmits.yaml
+++ b/ci-operator/jobs/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.21-presubmits.yaml
@@ -1,7 +1,7 @@
 presubmits:
   openshift/ovn-kubernetes:
   - agent: kubernetes
-    always_run: true
+    always_run: false
     branches:
     - ^release-4\.21$
     - ^release-4\.21-
@@ -16,6 +16,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-ovn-kubernetes-release-4.21-4.21-upgrade-from-stable-4.20-e2e-aws-ovn-upgrade
     rerun_command: /test 4.21-upgrade-from-stable-4.20-e2e-aws-ovn-upgrade
+    skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
     spec:
       containers:
       - args:
@@ -166,7 +167,7 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )4.21-upgrade-from-stable-4.20-e2e-aws-ovn-upgrade-ipsec,?($|\s.*)
   - agent: kubernetes
-    always_run: true
+    always_run: false
     branches:
     - ^release-4\.21$
     - ^release-4\.21-
@@ -181,6 +182,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-ovn-kubernetes-release-4.21-4.21-upgrade-from-stable-4.20-e2e-gcp-ovn-rt-upgrade
     rerun_command: /test 4.21-upgrade-from-stable-4.20-e2e-gcp-ovn-rt-upgrade
+    skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
     spec:
       containers:
       - args:
@@ -319,7 +321,6 @@ presubmits:
     name: pull-ci-openshift-ovn-kubernetes-release-4.21-e2e-agent-compact-ipv4
     optional: true
     rerun_command: /test e2e-agent-compact-ipv4
-    skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
     spec:
       containers:
       - args:
@@ -482,7 +483,6 @@ presubmits:
     name: pull-ci-openshift-ovn-kubernetes-release-4.21-e2e-aws-ovn-clusternetwork-cidr-expansion
     optional: true
     rerun_command: /test e2e-aws-ovn-clusternetwork-cidr-expansion
-    skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
     spec:
       containers:
       - args:
@@ -645,7 +645,6 @@ presubmits:
     name: pull-ci-openshift-ovn-kubernetes-release-4.21-e2e-aws-ovn-fdp-qe
     optional: true
     rerun_command: /test e2e-aws-ovn-fdp-qe
-    skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
     spec:
       containers:
       - args:
@@ -1051,7 +1050,6 @@ presubmits:
     name: pull-ci-openshift-ovn-kubernetes-release-4.21-e2e-aws-ovn-serial-ipsec
     optional: true
     rerun_command: /test e2e-aws-ovn-serial-ipsec
-    skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
     spec:
       containers:
       - args:
@@ -1214,7 +1212,6 @@ presubmits:
     name: pull-ci-openshift-ovn-kubernetes-release-4.21-e2e-aws-ovn-single-node-techpreview
     optional: true
     rerun_command: /test e2e-aws-ovn-single-node-techpreview
-    skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
     spec:
       containers:
       - args:
@@ -1296,7 +1293,6 @@ presubmits:
     name: pull-ci-openshift-ovn-kubernetes-release-4.21-e2e-aws-ovn-techpreview
     optional: true
     rerun_command: /test e2e-aws-ovn-techpreview
-    skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
     spec:
       containers:
       - args:
@@ -1459,7 +1455,6 @@ presubmits:
     name: pull-ci-openshift-ovn-kubernetes-release-4.21-e2e-aws-ovn-upgrade-ipsec
     optional: true
     rerun_command: /test e2e-aws-ovn-upgrade-ipsec
-    skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
     spec:
       containers:
       - args:
@@ -1703,7 +1698,6 @@ presubmits:
     name: pull-ci-openshift-ovn-kubernetes-release-4.21-e2e-azure-ovn
     optional: true
     rerun_command: /test e2e-azure-ovn
-    skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
     spec:
       containers:
       - args:
@@ -1785,7 +1779,6 @@ presubmits:
     name: pull-ci-openshift-ovn-kubernetes-release-4.21-e2e-azure-ovn-techpreview
     optional: true
     rerun_command: /test e2e-azure-ovn-techpreview
-    skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
     spec:
       containers:
       - args:
@@ -2111,7 +2104,6 @@ presubmits:
     name: pull-ci-openshift-ovn-kubernetes-release-4.21-e2e-metal-ipi-ovn-bgp-virt-dualstack
     optional: true
     rerun_command: /test e2e-metal-ipi-ovn-bgp-virt-dualstack
-    skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
     spec:
       containers:
       - args:
@@ -2194,7 +2186,6 @@ presubmits:
     name: pull-ci-openshift-ovn-kubernetes-release-4.21-e2e-metal-ipi-ovn-bgp-virt-dualstack-techpreview
     optional: true
     rerun_command: /test e2e-metal-ipi-ovn-bgp-virt-dualstack-techpreview
-    skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
     spec:
       containers:
       - args:
@@ -2523,7 +2514,6 @@ presubmits:
     name: pull-ci-openshift-ovn-kubernetes-release-4.21-e2e-metal-ipi-ovn-dualstack-local-gateway
     optional: true
     rerun_command: /test e2e-metal-ipi-ovn-dualstack-local-gateway
-    skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
     spec:
       containers:
       - args:
@@ -2606,7 +2596,6 @@ presubmits:
     name: pull-ci-openshift-ovn-kubernetes-release-4.21-e2e-metal-ipi-ovn-dualstack-local-gateway-techpreview
     optional: true
     rerun_command: /test e2e-metal-ipi-ovn-dualstack-local-gateway-techpreview
-    skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
     spec:
       containers:
       - args:
@@ -2689,7 +2678,6 @@ presubmits:
     name: pull-ci-openshift-ovn-kubernetes-release-4.21-e2e-metal-ipi-ovn-dualstack-techpreview
     optional: true
     rerun_command: /test e2e-metal-ipi-ovn-dualstack-techpreview
-    skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
     spec:
       containers:
       - args:
@@ -2772,7 +2760,6 @@ presubmits:
     name: pull-ci-openshift-ovn-kubernetes-release-4.21-e2e-metal-ipi-ovn-ipv4
     optional: true
     rerun_command: /test e2e-metal-ipi-ovn-ipv4
-    skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
     spec:
       containers:
       - args:
@@ -2937,7 +2924,6 @@ presubmits:
     name: pull-ci-openshift-ovn-kubernetes-release-4.21-e2e-metal-ipi-ovn-ipv6-techpreview
     optional: true
     rerun_command: /test e2e-metal-ipi-ovn-ipv6-techpreview
-    skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
     spec:
       containers:
       - args:
@@ -3020,7 +3006,6 @@ presubmits:
     name: pull-ci-openshift-ovn-kubernetes-release-4.21-e2e-metal-ipi-ovn-techpreview
     optional: true
     rerun_command: /test e2e-metal-ipi-ovn-techpreview
-    skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
     spec:
       containers:
       - args:
@@ -3104,7 +3089,6 @@ presubmits:
     name: pull-ci-openshift-ovn-kubernetes-release-4.21-e2e-metal-ovn-fdp-qe-ipv6
     optional: true
     rerun_command: /test e2e-metal-ovn-fdp-qe-ipv6
-    skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
     spec:
       containers:
       - args:
@@ -3186,7 +3170,6 @@ presubmits:
     name: pull-ci-openshift-ovn-kubernetes-release-4.21-e2e-openstack-ovn
     optional: true
     rerun_command: /test e2e-openstack-ovn
-    skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
     spec:
       containers:
       - args:
@@ -3268,7 +3251,6 @@ presubmits:
     name: pull-ci-openshift-ovn-kubernetes-release-4.21-e2e-ovn-hybrid-step-registry
     optional: true
     rerun_command: /test e2e-ovn-hybrid-step-registry
-    skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
     spec:
       containers:
       - args:
@@ -3350,7 +3332,6 @@ presubmits:
     name: pull-ci-openshift-ovn-kubernetes-release-4.21-e2e-vsphere-ovn
     optional: true
     rerun_command: /test e2e-vsphere-ovn
-    skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
     spec:
       containers:
       - args:
@@ -3432,7 +3413,6 @@ presubmits:
     name: pull-ci-openshift-ovn-kubernetes-release-4.21-e2e-vsphere-ovn-techpreview
     optional: true
     rerun_command: /test e2e-vsphere-ovn-techpreview
-    skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
     spec:
       containers:
       - args:
@@ -3514,7 +3494,6 @@ presubmits:
     name: pull-ci-openshift-ovn-kubernetes-release-4.21-e2e-vsphere-windows
     optional: true
     rerun_command: /test e2e-vsphere-windows
-    skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
     spec:
       containers:
       - args:
@@ -3915,7 +3894,6 @@ presubmits:
     name: pull-ci-openshift-ovn-kubernetes-release-4.21-openshift-e2e-gcp-ovn-techpreview-upgrade
     optional: true
     rerun_command: /test openshift-e2e-gcp-ovn-techpreview-upgrade
-    skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
     spec:
       containers:
       - args:
@@ -4429,7 +4407,6 @@ presubmits:
     name: pull-ci-openshift-ovn-kubernetes-release-4.21-perfscale-aws-ovn-medium-cluster-density-v2
     optional: true
     rerun_command: /test perfscale-aws-ovn-medium-cluster-density-v2
-    skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
     spec:
       containers:
       - args:
@@ -4511,7 +4488,6 @@ presubmits:
     name: pull-ci-openshift-ovn-kubernetes-release-4.21-perfscale-aws-ovn-medium-node-density-cni
     optional: true
     rerun_command: /test perfscale-aws-ovn-medium-node-density-cni
-    skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
     spec:
       containers:
       - args:
@@ -4593,7 +4569,6 @@ presubmits:
     name: pull-ci-openshift-ovn-kubernetes-release-4.21-perfscale-aws-ovn-small-cluster-density-v2
     optional: true
     rerun_command: /test perfscale-aws-ovn-small-cluster-density-v2
-    skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
     spec:
       containers:
       - args:
@@ -4675,7 +4650,6 @@ presubmits:
     name: pull-ci-openshift-ovn-kubernetes-release-4.21-perfscale-aws-ovn-small-node-density-cni
     optional: true
     rerun_command: /test perfscale-aws-ovn-small-node-density-cni
-    skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
     spec:
       containers:
       - args:
@@ -4757,7 +4731,6 @@ presubmits:
     name: pull-ci-openshift-ovn-kubernetes-release-4.21-qe-perfscale-aws-ovn-small-udn-density-l2
     optional: true
     rerun_command: /test qe-perfscale-aws-ovn-small-udn-density-l2
-    skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
     spec:
       containers:
       - args:


### PR DESCRIPTION
if jobs were already configured to be manually run (always_run: true, optional: true) then adding the skip_if_only_changed overrides that logic making those jobs actually run every time if the skip match doesn't hit. confusing...

this removes the skip config from those jobs.

docs here to explain the logic: https://docs.prow.k8s.io/docs/jobs/

we also missed the upgrade jobs in the initial work to implement this. this adds those as well.