### PR TITLE
OSASINFRA-4229: openstack: Add initial rhcos 10 testing

### DIFF
--- a/ci-operator/config/openshift/csi-driver-nfs/openshift-csi-driver-nfs-main.yaml
+++ b/ci-operator/config/openshift/csi-driver-nfs/openshift-csi-driver-nfs-main.yaml
@@ -46,6 +46,17 @@ tests:
       CONFIG_TYPE: minimal
       MANILA_SHARE_NETWORK_ID: b4b69cfe-b06e-4b01-ac34-4faa4bf94503
     workflow: openshift-e2e-openstack-csi-manila
+- as: e2e-openstack-csi-rhcos10-techpreview
+  optional: true
+  steps:
+    cluster_profile: openstack-vexxhost
+    env:
+      BASE_DOMAIN: shiftstack.devcluster.openshift.com
+      CONFIG_TYPE: minimal
+      FEATURE_SET: TechPreviewNoUpgrade
+      MANILA_SHARE_NETWORK_ID: b4b69cfe-b06e-4b01-ac34-4faa4bf94503
+      OSSTREAM: rhel-10
+    workflow: openshift-e2e-openstack-csi-manila
 - as: security
   optional: true
   steps:

--- a/ci-operator/config/openshift/csi-driver-nfs/openshift-csi-driver-nfs-release-4.22.yaml
+++ b/ci-operator/config/openshift/csi-driver-nfs/openshift-csi-driver-nfs-release-4.22.yaml
@@ -46,6 +46,17 @@ tests:
       CONFIG_TYPE: minimal
       MANILA_SHARE_NETWORK_ID: b4b69cfe-b06e-4b01-ac34-4faa4bf94503
     workflow: openshift-e2e-openstack-csi-manila
+- as: e2e-openstack-csi-rhcos10-techpreview
+  optional: true
+  steps:
+    cluster_profile: openstack-vexxhost
+    env:
+      BASE_DOMAIN: shiftstack.devcluster.openshift.com
+      CONFIG_TYPE: minimal
+      FEATURE_SET: TechPreviewNoUpgrade
+      MANILA_SHARE_NETWORK_ID: b4b69cfe-b06e-4b01-ac34-4faa4bf94503
+      OSSTREAM: rhel-10
+    workflow: openshift-e2e-openstack-csi-manila
 - as: security
   optional: true
   steps:

--- a/ci-operator/config/openshift/csi-driver-nfs/openshift-csi-driver-nfs-release-4.23.yaml
+++ b/ci-operator/config/openshift/csi-driver-nfs/openshift-csi-driver-nfs-release-4.23.yaml
@@ -46,6 +46,17 @@ tests:
       CONFIG_TYPE: minimal
       MANILA_SHARE_NETWORK_ID: b4b69cfe-b06e-4b01-ac34-4faa4bf94503
     workflow: openshift-e2e-openstack-csi-manila
+- as: e2e-openstack-csi-rhcos10-techpreview
+  optional: true
+  steps:
+    cluster_profile: openstack-vexxhost
+    env:
+      BASE_DOMAIN: shiftstack.devcluster.openshift.com
+      CONFIG_TYPE: minimal
+      FEATURE_SET: TechPreviewNoUpgrade
+      MANILA_SHARE_NETWORK_ID: b4b69cfe-b06e-4b01-ac34-4faa4bf94503
+      OSSTREAM: rhel-10
+    workflow: openshift-e2e-openstack-csi-manila
 - as: security
   optional: true
   steps:

--- a/ci-operator/config/openshift/csi-driver-nfs/openshift-csi-driver-nfs-release-5.0.yaml
+++ b/ci-operator/config/openshift/csi-driver-nfs/openshift-csi-driver-nfs-release-5.0.yaml
@@ -47,6 +47,17 @@ tests:
       CONFIG_TYPE: minimal
       MANILA_SHARE_NETWORK_ID: b4b69cfe-b06e-4b01-ac34-4faa4bf94503
     workflow: openshift-e2e-openstack-csi-manila
+- as: e2e-openstack-csi-rhcos10-techpreview
+  optional: true
+  steps:
+    cluster_profile: openstack-vexxhost
+    env:
+      BASE_DOMAIN: shiftstack.devcluster.openshift.com
+      CONFIG_TYPE: minimal
+      FEATURE_SET: TechPreviewNoUpgrade
+      MANILA_SHARE_NETWORK_ID: b4b69cfe-b06e-4b01-ac34-4faa4bf94503
+      OSSTREAM: rhel-10
+    workflow: openshift-e2e-openstack-csi-manila
 - as: security
   optional: true
   steps:

