### PR TITLE
Remove redundant repo copy

### DIFF
--- a/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main.yaml
+++ b/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main.yaml
@@ -74,8 +74,7 @@ images:
 - dockerfile_literal: |
     FROM src
     USER root
-    COPY /src /opt/app-root/src/github.com/Azure
-    WORKDIR /opt/app-root/src/github.com/Azure/ARO-HCP
+    WORKDIR /go/src/github.com/Azure/ARO-HCP
     ENV GOBIN="/usr/local/bin"
     ENV PATH="$GOBIN:/usr/local/bin:/usr/bin:$PATH"
     ENV GOFLAGS='-mod=readonly'
@@ -88,19 +87,13 @@ images:
     RUN mkdir -p "$(go env GOPATH)" && chmod -R 777 "$(go env GOPATH)"
     RUN mkdir -p "$(go env GOCACHE)" && chmod -R 777 "$(go env GOCACHE)"
     RUN mkdir -p "$(go env GOBIN)" && chmod -R 777 "$(go env GOBIN)"
-    RUN chmod 777 /opt/app-root/src/github.com/Azure/ARO-HCP
+    RUN chmod 777 /go/src/github.com/Azure/ARO-HCP
   from: src
-  inputs:
-    src:
-      paths:
-      - destination_dir: src
-        source_path: /go/src/github.com/Azure/ARO-HCP
   to: aro-hcp-e2e-tools
 - dockerfile_literal: |
     FROM src
     USER root
-    COPY /src /opt/app-root/src/github.com/Azure
-    WORKDIR /opt/app-root/src/github.com/Azure/ARO-HCP
+    WORKDIR /go/src/github.com/Azure/ARO-HCP
     # Install official Node.js binary from nodejs.org (pinned version)
     RUN curl -fsSL https://nodejs.org/dist/v22.5.1/node-v22.5.1-linux-x64.tar.xz | \
         tar -xJ -C /usr/local --strip-components=1 && \
@@ -108,11 +101,6 @@ images:
     # Install npm dependencies
     RUN cd api && npm ci --legacy-peer-deps
   from: src
-  inputs:
-    src:
-      paths:
-      - destination_dir: src
-        source_path: /go/src/github.com/Azure/ARO-HCP
   to: aro-hcp-api-tools
 promotion:
   to:

--- a/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__image-updater.yaml
+++ b/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__image-updater.yaml
@@ -19,8 +19,7 @@ images:
         mkdir -p /etc/containers && \
         echo '{"default":[{"type":"insecureAcceptAnything"}]}' > /etc/containers/policy.json
     # ARO-HCP
-    COPY /src /opt/app-root/src/github.com/Azure
-    WORKDIR /opt/app-root/src/github.com/Azure/ARO-HCP
+    WORKDIR /go/src/github.com/Azure/ARO-HCP
     ENV GOFLAGS='-mod=readonly'
     ENV GOPATH=/opt/app-root
     ENV GOCACHE=/opt/app-root/.cache
@@ -34,17 +33,14 @@ images:
     # Ensure all tools are in PATH
     ENV PATH="/usr/local/bin:$GOPATH/bin:$PATH"
     # Ensure all files are writable
-    RUN chmod -R a+w /opt/app-root
+    RUN chmod -R a+w /opt/app-root && \
+        chmod -R a+w /go/src/github.com/Azure/ARO-HCP
   from: src
   inputs:
     prcreator:
       paths:
       - destination_dir: .
         source_path: /usr/bin/prcreator
-    src:
-      paths:
-      - destination_dir: src
-        source_path: /go/src/github.com/Azure/ARO-HCP
   to: aro-hcp-automation-image-update
 resources:
   '*':


### PR DESCRIPTION
`src` image already fetches the repo at `/go/src/github.com/Azure/ARO-HCP` and hence no need of additional copy

```
podman run --rm registry.ci.openshift.org/aro-hcp/aro-hcp-e2e-tools:latest \         
      du -sh /go/src/github.com/Azure/ARO-HCP /opt/app-root/src/github.com/Azure/ARO-HCP
```
                                                                                         
  82M   /go/src/github.com/Azure/ARO-HCP                     - Only repo   
  842M  /opt/app-root/src/github.com/Azure/ARO-HCP  - Repo + built artifacts

