### PR TITLE
Add lvms baremetal jobs

### DIFF
--- a/ci-operator/config/openshift/lvm-operator/.config.prowgen
+++ b/ci-operator/config/openshift/lvm-operator/.config.prowgen
@@ -12,3 +12,5 @@ slack_reporter:
   - e2e-aws-mno-qe-integration-tests
   - e2e-aws-sno-arm-qe-integration-tests
   - e2e-aws-sno-qe-integration-tests
+  - e2e-baremetalds-sno-dualstack-qe-integration-tests
+  - e2e-baremetalds-mno-dualstack-qe-integration-tests

--- a/ci-operator/config/openshift/lvm-operator/openshift-lvm-operator-main.yaml
+++ b/ci-operator/config/openshift/lvm-operator/openshift-lvm-operator-main.yaml
@@ -3,6 +3,10 @@ base_images:
     name: cli-operator-sdk
     namespace: ocp
     tag: v1.31.0
+  dev-scripts:
+    name: test
+    namespace: ocp-kni
+    tag: dev-scripts
   must-gather:
     name: "4.22"
     namespace: ocp
@@ -379,6 +383,49 @@ tests:
           memory: 200Mi
       timeout: 4h0m0s
     workflow: cucushift-installer-rehearse-aws-ipi-mno-lvms
+- as: e2e-baremetalds-sno-dualstack-qe-integration-tests
+  capabilities:
+  - intranet
+  cron: '@weekly'
+  steps:
+    cluster_profile: equinix-ocp-metal-qe
+    env:
+      AUX_HOST: openshift-qe-metal-ci.arm.eng.rdu2.redhat.com
+      LVM_OPERATOR_SUB_INSTALL_NAMESPACE: openshift-lvm-storage
+      LVM_OPERATOR_SUB_SOURCE: lvm-catalogsource
+      RESERVE_BOOTSTRAP: "false"
+      architecture: amd64
+      masters: "1"
+      workers: "0"
+    test:
+    - as: lvms-sno-integration-test
+      cli: latest
+      commands: |
+        ./integration-test run-suite -c 1 --junit-path ${ARTIFACT_DIR}/junit_results.xml openshift/lvm-operator/test/integration/qe_tests/sno
+      from: lvm-operator-integration-test
+      resources:
+        requests:
+          cpu: 100m
+          memory: 200Mi
+    workflow: cucushift-installer-rehearse-baremetalds-ipi-ovn-dualstack-sno-lvms
+- as: e2e-baremetalds-mno-dualstack-qe-integration-tests
+  cron: '@weekly'
+  steps:
+    cluster_profile: equinix-ocp-metal-qe
+    env:
+      LVM_OPERATOR_SUB_INSTALL_NAMESPACE: openshift-lvm-storage
+      LVM_OPERATOR_SUB_SOURCE: lvm-catalogsource
+    test:
+    - as: lvms-mno-integration-test
+      cli: latest
+      commands: |
+        ./integration-test run-suite -c 1 --junit-path ${ARTIFACT_DIR}/junit_results.xml openshift/lvm-operator/test/integration/qe_tests/mno
+      from: lvm-operator-integration-test
+      resources:
+        requests:
+          cpu: 100m
+          memory: 200Mi
+    workflow: cucushift-installer-rehearse-baremetalds-ipi-ovn-dualstack-mno-lvms
 zz_generated_metadata:
   branch: main
   org: openshift

--- a/ci-operator/jobs/openshift/lvm-operator/openshift-lvm-operator-main-periodics.yaml
+++ b/ci-operator/jobs/openshift/lvm-operator/openshift-lvm-operator-main-periodics.yaml
@@ -603,3 +603,186 @@ periodics:
     - name: result-aggregator
       secret:
         secretName: result-aggregator