--- a/ci-operator/config/openshift/sriov-network-operator/openshift-sriov-network-operator-main.yaml
+++ b/ci-operator/config/openshift/sriov-network-operator/openshift-sriov-network-operator-main.yaml
@@ -159,6 +159,18 @@ tests:
       OPENSTACK_DPDK_NETWORK: intel-dpdk
     workflow: openshift-e2e-openstack-sriov
 - always_run: false
+  as: e2e-openstack-nfv-rhcos10-techpreview
+  optional: true
+  steps:
+    cluster_profile: openstack-nfv
+    dependencies:
+      OO_INDEX: ci-index-operator-bundle
+    env:
+      FEATURE_SET: TechPreviewNoUpgrade
+      OPENSTACK_DPDK_NETWORK: intel-dpdk
+      OSSTREAM: rhel-10
+    workflow: openshift-e2e-openstack-sriov
+- always_run: false
   as: e2e-openstack-nfv-config-drive
   optional: true
   steps:

--- a/ci-operator/config/openshift/sriov-network-operator/openshift-sriov-network-operator-release-4.22.yaml
+++ b/ci-operator/config/openshift/sriov-network-operator/openshift-sriov-network-operator-release-4.22.yaml
@@ -159,6 +159,18 @@ tests:
       OPENSTACK_DPDK_NETWORK: intel-dpdk
     workflow: openshift-e2e-openstack-sriov
 - always_run: false
+  as: e2e-openstack-nfv-rhcos10-techpreview
+  optional: true
+  steps:
+    cluster_profile: openstack-nfv
+    dependencies:
+      OO_INDEX: ci-index-operator-bundle
+    env:
+      FEATURE_SET: TechPreviewNoUpgrade
+      OPENSTACK_DPDK_NETWORK: intel-dpdk
+      OSSTREAM: rhel-10
+    workflow: openshift-e2e-openstack-sriov
+- always_run: false
   as: e2e-openstack-nfv-config-drive
   optional: true
   steps:

--- a/ci-operator/config/openshift/sriov-network-operator/openshift-sriov-network-operator-release-4.23.yaml
+++ b/ci-operator/config/openshift/sriov-network-operator/openshift-sriov-network-operator-release-4.23.yaml
@@ -159,6 +159,18 @@ tests:
       OPENSTACK_DPDK_NETWORK: intel-dpdk
     workflow: openshift-e2e-openstack-sriov
 - always_run: false
+  as: e2e-openstack-nfv-rhcos10-techpreview
+  optional: true
+  steps:
+    cluster_profile: openstack-nfv
+    dependencies:
+      OO_INDEX: ci-index-operator-bundle
+    env:
+      FEATURE_SET: TechPreviewNoUpgrade
+      OPENSTACK_DPDK_NETWORK: intel-dpdk
+      OSSTREAM: rhel-10
+    workflow: openshift-e2e-openstack-sriov
+- always_run: false
   as: e2e-openstack-nfv-config-drive
   optional: true
   steps:

--- a/ci-operator/config/openshift/sriov-network-operator/openshift-sriov-network-operator-release-5.0.yaml
+++ b/ci-operator/config/openshift/sriov-network-operator/openshift-sriov-network-operator-release-5.0.yaml
@@ -161,6 +161,18 @@ tests:
       OPENSTACK_DPDK_NETWORK: intel-dpdk
     workflow: openshift-e2e-openstack-sriov
 - always_run: false
+  as: e2e-openstack-nfv-rhcos10-techpreview
+  optional: true
+  steps:
+    cluster_profile: openstack-nfv
+    dependencies:
+      OO_INDEX: ci-index-operator-bundle
+    env:
+      FEATURE_SET: TechPreviewNoUpgrade
+      OPENSTACK_DPDK_NETWORK: intel-dpdk
+      OSSTREAM: rhel-10
+    workflow: openshift-e2e-openstack-sriov
+- always_run: false
   as: e2e-openstack-nfv-config-drive
   optional: true
   steps:

--- a/ci-operator/jobs/openshift/csi-driver-nfs/openshift-csi-driver-nfs-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/csi-driver-nfs/openshift-csi-driver-nfs-main-presubmits.yaml
@@ -86,6 +86,88 @@ presubmits:
     branches:
     - ^main$
     - ^main-
