### PR TITLE
fix: use from: src for odh-model-controller E2E to fix manifest mismatch

### DIFF
--- a/ci-operator/config/opendatahub-io/odh-model-controller/opendatahub-io-odh-model-controller-incubating.yaml
+++ b/ci-operator/config/opendatahub-io/odh-model-controller/opendatahub-io-odh-model-controller-incubating.yaml
@@ -4,30 +4,26 @@ base_images:
     namespace: ocp
     tag: "9"
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-9-release-golang-1.25-openshift-4.21
+  project_image:
+    dockerfile_literal: |-
+      FROM registry.access.redhat.com/ubi9/python-311:1
+
+      # Prow expects to be able to check out a repo under /go
+      USER 0:0
+      WORKDIR /go
+      RUN chown 1001:0 .
+
+      USER 1001:0
+
+      # The VENV that is activated by default conflicts with KServe
+      # scripts. These variables are set to empty to not activate any
+      # VENV by default.
+      ENV BASH_ENV="" ENV="" PROMPT_COMMAND=""
 images:
 - context_dir: .
   dockerfile_path: Containerfile
   from: ubi_minimal
   to: odh-model-controller
-- dockerfile_literal: |-
-    FROM registry.access.redhat.com/ubi9/python-311:1
-
-    # Prow expects to be able to check out a repo under /go
-    USER 0:0
-    WORKDIR /go
-    RUN chown 1001:0 .
-
-    USER 1001:0
-
-    # The VENV that is activated by default conflicts with KServe
-    # scripts. These variables are set to empty to not activate any
-    # VENV by default.
-    ENV BASH_ENV="" ENV="" PROMPT_COMMAND=""
-  to: odhmc-kserve-tests
 promotion:
   to:
   - namespace: opendatahub-io
@@ -64,7 +60,7 @@ tests:
       cli: latest
       commands: |
         cp -v ${SHARED_DIR}/debuglog-*.log ${SHARED_DIR}/stdout-*.log ${SHARED_DIR}/stderr-*.log "${ARTIFACT_DIR}/" || true
-      from: odhmc-kserve-tests
+      from: src
       resources:
         requests:
           cpu: 100m
@@ -77,7 +73,7 @@ tests:
           --image=quay.io/modh/must-gather:rhoai-2.24 \
           --dest-dir "${ARTIFACT_DIR}/gather-kserve" \
           -- "export COMPONENT=kserve; /usr/bin/gather"
-      from: odhmc-kserve-tests
+      from: src
       resources:
         requests:
           cpu: 100m
@@ -86,7 +82,7 @@ tests:
       best_effort: true
       cli: latest
       commands: oc adm must-gather --dest-dir "${ARTIFACT_DIR}/gather-openshift"
-      from: odhmc-kserve-tests
+      from: src
       resources:
         requests:
           cpu: 100m
@@ -99,14 +95,14 @@ tests:
         set -euxo pipefail
         echo "ODH_MODEL_CONTROLLER_IMAGE=${ODH_MODEL_CONTROLLER_IMAGE}"
 
+        ODH_MC_ROOT="$(pwd)"
+
         git clone https://github.com/opendatahub-io/kserve.git /tmp/kserve
         pushd /tmp/kserve
           git fetch --all --tags
           git checkout release-v0.15
 
-          git clone --depth 1 --branch incubating \
-            https://github.com/opendatahub-io/odh-model-controller.git /tmp/kserve/odh-model-controller
-          export ODH_MC_MANIFEST_SOURCE=../../odh-model-controller/config/base
+          export ODH_MC_MANIFEST_SOURCE="${ODH_MC_ROOT}/config/base"
 
           export GITHUB_SHA="${PULL_BASE_SHA:-stable}"
           export ODH_MODEL_CONTROLLER_IMAGE="${ODH_MODEL_CONTROLLER_IMAGE}"
@@ -147,7 +143,7 @@ tests:
       dependencies:
       - env: ODH_MODEL_CONTROLLER_IMAGE
         name: odh-model-controller
-      from: odhmc-kserve-tests
+      from: src
       resources:
         requests:
           cpu: 100m

--- a/ci-operator/config/opendatahub-io/odh-model-controller/opendatahub-io-odh-model-controller-main.yaml
+++ b/ci-operator/config/opendatahub-io/odh-model-controller/opendatahub-io-odh-model-controller-main.yaml
@@ -4,30 +4,26 @@ base_images:
     namespace: ocp
     tag: "9"
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-9-release-golang-1.25-openshift-4.21
+  project_image:
+    dockerfile_literal: |-
+      FROM registry.access.redhat.com/ubi9/python-311:1
+
+      # Prow expects to be able to check out a repo under /go
+      USER 0:0
+      WORKDIR /go
+      RUN chown 1001:0 .
+
+      USER 1001:0
+
+      # The VENV that is activated by default conflicts with KServe
+      # scripts. These variables are set to empty to not activate any
+      # VENV by default.
+      ENV BASH_ENV="" ENV="" PROMPT_COMMAND=""
 images:
 - context_dir: .
   dockerfile_path: Containerfile
   from: ubi_minimal
   to: odh-model-controller
