### PR TITLE
Changed containers orders based on main app

### DIFF
--- a/clusters/app.ci/prow/03_deployment/boskos.yaml
+++ b/clusters/app.ci/prow/03_deployment/boskos.yaml
@@ -53,6 +53,34 @@ objects:
         serviceAccountName: boskos
         terminationGracePeriodSeconds: 30
         containers:
+        - name: boskos
+          image: quay-proxy.ci.openshift.org/openshift/ci:ci_boskos_latest
+          imagePullPolicy: Always
+          args:
+          - --config=/etc/config/boskos.yaml
+          - --namespace=${namespace}
+          - --projected-token-file=/var/sa-token/token
+          - --log-level=debug
+          - --pod-name=$(POD_NAME)
+          - --boskos-label-selector=app=prow,component=boskos
+          - --enable-leader-election=true
+          env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+            - name: metrics
+              containerPort: 9090
+              protocol: TCP
+          volumeMounts:
+          - name: boskos-config
+            mountPath: /etc/config
+            readOnly: true
+          - name: service-account-token
+            mountPath: /var/sa-token
         - args:
           - -provider=openshift
           - -https-address=:8082
@@ -85,34 +113,6 @@ objects:
             name: secret-boskos-tls
           - mountPath: /etc/proxy/secrets
             name: secret-boskos-proxy
-        - name: boskos
-          image: quay-proxy.ci.openshift.org/openshift/ci:ci_boskos_latest
-          imagePullPolicy: Always
-          args:
-          - --config=/etc/config/boskos.yaml
-          - --namespace=${namespace}
-          - --projected-token-file=/var/sa-token/token
-          - --log-level=debug
-          - --pod-name=$(POD_NAME)
-          - --boskos-label-selector=app=prow,component=boskos
-          - --enable-leader-election=true
-          env:
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          ports:
-            - containerPort: 8080
-              protocol: TCP
-            - name: metrics
-              containerPort: 9090
-              protocol: TCP
-          volumeMounts:
-          - name: boskos-config
-            mountPath: /etc/config
-            readOnly: true
-          - name: service-account-token
-            mountPath: /var/sa-token
         volumes:
           - name: boskos-config
             configMap:

--- a/clusters/app.ci/prow/03_deployment/crier.yaml
+++ b/clusters/app.ci/prow/03_deployment/crier.yaml
@@ -58,24 +58,6 @@ spec:
         - name: release
           mountPath: /tmp/git-sync
       containers:
-      - name: git-sync
-        command:
-        - /git-sync
-        args:
-        - --repo=https://github.com/openshift/release.git
-        - --ref=main
-        - --period=30s
-        - --root=/tmp/git-sync
-        - --max-failures=3
-        - --link=release
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_git-sync_v4.3.0
-        volumeMounts:
-        - name: release
-          mountPath: /tmp/git-sync
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "0.5"
       - name: crier
         image: us-docker.pkg.dev/k8s-infra-prow/images/crier:v20260316-25576911a
         args:
@@ -126,6 +108,24 @@ spec:
           requests:
             memory: "10Gi"
             cpu: "600m"
+      - name: git-sync
+        command:
+        - /git-sync
+        args:
+        - --repo=https://github.com/openshift/release.git
+        - --ref=main
+        - --period=30s
+        - --root=/tmp/git-sync
+        - --max-failures=3
+        - --link=release
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_git-sync_v4.3.0
+        volumeMounts:
+        - name: release
+          mountPath: /tmp/git-sync
+        resources:
+          requests:
+            memory: "1Gi"
+            cpu: "0.5"
       volumes:
       - name: service-account-token
         projected:

--- a/clusters/app.ci/prow/03_deployment/deck.yaml
+++ b/clusters/app.ci/prow/03_deployment/deck.yaml
@@ -117,24 +117,6 @@ objects:
           - name: release
             mountPath: /tmp/git-sync
         containers:
-        - name: git-sync
-          command:
-          - /git-sync
-          args:
-          - --repo=https://github.com/openshift/release.git
-          - --ref=main
-          - --period=30s
-          - --root=/tmp/git-sync
-          - --max-failures=3
-          - --link=release
-          image: quay-proxy.ci.openshift.org/openshift/ci:ci_git-sync_v4.3.0
-          volumeMounts:
-          - name: release
-            mountPath: /tmp/git-sync
-          resources:
-            requests:
-              memory: "1Gi"
-              cpu: "0.5"
         - name: deck
           image: us-docker.pkg.dev/k8s-infra-prow/images/deck:v20260316-25576911a
           args:
