### PR TITLE
Normalize vSphere UPI test names to include upi

### DIFF
--- a/ci-operator/config/openshift-knative/serverless-operator/openshift-knative-serverless-operator-main__420-vsphere.yaml
+++ b/ci-operator/config/openshift-knative/serverless-operator/openshift-knative-serverless-operator-main__420-vsphere.yaml
@@ -135,7 +135,7 @@ resources:
       cpu: 100m
       memory: 200Mi
 tests:
-- as: e2e-vsphere-continuous
+- as: e2e-vsphere-continuous-upi
   cron: 26 4 * * 3
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-main.yaml
+++ b/ci-operator/config/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-main.yaml
@@ -81,7 +81,7 @@ tests:
     cluster_profile: gcp
     workflow: openshift-e2e-gcp-csi
 - always_run: false
-  as: e2e-ovn-vsphere
+  as: e2e-ovn-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.10.yaml
+++ b/ci-operator/config/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.10.yaml
@@ -68,7 +68,7 @@ tests:
     cluster_profile: ovirt
     workflow: openshift-e2e-ovirt-csi
 - always_run: false
-  as: e2e-vsphere
+  as: e2e-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.11.yaml
+++ b/ci-operator/config/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.11.yaml
@@ -68,7 +68,7 @@ tests:
     cluster_profile: ovirt
     workflow: openshift-e2e-ovirt-csi
 - always_run: false
-  as: e2e-vsphere
+  as: e2e-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.12.yaml
+++ b/ci-operator/config/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.12.yaml
@@ -76,7 +76,7 @@ tests:
     cluster_profile: ovirt
     workflow: openshift-e2e-ovirt-csi
 - always_run: false
-  as: e2e-vsphere-ovn
+  as: e2e-vsphere-ovn-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.13.yaml
+++ b/ci-operator/config/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.13.yaml
@@ -72,7 +72,7 @@ tests:
     cluster_profile: ovirt
     workflow: openshift-e2e-ovirt-csi
 - always_run: false
-  as: e2e-vsphere-ovn
+  as: e2e-vsphere-ovn-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.14.yaml
+++ b/ci-operator/config/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.14.yaml
@@ -86,7 +86,7 @@ tests:
     cluster_profile: gcp
     workflow: openshift-e2e-gcp-csi
 - always_run: false
-  as: e2e-ovn-vsphere
+  as: e2e-ovn-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.15.yaml
+++ b/ci-operator/config/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.15.yaml
@@ -83,7 +83,7 @@ tests:
     cluster_profile: gcp
     workflow: openshift-e2e-gcp-csi
 - always_run: false
-  as: e2e-ovn-vsphere
+  as: e2e-ovn-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.16.yaml
+++ b/ci-operator/config/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.16.yaml
@@ -83,7 +83,7 @@ tests:
     cluster_profile: gcp
     workflow: openshift-e2e-gcp-csi
 - always_run: false
-  as: e2e-ovn-vsphere
+  as: e2e-ovn-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.17.yaml
+++ b/ci-operator/config/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.17.yaml
@@ -83,7 +83,7 @@ tests:
     cluster_profile: gcp
     workflow: openshift-e2e-gcp-csi
 - always_run: false
-  as: e2e-ovn-vsphere
+  as: e2e-ovn-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.18.yaml
+++ b/ci-operator/config/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.18.yaml
@@ -81,7 +81,7 @@ tests:
     cluster_profile: gcp
     workflow: openshift-e2e-gcp-csi
 - always_run: false
-  as: e2e-ovn-vsphere
+  as: e2e-ovn-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.19.yaml
+++ b/ci-operator/config/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.19.yaml
@@ -81,7 +81,7 @@ tests:
     cluster_profile: gcp
     workflow: openshift-e2e-gcp-csi
 - always_run: false
-  as: e2e-ovn-vsphere
+  as: e2e-ovn-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.20.yaml
+++ b/ci-operator/config/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.20.yaml
@@ -81,7 +81,7 @@ tests:
     cluster_profile: gcp
     workflow: openshift-e2e-gcp-csi
 - always_run: false
-  as: e2e-ovn-vsphere
+  as: e2e-ovn-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.21.yaml
+++ b/ci-operator/config/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.21.yaml
@@ -81,7 +81,7 @@ tests:
     cluster_profile: gcp
     workflow: openshift-e2e-gcp-csi
 - always_run: false
-  as: e2e-ovn-vsphere
+  as: e2e-ovn-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.22.yaml
+++ b/ci-operator/config/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.22.yaml
@@ -82,7 +82,7 @@ tests:
     cluster_profile: gcp
     workflow: openshift-e2e-gcp-csi
 - always_run: false
-  as: e2e-ovn-vsphere
+  as: e2e-ovn-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.23.yaml
+++ b/ci-operator/config/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.23.yaml
@@ -81,7 +81,7 @@ tests:
     cluster_profile: gcp
     workflow: openshift-e2e-gcp-csi
 - always_run: false
-  as: e2e-ovn-vsphere
+  as: e2e-ovn-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.8.yaml
+++ b/ci-operator/config/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.8.yaml
@@ -69,7 +69,7 @@ tests:
     cluster_profile: ovirt
     workflow: openshift-e2e-ovirt-csi-release-4.8
 - always_run: false
-  as: e2e-vsphere
+  as: e2e-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.9.yaml
+++ b/ci-operator/config/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.9.yaml
@@ -68,7 +68,7 @@ tests:
     cluster_profile: ovirt
     workflow: openshift-e2e-ovirt-csi
 - always_run: false
-  as: e2e-vsphere
+  as: e2e-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-5.0.yaml
+++ b/ci-operator/config/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-5.0.yaml
@@ -81,7 +81,7 @@ tests:
     cluster_profile: gcp
     workflow: openshift-e2e-gcp-csi
 - always_run: false
-  as: e2e-ovn-vsphere
+  as: e2e-ovn-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift-priv/origin/openshift-priv-origin-main.yaml
+++ b/ci-operator/config/openshift-priv/origin/openshift-priv-origin-main.yaml
@@ -792,7 +792,7 @@ tests:
       - observers-resource-watch
     workflow: openshift-e2e-external-aws
 - always_run: false
-  as: e2e-external-vsphere-ccm
+  as: e2e-external-vsphere-ccm-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift-priv/origin/openshift-priv-origin-release-4.10.yaml
+++ b/ci-operator/config/openshift-priv/origin/openshift-priv-origin-release-4.10.yaml
@@ -190,7 +190,7 @@ tests:
       TEST_SUITE: openshift/csi
     workflow: openshift-e2e-aws-csi
 - always_run: false
-  as: e2e-vsphere
+  as: e2e-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift-priv/origin/openshift-priv-origin-release-4.12.yaml
+++ b/ci-operator/config/openshift-priv/origin/openshift-priv-origin-release-4.12.yaml
@@ -208,7 +208,7 @@ tests:
       TEST_SUITE: openshift/csi
     workflow: openshift-e2e-aws-csi
 - always_run: false
-  as: e2e-vsphere
+  as: e2e-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift-priv/origin/openshift-priv-origin-release-4.13.yaml
+++ b/ci-operator/config/openshift-priv/origin/openshift-priv-origin-release-4.13.yaml
@@ -208,7 +208,7 @@ tests:
       TEST_SUITE: openshift/csi
     workflow: openshift-e2e-aws-csi
 - always_run: false
-  as: e2e-vsphere
+  as: e2e-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift-priv/origin/openshift-priv-origin-release-4.14.yaml
+++ b/ci-operator/config/openshift-priv/origin/openshift-priv-origin-release-4.14.yaml
@@ -208,7 +208,7 @@ tests:
       TEST_SUITE: openshift/csi
     workflow: openshift-e2e-aws-csi
 - always_run: false
-  as: e2e-vsphere
+  as: e2e-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift-priv/origin/openshift-priv-origin-release-4.15.yaml
+++ b/ci-operator/config/openshift-priv/origin/openshift-priv-origin-release-4.15.yaml
@@ -207,7 +207,7 @@ tests:
       TEST_SUITE: openshift/csi
     workflow: openshift-e2e-aws-csi
 - always_run: false
-  as: e2e-vsphere
+  as: e2e-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift-priv/origin/openshift-priv-origin-release-4.16.yaml
+++ b/ci-operator/config/openshift-priv/origin/openshift-priv-origin-release-4.16.yaml
@@ -235,7 +235,7 @@ tests:
       TEST_SUITE: openshift/csi
     workflow: openshift-e2e-aws-csi
 - always_run: false
-  as: e2e-vsphere
+  as: e2e-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift-priv/origin/openshift-priv-origin-release-4.17.yaml
+++ b/ci-operator/config/openshift-priv/origin/openshift-priv-origin-release-4.17.yaml
@@ -240,7 +240,7 @@ tests:
       TEST_SUITE: openshift/csi
     workflow: openshift-e2e-aws-csi
 - always_run: false
-  as: e2e-vsphere
+  as: e2e-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift-priv/origin/openshift-priv-origin-release-4.18.yaml
+++ b/ci-operator/config/openshift-priv/origin/openshift-priv-origin-release-4.18.yaml
@@ -322,7 +322,7 @@ tests:
       - observers-resource-watch
     workflow: openshift-e2e-aws-csi
 - always_run: false
-  as: e2e-vsphere
+  as: e2e-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic
@@ -688,7 +688,7 @@ tests:
       - observers-resource-watch
     workflow: openshift-e2e-external-aws
 - always_run: false
-  as: e2e-external-vsphere-ccm
+  as: e2e-external-vsphere-ccm-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift-priv/origin/openshift-priv-origin-release-4.19.yaml
+++ b/ci-operator/config/openshift-priv/origin/openshift-priv-origin-release-4.19.yaml
@@ -723,7 +723,7 @@ tests:
       - observers-resource-watch
     workflow: openshift-e2e-external-aws
 - always_run: false
-  as: e2e-external-vsphere-ccm
+  as: e2e-external-vsphere-ccm-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift-priv/origin/openshift-priv-origin-release-4.20.yaml
+++ b/ci-operator/config/openshift-priv/origin/openshift-priv-origin-release-4.20.yaml
@@ -741,7 +741,7 @@ tests:
       - observers-resource-watch
     workflow: openshift-e2e-external-aws
 - always_run: false
-  as: e2e-external-vsphere-ccm
+  as: e2e-external-vsphere-ccm-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift-priv/origin/openshift-priv-origin-release-4.21.yaml
+++ b/ci-operator/config/openshift-priv/origin/openshift-priv-origin-release-4.21.yaml
@@ -770,7 +770,7 @@ tests:
       - observers-resource-watch
     workflow: openshift-e2e-external-aws
 - always_run: false
-  as: e2e-external-vsphere-ccm
+  as: e2e-external-vsphere-ccm-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift-priv/origin/openshift-priv-origin-release-4.22.yaml
+++ b/ci-operator/config/openshift-priv/origin/openshift-priv-origin-release-4.22.yaml
@@ -793,7 +793,7 @@ tests:
       - observers-resource-watch
     workflow: openshift-e2e-external-aws
 - always_run: false
-  as: e2e-external-vsphere-ccm
+  as: e2e-external-vsphere-ccm-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift-priv/origin/openshift-priv-origin-release-4.23.yaml
+++ b/ci-operator/config/openshift-priv/origin/openshift-priv-origin-release-4.23.yaml
@@ -792,7 +792,7 @@ tests:
       - observers-resource-watch
     workflow: openshift-e2e-external-aws
 - always_run: false
-  as: e2e-external-vsphere-ccm
+  as: e2e-external-vsphere-ccm-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift-priv/origin/openshift-priv-origin-release-4.6.yaml
+++ b/ci-operator/config/openshift-priv/origin/openshift-priv-origin-release-4.6.yaml
@@ -127,7 +127,7 @@ tests:
     cluster_profile: openshift-org-aws
     workflow: openshift-e2e-aws-csi
 - always_run: false
-  as: e2e-vsphere
+  as: e2e-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift-priv/origin/openshift-priv-origin-release-4.7.yaml
+++ b/ci-operator/config/openshift-priv/origin/openshift-priv-origin-release-4.7.yaml
@@ -158,7 +158,7 @@ tests:
     cluster_profile: openshift-org-aws
     workflow: openshift-e2e-aws-csi
 - always_run: false
-  as: e2e-vsphere
+  as: e2e-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift-priv/origin/openshift-priv-origin-release-4.8.yaml
+++ b/ci-operator/config/openshift-priv/origin/openshift-priv-origin-release-4.8.yaml
@@ -161,7 +161,7 @@ tests:
     cluster_profile: openshift-org-aws
     workflow: openshift-e2e-aws-csi
 - always_run: false
-  as: e2e-vsphere
+  as: e2e-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift-priv/origin/openshift-priv-origin-release-4.9.yaml
+++ b/ci-operator/config/openshift-priv/origin/openshift-priv-origin-release-4.9.yaml
@@ -181,7 +181,7 @@ tests:
       TEST_SUITE: openshift/csi
     workflow: openshift-e2e-aws-csi
 - always_run: false
-  as: e2e-vsphere
+  as: e2e-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift-priv/origin/openshift-priv-origin-release-5.0.yaml
+++ b/ci-operator/config/openshift-priv/origin/openshift-priv-origin-release-5.0.yaml
@@ -792,7 +792,7 @@ tests:
       - observers-resource-watch
     workflow: openshift-e2e-external-aws
 - always_run: false
-  as: e2e-external-vsphere-ccm
+  as: e2e-external-vsphere-ccm-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift-priv/vmware-vsphere-csi-driver-operator/openshift-priv-vmware-vsphere-csi-driver-operator-release-4.8.yaml
+++ b/ci-operator/config/openshift-priv/vmware-vsphere-csi-driver-operator/openshift-priv-vmware-vsphere-csi-driver-operator-release-4.8.yaml
@@ -42,7 +42,7 @@ tests:
   commands: make test-unit
   container:
     from: src
-- as: e2e-vsphere
+- as: e2e-vsphere-upi
   steps:
     cluster_profile: vsphere-elastic
     env:

--- a/ci-operator/config/openshift-priv/vmware-vsphere-csi-driver-operator/openshift-priv-vmware-vsphere-csi-driver-operator-release-4.9.yaml
+++ b/ci-operator/config/openshift-priv/vmware-vsphere-csi-driver-operator/openshift-priv-vmware-vsphere-csi-driver-operator-release-4.9.yaml
@@ -39,7 +39,7 @@ tests:
   commands: make test-unit
   container:
     from: src
-- as: e2e-vsphere
+- as: e2e-vsphere-upi
   steps:
     cluster_profile: vsphere-elastic
     env:

--- a/ci-operator/config/openshift-priv/vmware-vsphere-csi-driver/openshift-priv-vmware-vsphere-csi-driver-release-4.8.yaml
+++ b/ci-operator/config/openshift-priv/vmware-vsphere-csi-driver/openshift-priv-vmware-vsphere-csi-driver-release-4.8.yaml
@@ -42,7 +42,7 @@ tests:
   commands: make unit-test
   container:
     from: src
-- as: e2e-vsphere
+- as: e2e-vsphere-upi
   steps:
     cluster_profile: vsphere-elastic
     env:

--- a/ci-operator/config/openshift-priv/vmware-vsphere-csi-driver/openshift-priv-vmware-vsphere-csi-driver-release-4.9.yaml
+++ b/ci-operator/config/openshift-priv/vmware-vsphere-csi-driver/openshift-priv-vmware-vsphere-csi-driver-release-4.9.yaml
@@ -39,7 +39,7 @@ tests:
   commands: "true"
   container:
     from: src
-- as: e2e-vsphere
+- as: e2e-vsphere-upi
   steps:
     cluster_profile: vsphere-elastic
     env:

--- a/ci-operator/config/openshift/cluster-storage-operator/openshift-cluster-storage-operator-main.yaml
+++ b/ci-operator/config/openshift/cluster-storage-operator/openshift-cluster-storage-operator-main.yaml
@@ -80,7 +80,7 @@ tests:
     cluster_profile: gcp
     workflow: openshift-e2e-gcp-csi
 - always_run: false
-  as: e2e-ovn-vsphere
+  as: e2e-ovn-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.10.yaml
+++ b/ci-operator/config/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.10.yaml
@@ -67,7 +67,7 @@ tests:
     cluster_profile: ovirt
     workflow: openshift-e2e-ovirt-csi
 - always_run: false
-  as: e2e-vsphere
+  as: e2e-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.11.yaml
+++ b/ci-operator/config/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.11.yaml
@@ -67,7 +67,7 @@ tests:
     cluster_profile: ovirt
     workflow: openshift-e2e-ovirt-csi
 - always_run: false
-  as: e2e-vsphere
+  as: e2e-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.12.yaml
+++ b/ci-operator/config/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.12.yaml
@@ -75,7 +75,7 @@ tests:
     cluster_profile: ovirt
     workflow: openshift-e2e-ovirt-csi
 - always_run: false
-  as: e2e-vsphere-ovn
+  as: e2e-vsphere-ovn-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.13.yaml
+++ b/ci-operator/config/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.13.yaml
@@ -71,7 +71,7 @@ tests:
     cluster_profile: ovirt
     workflow: openshift-e2e-ovirt-csi
 - always_run: false
-  as: e2e-vsphere-ovn
+  as: e2e-vsphere-ovn-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.14.yaml
+++ b/ci-operator/config/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.14.yaml
@@ -85,7 +85,7 @@ tests:
     cluster_profile: gcp
     workflow: openshift-e2e-gcp-csi
 - always_run: false
-  as: e2e-ovn-vsphere
+  as: e2e-ovn-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.15.yaml
+++ b/ci-operator/config/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.15.yaml
@@ -82,7 +82,7 @@ tests:
     cluster_profile: gcp
     workflow: openshift-e2e-gcp-csi
 - always_run: false
