### PR TITLE
MCO-2170: Use installer osImageStream

### DIFF
--- a/ci-operator/config/openshift-priv/cluster-network-operator/openshift-priv-cluster-network-operator-master.yaml
+++ b/ci-operator/config/openshift-priv/cluster-network-operator/openshift-priv-cluster-network-operator-master.yaml
@@ -241,7 +241,7 @@ tests:
     env:
       EXTRA_MG_ARGS: --host-network
       FEATURE_SET: TechPreviewNoUpgrade
-      OSSTREAM: rhel-10
+      OS_IMAGE_STREAM: rhel-10
     workflow: openshift-e2e-aws-ovn
 - always_run: false
   as: e2e-aws-ovn-techpreview-serial

--- a/ci-operator/config/openshift-priv/cluster-network-operator/openshift-priv-cluster-network-operator-release-4.22.yaml
+++ b/ci-operator/config/openshift-priv/cluster-network-operator/openshift-priv-cluster-network-operator-release-4.22.yaml
@@ -242,7 +242,7 @@ tests:
     env:
       EXTRA_MG_ARGS: --host-network
       FEATURE_SET: TechPreviewNoUpgrade
-      OSSTREAM: rhel-10
+      OS_IMAGE_STREAM: rhel-10
     workflow: openshift-e2e-aws-ovn
 - always_run: false
   as: e2e-aws-ovn-techpreview-serial

--- a/ci-operator/config/openshift-priv/cluster-network-operator/openshift-priv-cluster-network-operator-release-4.23.yaml
+++ b/ci-operator/config/openshift-priv/cluster-network-operator/openshift-priv-cluster-network-operator-release-4.23.yaml
@@ -241,7 +241,7 @@ tests:
     env:
       EXTRA_MG_ARGS: --host-network
       FEATURE_SET: TechPreviewNoUpgrade
-      OSSTREAM: rhel-10
+      OS_IMAGE_STREAM: rhel-10
     workflow: openshift-e2e-aws-ovn
 - always_run: false
   as: e2e-aws-ovn-techpreview-serial

--- a/ci-operator/config/openshift-priv/cluster-network-operator/openshift-priv-cluster-network-operator-release-5.0.yaml
+++ b/ci-operator/config/openshift-priv/cluster-network-operator/openshift-priv-cluster-network-operator-release-5.0.yaml
@@ -241,7 +241,7 @@ tests:
     env:
       EXTRA_MG_ARGS: --host-network
       FEATURE_SET: TechPreviewNoUpgrade
-      OSSTREAM: rhel-10
+      OS_IMAGE_STREAM: rhel-10
     workflow: openshift-e2e-aws-ovn
 - always_run: false
   as: e2e-aws-ovn-techpreview-serial

--- a/ci-operator/config/openshift-priv/ovn-kubernetes/openshift-priv-ovn-kubernetes-master.yaml
+++ b/ci-operator/config/openshift-priv/ovn-kubernetes/openshift-priv-ovn-kubernetes-master.yaml
@@ -496,7 +496,7 @@ tests:
     env:
       EXTRA_MG_ARGS: --host-network
       FEATURE_SET: TechPreviewNoUpgrade
-      OSSTREAM: rhel-10
+      OS_IMAGE_STREAM: rhel-10
     workflow: openshift-e2e-aws-ovn
 - always_run: false
   as: openshift-e2e-gcp-ovn-techpreview-upgrade

--- a/ci-operator/config/openshift-priv/ovn-kubernetes/openshift-priv-ovn-kubernetes-release-4.22.yaml
+++ b/ci-operator/config/openshift-priv/ovn-kubernetes/openshift-priv-ovn-kubernetes-release-4.22.yaml
@@ -497,7 +497,7 @@ tests:
     env:
       EXTRA_MG_ARGS: --host-network
       FEATURE_SET: TechPreviewNoUpgrade
-      OSSTREAM: rhel-10
+      OS_IMAGE_STREAM: rhel-10
     workflow: openshift-e2e-aws-ovn
 - always_run: false
   as: openshift-e2e-gcp-ovn-techpreview-upgrade

--- a/ci-operator/config/openshift-priv/ovn-kubernetes/openshift-priv-ovn-kubernetes-release-4.23.yaml
+++ b/ci-operator/config/openshift-priv/ovn-kubernetes/openshift-priv-ovn-kubernetes-release-4.23.yaml
@@ -496,7 +496,7 @@ tests:
     env:
       EXTRA_MG_ARGS: --host-network
       FEATURE_SET: TechPreviewNoUpgrade
