### PR TITLE
Remove vSphere CI jobs for OpenShift 4.6 through 4.11

### DIFF
--- a/ci-operator/config/openshift/release/openshift-release-main__ci-4.10-upgrade-from-stable-4.9.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__ci-4.10-upgrade-from-stable-4.9.yaml
@@ -3,10 +3,6 @@ base_images:
     name: "4.10"
     namespace: ocp
     tag: upi-installer
-  vsphere-ci-python:
-    name: vsphere-python
-    namespace: ci
-    tag: latest
 releases:
   initial:
     release:
@@ -48,11 +44,6 @@ tests:
   steps:
     cluster_profile: ovirt
     workflow: openshift-upgrade-ovirt
-- as: e2e-vsphere-upgrade
-  cron: '@yearly'
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: openshift-upgrade-vsphere
 - as: e2e-aws-ovn-upgrade
   cron: 21 4 23 */12 *
   steps:

--- a/ci-operator/config/openshift/release/openshift-release-main__ci-4.11-upgrade-from-stable-4.10.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__ci-4.11-upgrade-from-stable-4.10.yaml
@@ -3,10 +3,6 @@ base_images:
     name: "4.11"
     namespace: ocp
     tag: upi-installer
-  vsphere-ci-python:
-    name: vsphere-python
-    namespace: ci
-    tag: latest
 releases:
   initial:
     release:
@@ -48,11 +44,6 @@ tests:
   steps:
     cluster_profile: ovirt
     workflow: openshift-upgrade-ovirt
-- as: e2e-vsphere-upgrade
-  cron: 0 0 1 1 *
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: openshift-upgrade-vsphere
 - as: e2e-aws-ovn-upgrade
   cron: 47 1 7 */12 *
   steps:

--- a/ci-operator/config/openshift/release/openshift-release-main__ci-4.12-upgrade-from-stable-4.11.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__ci-4.12-upgrade-from-stable-4.11.yaml
@@ -3,10 +3,6 @@ base_images:
     name: "4.12"
     namespace: ocp
     tag: upi-installer
-  vsphere-ci-python:
-    name: vsphere-python
-    namespace: ci
-    tag: latest
 releases:
   initial:
     release:
@@ -62,11 +58,6 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-upgrade-ovirt
-- as: e2e-vsphere-sdn-upgrade
-  cron: 4 14 * * 0
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: openshift-upgrade-vsphere
 - as: e2e-aws-ovn-upgrade
   cron: 31 17 */11,23 * *
   steps:

--- a/ci-operator/config/openshift/release/openshift-release-main__ci-4.6-upgrade-from-stable-4.5.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__ci-4.6-upgrade-from-stable-4.5.yaml
@@ -3,10 +3,6 @@ base_images:
     name: "4.6"
     namespace: ocp
     tag: upi-installer
-  vsphere-ci-python:
-    name: vsphere-python
-    namespace: ci
-    tag: latest
 releases:
   initial:
     release:
@@ -44,13 +40,6 @@ tests:
     env:
       LOKI_USE_SERVICEMONITOR: ""
     workflow: openshift-upgrade-azure
-- as: e2e-vsphere-upgrade
-  cron: '@yearly'
-  steps:
-    cluster_profile: vsphere-elastic
-    env:
-      LOKI_USE_SERVICEMONITOR: ""
-    workflow: openshift-upgrade-vsphere
 - as: e2e-ovirt-upgrade
   cron: 17 13 12 */12 *
   steps:

--- a/ci-operator/config/openshift/release/openshift-release-main__ci-4.7-upgrade-from-stable-4.6.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__ci-4.7-upgrade-from-stable-4.6.yaml
@@ -3,10 +3,6 @@ base_images:
     name: "4.6"
     namespace: ocp
     tag: upi-installer
-  vsphere-ci-python:
-    name: vsphere-python
-    namespace: ci
-    tag: latest
 releases:
   initial:
     release:
@@ -44,11 +40,6 @@ tests:
     env:
       TEST_TYPE: upgrade-conformance
     workflow: openshift-upgrade-azure
-- as: e2e-vsphere-upgrade
-  cron: '@yearly'
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: openshift-upgrade-vsphere
 - as: e2e-ovirt-upgrade
   cron: 32 7 5,28 * *
   steps:

--- a/ci-operator/config/openshift/release/openshift-release-main__ci-4.8-upgrade-from-stable-4.7.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__ci-4.8-upgrade-from-stable-4.7.yaml
@@ -3,10 +3,6 @@ base_images:
     name: "4.7"
     namespace: ocp
     tag: upi-installer
-  vsphere-ci-python:
-    name: vsphere-python
-    namespace: ci
-    tag: latest
 releases:
   initial:
     release:
@@ -49,11 +45,6 @@ tests:
   steps:
     cluster_profile: ovirt
     workflow: openshift-upgrade-ovirt
-- as: e2e-vsphere-upgrade
-  cron: '@yearly'
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: openshift-upgrade-vsphere
 - as: e2e-aws-ovn-upgrade
   cron: 41 9 19 */12 *
   steps:

--- a/ci-operator/config/openshift/release/openshift-release-main__ci-4.9-upgrade-from-stable-4.8.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__ci-4.9-upgrade-from-stable-4.8.yaml
@@ -3,10 +3,6 @@ base_images:
     name: "4.9"
     namespace: ocp
     tag: upi-installer
-  vsphere-ci-python:
-    name: vsphere-python
-    namespace: ci
-    tag: latest
 releases:
   initial:
     release:
@@ -49,11 +45,6 @@ tests:
   steps:
     cluster_profile: ovirt
     workflow: openshift-upgrade-ovirt
-- as: e2e-vsphere-upgrade
-  cron: '@yearly'
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: openshift-upgrade-vsphere
 - as: e2e-aws-ovn-upgrade
   cron: 34 11 7 */12 *
   steps:

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.10.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.10.yaml
@@ -55,14 +55,6 @@ base_images:
     name: "4.10"
     namespace: ocp
     tag: upi-installer
-  vsphere-ci-python:
-    name: vsphere-python
-    namespace: ci
-    tag: latest
-  vsphere-csi-driver-operator-test:
-    name: "4.10"
-    namespace: ocp
-    tag: vsphere-csi-driver-operator-test
 releases:
   initial:
     candidate:
@@ -187,31 +179,6 @@ tests:
   steps:
     cluster_profile: openshift-org-aws
     workflow: openshift-e2e-aws-proxy
-- as: e2e-vsphere
-  cron: 35 9 13 10 *
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: openshift-e2e-vsphere
-- as: e2e-vsphere-serial
-  cron: 47 14 10 7 *
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: openshift-e2e-vsphere-serial
-- as: e2e-vsphere-upi
-  cron: 17 2 2 1 *
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: openshift-e2e-vsphere-upi
-- as: e2e-vsphere-upi-serial
-  cron: 34 13 14 9 *
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: openshift-e2e-vsphere-upi-serial
-- as: e2e-vsphere-techpreview
-  cron: 11 16 3 1 *
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: openshift-e2e-vsphere-techpreview
 - as: e2e-aws-ovn-local-gateway
   cron: 30 4 5 */12 *
   steps:
@@ -219,21 +186,6 @@ tests:
     env:
       GATEWAY_MODE: local
     workflow: openshift-e2e-aws-ovn
-- as: e2e-vsphere-ovn
-  cron: 11 8 4 4 *
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: openshift-e2e-vsphere-ovn
-- as: e2e-vsphere-techpreview-serial
-  cron: 7 8 1 6 *
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: openshift-e2e-vsphere-techpreview-serial
-- as: e2e-vsphere-csi
-  cron: 58 13 25 5 *
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: openshift-e2e-vsphere-csi
 - as: e2e-aws-workers-rhel8
   cron: 40 1 7 */12 *
   steps:

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.11.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.11.yaml
@@ -55,14 +55,6 @@ base_images:
     name: "4.11"
     namespace: ocp
     tag: upi-installer