+- agent: kubernetes
+  cluster: build05
+  cron: '@weekly'
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: lvm-operator
+  labels:
+    ci-operator.openshift.io/cloud: equinix-ocp-metal
+    ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal-qe
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-lvm-operator-main-e2e-baremetalds-mno-dualstack-qe-integration-tests
+  reporter_config:
+    slack:
+      channel: '#lvms-release-coordination'
+      job_states_to_report:
+      - error
+      - failure
+      - success
+      report_template: '{{if eq .Status.State "success"}} :large_green_circle: Job
+        *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs>
+        :large_green_circle: {{else}} :red_circle: Job *{{.Spec.Job}}* ended with
+        *{{.Status.State}}*. <{{.Status.URL}}|View logs> :red_circle: {{end}}'
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-baremetalds-mno-dualstack-qe-integration-tests
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build03
+  cron: '@weekly'
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: lvm-operator
+  labels:
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: equinix-ocp-metal
+    ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal-qe
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-lvm-operator-main-e2e-baremetalds-sno-dualstack-qe-integration-tests
+  reporter_config:
+    slack:
+      channel: '#lvms-release-coordination'
+      job_states_to_report:
+      - error
+      - failure
+      - success
+      report_template: '{{if eq .Status.State "success"}} :large_green_circle: Job
+        *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs>
+        :large_green_circle: {{else}} :red_circle: Job *{{.Spec.Job}}* ended with
+        *{{.Status.State}}*. <{{.Status.URL}}|View logs> :red_circle: {{end}}'
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-baremetalds-sno-dualstack-qe-integration-tests
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator

--- a/ci-operator/step-registry/cucushift/installer/rehearse/baremetalds/ipi/ovn/dualstack/mno/OWNERS
+++ b/ci-operator/step-registry/cucushift/installer/rehearse/baremetalds/ipi/ovn/dualstack/mno/OWNERS
@@ -1,0 +1,10 @@
+approvers:
+- edge-enablement-approvers
+- mmakwana30
+- kasturinarra
+- jadhaj
+reviewers:
+- edge-enablement-reviewers
+- mmakwana30
+- kasturinarra
+- jadhaj

--- a/ci-operator/step-registry/cucushift/installer/rehearse/baremetalds/ipi/ovn/dualstack/mno/lvms/OWNERS
+++ b/ci-operator/step-registry/cucushift/installer/rehearse/baremetalds/ipi/ovn/dualstack/mno/lvms/OWNERS
@@ -1,0 +1,10 @@
+approvers:
+- edge-enablement-approvers
+- mmakwana30
+- kasturinarra
+- jadhaj
+reviewers:
+- edge-enablement-reviewers
+- mmakwana30
+- kasturinarra
+- jadhaj

--- a/ci-operator/step-registry/cucushift/installer/rehearse/baremetalds/ipi/ovn/dualstack/mno/lvms/cucushift-installer-rehearse-baremetalds-ipi-ovn-dualstack-mno-lvms-workflow.metadata.json
+++ b/ci-operator/step-registry/cucushift/installer/rehearse/baremetalds/ipi/ovn/dualstack/mno/lvms/cucushift-installer-rehearse-baremetalds-ipi-ovn-dualstack-mno-lvms-workflow.metadata.json
@@ -1,0 +1,17 @@
+{
+	"path": "cucushift/installer/rehearse/baremetalds/ipi/ovn/dualstack/mno/lvms/cucushift-installer-rehearse-baremetalds-ipi-ovn-dualstack-mno-lvms-workflow.yaml",
+	"owners": {
+		"approvers": [
+			"edge-enablement-approvers",
+			"mmakwana30",
+			"kasturinarra",
+			"jadhaj"
+		],
+		"reviewers": [
+			"edge-enablement-reviewers",
+			"mmakwana30",
+			"kasturinarra",
+			"jadhaj"
+		]
+	}
+}

--- a/ci-operator/step-registry/cucushift/installer/rehearse/baremetalds/ipi/ovn/dualstack/mno/lvms/cucushift-installer-rehearse-baremetalds-ipi-ovn-dualstack-mno-lvms-workflow.yaml
+++ b/ci-operator/step-registry/cucushift/installer/rehearse/baremetalds/ipi/ovn/dualstack/mno/lvms/cucushift-installer-rehearse-baremetalds-ipi-ovn-dualstack-mno-lvms-workflow.yaml
@@ -1,0 +1,18 @@
+workflow:
+  as: cucushift-installer-rehearse-baremetalds-ipi-ovn-dualstack-mno-lvms
+  steps:
+    pre:
+      - chain: cucushift-installer-rehearse-baremetalds-ipi-ofcir-provision
+      - chain: storage-conf-csi-optional-topolvm
+    post:
+      - chain: cucushift-installer-rehearse-baremetalds-ipi-ofcir-deprovision
+    env:
+      DEVSCRIPTS_CONFIG: |
+        IP_STACK=v4v6
+        NETWORK_TYPE=OVNKubernetes
+        VM_EXTRADISKS=true
+        VM_EXTRADISKS_LIST="vda vdb"
+        VM_EXTRADISKS_SIZE=100G
+      LVM_CLUSTER_AUTO_SELECT_AVAILABLE_DEVICES: "true"
+  documentation: |-
+    Create a dual-stack MNO (Multi Node OpenShift) cluster on Baremetal (via devscripts) for QE LVMS Operator e2e tests.