-  as: e2e-ovn-vsphere
+  as: e2e-ovn-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.16.yaml
+++ b/ci-operator/config/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.16.yaml
@@ -82,7 +82,7 @@ tests:
     cluster_profile: gcp
     workflow: openshift-e2e-gcp-csi
 - always_run: false
-  as: e2e-ovn-vsphere
+  as: e2e-ovn-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.17.yaml
+++ b/ci-operator/config/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.17.yaml
@@ -82,7 +82,7 @@ tests:
     cluster_profile: gcp
     workflow: openshift-e2e-gcp-csi
 - always_run: false
-  as: e2e-ovn-vsphere
+  as: e2e-ovn-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.18.yaml
+++ b/ci-operator/config/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.18.yaml
@@ -80,7 +80,7 @@ tests:
     cluster_profile: gcp
     workflow: openshift-e2e-gcp-csi
 - always_run: false
-  as: e2e-ovn-vsphere
+  as: e2e-ovn-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.19.yaml
+++ b/ci-operator/config/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.19.yaml
@@ -80,7 +80,7 @@ tests:
     cluster_profile: gcp
     workflow: openshift-e2e-gcp-csi
 - always_run: false
-  as: e2e-ovn-vsphere
+  as: e2e-ovn-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.20.yaml
+++ b/ci-operator/config/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.20.yaml
@@ -80,7 +80,7 @@ tests:
     cluster_profile: gcp
     workflow: openshift-e2e-gcp-csi
 - always_run: false
-  as: e2e-ovn-vsphere
+  as: e2e-ovn-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.21.yaml
+++ b/ci-operator/config/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.21.yaml
@@ -80,7 +80,7 @@ tests:
     cluster_profile: gcp
     workflow: openshift-e2e-gcp-csi
 - always_run: false
-  as: e2e-ovn-vsphere
+  as: e2e-ovn-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.22.yaml
+++ b/ci-operator/config/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.22.yaml
@@ -81,7 +81,7 @@ tests:
     cluster_profile: gcp
     workflow: openshift-e2e-gcp-csi
 - always_run: false
-  as: e2e-ovn-vsphere
+  as: e2e-ovn-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.23.yaml
+++ b/ci-operator/config/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.23.yaml
@@ -80,7 +80,7 @@ tests:
     cluster_profile: gcp
     workflow: openshift-e2e-gcp-csi
 - always_run: false
-  as: e2e-ovn-vsphere
+  as: e2e-ovn-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.8.yaml
+++ b/ci-operator/config/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.8.yaml
@@ -68,7 +68,7 @@ tests:
     cluster_profile: ovirt
     workflow: openshift-e2e-ovirt-csi-release-4.8
 - always_run: false
-  as: e2e-vsphere
+  as: e2e-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.9.yaml
+++ b/ci-operator/config/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.9.yaml
@@ -67,7 +67,7 @@ tests:
     cluster_profile: ovirt
     workflow: openshift-e2e-ovirt-csi
 - always_run: false
-  as: e2e-vsphere
+  as: e2e-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-5.0.yaml
+++ b/ci-operator/config/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-5.0.yaml
@@ -80,7 +80,7 @@ tests:
     cluster_profile: gcp
     workflow: openshift-e2e-gcp-csi
 - always_run: false
-  as: e2e-ovn-vsphere
+  as: e2e-ovn-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift/origin/openshift-origin-main.yaml
+++ b/ci-operator/config/openshift/origin/openshift-origin-main.yaml
@@ -791,7 +791,7 @@ tests:
       - observers-resource-watch
     workflow: openshift-e2e-external-aws
 - always_run: false
-  as: e2e-external-vsphere-ccm
+  as: e2e-external-vsphere-ccm-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift/origin/openshift-origin-release-4.10.yaml
+++ b/ci-operator/config/openshift/origin/openshift-origin-release-4.10.yaml
@@ -189,7 +189,7 @@ tests:
       TEST_SUITE: openshift/csi
     workflow: openshift-e2e-aws-csi
 - always_run: false
-  as: e2e-vsphere
+  as: e2e-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift/origin/openshift-origin-release-4.12.yaml
+++ b/ci-operator/config/openshift/origin/openshift-origin-release-4.12.yaml
@@ -207,7 +207,7 @@ tests:
       TEST_SUITE: openshift/csi
     workflow: openshift-e2e-aws-csi
 - always_run: false
-  as: e2e-vsphere
+  as: e2e-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift/origin/openshift-origin-release-4.13.yaml
+++ b/ci-operator/config/openshift/origin/openshift-origin-release-4.13.yaml
@@ -207,7 +207,7 @@ tests:
       TEST_SUITE: openshift/csi
     workflow: openshift-e2e-aws-csi
 - always_run: false
-  as: e2e-vsphere
+  as: e2e-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift/origin/openshift-origin-release-4.14.yaml
+++ b/ci-operator/config/openshift/origin/openshift-origin-release-4.14.yaml
@@ -207,7 +207,7 @@ tests:
       TEST_SUITE: openshift/csi
     workflow: openshift-e2e-aws-csi
 - always_run: false
-  as: e2e-vsphere
+  as: e2e-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift/origin/openshift-origin-release-4.15.yaml
+++ b/ci-operator/config/openshift/origin/openshift-origin-release-4.15.yaml
@@ -206,7 +206,7 @@ tests:
       TEST_SUITE: openshift/csi
     workflow: openshift-e2e-aws-csi
 - always_run: false
-  as: e2e-vsphere
+  as: e2e-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift/origin/openshift-origin-release-4.16.yaml
+++ b/ci-operator/config/openshift/origin/openshift-origin-release-4.16.yaml
@@ -234,7 +234,7 @@ tests:
       TEST_SUITE: openshift/csi
     workflow: openshift-e2e-aws-csi
 - always_run: false
-  as: e2e-vsphere
+  as: e2e-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift/origin/openshift-origin-release-4.17.yaml
+++ b/ci-operator/config/openshift/origin/openshift-origin-release-4.17.yaml
@@ -239,7 +239,7 @@ tests:
       TEST_SUITE: openshift/csi
     workflow: openshift-e2e-aws-csi
 - always_run: false
-  as: e2e-vsphere
+  as: e2e-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift/origin/openshift-origin-release-4.18.yaml
+++ b/ci-operator/config/openshift/origin/openshift-origin-release-4.18.yaml
@@ -321,7 +321,7 @@ tests:
       - observers-resource-watch
     workflow: openshift-e2e-aws-csi
 - always_run: false
-  as: e2e-vsphere
+  as: e2e-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic
@@ -687,7 +687,7 @@ tests:
       - observers-resource-watch
     workflow: openshift-e2e-external-aws
 - always_run: false
-  as: e2e-external-vsphere-ccm
+  as: e2e-external-vsphere-ccm-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift/origin/openshift-origin-release-4.19.yaml
+++ b/ci-operator/config/openshift/origin/openshift-origin-release-4.19.yaml
@@ -722,7 +722,7 @@ tests:
       - observers-resource-watch
     workflow: openshift-e2e-external-aws
 - always_run: false
-  as: e2e-external-vsphere-ccm
+  as: e2e-external-vsphere-ccm-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift/origin/openshift-origin-release-4.20.yaml
+++ b/ci-operator/config/openshift/origin/openshift-origin-release-4.20.yaml
@@ -740,7 +740,7 @@ tests:
       - observers-resource-watch
     workflow: openshift-e2e-external-aws
 - always_run: false
-  as: e2e-external-vsphere-ccm
+  as: e2e-external-vsphere-ccm-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift/origin/openshift-origin-release-4.21.yaml
+++ b/ci-operator/config/openshift/origin/openshift-origin-release-4.21.yaml
@@ -769,7 +769,7 @@ tests:
       - observers-resource-watch
     workflow: openshift-e2e-external-aws
 - always_run: false
-  as: e2e-external-vsphere-ccm
+  as: e2e-external-vsphere-ccm-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift/origin/openshift-origin-release-4.22.yaml
+++ b/ci-operator/config/openshift/origin/openshift-origin-release-4.22.yaml
@@ -792,7 +792,7 @@ tests:
       - observers-resource-watch
     workflow: openshift-e2e-external-aws
 - always_run: false
-  as: e2e-external-vsphere-ccm
+  as: e2e-external-vsphere-ccm-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift/origin/openshift-origin-release-4.23.yaml
+++ b/ci-operator/config/openshift/origin/openshift-origin-release-4.23.yaml
@@ -791,7 +791,7 @@ tests:
       - observers-resource-watch
     workflow: openshift-e2e-external-aws
 - always_run: false
-  as: e2e-external-vsphere-ccm
+  as: e2e-external-vsphere-ccm-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift/origin/openshift-origin-release-4.6.yaml
+++ b/ci-operator/config/openshift/origin/openshift-origin-release-4.6.yaml
@@ -126,7 +126,7 @@ tests:
     cluster_profile: openshift-org-aws
     workflow: openshift-e2e-aws-csi
 - always_run: false
-  as: e2e-vsphere
+  as: e2e-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift/origin/openshift-origin-release-4.7.yaml
+++ b/ci-operator/config/openshift/origin/openshift-origin-release-4.7.yaml
@@ -157,7 +157,7 @@ tests:
     cluster_profile: openshift-org-aws
     workflow: openshift-e2e-aws-csi
 - always_run: false
-  as: e2e-vsphere
+  as: e2e-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift/origin/openshift-origin-release-4.8.yaml
+++ b/ci-operator/config/openshift/origin/openshift-origin-release-4.8.yaml
@@ -160,7 +160,7 @@ tests:
     cluster_profile: openshift-org-aws
     workflow: openshift-e2e-aws-csi
 - always_run: false
-  as: e2e-vsphere
+  as: e2e-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift/origin/openshift-origin-release-4.9.yaml
+++ b/ci-operator/config/openshift/origin/openshift-origin-release-4.9.yaml
@@ -180,7 +180,7 @@ tests:
       TEST_SUITE: openshift/csi
     workflow: openshift-e2e-aws-csi
 - always_run: false
-  as: e2e-vsphere
+  as: e2e-vsphere-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift/origin/openshift-origin-release-5.0.yaml
+++ b/ci-operator/config/openshift/origin/openshift-origin-release-5.0.yaml
@@ -791,7 +791,7 @@ tests:
       - observers-resource-watch
     workflow: openshift-e2e-external-aws
 - always_run: false