-- dockerfile_literal: |-
-    FROM registry.access.redhat.com/ubi9/python-311:1
-
-    # Prow expects to be able to check out a repo under /go
-    USER 0:0
-    WORKDIR /go
-    RUN chown 1001:0 .
-
-    USER 1001:0
-
-    # The VENV that is activated by default conflicts with KServe
-    # scripts. These variables are set to empty to not activate any
-    # VENV by default.
-    ENV BASH_ENV="" ENV="" PROMPT_COMMAND=""
-  to: odhmc-kserve-tests
 promotion:
   to:
   - namespace: opendatahub-io
@@ -64,7 +60,7 @@ tests:
       cli: latest
       commands: |
         cp -v ${SHARED_DIR}/debuglog-*.log ${SHARED_DIR}/stdout-*.log ${SHARED_DIR}/stderr-*.log "${ARTIFACT_DIR}/" || true
-      from: odhmc-kserve-tests
+      from: src
       resources:
         requests:
           cpu: 100m
@@ -77,7 +73,7 @@ tests:
           --image=quay.io/modh/must-gather:rhoai-2.24 \
           --dest-dir "${ARTIFACT_DIR}/gather-kserve" \
           -- "export COMPONENT=kserve; /usr/bin/gather"
-      from: odhmc-kserve-tests
+      from: src
       resources:
         requests:
           cpu: 100m
@@ -86,7 +82,7 @@ tests:
       best_effort: true
       cli: latest
       commands: oc adm must-gather --dest-dir "${ARTIFACT_DIR}/gather-openshift"
-      from: odhmc-kserve-tests
+      from: src
       resources:
         requests:
           cpu: 100m
@@ -99,14 +95,14 @@ tests:
         set -euxo pipefail
         echo "ODH_MODEL_CONTROLLER_IMAGE=${ODH_MODEL_CONTROLLER_IMAGE}"
 
+        ODH_MC_ROOT="$(pwd)"
+
         git clone https://github.com/opendatahub-io/kserve.git /tmp/kserve
         pushd /tmp/kserve
           git fetch --all --tags
           git checkout release-v0.15
 
-          git clone --depth 1 --branch main \
-            https://github.com/opendatahub-io/odh-model-controller.git /tmp/kserve/odh-model-controller
-          export ODH_MC_MANIFEST_SOURCE=../../odh-model-controller/config/base
+          export ODH_MC_MANIFEST_SOURCE="${ODH_MC_ROOT}/config/base"
 
           export GITHUB_SHA="${PULL_BASE_SHA:-stable}"
           export ODH_MODEL_CONTROLLER_IMAGE="${ODH_MODEL_CONTROLLER_IMAGE}"
@@ -147,7 +143,7 @@ tests:
       dependencies:
       - env: ODH_MODEL_CONTROLLER_IMAGE
         name: odh-model-controller
-      from: odhmc-kserve-tests
+      from: src
       resources:
         requests:
           cpu: 100m
@@ -170,7 +166,7 @@ tests:
       cli: latest
       commands: |
         cp -v ${SHARED_DIR}/debuglog-*.log ${SHARED_DIR}/stdout-*.log ${SHARED_DIR}/stderr-*.log "${ARTIFACT_DIR}/" || true
-      from: odhmc-kserve-tests
+      from: src
       resources:
         requests:
           cpu: 100m
@@ -183,7 +179,7 @@ tests:
           --image=quay.io/modh/must-gather:rhoai-2.24 \
           --dest-dir "${ARTIFACT_DIR}/gather-kserve" \
           -- "export COMPONENT=kserve; /usr/bin/gather"
-      from: odhmc-kserve-tests
+      from: src
       resources:
         requests:
           cpu: 100m
@@ -192,7 +188,7 @@ tests:
       best_effort: true
       cli: latest
       commands: oc adm must-gather --dest-dir "${ARTIFACT_DIR}/gather-openshift"
-      from: odhmc-kserve-tests
+      from: src
       resources:
         requests:
           cpu: 100m
@@ -247,7 +243,7 @@ tests:
       dependencies:
       - env: ODH_MODEL_CONTROLLER_IMAGE
         name: odh-model-controller
-      from: odhmc-kserve-tests
+      from: src
       resources:
         requests:
           cpu: 100m

--- a/ci-operator/config/opendatahub-io/odh-model-controller/opendatahub-io-odh-model-controller-stable-2.x.yaml
+++ b/ci-operator/config/opendatahub-io/odh-model-controller/opendatahub-io-odh-model-controller-stable-2.x.yaml
@@ -4,30 +4,26 @@ base_images:
     namespace: ocp
     tag: "9"
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-9-release-golang-1.25-openshift-4.21
+  project_image:
+    dockerfile_literal: |-
+      FROM registry.access.redhat.com/ubi9/python-311:1
+
+      # Prow expects to be able to check out a repo under /go
+      USER 0:0
+      WORKDIR /go
+      RUN chown 1001:0 .
+
+      USER 1001:0
+
+      # The VENV that is activated by default conflicts with KServe
+      # scripts. These variables are set to empty to not activate any
+      # VENV by default.
+      ENV BASH_ENV="" ENV="" PROMPT_COMMAND=""
 images:
 - context_dir: .
   dockerfile_path: Containerfile
   from: ubi_minimal
   to: odh-model-controller