-  vsphere-ci-python:
-    name: vsphere-python
-    namespace: ci
-    tag: latest
-  vsphere-csi-driver-operator-test:
-    name: "4.11"
-    namespace: ocp
-    tag: vsphere-csi-driver-operator-test
 releases:
   initial:
     candidate:
@@ -220,19 +212,6 @@ tests:
   steps:
     cluster_profile: openshift-org-aws
     workflow: openshift-e2e-aws-proxy
-- as: e2e-vsphere
-  cron: 10 0 1 1 *
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: openshift-e2e-vsphere
-- as: e2e-vsphere-techpreview
-  cron: 20 0 1 1 *
-  steps:
-    cluster_profile: vsphere-elastic
-    env:
-      TEST_SKIPS: 'In-tree Volumes \[Driver: vsphere\] \[Testpattern: Inline-volume\|
-        In-tree Volumes \[Driver: vsphere\] \[Testpattern: Pre-provisioned PV'
-    workflow: openshift-e2e-vsphere-techpreview
 - as: e2e-aws-ovn-local-gateway
   cron: 9 1 9 */12 *
   steps:
@@ -240,39 +219,6 @@ tests:
     env:
       GATEWAY_MODE: local
     workflow: openshift-e2e-aws-ovn
-- as: e2e-vsphere-ovn
-  cron: 30 0 1 1 *
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: openshift-e2e-vsphere-ovn
-- as: e2e-vsphere-serial
-  cron: 40 0 1 1 *
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: openshift-e2e-vsphere-serial
-- as: e2e-vsphere-techpreview-serial
-  cron: 50 0 1 1 *
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: openshift-e2e-vsphere-techpreview-serial
-- as: e2e-vsphere-upi
-  cron: 0 1 1 1 *
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: openshift-e2e-vsphere-upi
-- as: e2e-vsphere-upi-serial
-  cron: 10 1 1 1 *
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: openshift-e2e-vsphere-upi-serial
-- as: e2e-vsphere-csi
-  cron: 20 1 1 1 *
-  steps:
-    cluster_profile: vsphere-elastic
-    env:
-      TEST_SKIPS: provisioning should mount multiple PV pointing to the same storage
-        on the same node
-    workflow: openshift-e2e-vsphere-csi
 - as: e2e-aws-workers-rhel8
   cron: 12 10 9 */12 *
   steps:

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.6.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.6.yaml
@@ -27,10 +27,6 @@ base_images:
     name: "4.6"
     namespace: ocp
     tag: upi-installer
-  vsphere-ci-python:
-    name: vsphere-python
-    namespace: ci
-    tag: latest
 releases:
   initial:
     candidate:
@@ -54,26 +50,6 @@ tests:
   steps:
     cluster_profile: openshift-org-aws
     workflow: openshift-e2e-aws-proxy
-- as: e2e-vsphere
-  cron: 6 2 23 10 *
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: openshift-e2e-vsphere-release46
-- as: e2e-vsphere-serial
-  cron: 26 18 6 11 *
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: openshift-e2e-vsphere-serial
-- as: e2e-vsphere-upi
-  cron: 38 8 20 5 *
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: openshift-e2e-vsphere-upi-release46
-- as: e2e-vsphere-upi-serial
-  cron: 8 4 4 11 *
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: openshift-e2e-vsphere-upi-serial
 - as: e2e-aws-workers-rhel7
   cron: 25 4 14 */12 *
   steps:

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.7.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.7.yaml
@@ -23,10 +23,6 @@ base_images:
     name: "4.7"
     namespace: ocp
     tag: upi-installer
-  vsphere-ci-python:
-    name: vsphere-python
-    namespace: ci
-    tag: latest
 releases:
   initial:
     candidate:
@@ -117,31 +113,6 @@ tests:
   steps:
     cluster_profile: openshift-org-aws
     workflow: openshift-e2e-aws-proxy
-- as: e2e-vsphere
-  cron: 44 19 5 7 *
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: openshift-e2e-vsphere
-- as: e2e-vsphere-ovn
-  cron: 30 6 5 3 *
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: openshift-e2e-vsphere-ovn
-- as: e2e-vsphere-serial
-  cron: 16 21 9 7 *
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: openshift-e2e-vsphere-serial
-- as: e2e-vsphere-upi
-  cron: 59 14 2 1 *
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: openshift-e2e-vsphere-upi
-- as: e2e-vsphere-upi-serial
-  cron: 52 17 5 12 *
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: openshift-e2e-vsphere-upi-serial
 - as: e2e-aws-workers-rhel7
   cron: 6 1 7 */12 *
   steps:

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.8.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.8.yaml
@@ -39,14 +39,6 @@ base_images:
     name: "4.8"
     namespace: ocp
     tag: upi-installer
-  vsphere-ci-python:
-    name: vsphere-python
-    namespace: ci
-    tag: latest
-  vsphere-csi-driver-operator-test:
-    name: "4.8"
-    namespace: ocp
-    tag: vsphere-csi-driver-operator-test
 releases:
   initial:
     candidate:
@@ -143,26 +135,6 @@ tests:
   steps:
     cluster_profile: openshift-org-aws
     workflow: openshift-e2e-aws-proxy
-- as: e2e-vsphere
-  cron: 5 11 22 9 *
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: openshift-e2e-vsphere
-- as: e2e-vsphere-serial
-  cron: 12 21 26 4 *
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: openshift-e2e-vsphere-serial
-- as: e2e-vsphere-upi
-  cron: 58 9 10 2 *
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: openshift-e2e-vsphere-upi
-- as: e2e-vsphere-upi-serial
-  cron: 25 18 1 12 *
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: openshift-e2e-vsphere-upi-serial
 - as: e2e-aws-ovn-local-gateway
   cron: 22 20 8 */12 *
   steps:
@@ -170,16 +142,6 @@ tests:
     env:
       GATEWAY_MODE: local
     workflow: openshift-e2e-aws-ovn
-- as: e2e-vsphere-ovn
-  cron: 1 17 15 8 *
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: openshift-e2e-vsphere-ovn
-- as: e2e-vsphere-csi
-  cron: 11 19 5 6 *
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: openshift-e2e-vsphere-csi-techpreview
 - as: e2e-aws-workers-rhel7
   cron: 49 13 1 */12 *
   steps:

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.9.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.9.yaml
@@ -47,14 +47,6 @@ base_images:
     name: "4.9"
     namespace: ocp
     tag: upi-installer
-  vsphere-ci-python:
-    name: vsphere-python
-    namespace: ci
-    tag: latest
-  vsphere-csi-driver-operator-test:
-    name: "4.9"
-    namespace: ocp
-    tag: vsphere-csi-driver-operator-test
 releases:
   initial:
     candidate:
@@ -158,26 +150,6 @@ tests:
   steps:
     cluster_profile: openshift-org-aws
     workflow: openshift-e2e-aws-proxy
-- as: e2e-vsphere
-  cron: 46 17 17 3 *
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: openshift-e2e-vsphere
-- as: e2e-vsphere-serial
-  cron: 58 13 4 11 *
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: openshift-e2e-vsphere-serial
-- as: e2e-vsphere-upi
-  cron: 25 7 4 6 *
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: openshift-e2e-vsphere-upi
-- as: e2e-vsphere-upi-serial
-  cron: 50 17 27 5 *
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: openshift-e2e-vsphere-upi-serial
 - as: e2e-aws-ovn-local-gateway
   cron: 51 17 11 */12 *
   steps:
@@ -185,16 +157,6 @@ tests:
     env:
       GATEWAY_MODE: local
     workflow: openshift-e2e-aws-ovn
-- as: e2e-vsphere-ovn
-  cron: 19 22 18 1 *
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: openshift-e2e-vsphere-ovn
-- as: e2e-vsphere-csi
-  cron: 27 4 22 9 *
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: openshift-e2e-vsphere-csi-techpreview
 - as: e2e-aws-workers-rhel7
   cron: 31 9 8 */12 *
   steps:

--- a/core-services/release-controller/_releases/priv/release-ocp-4.10.json
+++ b/core-services/release-controller/_releases/priv/release-ocp-4.10.json
@@ -335,41 +335,6 @@
             },
             "upgrade": true,
             "upgradeFrom": "PreviousMinor"