@@ -214,6 +196,24 @@ objects:
             requests:
               memory: "11Gi"
               cpu: "500m"
+        - name: git-sync
+          command:
+          - /git-sync
+          args:
+          - --repo=https://github.com/openshift/release.git
+          - --ref=main
+          - --period=30s
+          - --root=/tmp/git-sync
+          - --max-failures=3
+          - --link=release
+          image: quay-proxy.ci.openshift.org/openshift/ci:ci_git-sync_v4.3.0
+          volumeMounts:
+          - name: release
+            mountPath: /tmp/git-sync
+          resources:
+            requests:
+              memory: "1Gi"
+              cpu: "0.5"
         volumes:
         - name: github-app-credentials
           secret:

--- a/clusters/app.ci/prow/03_deployment/gangway.yaml
+++ b/clusters/app.ci/prow/03_deployment/gangway.yaml
@@ -91,62 +91,6 @@ objects:
           - name: release
             mountPath: /tmp/git-sync
         containers:
-        - name: git-sync
-          command:
-          - /git-sync
-          args:
-          - --repo=https://github.com/openshift/release.git
-          - --ref=main
-          - --period=30s
-          - --root=/tmp/git-sync
-          - --max-failures=3
-          - --link=release
-          image: quay-proxy.ci.openshift.org/openshift/ci:ci_git-sync_v4.3.0
-          volumeMounts:
-          - name: release
-            mountPath: /tmp/git-sync
-          resources:
-            requests:
-              memory: "1Gi"
-              cpu: "0.5"
-        - name: oauth-proxy
-          image: quay.io/openshift/origin-oauth-proxy:4.16
-          imagePullPolicy: IfNotPresent
-          ports:
-          - containerPort: 8443
-            name: web
-          args:
-          - -provider=openshift
-          - -https-address=:8443
-          - -http-address=
-          - -email-domain=*
-          - -upstream=http://localhost:31999
-          - -client-id=system:serviceaccount:ci:gangway
-          - -openshift-ca=/etc/pki/tls/cert.pem
-          - -openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-          - '-openshift-sar=[{"resource": "namespaces", "verb": "get"},{"resource": "systemusers", "verb": "impersonate"}]'
-          - '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get"}, "/bulk-job-status-update": {"resource": "systemusers", "verb": "impersonate"}}'
-          - -client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
-          - -cookie-secret-file=/etc/proxy/secrets/session_secret
-          - -cookie-samesite=none
-          - -tls-cert=/etc/tls/private/tls.crt
-          - -tls-key=/etc/tls/private/tls.key
-          volumeMounts:
-          - mountPath: /etc/tls/private
-            name: gangway-tls
-          - mountPath: /etc/proxy/secrets
-            name: session-secret
-        - name: envoyproxy
-          imagePullPolicy: Always
-          image: quay-proxy.ci.openshift.org/openshift/ci:ci_tp-envoyproxy_latest
-        - name: nginx-rate-limit
-          imagePullPolicy: Always
-          image: quay-proxy.ci.openshift.org/openshift/ci:ci_nging-rate-limit_latest
-          volumeMounts:
-          - mountPath: /var/cache/nginx
-            name: nginx-cache
-          - mountPath: /tmp
-            name: nginx-tmp
         - name: gangway
           image: us-docker.pkg.dev/k8s-infra-prow/images/gangway:v20260316-25576911a
           args:
@@ -205,6 +149,62 @@ objects:
             requests:
               memory: "5Gi"
               cpu: "1"
