### PR TITLE
AGENT-1429: Add a periodic job for agent installer iso-no-registry

### DIFF
--- a/ci-operator/config/openshift/release/openshift-release-main__ci-4.22.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__ci-4.22.yaml
@@ -1,4 +1,32 @@
 base_images:
+  assisted-image-service:
+    name: ocm-2.17
+    namespace: edge-infrastructure
+    tag: assisted-image-service
+  assisted-installer:
+    name: ocm-2.17
+    namespace: edge-infrastructure
+    tag: assisted-installer
+  assisted-installer-agent:
+    name: ocm-2.17
+    namespace: edge-infrastructure
+    tag: assisted-installer-agent
+  assisted-installer-controller:
+    name: ocm-2.17
+    namespace: edge-infrastructure
+    tag: assisted-installer-controller
+  assisted-service:
+    name: ocm-2.17
+    namespace: edge-infrastructure
+    tag: assisted-service
+  assisted-test-infra:
+    name: ocm-2.17
+    namespace: edge-infrastructure
+    tag: assisted-test-infra
+  dev-scripts:
+    name: test
+    namespace: ocp-kni
+    tag: dev-scripts
   upi-installer:
     name: "4.22"
     namespace: ocp
@@ -450,6 +478,19 @@ tests:
   steps:
     cluster_profile: vsphere-elastic
     workflow: openshift-upgrade-vsphere-runc
+- as: e2e-agent-iso-no-registry-conformance-techpreview
+  capabilities:
+  - intranet
+  interval: 12h
+  steps:
+    cluster_profile: equinix-ocp-metal
+    env:
+      DEVSCRIPTS_CONFIG: |
+        AGENT_E2E_TEST_SCENARIO=COMPACT_IPV4
+        AGENT_E2E_TEST_BOOT_MODE=ISO_NO_REGISTRY
+        AGENT_CLEANUP_ISO_BUILDER_CACHE_LOCAL_DEV=true
+        FEATURE_SET=TechPreviewNoUpgrade
+    workflow: agent-e2e-generic-conformance-iso-no-registry
 zz_generated_metadata:
   branch: main
   org: openshift

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22.yaml
@@ -1756,6 +1756,19 @@ tests:
         MASTER_VCPU=8
       TEST_SUITE: openshift/conformance/parallel
     workflow: agent-e2e-generic-conformance
+- as: e2e-agent-iso-no-registry-conformance-techpreview
+  capabilities:
+  - intranet
+  cron: 0 */12 * * *
+  steps:
+    cluster_profile: equinix-ocp-metal
+    env:
+      DEVSCRIPTS_CONFIG: |
+        AGENT_E2E_TEST_SCENARIO=COMPACT_IPV4
+        AGENT_E2E_TEST_BOOT_MODE=ISO_NO_REGISTRY
+        AGENT_CLEANUP_ISO_BUILDER_CACHE_LOCAL_DEV=true
+        FEATURE_SET=TechPreviewNoUpgrade
+    workflow: agent-e2e-generic-conformance-iso-no-registry
 - as: e2e-agent-single-node-ipv6-conformance
   capabilities:
   - intranet

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.23.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.23.yaml
@@ -1717,6 +1717,19 @@ tests:
         FIPS_MODE=true
       TEST_SUITE: openshift/conformance/parallel
     workflow: agent-e2e-generic-conformance
+- as: e2e-agent-iso-no-registry-conformance-techpreview
+  capabilities:
+  - intranet
+  cron: 0 */12 * * *
+  steps:
+    cluster_profile: equinix-ocp-metal
+    env:
+      DEVSCRIPTS_CONFIG: |
+        AGENT_E2E_TEST_SCENARIO=COMPACT_IPV4
+        AGENT_E2E_TEST_BOOT_MODE=ISO_NO_REGISTRY
+        AGENT_CLEANUP_ISO_BUILDER_CACHE_LOCAL_DEV=true
+        FEATURE_SET=TechPreviewNoUpgrade
+    workflow: agent-e2e-generic-conformance-iso-no-registry
 - as: e2e-agent-single-node-ipv6-conformance
   capabilities:
   - intranet

--- a/ci-operator/step-registry/agent/e2e/generic/conformance/iso-no-registry/OWNERS
+++ b/ci-operator/step-registry/agent/e2e/generic/conformance/iso-no-registry/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+- andfasano
+- bfournie
+- pawanpinjarkar
+- rwsu
+- sadasu
+- zaneb

