### PR TITLE
kueue-operator: Add presubmit that builds images in CI to fix drift

### DIFF
--- a/ci-operator/config/openshift/kueue-operator/openshift-kueue-operator-main.yaml
+++ b/ci-operator/config/openshift/kueue-operator/openshift-kueue-operator-main.yaml
@@ -30,6 +30,7 @@ images:
   - dockerfile_literal: |
       FROM src
       COPY oc /usr/bin/oc
+      COPY operator-sdk /usr/local/bin/operator-sdk
       RUN ln -s /usr/bin/oc /usr/bin/kubectl
       RUN wget -qO /usr/local/bin/jq https://github.com/jqlang/jq/releases/latest/download/jq-linux64 && chmod +x /usr/local/bin/jq
       RUN dnf install -y skopeo git podman && dnf clean all
@@ -39,7 +40,30 @@ images:
         paths:
         - destination_dir: .
           source_path: /usr/bin/oc
+      operator-sdk:
+        paths:
+        - destination_dir: .
+          source_path: /usr/local/bin/operator-sdk
     to: src-with-oc-and-kubectl
+  - dockerfile_literal: |
+      FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.21 AS build
+      WORKDIR /workspace
+      COPY . .
+      WORKDIR /workspace/upstream/kueue
+      RUN ./build.sh
+      FROM registry.ci.openshift.org/ocp/builder:rhel-9-base-openshift-4.19
+      COPY --from=build /workspace/upstream/kueue/src/bin/manager /manager
+      ENTRYPOINT ["/manager"]
+    to: kueue-operand
+operator:
+  bundles:
+  - as: kueue-bundle
+    skip_building_index: true
+  substitutions:
+  - pullspec: registry.redhat.io/kueue/kueue-rhel9-operator[@:].*
+    with: pipeline:kueue-operator
+  - pullspec: registry.redhat.io/kueue/kueue-rhel9[@:].*
+    with: pipeline:kueue-operand
 releases:
   4-21-latest:
     candidate:
@@ -92,6 +116,53 @@ tests:
   skip_if_only_changed: ^\.tekton/|\.md$|^(LICENSE|OWNERS)$
   steps:
     workflow: openshift-ci-security
+- as: test-e2e-ci-build-4-20
+  cluster_claim:
+    architecture: amd64
+    cloud: aws
+    owner: openshift-ci
+    product: ocp
+    timeout: 1h0m0s
+    version: "4.20"
+  steps:
+    post:
+    - chain: kueue-operator-post
+    test:
+    - ref: cert-manager-install-operator
+    - as: install-operator
+      cli: latest
+      commands: |
+        oc create namespace openshift-kueue-operator || true
+        oc label ns openshift-kueue-operator openshift.io/cluster-monitoring=true --overwrite
+
+        # Inject CI registry credentials into the cluster's global pull secret
+        # so that cluster nodes can pull CI-built bundle images
+        KUBECONFIG="" oc registry login --to=/tmp/ci-registry-auth.json
+        oc extract secret/pull-secret -n openshift-config --confirm --to=/tmp
+        jq -s '.[0] * .[1]' /tmp/.dockerconfigjson /tmp/ci-registry-auth.json > /tmp/merged-pull-secret.json
+        oc set data secret/pull-secret -n openshift-config --from-file=.dockerconfigjson=/tmp/merged-pull-secret.json
+        sleep 10
+        oc wait mcp/worker --for=condition=Updated=True --timeout=10m || true
+
+        operator-sdk run bundle --timeout=10m -n openshift-kueue-operator "$OO_BUNDLE" --security-context-config=restricted
+      dependencies:
+      - env: OO_BUNDLE
+        name: kueue-bundle
+      from: src-with-oc-and-kubectl
+      resources:
+        requests:
+          cpu: 200m
+          memory: 300Mi
+    - ref: jobset-install-operator
+    - ref: leader-worker-set-install-operator
+    - as: e2e-kueue
+      cli: latest
+      commands: make e2e-ci-test
+      from: kueue-operator-src
+      resources:
+        requests:
+          cpu: "4"
+          memory: 4Gi
 - as: test-e2e-4-18
   capabilities:
   - arm64

--- a/ci-operator/jobs/openshift/kueue-operator/openshift-kueue-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/kueue-operator/openshift-kueue-operator-main-presubmits.yaml
@@ -1,6 +1,59 @@
 presubmits:
   openshift/kueue-operator:
   - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build01
+    context: ci/prow/ci-bundle-kueue-bundle
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-kueue-operator-main-ci-bundle-kueue-bundle
+    rerun_command: /test ci-bundle-kueue-bundle
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=kueue-bundle
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )ci-bundle-kueue-bundle,?($|\s.*)
+  - agent: kubernetes
     always_run: false
     branches:
     - ^main$
@@ -416,6 +469,91 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )test,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build01
+    context: ci/prow/test-e2e-ci-build-4-20
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-kueue-operator-main-test-e2e-ci-build-4-20
+    rerun_command: /test test-e2e-ci-build-4-20
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --hive-kubeconfig=/secrets/hive-hive-credentials/kubeconfig
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=test-e2e-ci-build-4-20
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/hive-hive-credentials
+          name: hive-hive-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: hive-hive-credentials
+        secret:
+          secretName: hive-hive-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )test-e2e-ci-build-4-20,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:


### PR DESCRIPTION
## Summary

Adds a new presubmit test (`test-e2e-ci-build-4-20`) that builds operator and operand images
from PR code using ci-operator's native OLM bundle support, eliminating image drift caused by
relying on external Konflux images.

### What changed

- **New `kueue-operand` image build**: Builds the kueue operand binary in CI using
  `dockerfile_literal` with CI-accessible base images (`registry.ci.openshift.org/ocp/builder`)
- **`operator` stanza**: Configures ci-operator to build a `kueue-bundle` and apply pullspec
  substitutions replacing `registry.redhat.io` references with CI-built operator and operand images
- **New `test-e2e-ci-build-4-20` presubmit**: Installs the operator via `operator-sdk run bundle`
  using the `OO_BUNDLE` dependency pattern from the
  [operator SDK testing docs](https://docs.ci.openshift.org/how-tos/testing-operator-sdk-operators/)
- **Existing periodic tests are unchanged**

### Why

The current CI pipeline resolves images from Konflux at test runtime. If upstream images haven't
been rebuilt, tests can run against stale operand code with up-to-date test code ([OCPKUEUE-579](https://redhat.atlassian.net/browse/OCPKUEUE-579)).
Building images directly in ci-operator ensures presubmit tests always use images matching the
code under review.

### Things to verify

1. Git submodule `upstream/kueue` is initialized by ci-operator for the operand build
2. `bundle.Dockerfile` builds successfully in CI (uses `registry.redhat.io/ubi9/ubi` base)
3. Regex pullspec substitutions (`[@:].*`) correctly match SHA-pinned digests in the built bundle

---
> **AI Assistance Disclosure**: This pull request was created with the assistance of AI (Claude Code by Anthropic).

[OCPKUEUE-579]: https://redhat.atlassian.net/browse/OCPKUEUE-579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