+        - name: git-sync
+          command:
+          - /git-sync
+          args:
+          - --repo=https://github.com/openshift/release.git
+          - --ref=main
+          - --period=30s
+          - --root=/tmp/git-sync
+          - --max-failures=3
+          - --link=release
+          image: quay-proxy.ci.openshift.org/openshift/ci:ci_git-sync_v4.3.0
+          volumeMounts:
+          - name: release
+            mountPath: /tmp/git-sync
+          resources:
+            requests:
+              memory: "1Gi"
+              cpu: "0.5"
+        - name: oauth-proxy
+          image: quay.io/openshift/origin-oauth-proxy:4.16
+          imagePullPolicy: IfNotPresent
+          ports:
+          - containerPort: 8443
+            name: web
+          args:
+          - -provider=openshift
+          - -https-address=:8443
+          - -http-address=
+          - -email-domain=*
+          - -upstream=http://localhost:31999
+          - -client-id=system:serviceaccount:ci:gangway
+          - -openshift-ca=/etc/pki/tls/cert.pem
+          - -openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          - '-openshift-sar=[{"resource": "namespaces", "verb": "get"},{"resource": "systemusers", "verb": "impersonate"}]'
+          - '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get"}, "/bulk-job-status-update": {"resource": "systemusers", "verb": "impersonate"}}'
+          - -client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
+          - -cookie-secret-file=/etc/proxy/secrets/session_secret
+          - -cookie-samesite=none
+          - -tls-cert=/etc/tls/private/tls.crt
+          - -tls-key=/etc/tls/private/tls.key
+          volumeMounts:
+          - mountPath: /etc/tls/private
+            name: gangway-tls
+          - mountPath: /etc/proxy/secrets
+            name: session-secret
+        - name: envoyproxy
+          imagePullPolicy: Always
+          image: quay-proxy.ci.openshift.org/openshift/ci:ci_tp-envoyproxy_latest
+        - name: nginx-rate-limit
+          imagePullPolicy: Always
+          image: quay-proxy.ci.openshift.org/openshift/ci:ci_nging-rate-limit_latest
+          volumeMounts:
+          - mountPath: /var/cache/nginx
+            name: nginx-cache
+          - mountPath: /tmp
+            name: nginx-tmp
         volumes:
         - name: github-app-credentials
           secret:

--- a/clusters/app.ci/prow/03_deployment/gcsweb-private.yaml
+++ b/clusters/app.ci/prow/03_deployment/gcsweb-private.yaml
@@ -32,6 +32,25 @@ objects:
       spec:
         serviceAccountName: gcsweb-private
         containers:
+        - image: quay.io/openshift/ci:ci_gcsweb_latest
+          name: gcsweb-private
+          args:
+          - "-b"
+          - "origin-ci-private"
+          - --gcs-credentials-file=/etc/sa/credentials.json
+          volumeMounts:
+          - mountPath: /etc/sa
+            name: gcs-credentials-file
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds:
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthz/ready
+              port: 8081
         - name: oauth-proxy
           image: quay.io/openshift/origin-oauth-proxy:4.16
           imagePullPolicy: IfNotPresent
@@ -58,25 +77,6 @@ objects:
             name: gcsweb-private-tls
           - mountPath: /etc/proxy/secrets
             name: session-secret
-        - image: quay.io/openshift/ci:ci_gcsweb_latest
-          name: gcsweb-private
-          args:
-          - "-b"
-          - "origin-ci-private"
-          - --gcs-credentials-file=/etc/sa/credentials.json
-          volumeMounts:
-          - mountPath: /etc/sa
-            name: gcs-credentials-file
-          livenessProbe:
-            httpGet:
-              path: /healthz
-              port: 8081
-            initialDelaySeconds:
-            periodSeconds: 3
-          readinessProbe:
-            httpGet:
-              path: /healthz/ready
-              port: 8081
         volumes:
         - name: gcsweb-private-tls
           secret:

--- a/clusters/app.ci/prow/03_deployment/gcsweb-qe-private-deck.yaml
+++ b/clusters/app.ci/prow/03_deployment/gcsweb-qe-private-deck.yaml
@@ -32,6 +32,25 @@ objects:
       spec:
         serviceAccountName: gcsweb-qe-private-deck
         containers:
+        - image: quay.io/openshift/ci:ci_gcsweb_latest
+          name: gcsweb-qe-private-deck
+          args:
+          - "-b"
+          - "qe-private-deck"
+          - --gcs-credentials-file=/etc/sa/credentials.json
+          volumeMounts:
+          - mountPath: /etc/sa
+            name: gcs-credentials-file
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds:
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthz/ready
+              port: 8081
         - name: oauth-proxy
           image: quay.io/openshift/origin-oauth-proxy:4.16
           imagePullPolicy: IfNotPresent
@@ -58,25 +77,6 @@ objects:
             name: gcsweb-qe-private-deck-tls
           - mountPath: /etc/proxy/secrets
             name: session-secret
-        - image: quay.io/openshift/ci:ci_gcsweb_latest
-          name: gcsweb-qe-private-deck
-          args:
-          - "-b"
-          - "qe-private-deck"
-          - --gcs-credentials-file=/etc/sa/credentials.json
-          volumeMounts:
-          - mountPath: /etc/sa
-            name: gcs-credentials-file
-          livenessProbe:
-            httpGet:
-              path: /healthz
-              port: 8081
-            initialDelaySeconds:
-            periodSeconds: 3
-          readinessProbe:
-            httpGet:
-              path: /healthz/ready
-              port: 8081
         volumes:
         - name: gcsweb-qe-private-deck-tls
           secret:

--- a/clusters/app.ci/prow/03_deployment/hook.yaml
+++ b/clusters/app.ci/prow/03_deployment/hook.yaml
@@ -128,24 +128,6 @@ spec:
         - name: release
           mountPath: /tmp/git-sync
       containers:
-      - name: git-sync
-        command:
-        - /git-sync
-        args:
-        - --repo=https://github.com/openshift/release.git
-        - --ref=main
-        - --period=30s
-        - --root=/tmp/git-sync
-        - --max-failures=3
-        - --link=release
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_git-sync_v4.3.0
-        volumeMounts:
-        - name: release
-          mountPath: /tmp/git-sync
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "0.5"
       - name: hook
         image: us-docker.pkg.dev/k8s-infra-prow/images/hook:v20260316-25576911a
         args:
@@ -222,6 +204,24 @@ spec:
           httpGet:
             path: /healthz/ready
             port: 8081
+      - name: git-sync
+        command:
+        - /git-sync
+        args:
+        - --repo=https://github.com/openshift/release.git
+        - --ref=main
+        - --period=30s
+        - --root=/tmp/git-sync
+        - --max-failures=3
+        - --link=release
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_git-sync_v4.3.0
+        volumeMounts:
+        - name: release
+          mountPath: /tmp/git-sync
+        resources:
+          requests:
+            memory: "1Gi"
+            cpu: "0.5"
       volumes:
       - name: service-account-token
         projected:

--- a/clusters/app.ci/prow/03_deployment/horologium.yaml
+++ b/clusters/app.ci/prow/03_deployment/horologium.yaml
@@ -37,24 +37,6 @@ spec:
         - name: release
           mountPath: /tmp/git-sync
       containers:
-      - name: git-sync
-        command:
-        - /git-sync
-        args:
-        - --repo=https://github.com/openshift/release.git
-        - --ref=main
-        - --period=30s
-        - --root=/tmp/git-sync
-        - --max-failures=3
-        - --link=release
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_git-sync_v4.3.0
-        volumeMounts:
-        - name: release
-          mountPath: /tmp/git-sync
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "0.5"
       - name: horologium
         args:
         - --config-path=/etc/config/config.yaml
@@ -75,6 +57,24 @@ spec:
           requests:
             memory: "7.5Gi"
             cpu: "150m"
+      - name: git-sync
+        command:
+        - /git-sync
+        args:
+        - --repo=https://github.com/openshift/release.git
+        - --ref=main
+        - --period=30s
+        - --root=/tmp/git-sync
+        - --max-failures=3
+        - --link=release
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_git-sync_v4.3.0
+        volumeMounts:
+        - name: release
+          mountPath: /tmp/git-sync
+        resources:
+          requests:
+            memory: "1Gi"
+            cpu: "0.5"
       volumes:
       - name: service-account-token
         projected:

--- a/clusters/app.ci/prow/03_deployment/multi-pr-prow-plugin.yaml
+++ b/clusters/app.ci/prow/03_deployment/multi-pr-prow-plugin.yaml
@@ -105,24 +105,6 @@ spec:
         - name: release
           mountPath: /tmp/git-sync
       containers:
-      - name: git-sync
-        command:
-        - /git-sync
-        args:
-        - --repo=https://github.com/openshift/release.git
-        - --ref=main
-        - --period=30s
-        - --root=/tmp/git-sync
-        - --link=release
-        - --max-failures=3
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_git-sync_v4.3.0
-        volumeMounts:
-        - name: release
-          mountPath: /tmp/git-sync
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "0.5"
       - name: multi-pr-prow-plugin
         image: quay-proxy.ci.openshift.org/openshift/ci:ci_multi-pr-prow-plugin_latest
         imagePullPolicy: Always
@@ -176,6 +158,24 @@ spec:
           httpGet:
             path: /healthz/ready
             port: 8081
+      - name: git-sync
+        command:
+        - /git-sync
+        args:
+        - --repo=https://github.com/openshift/release.git
+        - --ref=main
+        - --period=30s
+        - --root=/tmp/git-sync
+        - --link=release
+        - --max-failures=3
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_git-sync_v4.3.0
+        volumeMounts:
+        - name: release
+          mountPath: /tmp/git-sync
+        resources:
+          requests:
+            memory: "1Gi"
+            cpu: "0.5"
       serviceAccountName: multi-pr-prow-plugin
       volumes:
       - name: hmac