-  as: e2e-external-vsphere-ccm
+  as: e2e-external-vsphere-ccm-upi
   optional: true
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.15.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.15.yaml
@@ -401,7 +401,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-vsphere-cgroupsv1
-- as: e2e-external-vsphere-ccm
+- as: e2e-external-vsphere-ccm-upi
   cron: 17 21 21 12 *
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.16.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.16.yaml
@@ -412,7 +412,7 @@ tests:
       TEST_SKIPS: 'In-tree Volumes \[Driver: vsphere\] \[Testpattern: Inline-volume\|
         In-tree Volumes \[Driver: vsphere\] \[Testpattern: Pre-provisioned PV'
     workflow: openshift-e2e-vsphere-upi-zones
-- as: e2e-external-vsphere-ccm
+- as: e2e-external-vsphere-ccm-upi
   cron: 28 10 4 7 *
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.17.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.17.yaml
@@ -490,7 +490,7 @@ tests:
         vcenter-1.ci.ibmc.devcluster.openshift.com-cidatacenter-2-cicluster-3
       TEST_SKIPS: 'In-tree Volumes \[Driver: vsphere\]'
     workflow: openshift-e2e-vsphere-upi-multi-vcenter
-- as: e2e-external-vsphere-ccm
+- as: e2e-external-vsphere-ccm-upi
   cron: 0 4 15 7 *
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.18.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.18.yaml
@@ -457,7 +457,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-vsphere
-- as: e2e-external-vsphere-ccm
+- as: e2e-external-vsphere-ccm-upi
   cron: 46 20 18 6 *
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.19.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.19.yaml
@@ -486,7 +486,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-vsphere
-- as: e2e-external-vsphere-ccm
+- as: e2e-external-vsphere-ccm-upi
   cron: 3 2 * * 4
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.20.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.20.yaml
@@ -595,7 +595,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-vsphere
-- as: e2e-external-vsphere-ccm
+- as: e2e-external-vsphere-ccm-upi
   cron: 27 1 * * 5
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.21.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.21.yaml
@@ -796,7 +796,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-vsphere
-- as: e2e-external-vsphere-ccm
+- as: e2e-external-vsphere-ccm-upi
   cron: 24 7 * * 5
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22.yaml
@@ -888,7 +888,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-vsphere
-- as: e2e-external-vsphere-ccm
+- as: e2e-external-vsphere-ccm-upi
   cron: 26 13 * * 2
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.23.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.23.yaml
@@ -865,7 +865,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-vsphere
-- as: e2e-external-vsphere-ccm
+- as: e2e-external-vsphere-ccm-upi
   cron: 26 13 * * 2
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
@@ -865,7 +865,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-vsphere
-- as: e2e-external-vsphere-ccm
+- as: e2e-external-vsphere-ccm-upi
   cron: 5 0 * * 3
   steps:
     cluster_profile: vsphere-elastic

--- a/ci-operator/config/openshift/verification-tests/openshift-verification-tests-main__installer-rehearse-4.12.yaml
+++ b/ci-operator/config/openshift/verification-tests/openshift-verification-tests-main__installer-rehearse-4.12.yaml
@@ -117,7 +117,7 @@ tests:
     allow_skip_on_success: true
     cluster_profile: vsphere-elastic
     workflow: cucushift-installer-rehearse-vsphere-ipi-external-lb-post
-- as: installer-rehearse-vsphere-dis
+- as: installer-rehearse-vsphere-dis-upi
   cron: '@yearly'
   steps:
     allow_skip_on_success: true

--- a/ci-operator/config/openshift/verification-tests/openshift-verification-tests-main__installer-rehearse-4.14.yaml
+++ b/ci-operator/config/openshift/verification-tests/openshift-verification-tests-main__installer-rehearse-4.14.yaml
@@ -98,7 +98,7 @@ tests:
     allow_skip_on_success: true
     cluster_profile: ibmcloud-qe
     workflow: cucushift-installer-rehearse-ibmcloud-ipi-minimal-permission
-- as: installer-rehearse-vsphere-dis
+- as: installer-rehearse-vsphere-dis-upi
   cron: '@yearly'
   steps:
     allow_skip_on_success: true

--- a/ci-operator/config/openshift/vmware-vsphere-csi-driver-operator/openshift-vmware-vsphere-csi-driver-operator-release-4.8.yaml
+++ b/ci-operator/config/openshift/vmware-vsphere-csi-driver-operator/openshift-vmware-vsphere-csi-driver-operator-release-4.8.yaml
@@ -41,7 +41,7 @@ tests:
   commands: make test-unit
   container:
     from: src
-- as: e2e-vsphere
+- as: e2e-vsphere-upi
   steps:
     cluster_profile: vsphere-elastic
     env:

--- a/ci-operator/config/openshift/vmware-vsphere-csi-driver-operator/openshift-vmware-vsphere-csi-driver-operator-release-4.9.yaml
+++ b/ci-operator/config/openshift/vmware-vsphere-csi-driver-operator/openshift-vmware-vsphere-csi-driver-operator-release-4.9.yaml
@@ -38,7 +38,7 @@ tests:
   commands: make test-unit
   container:
     from: src
-- as: e2e-vsphere
+- as: e2e-vsphere-upi
   steps:
     cluster_profile: vsphere-elastic
     env:

--- a/ci-operator/config/openshift/vmware-vsphere-csi-driver/openshift-vmware-vsphere-csi-driver-release-4.8.yaml
+++ b/ci-operator/config/openshift/vmware-vsphere-csi-driver/openshift-vmware-vsphere-csi-driver-release-4.8.yaml
@@ -42,7 +42,7 @@ tests:
   commands: make unit-test
   container:
     from: src
-- as: e2e-vsphere
+- as: e2e-vsphere-upi
   steps:
     cluster_profile: vsphere-elastic
     env:

--- a/ci-operator/config/openshift/vmware-vsphere-csi-driver/openshift-vmware-vsphere-csi-driver-release-4.9.yaml
+++ b/ci-operator/config/openshift/vmware-vsphere-csi-driver/openshift-vmware-vsphere-csi-driver-release-4.9.yaml
@@ -39,7 +39,7 @@ tests:
   commands: "true"
   container:
     from: src
-- as: e2e-vsphere
+- as: e2e-vsphere-upi
   steps:
     cluster_profile: vsphere-elastic
     env:

--- a/ci-operator/jobs/openshift-knative/serverless-operator/openshift-knative-serverless-operator-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-knative/serverless-operator/openshift-knative-serverless-operator-main-periodics.yaml
@@ -2022,18 +2022,7 @@ periodics:
     ci-operator.openshift.io/variant: 420-vsphere
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-knative-serverless-operator-main-420-vsphere-e2e-vsphere-continuous
-  reporter_config:
-    slack:
-      channel: '#serverless-ci'
-      job_states_to_report:
-      - success
-      - failure
-      - error
-      report_template: '{{if eq .Status.State "success"}} :rainbow: Job *{{.Spec.Job}}*
-        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :rainbow: {{else}}
-        :volcano: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
-        logs> :volcano: {{end}}'
+  name: periodic-ci-openshift-knative-serverless-operator-main-420-vsphere-e2e-vsphere-continuous-upi
   spec:
     containers:
     - args:
@@ -2042,7 +2031,7 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=e2e-vsphere-continuous
+      - --target=e2e-vsphere-continuous-upi
       - --variant=420-vsphere
       command:
       - ci-operator

--- a/ci-operator/jobs/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-main-presubmits.yaml
@@ -1366,7 +1366,7 @@ presubmits:
     - ^main$
     - ^main-
     cluster: vsphere02
-    context: ci/prow/e2e-ovn-vsphere
+    context: ci/prow/e2e-ovn-vsphere-upi
     decorate: true
     decoration_config:
       oauth_token_secret:
@@ -1378,10 +1378,10 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-storage-operator-main-e2e-ovn-vsphere
+    name: pull-ci-openshift-priv-cluster-storage-operator-main-e2e-ovn-vsphere-upi
     optional: true
     path_alias: github.com/openshift/cluster-storage-operator
-    rerun_command: /test e2e-ovn-vsphere
+    rerun_command: /test e2e-ovn-vsphere-upi
     spec:
       containers:
       - args:
@@ -1391,7 +1391,7 @@ presubmits:
         - --oauth-token-path=/usr/local/github-credentials/oauth
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-ovn-vsphere
+        - --target=e2e-ovn-vsphere-upi
         command:
         - ci-operator
         env:
@@ -1450,7 +1450,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-ovn-vsphere,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-ovn-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.10-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.10-presubmits.yaml
@@ -1095,97 +1095,6 @@ presubmits:
     - ^release-4\.10$
     - ^release-4\.10-
     cluster: vsphere02
-    context: ci/prow/e2e-vsphere
-    decorate: true
-    decoration_config:
-      oauth_token_secret:
-        key: oauth
-        name: github-credentials-openshift-ci-robot-private-git-cloner
-    hidden: true
-    labels:
-      ci-operator.openshift.io/cloud: vsphere
-      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-storage-operator-release-4.10-e2e-vsphere
-    optional: true
-    path_alias: github.com/openshift/cluster-storage-operator
-    rerun_command: /test e2e-vsphere
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --oauth-token-path=/usr/local/github-credentials/oauth
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-vsphere
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /usr/local/github-credentials
-          name: github-credentials-openshift-ci-robot-private-git-cloner
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-vsphere,?($|\s.*)
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - ^release-4\.10$
-    - ^release-4\.10-
-    cluster: vsphere02
     context: ci/prow/e2e-vsphere-csi
     decorate: true
     decoration_config:
@@ -1271,6 +1180,97 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-vsphere-csi,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.10$
+    - ^release-4\.10-
+    cluster: vsphere02
+    context: ci/prow/e2e-vsphere-upi
+    decorate: true
+    decoration_config:
+      oauth_token_secret:
+        key: oauth
+        name: github-credentials-openshift-ci-robot-private-git-cloner
+    hidden: true
+    labels:
+      ci-operator.openshift.io/cloud: vsphere
+      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-priv-cluster-storage-operator-release-4.10-e2e-vsphere-upi
+    optional: true
+    path_alias: github.com/openshift/cluster-storage-operator
+    rerun_command: /test e2e-vsphere-upi
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-vsphere-upi
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.11-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.11-presubmits.yaml
@@ -1095,97 +1095,6 @@ presubmits:
     - ^release-4\.11$
     - ^release-4\.11-
     cluster: vsphere02
-    context: ci/prow/e2e-vsphere
-    decorate: true
-    decoration_config:
-      oauth_token_secret:
-        key: oauth
-        name: github-credentials-openshift-ci-robot-private-git-cloner
-    hidden: true
-    labels:
-      ci-operator.openshift.io/cloud: vsphere
-      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-storage-operator-release-4.11-e2e-vsphere
-    optional: true
-    path_alias: github.com/openshift/cluster-storage-operator
-    rerun_command: /test e2e-vsphere
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --oauth-token-path=/usr/local/github-credentials/oauth
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-vsphere
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /usr/local/github-credentials
-          name: github-credentials-openshift-ci-robot-private-git-cloner
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-vsphere,?($|\s.*)
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - ^release-4\.11$
-    - ^release-4\.11-
-    cluster: vsphere02
     context: ci/prow/e2e-vsphere-csi
     decorate: true
     decoration_config:
@@ -1271,6 +1180,97 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-vsphere-csi,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.11$
+    - ^release-4\.11-
+    cluster: vsphere02
+    context: ci/prow/e2e-vsphere-upi
+    decorate: true
+    decoration_config:
+      oauth_token_secret:
+        key: oauth
+        name: github-credentials-openshift-ci-robot-private-git-cloner
+    hidden: true
+    labels:
+      ci-operator.openshift.io/cloud: vsphere
+      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-priv-cluster-storage-operator-release-4.11-e2e-vsphere-upi
+    optional: true
+    path_alias: github.com/openshift/cluster-storage-operator
+    rerun_command: /test e2e-vsphere-upi
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-vsphere-upi
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.12-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.12-presubmits.yaml
@@ -1186,7 +1186,7 @@ presubmits:
     - ^release-4\.12$
     - ^release-4\.12-
     cluster: vsphere02
-    context: ci/prow/e2e-vsphere-ovn
+    context: ci/prow/e2e-vsphere-ovn-upi
     decorate: true
     decoration_config:
       oauth_token_secret:
@@ -1198,10 +1198,10 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-storage-operator-release-4.12-e2e-vsphere-ovn
+    name: pull-ci-openshift-priv-cluster-storage-operator-release-4.12-e2e-vsphere-ovn-upi
     optional: true
     path_alias: github.com/openshift/cluster-storage-operator
-    rerun_command: /test e2e-vsphere-ovn
+    rerun_command: /test e2e-vsphere-ovn-upi
     spec:
       containers:
       - args:
@@ -1211,7 +1211,7 @@ presubmits:
         - --oauth-token-path=/usr/local/github-credentials/oauth
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-vsphere-ovn
+        - --target=e2e-vsphere-ovn-upi
         command:
         - ci-operator
         env:
@@ -1270,7 +1270,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-vsphere-ovn,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-vsphere-ovn-upi,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:

--- a/ci-operator/jobs/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.13-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.13-presubmits.yaml
@@ -1277,7 +1277,7 @@ presubmits:
     - ^release-4\.13$
     - ^release-4\.13-
     cluster: vsphere02
-    context: ci/prow/e2e-vsphere-ovn
+    context: ci/prow/e2e-vsphere-ovn-upi
     decorate: true
     decoration_config:
       oauth_token_secret:
@@ -1289,10 +1289,10 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-storage-operator-release-4.13-e2e-vsphere-ovn
+    name: pull-ci-openshift-priv-cluster-storage-operator-release-4.13-e2e-vsphere-ovn-upi
     optional: true
     path_alias: github.com/openshift/cluster-storage-operator
-    rerun_command: /test e2e-vsphere-ovn
+    rerun_command: /test e2e-vsphere-ovn-upi
     spec:
       containers:
       - args:
@@ -1302,7 +1302,7 @@ presubmits:
         - --oauth-token-path=/usr/local/github-credentials/oauth
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-vsphere-ovn
+        - --target=e2e-vsphere-ovn-upi
         command:
         - ci-operator
         env:
@@ -1361,7 +1361,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-vsphere-ovn,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-vsphere-ovn-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.14-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.14-presubmits.yaml
@@ -1186,7 +1186,7 @@ presubmits:
     - ^release-4\.14$
     - ^release-4\.14-
     cluster: vsphere02
-    context: ci/prow/e2e-ovn-vsphere
+    context: ci/prow/e2e-ovn-vsphere-upi
     decorate: true
     decoration_config:
       oauth_token_secret:
@@ -1198,10 +1198,10 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-storage-operator-release-4.14-e2e-ovn-vsphere
+    name: pull-ci-openshift-priv-cluster-storage-operator-release-4.14-e2e-ovn-vsphere-upi
     optional: true
     path_alias: github.com/openshift/cluster-storage-operator
-    rerun_command: /test e2e-ovn-vsphere
+    rerun_command: /test e2e-ovn-vsphere-upi
     spec:
       containers:
       - args:
@@ -1211,7 +1211,7 @@ presubmits:
         - --oauth-token-path=/usr/local/github-credentials/oauth
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-ovn-vsphere
+        - --target=e2e-ovn-vsphere-upi
         command:
         - ci-operator
         env:
@@ -1270,7 +1270,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-ovn-vsphere,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-ovn-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:

--- a/ci-operator/jobs/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.15-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.15-presubmits.yaml
@@ -1275,7 +1275,7 @@ presubmits:
     - ^release-4\.15$
     - ^release-4\.15-
     cluster: vsphere02
-    context: ci/prow/e2e-ovn-vsphere
+    context: ci/prow/e2e-ovn-vsphere-upi
     decorate: true
     decoration_config:
       oauth_token_secret:
@@ -1287,10 +1287,10 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-storage-operator-release-4.15-e2e-ovn-vsphere
+    name: pull-ci-openshift-priv-cluster-storage-operator-release-4.15-e2e-ovn-vsphere-upi
     optional: true
     path_alias: github.com/openshift/cluster-storage-operator
-    rerun_command: /test e2e-ovn-vsphere
+    rerun_command: /test e2e-ovn-vsphere-upi
     spec:
       containers:
       - args:
@@ -1300,7 +1300,7 @@ presubmits:
         - --oauth-token-path=/usr/local/github-credentials/oauth
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-ovn-vsphere
+        - --target=e2e-ovn-vsphere-upi
         command:
         - ci-operator
         env:
@@ -1359,7 +1359,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-ovn-vsphere,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-ovn-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.16-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.16-presubmits.yaml
@@ -1275,7 +1275,7 @@ presubmits:
     - ^release-4\.16$
     - ^release-4\.16-
     cluster: vsphere02
-    context: ci/prow/e2e-ovn-vsphere
+    context: ci/prow/e2e-ovn-vsphere-upi
     decorate: true
     decoration_config:
       oauth_token_secret:
@@ -1287,10 +1287,10 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-storage-operator-release-4.16-e2e-ovn-vsphere
+    name: pull-ci-openshift-priv-cluster-storage-operator-release-4.16-e2e-ovn-vsphere-upi
     optional: true
     path_alias: github.com/openshift/cluster-storage-operator
-    rerun_command: /test e2e-ovn-vsphere
+    rerun_command: /test e2e-ovn-vsphere-upi
     spec:
       containers:
       - args:
@@ -1300,7 +1300,7 @@ presubmits:
         - --oauth-token-path=/usr/local/github-credentials/oauth
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-ovn-vsphere
+        - --target=e2e-ovn-vsphere-upi
         command:
         - ci-operator
         env:
@@ -1359,7 +1359,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-ovn-vsphere,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-ovn-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.17-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.17-presubmits.yaml
@@ -1275,7 +1275,7 @@ presubmits:
     - ^release-4\.17$
     - ^release-4\.17-
     cluster: vsphere02
-    context: ci/prow/e2e-ovn-vsphere
+    context: ci/prow/e2e-ovn-vsphere-upi
     decorate: true
     decoration_config:
       oauth_token_secret:
@@ -1287,10 +1287,10 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-storage-operator-release-4.17-e2e-ovn-vsphere
+    name: pull-ci-openshift-priv-cluster-storage-operator-release-4.17-e2e-ovn-vsphere-upi
     optional: true
     path_alias: github.com/openshift/cluster-storage-operator
-    rerun_command: /test e2e-ovn-vsphere
+    rerun_command: /test e2e-ovn-vsphere-upi
     spec:
       containers:
       - args:
@@ -1300,7 +1300,7 @@ presubmits:
         - --oauth-token-path=/usr/local/github-credentials/oauth
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-ovn-vsphere
+        - --target=e2e-ovn-vsphere-upi
         command:
         - ci-operator
         env:
@@ -1359,7 +1359,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-ovn-vsphere,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-ovn-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.18-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.18-presubmits.yaml
@@ -1366,7 +1366,7 @@ presubmits:
     - ^release-4\.18$
     - ^release-4\.18-
     cluster: vsphere02
-    context: ci/prow/e2e-ovn-vsphere
+    context: ci/prow/e2e-ovn-vsphere-upi
     decorate: true
     decoration_config:
       oauth_token_secret:
@@ -1378,10 +1378,10 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-storage-operator-release-4.18-e2e-ovn-vsphere
+    name: pull-ci-openshift-priv-cluster-storage-operator-release-4.18-e2e-ovn-vsphere-upi
     optional: true
     path_alias: github.com/openshift/cluster-storage-operator
-    rerun_command: /test e2e-ovn-vsphere
+    rerun_command: /test e2e-ovn-vsphere-upi
     spec:
       containers:
       - args:
@@ -1391,7 +1391,7 @@ presubmits:
         - --oauth-token-path=/usr/local/github-credentials/oauth
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-ovn-vsphere
+        - --target=e2e-ovn-vsphere-upi
         command:
         - ci-operator
         env:
@@ -1450,7 +1450,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-ovn-vsphere,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-ovn-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.19-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.19-presubmits.yaml
@@ -1366,7 +1366,7 @@ presubmits:
     - ^release-4\.19$
     - ^release-4\.19-
     cluster: vsphere02
-    context: ci/prow/e2e-ovn-vsphere
+    context: ci/prow/e2e-ovn-vsphere-upi
     decorate: true
     decoration_config:
       oauth_token_secret:
@@ -1378,10 +1378,10 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-storage-operator-release-4.19-e2e-ovn-vsphere
+    name: pull-ci-openshift-priv-cluster-storage-operator-release-4.19-e2e-ovn-vsphere-upi
     optional: true
     path_alias: github.com/openshift/cluster-storage-operator
-    rerun_command: /test e2e-ovn-vsphere
+    rerun_command: /test e2e-ovn-vsphere-upi
     spec:
       containers:
       - args:
@@ -1391,7 +1391,7 @@ presubmits:
         - --oauth-token-path=/usr/local/github-credentials/oauth
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-ovn-vsphere
+        - --target=e2e-ovn-vsphere-upi
         command:
         - ci-operator
         env:
@@ -1450,7 +1450,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-ovn-vsphere,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-ovn-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.20-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.20-presubmits.yaml
@@ -1366,7 +1366,7 @@ presubmits:
     - ^release-4\.20$
     - ^release-4\.20-
     cluster: vsphere02
-    context: ci/prow/e2e-ovn-vsphere
+    context: ci/prow/e2e-ovn-vsphere-upi
     decorate: true
     decoration_config:
       oauth_token_secret:
@@ -1378,10 +1378,10 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-storage-operator-release-4.20-e2e-ovn-vsphere
+    name: pull-ci-openshift-priv-cluster-storage-operator-release-4.20-e2e-ovn-vsphere-upi
     optional: true
     path_alias: github.com/openshift/cluster-storage-operator
-    rerun_command: /test e2e-ovn-vsphere
+    rerun_command: /test e2e-ovn-vsphere-upi
     spec:
       containers:
       - args:
@@ -1391,7 +1391,7 @@ presubmits:
         - --oauth-token-path=/usr/local/github-credentials/oauth
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-ovn-vsphere
+        - --target=e2e-ovn-vsphere-upi
         command:
         - ci-operator
         env:
@@ -1450,7 +1450,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-ovn-vsphere,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-ovn-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.21-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.21-presubmits.yaml
@@ -1366,7 +1366,7 @@ presubmits:
     - ^release-4\.21$
     - ^release-4\.21-
     cluster: vsphere02
-    context: ci/prow/e2e-ovn-vsphere
+    context: ci/prow/e2e-ovn-vsphere-upi
     decorate: true
     decoration_config:
       oauth_token_secret:
@@ -1378,10 +1378,10 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-storage-operator-release-4.21-e2e-ovn-vsphere
+    name: pull-ci-openshift-priv-cluster-storage-operator-release-4.21-e2e-ovn-vsphere-upi
     optional: true
     path_alias: github.com/openshift/cluster-storage-operator
-    rerun_command: /test e2e-ovn-vsphere
+    rerun_command: /test e2e-ovn-vsphere-upi
     spec:
       containers:
       - args:
@@ -1391,7 +1391,7 @@ presubmits:
         - --oauth-token-path=/usr/local/github-credentials/oauth
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-ovn-vsphere
+        - --target=e2e-ovn-vsphere-upi
         command:
         - ci-operator
         env:
@@ -1450,7 +1450,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-ovn-vsphere,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-ovn-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.22-presubmits.yaml
@@ -1366,7 +1366,7 @@ presubmits:
     - ^release-4\.22$
     - ^release-4\.22-
     cluster: vsphere02
-    context: ci/prow/e2e-ovn-vsphere
+    context: ci/prow/e2e-ovn-vsphere-upi
     decorate: true
     decoration_config:
       oauth_token_secret:
@@ -1378,10 +1378,10 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-storage-operator-release-4.22-e2e-ovn-vsphere
+    name: pull-ci-openshift-priv-cluster-storage-operator-release-4.22-e2e-ovn-vsphere-upi
     optional: true
     path_alias: github.com/openshift/cluster-storage-operator
-    rerun_command: /test e2e-ovn-vsphere
+    rerun_command: /test e2e-ovn-vsphere-upi
     spec:
       containers:
       - args:
@@ -1391,7 +1391,7 @@ presubmits:
         - --oauth-token-path=/usr/local/github-credentials/oauth
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-ovn-vsphere
+        - --target=e2e-ovn-vsphere-upi
         command:
         - ci-operator
         env:
@@ -1450,7 +1450,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-ovn-vsphere,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-ovn-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.23-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.23-presubmits.yaml
@@ -1366,7 +1366,7 @@ presubmits:
     - ^release-4\.23$
     - ^release-4\.23-
     cluster: vsphere02
-    context: ci/prow/e2e-ovn-vsphere
+    context: ci/prow/e2e-ovn-vsphere-upi
     decorate: true
     decoration_config:
       oauth_token_secret:
@@ -1378,10 +1378,10 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-storage-operator-release-4.23-e2e-ovn-vsphere
+    name: pull-ci-openshift-priv-cluster-storage-operator-release-4.23-e2e-ovn-vsphere-upi
     optional: true
     path_alias: github.com/openshift/cluster-storage-operator
-    rerun_command: /test e2e-ovn-vsphere
+    rerun_command: /test e2e-ovn-vsphere-upi
     spec:
       containers:
       - args:
@@ -1391,7 +1391,7 @@ presubmits:
         - --oauth-token-path=/usr/local/github-credentials/oauth
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-ovn-vsphere
+        - --target=e2e-ovn-vsphere-upi
         command:
         - ci-operator
         env:
@@ -1450,7 +1450,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-ovn-vsphere,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-ovn-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.8-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.8-presubmits.yaml
@@ -922,98 +922,6 @@ presubmits:
     - ^release-4\.8$
     - ^release-4\.8-
     cluster: vsphere02
-    context: ci/prow/e2e-vsphere
-    decorate: true
-    decoration_config:
-      skip_cloning: true
-    hidden: true
-    labels:
-      ci-operator.openshift.io/cloud: vsphere
-      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-storage-operator-release-4.8-e2e-vsphere
-    optional: true
-    path_alias: github.com/openshift/cluster-storage-operator
-    rerun_command: /test e2e-vsphere
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --oauth-token-path=/usr/local/github-credentials/oauth
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-vsphere
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /usr/local/github-credentials
-          name: github-credentials-openshift-ci-robot-private-git-cloner
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: github-credentials-openshift-ci-robot-private-git-cloner
-        secret:
-          secretName: github-credentials-openshift-ci-robot-private-git-cloner
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-vsphere,?($|\s.*)
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - ^release-4\.8$
-    - ^release-4\.8-
-    cluster: vsphere02
     context: ci/prow/e2e-vsphere-csi
     decorate: true
     decoration_config:
@@ -1100,6 +1008,98 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-vsphere-csi,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.8$
+    - ^release-4\.8-
+    cluster: vsphere02
+    context: ci/prow/e2e-vsphere-upi
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    hidden: true
+    labels:
+      ci-operator.openshift.io/cloud: vsphere
+      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-priv-cluster-storage-operator-release-4.8-e2e-vsphere-upi
+    optional: true
+    path_alias: github.com/openshift/cluster-storage-operator
+    rerun_command: /test e2e-vsphere-upi
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-vsphere-upi
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: github-credentials-openshift-ci-robot-private-git-cloner
+        secret:
+          secretName: github-credentials-openshift-ci-robot-private-git-cloner
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.9-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-4.9-presubmits.yaml
@@ -913,97 +913,6 @@ presubmits:
     - ^release-4\.9$
     - ^release-4\.9-
     cluster: vsphere02
-    context: ci/prow/e2e-vsphere
-    decorate: true
-    decoration_config:
-      oauth_token_secret:
-        key: oauth
-        name: github-credentials-openshift-ci-robot-private-git-cloner
-    hidden: true
-    labels:
-      ci-operator.openshift.io/cloud: vsphere
-      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-storage-operator-release-4.9-e2e-vsphere
-    optional: true
-    path_alias: github.com/openshift/cluster-storage-operator
-    rerun_command: /test e2e-vsphere
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --oauth-token-path=/usr/local/github-credentials/oauth
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-vsphere
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /usr/local/github-credentials
-          name: github-credentials-openshift-ci-robot-private-git-cloner
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-vsphere,?($|\s.*)
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - ^release-4\.9$
-    - ^release-4\.9-
-    cluster: vsphere02
     context: ci/prow/e2e-vsphere-csi
     decorate: true
     decoration_config:
@@ -1089,6 +998,97 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-vsphere-csi,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.9$
+    - ^release-4\.9-
+    cluster: vsphere02
+    context: ci/prow/e2e-vsphere-upi
+    decorate: true
+    decoration_config:
+      oauth_token_secret:
+        key: oauth
+        name: github-credentials-openshift-ci-robot-private-git-cloner
+    hidden: true
+    labels:
+      ci-operator.openshift.io/cloud: vsphere
+      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-priv-cluster-storage-operator-release-4.9-e2e-vsphere-upi
+    optional: true
+    path_alias: github.com/openshift/cluster-storage-operator
+    rerun_command: /test e2e-vsphere-upi
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-vsphere-upi
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-5.0-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/cluster-storage-operator/openshift-priv-cluster-storage-operator-release-5.0-presubmits.yaml
@@ -1366,7 +1366,7 @@ presubmits:
     - ^release-5\.0$
     - ^release-5\.0-
     cluster: vsphere02
-    context: ci/prow/e2e-ovn-vsphere
+    context: ci/prow/e2e-ovn-vsphere-upi
     decorate: true
     decoration_config:
       oauth_token_secret:
@@ -1378,10 +1378,10 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-cluster-storage-operator-release-5.0-e2e-ovn-vsphere
+    name: pull-ci-openshift-priv-cluster-storage-operator-release-5.0-e2e-ovn-vsphere-upi
     optional: true
     path_alias: github.com/openshift/cluster-storage-operator
-    rerun_command: /test e2e-ovn-vsphere
+    rerun_command: /test e2e-ovn-vsphere-upi
     spec:
       containers:
       - args:
@@ -1391,7 +1391,7 @@ presubmits:
         - --oauth-token-path=/usr/local/github-credentials/oauth
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-ovn-vsphere
+        - --target=e2e-ovn-vsphere-upi
         command:
         - ci-operator
         env:
@@ -1450,7 +1450,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-ovn-vsphere,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-ovn-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift-priv/origin/openshift-priv-origin-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/origin/openshift-priv-origin-main-presubmits.yaml
@@ -3379,7 +3379,7 @@ presubmits:
     - ^main$
     - ^main-
     cluster: vsphere02
-    context: ci/prow/e2e-external-vsphere-ccm
+    context: ci/prow/e2e-external-vsphere-ccm-upi
     decorate: true
     decoration_config:
       oauth_token_secret:
@@ -3391,10 +3391,10 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-origin-main-e2e-external-vsphere-ccm
+    name: pull-ci-openshift-priv-origin-main-e2e-external-vsphere-ccm-upi
     optional: true
     path_alias: github.com/openshift/origin
-    rerun_command: /test e2e-external-vsphere-ccm
+    rerun_command: /test e2e-external-vsphere-ccm-upi
     spec:
       containers:
       - args:
@@ -3404,7 +3404,7 @@ presubmits:
         - --oauth-token-path=/usr/local/github-credentials/oauth
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-external-vsphere-ccm
+        - --target=e2e-external-vsphere-ccm-upi
         command:
         - ci-operator
         env:
@@ -3463,7 +3463,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-external-vsphere-ccm,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-external-vsphere-ccm-upi,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:

--- a/ci-operator/jobs/openshift-priv/origin/openshift-priv-origin-release-4.10-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/origin/openshift-priv-origin-release-4.10-presubmits.yaml
@@ -2828,7 +2828,7 @@ presubmits:
     - ^release-4\.10$
     - ^release-4\.10-
     cluster: vsphere02
-    context: ci/prow/e2e-vsphere
+    context: ci/prow/e2e-vsphere-upi
     decorate: true
     decoration_config:
       oauth_token_secret:
@@ -2840,10 +2840,10 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-origin-release-4.10-e2e-vsphere
+    name: pull-ci-openshift-priv-origin-release-4.10-e2e-vsphere-upi
     optional: true
     path_alias: github.com/openshift/origin
-    rerun_command: /test e2e-vsphere
+    rerun_command: /test e2e-vsphere-upi
     spec:
       containers:
       - args:
@@ -2853,7 +2853,7 @@ presubmits:
         - --oauth-token-path=/usr/local/github-credentials/oauth
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-vsphere
+        - --target=e2e-vsphere-upi
         command:
         - ci-operator
         env:
@@ -2912,7 +2912,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-vsphere,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift-priv/origin/openshift-priv-origin-release-4.12-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/origin/openshift-priv-origin-release-4.12-presubmits.yaml
@@ -3375,97 +3375,6 @@ presubmits:
     - ^release-4\.12$
     - ^release-4\.12-
     cluster: vsphere02
-    context: ci/prow/e2e-vsphere
-    decorate: true
-    decoration_config:
-      oauth_token_secret:
-        key: oauth
-        name: github-credentials-openshift-ci-robot-private-git-cloner
-    hidden: true
-    labels:
-      ci-operator.openshift.io/cloud: vsphere
-      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-origin-release-4.12-e2e-vsphere
-    optional: true
-    path_alias: github.com/openshift/origin
-    rerun_command: /test e2e-vsphere
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --oauth-token-path=/usr/local/github-credentials/oauth
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-vsphere
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /usr/local/github-credentials
-          name: github-credentials-openshift-ci-robot-private-git-cloner
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-vsphere,?($|\s.*)
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - ^release-4\.12$
-    - ^release-4\.12-
-    cluster: vsphere02
     context: ci/prow/e2e-vsphere-ovn-etcd-scaling
     decorate: true
     decoration_config:
@@ -3551,6 +3460,97 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-vsphere-ovn-etcd-scaling,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.12$
+    - ^release-4\.12-
+    cluster: vsphere02
+    context: ci/prow/e2e-vsphere-upi
+    decorate: true
+    decoration_config:
+      oauth_token_secret:
+        key: oauth
+        name: github-credentials-openshift-ci-robot-private-git-cloner
+    hidden: true
+    labels:
+      ci-operator.openshift.io/cloud: vsphere
+      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-priv-origin-release-4.12-e2e-vsphere-upi
+    optional: true
+    path_alias: github.com/openshift/origin
+    rerun_command: /test e2e-vsphere-upi
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-vsphere-upi
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift-priv/origin/openshift-priv-origin-release-4.13-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/origin/openshift-priv-origin-release-4.13-presubmits.yaml
@@ -3557,97 +3557,6 @@ presubmits:
     - ^release-4\.13$
     - ^release-4\.13-
     cluster: vsphere02
-    context: ci/prow/e2e-vsphere
-    decorate: true
-    decoration_config:
-      oauth_token_secret:
-        key: oauth
-        name: github-credentials-openshift-ci-robot-private-git-cloner
-    hidden: true
-    labels:
-      ci-operator.openshift.io/cloud: vsphere
-      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-origin-release-4.13-e2e-vsphere
-    optional: true
-    path_alias: github.com/openshift/origin
-    rerun_command: /test e2e-vsphere
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --oauth-token-path=/usr/local/github-credentials/oauth
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-vsphere
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /usr/local/github-credentials
-          name: github-credentials-openshift-ci-robot-private-git-cloner
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-vsphere,?($|\s.*)
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - ^release-4\.13$
-    - ^release-4\.13-
-    cluster: vsphere02
     context: ci/prow/e2e-vsphere-ovn-etcd-scaling
     decorate: true
     decoration_config:
@@ -3733,6 +3642,97 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-vsphere-ovn-etcd-scaling,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.13$
+    - ^release-4\.13-
+    cluster: vsphere02
+    context: ci/prow/e2e-vsphere-upi
+    decorate: true
+    decoration_config:
+      oauth_token_secret:
+        key: oauth
+        name: github-credentials-openshift-ci-robot-private-git-cloner
+    hidden: true
+    labels:
+      ci-operator.openshift.io/cloud: vsphere
+      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-priv-origin-release-4.13-e2e-vsphere-upi
+    optional: true
+    path_alias: github.com/openshift/origin
+    rerun_command: /test e2e-vsphere-upi
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-vsphere-upi
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift-priv/origin/openshift-priv-origin-release-4.14-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/origin/openshift-priv-origin-release-4.14-presubmits.yaml
@@ -3832,97 +3832,6 @@ presubmits:
     - ^release-4\.14$
     - ^release-4\.14-
     cluster: vsphere02
-    context: ci/prow/e2e-vsphere
-    decorate: true
-    decoration_config:
-      oauth_token_secret:
-        key: oauth
-        name: github-credentials-openshift-ci-robot-private-git-cloner
-    hidden: true
-    labels:
-      ci-operator.openshift.io/cloud: vsphere
-      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-origin-release-4.14-e2e-vsphere
-    optional: true
-    path_alias: github.com/openshift/origin
-    rerun_command: /test e2e-vsphere
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --oauth-token-path=/usr/local/github-credentials/oauth
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-vsphere
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /usr/local/github-credentials
-          name: github-credentials-openshift-ci-robot-private-git-cloner
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-vsphere,?($|\s.*)
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - ^release-4\.14$
-    - ^release-4\.14-
-    cluster: vsphere02
     context: ci/prow/e2e-vsphere-ovn-etcd-scaling
     decorate: true
     decoration_config:
@@ -4008,6 +3917,97 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-vsphere-ovn-etcd-scaling,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.14$
+    - ^release-4\.14-
+    cluster: vsphere02
+    context: ci/prow/e2e-vsphere-upi
+    decorate: true
+    decoration_config:
+      oauth_token_secret:
+        key: oauth
+        name: github-credentials-openshift-ci-robot-private-git-cloner
+    hidden: true
+    labels:
+      ci-operator.openshift.io/cloud: vsphere
+      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-priv-origin-release-4.14-e2e-vsphere-upi
+    optional: true
+    path_alias: github.com/openshift/origin
+    rerun_command: /test e2e-vsphere-upi
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-vsphere-upi
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift-priv/origin/openshift-priv-origin-release-4.15-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/origin/openshift-priv-origin-release-4.15-presubmits.yaml
@@ -3831,97 +3831,6 @@ presubmits:
     - ^release-4\.15$
     - ^release-4\.15-
     cluster: vsphere02
-    context: ci/prow/e2e-vsphere
-    decorate: true
-    decoration_config:
-      oauth_token_secret:
-        key: oauth
-        name: github-credentials-openshift-ci-robot-private-git-cloner
-    hidden: true
-    labels:
-      ci-operator.openshift.io/cloud: vsphere
-      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-origin-release-4.15-e2e-vsphere
-    optional: true
-    path_alias: github.com/openshift/origin
-    rerun_command: /test e2e-vsphere
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --oauth-token-path=/usr/local/github-credentials/oauth
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-vsphere
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /usr/local/github-credentials
-          name: github-credentials-openshift-ci-robot-private-git-cloner
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-vsphere,?($|\s.*)
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - ^release-4\.15$
-    - ^release-4\.15-
-    cluster: vsphere02
     context: ci/prow/e2e-vsphere-ovn-etcd-scaling
     decorate: true
     decoration_config:
@@ -4007,6 +3916,97 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-vsphere-ovn-etcd-scaling,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.15$
+    - ^release-4\.15-
+    cluster: vsphere02
+    context: ci/prow/e2e-vsphere-upi
+    decorate: true
+    decoration_config:
+      oauth_token_secret:
+        key: oauth
+        name: github-credentials-openshift-ci-robot-private-git-cloner
+    hidden: true
+    labels:
+      ci-operator.openshift.io/cloud: vsphere
+      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-priv-origin-release-4.15-e2e-vsphere-upi
+    optional: true
+    path_alias: github.com/openshift/origin
+    rerun_command: /test e2e-vsphere-upi
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-vsphere-upi
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift-priv/origin/openshift-priv-origin-release-4.16-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/origin/openshift-priv-origin-release-4.16-presubmits.yaml
@@ -4474,97 +4474,6 @@ presubmits:
     - ^release-4\.16$
     - ^release-4\.16-
     cluster: vsphere02
-    context: ci/prow/e2e-vsphere
-    decorate: true
-    decoration_config:
-      oauth_token_secret:
-        key: oauth
-        name: github-credentials-openshift-ci-robot-private-git-cloner
-    hidden: true
-    labels:
-      ci-operator.openshift.io/cloud: vsphere
-      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-origin-release-4.16-e2e-vsphere
-    optional: true
-    path_alias: github.com/openshift/origin
-    rerun_command: /test e2e-vsphere
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --oauth-token-path=/usr/local/github-credentials/oauth
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-vsphere
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /usr/local/github-credentials
-          name: github-credentials-openshift-ci-robot-private-git-cloner
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-vsphere,?($|\s.*)
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - ^release-4\.16$
-    - ^release-4\.16-
-    cluster: vsphere02
     context: ci/prow/e2e-vsphere-ovn-etcd-scaling
     decorate: true
     decoration_config:
@@ -4650,6 +4559,97 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-vsphere-ovn-etcd-scaling,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.16$
+    - ^release-4\.16-
+    cluster: vsphere02
+    context: ci/prow/e2e-vsphere-upi
+    decorate: true
+    decoration_config:
+      oauth_token_secret:
+        key: oauth
+        name: github-credentials-openshift-ci-robot-private-git-cloner
+    hidden: true
+    labels:
+      ci-operator.openshift.io/cloud: vsphere
+      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-priv-origin-release-4.16-e2e-vsphere-upi
+    optional: true
+    path_alias: github.com/openshift/origin
+    rerun_command: /test e2e-vsphere-upi
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-vsphere-upi
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift-priv/origin/openshift-priv-origin-release-4.17-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/origin/openshift-priv-origin-release-4.17-presubmits.yaml
@@ -4839,97 +4839,6 @@ presubmits:
     - ^release-4\.17$
     - ^release-4\.17-
     cluster: vsphere02
-    context: ci/prow/e2e-vsphere
-    decorate: true
-    decoration_config:
-      oauth_token_secret:
-        key: oauth
-        name: github-credentials-openshift-ci-robot-private-git-cloner
-    hidden: true
-    labels:
-      ci-operator.openshift.io/cloud: vsphere
-      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-origin-release-4.17-e2e-vsphere
-    optional: true
-    path_alias: github.com/openshift/origin
-    rerun_command: /test e2e-vsphere
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --oauth-token-path=/usr/local/github-credentials/oauth
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-vsphere
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /usr/local/github-credentials
-          name: github-credentials-openshift-ci-robot-private-git-cloner
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-vsphere,?($|\s.*)
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - ^release-4\.17$
-    - ^release-4\.17-
-    cluster: vsphere02
     context: ci/prow/e2e-vsphere-ovn-etcd-scaling
     decorate: true
     decoration_config:
@@ -5015,6 +4924,97 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-vsphere-ovn-etcd-scaling,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.17$
+    - ^release-4\.17-
+    cluster: vsphere02
+    context: ci/prow/e2e-vsphere-upi
+    decorate: true
+    decoration_config:
+      oauth_token_secret:
+        key: oauth
+        name: github-credentials-openshift-ci-robot-private-git-cloner
+    hidden: true
+    labels:
+      ci-operator.openshift.io/cloud: vsphere
+      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-priv-origin-release-4.17-e2e-vsphere-upi
+    optional: true
+    path_alias: github.com/openshift/origin
+    rerun_command: /test e2e-vsphere-upi
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-vsphere-upi
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift-priv/origin/openshift-priv-origin-release-4.18-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/origin/openshift-priv-origin-release-4.18-presubmits.yaml
@@ -3192,7 +3192,7 @@ presubmits:
     - ^release-4\.18$
     - ^release-4\.18-
     cluster: vsphere02
-    context: ci/prow/e2e-external-vsphere-ccm
+    context: ci/prow/e2e-external-vsphere-ccm-upi
     decorate: true
     decoration_config:
       oauth_token_secret:
@@ -3204,10 +3204,10 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-origin-release-4.18-e2e-external-vsphere-ccm
+    name: pull-ci-openshift-priv-origin-release-4.18-e2e-external-vsphere-ccm-upi
     optional: true
     path_alias: github.com/openshift/origin
-    rerun_command: /test e2e-external-vsphere-ccm
+    rerun_command: /test e2e-external-vsphere-ccm-upi
     spec:
       containers:
       - args:
@@ -3217,7 +3217,7 @@ presubmits:
         - --oauth-token-path=/usr/local/github-credentials/oauth
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-external-vsphere-ccm
+        - --target=e2e-external-vsphere-ccm-upi
         command:
         - ci-operator
         env:
@@ -3276,7 +3276,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-external-vsphere-ccm,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-external-vsphere-ccm-upi,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:
@@ -5568,97 +5568,6 @@ presubmits:
     - ^release-4\.18$
     - ^release-4\.18-
     cluster: vsphere02
-    context: ci/prow/e2e-vsphere
-    decorate: true
-    decoration_config:
-      oauth_token_secret:
-        key: oauth
-        name: github-credentials-openshift-ci-robot-private-git-cloner
-    hidden: true
-    labels:
-      ci-operator.openshift.io/cloud: vsphere
-      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-origin-release-4.18-e2e-vsphere
-    optional: true
-    path_alias: github.com/openshift/origin
-    rerun_command: /test e2e-vsphere
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --oauth-token-path=/usr/local/github-credentials/oauth
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-vsphere
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /usr/local/github-credentials
-          name: github-credentials-openshift-ci-robot-private-git-cloner
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-vsphere,?($|\s.*)
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - ^release-4\.18$
-    - ^release-4\.18-
-    cluster: vsphere02
     context: ci/prow/e2e-vsphere-ovn-etcd-scaling
     decorate: true
     decoration_config:
@@ -5744,6 +5653,97 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-vsphere-ovn-etcd-scaling,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.18$
+    - ^release-4\.18-
+    cluster: vsphere02
+    context: ci/prow/e2e-vsphere-upi
+    decorate: true
+    decoration_config:
+      oauth_token_secret:
+        key: oauth
+        name: github-credentials-openshift-ci-robot-private-git-cloner
+    hidden: true
+    labels:
+      ci-operator.openshift.io/cloud: vsphere
+      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-priv-origin-release-4.18-e2e-vsphere-upi
+    optional: true
+    path_alias: github.com/openshift/origin
+    rerun_command: /test e2e-vsphere-upi
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-vsphere-upi
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift-priv/origin/openshift-priv-origin-release-4.19-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/origin/openshift-priv-origin-release-4.19-presubmits.yaml
@@ -3285,7 +3285,7 @@ presubmits:
     - ^release-4\.19$
     - ^release-4\.19-
     cluster: vsphere02
-    context: ci/prow/e2e-external-vsphere-ccm
+    context: ci/prow/e2e-external-vsphere-ccm-upi
     decorate: true
     decoration_config:
       oauth_token_secret:
@@ -3297,10 +3297,10 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-origin-release-4.19-e2e-external-vsphere-ccm
+    name: pull-ci-openshift-priv-origin-release-4.19-e2e-external-vsphere-ccm-upi
     optional: true
     path_alias: github.com/openshift/origin
-    rerun_command: /test e2e-external-vsphere-ccm
+    rerun_command: /test e2e-external-vsphere-ccm-upi
     spec:
       containers:
       - args:
@@ -3310,7 +3310,7 @@ presubmits:
         - --oauth-token-path=/usr/local/github-credentials/oauth
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-external-vsphere-ccm
+        - --target=e2e-external-vsphere-ccm-upi
         command:
         - ci-operator
         env:
@@ -3369,7 +3369,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-external-vsphere-ccm,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-external-vsphere-ccm-upi,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:

--- a/ci-operator/jobs/openshift-priv/origin/openshift-priv-origin-release-4.20-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/origin/openshift-priv-origin-release-4.20-presubmits.yaml
@@ -3287,7 +3287,7 @@ presubmits:
     - ^release-4\.20$
     - ^release-4\.20-
     cluster: vsphere02
-    context: ci/prow/e2e-external-vsphere-ccm
+    context: ci/prow/e2e-external-vsphere-ccm-upi
     decorate: true
     decoration_config:
       oauth_token_secret:
@@ -3299,10 +3299,10 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-origin-release-4.20-e2e-external-vsphere-ccm
+    name: pull-ci-openshift-priv-origin-release-4.20-e2e-external-vsphere-ccm-upi
     optional: true
     path_alias: github.com/openshift/origin
-    rerun_command: /test e2e-external-vsphere-ccm
+    rerun_command: /test e2e-external-vsphere-ccm-upi
     spec:
       containers:
       - args:
@@ -3312,7 +3312,7 @@ presubmits:
         - --oauth-token-path=/usr/local/github-credentials/oauth
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-external-vsphere-ccm
+        - --target=e2e-external-vsphere-ccm-upi
         command:
         - ci-operator
         env:
@@ -3371,7 +3371,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-external-vsphere-ccm,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-external-vsphere-ccm-upi,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:

--- a/ci-operator/jobs/openshift-priv/origin/openshift-priv-origin-release-4.21-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/origin/openshift-priv-origin-release-4.21-presubmits.yaml
@@ -3379,7 +3379,7 @@ presubmits:
     - ^release-4\.21$
     - ^release-4\.21-
     cluster: vsphere02
-    context: ci/prow/e2e-external-vsphere-ccm
+    context: ci/prow/e2e-external-vsphere-ccm-upi
     decorate: true
     decoration_config:
       oauth_token_secret:
@@ -3391,10 +3391,10 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-origin-release-4.21-e2e-external-vsphere-ccm
+    name: pull-ci-openshift-priv-origin-release-4.21-e2e-external-vsphere-ccm-upi
     optional: true
     path_alias: github.com/openshift/origin
-    rerun_command: /test e2e-external-vsphere-ccm
+    rerun_command: /test e2e-external-vsphere-ccm-upi
     spec:
       containers:
       - args:
@@ -3404,7 +3404,7 @@ presubmits:
         - --oauth-token-path=/usr/local/github-credentials/oauth
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-external-vsphere-ccm
+        - --target=e2e-external-vsphere-ccm-upi
         command:
         - ci-operator
         env:
@@ -3463,7 +3463,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-external-vsphere-ccm,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-external-vsphere-ccm-upi,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:

--- a/ci-operator/jobs/openshift-priv/origin/openshift-priv-origin-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/origin/openshift-priv-origin-release-4.22-presubmits.yaml
@@ -3379,7 +3379,7 @@ presubmits:
     - ^release-4\.22$
     - ^release-4\.22-
     cluster: vsphere02
-    context: ci/prow/e2e-external-vsphere-ccm
+    context: ci/prow/e2e-external-vsphere-ccm-upi
     decorate: true
     decoration_config:
       oauth_token_secret:
@@ -3391,10 +3391,10 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-origin-release-4.22-e2e-external-vsphere-ccm
+    name: pull-ci-openshift-priv-origin-release-4.22-e2e-external-vsphere-ccm-upi
     optional: true
     path_alias: github.com/openshift/origin
-    rerun_command: /test e2e-external-vsphere-ccm
+    rerun_command: /test e2e-external-vsphere-ccm-upi
     spec:
       containers:
       - args:
@@ -3404,7 +3404,7 @@ presubmits:
         - --oauth-token-path=/usr/local/github-credentials/oauth
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-external-vsphere-ccm
+        - --target=e2e-external-vsphere-ccm-upi
         command:
         - ci-operator
         env:
@@ -3463,7 +3463,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-external-vsphere-ccm,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-external-vsphere-ccm-upi,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:

--- a/ci-operator/jobs/openshift-priv/origin/openshift-priv-origin-release-4.23-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/origin/openshift-priv-origin-release-4.23-presubmits.yaml
@@ -3379,7 +3379,7 @@ presubmits:
     - ^release-4\.23$
     - ^release-4\.23-
     cluster: vsphere02
-    context: ci/prow/e2e-external-vsphere-ccm
+    context: ci/prow/e2e-external-vsphere-ccm-upi
     decorate: true
     decoration_config:
       oauth_token_secret:
@@ -3391,10 +3391,10 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-origin-release-4.23-e2e-external-vsphere-ccm
+    name: pull-ci-openshift-priv-origin-release-4.23-e2e-external-vsphere-ccm-upi
     optional: true
     path_alias: github.com/openshift/origin
-    rerun_command: /test e2e-external-vsphere-ccm
+    rerun_command: /test e2e-external-vsphere-ccm-upi
     spec:
       containers:
       - args:
@@ -3404,7 +3404,7 @@ presubmits:
         - --oauth-token-path=/usr/local/github-credentials/oauth
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-external-vsphere-ccm
+        - --target=e2e-external-vsphere-ccm-upi
         command:
         - ci-operator
         env:
@@ -3463,7 +3463,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-external-vsphere-ccm,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-external-vsphere-ccm-upi,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:

--- a/ci-operator/jobs/openshift-priv/origin/openshift-priv-origin-release-4.6-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/origin/openshift-priv-origin-release-4.6-presubmits.yaml
@@ -1657,7 +1657,7 @@ presubmits:
     - ^release-4\.6$
     - ^release-4\.6-
     cluster: vsphere02
-    context: ci/prow/e2e-vsphere
+    context: ci/prow/e2e-vsphere-upi
     decorate: true
     decoration_config:
       skip_cloning: true
@@ -1667,10 +1667,10 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-origin-release-4.6-e2e-vsphere
+    name: pull-ci-openshift-priv-origin-release-4.6-e2e-vsphere-upi
     optional: true
     path_alias: github.com/openshift/origin
-    rerun_command: /test e2e-vsphere
+    rerun_command: /test e2e-vsphere-upi
     spec:
       containers:
       - args:
@@ -1680,7 +1680,7 @@ presubmits:
         - --oauth-token-path=/usr/local/github-credentials/oauth
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-vsphere
+        - --target=e2e-vsphere-upi
         command:
         - ci-operator
         env:
@@ -1742,7 +1742,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-vsphere,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift-priv/origin/openshift-priv-origin-release-4.7-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/origin/openshift-priv-origin-release-4.7-presubmits.yaml
@@ -2024,7 +2024,7 @@ presubmits:
     - ^release-4\.7$
     - ^release-4\.7-
     cluster: vsphere02
-    context: ci/prow/e2e-vsphere
+    context: ci/prow/e2e-vsphere-upi
     decorate: true
     decoration_config:
       skip_cloning: true
@@ -2034,10 +2034,10 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-origin-release-4.7-e2e-vsphere
+    name: pull-ci-openshift-priv-origin-release-4.7-e2e-vsphere-upi
     optional: true
     path_alias: github.com/openshift/origin
-    rerun_command: /test e2e-vsphere
+    rerun_command: /test e2e-vsphere-upi
     spec:
       containers:
       - args:
@@ -2047,7 +2047,7 @@ presubmits:
         - --oauth-token-path=/usr/local/github-credentials/oauth
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-vsphere
+        - --target=e2e-vsphere-upi
         command:
         - ci-operator
         env:
@@ -2109,7 +2109,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-vsphere,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift-priv/origin/openshift-priv-origin-release-4.8-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/origin/openshift-priv-origin-release-4.8-presubmits.yaml
@@ -2487,7 +2487,7 @@ presubmits:
     - ^release-4\.8$
     - ^release-4\.8-
     cluster: vsphere02
-    context: ci/prow/e2e-vsphere
+    context: ci/prow/e2e-vsphere-upi
     decorate: true
     decoration_config:
       skip_cloning: true
@@ -2497,10 +2497,10 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-origin-release-4.8-e2e-vsphere
+    name: pull-ci-openshift-priv-origin-release-4.8-e2e-vsphere-upi
     optional: true
     path_alias: github.com/openshift/origin
-    rerun_command: /test e2e-vsphere
+    rerun_command: /test e2e-vsphere-upi
     spec:
       containers:
       - args:
@@ -2510,7 +2510,7 @@ presubmits:
         - --oauth-token-path=/usr/local/github-credentials/oauth
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-vsphere
+        - --target=e2e-vsphere-upi
         command:
         - ci-operator
         env:
@@ -2572,7 +2572,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-vsphere,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift-priv/origin/openshift-priv-origin-release-4.9-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/origin/openshift-priv-origin-release-4.9-presubmits.yaml
@@ -2581,7 +2581,7 @@ presubmits:
     - ^release-4\.9$
     - ^release-4\.9-
     cluster: vsphere02
-    context: ci/prow/e2e-vsphere
+    context: ci/prow/e2e-vsphere-upi
     decorate: true
     decoration_config:
       skip_cloning: true
@@ -2591,10 +2591,10 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-origin-release-4.9-e2e-vsphere
+    name: pull-ci-openshift-priv-origin-release-4.9-e2e-vsphere-upi
     optional: true
     path_alias: github.com/openshift/origin
-    rerun_command: /test e2e-vsphere
+    rerun_command: /test e2e-vsphere-upi
     spec:
       containers:
       - args:
@@ -2604,7 +2604,7 @@ presubmits:
         - --oauth-token-path=/usr/local/github-credentials/oauth
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-vsphere
+        - --target=e2e-vsphere-upi
         command:
         - ci-operator
         env:
@@ -2666,7 +2666,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-vsphere,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift-priv/origin/openshift-priv-origin-release-5.0-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/origin/openshift-priv-origin-release-5.0-presubmits.yaml
@@ -3379,7 +3379,7 @@ presubmits:
     - ^release-5\.0$
     - ^release-5\.0-
     cluster: vsphere02
-    context: ci/prow/e2e-external-vsphere-ccm
+    context: ci/prow/e2e-external-vsphere-ccm-upi
     decorate: true
     decoration_config:
       oauth_token_secret:
@@ -3391,10 +3391,10 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-origin-release-5.0-e2e-external-vsphere-ccm
+    name: pull-ci-openshift-priv-origin-release-5.0-e2e-external-vsphere-ccm-upi
     optional: true
     path_alias: github.com/openshift/origin
-    rerun_command: /test e2e-external-vsphere-ccm
+    rerun_command: /test e2e-external-vsphere-ccm-upi
     spec:
       containers:
       - args:
@@ -3404,7 +3404,7 @@ presubmits:
         - --oauth-token-path=/usr/local/github-credentials/oauth
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-external-vsphere-ccm
+        - --target=e2e-external-vsphere-ccm-upi
         command:
         - ci-operator
         env:
@@ -3463,7 +3463,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-external-vsphere-ccm,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-external-vsphere-ccm-upi,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:

--- a/ci-operator/jobs/openshift-priv/vmware-vsphere-csi-driver-operator/openshift-priv-vmware-vsphere-csi-driver-operator-release-4.8-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/vmware-vsphere-csi-driver-operator/openshift-priv-vmware-vsphere-csi-driver-operator-release-4.8-presubmits.yaml
@@ -1,97 +1,6 @@
 presubmits:
   openshift-priv/vmware-vsphere-csi-driver-operator:
   - agent: kubernetes
-    always_run: true
-    branches:
-    - ^release-4\.8$
-    - ^release-4\.8-
-    cluster: vsphere02
-    context: ci/prow/e2e-vsphere
-    decorate: true
-    decoration_config:
-      skip_cloning: true
-    hidden: true
-    labels:
-      ci-operator.openshift.io/cloud: vsphere
-      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-vmware-vsphere-csi-driver-operator-release-4.8-e2e-vsphere
-    path_alias: github.com/openshift/vmware-vsphere-csi-driver-operator
-    rerun_command: /test e2e-vsphere
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --oauth-token-path=/usr/local/github-credentials/oauth
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-vsphere
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /usr/local/github-credentials
-          name: github-credentials-openshift-ci-robot-private-git-cloner
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: github-credentials-openshift-ci-robot-private-git-cloner
-        secret:
-          secretName: github-credentials-openshift-ci-robot-private-git-cloner
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-vsphere,?($|\s.*)
-  - agent: kubernetes
     always_run: false
     branches:
     - ^release-4\.8$
@@ -183,6 +92,97 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-vsphere-csi,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.8$
+    - ^release-4\.8-
+    cluster: vsphere02
+    context: ci/prow/e2e-vsphere-upi
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    hidden: true
+    labels:
+      ci-operator.openshift.io/cloud: vsphere
+      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-priv-vmware-vsphere-csi-driver-operator-release-4.8-e2e-vsphere-upi
+    path_alias: github.com/openshift/vmware-vsphere-csi-driver-operator
+    rerun_command: /test e2e-vsphere-upi
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-vsphere-upi
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: github-credentials-openshift-ci-robot-private-git-cloner
+        secret:
+          secretName: github-credentials-openshift-ci-robot-private-git-cloner
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift-priv/vmware-vsphere-csi-driver-operator/openshift-priv-vmware-vsphere-csi-driver-operator-release-4.9-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/vmware-vsphere-csi-driver-operator/openshift-priv-vmware-vsphere-csi-driver-operator-release-4.9-presubmits.yaml
@@ -6,96 +6,6 @@ presubmits:
     - ^release-4\.9$
     - ^release-4\.9-
     cluster: vsphere02
-    context: ci/prow/e2e-vsphere
-    decorate: true
-    decoration_config:
-      oauth_token_secret:
-        key: oauth
-        name: github-credentials-openshift-ci-robot-private-git-cloner
-    hidden: true
-    labels:
-      ci-operator.openshift.io/cloud: vsphere
-      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-vmware-vsphere-csi-driver-operator-release-4.9-e2e-vsphere
-    path_alias: github.com/openshift/vmware-vsphere-csi-driver-operator
-    rerun_command: /test e2e-vsphere
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --oauth-token-path=/usr/local/github-credentials/oauth
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-vsphere
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /usr/local/github-credentials
-          name: github-credentials-openshift-ci-robot-private-git-cloner
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-vsphere,?($|\s.*)
-  - agent: kubernetes
-    always_run: true
-    branches:
-    - ^release-4\.9$
-    - ^release-4\.9-
-    cluster: vsphere02
     context: ci/prow/e2e-vsphere-csi
     decorate: true
     decoration_config:
@@ -180,6 +90,96 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-vsphere-csi,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.9$
+    - ^release-4\.9-
+    cluster: vsphere02
+    context: ci/prow/e2e-vsphere-upi
+    decorate: true
+    decoration_config:
+      oauth_token_secret:
+        key: oauth
+        name: github-credentials-openshift-ci-robot-private-git-cloner
+    hidden: true
+    labels:
+      ci-operator.openshift.io/cloud: vsphere
+      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-priv-vmware-vsphere-csi-driver-operator-release-4.9-e2e-vsphere-upi
+    path_alias: github.com/openshift/vmware-vsphere-csi-driver-operator
+    rerun_command: /test e2e-vsphere-upi
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-vsphere-upi
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift-priv/vmware-vsphere-csi-driver/openshift-priv-vmware-vsphere-csi-driver-release-4.8-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/vmware-vsphere-csi-driver/openshift-priv-vmware-vsphere-csi-driver-release-4.8-presubmits.yaml
@@ -1,97 +1,6 @@
 presubmits:
   openshift-priv/vmware-vsphere-csi-driver:
   - agent: kubernetes
-    always_run: true
-    branches:
-    - ^release-4\.8$
-    - ^release-4\.8-
-    cluster: vsphere02
-    context: ci/prow/e2e-vsphere
-    decorate: true
-    decoration_config:
-      skip_cloning: true
-    hidden: true
-    labels:
-      ci-operator.openshift.io/cloud: vsphere
-      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-vmware-vsphere-csi-driver-release-4.8-e2e-vsphere
-    path_alias: sigs.k8s.io/vsphere-csi-driver
-    rerun_command: /test e2e-vsphere
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --oauth-token-path=/usr/local/github-credentials/oauth
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-vsphere
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /usr/local/github-credentials
-          name: github-credentials-openshift-ci-robot-private-git-cloner
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: github-credentials-openshift-ci-robot-private-git-cloner
-        secret:
-          secretName: github-credentials-openshift-ci-robot-private-git-cloner
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-vsphere,?($|\s.*)
-  - agent: kubernetes
     always_run: false
     branches:
     - ^release-4\.8$
@@ -183,6 +92,97 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-vsphere-csi,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.8$
+    - ^release-4\.8-
+    cluster: vsphere02
+    context: ci/prow/e2e-vsphere-upi
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    hidden: true
+    labels:
+      ci-operator.openshift.io/cloud: vsphere
+      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-priv-vmware-vsphere-csi-driver-release-4.8-e2e-vsphere-upi
+    path_alias: sigs.k8s.io/vsphere-csi-driver
+    rerun_command: /test e2e-vsphere-upi
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-vsphere-upi
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: github-credentials-openshift-ci-robot-private-git-cloner
+        secret:
+          secretName: github-credentials-openshift-ci-robot-private-git-cloner
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift-priv/vmware-vsphere-csi-driver/openshift-priv-vmware-vsphere-csi-driver-release-4.9-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/vmware-vsphere-csi-driver/openshift-priv-vmware-vsphere-csi-driver-release-4.9-presubmits.yaml
@@ -1,96 +1,6 @@
 presubmits:
   openshift-priv/vmware-vsphere-csi-driver:
   - agent: kubernetes
-    always_run: true
-    branches:
-    - ^release-4\.9$
-    - ^release-4\.9-
-    cluster: vsphere02
-    context: ci/prow/e2e-vsphere
-    decorate: true
-    decoration_config:
-      oauth_token_secret:
-        key: oauth
-        name: github-credentials-openshift-ci-robot-private-git-cloner
-    hidden: true
-    labels:
-      ci-operator.openshift.io/cloud: vsphere
-      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-vmware-vsphere-csi-driver-release-4.9-e2e-vsphere
-    path_alias: sigs.k8s.io/vsphere-csi-driver
-    rerun_command: /test e2e-vsphere
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --oauth-token-path=/usr/local/github-credentials/oauth
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-vsphere
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /usr/local/github-credentials
-          name: github-credentials-openshift-ci-robot-private-git-cloner
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-vsphere,?($|\s.*)
-  - agent: kubernetes
     always_run: false
     branches:
     - ^release-4\.9$
@@ -181,6 +91,96 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-vsphere-csi,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.9$
+    - ^release-4\.9-
+    cluster: vsphere02
+    context: ci/prow/e2e-vsphere-upi
+    decorate: true
+    decoration_config:
+      oauth_token_secret:
+        key: oauth
+        name: github-credentials-openshift-ci-robot-private-git-cloner
+    hidden: true
+    labels:
+      ci-operator.openshift.io/cloud: vsphere
+      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-priv-vmware-vsphere-csi-driver-release-4.9-e2e-vsphere-upi
+    path_alias: sigs.k8s.io/vsphere-csi-driver
+    rerun_command: /test e2e-vsphere-upi
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-vsphere-upi
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift/cluster-storage-operator/openshift-cluster-storage-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-storage-operator/openshift-cluster-storage-operator-main-presubmits.yaml
@@ -1216,16 +1216,16 @@ presubmits:
     - ^main$
     - ^main-
     cluster: vsphere02
-    context: ci/prow/e2e-ovn-vsphere
+    context: ci/prow/e2e-ovn-vsphere-upi
     decorate: true
     labels:
       ci-operator.openshift.io/cloud: vsphere
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-storage-operator-main-e2e-ovn-vsphere
+    name: pull-ci-openshift-cluster-storage-operator-main-e2e-ovn-vsphere-upi
     optional: true
-    rerun_command: /test e2e-ovn-vsphere
+    rerun_command: /test e2e-ovn-vsphere-upi
     spec:
       containers:
       - args:
@@ -1234,7 +1234,7 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-ovn-vsphere
+        - --target=e2e-ovn-vsphere-upi
         command:
         - ci-operator
         env:
@@ -1290,7 +1290,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-ovn-vsphere,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-ovn-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.10-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.10-presubmits.yaml
@@ -975,87 +975,6 @@ presubmits:
     - ^release-4\.10$
     - ^release-4\.10-
     cluster: vsphere02
-    context: ci/prow/e2e-vsphere
-    decorate: true
-    labels:
-      ci-operator.openshift.io/cloud: vsphere
-      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-storage-operator-release-4.10-e2e-vsphere
-    optional: true
-    rerun_command: /test e2e-vsphere
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-vsphere
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-vsphere,?($|\s.*)
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - ^release-4\.10$
-    - ^release-4\.10-
-    cluster: vsphere02
     context: ci/prow/e2e-vsphere-csi
     decorate: true
     labels:
@@ -1131,6 +1050,87 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-vsphere-csi,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.10$
+    - ^release-4\.10-
+    cluster: vsphere02
+    context: ci/prow/e2e-vsphere-upi
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: vsphere
+      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-storage-operator-release-4.10-e2e-vsphere-upi
+    optional: true
+    rerun_command: /test e2e-vsphere-upi
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-vsphere-upi
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.11-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.11-presubmits.yaml
@@ -975,87 +975,6 @@ presubmits:
     - ^release-4\.11$
     - ^release-4\.11-
     cluster: vsphere02
-    context: ci/prow/e2e-vsphere
-    decorate: true
-    labels:
-      ci-operator.openshift.io/cloud: vsphere
-      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-storage-operator-release-4.11-e2e-vsphere
-    optional: true
-    rerun_command: /test e2e-vsphere
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-vsphere
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-vsphere,?($|\s.*)
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - ^release-4\.11$
-    - ^release-4\.11-
-    cluster: vsphere02
     context: ci/prow/e2e-vsphere-csi
     decorate: true
     labels:
@@ -1131,6 +1050,87 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-vsphere-csi,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.11$
+    - ^release-4\.11-
+    cluster: vsphere02
+    context: ci/prow/e2e-vsphere-upi
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: vsphere
+      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-storage-operator-release-4.11-e2e-vsphere-upi
+    optional: true
+    rerun_command: /test e2e-vsphere-upi
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-vsphere-upi
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.12-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.12-presubmits.yaml
@@ -1056,16 +1056,16 @@ presubmits:
     - ^release-4\.12$
     - ^release-4\.12-
     cluster: vsphere02
-    context: ci/prow/e2e-vsphere-ovn
+    context: ci/prow/e2e-vsphere-ovn-upi
     decorate: true
     labels:
       ci-operator.openshift.io/cloud: vsphere
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-storage-operator-release-4.12-e2e-vsphere-ovn
+    name: pull-ci-openshift-cluster-storage-operator-release-4.12-e2e-vsphere-ovn-upi
     optional: true
-    rerun_command: /test e2e-vsphere-ovn
+    rerun_command: /test e2e-vsphere-ovn-upi
     spec:
       containers:
       - args:
@@ -1074,7 +1074,7 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-vsphere-ovn
+        - --target=e2e-vsphere-ovn-upi
         command:
         - ci-operator
         env:
@@ -1130,7 +1130,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-vsphere-ovn,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-vsphere-ovn-upi,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:

--- a/ci-operator/jobs/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.13-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.13-presubmits.yaml
@@ -1137,16 +1137,16 @@ presubmits:
     - ^release-4\.13$
     - ^release-4\.13-
     cluster: vsphere02
-    context: ci/prow/e2e-vsphere-ovn
+    context: ci/prow/e2e-vsphere-ovn-upi
     decorate: true
     labels:
       ci-operator.openshift.io/cloud: vsphere
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-storage-operator-release-4.13-e2e-vsphere-ovn
+    name: pull-ci-openshift-cluster-storage-operator-release-4.13-e2e-vsphere-ovn-upi
     optional: true
-    rerun_command: /test e2e-vsphere-ovn
+    rerun_command: /test e2e-vsphere-ovn-upi
     spec:
       containers:
       - args:
@@ -1155,7 +1155,7 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-vsphere-ovn
+        - --target=e2e-vsphere-ovn-upi
         command:
         - ci-operator
         env:
@@ -1211,7 +1211,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-vsphere-ovn,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-vsphere-ovn-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.14-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.14-presubmits.yaml
@@ -1056,16 +1056,16 @@ presubmits:
     - ^release-4\.14$
     - ^release-4\.14-
     cluster: vsphere02
-    context: ci/prow/e2e-ovn-vsphere
+    context: ci/prow/e2e-ovn-vsphere-upi
     decorate: true
     labels:
       ci-operator.openshift.io/cloud: vsphere
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-storage-operator-release-4.14-e2e-ovn-vsphere
+    name: pull-ci-openshift-cluster-storage-operator-release-4.14-e2e-ovn-vsphere-upi
     optional: true
-    rerun_command: /test e2e-ovn-vsphere
+    rerun_command: /test e2e-ovn-vsphere-upi
     spec:
       containers:
       - args:
@@ -1074,7 +1074,7 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-ovn-vsphere
+        - --target=e2e-ovn-vsphere-upi
         command:
         - ci-operator
         env:
@@ -1130,7 +1130,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-ovn-vsphere,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-ovn-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:

--- a/ci-operator/jobs/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.15-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.15-presubmits.yaml
@@ -1135,16 +1135,16 @@ presubmits:
     - ^release-4\.15$
     - ^release-4\.15-
     cluster: vsphere02
-    context: ci/prow/e2e-ovn-vsphere
+    context: ci/prow/e2e-ovn-vsphere-upi
     decorate: true
     labels:
       ci-operator.openshift.io/cloud: vsphere
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-storage-operator-release-4.15-e2e-ovn-vsphere
+    name: pull-ci-openshift-cluster-storage-operator-release-4.15-e2e-ovn-vsphere-upi
     optional: true
-    rerun_command: /test e2e-ovn-vsphere
+    rerun_command: /test e2e-ovn-vsphere-upi
     spec:
       containers:
       - args:
@@ -1153,7 +1153,7 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-ovn-vsphere
+        - --target=e2e-ovn-vsphere-upi
         command:
         - ci-operator
         env:
@@ -1209,7 +1209,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-ovn-vsphere,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-ovn-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.16-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.16-presubmits.yaml
@@ -1135,16 +1135,16 @@ presubmits:
     - ^release-4\.16$
     - ^release-4\.16-
     cluster: vsphere02
-    context: ci/prow/e2e-ovn-vsphere
+    context: ci/prow/e2e-ovn-vsphere-upi
     decorate: true
     labels:
       ci-operator.openshift.io/cloud: vsphere
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-storage-operator-release-4.16-e2e-ovn-vsphere
+    name: pull-ci-openshift-cluster-storage-operator-release-4.16-e2e-ovn-vsphere-upi
     optional: true
-    rerun_command: /test e2e-ovn-vsphere
+    rerun_command: /test e2e-ovn-vsphere-upi
     spec:
       containers:
       - args:
@@ -1153,7 +1153,7 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-ovn-vsphere
+        - --target=e2e-ovn-vsphere-upi
         command:
         - ci-operator
         env:
@@ -1209,7 +1209,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-ovn-vsphere,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-ovn-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.17-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.17-presubmits.yaml
@@ -1135,16 +1135,16 @@ presubmits:
     - ^release-4\.17$
     - ^release-4\.17-
     cluster: vsphere02
-    context: ci/prow/e2e-ovn-vsphere
+    context: ci/prow/e2e-ovn-vsphere-upi
     decorate: true
     labels:
       ci-operator.openshift.io/cloud: vsphere
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-storage-operator-release-4.17-e2e-ovn-vsphere
+    name: pull-ci-openshift-cluster-storage-operator-release-4.17-e2e-ovn-vsphere-upi
     optional: true
-    rerun_command: /test e2e-ovn-vsphere
+    rerun_command: /test e2e-ovn-vsphere-upi
     spec:
       containers:
       - args:
@@ -1153,7 +1153,7 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-ovn-vsphere
+        - --target=e2e-ovn-vsphere-upi
         command:
         - ci-operator
         env:
@@ -1209,7 +1209,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-ovn-vsphere,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-ovn-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.18-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.18-presubmits.yaml
@@ -1216,16 +1216,16 @@ presubmits:
     - ^release-4\.18$
     - ^release-4\.18-
     cluster: vsphere02
-    context: ci/prow/e2e-ovn-vsphere
+    context: ci/prow/e2e-ovn-vsphere-upi
     decorate: true
     labels:
       ci-operator.openshift.io/cloud: vsphere
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-storage-operator-release-4.18-e2e-ovn-vsphere
+    name: pull-ci-openshift-cluster-storage-operator-release-4.18-e2e-ovn-vsphere-upi
     optional: true
-    rerun_command: /test e2e-ovn-vsphere
+    rerun_command: /test e2e-ovn-vsphere-upi
     spec:
       containers:
       - args:
@@ -1234,7 +1234,7 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-ovn-vsphere
+        - --target=e2e-ovn-vsphere-upi
         command:
         - ci-operator
         env:
@@ -1290,7 +1290,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-ovn-vsphere,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-ovn-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.19-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.19-presubmits.yaml
@@ -1216,16 +1216,16 @@ presubmits:
     - ^release-4\.19$
     - ^release-4\.19-
     cluster: vsphere02
-    context: ci/prow/e2e-ovn-vsphere
+    context: ci/prow/e2e-ovn-vsphere-upi
     decorate: true
     labels:
       ci-operator.openshift.io/cloud: vsphere
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-storage-operator-release-4.19-e2e-ovn-vsphere
+    name: pull-ci-openshift-cluster-storage-operator-release-4.19-e2e-ovn-vsphere-upi
     optional: true
-    rerun_command: /test e2e-ovn-vsphere
+    rerun_command: /test e2e-ovn-vsphere-upi
     spec:
       containers:
       - args:
@@ -1234,7 +1234,7 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-ovn-vsphere
+        - --target=e2e-ovn-vsphere-upi
         command:
         - ci-operator
         env:
@@ -1290,7 +1290,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-ovn-vsphere,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-ovn-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.20-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.20-presubmits.yaml
@@ -1216,16 +1216,16 @@ presubmits:
     - ^release-4\.20$
     - ^release-4\.20-
     cluster: vsphere02
-    context: ci/prow/e2e-ovn-vsphere
+    context: ci/prow/e2e-ovn-vsphere-upi
     decorate: true
     labels:
       ci-operator.openshift.io/cloud: vsphere
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-storage-operator-release-4.20-e2e-ovn-vsphere
+    name: pull-ci-openshift-cluster-storage-operator-release-4.20-e2e-ovn-vsphere-upi
     optional: true
-    rerun_command: /test e2e-ovn-vsphere
+    rerun_command: /test e2e-ovn-vsphere-upi
     spec:
       containers:
       - args:
@@ -1234,7 +1234,7 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-ovn-vsphere
+        - --target=e2e-ovn-vsphere-upi
         command:
         - ci-operator
         env:
@@ -1290,7 +1290,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-ovn-vsphere,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-ovn-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.21-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.21-presubmits.yaml
@@ -1216,16 +1216,16 @@ presubmits:
     - ^release-4\.21$
     - ^release-4\.21-
     cluster: vsphere02
-    context: ci/prow/e2e-ovn-vsphere
+    context: ci/prow/e2e-ovn-vsphere-upi
     decorate: true
     labels:
       ci-operator.openshift.io/cloud: vsphere
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-storage-operator-release-4.21-e2e-ovn-vsphere
+    name: pull-ci-openshift-cluster-storage-operator-release-4.21-e2e-ovn-vsphere-upi
     optional: true
-    rerun_command: /test e2e-ovn-vsphere
+    rerun_command: /test e2e-ovn-vsphere-upi
     spec:
       containers:
       - args:
@@ -1234,7 +1234,7 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-ovn-vsphere
+        - --target=e2e-ovn-vsphere-upi
         command:
         - ci-operator
         env:
@@ -1290,7 +1290,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-ovn-vsphere,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-ovn-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.22-presubmits.yaml
@@ -1216,16 +1216,16 @@ presubmits:
     - ^release-4\.22$
     - ^release-4\.22-
     cluster: vsphere02
-    context: ci/prow/e2e-ovn-vsphere
+    context: ci/prow/e2e-ovn-vsphere-upi
     decorate: true
     labels:
       ci-operator.openshift.io/cloud: vsphere
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-storage-operator-release-4.22-e2e-ovn-vsphere
+    name: pull-ci-openshift-cluster-storage-operator-release-4.22-e2e-ovn-vsphere-upi
     optional: true
-    rerun_command: /test e2e-ovn-vsphere
+    rerun_command: /test e2e-ovn-vsphere-upi
     spec:
       containers:
       - args:
@@ -1234,7 +1234,7 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-ovn-vsphere
+        - --target=e2e-ovn-vsphere-upi
         command:
         - ci-operator
         env:
@@ -1290,7 +1290,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-ovn-vsphere,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-ovn-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.23-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.23-presubmits.yaml
@@ -1216,16 +1216,16 @@ presubmits:
     - ^release-4\.23$
     - ^release-4\.23-
     cluster: vsphere02
-    context: ci/prow/e2e-ovn-vsphere
+    context: ci/prow/e2e-ovn-vsphere-upi
     decorate: true
     labels:
       ci-operator.openshift.io/cloud: vsphere
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-storage-operator-release-4.23-e2e-ovn-vsphere
+    name: pull-ci-openshift-cluster-storage-operator-release-4.23-e2e-ovn-vsphere-upi
     optional: true
-    rerun_command: /test e2e-ovn-vsphere
+    rerun_command: /test e2e-ovn-vsphere-upi
     spec:
       containers:
       - args:
@@ -1234,7 +1234,7 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-ovn-vsphere
+        - --target=e2e-ovn-vsphere-upi
         command:
         - ci-operator
         env:
@@ -1290,7 +1290,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-ovn-vsphere,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-ovn-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.8-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.8-presubmits.yaml
@@ -832,89 +832,6 @@ presubmits:
     - ^release-4\.8$
     - ^release-4\.8-
     cluster: vsphere02
-    context: ci/prow/e2e-vsphere
-    decorate: true
-    decoration_config:
-      skip_cloning: true
-    labels:
-      ci-operator.openshift.io/cloud: vsphere
-      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-storage-operator-release-4.8-e2e-vsphere
-    optional: true
-    rerun_command: /test e2e-vsphere
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-vsphere
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-vsphere,?($|\s.*)
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - ^release-4\.8$
-    - ^release-4\.8-
-    cluster: vsphere02
     context: ci/prow/e2e-vsphere-csi
     decorate: true
     decoration_config:
@@ -992,6 +909,89 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-vsphere-csi,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.8$
+    - ^release-4\.8-
+    cluster: vsphere02
+    context: ci/prow/e2e-vsphere-upi
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: vsphere
+      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-storage-operator-release-4.8-e2e-vsphere-upi
+    optional: true
+    rerun_command: /test e2e-vsphere-upi
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-vsphere-upi
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.9-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-4.9-presubmits.yaml
@@ -813,87 +813,6 @@ presubmits:
     - ^release-4\.9$
     - ^release-4\.9-
     cluster: vsphere02
-    context: ci/prow/e2e-vsphere
-    decorate: true
-    labels:
-      ci-operator.openshift.io/cloud: vsphere
-      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-storage-operator-release-4.9-e2e-vsphere
-    optional: true
-    rerun_command: /test e2e-vsphere
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-vsphere
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-vsphere,?($|\s.*)
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - ^release-4\.9$
-    - ^release-4\.9-
-    cluster: vsphere02
     context: ci/prow/e2e-vsphere-csi
     decorate: true
     labels:
@@ -969,6 +888,87 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-vsphere-csi,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.9$
+    - ^release-4\.9-
+    cluster: vsphere02
+    context: ci/prow/e2e-vsphere-upi
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: vsphere
+      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-storage-operator-release-4.9-e2e-vsphere-upi
+    optional: true
+    rerun_command: /test e2e-vsphere-upi
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-vsphere-upi
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-5.0-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-storage-operator/openshift-cluster-storage-operator-release-5.0-presubmits.yaml
@@ -1216,16 +1216,16 @@ presubmits:
     - ^release-5\.0$
     - ^release-5\.0-
     cluster: vsphere02
-    context: ci/prow/e2e-ovn-vsphere
+    context: ci/prow/e2e-ovn-vsphere-upi
     decorate: true
     labels:
       ci-operator.openshift.io/cloud: vsphere
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-storage-operator-release-5.0-e2e-ovn-vsphere
+    name: pull-ci-openshift-cluster-storage-operator-release-5.0-e2e-ovn-vsphere-upi
     optional: true
-    rerun_command: /test e2e-ovn-vsphere
+    rerun_command: /test e2e-ovn-vsphere-upi
     spec:
       containers:
       - args:
@@ -1234,7 +1234,7 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-ovn-vsphere
+        - --target=e2e-ovn-vsphere-upi
         command:
         - ci-operator
         env:
@@ -1290,7 +1290,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-ovn-vsphere,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-ovn-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift/origin/openshift-origin-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/origin/openshift-origin-main-presubmits.yaml
@@ -3009,16 +3009,16 @@ presubmits:
     - ^main$
     - ^main-
     cluster: vsphere02
-    context: ci/prow/e2e-external-vsphere-ccm
+    context: ci/prow/e2e-external-vsphere-ccm-upi
     decorate: true
     labels:
       ci-operator.openshift.io/cloud: vsphere
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-origin-main-e2e-external-vsphere-ccm
+    name: pull-ci-openshift-origin-main-e2e-external-vsphere-ccm-upi
     optional: true
-    rerun_command: /test e2e-external-vsphere-ccm
+    rerun_command: /test e2e-external-vsphere-ccm-upi
     spec:
       containers:
       - args:
@@ -3027,7 +3027,7 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-external-vsphere-ccm
+        - --target=e2e-external-vsphere-ccm-upi
         command:
         - ci-operator
         env:
@@ -3083,7 +3083,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-external-vsphere-ccm,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-external-vsphere-ccm-upi,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:

--- a/ci-operator/jobs/openshift/origin/openshift-origin-release-4.10-presubmits.yaml
+++ b/ci-operator/jobs/openshift/origin/openshift-origin-release-4.10-presubmits.yaml
@@ -2518,16 +2518,16 @@ presubmits:
     - ^release-4\.10$
     - ^release-4\.10-
     cluster: vsphere02
-    context: ci/prow/e2e-vsphere
+    context: ci/prow/e2e-vsphere-upi
     decorate: true
     labels:
       ci-operator.openshift.io/cloud: vsphere
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-origin-release-4.10-e2e-vsphere
+    name: pull-ci-openshift-origin-release-4.10-e2e-vsphere-upi
     optional: true
-    rerun_command: /test e2e-vsphere
+    rerun_command: /test e2e-vsphere-upi
     spec:
       containers:
       - args:
@@ -2536,7 +2536,7 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-vsphere
+        - --target=e2e-vsphere-upi
         command:
         - ci-operator
         env:
@@ -2592,7 +2592,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-vsphere,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift/origin/openshift-origin-release-4.12-presubmits.yaml
+++ b/ci-operator/jobs/openshift/origin/openshift-origin-release-4.12-presubmits.yaml
@@ -3005,87 +3005,6 @@ presubmits:
     - ^release-4\.12$
     - ^release-4\.12-
     cluster: vsphere02
-    context: ci/prow/e2e-vsphere
-    decorate: true
-    labels:
-      ci-operator.openshift.io/cloud: vsphere
-      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-origin-release-4.12-e2e-vsphere
-    optional: true
-    rerun_command: /test e2e-vsphere
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-vsphere
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-vsphere,?($|\s.*)
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - ^release-4\.12$
-    - ^release-4\.12-
-    cluster: vsphere02
     context: ci/prow/e2e-vsphere-ovn-etcd-scaling
     decorate: true
     labels:
@@ -3161,6 +3080,87 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-vsphere-ovn-etcd-scaling,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.12$
+    - ^release-4\.12-
+    cluster: vsphere02
+    context: ci/prow/e2e-vsphere-upi
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: vsphere
+      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-origin-release-4.12-e2e-vsphere-upi
+    optional: true
+    rerun_command: /test e2e-vsphere-upi
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-vsphere-upi
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift/origin/openshift-origin-release-4.13-presubmits.yaml
+++ b/ci-operator/jobs/openshift/origin/openshift-origin-release-4.13-presubmits.yaml
@@ -3167,87 +3167,6 @@ presubmits:
     - ^release-4\.13$
     - ^release-4\.13-
     cluster: vsphere02
-    context: ci/prow/e2e-vsphere
-    decorate: true
-    labels:
-      ci-operator.openshift.io/cloud: vsphere
-      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-origin-release-4.13-e2e-vsphere
-    optional: true
-    rerun_command: /test e2e-vsphere
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-vsphere
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-vsphere,?($|\s.*)
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - ^release-4\.13$
-    - ^release-4\.13-
-    cluster: vsphere02
     context: ci/prow/e2e-vsphere-ovn-etcd-scaling
     decorate: true
     labels:
@@ -3323,6 +3242,87 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-vsphere-ovn-etcd-scaling,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.13$
+    - ^release-4\.13-
+    cluster: vsphere02
+    context: ci/prow/e2e-vsphere-upi
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: vsphere
+      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-origin-release-4.13-e2e-vsphere-upi
+    optional: true
+    rerun_command: /test e2e-vsphere-upi
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-vsphere-upi
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift/origin/openshift-origin-release-4.14-presubmits.yaml
+++ b/ci-operator/jobs/openshift/origin/openshift-origin-release-4.14-presubmits.yaml
@@ -3412,87 +3412,6 @@ presubmits:
     - ^release-4\.14$
     - ^release-4\.14-
     cluster: vsphere02
-    context: ci/prow/e2e-vsphere
-    decorate: true
-    labels:
-      ci-operator.openshift.io/cloud: vsphere
-      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-origin-release-4.14-e2e-vsphere
-    optional: true
-    rerun_command: /test e2e-vsphere
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-vsphere
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-vsphere,?($|\s.*)
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - ^release-4\.14$
-    - ^release-4\.14-
-    cluster: vsphere02
     context: ci/prow/e2e-vsphere-ovn-etcd-scaling
     decorate: true
     labels:
@@ -3568,6 +3487,87 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-vsphere-ovn-etcd-scaling,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.14$
+    - ^release-4\.14-
+    cluster: vsphere02
+    context: ci/prow/e2e-vsphere-upi
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: vsphere
+      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-origin-release-4.14-e2e-vsphere-upi
+    optional: true
+    rerun_command: /test e2e-vsphere-upi
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-vsphere-upi
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift/origin/openshift-origin-release-4.15-presubmits.yaml
+++ b/ci-operator/jobs/openshift/origin/openshift-origin-release-4.15-presubmits.yaml
@@ -3411,87 +3411,6 @@ presubmits:
     - ^release-4\.15$
     - ^release-4\.15-
     cluster: vsphere02
-    context: ci/prow/e2e-vsphere
-    decorate: true
-    labels:
-      ci-operator.openshift.io/cloud: vsphere
-      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-origin-release-4.15-e2e-vsphere
-    optional: true
-    rerun_command: /test e2e-vsphere
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-vsphere
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-vsphere,?($|\s.*)
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - ^release-4\.15$
-    - ^release-4\.15-
-    cluster: vsphere02
     context: ci/prow/e2e-vsphere-ovn-etcd-scaling
     decorate: true
     labels:
@@ -3567,6 +3486,87 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-vsphere-ovn-etcd-scaling,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.15$
+    - ^release-4\.15-
+    cluster: vsphere02
+    context: ci/prow/e2e-vsphere-upi
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: vsphere
+      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-origin-release-4.15-e2e-vsphere-upi
+    optional: true
+    rerun_command: /test e2e-vsphere-upi
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-vsphere-upi
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift/origin/openshift-origin-release-4.16-presubmits.yaml
+++ b/ci-operator/jobs/openshift/origin/openshift-origin-release-4.16-presubmits.yaml
@@ -3984,87 +3984,6 @@ presubmits:
     - ^release-4\.16$
     - ^release-4\.16-
     cluster: vsphere02
-    context: ci/prow/e2e-vsphere
-    decorate: true
-    labels:
-      ci-operator.openshift.io/cloud: vsphere
-      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-origin-release-4.16-e2e-vsphere
-    optional: true
-    rerun_command: /test e2e-vsphere
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-vsphere
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-vsphere,?($|\s.*)
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - ^release-4\.16$
-    - ^release-4\.16-
-    cluster: vsphere02
     context: ci/prow/e2e-vsphere-ovn-etcd-scaling
     decorate: true
     labels:
@@ -4140,6 +4059,87 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-vsphere-ovn-etcd-scaling,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.16$
+    - ^release-4\.16-
+    cluster: vsphere02
+    context: ci/prow/e2e-vsphere-upi
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: vsphere
+      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-origin-release-4.16-e2e-vsphere-upi
+    optional: true
+    rerun_command: /test e2e-vsphere-upi
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-vsphere-upi
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift/origin/openshift-origin-release-4.17-presubmits.yaml
+++ b/ci-operator/jobs/openshift/origin/openshift-origin-release-4.17-presubmits.yaml
@@ -4309,87 +4309,6 @@ presubmits:
     - ^release-4\.17$
     - ^release-4\.17-
     cluster: vsphere02
-    context: ci/prow/e2e-vsphere
-    decorate: true
-    labels:
-      ci-operator.openshift.io/cloud: vsphere
-      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-origin-release-4.17-e2e-vsphere
-    optional: true
-    rerun_command: /test e2e-vsphere
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-vsphere
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-vsphere,?($|\s.*)
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - ^release-4\.17$
-    - ^release-4\.17-
-    cluster: vsphere02
     context: ci/prow/e2e-vsphere-ovn-etcd-scaling
     decorate: true
     labels:
@@ -4465,6 +4384,87 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-vsphere-ovn-etcd-scaling,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.17$
+    - ^release-4\.17-
+    cluster: vsphere02
+    context: ci/prow/e2e-vsphere-upi
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: vsphere
+      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-origin-release-4.17-e2e-vsphere-upi
+    optional: true
+    rerun_command: /test e2e-vsphere-upi
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-vsphere-upi
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift/origin/openshift-origin-release-4.18-presubmits.yaml
+++ b/ci-operator/jobs/openshift/origin/openshift-origin-release-4.18-presubmits.yaml
@@ -2842,16 +2842,16 @@ presubmits:
     - ^release-4\.18$
     - ^release-4\.18-
     cluster: vsphere02
-    context: ci/prow/e2e-external-vsphere-ccm
+    context: ci/prow/e2e-external-vsphere-ccm-upi
     decorate: true
     labels:
       ci-operator.openshift.io/cloud: vsphere
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-origin-release-4.18-e2e-external-vsphere-ccm
+    name: pull-ci-openshift-origin-release-4.18-e2e-external-vsphere-ccm-upi
     optional: true
-    rerun_command: /test e2e-external-vsphere-ccm
+    rerun_command: /test e2e-external-vsphere-ccm-upi
     spec:
       containers:
       - args:
@@ -2860,7 +2860,7 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-external-vsphere-ccm
+        - --target=e2e-external-vsphere-ccm-upi
         command:
         - ci-operator
         env:
@@ -2916,7 +2916,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-external-vsphere-ccm,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-external-vsphere-ccm-upi,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:
@@ -4958,87 +4958,6 @@ presubmits:
     - ^release-4\.18$
     - ^release-4\.18-
     cluster: vsphere02
-    context: ci/prow/e2e-vsphere
-    decorate: true
-    labels:
-      ci-operator.openshift.io/cloud: vsphere
-      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-origin-release-4.18-e2e-vsphere
-    optional: true
-    rerun_command: /test e2e-vsphere
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-vsphere
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-vsphere,?($|\s.*)
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - ^release-4\.18$
-    - ^release-4\.18-
-    cluster: vsphere02
     context: ci/prow/e2e-vsphere-ovn-etcd-scaling
     decorate: true
     labels:
@@ -5114,6 +5033,87 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-vsphere-ovn-etcd-scaling,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.18$
+    - ^release-4\.18-
+    cluster: vsphere02
+    context: ci/prow/e2e-vsphere-upi
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: vsphere
+      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-origin-release-4.18-e2e-vsphere-upi
+    optional: true
+    rerun_command: /test e2e-vsphere-upi
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-vsphere-upi
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift/origin/openshift-origin-release-4.19-presubmits.yaml
+++ b/ci-operator/jobs/openshift/origin/openshift-origin-release-4.19-presubmits.yaml
@@ -2925,16 +2925,16 @@ presubmits:
     - ^release-4\.19$
     - ^release-4\.19-
     cluster: vsphere02
-    context: ci/prow/e2e-external-vsphere-ccm
+    context: ci/prow/e2e-external-vsphere-ccm-upi
     decorate: true
     labels:
       ci-operator.openshift.io/cloud: vsphere
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-origin-release-4.19-e2e-external-vsphere-ccm
+    name: pull-ci-openshift-origin-release-4.19-e2e-external-vsphere-ccm-upi
     optional: true
-    rerun_command: /test e2e-external-vsphere-ccm
+    rerun_command: /test e2e-external-vsphere-ccm-upi
     spec:
       containers:
       - args:
@@ -2943,7 +2943,7 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-external-vsphere-ccm
+        - --target=e2e-external-vsphere-ccm-upi
         command:
         - ci-operator
         env:
@@ -2999,7 +2999,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-external-vsphere-ccm,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-external-vsphere-ccm-upi,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:

--- a/ci-operator/jobs/openshift/origin/openshift-origin-release-4.20-presubmits.yaml
+++ b/ci-operator/jobs/openshift/origin/openshift-origin-release-4.20-presubmits.yaml
@@ -2927,16 +2927,16 @@ presubmits:
     - ^release-4\.20$
     - ^release-4\.20-
     cluster: vsphere02
-    context: ci/prow/e2e-external-vsphere-ccm
+    context: ci/prow/e2e-external-vsphere-ccm-upi
     decorate: true
     labels:
       ci-operator.openshift.io/cloud: vsphere
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-origin-release-4.20-e2e-external-vsphere-ccm
+    name: pull-ci-openshift-origin-release-4.20-e2e-external-vsphere-ccm-upi
     optional: true
-    rerun_command: /test e2e-external-vsphere-ccm
+    rerun_command: /test e2e-external-vsphere-ccm-upi
     spec:
       containers:
       - args:
@@ -2945,7 +2945,7 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-external-vsphere-ccm
+        - --target=e2e-external-vsphere-ccm-upi
         command:
         - ci-operator
         env:
@@ -3001,7 +3001,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-external-vsphere-ccm,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-external-vsphere-ccm-upi,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:

--- a/ci-operator/jobs/openshift/origin/openshift-origin-release-4.21-presubmits.yaml
+++ b/ci-operator/jobs/openshift/origin/openshift-origin-release-4.21-presubmits.yaml
@@ -3009,16 +3009,16 @@ presubmits:
     - ^release-4\.21$
     - ^release-4\.21-
     cluster: vsphere02
-    context: ci/prow/e2e-external-vsphere-ccm
+    context: ci/prow/e2e-external-vsphere-ccm-upi
     decorate: true
     labels:
       ci-operator.openshift.io/cloud: vsphere
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-origin-release-4.21-e2e-external-vsphere-ccm
+    name: pull-ci-openshift-origin-release-4.21-e2e-external-vsphere-ccm-upi
     optional: true
-    rerun_command: /test e2e-external-vsphere-ccm
+    rerun_command: /test e2e-external-vsphere-ccm-upi
     spec:
       containers:
       - args:
@@ -3027,7 +3027,7 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-external-vsphere-ccm
+        - --target=e2e-external-vsphere-ccm-upi
         command:
         - ci-operator
         env:
@@ -3083,7 +3083,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-external-vsphere-ccm,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-external-vsphere-ccm-upi,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:

--- a/ci-operator/jobs/openshift/origin/openshift-origin-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift/origin/openshift-origin-release-4.22-presubmits.yaml
@@ -3009,16 +3009,16 @@ presubmits:
     - ^release-4\.22$
     - ^release-4\.22-
     cluster: vsphere02
-    context: ci/prow/e2e-external-vsphere-ccm
+    context: ci/prow/e2e-external-vsphere-ccm-upi
     decorate: true
     labels:
       ci-operator.openshift.io/cloud: vsphere
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-origin-release-4.22-e2e-external-vsphere-ccm
+    name: pull-ci-openshift-origin-release-4.22-e2e-external-vsphere-ccm-upi
     optional: true
-    rerun_command: /test e2e-external-vsphere-ccm
+    rerun_command: /test e2e-external-vsphere-ccm-upi
     spec:
       containers:
       - args:
@@ -3027,7 +3027,7 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-external-vsphere-ccm
+        - --target=e2e-external-vsphere-ccm-upi
         command:
         - ci-operator
         env:
@@ -3083,7 +3083,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-external-vsphere-ccm,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-external-vsphere-ccm-upi,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:

--- a/ci-operator/jobs/openshift/origin/openshift-origin-release-4.23-presubmits.yaml
+++ b/ci-operator/jobs/openshift/origin/openshift-origin-release-4.23-presubmits.yaml
@@ -3009,16 +3009,16 @@ presubmits:
     - ^release-4\.23$
     - ^release-4\.23-
     cluster: vsphere02
-    context: ci/prow/e2e-external-vsphere-ccm
+    context: ci/prow/e2e-external-vsphere-ccm-upi
     decorate: true
     labels:
       ci-operator.openshift.io/cloud: vsphere
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-origin-release-4.23-e2e-external-vsphere-ccm
+    name: pull-ci-openshift-origin-release-4.23-e2e-external-vsphere-ccm-upi
     optional: true
-    rerun_command: /test e2e-external-vsphere-ccm
+    rerun_command: /test e2e-external-vsphere-ccm-upi
     spec:
       containers:
       - args:
@@ -3027,7 +3027,7 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-external-vsphere-ccm
+        - --target=e2e-external-vsphere-ccm-upi
         command:
         - ci-operator
         env:
@@ -3083,7 +3083,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-external-vsphere-ccm,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-external-vsphere-ccm-upi,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:

--- a/ci-operator/jobs/openshift/origin/openshift-origin-release-4.6-presubmits.yaml
+++ b/ci-operator/jobs/openshift/origin/openshift-origin-release-4.6-presubmits.yaml
@@ -1495,7 +1495,7 @@ presubmits:
     - ^release-4\.6$
     - ^release-4\.6-
     cluster: vsphere02
-    context: ci/prow/e2e-vsphere
+    context: ci/prow/e2e-vsphere-upi
     decorate: true
     decoration_config:
       skip_cloning: true
@@ -1504,9 +1504,9 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-origin-release-4.6-e2e-vsphere
+    name: pull-ci-openshift-origin-release-4.6-e2e-vsphere-upi
     optional: true
-    rerun_command: /test e2e-vsphere
+    rerun_command: /test e2e-vsphere-upi
     spec:
       containers:
       - args:
@@ -1515,7 +1515,7 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-vsphere
+        - --target=e2e-vsphere-upi
         command:
         - ci-operator
         env:
@@ -1571,7 +1571,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-vsphere,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift/origin/openshift-origin-release-4.7-presubmits.yaml
+++ b/ci-operator/jobs/openshift/origin/openshift-origin-release-4.7-presubmits.yaml
@@ -1827,7 +1827,7 @@ presubmits:
     - ^release-4\.7$
     - ^release-4\.7-
     cluster: vsphere02
-    context: ci/prow/e2e-vsphere
+    context: ci/prow/e2e-vsphere-upi
     decorate: true
     decoration_config:
       skip_cloning: true
@@ -1836,9 +1836,9 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-origin-release-4.7-e2e-vsphere
+    name: pull-ci-openshift-origin-release-4.7-e2e-vsphere-upi
     optional: true
-    rerun_command: /test e2e-vsphere
+    rerun_command: /test e2e-vsphere-upi
     spec:
       containers:
       - args:
@@ -1847,7 +1847,7 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-vsphere
+        - --target=e2e-vsphere-upi
         command:
         - ci-operator
         env:
@@ -1903,7 +1903,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-vsphere,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift/origin/openshift-origin-release-4.8-presubmits.yaml
+++ b/ci-operator/jobs/openshift/origin/openshift-origin-release-4.8-presubmits.yaml
@@ -2245,7 +2245,7 @@ presubmits:
     - ^release-4\.8$
     - ^release-4\.8-
     cluster: vsphere02
-    context: ci/prow/e2e-vsphere
+    context: ci/prow/e2e-vsphere-upi
     decorate: true
     decoration_config:
       skip_cloning: true
@@ -2254,9 +2254,9 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-origin-release-4.8-e2e-vsphere
+    name: pull-ci-openshift-origin-release-4.8-e2e-vsphere-upi
     optional: true
-    rerun_command: /test e2e-vsphere
+    rerun_command: /test e2e-vsphere-upi
     spec:
       containers:
       - args:
@@ -2265,7 +2265,7 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-vsphere
+        - --target=e2e-vsphere-upi
         command:
         - ci-operator
         env:
@@ -2321,7 +2321,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-vsphere,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift/origin/openshift-origin-release-4.9-presubmits.yaml
+++ b/ci-operator/jobs/openshift/origin/openshift-origin-release-4.9-presubmits.yaml
@@ -2329,7 +2329,7 @@ presubmits:
     - ^release-4\.9$
     - ^release-4\.9-
     cluster: vsphere02
-    context: ci/prow/e2e-vsphere
+    context: ci/prow/e2e-vsphere-upi
     decorate: true
     decoration_config:
       skip_cloning: true
@@ -2338,9 +2338,9 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-origin-release-4.9-e2e-vsphere
+    name: pull-ci-openshift-origin-release-4.9-e2e-vsphere-upi
     optional: true
-    rerun_command: /test e2e-vsphere
+    rerun_command: /test e2e-vsphere-upi
     spec:
       containers:
       - args:
@@ -2349,7 +2349,7 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-vsphere
+        - --target=e2e-vsphere-upi
         command:
         - ci-operator
         env:
@@ -2405,7 +2405,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-vsphere,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift/origin/openshift-origin-release-5.0-presubmits.yaml
+++ b/ci-operator/jobs/openshift/origin/openshift-origin-release-5.0-presubmits.yaml
@@ -3009,16 +3009,16 @@ presubmits:
     - ^release-5\.0$
     - ^release-5\.0-
     cluster: vsphere02
-    context: ci/prow/e2e-external-vsphere-ccm
+    context: ci/prow/e2e-external-vsphere-ccm-upi
     decorate: true
     labels:
       ci-operator.openshift.io/cloud: vsphere
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-origin-release-5.0-e2e-external-vsphere-ccm
+    name: pull-ci-openshift-origin-release-5.0-e2e-external-vsphere-ccm-upi
     optional: true
-    rerun_command: /test e2e-external-vsphere-ccm
+    rerun_command: /test e2e-external-vsphere-ccm-upi
     spec:
       containers:
       - args:
@@ -3027,7 +3027,7 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-external-vsphere-ccm
+        - --target=e2e-external-vsphere-ccm-upi
         command:
         - ci-operator
         env:
@@ -3083,7 +3083,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-external-vsphere-ccm,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-external-vsphere-ccm-upi,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:

--- a/ci-operator/jobs/openshift/verification-tests/openshift-verification-tests-main-periodics.yaml
+++ b/ci-operator/jobs/openshift/verification-tests/openshift-verification-tests-main-periodics.yaml
@@ -69858,7 +69858,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.12"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-verification-tests-main-installer-rehearse-4.12-installer-rehearse-vsphere-dis
+  name: periodic-ci-openshift-verification-tests-main-installer-rehearse-4.12-installer-rehearse-vsphere-dis-upi
   spec:
     containers:
     - args:
@@ -69867,7 +69867,7 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=installer-rehearse-vsphere-dis
+      - --target=installer-rehearse-vsphere-dis-upi
       - --variant=installer-rehearse-4.12
       command:
       - ci-operator
@@ -71438,7 +71438,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.14"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-verification-tests-main-installer-rehearse-4.14-installer-rehearse-vsphere-dis
+  name: periodic-ci-openshift-verification-tests-main-installer-rehearse-4.14-installer-rehearse-vsphere-dis-upi
   spec:
     containers:
     - args:
@@ -71447,7 +71447,7 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=installer-rehearse-vsphere-dis
+      - --target=installer-rehearse-vsphere-dis-upi
       - --variant=installer-rehearse-4.14
       command:
       - ci-operator

--- a/ci-operator/jobs/openshift/vmware-vsphere-csi-driver-operator/openshift-vmware-vsphere-csi-driver-operator-release-4.8-presubmits.yaml
+++ b/ci-operator/jobs/openshift/vmware-vsphere-csi-driver-operator/openshift-vmware-vsphere-csi-driver-operator-release-4.8-presubmits.yaml
@@ -1,88 +1,6 @@
 presubmits:
   openshift/vmware-vsphere-csi-driver-operator:
   - agent: kubernetes
-    always_run: true
-    branches:
-    - ^release-4\.8$
-    - ^release-4\.8-
-    cluster: vsphere02
-    context: ci/prow/e2e-vsphere
-    decorate: true
-    decoration_config:
-      skip_cloning: true
-    labels:
-      ci-operator.openshift.io/cloud: vsphere
-      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-vmware-vsphere-csi-driver-operator-release-4.8-e2e-vsphere
-    rerun_command: /test e2e-vsphere
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-vsphere
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-vsphere,?($|\s.*)
-  - agent: kubernetes
     always_run: false
     branches:
     - ^release-4\.8$
@@ -165,6 +83,88 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-vsphere-csi,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.8$
+    - ^release-4\.8-
+    cluster: vsphere02
+    context: ci/prow/e2e-vsphere-upi
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: vsphere
+      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-vmware-vsphere-csi-driver-operator-release-4.8-e2e-vsphere-upi
+    rerun_command: /test e2e-vsphere-upi
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-vsphere-upi
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift/vmware-vsphere-csi-driver-operator/openshift-vmware-vsphere-csi-driver-operator-release-4.9-presubmits.yaml
+++ b/ci-operator/jobs/openshift/vmware-vsphere-csi-driver-operator/openshift-vmware-vsphere-csi-driver-operator-release-4.9-presubmits.yaml
@@ -6,86 +6,6 @@ presubmits:
     - ^release-4\.9$
     - ^release-4\.9-
     cluster: vsphere02
-    context: ci/prow/e2e-vsphere
-    decorate: true
-    labels:
-      ci-operator.openshift.io/cloud: vsphere
-      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-vmware-vsphere-csi-driver-operator-release-4.9-e2e-vsphere
-    rerun_command: /test e2e-vsphere
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-vsphere
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-vsphere,?($|\s.*)
-  - agent: kubernetes
-    always_run: true
-    branches:
-    - ^release-4\.9$
-    - ^release-4\.9-
-    cluster: vsphere02
     context: ci/prow/e2e-vsphere-csi
     decorate: true
     labels:
@@ -160,6 +80,86 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-vsphere-csi,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.9$
+    - ^release-4\.9-
+    cluster: vsphere02
+    context: ci/prow/e2e-vsphere-upi
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: vsphere
+      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-vmware-vsphere-csi-driver-operator-release-4.9-e2e-vsphere-upi
+    rerun_command: /test e2e-vsphere-upi
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-vsphere-upi
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift/vmware-vsphere-csi-driver/openshift-vmware-vsphere-csi-driver-release-4.8-presubmits.yaml
+++ b/ci-operator/jobs/openshift/vmware-vsphere-csi-driver/openshift-vmware-vsphere-csi-driver-release-4.8-presubmits.yaml
@@ -1,89 +1,6 @@
 presubmits:
   openshift/vmware-vsphere-csi-driver:
   - agent: kubernetes
-    always_run: true
-    branches:
-    - ^release-4\.8$
-    - ^release-4\.8-
-    cluster: vsphere02
-    context: ci/prow/e2e-vsphere
-    decorate: true
-    decoration_config:
-      skip_cloning: true
-    labels:
-      ci-operator.openshift.io/cloud: vsphere
-      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-vmware-vsphere-csi-driver-release-4.8-e2e-vsphere
-    path_alias: sigs.k8s.io/vsphere-csi-driver
-    rerun_command: /test e2e-vsphere
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-vsphere
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-vsphere,?($|\s.*)
-  - agent: kubernetes
     always_run: false
     branches:
     - ^release-4\.8$
@@ -167,6 +84,89 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-vsphere-csi,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.8$
+    - ^release-4\.8-
+    cluster: vsphere02
+    context: ci/prow/e2e-vsphere-upi
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: vsphere
+      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-vmware-vsphere-csi-driver-release-4.8-e2e-vsphere-upi
+    path_alias: sigs.k8s.io/vsphere-csi-driver
+    rerun_command: /test e2e-vsphere-upi
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-vsphere-upi
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift/vmware-vsphere-csi-driver/openshift-vmware-vsphere-csi-driver-release-4.9-presubmits.yaml
+++ b/ci-operator/jobs/openshift/vmware-vsphere-csi-driver/openshift-vmware-vsphere-csi-driver-release-4.9-presubmits.yaml
@@ -1,87 +1,6 @@
 presubmits:
   openshift/vmware-vsphere-csi-driver:
   - agent: kubernetes
-    always_run: true
-    branches:
-    - ^release-4\.9$
-    - ^release-4\.9-
-    cluster: vsphere02
-    context: ci/prow/e2e-vsphere
-    decorate: true
-    labels:
-      ci-operator.openshift.io/cloud: vsphere
-      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-vmware-vsphere-csi-driver-release-4.9-e2e-vsphere
-    path_alias: sigs.k8s.io/vsphere-csi-driver
-    rerun_command: /test e2e-vsphere
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-vsphere
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-vsphere,?($|\s.*)
-  - agent: kubernetes
     always_run: false
     branches:
     - ^release-4\.9$
@@ -163,6 +82,87 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-vsphere-csi,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.9$
+    - ^release-4\.9-
+    cluster: vsphere02
+    context: ci/prow/e2e-vsphere-upi
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: vsphere
+      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-vmware-vsphere-csi-driver-release-4.9-e2e-vsphere-upi
+    path_alias: sigs.k8s.io/vsphere-csi-driver
+    rerun_command: /test e2e-vsphere-upi
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-vsphere-upi
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-vsphere-upi,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:


### PR DESCRIPTION
Align tests using vSphere UPI workflows so their `as` names consistently include `upi`, then regenerate prow jobs to keep generated config in sync.

Made-with: Cursor