--- a/ci-operator/step-registry/cucushift/installer/rehearse/baremetalds/ipi/ovn/dualstack/sno/OWNERS
+++ b/ci-operator/step-registry/cucushift/installer/rehearse/baremetalds/ipi/ovn/dualstack/sno/OWNERS
@@ -1,0 +1,10 @@
+approvers:
+- edge-enablement-approvers
+- mmakwana30
+- kasturinarra
+- jadhaj
+reviewers:
+- edge-enablement-reviewers
+- mmakwana30
+- kasturinarra
+- jadhaj

--- a/ci-operator/step-registry/cucushift/installer/rehearse/baremetalds/ipi/ovn/dualstack/sno/lvms/OWNERS
+++ b/ci-operator/step-registry/cucushift/installer/rehearse/baremetalds/ipi/ovn/dualstack/sno/lvms/OWNERS
@@ -1,0 +1,10 @@
+approvers:
+- edge-enablement-approvers
+- mmakwana30
+- kasturinarra
+- jadhaj
+reviewers:
+- edge-enablement-reviewers
+- mmakwana30
+- kasturinarra
+- jadhaj

--- a/ci-operator/step-registry/cucushift/installer/rehearse/baremetalds/ipi/ovn/dualstack/sno/lvms/cucushift-installer-rehearse-baremetalds-ipi-ovn-dualstack-sno-lvms-workflow.metadata.json
+++ b/ci-operator/step-registry/cucushift/installer/rehearse/baremetalds/ipi/ovn/dualstack/sno/lvms/cucushift-installer-rehearse-baremetalds-ipi-ovn-dualstack-sno-lvms-workflow.metadata.json
@@ -1,0 +1,17 @@
+{
+	"path": "cucushift/installer/rehearse/baremetalds/ipi/ovn/dualstack/sno/lvms/cucushift-installer-rehearse-baremetalds-ipi-ovn-dualstack-sno-lvms-workflow.yaml",
+	"owners": {
+		"approvers": [
+			"edge-enablement-approvers",
+			"mmakwana30",
+			"kasturinarra",
+			"jadhaj"
+		],
+		"reviewers": [
+			"edge-enablement-reviewers",
+			"mmakwana30",
+			"kasturinarra",
+			"jadhaj"
+		]
+	}
+}

--- a/ci-operator/step-registry/cucushift/installer/rehearse/baremetalds/ipi/ovn/dualstack/sno/lvms/cucushift-installer-rehearse-baremetalds-ipi-ovn-dualstack-sno-lvms-workflow.yaml
+++ b/ci-operator/step-registry/cucushift/installer/rehearse/baremetalds/ipi/ovn/dualstack/sno/lvms/cucushift-installer-rehearse-baremetalds-ipi-ovn-dualstack-sno-lvms-workflow.yaml
@@ -1,0 +1,19 @@
+workflow:
+  as: cucushift-installer-rehearse-baremetalds-ipi-ovn-dualstack-sno-lvms
+  steps:
+    pre:
+      - chain: baremetal-lab-sno-conf
+      - chain: baremetal-lab-upi-install
+      - ref: upi-install-heterogeneous
+      - chain: storage-conf-csi-optional-topolvm
+    post:
+      - chain: baremetal-lab-post
+    env:
+      BOOTSTRAP_IN_PLACE: "true"
+      ADDITIONAL_WORKERS: "0"
+      ipv6_enabled: "true"
+      PRIMARY_NET: "ipv4"
+      LVM_CLUSTER_TOLERATE_MASTER: true
+      LVM_CLUSTER_AUTO_SELECT_AVAILABLE_DEVICES: "true"
+  documentation: |-
+    Create a dual-stack SNO (Single Node OpenShift) cluster on Baremetal lab (UPI with bootstrap-in-place) for QE LVMS Operator e2e tests.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added weekly bare-metal dual‑stack integration tests for LVM Operator (SNO and MNO variants).

* **Tests**
  * Added CI workflows and periodic jobs to run the new SNO and MNO integration suites.
  * StorageClass defaulting is now version-aware to skip unnecessary default changes on newer clusters.

* **Chores**
  * Added ownership/approver metadata for the new rehearsals and workflows.
  * Added Slack reporting configuration for the new CI jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->