### PR TITLE
Point e2e periodic to fork for RHOAI version bump testing

### DIFF
--- a/ci-operator/config/lightspeed-core/lightspeed-stack/lightspeed-core-lightspeed-stack-main.yaml
+++ b/ci-operator/config/lightspeed-core/lightspeed-stack/lightspeed-core-lightspeed-stack-main.yaml
@@ -27,7 +27,7 @@ tests:
       variant: gpu
     owner: obs
     product: ocp
-    timeout: 4h0m0s
+    timeout: 2h0m0s
     version: "4.20"
   cron: 10 4 * * *
   steps:
@@ -62,6 +62,7 @@ tests:
       resources:
         requests:
           cpu: 100m
+      timeout: 4h0m0s
     workflow: generic-claim
 zz_generated_metadata:
   branch: main

--- a/ci-operator/config/lightspeed-core/lightspeed-stack/lightspeed-core-lightspeed-stack-main.yaml
+++ b/ci-operator/config/lightspeed-core/lightspeed-stack/lightspeed-core-lightspeed-stack-main.yaml
@@ -27,7 +27,7 @@ tests:
       variant: gpu
     owner: obs
     product: ocp
-    timeout: 1h0m0s
+    timeout: 2h0m0s
     version: "4.20"
   cron: 10 4 * * *
   steps:
@@ -37,10 +37,14 @@ tests:
     test:
     - as: e2e
       cli: latest
-      commands: "REPO_URL=\"https://github.com/lightspeed-core/lightspeed-stack.git\"\necho
-        \"===== Cloning lightspeed-stack repo =====\"\ngit clone \"$REPO_URL\"\ncd
-        lightspeed-stack\ncd tests/e2e-prow/rhoai\n\nchmod +x pipeline.sh\n./pipeline.sh
-        \    \n"
+      commands: |
+        REPO_URL="https://github.com/are-ces/lightspeed-stack.git"
+        echo "===== Cloning lightspeed-stack repo ====="
+        git clone -b LCORE-1496-rhoai-version-bump "$REPO_URL"
+        cd lightspeed-stack
+        cd tests/e2e-prow/rhoai
+        chmod +x pipeline.sh
+        ./pipeline.sh
       credentials:
       - mount_path: /var/run/huggingface
         name: hf-token

--- a/ci-operator/config/lightspeed-core/lightspeed-stack/lightspeed-core-lightspeed-stack-main.yaml
+++ b/ci-operator/config/lightspeed-core/lightspeed-stack/lightspeed-core-lightspeed-stack-main.yaml
@@ -27,7 +27,7 @@ tests:
       variant: gpu
     owner: obs
     product: ocp
-    timeout: 2h0m0s
+    timeout: 4h0m0s
     version: "4.20"
   cron: 10 4 * * *
   steps:

--- a/ci-operator/config/lightspeed-core/lightspeed-stack/lightspeed-core-lightspeed-stack-main.yaml
+++ b/ci-operator/config/lightspeed-core/lightspeed-stack/lightspeed-core-lightspeed-stack-main.yaml
@@ -38,9 +38,9 @@ tests:
     - as: e2e
       cli: latest
       commands: |
-        REPO_URL="https://github.com/are-ces/lightspeed-stack.git"
+        REPO_URL="https://github.com/lightspeed-core/lightspeed-stack.git"
         echo "===== Cloning lightspeed-stack repo ====="
-        git clone -b LCORE-1496-rhoai-version-bump "$REPO_URL"
+        git clone "$REPO_URL"
         cd lightspeed-stack
         cd tests/e2e-prow/rhoai
         chmod +x pipeline.sh


### PR DESCRIPTION
## Summary
- Increased timeout for cluster claim
 
## Test plan
- [ ] No timeout happens on cluster claim


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR changes the OpenShift CI configuration for the lightspeed-core/lightspeed-stack repository's periodic e2e job (e2e-lcore-cluster-periodics) to support validating a RHOAI version bump.

Key changes (file: ci-operator/config/lightspeed-core/lightspeed-stack/lightspeed-core-lightspeed-stack-main.yaml)
- Cluster claim timeout increased from 1h0m0s to 2h0m0s (gives more time for AWS cluster provisioning).
- E2E test step timeout set to 4h0m0s (allows the e2e pipeline more time to complete).

[LCORE-1496]: https://redhat.atlassian.net/browse/LCORE-1496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