### PR TITLE
MCO-2171: Switch cloud mco-disruptives to use longrun flow

### DIFF
--- a/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-4.22__periodics.yaml
+++ b/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-4.22__periodics.yaml
@@ -45,14 +45,17 @@ tests:
     cluster_profile: openshift-org-aws
     env:
       TEST_SUITE: openshift/machine-config-operator/disruptive
+    test:
+    - ref: openshift-e2e-test-longrun
     workflow: openshift-e2e-aws
 - as: e2e-azure-mco-disruptive
   interval: 72h
-  shard_count: 2
   steps:
     cluster_profile: openshift-org-azure
     env:
       TEST_SUITE: openshift/machine-config-operator/disruptive
+    test:
+    - ref: openshift-e2e-test-longrun
     workflow: openshift-e2e-azure
 - as: e2e-gcp-mco-disruptive
   interval: 72h
@@ -60,6 +63,8 @@ tests:
     cluster_profile: gcp
     env:
       TEST_SUITE: openshift/machine-config-operator/disruptive
+    test:
+    - ref: openshift-e2e-test-longrun
     workflow: openshift-e2e-gcp
 - as: e2e-vsphere-mco-disruptive
   cron: 0 6 */3 * *
@@ -67,6 +72,8 @@ tests:
     cluster_profile: vsphere-elastic
     env:
       TEST_SUITE: openshift/machine-config-operator/disruptive
+    test:
+    - ref: openshift-e2e-test-longrun
     workflow: openshift-e2e-vsphere
 - as: e2e-metal-ipi-ovn-ipv4-mco-disruptive
   capabilities:

--- a/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-4.23__periodics.yaml
+++ b/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-4.23__periodics.yaml
@@ -45,14 +45,17 @@ tests:
     cluster_profile: openshift-org-aws
     env:
       TEST_SUITE: openshift/machine-config-operator/disruptive
+    test:
+    - ref: openshift-e2e-test-longrun
     workflow: openshift-e2e-aws
 - as: e2e-azure-mco-disruptive
   interval: 168h
-  shard_count: 2
   steps:
     cluster_profile: openshift-org-azure
     env:
       TEST_SUITE: openshift/machine-config-operator/disruptive
+    test:
+    - ref: openshift-e2e-test-longrun
     workflow: openshift-e2e-azure
 - as: e2e-gcp-mco-disruptive
   interval: 168h
@@ -60,6 +63,8 @@ tests:
     cluster_profile: gcp
     env:
       TEST_SUITE: openshift/machine-config-operator/disruptive
+    test:
+    - ref: openshift-e2e-test-longrun
     workflow: openshift-e2e-gcp
 - as: e2e-vsphere-mco-disruptive
   cron: 0 6 */3 * *
@@ -67,6 +72,8 @@ tests:
     cluster_profile: vsphere-elastic
     env:
       TEST_SUITE: openshift/machine-config-operator/disruptive
+    test:
+    - ref: openshift-e2e-test-longrun
     workflow: openshift-e2e-vsphere
 - as: e2e-metal-ipi-ovn-ipv4-mco-disruptive
   capabilities:

--- a/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-5.0__periodics.yaml
+++ b/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-5.0__periodics.yaml
@@ -45,14 +45,17 @@ tests:
     cluster_profile: openshift-org-aws
     env:
       TEST_SUITE: openshift/machine-config-operator/disruptive
+    test:
+    - ref: openshift-e2e-test-longrun
     workflow: openshift-e2e-aws
 - as: e2e-azure-mco-disruptive
   interval: 168h
-  shard_count: 2
   steps:
     cluster_profile: openshift-org-azure
     env:
       TEST_SUITE: openshift/machine-config-operator/disruptive
+    test:
+    - ref: openshift-e2e-test-longrun
     workflow: openshift-e2e-azure
 - as: e2e-gcp-mco-disruptive
   interval: 168h
@@ -60,6 +63,8 @@ tests:
     cluster_profile: gcp
     env:
       TEST_SUITE: openshift/machine-config-operator/disruptive
+    test:
+    - ref: openshift-e2e-test-longrun
     workflow: openshift-e2e-gcp
 - as: e2e-vsphere-mco-disruptive
   cron: 0 6 */3 * *
@@ -67,6 +72,8 @@ tests:
     cluster_profile: vsphere-elastic
     env:
       TEST_SUITE: openshift/machine-config-operator/disruptive
+    test:
+    - ref: openshift-e2e-test-longrun
     workflow: openshift-e2e-vsphere
 - as: e2e-metal-ipi-ovn-ipv4-mco-disruptive
   capabilities:

--- a/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-release-4.22-periodics.yaml
+++ b/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-release-4.22-periodics.yaml
@@ -1100,96 +1100,21 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-machine-config-operator-release-4.22-periodics-e2e-azure-mco-disruptive-1of2
+  name: periodic-ci-openshift-machine-config-operator-release-4.22-periodics-e2e-azure-mco-disruptive
+  reporter_config:
+    slack:
+      channel: '#trt-alert-mco'
+      job_states_to_report:
+      - failure
+      - error
+      report_template: ':failed: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*.
+        <{{.Status.URL}}|View logs> {{end}}'
   spec:
     containers:
     - args:
       - --gcs-upload-secret=/secrets/gcs/service-account.json
       - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
       - --lease-server-credentials-file=/etc/boskos/credentials
-      - --multi-stage-param=SHARD_ARGS="--shard-count 2 --shard-id 1"
-      - --report-credentials-file=/etc/report/credentials
-      - --secret-dir=/secrets/ci-pull-credentials
-      - --target=e2e-azure-mco-disruptive
-      - --variant=periodics
-      command:
-      - ci-operator
-      env:
-      - name: HTTP_SERVER_IP
-        valueFrom:
-          fieldRef:
-            fieldPath: status.podIP
-      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-      imagePullPolicy: Always
-      name: ""
-      ports:
-      - containerPort: 8080
-        name: http
-      resources:
-        requests:
-          cpu: 10m
-      volumeMounts:
-      - mountPath: /etc/boskos
-        name: boskos
-        readOnly: true
-      - mountPath: /secrets/ci-pull-credentials
-        name: ci-pull-credentials
-        readOnly: true
-      - mountPath: /secrets/gcs
-        name: gcs-credentials
-        readOnly: true
-      - mountPath: /secrets/manifest-tool
-        name: manifest-tool-local-pusher
-        readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
-      - mountPath: /etc/report
-        name: result-aggregator
-        readOnly: true
-    serviceAccountName: ci-operator
-    volumes:
-    - name: boskos
-      secret:
-        items:
-        - key: credentials
-          path: credentials
-        secretName: boskos-credentials
-    - name: ci-pull-credentials
-      secret:
-        secretName: ci-pull-credentials
-    - name: manifest-tool-local-pusher
-      secret:
-        secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
-    - name: result-aggregator
-      secret:
-        secretName: result-aggregator
-- agent: kubernetes
-  cluster: build10
-  decorate: true
-  extra_refs:
-  - base_ref: release-4.22
-    org: openshift
-    repo: machine-config-operator
-  interval: 72h
-  labels:
-    ci-operator.openshift.io/cloud: azure4
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-azure
-    ci-operator.openshift.io/variant: periodics
-    ci.openshift.io/generator: prowgen
-    job-release: "4.22"
-    pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-machine-config-operator-release-4.22-periodics-e2e-azure-mco-disruptive-2of2
-  spec:
-    containers:
-    - args:
-      - --gcs-upload-secret=/secrets/gcs/service-account.json
-      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-      - --lease-server-credentials-file=/etc/boskos/credentials
-      - --multi-stage-param=SHARD_ARGS="--shard-count 2 --shard-id 2"
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
       - --target=e2e-azure-mco-disruptive

--- a/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-release-4.23-periodics.yaml
+++ b/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-release-4.23-periodics.yaml
@@ -1100,96 +1100,21 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.23"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-machine-config-operator-release-4.23-periodics-e2e-azure-mco-disruptive-1of2
+  name: periodic-ci-openshift-machine-config-operator-release-4.23-periodics-e2e-azure-mco-disruptive
+  reporter_config:
+    slack:
+      channel: '#trt-alert-mco'
+      job_states_to_report:
+      - failure
+      - error
+      report_template: ':failed: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*.
+        <{{.Status.URL}}|View logs> {{end}}'
   spec:
     containers:
     - args:
       - --gcs-upload-secret=/secrets/gcs/service-account.json
       - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
       - --lease-server-credentials-file=/etc/boskos/credentials