-      OSSTREAM: rhel-10
+      OS_IMAGE_STREAM: rhel-10
     workflow: openshift-e2e-aws-ovn
 - always_run: false
   as: openshift-e2e-gcp-ovn-techpreview-upgrade

--- a/ci-operator/config/openshift-priv/ovn-kubernetes/openshift-priv-ovn-kubernetes-release-5.0.yaml
+++ b/ci-operator/config/openshift-priv/ovn-kubernetes/openshift-priv-ovn-kubernetes-release-5.0.yaml
@@ -496,7 +496,7 @@ tests:
     env:
       EXTRA_MG_ARGS: --host-network
       FEATURE_SET: TechPreviewNoUpgrade
-      OSSTREAM: rhel-10
+      OS_IMAGE_STREAM: rhel-10
     workflow: openshift-e2e-aws-ovn
 - always_run: false
   as: openshift-e2e-gcp-ovn-techpreview-upgrade

--- a/ci-operator/config/openshift/cluster-network-operator/openshift-cluster-network-operator-master.yaml
+++ b/ci-operator/config/openshift/cluster-network-operator/openshift-cluster-network-operator-master.yaml
@@ -240,7 +240,7 @@ tests:
     env:
       EXTRA_MG_ARGS: --host-network
       FEATURE_SET: TechPreviewNoUpgrade
-      OSSTREAM: rhel-10
+      OS_IMAGE_STREAM: rhel-10
     workflow: openshift-e2e-aws-ovn
 - always_run: false
   as: e2e-aws-ovn-techpreview-serial

--- a/ci-operator/config/openshift/cluster-network-operator/openshift-cluster-network-operator-release-4.22.yaml
+++ b/ci-operator/config/openshift/cluster-network-operator/openshift-cluster-network-operator-release-4.22.yaml
@@ -241,7 +241,7 @@ tests:
     env:
       EXTRA_MG_ARGS: --host-network
       FEATURE_SET: TechPreviewNoUpgrade
-      OSSTREAM: rhel-10
+      OS_IMAGE_STREAM: rhel-10
     workflow: openshift-e2e-aws-ovn
 - always_run: false
   as: e2e-aws-ovn-techpreview-serial

--- a/ci-operator/config/openshift/cluster-network-operator/openshift-cluster-network-operator-release-4.23.yaml
+++ b/ci-operator/config/openshift/cluster-network-operator/openshift-cluster-network-operator-release-4.23.yaml
@@ -240,7 +240,7 @@ tests:
     env:
       EXTRA_MG_ARGS: --host-network
       FEATURE_SET: TechPreviewNoUpgrade
-      OSSTREAM: rhel-10
+      OS_IMAGE_STREAM: rhel-10
     workflow: openshift-e2e-aws-ovn
 - always_run: false
   as: e2e-aws-ovn-techpreview-serial

--- a/ci-operator/config/openshift/cluster-network-operator/openshift-cluster-network-operator-release-5.0.yaml
+++ b/ci-operator/config/openshift/cluster-network-operator/openshift-cluster-network-operator-release-5.0.yaml
@@ -240,7 +240,7 @@ tests:
     env:
       EXTRA_MG_ARGS: --host-network
       FEATURE_SET: TechPreviewNoUpgrade
-      OSSTREAM: rhel-10
+      OS_IMAGE_STREAM: rhel-10
     workflow: openshift-e2e-aws-ovn
 - always_run: false
   as: e2e-aws-ovn-techpreview-serial

--- a/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-master.yaml
+++ b/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-master.yaml
@@ -517,7 +517,7 @@ tests:
     env:
       EXTRA_MG_ARGS: --host-network
       FEATURE_SET: TechPreviewNoUpgrade
-      OSSTREAM: rhel-10
+      OS_IMAGE_STREAM: rhel-10
     workflow: openshift-e2e-aws-ovn
 - always_run: false
   as: openshift-e2e-gcp-ovn-techpreview-upgrade

--- a/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.22.yaml
+++ b/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.22.yaml
@@ -496,7 +496,7 @@ tests:
     env:
       EXTRA_MG_ARGS: --host-network
       FEATURE_SET: TechPreviewNoUpgrade
-      OSSTREAM: rhel-10
+      OS_IMAGE_STREAM: rhel-10
     workflow: openshift-e2e-aws-ovn
 - always_run: false
   as: openshift-e2e-gcp-ovn-techpreview-upgrade

