### PR TITLE
ART-14540: enforce branch protection

### DIFF
--- a/core-services/prow/02_config/openshift/alibaba-cloud-csi-driver/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/alibaba-cloud-csi-driver/_prowconfig.yaml
@@ -1,3 +1,11 @@
+branch-protection:
+  orgs:
+    openshift:
+      repos:
+        alibaba-cloud-csi-driver:
+          branches:
+            main:
+              protect: true
 tide:
   queries:
   - includedBranches:

--- a/core-services/prow/02_config/openshift/alibaba-disk-csi-driver-operator/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/alibaba-disk-csi-driver-operator/_prowconfig.yaml
@@ -1,3 +1,11 @@
+branch-protection:
+  orgs:
+    openshift:
+      repos:
+        alibaba-disk-csi-driver-operator:
+          branches:
+            main:
+              protect: true
 tide:
   queries:
   - includedBranches:

--- a/core-services/prow/02_config/openshift/aws-ebs-csi-driver-operator/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/aws-ebs-csi-driver-operator/_prowconfig.yaml
@@ -1,3 +1,11 @@
+branch-protection:
+  orgs:
+    openshift:
+      repos:
+        aws-ebs-csi-driver-operator:
+          branches:
+            main:
+              protect: true
 tide:
   queries:
   - includedBranches:

--- a/core-services/prow/02_config/openshift/aws-efs-csi-driver-operator/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/aws-efs-csi-driver-operator/_prowconfig.yaml
@@ -1,3 +1,11 @@
+branch-protection:
+  orgs:
+    openshift:
+      repos:
+        aws-efs-csi-driver-operator:
+          branches:
+            main:
+              protect: true
 tide:
   queries:
   - includedBranches:

--- a/core-services/prow/02_config/openshift/azure-disk-csi-driver-operator/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/azure-disk-csi-driver-operator/_prowconfig.yaml
@@ -1,3 +1,11 @@
+branch-protection:
+  orgs:
+    openshift:
+      repos:
+        azure-disk-csi-driver-operator:
+          branches:
+            main:
+              protect: true
 tide:
   queries:
   - includedBranches:

--- a/core-services/prow/02_config/openshift/azure-file-csi-driver-operator/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/azure-file-csi-driver-operator/_prowconfig.yaml
@@ -1,3 +1,11 @@
+branch-protection:
+  orgs:
+    openshift:
+      repos:
+        azure-file-csi-driver-operator:
+          branches:
+            main:
+              protect: true
 tide:
   queries:
   - includedBranches:

--- a/core-services/prow/02_config/openshift/cluster-api-operator/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/cluster-api-operator/_prowconfig.yaml
@@ -1,3 +1,11 @@
+branch-protection:
+  orgs:
+    openshift:
+      repos:
+        cluster-api-operator:
+          branches:
+            main:
+              protect: true
 tide:
   queries:
   - includedBranches:

--- a/core-services/prow/02_config/openshift/csi-driver-manila-operator/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/csi-driver-manila-operator/_prowconfig.yaml
@@ -1,3 +1,11 @@
+branch-protection:
+  orgs:
+    openshift:
+      repos:
+        csi-driver-manila-operator:
+          branches:
+            main:
+              protect: true
 tide:
   queries:
   - includedBranches:

--- a/core-services/prow/02_config/openshift/etcd/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/etcd/_prowconfig.yaml
@@ -1,3 +1,11 @@
+branch-protection:
+  orgs:
+    openshift:
+      repos:
+        etcd:
+          branches:
+            main:
+              protect: true
 tide:
   queries:
   - includedBranches:

--- a/core-services/prow/02_config/openshift/ibm-vpc-node-label-updater/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/ibm-vpc-node-label-updater/_prowconfig.yaml
@@ -1,3 +1,11 @@
+branch-protection:
+  orgs:
+    openshift:
+      repos:
+        ibm-vpc-node-label-updater:
+          branches:
+            main:
+              protect: true
 tide:
   queries:
   - includedBranches:

--- a/core-services/prow/02_config/openshift/kubevirt-csi-driver/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/kubevirt-csi-driver/_prowconfig.yaml
@@ -6,6 +6,32 @@ branch-protection:
           branches:
             master:
               protect: true
+            release-4.12:
+              protect: true
+            release-4.13:
+              protect: true
+            release-4.14:
+              protect: true
+            release-4.15:
+              protect: true
+            release-4.16:
+              protect: true
+            release-4.17:
+              protect: true
+            release-4.18:
+              protect: true
+            release-4.19:
+              protect: true
+            release-4.20:
+              protect: true
+            release-4.21:
+              protect: true
+            release-4.22:
+              protect: true
+            release-4.23:
+              protect: true
+            release-5.0:
+              protect: true
           protect: false
 tide:
   queries:

--- a/core-services/prow/02_config/openshift/openstack-cinder-csi-driver-operator/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/openstack-cinder-csi-driver-operator/_prowconfig.yaml
@@ -1,3 +1,11 @@
+branch-protection:
+  orgs:
+    openshift:
+      repos:
+        openstack-cinder-csi-driver-operator:
+          branches:
+            main:
+              protect: true
 tide:
   queries:
   - includedBranches:

--- a/core-services/prow/02_config/openshift/operator-framework-catalogd/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/operator-framework-catalogd/_prowconfig.yaml
@@ -1,3 +1,11 @@
+branch-protection:
+  orgs:
+    openshift:
+      repos:
+        operator-framework-catalogd:
+          branches:
+            main:
+              protect: true
 tide:
   queries:
   - includedBranches:

--- a/core-services/prow/02_config/openshift/ovirt-csi-driver-operator/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/ovirt-csi-driver-operator/_prowconfig.yaml
@@ -1,3 +1,11 @@
+branch-protection:
+  orgs:
+    openshift:
+      repos:
+        ovirt-csi-driver-operator:
+          branches:
+            main:
+              protect: true
 tide:
   queries:
   - includedBranches:

--- a/core-services/prow/02_config/openshift/ovirt-csi-driver/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/ovirt-csi-driver/_prowconfig.yaml
@@ -1,3 +1,11 @@
+branch-protection:
+  orgs:
+    openshift:
+      repos:
+        ovirt-csi-driver:
+          branches:
+            main:
+              protect: true
 tide:
   queries:
   - includedBranches:

--- a/core-services/prow/02_config/openshift/sdn/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/sdn/_prowconfig.yaml
@@ -1,3 +1,11 @@
+branch-protection:
+  orgs:
+    openshift:
+      repos:
+        sdn:
+          branches:
+            main:
+              protect: true
 tide:
   queries:
   - includedBranches:


### PR DESCRIPTION
  ## Summary                                                                                                                                                                             
                                                                                                                                                                                         
  [Red Hat's internal security policy](https://groups.google.com/a/redhat.com/g/global-engineering-all/c/VpG5jEPdpxo) requires that branch protection is enabled on all release branches of repositories that produce OCP content.
  
  This PR enables branch protection for repositories that were identified as missing it.                                                                                                                                       

