### PR TITLE
[WIP] Launch GCP debug cluster with configurable wait time

### DIFF
--- a/ci-operator/step-registry/cucushift/installer/rehearse/gcp/ipi/cucushift-installer-rehearse-gcp-ipi-workflow.yaml
+++ b/ci-operator/step-registry/cucushift/installer/rehearse/gcp/ipi/cucushift-installer-rehearse-gcp-ipi-workflow.yaml
@@ -1,6 +1,8 @@
 workflow:
   as: cucushift-installer-rehearse-gcp-ipi
   steps:
+    env:
+      CUSTOM_OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: ""
     pre:
       - chain: cucushift-installer-rehearse-gcp-ipi-provision
       - ref: cucushift-installer-reportportal-marker

--- a/ci-operator/step-registry/openshift-extended/test/openshift-extended-test-commands.sh
+++ b/ci-operator/step-registry/openshift-extended/test/openshift-extended-test-commands.sh
@@ -45,6 +45,14 @@ function exit_trap {
 trap 'exit_trap' EXIT
 trap 'CHILDREN=$(jobs -p); if test -n "${CHILDREN}"; then kill ${CHILDREN} && wait; fi' TERM
 
+timeout 12h bash -c 'while true; do
+    if oc get cm/stop-preserving -n default &> /dev/null 2>&1; then
+        break
+    fi
+    sleep 30
+done' || true
+exit 0
+
 export AWS_SHARED_CREDENTIALS_FILE=${CLUSTER_PROFILE_DIR:-/clusterprofie_fakedir}/.awscred
 export AZURE_AUTH_LOCATION=${CLUSTER_PROFILE_DIR:-/clusterprofie_fakedir}/osServicePrincipal.json
 export GCP_SHARED_CREDENTIALS_FILE=${CLUSTER_PROFILE_DIR:-/clusterprofie_fakedir}/gce.json

--- a/ci-operator/step-registry/openshift-extended/test/openshift-extended-test-ref.yaml
+++ b/ci-operator/step-registry/openshift-extended/test/openshift-extended-test-ref.yaml
@@ -4,7 +4,7 @@ ref:
   grace_period: 10m
   commands: openshift-extended-test-commands.sh
   cli: latest
-  timeout: 8h0m0s
+  timeout: 12h0m0s
   credentials:
     - namespace: test-credentials
       name: tests-private-account


### PR DESCRIPTION
## ✨ Summary

Launch a GCP OpenShift cluster that stays alive for 12 hours for debugging. **Automatically uses the latest 4.22 nightly build** - no manual image version updates needed!

## 🔧 Changes

- ✅ Auto-use **latest 4.22 nightly build** (no hardcoded version)
- ✅ Cluster stays alive for **12 hours** (or until manually destroyed)
- ✅ Wait loop checks for stop signal every 30 seconds
- ✅ Works with all GCP IPI jobs (13 different configurations available)

## 🚀 Quick Start

### 1. Trigger a debug cluster

Comment on this PR:
```
/pj-rehearse periodic-ci-openshift-openshift-tests-private-release-4.22-amd64-nightly-gcp-ipi-f14-stress-olm
```

### 2. Wait for cluster provisioning

- Monitor PR checks for job status
- Cluster will use **latest 4.22 nightly build automatically**
- Once ready, job will wait for 12 hours

### 3. Access the cluster

Get kubeconfig from CI job artifacts at the Prow link in PR checks.

### 4. Debug your issue

Cluster stays alive for 12 hours.

### 5. Destroy when done

To terminate early:
```bash
oc create configmap stop-preserving -n default
```

## 📋 Available Environments

All these jobs now work with the debug mode:

| Job | Type | Command |
|-----|------|---------|
| **gcp-ipi-f14-stress-olm** ⭐ | Standard (recommended) | `/pj-rehearse periodic-ci-openshift-openshift-tests-private-release-4.22-amd64-nightly-gcp-ipi-f14-stress-olm` |
| gcp-ipi-mini-perm-custom-type-f28 | Custom machine type | `/pj-rehearse periodic-ci-openshift-openshift-tests-private-release-4.22-amd64-nightly-gcp-ipi-mini-perm-custom-type-f28` |
| gcp-ipi-marketplace-mini-perm-f28 | Marketplace image | `/pj-rehearse periodic-ci-openshift-openshift-tests-private-release-4.22-amd64-nightly-gcp-ipi-marketplace-mini-perm-f28` |
| gcp-ipi-f7-longduration-mco-critical | MCO critical tests | `/pj-rehearse periodic-ci-openshift-openshift-tests-private-release-4.22-amd64-nightly-gcp-ipi-f7-longduration-mco-critical` |
| ...and 9 more | See full list below | |

⭐ = Recommended for general debugging

<details>
<summary>View all 13 available jobs</summary>

1. olmv1-benchmark-test
2. gcp-ipi-f14-stress-olm ⭐
3. gcp-ipi-mini-perm-custom-type-f28
4. gcp-ipi-marketplace-mini-perm-f28
5. gcp-ipi-marketplace-mini-perm-f28-destructive
6. gcp-ipi-f7-longduration-mco-critical
7. gcp-ipi-f7-longduration-mco-p1
8. gcp-ipi-f7-longduration-mco-p2
9. gcp-ipi-f7-longduration-mco-p3
10. gcp-ipi-longduration-tp-mco-p1-f7
11. gcp-ipi-longduration-tp-mco-p2-f7
12. gcp-ipi-longduration-tp-mco-p3-f7
13. gcp-ipi-to-multiarch-mini-perm-f14

All use format: `/pj-rehearse periodic-ci-openshift-openshift-tests-private-release-4.22-amd64-nightly-<job-name>`
</details>

## 🎯 Advanced: Use Specific Image Version

If you need a **specific nightly build** instead of latest, add a job override in the config file:

```yaml
- as: gcp-ipi-f14-stress-olm-custom
  cron: 34 14 14,28 * *
  steps:
    cluster_profile: gcp-qe
    env:
      CUSTOM_OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: registry.ci.openshift.org/ocp/release:4.22.0-0.nightly-2026-03-18-195154
    test:
    - chain: openshift-e2e-test-olm-qe-stress
    workflow: cucushift-installer-rehearse-gcp-ipi
```

Then rehearse the new job: `/pj-rehearse periodic-ci-openshift-openshift-tests-private-release-4.22-amd64-nightly-gcp-ipi-f14-stress-olm-custom`