--- a/ci-operator/step-registry/agent/e2e/generic/conformance/iso-no-registry/agent-e2e-generic-conformance-iso-no-registry-workflow.metadata.json
+++ b/ci-operator/step-registry/agent/e2e/generic/conformance/iso-no-registry/agent-e2e-generic-conformance-iso-no-registry-workflow.metadata.json
@@ -1,0 +1,13 @@
+{
+	"path": "agent/e2e/generic/conformance/iso-no-registry/agent-e2e-generic-conformance-iso-no-registry-workflow.yaml",
+	"owners": {
+		"approvers": [
+			"andfasano",
+			"bfournie",
+			"pawanpinjarkar",
+			"rwsu",
+			"sadasu",
+			"zaneb"
+		]
+	}
+}

--- a/ci-operator/step-registry/agent/e2e/generic/conformance/iso-no-registry/agent-e2e-generic-conformance-iso-no-registry-workflow.yaml
+++ b/ci-operator/step-registry/agent/e2e/generic/conformance/iso-no-registry/agent-e2e-generic-conformance-iso-no-registry-workflow.yaml
@@ -1,0 +1,16 @@
+workflow:
+  as: agent-e2e-generic-conformance-iso-no-registry
+  steps:
+    allow_best_effort_post_steps: true
+    allow_skip_on_success: true
+    env:
+      DEVSCRIPTS_TARGET: agent
+    pre:
+      - chain: agent-pre
+    test:
+      - chain: agent-test-conformance-iso-no-registry
+    post:
+      - chain: agent-post
+  documentation: |-
+    This workflow is a generic conformance one to deploy a no registry cluster provisioned by running agent installer, and it
+    will require to set the env variable DEVSCRIPTS_CONFIG to work properly.

--- a/ci-operator/step-registry/agent/e2e/test/OWNERS
+++ b/ci-operator/step-registry/agent/e2e/test/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+- andfasano
+- bfournie
+- pawanpinjarkar
+- rwsu
+- sadasu
+- zaneb

--- a/ci-operator/step-registry/agent/e2e/test/conformance/OWNERS
+++ b/ci-operator/step-registry/agent/e2e/test/conformance/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+- andfasano
+- bfournie
+- pawanpinjarkar
+- rwsu
+- sadasu
+- zaneb

--- a/ci-operator/step-registry/agent/e2e/test/conformance/iso-no-registry/OWNERS
+++ b/ci-operator/step-registry/agent/e2e/test/conformance/iso-no-registry/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+- andfasano
+- bfournie
+- pawanpinjarkar
+- rwsu
+- sadasu
+- zaneb

--- a/ci-operator/step-registry/agent/e2e/test/conformance/iso-no-registry/agent-e2e-test-conformance-iso-no-registry-commands.sh
+++ b/ci-operator/step-registry/agent/e2e/test/conformance/iso-no-registry/agent-e2e-test-conformance-iso-no-registry-commands.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+export KUBECONFIG="${SHARED_DIR}/kubeconfig"
+
+date +%s > "${SHARED_DIR}/TEST_TIME_TEST_START"
+trap 'date +%s > "${SHARED_DIR}/TEST_TIME_TEST_END"' EXIT
+
+# Get all tests filtered for NoRegistryClusterInstall
+ALL_TESTS="$(openshift-tests run all --provider '{"type":"baremetal"}' --dry-run)"
+TESTS="$(printf '%s\n' "${ALL_TESTS}" | grep -E 'NoRegistryClusterInstall' || true)"
+if [[ -z "${TESTS}" ]]; then
+    echo "No tests matched NoRegistryClusterInstall"
+    exit 1
+fi
+
+# Apply TEST_SKIPS filter if set
+if [[ -n "${TEST_SKIPS:-}" ]]; then
+    echo "Skipping tests matching: ${TEST_SKIPS}"
+    echo "${TESTS}" | grep -E -- "${TEST_SKIPS}" || true
+    set +e
+    FILTERED_TESTS="$(printf '%s\n' "${TESTS}" | grep -Ev -- "${TEST_SKIPS}")"
+    grep_status=$?
+    set -e
+    if [[ ${grep_status} -eq 2 ]]; then
+        echo "Invalid TEST_SKIPS regex: ${TEST_SKIPS}" >&2
+	exit 1
+    fi
+    if [[ -z "${FILTERED_TESTS}" ]]; then
+        echo "All candidate tests were filtered by TEST_SKIPS=${TEST_SKIPS}"
+        exit 1
+    fi
+    TESTS="${FILTERED_TESTS}"
+fi
+
+# Run the filtered tests
+echo "${TESTS}" | openshift-tests run \
+    --monitor "watch-namespaces" \
+    --max-parallel-tests 1 \
+    -f - \
+    -o "${ARTIFACT_DIR}/e2e.log" \
+    --junit-dir "${ARTIFACT_DIR}/junit"

