### PR TITLE
ARO HCP Switch build_root of baseimage to inrepo config

### DIFF
--- a/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__baseimage-generator.yaml
+++ b/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__baseimage-generator.yaml
@@ -1,8 +1,5 @@
 build_root:
-  image_stream_tag:
-    name: builder
-    namespace: ocp
-    tag: rhel-9-golang-1.25-openshift-4.21
+  from_repository: true
 images:
 - dockerfile_path: dev-infrastructure/openshift-ci/Dockerfile
   from: src

--- a/ci-operator/jobs/Azure/ARO-HCP/Azure-ARO-HCP-main-postsubmits.yaml
+++ b/ci-operator/jobs/Azure/ARO-HCP/Azure-ARO-HCP-main-postsubmits.yaml
@@ -6,8 +6,6 @@ postsubmits:
     - ^main$
     cluster: build09
     decorate: true
-    decoration_config:
-      skip_cloning: true
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci-operator.openshift.io/variant: baseimage-generator

--- a/ci-operator/jobs/Azure/ARO-HCP/Azure-ARO-HCP-main-presubmits.yaml
+++ b/ci-operator/jobs/Azure/ARO-HCP/Azure-ARO-HCP-main-presubmits.yaml
@@ -79,8 +79,6 @@ presubmits:
     cluster: build05
     context: ci/prow/baseimage-generator-images
     decorate: true
-    decoration_config:
-      skip_cloning: true
     labels:
       ci-operator.openshift.io/variant: baseimage-generator
       ci.openshift.io/generator: prowgen


### PR DESCRIPTION
Follow up after https://github.com/Azure/ARO-HCP/pull/4347 to enable inrepo config to manage build_root image with golang version.