-        },
-        "vsphere": {
-            "disabled": true,
-            "optional": true,
-            "prowJob": {
-                "name": "periodic-ci-openshift-release-main-nightly-4.10-e2e-vsphere-priv"
-            }
-        },
-        "vsphere-csi": {
-            "disabled": true,
-            "optional": true,
-            "prowJob": {
-                "name": "periodic-ci-openshift-release-main-nightly-4.10-e2e-vsphere-csi-priv"
-            }
-        },
-        "vsphere-serial": {
-            "disabled": true,
-            "optional": true,
-            "prowJob": {
-                "name": "periodic-ci-openshift-release-main-nightly-4.10-e2e-vsphere-serial-priv"
-            }
-        },
-        "vsphere-upi": {
-            "disabled": true,
-            "optional": true,
-            "prowJob": {
-                "name": "periodic-ci-openshift-release-main-nightly-4.10-e2e-vsphere-upi-priv"
-            }
-        },
-        "vsphere-upi-serial": {
-            "disabled": true,
-            "optional": true,
-            "prowJob": {
-                "name": "periodic-ci-openshift-release-main-nightly-4.10-e2e-vsphere-upi-serial-priv"
-            }
         }
     }
 }

--- a/core-services/release-controller/_releases/priv/release-ocp-4.7.json
+++ b/core-services/release-controller/_releases/priv/release-ocp-4.7.json
@@ -147,34 +147,6 @@
             },
             "upgrade": true,
             "upgradeFrom": "PreviousMinor"
