### PR TITLE
NVIDIA-556: Add a new E2E workflow for the dpf-hcp-provisioner operator, focusing on single-replica scenario

### DIFF
--- a/ci-operator/config/rh-ecosystem-edge/dpf-hcp-provisioner-operator/rh-ecosystem-edge-dpf-hcp-provisioner-operator-main__4.22.yaml
+++ b/ci-operator/config/rh-ecosystem-edge/dpf-hcp-provisioner-operator/rh-ecosystem-edge-dpf-hcp-provisioner-operator-main__4.22.yaml
@@ -1,0 +1,38 @@
+build_root:
+  image_stream_tag:
+    name: release
+    namespace: openshift
+    tag: rhel-9-release-golang-1.25-openshift-4.23
+images:
+  items:
+  - dockerfile_path: Containerfile
+    to: dpf-hcp-provisioner-operator
+  - dockerfile_path: e2e-tests.Containerfile
+    to: dpf-hcp-provisioner-operator-ci
+releases:
+  latest:
+    candidate:
+      product: ocp
+      stream: nightly
+      version: "4.22"
+resources:
+  '*':
+    limits:
+      memory: 2Gi
+    requests:
+      cpu: 2000m
+      memory: 2Gi
+tests:
+- always_run: false
+  as: dpf-hcp-provisioner-operator-e2e-aws-single-replica
+  steps:
+    cluster_profile: aws-edge-infra
+    env:
+      BASE_DOMAIN: edge-sro.rhecoeng.com
+      MACHINE_OS_URL: quay.io/eelgaev/rhcos-bfb:4.22.0-ec.2
+    workflow: rh-ecosystem-edge-dpf-hcp-provisioner-operator
+zz_generated_metadata:
+  branch: main
+  org: rh-ecosystem-edge
+  repo: dpf-hcp-provisioner-operator
+  variant: "4.22"

--- a/ci-operator/jobs/rh-ecosystem-edge/dpf-hcp-provisioner-operator/rh-ecosystem-edge-dpf-hcp-provisioner-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/rh-ecosystem-edge/dpf-hcp-provisioner-operator/rh-ecosystem-edge-dpf-hcp-provisioner-operator-main-presubmits.yaml
@@ -1,6 +1,149 @@
 presubmits:
   rh-ecosystem-edge/dpf-hcp-provisioner-operator:
   - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build06
+    context: ci/prow/4.22-dpf-hcp-provisioner-operator-e2e-aws-single-replica
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: aws-edge-infra
+      ci-operator.openshift.io/variant: "4.22"
+      ci.openshift.io/generator: prowgen
+      job-release: "4.22"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-rh-ecosystem-edge-dpf-hcp-provisioner-operator-main-4.22-dpf-hcp-provisioner-operator-e2e-aws-single-replica
+    rerun_command: /test 4.22-dpf-hcp-provisioner-operator-e2e-aws-single-replica
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=dpf-hcp-provisioner-operator-e2e-aws-single-replica
+        - --variant=4.22
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )(4.22-dpf-hcp-provisioner-operator-e2e-aws-single-replica|remaining-required),?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build03
+    context: ci/prow/4.22-images
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/variant: "4.22"
+      ci.openshift.io/generator: prowgen
+      job-release: "4.22"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-rh-ecosystem-edge-dpf-hcp-provisioner-operator-main-4.22-images
+    rerun_command: /test 4.22-images
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=[images]
+        - --variant=4.22
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )4.22-images,?($|\s.*)
+  - agent: kubernetes
     always_run: true
     branches:
     - ^main$

--- a/ci-operator/step-registry/cluster-profiles/cluster-profiles-config.yaml
+++ b/ci-operator/step-registry/cluster-profiles/cluster-profiles-config.yaml
@@ -831,6 +831,7 @@ cluster_profiles:
     - bip-orchestrate-vm
     - ci-artifacts
     - ci-tools-nvidia-gpu-operator
+    - dpf-hcp-provisioner-operator
     - ib-orchestrate-vm
     - neuron-ci
     - nvidia-ci

--- a/ci-operator/step-registry/rh-ecosystem-edge/dpf-hcp-provisioner-operator/OWNERS
+++ b/ci-operator/step-registry/rh-ecosystem-edge/dpf-hcp-provisioner-operator/OWNERS
@@ -1,0 +1,13 @@
+# DO NOT EDIT; this file is auto-generated using https://github.com/openshift/ci-tools.
+# Fetched from https://github.com/rh-ecosystem-edge/dpf-hcp-provisioner-operator root OWNERS
+# If the repo had OWNERS_ALIASES then the aliases were expanded
+# Logins who are not members of 'openshift' organization were filtered out
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+- linoyaslan
+- tsorya
+options: {}
+reviewers:
+- linoyaslan
+- tsorya