-      - --multi-stage-param=SHARD_ARGS="--shard-count 2 --shard-id 1"
-      - --report-credentials-file=/etc/report/credentials
-      - --secret-dir=/secrets/ci-pull-credentials
-      - --target=e2e-azure-mco-disruptive
-      - --variant=periodics
-      command:
-      - ci-operator
-      env:
-      - name: HTTP_SERVER_IP
-        valueFrom:
-          fieldRef:
-            fieldPath: status.podIP
-      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-      imagePullPolicy: Always
-      name: ""
-      ports:
-      - containerPort: 8080
-        name: http
-      resources:
-        requests:
-          cpu: 10m
-      volumeMounts:
-      - mountPath: /etc/boskos
-        name: boskos
-        readOnly: true
-      - mountPath: /secrets/ci-pull-credentials
-        name: ci-pull-credentials
-        readOnly: true
-      - mountPath: /secrets/gcs
-        name: gcs-credentials
-        readOnly: true
-      - mountPath: /secrets/manifest-tool
-        name: manifest-tool-local-pusher
-        readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
-      - mountPath: /etc/report
-        name: result-aggregator
-        readOnly: true
-    serviceAccountName: ci-operator
-    volumes:
-    - name: boskos
-      secret:
-        items:
-        - key: credentials
-          path: credentials
-        secretName: boskos-credentials
-    - name: ci-pull-credentials
-      secret:
-        secretName: ci-pull-credentials
-    - name: manifest-tool-local-pusher
-      secret:
-        secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
-    - name: result-aggregator
-      secret:
-        secretName: result-aggregator
-- agent: kubernetes
-  cluster: build10
-  decorate: true
-  extra_refs:
-  - base_ref: release-4.23
-    org: openshift
-    repo: machine-config-operator
-  interval: 168h
-  labels:
-    ci-operator.openshift.io/cloud: azure4
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-azure
-    ci-operator.openshift.io/variant: periodics
-    ci.openshift.io/generator: prowgen
-    job-release: "4.23"
-    pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-machine-config-operator-release-4.23-periodics-e2e-azure-mco-disruptive-2of2
-  spec:
-    containers:
-    - args:
-      - --gcs-upload-secret=/secrets/gcs/service-account.json
-      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-      - --lease-server-credentials-file=/etc/boskos/credentials
-      - --multi-stage-param=SHARD_ARGS="--shard-count 2 --shard-id 2"
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
       - --target=e2e-azure-mco-disruptive

--- a/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-release-5.0-periodics.yaml
+++ b/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-release-5.0-periodics.yaml
@@ -1100,96 +1100,21 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-machine-config-operator-release-5.0-periodics-e2e-azure-mco-disruptive-1of2
+  name: periodic-ci-openshift-machine-config-operator-release-5.0-periodics-e2e-azure-mco-disruptive
+  reporter_config:
+    slack:
+      channel: '#trt-alert-mco'
+      job_states_to_report:
+      - failure
+      - error
+      report_template: ':failed: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*.
+        <{{.Status.URL}}|View logs> {{end}}'
   spec:
     containers:
     - args:
       - --gcs-upload-secret=/secrets/gcs/service-account.json
       - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
       - --lease-server-credentials-file=/etc/boskos/credentials
-      - --multi-stage-param=SHARD_ARGS="--shard-count 2 --shard-id 1"
-      - --report-credentials-file=/etc/report/credentials
-      - --secret-dir=/secrets/ci-pull-credentials
-      - --target=e2e-azure-mco-disruptive
-      - --variant=periodics
-      command:
-      - ci-operator
-      env:
-      - name: HTTP_SERVER_IP
-        valueFrom:
-          fieldRef:
-            fieldPath: status.podIP
-      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-      imagePullPolicy: Always
-      name: ""
-      ports:
-      - containerPort: 8080
-        name: http
-      resources:
-        requests:
-          cpu: 10m
-      volumeMounts:
-      - mountPath: /etc/boskos
-        name: boskos
-        readOnly: true
-      - mountPath: /secrets/ci-pull-credentials
-        name: ci-pull-credentials
-        readOnly: true
-      - mountPath: /secrets/gcs
-        name: gcs-credentials
-        readOnly: true
-      - mountPath: /secrets/manifest-tool
-        name: manifest-tool-local-pusher
-        readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
-      - mountPath: /etc/report
-        name: result-aggregator
-        readOnly: true
-    serviceAccountName: ci-operator
-    volumes:
-    - name: boskos
-      secret:
-        items:
-        - key: credentials
-          path: credentials
-        secretName: boskos-credentials
-    - name: ci-pull-credentials
-      secret:
-        secretName: ci-pull-credentials
-    - name: manifest-tool-local-pusher
-      secret:
-        secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
-    - name: result-aggregator
-      secret:
-        secretName: result-aggregator
-- agent: kubernetes
-  cluster: build09
-  decorate: true
-  extra_refs:
-  - base_ref: release-5.0
-    org: openshift
-    repo: machine-config-operator
-  interval: 168h
-  labels:
-    ci-operator.openshift.io/cloud: azure4
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-azure
-    ci-operator.openshift.io/variant: periodics
-    ci.openshift.io/generator: prowgen
-    job-release: "5.0"
-    pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-machine-config-operator-release-5.0-periodics-e2e-azure-mco-disruptive-2of2
-  spec:
-    containers:
-    - args:
-      - --gcs-upload-secret=/secrets/gcs/service-account.json
-      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-      - --lease-server-credentials-file=/etc/boskos/credentials
-      - --multi-stage-param=SHARD_ARGS="--shard-count 2 --shard-id 2"
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
       - --target=e2e-azure-mco-disruptive


### PR DESCRIPTION
This switches the cloud mco-disruptive suites to use the longrun test flow. This would allow it to handle the additional tests added by https://github.com/openshift/machine-config-operator/pull/5808. 