### PR TITLE
Add dev-scripts log fallback to gather post step

### DIFF
--- a/ci-operator/step-registry/baremetalds/devscripts/gather/baremetalds-devscripts-gather-commands.sh
+++ b/ci-operator/step-registry/baremetalds/devscripts/gather/baremetalds-devscripts-gather-commands.sh
@@ -23,6 +23,28 @@ function getlogs() {
 # Gather logs regardless of what happens after this
 trap getlogs EXIT
 
+if [[ ! -d "${ARTIFACT_DIR}/root/dev-scripts/logs" ]]; then
+  echo "### Dev-scripts logs not found, collecting as fallback..."
+  timeout -s 9 5m ssh "${SSHOPTS[@]}" "root@${IP}" tar -czf - /root/dev-scripts/logs 2>/dev/null | tar -C "${ARTIFACT_DIR}" -xzf - || true
+  if [[ -d "${ARTIFACT_DIR}/root/dev-scripts/logs" ]]; then
+    find "${ARTIFACT_DIR}/root/dev-scripts/logs" -type f -exec sed -i '
+      /auths/ s/.*/*** PULL_SECRET ***/;
+      s/password: .*/password: REDACTED/;
+      s/X-Auth-Token.*/X-Auth-Token REDACTED/;
+      s/UserData:.*,/UserData: REDACTED,/;
+      ' {} + || true
+  fi
+fi
+
+if [[ ! -f "${SHARED_DIR}/install-status.txt" ]]; then
+  status_file="${ARTIFACT_DIR}/root/dev-scripts/logs/installer-status.txt"
+  if [[ -f "${status_file}" ]]; then
+    cp "${status_file}" "${SHARED_DIR}/install-status.txt"
+  else
+    echo "1" > "${SHARED_DIR}/install-status.txt"
+  fi
+fi
+
 echo "### Gathering logs..."
 timeout -s 9 15m ssh "${SSHOPTS[@]}" "root@${IP}" bash - <<EOF |& sed -e 's/.*auths.*/*** PULL_SECRET ***/g'
 cd dev-scripts


### PR DESCRIPTION
When the setup step times out, bash defers trap execution while waiting
for the foreground SSH command to complete (per bash signal handling
semantics). This means the finished() cleanup never runs before SIGKILL,
and dev-scripts logs and install-status.txt are lost.

Add a fallback to baremetalds-devscripts-gather that collects dev-scripts
logs and install-status if the setup trap did not. The check is a no-op
on the normal (success) path since the logs are already present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced log gathering and fallback handling for bare metal developer scripts, including automatic retrieval and extraction of log artifacts.
  * Added automatic redaction of authentication fields in diagnostic logs for improved security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->