### PR TITLE
Revert "Temporary cred request filter workaround"

### DIFF
--- a/ci-operator/step-registry/aws/c2s/init-token-service/aws-c2s-init-token-service-ref.yaml
+++ b/ci-operator/step-registry/aws/c2s/init-token-service/aws-c2s-init-token-service-ref.yaml
@@ -20,7 +20,7 @@ ref:
     documentation: |-
       Determine whether remove TechPreview credentionals or not.
   - name: EXTRACT_MANIFEST_INCLUDED
-    default: "false"
+    default: "true"
     documentation: |-
       Determine whether to exclude manifests that are not expected to be included in the cluster when extracting.
   - name: SELF_MANAGED_ADDITIONAL_CA

--- a/ci-operator/step-registry/aws/provision/cco-manual-users/static/aws-provision-cco-manual-users-static-ref.yaml
+++ b/ci-operator/step-registry/aws/provision/cco-manual-users/static/aws-provision-cco-manual-users-static-ref.yaml
@@ -16,7 +16,7 @@ ref:
     documentation: |-
       Determine whether remove TechPreview credentionals or not.
   - name: EXTRACT_MANIFEST_INCLUDED
-    default: "false"
+    default: "true"
     documentation: |-
       Determine whether to exclude manifests that are not expected to be included in the cluster when extracting.
   documentation: |-

--- a/ci-operator/step-registry/gcp/provision/cco-manual-users/static/gcp-provision-cco-manual-users-static-ref.yaml
+++ b/ci-operator/step-registry/gcp/provision/cco-manual-users/static/gcp-provision-cco-manual-users-static-ref.yaml
@@ -16,7 +16,7 @@ ref:
     documentation: |-
       Add --enable-tech-preview option to ccoctl, allow ccoctl process tech-preview CRs
   - name: EXTRACT_MANIFEST_INCLUDED
-    default: "false"
+    default: "true"
     documentation: |-
       Determine whether to exclude manifests that are not expected to be included in the cluster when extracting.
   documentation: |-

--- a/ci-operator/step-registry/ipi/conf/aws/oidc-creds-provision/ipi-conf-aws-oidc-creds-provision-commands.sh
+++ b/ci-operator/step-registry/ipi/conf/aws/oidc-creds-provision/ipi-conf-aws-oidc-creds-provision-commands.sh
@@ -71,18 +71,6 @@ popd
 echo "CR manifest files:"
 ls "/tmp/credrequests"
 
-# TODO(OCPBUGS-77845): Temporary workaround - must be reverted when the bug is resolved.
-# The cluster-api credentials request changed from feature-set to feature-gate
-# annotation, but oc adm release extract does not yet filter on feature-gate.
-# Remove the cluster-api CR when FEATURE_SET is not set.
-if [[ -z "${FEATURE_SET:-}" ]]; then
-  capi_cr="/tmp/credrequests/0000_30_cluster-api_01_credentials-request.yaml"
-  if [[ -f "${capi_cr}" ]]; then
-    echo "Removing cluster-api credentials request (feature-gate not supported by current tooling)"
-    rm -f "${capi_cr}"
-  fi
-fi
-
 if [[ ${ENABLE_SHARED_VPC} == "yes" ]]; then
   echo "Shared VPC is enabled"
   echo "Checking if ingress CR file exits"

--- a/ci-operator/step-registry/ipi/conf/aws/oidc-creds-provision/ipi-conf-aws-oidc-creds-provision-ref.yaml
+++ b/ci-operator/step-registry/ipi/conf/aws/oidc-creds-provision/ipi-conf-aws-oidc-creds-provision-ref.yaml
@@ -21,7 +21,7 @@ ref:
     documentation: |-
       Add --enable-tech-preview option to ccoctl, allow ccoctl process tech-preview CRs
   - name: EXTRACT_MANIFEST_INCLUDED
-    default: "false"
+    default: "true"
     documentation: |-
       Determine whether to exclude manifests that are not expected to be included in the cluster when extracting.
   - name: STS_USE_PRIVATE_S3

--- a/ci-operator/step-registry/ipi/conf/azure/oidc-creds-provision/ipi-conf-azure-oidc-creds-provision-commands.sh
+++ b/ci-operator/step-registry/ipi/conf/azure/oidc-creds-provision/ipi-conf-azure-oidc-creds-provision-commands.sh
@@ -114,18 +114,6 @@ popd
 echo "CR manifest files:"
 ls "/tmp/credrequests"
 
-# TODO(OCPBUGS-77845): Temporary workaround - must be reverted when the bug is resolved.
-# The cluster-api credentials request changed from feature-set to feature-gate
-# annotation, but oc adm release extract does not yet filter on feature-gate.
-# Remove the cluster-api CR when FEATURE_SET is not set.
-if [[ -z "${FEATURE_SET:-}" ]]; then
-  capi_cr="/tmp/credrequests/0000_30_cluster-api_01_credentials-request.yaml"
-  if [[ -f "${capi_cr}" ]]; then
-    echo "Removing cluster-api credentials request (feature-gate not supported by current tooling)"
-    rm -f "${capi_cr}"
-  fi
-fi
-
 ADDITIONAL_CCOCTL_ARGS=""
 # ENABLE_TECH_PREVIEW_CREDENTIALS_REQUESTS enables the relevant job for each operator to decide
 # independantly if it needs the --enable-tech-preview added to the ccoctl command. It is very