-        },
-        "vsphere": {
-            "disabled": true,
-            "optional": true,
-            "prowJob": {
-                "name": "periodic-ci-openshift-release-main-nightly-4.7-e2e-vsphere-priv"
-            }
-        },
-        "vsphere-serial": {
-            "disabled": true,
-            "optional": true,
-            "prowJob": {
-                "name": "periodic-ci-openshift-release-main-nightly-4.7-e2e-vsphere-serial-priv"
-            }
-        },
-        "vsphere-upi": {
-            "disabled": true,
-            "optional": true,
-            "prowJob": {
-                "name": "periodic-ci-openshift-release-main-nightly-4.7-e2e-vsphere-upi-priv"
-            }
-        },
-        "vsphere-upi-serial": {
-            "disabled": true,
-            "optional": true,
-            "prowJob": {
-                "name": "periodic-ci-openshift-release-main-nightly-4.7-e2e-vsphere-upi-serial-priv"
-            }
         }
     }
 }

--- a/core-services/release-controller/_releases/priv/release-ocp-4.8.json
+++ b/core-services/release-controller/_releases/priv/release-ocp-4.8.json
@@ -177,34 +177,6 @@
             },
             "upgrade": true,
             "upgradeFrom": "PreviousMinor"
-        },
-        "vsphere": {
-            "disabled": true,
-            "optional": true,
-            "prowJob": {
-                "name": "periodic-ci-openshift-release-main-nightly-4.8-e2e-vsphere-priv"
-            }
-        },
-        "vsphere-serial": {
-            "disabled": true,
-            "optional": true,
-            "prowJob": {
-                "name": "periodic-ci-openshift-release-main-nightly-4.8-e2e-vsphere-serial-priv"
-            }
-        },
-        "vsphere-upi": {
-            "disabled": true,
-            "optional": true,
-            "prowJob": {
-                "name": "periodic-ci-openshift-release-main-nightly-4.8-e2e-vsphere-upi-priv"
-            }
-        },
-        "vsphere-upi-serial": {
-            "disabled": true,
-            "optional": true,
-            "prowJob": {
-                "name": "periodic-ci-openshift-release-main-nightly-4.8-e2e-vsphere-upi-serial-priv"
-            }
         }
     }
 }

