### PR TITLE
Add deploy-sno-reconfig-ipv6 test job for jetlag

### DIFF
--- a/ci-operator/config/redhat-performance/jetlag/redhat-performance-jetlag-main.yaml
+++ b/ci-operator/config/redhat-performance/jetlag/redhat-performance-jetlag-main.yaml
@@ -34,9 +34,9 @@ tests:
   steps:
     cluster_profile: metal-perfscale-jetlag
     env:
-      TYPE: sno
-      REDEPLOY_IPV6: "true"
       JETLAG_PR: "787"
+      REDEPLOY_IPV6: "true"
+      TYPE: sno
     workflow: openshift-qe-installer-bm-deploy
 - always_run: false
   as: deploy-sno-private

--- a/ci-operator/config/redhat-performance/jetlag/redhat-performance-jetlag-main.yaml
+++ b/ci-operator/config/redhat-performance/jetlag/redhat-performance-jetlag-main.yaml
@@ -27,6 +27,18 @@ tests:
       TYPE: sno
     workflow: openshift-qe-installer-bm-deploy
 - always_run: false
+  as: deploy-sno-reconfig-ipv6
+  capabilities:
+  - intranet
+  restrict_network_access: false
+  steps:
+    cluster_profile: metal-perfscale-jetlag
+    env:
+      TYPE: sno
+      REDEPLOY_IPV6: "true"
+      JETLAG_PR: "787"
+    workflow: openshift-qe-installer-bm-deploy
+- always_run: false
   as: deploy-sno-private
   capabilities:
   - intranet

--- a/ci-operator/jobs/redhat-performance/jetlag/redhat-performance-jetlag-main-presubmits.yaml
+++ b/ci-operator/jobs/redhat-performance/jetlag/redhat-performance-jetlag-main-presubmits.yaml
@@ -1002,6 +1002,89 @@ presubmits:
     - ^main$
     - ^main-
     cluster: build09
+    context: ci/prow/deploy-sno-reconfig-ipv6
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      capability/intranet: intranet
+      ci-operator.openshift.io/cloud: metal-perfscale-jetlag
+      ci-operator.openshift.io/cloud-cluster-profile: metal-perfscale-jetlag
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-redhat-performance-jetlag-main-deploy-sno-reconfig-ipv6
+    rerun_command: /test deploy-sno-reconfig-ipv6
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=deploy-sno-reconfig-ipv6
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )(deploy-sno-reconfig-ipv6|remaining-required),?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build09
     context: ci/prow/deploy-sno-scaleout
     decorate: true
     decoration_config:

--- a/ci-operator/step-registry/openshift-qe/installer/bm/deploy/openshift-qe-installer-bm-deploy-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/installer/bm/deploy/openshift-qe-installer-bm-deploy-commands.sh
@@ -303,3 +303,53 @@ ssh ${SSH_ARGS} root@${bastion} "
 "
 
 scp -q ${SSH_ARGS} root@${bastion}:/root/$LAB/$LAB_CLOUD/$TYPE/kubeconfig ${SHARED_DIR}/kubeconfig
