### PR TITLE
Hive: e2e-azure: increase timeout

### DIFF
--- a/ci-operator/config/openshift/hive/openshift-hive-master.yaml
+++ b/ci-operator/config/openshift/hive/openshift-hive-master.yaml
@@ -217,7 +217,9 @@ tests:
       resources:
         requests:
           cpu: 100m
+      timeout: 2h30m0s
     workflow: ipi-azure
+  timeout: 4h30m0s
 - as: e2e-vsphere
   run_if_changed: vsphere
   steps:

--- a/ci-operator/jobs/openshift/hive/openshift-hive-master-presubmits.yaml
+++ b/ci-operator/jobs/openshift/hive/openshift-hive-master-presubmits.yaml
@@ -161,6 +161,7 @@ presubmits:
     decorate: true
     decoration_config:
       skip_cloning: true
+      timeout: 4h30m0s
     labels:
       ci-operator.openshift.io/cloud: azure4
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-azure


### PR DESCRIPTION
In 4.20, where we're still using gallery images by default, e2e-azure was consistently timing out. Increase the timeouts by half an hour.

Our presubmits are running on 4.21, which uses marketplace images by default, and is thus enough faster to still pass with the default timeouts.