--- a/ci-operator/step-registry/ipi/conf/azure/oidc-creds-provision/ipi-conf-azure-oidc-creds-provision-ref.yaml
+++ b/ci-operator/step-registry/ipi/conf/azure/oidc-creds-provision/ipi-conf-azure-oidc-creds-provision-ref.yaml
@@ -20,7 +20,7 @@ ref:
     documentation: |-
       Add --enable-tech-preview option to ccoctl, allow ccoctl process tech-preview CRs
   - name: EXTRACT_MANIFEST_INCLUDED
-    default: "false"
+    default: "true"
     documentation: |-
       Determine whether to exclude manifests that are not expected to be included in the cluster when extracting.
   - name: ENABLE_MIN_PERMISSION_FOR_STS

--- a/ci-operator/step-registry/ipi/conf/azurestack/creds/ipi-conf-azurestack-creds-ref.yaml
+++ b/ci-operator/step-registry/ipi/conf/azurestack/creds/ipi-conf-azurestack-creds-ref.yaml
@@ -11,7 +11,7 @@ ref:
     env: RELEASE_IMAGE_LATEST_FROM_BUILD_FARM
   env:
   - name: EXTRACT_MANIFEST_INCLUDED
-    default: "false"
+    default: "true"
     documentation: |-
       Determine whether to exclude manifests that are not expected to be included in the cluster when extracting.
   credentials:

--- a/ci-operator/step-registry/ipi/conf/gcp/oidc-creds-provision/ipi-conf-gcp-oidc-creds-provision-commands.sh
+++ b/ci-operator/step-registry/ipi/conf/gcp/oidc-creds-provision/ipi-conf-gcp-oidc-creds-provision-commands.sh
@@ -85,18 +85,6 @@ popd
 echo "> Output gcp credentials requests to directory: /tmp/credrequests"
 ls "/tmp/credrequests"
 
-# TODO(OCPBUGS-77845): Temporary workaround - must be reverted when the bug is resolved.
-# The cluster-api credentials request changed from feature-set to feature-gate
-# annotation, but oc adm release extract does not yet filter on feature-gate.
-# Remove the cluster-api CR when FEATURE_SET is not set.
-if [[ -z "${FEATURE_SET:-}" ]]; then
-  capi_cr="/tmp/credrequests/0000_30_cluster-api_01_credentials-request.yaml"
-  if [[ -f "${capi_cr}" ]]; then
-    echo "Removing cluster-api credentials request (feature-gate not supported by current tooling)"
-    rm -f "${capi_cr}"
-  fi
-fi
-
 ADDITIONAL_CCOCTL_ARGS=""
 if [[ "${FEATURE_SET}" == "TechPreviewNoUpgrade" ]]; then
   ADDITIONAL_CCOCTL_ARGS="$ADDITIONAL_CCOCTL_ARGS --enable-tech-preview"

--- a/ci-operator/step-registry/ipi/conf/gcp/oidc-creds-provision/ipi-conf-gcp-oidc-creds-provision-ref.yaml
+++ b/ci-operator/step-registry/ipi/conf/gcp/oidc-creds-provision/ipi-conf-gcp-oidc-creds-provision-ref.yaml
@@ -20,7 +20,7 @@ ref:
     documentation: |-
       Add --enable-tech-preview option to ccoctl, allow ccoctl process tech-preview CRs
   - name: EXTRACT_MANIFEST_INCLUDED
-    default: "false"
+    default: "true"
     documentation: |-
       Determine whether to exclude manifests that are not expected to be included in the cluster when extracting.
   documentation: |-

--- a/ci-operator/step-registry/ipi/conf/manual-creds/remove-unnecessary-creds/ipi-conf-manual-creds-remove-unnecessary-creds-ref.yaml
+++ b/ci-operator/step-registry/ipi/conf/manual-creds/remove-unnecessary-creds/ipi-conf-manual-creds-remove-unnecessary-creds-ref.yaml
@@ -24,7 +24,7 @@ ref:
       documentation: |-
         additional supported capabilities set.
     - name: EXTRACT_MANIFEST_INCLUDED
-      default: "false"
+      default: "true"
       documentation: |-
         Determine whether to exclude manifests that are not expected to be included in the cluster when extracting.
   documentation: |-

--- a/ci-operator/step-registry/ipi/conf/nutanix/manual-creds/ipi-conf-nutanix-manual-creds-ref.yaml
+++ b/ci-operator/step-registry/ipi/conf/nutanix/manual-creds/ipi-conf-nutanix-manual-creds-ref.yaml
@@ -16,7 +16,7 @@ ref:
     documentation: |-
       Add --enable-tech-preview option to ccoctl, allow ccoctl process tech-preview CRs
   - name: EXTRACT_MANIFEST_INCLUDED
-    default: "false"
+    default: "true"
     documentation: |-
       Determine whether to exclude manifests that are not expected to be included in the cluster when extracting.
   documentation: |-


### PR DESCRIPTION
Follow up to revert temporary workaround from #76228 

This reverts commit 068c4d1b743f94ce330eaa3ac7a97bd32bacb8e3.

https://redhat.atlassian.net/browse/OCPBUGS-77845
may be resolved with https://github.com/openshift/oc/pull/2241

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed temporary workaround logic from OIDC credential provisioning for AWS, Azure, and GCP.
  * Updated default configuration flags to enable manifest extraction/feature behavior by default across multiple provisioning and creds steps.
  * Changed default for TechPreview credential removal to enabled in relevant AWS step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->