+    cluster: build07
+    context: ci/prow/e2e-openstack-csi-rhcos10-techpreview
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-csi-driver-nfs-main-e2e-openstack-csi-rhcos10-techpreview
+    optional: true
+    path_alias: github.com/kubernetes-csi/csi-driver-nfs
+    rerun_command: /test e2e-openstack-csi-rhcos10-techpreview
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-openstack-csi-rhcos10-techpreview
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-openstack-csi-rhcos10-techpreview,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
     cluster: build11
     context: ci/prow/go-fmt
     decorate: true

--- a/ci-operator/jobs/openshift/csi-driver-nfs/openshift-csi-driver-nfs-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift/csi-driver-nfs/openshift-csi-driver-nfs-release-4.22-presubmits.yaml
@@ -86,6 +86,88 @@ presubmits:
     branches:
     - ^release-4\.22$
     - ^release-4\.22-
+    cluster: build09
+    context: ci/prow/e2e-openstack-csi-rhcos10-techpreview
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-csi-driver-nfs-release-4.22-e2e-openstack-csi-rhcos10-techpreview
+    optional: true
+    path_alias: github.com/kubernetes-csi/csi-driver-nfs
+    rerun_command: /test e2e-openstack-csi-rhcos10-techpreview
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-openstack-csi-rhcos10-techpreview
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-openstack-csi-rhcos10-techpreview,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.22$
+    - ^release-4\.22-
     cluster: build11
     context: ci/prow/go-fmt
     decorate: true

--- a/ci-operator/jobs/openshift/csi-driver-nfs/openshift-csi-driver-nfs-release-4.23-presubmits.yaml
+++ b/ci-operator/jobs/openshift/csi-driver-nfs/openshift-csi-driver-nfs-release-4.23-presubmits.yaml
@@ -86,6 +86,88 @@ presubmits:
     branches:
     - ^release-4\.23$
     - ^release-4\.23-
+    cluster: build09
+    context: ci/prow/e2e-openstack-csi-rhcos10-techpreview
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-csi-driver-nfs-release-4.23-e2e-openstack-csi-rhcos10-techpreview
+    optional: true
+    path_alias: github.com/kubernetes-csi/csi-driver-nfs
+    rerun_command: /test e2e-openstack-csi-rhcos10-techpreview
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-openstack-csi-rhcos10-techpreview
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-openstack-csi-rhcos10-techpreview,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.23$
+    - ^release-4\.23-
     cluster: build05
     context: ci/prow/go-fmt
     decorate: true

--- a/ci-operator/jobs/openshift/csi-driver-nfs/openshift-csi-driver-nfs-release-5.0-presubmits.yaml
+++ b/ci-operator/jobs/openshift/csi-driver-nfs/openshift-csi-driver-nfs-release-5.0-presubmits.yaml
@@ -86,6 +86,88 @@ presubmits:
     branches:
     - ^release-5\.0$
     - ^release-5\.0-
+    cluster: build07
+    context: ci/prow/e2e-openstack-csi-rhcos10-techpreview
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: openstack-vexxhost
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-csi-driver-nfs-release-5.0-e2e-openstack-csi-rhcos10-techpreview
+    optional: true
+    path_alias: github.com/kubernetes-csi/csi-driver-nfs
+    rerun_command: /test e2e-openstack-csi-rhcos10-techpreview
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-openstack-csi-rhcos10-techpreview
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-openstack-csi-rhcos10-techpreview,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-5\.0$
+    - ^release-5\.0-
     cluster: build05
     context: ci/prow/go-fmt
     decorate: true

--- a/ci-operator/jobs/openshift/sriov-network-operator/openshift-sriov-network-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/sriov-network-operator/openshift-sriov-network-operator-main-presubmits.yaml
@@ -403,6 +403,87 @@ presubmits:
     branches:
     - ^main$
     - ^main-
+    cluster: build08
+    context: ci/prow/e2e-openstack-nfv-rhcos10-techpreview
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: openstack-nfv
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-nfv
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-sriov-network-operator-main-e2e-openstack-nfv-rhcos10-techpreview
+    optional: true
+    rerun_command: /test e2e-openstack-nfv-rhcos10-techpreview
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-openstack-nfv-rhcos10-techpreview
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-openstack-nfv-rhcos10-techpreview,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
     cluster: build10
     context: ci/prow/e2e-telco5g-sriov
     decorate: true

--- a/ci-operator/jobs/openshift/sriov-network-operator/openshift-sriov-network-operator-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift/sriov-network-operator/openshift-sriov-network-operator-release-4.22-presubmits.yaml
@@ -403,6 +403,87 @@ presubmits:
     branches:
     - ^release-4\.22$
     - ^release-4\.22-