--- a/ci-operator/step-registry/agent/e2e/test/conformance/iso-no-registry/agent-e2e-test-conformance-iso-no-registry-ref.metadata.json
+++ b/ci-operator/step-registry/agent/e2e/test/conformance/iso-no-registry/agent-e2e-test-conformance-iso-no-registry-ref.metadata.json
@@ -1,0 +1,13 @@
+{
+	"path": "agent/e2e/test/conformance/iso-no-registry/agent-e2e-test-conformance-iso-no-registry-ref.yaml",
+	"owners": {
+		"approvers": [
+			"andfasano",
+			"bfournie",
+			"pawanpinjarkar",
+			"rwsu",
+			"sadasu",
+			"zaneb"
+		]
+	}
+}

--- a/ci-operator/step-registry/agent/e2e/test/conformance/iso-no-registry/agent-e2e-test-conformance-iso-no-registry-ref.yaml
+++ b/ci-operator/step-registry/agent/e2e/test/conformance/iso-no-registry/agent-e2e-test-conformance-iso-no-registry-ref.yaml
@@ -1,0 +1,21 @@
+ref:
+  as: agent-e2e-test-conformance-iso-no-registry
+  from: tests
+  grace_period: 10m
+  commands: agent-e2e-test-conformance-iso-no-registry-commands.sh
+  timeout: 5h0m0s
+  resources:
+    requests:
+      cpu: "3"
+      memory: 600Mi
+    limits:
+      memory: 12Gi
+  env:
+  - name: TEST_SKIPS
+    default: ""
+  - name: OPENSHIFT_SKIP_EXTERNAL_TESTS
+    default: "true"
+  documentation: |-
+    This step runs the openshift-tests filtering for NoRegistryClusterInstall tests.
+    Uses --provider baremetal to exclude unwanted tests and --monitor watch-namespaces
+    to prevent monitor test failures in disconnected environments.

--- a/ci-operator/step-registry/agent/test/conformance/iso-no-registry/OWNERS
+++ b/ci-operator/step-registry/agent/test/conformance/iso-no-registry/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+- andfasano
+- bfournie
+- pawanpinjarkar
+- rwsu
+- sadasu
+- zaneb

--- a/ci-operator/step-registry/agent/test/conformance/iso-no-registry/agent-test-conformance-iso-no-registry-chain.metadata.json
+++ b/ci-operator/step-registry/agent/test/conformance/iso-no-registry/agent-test-conformance-iso-no-registry-chain.metadata.json
@@ -1,0 +1,13 @@
+{
+	"path": "agent/test/conformance/iso-no-registry/agent-test-conformance-iso-no-registry-chain.yaml",
+	"owners": {
+		"approvers": [
+			"andfasano",
+			"bfournie",
+			"pawanpinjarkar",
+			"rwsu",
+			"sadasu",
+			"zaneb"
+		]
+	}
+}

--- a/ci-operator/step-registry/agent/test/conformance/iso-no-registry/agent-test-conformance-iso-no-registry-chain.yaml
+++ b/ci-operator/step-registry/agent/test/conformance/iso-no-registry/agent-test-conformance-iso-no-registry-chain.yaml
@@ -1,0 +1,6 @@
+chain:
+  as: agent-test-conformance-iso-no-registry
+  steps:
+  - ref: agent-e2e-test-conformance-iso-no-registry
+  documentation: |-
+    This chain encapsulates the e2e tests for the agent installer ISO No registry


### PR DESCRIPTION
Add a periodic job to run tests on and agent-based installer cluster created using iso-no-registry which uses the openshift/appliance to create a disconnected cluster with installed operators. The deployed cluster must be in TechPreview in 4.22.

As a follow on we will add tests to exercise the NoRegistryClusterInstall.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new E2E conformance test and workflow for the agent-installer ISO "no-registry" (TechPreview, COMPACT_IPV4, ISO_NO_REGISTRY); scheduled every 12 hours on equinix-ocp-metal with intranet capability (applies to main and nightly pipelines).
  * Added a test runner/filter script to run conformance tests matching NoRegistryClusterInstall and capture logs/JUnit outputs; step resource/time limits configured.

* **Chores**
  * Added assisted-component and dev-scripts base image references to CI configs.
  * Added approver/ownership metadata for the new workflows and test steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->