--- a/clusters/app.ci/prow/03_deployment/payload-testing-prow-plugin.yaml
+++ b/clusters/app.ci/prow/03_deployment/payload-testing-prow-plugin.yaml
@@ -97,25 +97,6 @@ spec:
         - name: release
           mountPath: /tmp/git-sync
       containers:
-      - name: git-sync
-        command:
-        - /git-sync
-        args:
-        - --repo=https://github.com/openshift/release.git
-        - --ref=main
-        - --period=30s
-        - --root=/tmp/git-sync
-        - --max-failures=3
-        - --link=release
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_git-sync_v4.3.0
-        imagePullPolicy: Always
-        volumeMounts:
-        - name: release
-          mountPath: /tmp/git-sync
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "0.5"
       - name: payload-testing-prow-plugin
         image: quay-proxy.ci.openshift.org/openshift/ci:ci_payload-testing-prow-plugin_latest
         imagePullPolicy: Always
@@ -174,6 +155,25 @@ spec:
           httpGet:
             path: /healthz/ready
             port: 8081
+      - name: git-sync
+        command:
+        - /git-sync
+        args:
+        - --repo=https://github.com/openshift/release.git
+        - --ref=main
+        - --period=30s
+        - --root=/tmp/git-sync
+        - --max-failures=3
+        - --link=release
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_git-sync_v4.3.0
+        imagePullPolicy: Always
+        volumeMounts:
+        - name: release
+          mountPath: /tmp/git-sync
+        resources:
+          requests:
+            memory: "1Gi"
+            cpu: "0.5"
       serviceAccountName: payload-testing-prow-plugin
       volumes:
       - name: hmac

--- a/clusters/app.ci/prow/03_deployment/pipeline-controller.yaml
+++ b/clusters/app.ci/prow/03_deployment/pipeline-controller.yaml
@@ -60,24 +60,6 @@ spec:
             - name: release
               mountPath: /tmp/git-sync
       containers:
-        - name: git-sync
-          command:
-            - /git-sync
-          args:
-            - --repo=https://github.com/openshift/release.git
-            - --ref=main
-            - --period=30s
-            - --root=/tmp/git-sync
-            - --max-failures=3
-            - --link=release
-          image: quay-proxy.ci.openshift.org/openshift/ci:ci_git-sync_v4.3.0
-          volumeMounts:
-            - name: release
-              mountPath: /tmp/git-sync
-          resources:
-            requests:
-              memory: "1Gi"
-              cpu: "0.5"
         - name: pipeline-controller
           image: quay-proxy.ci.openshift.org/openshift/ci:ci_pipeline-controller_latest
           imagePullPolicy: Always
@@ -112,6 +94,24 @@ spec:
             - name: hmac
               mountPath: /etc/webhook
               readOnly: true
+        - name: git-sync
+          command:
+            - /git-sync
+          args:
+            - --repo=https://github.com/openshift/release.git
+            - --ref=main
+            - --period=30s
+            - --root=/tmp/git-sync
+            - --max-failures=3
+            - --link=release
+          image: quay-proxy.ci.openshift.org/openshift/ci:ci_git-sync_v4.3.0
+          volumeMounts:
+            - name: release
+              mountPath: /tmp/git-sync
+          resources:
+            requests:
+              memory: "1Gi"
+              cpu: "0.5"
       volumes:
         - name: hmac
           secret:

--- a/clusters/app.ci/prow/03_deployment/prow-controller-manager.yaml
+++ b/clusters/app.ci/prow/03_deployment/prow-controller-manager.yaml
@@ -55,24 +55,6 @@ spec:
         - name: release
           mountPath: /tmp/git-sync
       containers:
-      - name: git-sync
-        command:
-        - /git-sync
-        args:
-        - --repo=https://github.com/openshift/release.git
-        - --ref=main
-        - --period=30s
-        - --root=/tmp/git-sync
-        - --max-failures=3
-        - --link=release
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_git-sync_v4.3.0
-        volumeMounts:
-        - name: release
-          mountPath: /tmp/git-sync
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "0.5"
       - name: prow-controller-manager
         image: us-docker.pkg.dev/k8s-infra-prow/images/prow-controller-manager:v20260316-25576911a
         args:
@@ -110,6 +92,24 @@ spec:
           requests:
             memory: "8Gi"
             cpu: "600m"