+    cluster: build11
+    context: ci/prow/e2e-openstack-nfv-rhcos10-techpreview
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: openstack-nfv
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-nfv
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-sriov-network-operator-release-4.22-e2e-openstack-nfv-rhcos10-techpreview
+    optional: true
+    rerun_command: /test e2e-openstack-nfv-rhcos10-techpreview
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-openstack-nfv-rhcos10-techpreview
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-openstack-nfv-rhcos10-techpreview,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.22$
+    - ^release-4\.22-
     cluster: build10
     context: ci/prow/e2e-telco5g-sriov
     decorate: true

--- a/ci-operator/jobs/openshift/sriov-network-operator/openshift-sriov-network-operator-release-4.23-presubmits.yaml
+++ b/ci-operator/jobs/openshift/sriov-network-operator/openshift-sriov-network-operator-release-4.23-presubmits.yaml
@@ -403,6 +403,87 @@ presubmits:
     branches:
     - ^release-4\.23$
     - ^release-4\.23-
+    cluster: build08
+    context: ci/prow/e2e-openstack-nfv-rhcos10-techpreview
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: openstack-nfv
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-nfv
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-sriov-network-operator-release-4.23-e2e-openstack-nfv-rhcos10-techpreview
+    optional: true
+    rerun_command: /test e2e-openstack-nfv-rhcos10-techpreview
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-openstack-nfv-rhcos10-techpreview
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-openstack-nfv-rhcos10-techpreview,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.23$
+    - ^release-4\.23-
     cluster: build10
     context: ci/prow/e2e-telco5g-sriov
     decorate: true

--- a/ci-operator/jobs/openshift/sriov-network-operator/openshift-sriov-network-operator-release-5.0-presubmits.yaml
+++ b/ci-operator/jobs/openshift/sriov-network-operator/openshift-sriov-network-operator-release-5.0-presubmits.yaml
@@ -403,6 +403,87 @@ presubmits:
     branches:
     - ^release-5\.0$
     - ^release-5\.0-
+    cluster: build11
+    context: ci/prow/e2e-openstack-nfv-rhcos10-techpreview
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: openstack-nfv
+      ci-operator.openshift.io/cloud-cluster-profile: openstack-nfv
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-sriov-network-operator-release-5.0-e2e-openstack-nfv-rhcos10-techpreview
+    optional: true
+    rerun_command: /test e2e-openstack-nfv-rhcos10-techpreview
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-openstack-nfv-rhcos10-techpreview
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-openstack-nfv-rhcos10-techpreview,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-5\.0$
+    - ^release-5\.0-
     cluster: build09
     context: ci/prow/e2e-telco5g-sriov
     decorate: true

--- a/ci-operator/step-registry/ipi/openstack/pre/ipi-openstack-pre-chain.yaml
+++ b/ci-operator/step-registry/ipi/openstack/pre/ipi-openstack-pre-chain.yaml
@@ -2,6 +2,7 @@ chain:
   as: ipi-openstack-pre
   steps:
   - chain: ipi-conf-openstack
+  - ref: rhcos-conf-osstream
   - chain: ipi-install
   - ref: openstack-provision-etcd-disk-speed
   - ref: openstack-rotate-cloud-credentials

--- a/ci-operator/step-registry/ipi/openstack/pre/noramfs/ipi-openstack-pre-noramfs-chain.yaml
+++ b/ci-operator/step-registry/ipi/openstack/pre/noramfs/ipi-openstack-pre-noramfs-chain.yaml
@@ -2,6 +2,7 @@ chain:
   as: ipi-openstack-pre-noramfs
   steps:
   - chain: ipi-conf-openstack-noramfs
+  - ref: rhcos-conf-osstream
   - chain: ipi-install
   - ref: openstack-provision-etcd-disk-speed
   env:

--- a/ci-operator/step-registry/upi/openstack/pre/upi-openstack-pre-chain.yaml
+++ b/ci-operator/step-registry/upi/openstack/pre/upi-openstack-pre-chain.yaml
@@ -2,6 +2,7 @@ chain:
   as: upi-openstack-pre
   steps:
   - chain: ipi-conf-openstack
+  - ref: rhcos-conf-osstream
   - chain: upi-install-openstack
   - ref: openstack-provision-etcd-disk-speed
   env:


### PR DESCRIPTION
Add a RHCOS 10 job for https://github.com/openshift/csi-driver-nfs, which is the component we suspect is most likely to be affected by this bump.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated end-to-end testing for Red Hat CoreOS 10 with tech preview features
  * Extended test coverage for CSI driver and SR-IOV network operator on OpenStack environments
  * Enhanced OpenStack infrastructure setup procedures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->