### PR TITLE
adding rhoe 4.22 jobs for operator-pipelines

### DIFF
--- a/ci-operator/config/redhat-openshift-ecosystem/certified-operators-preprod/redhat-openshift-ecosystem-certified-operators-preprod-ocp-4.22.yaml
+++ b/ci-operator/config/redhat-openshift-ecosystem/certified-operators-preprod/redhat-openshift-ecosystem-certified-operators-preprod-ocp-4.22.yaml
@@ -1,0 +1,45 @@
+releases:
+  latest:
+    candidate:
+      product: ocp
+      stream: nightly
+      version: "4.22"
+resources:
+  '*':
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: preflight-preprod-claim
+  cluster_claim:
+    architecture: amd64
+    cloud: aws
+    owner: rh-openshift-ecosystem
+    product: ocp
+    timeout: 1h0m0s
+    version: "4.22"
+  cron: '@yearly'
+  steps:
+    allow_best_effort_post_steps: true
+    env:
+      ASSET_TYPE: operator
+      PFLT_ARTIFACTS: artifacts
+      PFLT_INDEXIMAGE: quay.io/opdev/simple-demo-operator-catalog:latest
+      TEST_ASSET: quay.io/opdev/simple-demo-operator-bundle:latest
+    post:
+    - ref: gather-must-gather
+    pre:
+    - ref: operator-pipelines-preflight-preprod-health
+    - ref: ipi-install-rbac
+    - ref: operator-pipelines-preflight-preprod-approve-csrs
+    - ref: operator-pipelines-preflight-preprod-operator-registry-cache-fix
+    test:
+    - ref: operator-pipelines-preflight-preprod-decrypt
+    - ref: operator-pipelines-preflight-preprod-check
+    - ref: operator-pipelines-preflight-preprod-encrypt
+zz_generated_metadata:
+  branch: ocp-4.22
+  org: redhat-openshift-ecosystem
+  repo: certified-operators-preprod

--- a/ci-operator/config/redhat-openshift-ecosystem/certified-operators-prod/redhat-openshift-ecosystem-certified-operators-prod-ocp-4.22.yaml
+++ b/ci-operator/config/redhat-openshift-ecosystem/certified-operators-prod/redhat-openshift-ecosystem-certified-operators-prod-ocp-4.22.yaml
@@ -1,0 +1,45 @@
+releases:
+  latest:
+    candidate:
+      product: ocp
+      stream: nightly
+      version: "4.22"
+resources:
+  '*':
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: preflight-prod-claim
+  cluster_claim:
+    architecture: amd64
+    cloud: aws
+    owner: rh-openshift-ecosystem
+    product: ocp
+    timeout: 1h0m0s
+    version: "4.22"
+  cron: '@yearly'
+  steps:
+    allow_best_effort_post_steps: true
+    env:
+      ASSET_TYPE: operator
+      PFLT_ARTIFACTS: artifacts
+      PFLT_INDEXIMAGE: quay.io/opdev/simple-demo-operator-catalog:latest
+      TEST_ASSET: quay.io/opdev/simple-demo-operator-bundle:latest
+    post:
+    - ref: gather-must-gather
+    pre:
+    - ref: operator-pipelines-preflight-prod-health
+    - ref: ipi-install-rbac
+    - ref: operator-pipelines-preflight-prod-approve-csrs
+    - ref: operator-pipelines-preflight-prod-operator-registry-cache-fix
+    test:
+    - ref: operator-pipelines-preflight-prod-decrypt
+    - ref: operator-pipelines-preflight-prod-check
+    - ref: operator-pipelines-preflight-prod-encrypt
+zz_generated_metadata:
+  branch: ocp-4.22
+  org: redhat-openshift-ecosystem
+  repo: certified-operators-prod

--- a/ci-operator/jobs/redhat-openshift-ecosystem/certified-operators-preprod/redhat-openshift-ecosystem-certified-operators-preprod-ocp-4.22-periodics.yaml
+++ b/ci-operator/jobs/redhat-openshift-ecosystem/certified-operators-preprod/redhat-openshift-ecosystem-certified-operators-preprod-ocp-4.22-periodics.yaml
@@ -1,0 +1,87 @@
+periodics:
+- agent: kubernetes
+  cluster: build01
+  cron: '@yearly'
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: ocp-4.22
+    org: redhat-openshift-ecosystem
+    repo: certified-operators-preprod
+  labels:
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-redhat-openshift-ecosystem-certified-operators-preprod-ocp-4.22-preflight-preprod-claim
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --hive-kubeconfig=/secrets/hive-hive-credentials/kubeconfig
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=preflight-preprod-claim
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/hive-hive-credentials
+        name: hive-hive-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: hive-hive-credentials
+      secret:
+        secretName: hive-hive-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator

--- a/ci-operator/jobs/redhat-openshift-ecosystem/certified-operators-prod/redhat-openshift-ecosystem-certified-operators-prod-ocp-4.22-periodics.yaml
+++ b/ci-operator/jobs/redhat-openshift-ecosystem/certified-operators-prod/redhat-openshift-ecosystem-certified-operators-prod-ocp-4.22-periodics.yaml
@@ -1,0 +1,87 @@
+periodics:
+- agent: kubernetes
+  cluster: build01
+  cron: '@yearly'
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: ocp-4.22
+    org: redhat-openshift-ecosystem
+    repo: certified-operators-prod
+  labels:
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-redhat-openshift-ecosystem-certified-operators-prod-ocp-4.22-preflight-prod-claim
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --hive-kubeconfig=/secrets/hive-hive-credentials/kubeconfig
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=preflight-prod-claim
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/hive-hive-credentials
+        name: hive-hive-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: hive-hive-credentials
+      secret:
+        secretName: hive-hive-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added CI/CD test infrastructure configurations for OpenShift 4.22 certified operators.
  * Configured automated preflight validation workflows for pre-production and production testing environments.
  * Enabled periodic test scheduling to ensure ongoing operators certification compliance verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->