--- a/core-services/release-controller/_releases/priv/release-ocp-4.9.json
+++ b/core-services/release-controller/_releases/priv/release-ocp-4.9.json
@@ -239,34 +239,6 @@
             },
             "upgrade": true,
             "upgradeFrom": "PreviousMinor"
-        },
-        "vsphere": {
-            "disabled": true,
-            "optional": true,
-            "prowJob": {
-                "name": "periodic-ci-openshift-release-main-nightly-4.9-e2e-vsphere-priv"
-            }
-        },
-        "vsphere-serial": {
-            "disabled": true,
-            "optional": true,
-            "prowJob": {
-                "name": "periodic-ci-openshift-release-main-nightly-4.9-e2e-vsphere-serial-priv"
-            }
-        },
-        "vsphere-upi": {
-            "disabled": true,
-            "optional": true,
-            "prowJob": {
-                "name": "periodic-ci-openshift-release-main-nightly-4.9-e2e-vsphere-upi-priv"
-            }
-        },
-        "vsphere-upi-serial": {
-            "disabled": true,
-            "optional": true,
-            "prowJob": {
-                "name": "periodic-ci-openshift-release-main-nightly-4.9-e2e-vsphere-upi-serial-priv"
-            }
         }
     }
 }

--- a/core-services/release-controller/_releases/release-ocp-4.10.json
+++ b/core-services/release-controller/_releases/release-ocp-4.10.json
@@ -187,30 +187,6 @@
         "name": "periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-single-node-serial"
       }
     },
-    "vsphere-upi": {
-      "optional": true,
-      "prowJob": {
-        "name": "periodic-ci-openshift-release-main-nightly-4.10-e2e-vsphere-upi"
-      }
-    },
-    "vsphere": {
-      "optional": true,
-      "prowJob": {
-        "name": "periodic-ci-openshift-release-main-nightly-4.10-e2e-vsphere"
-      }
-    },
-    "vsphere-upi-serial": {
-      "optional": true,
-      "prowJob": {
-        "name": "periodic-ci-openshift-release-main-nightly-4.10-e2e-vsphere-upi-serial"
-      }
-    },
-    "vsphere-serial": {
-      "optional": true,
-      "prowJob": {
-        "name": "periodic-ci-openshift-release-main-nightly-4.10-e2e-vsphere-serial"
-      }
-    },
     "aws-console": {
       "optional": true,
       "prowJob": {
@@ -331,12 +307,6 @@
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-nightly-4.10-e2e-ovirt-csi"
-      }
-    },
-    "vsphere-csi": {
-      "optional": true,
-      "prowJob": {
-        "name": "periodic-ci-openshift-release-main-nightly-4.10-e2e-vsphere-csi"
       }
     },
     "alibaba": {

--- a/core-services/release-controller/_releases/release-ocp-4.7.json
+++ b/core-services/release-controller/_releases/release-ocp-4.7.json
@@ -69,22 +69,6 @@
       "optional": true,
       "prowJob":{"name":"periodic-ci-openshift-release-main-nightly-4.7-e2e-metal-ipi-virtualmedia"}
     },