+
+# IPv6 reconfig test: after successful IPv4 deploy, reconfigure for IPv6
+# and redeploy on the same bastion WITHOUT cleaning up containers.
+# This tests that setup-bastion.yml properly reconfigures the assisted-service pod.
+if [[ "${REDEPLOY_IPV6:-false}" == "true" ]]; then
+  echo "=== REDEPLOY_IPV6: Reconfiguring for IPv6 and redeploying ==="
+
+  # Write IPv6 network overrides to append to all.yml
+  cat > /tmp/ipv6-overrides.yml << 'IPV6_EOF'
+
+# IPv6 reconfiguration - appended by REDEPLOY_IPV6
+controlplane_network:
+- fd00:198:18:10::/64
+controlplane_network_prefix:
+- 64
+cluster_network_cidr:
+- fd01::/48
+cluster_network_host_prefix:
+- 64
+service_network_cidr:
+- fd02::/112
+setup_bastion_registry: true
+use_bastion_registry: true
+IPV6_EOF
+
+  scp -q ${SSH_ARGS} /tmp/ipv6-overrides.yml root@${bastion}:/tmp/ipv6-overrides.yml
+  ssh ${SSH_ARGS} root@${bastion} "cat /tmp/ipv6-overrides.yml >> ${jetlag_repo}/ansible/vars/all.yml"
+
+  echo "Updated all.yml for IPv6:"
+  ssh ${SSH_ARGS} root@${bastion} "cat ${jetlag_repo}/ansible/vars/all.yml"
+
+  # Redeploy: re-bootstrap, re-run setup-bastion + deploy (NO clean-resources.sh)
+  ssh ${SSH_ARGS} root@${bastion} "
+    set -e
+    set -o pipefail
+    cd ${jetlag_repo}
+    source bootstrap.sh
+    ansible-playbook ansible/create-inventory.yml | tee /tmp/ansible-create-inventory-ipv6-\$(date +%s)
+    ansible-playbook -i ansible/inventory/$LAB_CLOUD.local ansible/setup-bastion.yml | tee /tmp/ansible-setup-bastion-ipv6-\$(date +%s)
+    ansible-playbook -i ansible/inventory/$LAB_CLOUD.local ansible/sno-deploy.yml -v | tee /tmp/ansible-sno-deploy-ipv6-\$(date +%s)
+    mkdir -p /root/$LAB/$LAB_CLOUD/sno-ipv6
+    ansible -i ansible/inventory/$LAB_CLOUD.local bastion -m fetch -a 'src=${KUBECONFIG_SRC} dest=/root/$LAB/$LAB_CLOUD/sno-ipv6/kubeconfig flat=true'
+    deactivate
+    rm -rf .ansible
+  "
+
+  # Overwrite kubeconfig with IPv6 cluster's version
+  scp -q ${SSH_ARGS} root@${bastion}:/root/$LAB/$LAB_CLOUD/sno-ipv6/kubeconfig ${SHARED_DIR}/kubeconfig
+  echo "=== REDEPLOY_IPV6: IPv6 redeploy completed successfully ==="
+fi

--- a/ci-operator/step-registry/openshift-qe/installer/bm/deploy/openshift-qe-installer-bm-deploy-ref.yaml
+++ b/ci-operator/step-registry/openshift-qe/installer/bm/deploy/openshift-qe-installer-bm-deploy-ref.yaml
@@ -52,6 +52,12 @@ ref:
       default: "true"
       documentation: |-
         Host cluster on a lab public routable VLAN network
+    - name: REDEPLOY_IPV6
+      default: "false"
+      documentation: |-
+        After initial IPv4 deployment, reconfigure for single-stack IPv6 and
+        redeploy on the same bastion without cleaning up. Tests that the
+        assisted-service pod picks up configuration changes on redeploy.
     - name: RESET_IDRAC
       default: "true"
       documentation: |-


### PR DESCRIPTION
## Summary

Add a test job that verifies the assisted-service pod properly picks up configuration changes when redeploying on the same bastion. The job:

1. Deploys SNO with standard IPv4 configuration
2. Reconfigures `all.yml` for single-stack IPv6 with `setup_bastion_registry: true` and `use_bastion_registry: true`
3. Re-runs `setup-bastion.yml` + `sno-deploy.yml` **without** cleaning up containers
4. Verifies the IPv6 deployment succeeds (assisted-service pod picks up new config)

This tests the fix in https://github.com/redhat-performance/jetlag/pull/787.

## Changes

- **ref YAML**: Add `REDEPLOY_IPV6` env var (default `false`)
- **commands script**: After initial deploy, if `REDEPLOY_IPV6=true`, append IPv6 network config + `setup_bastion_registry: true` + `use_bastion_registry: true` to `all.yml` and redeploy without `clean-resources.sh`
- **test config**: Add `deploy-sno-reconfig-ipv6` test entry with `JETLAG_PR: "787"`

## After jetlag PR merges

Remove `JETLAG_PR: "787"` from the test entry and keep the job as a permanent regression test.

## Test plan

- [ ] `/test deploy-sno-reconfig-ipv6` — verifies the full IPv4→IPv6 reconfig path