--- a/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.23.yaml
+++ b/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.23.yaml
@@ -495,7 +495,7 @@ tests:
     env:
       EXTRA_MG_ARGS: --host-network
       FEATURE_SET: TechPreviewNoUpgrade
-      OSSTREAM: rhel-10
+      OS_IMAGE_STREAM: rhel-10
     workflow: openshift-e2e-aws-ovn
 - always_run: false
   as: openshift-e2e-gcp-ovn-techpreview-upgrade

--- a/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-5.0.yaml
+++ b/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-5.0.yaml
@@ -495,7 +495,7 @@ tests:
     env:
       EXTRA_MG_ARGS: --host-network
       FEATURE_SET: TechPreviewNoUpgrade
-      OSSTREAM: rhel-10
+      OS_IMAGE_STREAM: rhel-10
     workflow: openshift-e2e-aws-ovn
 - always_run: false
   as: openshift-e2e-gcp-ovn-techpreview-upgrade

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22.yaml
@@ -374,7 +374,7 @@ tests:
       DEVSCRIPTS_CONFIG: |
         IP_STACK=v6
         FEATURE_SET=TechPreviewNoUpgrade
-      OSSTREAM: rhel-10
+        OS_IMAGE_STREAM=rhel-10
     observers:
       enable:
       - observers-resource-watch
@@ -434,7 +434,7 @@ tests:
       DEVSCRIPTS_CONFIG: |
         IP_STACK=v4v6
         FEATURE_SET=TechPreviewNoUpgrade
-      OSSTREAM: rhel-10
+        OS_IMAGE_STREAM=rhel-10
     observers:
       enable:
       - observers-resource-watch
@@ -2415,7 +2415,7 @@ tests:
       DEVSCRIPTS_CONFIG: |
         IP_STACK=v4
         FEATURE_SET=TechPreviewNoUpgrade
-      OSSTREAM: rhel-10
+        OS_IMAGE_STREAM=rhel-10
     observers:
       enable:
       - observers-resource-watch

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.23.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.23.yaml
@@ -374,7 +374,7 @@ tests:
       DEVSCRIPTS_CONFIG: |
         IP_STACK=v6
         FEATURE_SET=TechPreviewNoUpgrade
-      OSSTREAM: rhel-10
+        OS_IMAGE_STREAM=rhel-10
     observers:
       enable:
       - observers-resource-watch
@@ -434,7 +434,7 @@ tests:
       DEVSCRIPTS_CONFIG: |
         IP_STACK=v4v6
         FEATURE_SET=TechPreviewNoUpgrade
-      OSSTREAM: rhel-10
+        OS_IMAGE_STREAM=rhel-10
     observers:
       enable:
       - observers-resource-watch
@@ -2380,7 +2380,7 @@ tests:
       DEVSCRIPTS_CONFIG: |
         IP_STACK=v4
         FEATURE_SET=TechPreviewNoUpgrade
-      OSSTREAM: rhel-10
+        OS_IMAGE_STREAM=rhel-10
     observers:
       enable:
       - observers-resource-watch

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
@@ -374,7 +374,7 @@ tests:
       DEVSCRIPTS_CONFIG: |
         IP_STACK=v6
         FEATURE_SET=TechPreviewNoUpgrade
-      OSSTREAM: rhel-10
+        OS_IMAGE_STREAM=rhel-10
     observers:
       enable:
       - observers-resource-watch
@@ -434,7 +434,7 @@ tests:
       DEVSCRIPTS_CONFIG: |
         IP_STACK=v4v6
         FEATURE_SET=TechPreviewNoUpgrade
-      OSSTREAM: rhel-10
+        OS_IMAGE_STREAM=rhel-10
     observers:
       enable:
       - observers-resource-watch
@@ -2371,7 +2371,7 @@ tests:
       DEVSCRIPTS_CONFIG: |
         IP_STACK=v4
         FEATURE_SET=TechPreviewNoUpgrade
-      OSSTREAM: rhel-10
+        OS_IMAGE_STREAM=rhel-10
     observers:
       enable:
       - observers-resource-watch


### PR DESCRIPTION
This change is about moving from the `rhcos-conf-osstream` step that creates 2 MCPs pointing to the configured OS Image Stream and inject them to the installer manifests to just set the new available osImageStream field in the install-config. This change aligns the way we test with what users will actually use.