-    "vsphere-upi":{
-      "optional": true,
-      "prowJob":{"name":"periodic-ci-openshift-release-main-nightly-4.7-e2e-vsphere-upi"}
-    },
-    "vsphere":{
-      "optional": true,
-      "prowJob":{"name":"periodic-ci-openshift-release-main-nightly-4.7-e2e-vsphere"}
-    },
-    "vsphere-upi-serial":{
-      "optional": true,
-      "prowJob":{"name":"periodic-ci-openshift-release-main-nightly-4.7-e2e-vsphere-upi-serial"}
-    },
-    "vsphere-serial":{
-      "optional": true,
-      "prowJob":{"name":"periodic-ci-openshift-release-main-nightly-4.7-e2e-vsphere-serial"}
-    },
     "aws-console":{
       "optional":true,
       "prowJob":{"name":"periodic-ci-openshift-release-main-nightly-4.7-console-aws"}

--- a/core-services/release-controller/_releases/release-ocp-4.8.json
+++ b/core-services/release-controller/_releases/release-ocp-4.8.json
@@ -87,22 +87,6 @@
       "optional":true,
       "prowJob":{"name":"periodic-ci-openshift-release-main-nightly-4.8-e2e-metal-single-node-live-iso"}
     },
-    "vsphere-upi":{
-      "optional": true,
-      "prowJob":{"name":"periodic-ci-openshift-release-main-nightly-4.8-e2e-vsphere-upi"}
-    },
-    "vsphere":{
-      "optional": true,
-      "prowJob":{"name":"periodic-ci-openshift-release-main-nightly-4.8-e2e-vsphere"}
-    },
-    "vsphere-upi-serial":{
-      "optional": true,
-      "prowJob":{"name":"periodic-ci-openshift-release-main-nightly-4.8-e2e-vsphere-upi-serial"}
-    },
-    "vsphere-serial":{
-      "optional": true,
-      "prowJob":{"name":"periodic-ci-openshift-release-main-nightly-4.8-e2e-vsphere-serial"}
-    },
     "aws-console":{
       "optional":true,
       "prowJob":{"name":"periodic-ci-openshift-release-main-nightly-4.8-console-aws"}

--- a/core-services/release-controller/_releases/release-ocp-4.9.json
+++ b/core-services/release-controller/_releases/release-ocp-4.9.json
@@ -120,22 +120,6 @@
       "optional":true,
       "prowJob":{"name":"periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-single-node-serial"}
     },
-    "vsphere-upi":{
-      "optional": true,
-      "prowJob":{"name":"periodic-ci-openshift-release-main-nightly-4.9-e2e-vsphere-upi"}
-    },
-    "vsphere":{
-      "optional": true,
-      "prowJob":{"name":"periodic-ci-openshift-release-main-nightly-4.9-e2e-vsphere"}
-    },
-    "vsphere-upi-serial":{
-      "optional": true,
-      "prowJob":{"name":"periodic-ci-openshift-release-main-nightly-4.9-e2e-vsphere-upi-serial"}
-    },
-    "vsphere-serial":{
-      "optional": true,
-      "prowJob":{"name":"periodic-ci-openshift-release-main-nightly-4.9-e2e-vsphere-serial"}
-    },
     "aws-console":{
       "optional":true,
       "prowJob":{"name":"periodic-ci-openshift-release-main-nightly-4.9-console-aws"}


### PR DESCRIPTION
- Remove vSphere test and upgrade job definitions from ci-operator configs for nightly-4.6, 4.7, 4.8, 4.9, 4.10 and corresponding ci-*-upgrade configs.
- Remove vSphere from OKD 4.10 config.
- Remove vSphere job references from release controller annotations (release-ocp-4.7 through 4.10, public and priv).


Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed vSphere-related CI images and testing jobs across OpenShift release and nightly pipelines (affecting multiple versions from 4.6 through 4.12).
  * Deleted scheduled vSphere E2E and upgrade tests, including nightly and periodic cron entries.
  * Cleared optional vSphere verification targets from release verification configs so vSphere suites will no longer run in nightly/upgrade verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->