### PR TITLE
NO-JIRA: feat: skip oom test on degraded runs

### DIFF
--- a/ci-operator/step-registry/baremetalds/two-node/fencing/degraded/baremetalds-two-node-fencing-degraded-workflow.yaml
+++ b/ci-operator/step-registry/baremetalds/two-node/fencing/degraded/baremetalds-two-node-fencing-degraded-workflow.yaml
@@ -103,7 +103,7 @@ workflow:
         when running the oc adm must-gather command timeout\|\[sig-cli\] oc adm must-gather
         must-gather support since and since-time flags timeout\|\[sig-cli\] oc adm
         must-gather run the must-gather command with own name space\|\[sig-instrumentation]
-        Prometheus .* should start and expose a secured proxy and unsecured metrics\|\[Disruptive\]
+        Prometheus .* should start and expose a secured proxy and unsecured metrics\|\[Disruptive\]\|OOM score adjustment set to -997
       TEST_SUITE: openshift/two-node
       ENABLE_HYPERVISOR_SSH_CONFIG: "true"
   documentation: |-


### PR DESCRIPTION
skipping the oom test for tnf degraded lanes, this test should be running on the conformance lane only