+      - name: git-sync
+        command:
+        - /git-sync
+        args:
+        - --repo=https://github.com/openshift/release.git
+        - --ref=main
+        - --period=30s
+        - --root=/tmp/git-sync
+        - --max-failures=3
+        - --link=release
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_git-sync_v4.3.0
+        volumeMounts:
+        - name: release
+          mountPath: /tmp/git-sync
+        resources:
+          requests:
+            memory: "1Gi"
+            cpu: "0.5"
       volumes:
       - name: service-account-token
         projected:

--- a/clusters/app.ci/prow/03_deployment/prowjob-dispatcher.yaml
+++ b/clusters/app.ci/prow/03_deployment/prowjob-dispatcher.yaml
@@ -76,24 +76,6 @@ spec:
         - name: release
           mountPath: /tmp/git-sync
       containers:
-      - name: git-sync
-        command:
-        - /git-sync
-        args:
-        - --repo=https://github.com/openshift/release.git
-        - --ref=main
-        - --period=30s
-        - --root=/tmp/git-sync
-        - --max-failures=3
-        - --link=release
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_git-sync_v4.3.0
-        volumeMounts:
-        - name: release
-          mountPath: /tmp/git-sync
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "0.5"
       - name: prowjob-dispatcher
         image: quay.io/openshift/ci-public:ci_prow-job-dispatcher_latest
         imagePullPolicy: Always
@@ -137,6 +119,24 @@ spec:
           requests:
             memory: "2Gi"
             cpu: "0.7"
+      - name: git-sync
+        command:
+        - /git-sync
+        args:
+        - --repo=https://github.com/openshift/release.git
+        - --ref=main
+        - --period=30s
+        - --root=/tmp/git-sync
+        - --max-failures=3
+        - --link=release
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_git-sync_v4.3.0
+        volumeMounts:
+        - name: release
+          mountPath: /tmp/git-sync
+        resources:
+          requests:
+            memory: "1Gi"
+            cpu: "0.5"
       volumes:
       - name: slack
         secret:

--- a/clusters/app.ci/prow/03_deployment/qe_private_deck.yaml
+++ b/clusters/app.ci/prow/03_deployment/qe_private_deck.yaml
@@ -103,51 +103,6 @@ objects:
             - name: release
               mountPath: /tmp/git-sync
           containers:
-            - name: git-sync
-              command:
-              - /git-sync
-              args:
-              - --repo=https://github.com/openshift/release.git
-              - --ref=main
-              - --period=30s
-              - --root=/tmp/git-sync
-              - --max-failures=3
-              - --link=release
-              image: quay-proxy.ci.openshift.org/openshift/ci:ci_git-sync_v4.3.0
-              volumeMounts:
-              - name: release
-                mountPath: /tmp/git-sync
-              resources:
-                requests:
-                  memory: "1Gi"
-                  cpu: "0.5"
-            - name: oauth-proxy
-              image: quay.io/openshift/origin-oauth-proxy:4.16
-              imagePullPolicy: IfNotPresent
-              ports:
-                - containerPort: 8443
-                  name: web
-              args:
-                - -provider=openshift
-                - -https-address=:8443
-                - -http-address=
-                - -email-domain=*
-                - -upstream=http://localhost:8080
-                - -client-id=system:serviceaccount:ci:qe-private-deck
-                - -openshift-ca=/etc/pki/tls/cert.pem
-                - -openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-                - '-openshift-sar={"verb": "get", "resource": "secrets", "namespace": "qe-private-deck"}'
-                - '-openshift-delegate-urls={"/": {"verb": "get", "resource": "secrets", "namespace": "qe-private-deck"}}'
-                - -client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
-                - -cookie-secret-file=/etc/proxy/secrets/session_secret
-                - -cookie-samesite=none
-                - -tls-cert=/etc/tls/private/tls.crt
-                - -tls-key=/etc/tls/private/tls.key
-              volumeMounts:
-                - mountPath: /etc/tls/private
-                  name: qe-private-deck-tls
-                - mountPath: /etc/proxy/secrets
-                  name: session-secret
             - name: deck
               image: us-docker.pkg.dev/k8s-infra-prow/images/deck:v20260316-25576911a
               args:
@@ -230,6 +185,51 @@ objects:
                 requests:
                   memory: "9Gi"
                   cpu: "500m"