--- a/ci-operator/step-registry/rh-ecosystem-edge/dpf-hcp-provisioner-operator/rh-ecosystem-edge-dpf-hcp-provisioner-operator-workflow.metadata.json
+++ b/ci-operator/step-registry/rh-ecosystem-edge/dpf-hcp-provisioner-operator/rh-ecosystem-edge-dpf-hcp-provisioner-operator-workflow.metadata.json
@@ -1,0 +1,13 @@
+{
+	"path": "rh-ecosystem-edge/dpf-hcp-provisioner-operator/rh-ecosystem-edge-dpf-hcp-provisioner-operator-workflow.yaml",
+	"owners": {
+		"approvers": [
+			"linoyaslan",
+			"tsorya"
+		],
+		"reviewers": [
+			"linoyaslan",
+			"tsorya"
+		]
+	}
+}

--- a/ci-operator/step-registry/rh-ecosystem-edge/dpf-hcp-provisioner-operator/rh-ecosystem-edge-dpf-hcp-provisioner-operator-workflow.yaml
+++ b/ci-operator/step-registry/rh-ecosystem-edge/dpf-hcp-provisioner-operator/rh-ecosystem-edge-dpf-hcp-provisioner-operator-workflow.yaml
@@ -1,0 +1,71 @@
+workflow:
+  as: rh-ecosystem-edge-dpf-hcp-provisioner-operator
+  steps:
+    pre:
+      - chain: ipi-conf-aws
+      - chain: ipi-install
+    test:
+      - as: dpf-hcp-provisioner-e2e
+        commands: |
+          unset GOFLAGS
+          make test-e2e
+        from: dpf-hcp-provisioner-operator-ci
+        resources:
+          requests:
+            cpu: 2000m
+            memory: 2Gi
+        timeout: 3h0m0s
+        dependencies:
+          - name: dpf-hcp-provisioner-operator
+            env: IMAGE_DPF_HCP_PROVISIONER_OPERATOR_CI
+        env:
+          - name: BASE_DOMAIN
+            default: ""
+            documentation: |-
+              Base domain for HostedCluster DNS.
+          - name: E2E_TEST_TIMEOUT
+            default: "60m"
+            documentation: |-
+              Timeout for the e2e test suite.
+          - name: CONTROL_PLANE_AVAILABILITY
+            default: "SingleReplica"
+            documentation: |-
+              Control plane availability policy for the HostedCluster.
+              SingleReplica avoids MetalLB dependency.
+          - name: MACHINE_OS_URL
+            default: ""
+            documentation: |-
+              URL for the DPU machine OS image. If set, skips
+              BlueField OCP layer registry lookup.
+          - name: HYPERSHIFT_IMAGE
+            default: "quay.io/hypershift/hypershift-operator:latest"
+            documentation: |-
+              HyperShift operator image used to deploy the hypershift operator.
+    post:
+      - ref: gather-must-gather
+      - as: gather-dpf-namespaces
+        best_effort: true
+        commands: |
+          oc adm inspect \
+            ns/dpf-hcp-provisioner-system \
+            ns/dpf-hcp-provisioner-system-e2e-test-provisioner \
+            --dest-dir="${ARTIFACT_DIR}/dpf-namespaces"
+        from: cli
+        resources:
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        timeout: 10m
+      - ref: ipi-deprovision-deprovision
+    allow_best_effort_post_steps: true
+    allow_skip_on_success: true
+    env:
+      CONTROL_PLANE_REPLICAS: "3"
+      CONTROL_PLANE_INSTANCE_TYPE: m5.2xlarge
+      COMPUTE_NODE_REPLICAS: "0"
+  documentation: |-
+    This workflow provisions an OpenShift cluster on AWS, then runs
+    e2e tests which deploys the HyperShift operator and dpf-hcp-provisioner-operator
+    and then create a real HostedCluster with stub DPF CRs to
+    validate the full provisioner lifecycle including ignition generation
+    and CSR auto-approval.


### PR DESCRIPTION
 Adds end-to-end tests that validate the full DPFHCPProvisioner lifecycle on a real OCP cluster with HyperShift.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added CI/CD build and test configuration for `dpf-hcp-provisioner-operator` variant `4.22`, including automated E2E testing workflow with AWS infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->