### PR TITLE
tide: require CodeQL checks for ARO-HCP

### DIFF
--- a/core-services/prow/02_config/_config.yaml
+++ b/core-services/prow/02_config/_config.yaml
@@ -659,6 +659,8 @@ tide:
                 - validate_bicep
                 - test-grafana-script
                 - test-prometheus-rules
+                - CodeQL Analysis / Analyze (go)
+                - CodeQL Analysis / Analyze (python)
                 skip-unknown-contexts: true
       ViaQ:
         repos:


### PR DESCRIPTION
This should correctly block PRs from merging where CodeQL fails.