+            - name: git-sync
+              command:
+              - /git-sync
+              args:
+              - --repo=https://github.com/openshift/release.git
+              - --ref=main
+              - --period=30s
+              - --root=/tmp/git-sync
+              - --max-failures=3
+              - --link=release
+              image: quay-proxy.ci.openshift.org/openshift/ci:ci_git-sync_v4.3.0
+              volumeMounts:
+              - name: release
+                mountPath: /tmp/git-sync
+              resources:
+                requests:
+                  memory: "1Gi"
+                  cpu: "0.5"
+            - name: oauth-proxy
+              image: quay.io/openshift/origin-oauth-proxy:4.16
+              imagePullPolicy: IfNotPresent
+              ports:
+                - containerPort: 8443
+                  name: web
+              args:
+                - -provider=openshift
+                - -https-address=:8443
+                - -http-address=
+                - -email-domain=*
+                - -upstream=http://localhost:8080
+                - -client-id=system:serviceaccount:ci:qe-private-deck
+                - -openshift-ca=/etc/pki/tls/cert.pem
+                - -openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                - '-openshift-sar={"verb": "get", "resource": "secrets", "namespace": "qe-private-deck"}'
+                - '-openshift-delegate-urls={"/": {"verb": "get", "resource": "secrets", "namespace": "qe-private-deck"}}'
+                - -client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
+                - -cookie-secret-file=/etc/proxy/secrets/session_secret
+                - -cookie-samesite=none
+                - -tls-cert=/etc/tls/private/tls.crt
+                - -tls-key=/etc/tls/private/tls.key
+              volumeMounts:
+                - mountPath: /etc/tls/private
+                  name: qe-private-deck-tls
+                - mountPath: /etc/proxy/secrets
+                  name: session-secret
           volumes:
             - name: github-app-credentials
               secret:

--- a/clusters/app.ci/prow/03_deployment/retester.yaml
+++ b/clusters/app.ci/prow/03_deployment/retester.yaml
@@ -61,25 +61,6 @@ spec:
         - name: release
           mountPath: /tmp/git-sync
       containers:
-      - name: git-sync
-        command:
-        - /git-sync
-        args:
-        - --repo=https://github.com/openshift/release.git
-        - --ref=main
-        - --period=30s
-        - --root=/tmp/git-sync
-        - --max-failures=3
-        - --link=release
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_git-sync_v4.3.0
-        imagePullPolicy: Always
-        volumeMounts:
-        - name: release
-          mountPath: /tmp/git-sync
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "0.5"
       - image: quay-proxy.ci.openshift.org/openshift/ci:ci_retester_latest
         name: retester
         imagePullPolicy: Always
@@ -127,6 +108,25 @@ spec:
           requests:
             memory: "5Gi"
             cpu: "250m"
+      - name: git-sync
+        command:
+        - /git-sync
+        args:
+        - --repo=https://github.com/openshift/release.git
+        - --ref=main
+        - --period=30s
+        - --root=/tmp/git-sync
+        - --max-failures=3
+        - --link=release
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_git-sync_v4.3.0
+        imagePullPolicy: Always
+        volumeMounts:
+        - name: release
+          mountPath: /tmp/git-sync
+        resources:
+          requests:
+            memory: "1Gi"
+            cpu: "0.5"
       volumes:
       - name: prow-config
         configMap:

--- a/clusters/app.ci/prow/03_deployment/sinker.yaml
+++ b/clusters/app.ci/prow/03_deployment/sinker.yaml
@@ -36,19 +36,6 @@ spec:
         - name: release
           mountPath: /tmp/git-sync
       containers:
-      - name: git-sync
-        command:
-        - /git-sync
-        args:
-        - --repo=https://github.com/openshift/release.git
-        - --ref=main
-        - --period=30s
-        - --root=/tmp/git-sync
-        - --link=release
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_git-sync_v4.3.0
-        volumeMounts:
-        - name: release
-          mountPath: /tmp/git-sync
       - name: sinker
         image: us-docker.pkg.dev/k8s-infra-prow/images/sinker:v20260316-25576911a
         args:
@@ -75,6 +62,19 @@ spec:
           requests:
             memory: "10Gi"
             cpu: "50m"
+      - name: git-sync
+        command:
+        - /git-sync
+        args:
+        - --repo=https://github.com/openshift/release.git
+        - --ref=main
+        - --period=30s
+        - --root=/tmp/git-sync
+        - --link=release
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_git-sync_v4.3.0
+        volumeMounts:
+        - name: release
+          mountPath: /tmp/git-sync
       volumes:
       - name: release
         emptyDir: {}

--- a/clusters/app.ci/prow/03_deployment/statusreconciler.yaml
+++ b/clusters/app.ci/prow/03_deployment/statusreconciler.yaml
@@ -36,24 +36,6 @@ spec:
         - name: release
           mountPath: /tmp/git-sync
       containers:
-      - name: git-sync
-        command:
-        - /git-sync
-        args:
-        - --repo=https://github.com/openshift/release.git
-        - --ref=main
-        - --period=30s
-        - --root=/tmp/git-sync
-        - --max-failures=3
-        - --link=release
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_git-sync_v4.3.0
-        volumeMounts:
-        - name: release
-          mountPath: /tmp/git-sync
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "0.5"
       - name: statusreconciler
         image: us-docker.pkg.dev/k8s-infra-prow/images/status-reconciler:v20260316-25576911a
         imagePullPolicy: IfNotPresent
@@ -98,6 +80,24 @@ spec:
           requests:
             memory: "12Gi"
             cpu: "20m"
+      - name: git-sync
+        command:
+        - /git-sync
+        args:
+        - --repo=https://github.com/openshift/release.git
+        - --ref=main
+        - --period=30s
+        - --root=/tmp/git-sync
+        - --max-failures=3
+        - --link=release
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_git-sync_v4.3.0
+        volumeMounts:
+        - name: release
+          mountPath: /tmp/git-sync
+        resources:
+          requests:
+            memory: "1Gi"
+            cpu: "0.5"
       volumes:
       - name: service-account-token
         projected:

--- a/clusters/app.ci/prow/03_deployment/tide.yaml
+++ b/clusters/app.ci/prow/03_deployment/tide.yaml
@@ -61,24 +61,6 @@ spec:
         - name: release
           mountPath: /tmp/git-sync
       containers:
-      - name: git-sync
-        command:
-        - /git-sync
-        args:
-        - --repo=https://github.com/openshift/release.git
-        - --ref=main
-        - --period=30s
-        - --root=/tmp/git-sync
-        - --max-failures=3
-        - --link=release
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_git-sync_v4.3.0
-        volumeMounts:
-        - name: release
-          mountPath: /tmp/git-sync
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "0.5"
       - name: tide
         image: us-docker.pkg.dev/k8s-infra-prow/images/tide:v20260316-25576911a
         args:
@@ -128,6 +110,24 @@ spec:
           requests:
             memory: "10Gi"
             cpu: "750m"
+      - name: git-sync
+        command:
+        - /git-sync
+        args:
+        - --repo=https://github.com/openshift/release.git
+        - --ref=main
+        - --period=30s
+        - --root=/tmp/git-sync
+        - --max-failures=3
+        - --link=release
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_git-sync_v4.3.0
+        volumeMounts:
+        - name: release
+          mountPath: /tmp/git-sync
+        resources:
+          requests:
+            memory: "1Gi"
+            cpu: "0.5"
       volumes:
       - name: service-account-token
         projected:

--- a/clusters/app.ci/prow/03_deployment/tot.yaml
+++ b/clusters/app.ci/prow/03_deployment/tot.yaml
@@ -70,24 +70,6 @@ spec:
         - name: release
           mountPath: /tmp/git-sync
       containers:
-      - name: git-sync
-        command:
-        - /git-sync
-        args:
-        - --repo=https://github.com/openshift/release.git
-        - --ref=main
-        - --period=30s
-        - --root=/tmp/git-sync
-        - --max-failures=3
-        - --link=release
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_git-sync_v4.3.0
-        volumeMounts:
-        - name: release
-          mountPath: /tmp/git-sync
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "0.5"
       - name: tot
         image: us-docker.pkg.dev/k8s-infra-prow/images/tot:v20260316-25576911a
         args:
@@ -121,6 +103,24 @@ spec:
           httpGet:
             path: /healthz/ready
             port: 8081
+      - name: git-sync
+        command:
+        - /git-sync
+        args:
+        - --repo=https://github.com/openshift/release.git
+        - --ref=main
+        - --period=30s
+        - --root=/tmp/git-sync
+        - --max-failures=3
+        - --link=release
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_git-sync_v4.3.0
+        volumeMounts:
+        - name: release
+          mountPath: /tmp/git-sync
+        resources:
+          requests:
+            memory: "1Gi"
+            cpu: "0.5"
       volumes:
       - name: tot-volume
         persistentVolumeClaim:


### PR DESCRIPTION
From time to time we need to check container logs and the default one is generally `git-sync`, this is not useful since most of the time we need the main application like crier, tide, etc.

This is also possible with `kubectl.kubernetes.io/default-container: <container-name>`, but since a simply order can achieve the same result without any extra field, I preferred just to order them.