### PR TITLE
Add weekly-rhoso-dynamic-workload to metal-rhoso-x86 CI config

### DIFF
--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__metal-rhoso-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__metal-rhoso-x86.yaml
@@ -362,6 +362,35 @@ tests:
     - ref: openshift-qe-rhoso-browbeat-install
     - ref: openshift-qe-rhoso-browbeat-run
     - ref: openshift-qe-rhoso-browbeat-results-backup
+- as: weekly-rhoso-dynamic-workload
+  capabilities:
+  - intranet
+  cron: 0 17 * * 4
+  reporter_config:
+    channel: '#forum-rhos-scale'
+    job_states_to_report:
+    - success
+    - failure
+    - error
+    report_template: '{{if eq .Status.State "success"}} :white_check_mark: Job *{{.Spec.Job}}*
+      ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :white_check_mark:
+      {{else}} :warning:  Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+      logs> :warning: {{end}}'
+  restrict_network_access: false
+  steps:
+    cluster_profile: metal-perfscale-osp
+    env:
+      FOREMAN_OS: RHEL 9.4
+      NUM_NODES: "17"
+      STARTING_NODE: "4"
+      WORKLOAD: dynamic-workload
+    test:
+    - ref: openshift-qe-rhoso-uninstaller
+    - ref: openshift-qe-installer-bm-foreman
+    - ref: openshift-qe-rhoso-installer-pre-provisioned
+    - ref: openshift-qe-rhoso-browbeat-install
+    - ref: openshift-qe-rhoso-browbeat-run
+    - ref: openshift-qe-rhoso-browbeat-results-backup
 zz_generated_metadata:
   branch: main
   org: openshift-eng

--- a/ci-operator/jobs/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main-periodics.yaml
@@ -7379,6 +7379,100 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
+  cluster: build09
+  cron: 0 17 * * 4
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-eng
+    repo: ocp-qe-perfscale-ci
+  labels:
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: metal-perfscale-osp
+    ci-operator.openshift.io/cloud-cluster-profile: metal-perfscale-osp
+    ci-operator.openshift.io/variant: metal-rhoso-x86
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-metal-rhoso-x86-weekly-rhoso-dynamic-workload
+  reporter_config:
+    slack:
+      channel: '#forum-rhos-scale'
+      job_states_to_report:
+      - success
+      - failure
+      - error
+      report_template: '{{if eq .Status.State "success"}} :white_check_mark: Job *{{.Spec.Job}}*
+        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :white_check_mark:
+        {{else}} :warning:  Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+        logs> :warning: {{end}}'
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=weekly-rhoso-dynamic-workload
+      - --variant=metal-rhoso-x86
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
   cluster: build10
   cron: 0 5 * * 4
   decorate: true

--- a/ci-operator/step-registry/openshift-qe/rhoso/browbeat-run/openshift-qe-rhoso-browbeat-run-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/rhoso/browbeat-run/openshift-qe-rhoso-browbeat-run-commands.sh
@@ -4,7 +4,7 @@ set -o nounset
 set -o pipefail
 set -x
 
-SSH_ARGS="-i ${CLUSTER_PROFILE_DIR}/jh_priv_ssh_key -oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null"
+SSH_ARGS="-i ${CLUSTER_PROFILE_DIR}/jh_priv_ssh_key -oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null -o ServerAliveInterval=60 -o ServerAliveCountMax=240"
 jumphost=$(cat ${CLUSTER_PROFILE_DIR}/address)
 bastion=$(cat ${CLUSTER_PROFILE_DIR}/bastion)
 build_id="${BUILD_ID:-unknown}"
@@ -19,7 +19,7 @@ set -o nounset
 set -o pipefail
 set -x
 
-ssh root@${bastion} "
+ssh -o ServerAliveInterval=60 -o ServerAliveCountMax=240 root@${bastion} "
   set -o errexit
   set -o pipefail
   # Export CI metadata and ES host to the remote environment


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new weekly performance-scale test (Thursday 5 PM) running a dynamic workload on the metal perfscale profile.
  * Test results are now reported to the team communication channel.
* **Improvements**
  * Increased stability of long-running remote test steps by keeping SSH sessions alive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->