-- dockerfile_literal: |-
-    FROM registry.access.redhat.com/ubi9/python-311:1
-
-    # Prow expects to be able to check out a repo under /go
-    USER 0:0
-    WORKDIR /go
-    RUN chown 1001:0 .
-
-    USER 1001:0
-
-    # The VENV that is activated by default conflicts with KServe
-    # scripts. These variables are set to empty to not activate any
-    # VENV by default.
-    ENV BASH_ENV="" ENV="" PROMPT_COMMAND=""
-  to: odhmc-kserve-tests
 promotion:
   to:
   - namespace: opendatahub-io
@@ -64,7 +60,7 @@ tests:
       cli: latest
       commands: |
         cp -v ${SHARED_DIR}/debuglog-*.log ${SHARED_DIR}/stdout-*.log ${SHARED_DIR}/stderr-*.log "${ARTIFACT_DIR}/" || true
-      from: odhmc-kserve-tests
+      from: src
       resources:
         requests:
           cpu: 100m
@@ -77,7 +73,7 @@ tests:
           --image=quay.io/modh/must-gather:rhoai-2.24 \
           --dest-dir "${ARTIFACT_DIR}/gather-kserve" \
           -- "export COMPONENT=kserve; /usr/bin/gather"
-      from: odhmc-kserve-tests
+      from: src
       resources:
         requests:
           cpu: 100m
@@ -86,7 +82,7 @@ tests:
       best_effort: true
       cli: latest
       commands: oc adm must-gather --dest-dir "${ARTIFACT_DIR}/gather-openshift"
-      from: odhmc-kserve-tests
+      from: src
       resources:
         requests:
           cpu: 100m
@@ -99,14 +95,14 @@ tests:
         set -euxo pipefail
         echo "ODH_MODEL_CONTROLLER_IMAGE=${ODH_MODEL_CONTROLLER_IMAGE}"
 
+        ODH_MC_ROOT="$(pwd)"
+
         git clone https://github.com/opendatahub-io/kserve.git /tmp/kserve
         pushd /tmp/kserve
           git fetch --all --tags
           git checkout stable-2.x
 
-          git clone --depth 1 --branch stable-2.x \
-            https://github.com/opendatahub-io/odh-model-controller.git /tmp/kserve/odh-model-controller
-          export ODH_MC_MANIFEST_SOURCE=../../odh-model-controller/config/base
+          export ODH_MC_MANIFEST_SOURCE="${ODH_MC_ROOT}/config/base"
 
           export GITHUB_SHA="${PULL_BASE_SHA:-stable}"
           export ODH_MODEL_CONTROLLER_IMAGE="${ODH_MODEL_CONTROLLER_IMAGE}"
@@ -147,7 +143,7 @@ tests:
       dependencies:
       - env: ODH_MODEL_CONTROLLER_IMAGE
         name: odh-model-controller
-      from: odhmc-kserve-tests
+      from: src
       resources:
         requests:
           cpu: 100m


### PR DESCRIPTION
## Problem

The `e2e-odh-kserve` presubmit tests clone `odh-model-controller` at the base branch tip to source kustomize manifests. This causes a mismatch between the controller binary (built from the PR) and the deployed manifests (from the branch tip), leading to crashes when PRs modify webhooks, CRDs, or API versions.

## Fix

Switch `build_root` to `project_image` (matching kserve's pattern) so the `src` image includes the PR source checkout. Test steps now use `from: src` instead of the separate `odhmc-kserve-tests` image, and `ODH_MC_MANIFEST_SOURCE` points to the local `config/base` rather than a cloned copy.

### Changes across all three branch configs (main, incubating, stable-2.x):

- **`build_root`**: Changed from `image_stream_tag` to `project_image` with a Python 3.11 `dockerfile_literal` (same image that was previously built as `odhmc-kserve-tests`)
- **Removed `odhmc-kserve-tests` image**: No longer needed since `src` now serves this role
- **`from: odhmc-kserve-tests` -> `from: src`**: All test and post steps updated
- **Removed `git clone` of odh-model-controller** in the test script; `ODH_MC_MANIFEST_SOURCE` now points to the local checkout (`${ODH_MC_ROOT}/config/base`)

## Context

Supersedes #76396. pierDipi's review on that PR suggested using `from: src` (as kserve does), which is the approach taken here.

## Future

The inline CI scripts can be further simplified by invoking `make test-e2e-kserve-ocp` (added in opendatahub-io/odh-model-controller#756) once `kustomize` is available in the `build_root` image.