### PR TITLE
CNTRLPLANE-3002: allow conversion webhooks on azure

### DIFF
--- a/ci-operator/step-registry/hypershift/install/hypershift-install-commands.sh
+++ b/ci-operator/step-registry/hypershift/install/hypershift-install-commands.sh
@@ -101,7 +101,6 @@ case "${CLOUD_PROVIDER}" in
     fi
 
     "${HCP_CLI}" install --hypershift-image="${OPERATOR_IMAGE}" \
-    --enable-conversion-webhook=false \
     ${AZURE_MANAGED_SERVICE_ARGS} \
     ${AZURE_EXTERNAL_DNS_ARGS} \
     --platform-monitoring=All \


### PR DESCRIPTION
For the upgrade to CAPI 1.11 conversion between v1beta1 and v1beta2 is needed.