### PR TITLE
Add minimal set of RHCOS 9 periodic CI jobs for OCP 5.0

### DIFF
--- a/ci-operator/config/openshift/release/openshift-release-main__ci-5.0.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__ci-5.0.yaml
@@ -102,6 +102,7 @@ tests:
   steps:
     cluster_profile: openshift-org-aws
     env:
+      FEATURE_SET: TechPreviewNoUpgrade
       OS_IMAGE_STREAM: rhel-9
     observers:
       enable:
@@ -227,6 +228,7 @@ tests:
   steps:
     cluster_profile: openshift-org-azure
     env:
+      FEATURE_SET: TechPreviewNoUpgrade
       OS_IMAGE_STREAM: rhel-9
     observers:
       enable:
@@ -272,6 +274,7 @@ tests:
     cluster_profile: openshift-org-azure
     env:
       FAIL_ON_CORE_DUMP: "true"
+      FEATURE_SET: TechPreviewNoUpgrade
       OS_IMAGE_STREAM: rhel-9
       TEST_TYPE: upgrade-conformance
     observers:
@@ -359,6 +362,7 @@ tests:
     cluster_profile: gcp-openshift-gce-devel-ci-2
     env:
       FAIL_ON_CORE_DUMP: "true"
+      FEATURE_SET: TechPreviewNoUpgrade
       OS_IMAGE_STREAM: rhel-9
     observers:
       enable:

--- a/ci-operator/config/openshift/release/openshift-release-main__ci-5.0.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__ci-5.0.yaml
@@ -97,17 +97,6 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-aws-ovn
-- as: e2e-aws-ovn-rhcos9
-  interval: 12h
-  steps:
-    cluster_profile: openshift-org-aws
-    env:
-      FEATURE_SET: TechPreviewNoUpgrade
-      OS_IMAGE_STREAM: rhel-9
-    observers:
-      enable:
-      - observers-resource-watch
-    workflow: openshift-e2e-aws-ovn
 - as: e2e-aws-ovn-proxy
   interval: 168h
   steps:
@@ -223,7 +212,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-azure-serial
-- as: e2e-azure-ovn-serial-rhcos9
+- as: e2e-azure-ovn-serial-rhcos9-techpreview
   interval: 12h
   steps:
     cluster_profile: openshift-org-azure
@@ -268,7 +257,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-upgrade-azure-ovn
-- as: e2e-azure-ovn-upgrade-rhcos9
+- as: e2e-azure-ovn-upgrade-rhcos9-techpreview
   interval: 12h
   steps:
     cluster_profile: openshift-org-azure
@@ -356,7 +345,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-gcp-ovn
-- as: e2e-gcp-ovn-rhcos9
+- as: e2e-gcp-ovn-rhcos9-techpreview
   interval: 12h
   steps:
     cluster_profile: gcp-openshift-gce-devel-ci-2

--- a/ci-operator/config/openshift/release/openshift-release-main__ci-5.0.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__ci-5.0.yaml
@@ -348,7 +348,7 @@ tests:
 - as: e2e-gcp-ovn-rhcos9-techpreview
   interval: 12h
   steps:
-    cluster_profile: gcp-openshift-gce-devel-ci-2
+    cluster_profile: openshift-org-gcp
     env:
       FAIL_ON_CORE_DUMP: "true"
       FEATURE_SET: TechPreviewNoUpgrade

--- a/ci-operator/config/openshift/release/openshift-release-main__ci-5.0.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__ci-5.0.yaml
@@ -35,6 +35,17 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-aws-ovn
+- as: e2e-aws-ovn-rhcos9-techpreview
+  interval: 168h
+  steps:
+    cluster_profile: openshift-org-aws
+    env:
+      FEATURE_SET: TechPreviewNoUpgrade
+      OS_IMAGE_STREAM: rhel-9
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: openshift-e2e-aws-ovn
 - as: e2e-aws-ovn-rhcos10-techpreview
   interval: 168h
   steps:
@@ -86,6 +97,16 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-aws-ovn
+- as: e2e-aws-ovn-rhcos9
+  interval: 168h
+  steps:
+    cluster_profile: openshift-org-aws
+    env:
+      OS_IMAGE_STREAM: rhel-9
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: openshift-e2e-aws-ovn
 - as: e2e-aws-ovn-proxy
   interval: 168h
   steps:
@@ -109,6 +130,18 @@ tests:
     cluster_profile: openshift-org-aws
     env:
       FEATURE_SET: TechPreviewNoUpgrade
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: openshift-e2e-aws-ovn-serial
+- as: e2e-aws-ovn-rhcos9-techpreview-serial
+  interval: 168h
+  shard_count: 3
+  steps:
+    cluster_profile: openshift-org-aws
+    env:
+      FEATURE_SET: TechPreviewNoUpgrade
+      OS_IMAGE_STREAM: rhel-9
     observers:
       enable:
       - observers-resource-watch
@@ -189,6 +222,16 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-azure-serial
+- as: e2e-azure-ovn-serial-rhcos9
+  interval: 168h
+  steps:
+    cluster_profile: openshift-org-azure
+    env:
+      OS_IMAGE_STREAM: rhel-9
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: openshift-e2e-azure-serial
 - as: e2e-azure-ovn-techpreview-serial
   interval: 168h
   steps:
@@ -218,6 +261,18 @@ tests:
     cluster_profile: openshift-org-azure
     env:
       FAIL_ON_CORE_DUMP: "true"
+      TEST_TYPE: upgrade-conformance
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: openshift-upgrade-azure-ovn
+- as: e2e-azure-ovn-upgrade-rhcos9
+  interval: 168h
+  steps:
+    cluster_profile: openshift-org-azure
+    env:
+      FAIL_ON_CORE_DUMP: "true"
+      OS_IMAGE_STREAM: rhel-9
       TEST_TYPE: upgrade-conformance
     observers:
       enable:
@@ -294,6 +349,17 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       FAIL_ON_CORE_DUMP: "true"
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: openshift-e2e-gcp-ovn
+- as: e2e-gcp-ovn-rhcos9
+  interval: 168h
+  steps:
+    cluster_profile: gcp-openshift-gce-devel-ci-2
+    env:
+      FAIL_ON_CORE_DUMP: "true"
+      OS_IMAGE_STREAM: rhel-9
     observers:
       enable:
       - observers-resource-watch

--- a/ci-operator/config/openshift/release/openshift-release-main__ci-5.0.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__ci-5.0.yaml
@@ -36,7 +36,7 @@ tests:
       - observers-resource-watch
     workflow: openshift-e2e-aws-ovn
 - as: e2e-aws-ovn-rhcos9-techpreview
-  interval: 168h
+  interval: 12h
   steps:
     cluster_profile: openshift-org-aws
     env:
@@ -98,7 +98,7 @@ tests:
       - observers-resource-watch
     workflow: openshift-e2e-aws-ovn
 - as: e2e-aws-ovn-rhcos9
-  interval: 168h
+  interval: 12h
   steps:
     cluster_profile: openshift-org-aws
     env:
@@ -136,7 +136,7 @@ tests:
       - observers-resource-watch
     workflow: openshift-e2e-aws-ovn-serial
 - as: e2e-aws-ovn-rhcos9-techpreview-serial
-  interval: 168h
+  interval: 12h
   shard_count: 3
   steps:
     cluster_profile: openshift-org-aws
@@ -224,7 +224,7 @@ tests:
       - observers-resource-watch
     workflow: openshift-e2e-azure-serial
 - as: e2e-azure-ovn-serial-rhcos9
-  interval: 168h
+  interval: 12h
   steps:
     cluster_profile: openshift-org-azure
     env:
@@ -269,7 +269,7 @@ tests:
       - observers-resource-watch
     workflow: openshift-upgrade-azure-ovn
 - as: e2e-azure-ovn-upgrade-rhcos9
-  interval: 168h
+  interval: 12h
   steps:
     cluster_profile: openshift-org-azure
     env:
@@ -357,7 +357,7 @@ tests:
       - observers-resource-watch
     workflow: openshift-e2e-gcp-ovn
 - as: e2e-gcp-ovn-rhcos9
-  interval: 168h
+  interval: 12h
   steps:
     cluster_profile: gcp-openshift-gce-devel-ci-2
     env:

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
@@ -328,7 +328,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: baremetalds-e2e-upgrade-ovn-ipv4
-- as: e2e-metal-ipi-ovn-upgrade-rhcos9
+- as: e2e-metal-ipi-ovn-upgrade-rhcos9-techpreview
   capabilities:
   - intranet
   interval: 12h
@@ -486,7 +486,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: baremetalds-e2e-ovn-ipv6
-- as: e2e-metal-ipi-ovn-ipv6-rhcos9
+- as: e2e-metal-ipi-ovn-ipv6-rhcos9-techpreview
   capabilities:
   - intranet
   interval: 12h
@@ -521,7 +521,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: baremetalds-e2e-ovn-dualstack
-- as: e2e-metal-ipi-ovn-dualstack-rhcos9
+- as: e2e-metal-ipi-ovn-dualstack-rhcos9-techpreview
   capabilities:
   - intranet
   interval: 12h
@@ -975,7 +975,7 @@ tests:
       TEST_SKIPS: provisioning should mount multiple PV pointing to the same storage
         on the same node
     workflow: openshift-e2e-vsphere-ovn
-- as: e2e-vsphere-ovn-rhcos9
+- as: e2e-vsphere-ovn-rhcos9-techpreview-ovn
   interval: 24h
   steps:
     cluster_profile: vsphere-elastic
@@ -1022,7 +1022,7 @@ tests:
       TEST_SKIPS: provisioning should mount multiple PV pointing to the same storage
         on the same node
     workflow: openshift-e2e-vsphere-serial
-- as: e2e-vsphere-ovn-serial-rhcos9
+- as: e2e-vsphere-ovn-serial-rhcos9-techpreview
   interval: 24h
   steps:
     cluster_profile: vsphere-elastic
@@ -1270,7 +1270,7 @@ tests:
     - chain: ipi-aws-pre-stableinitial
     - ref: fips-check
     workflow: openshift-upgrade-aws-ovn
-- as: e2e-aws-ovn-upgrade-fips-rhcos9
+- as: e2e-aws-ovn-upgrade-fips-rhcos9-techpreview
   interval: 12h
   steps:
     cluster_profile: openshift-org-aws
@@ -1394,7 +1394,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-aws-ovn-serial
-- as: e2e-aws-ovn-serial-rhcos9
+- as: e2e-aws-ovn-serial-rhcos9-techpreview
   interval: 12h
   shard_count: 2
   steps:

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
@@ -328,6 +328,19 @@ tests:
       enable:
       - observers-resource-watch
     workflow: baremetalds-e2e-upgrade-ovn-ipv4
+- as: e2e-metal-ipi-ovn-upgrade-rhcos9
+  capabilities:
+  - intranet
+  interval: 168h
+  steps:
+    cluster_profile: equinix-ocp-metal
+    env:
+      OSSTREAM: rhel-9
+      TEST_TYPE: upgrade-conformance
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: baremetalds-e2e-upgrade-ovn-ipv4
 - as: e2e-metal-ipi-upgrade-ovn-ipv6
   capabilities:
   - intranet
@@ -471,6 +484,18 @@ tests:
       enable:
       - observers-resource-watch
     workflow: baremetalds-e2e-ovn-ipv6
+- as: e2e-metal-ipi-ovn-ipv6-rhcos9
+  capabilities:
+  - intranet
+  interval: 168h
+  steps:
+    cluster_profile: equinix-ocp-metal
+    env:
+      OSSTREAM: rhel-9
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: baremetalds-e2e-ovn-ipv6
 - as: e2e-metal-ipi-ovn-ipv6-runc
   capabilities:
   - intranet
@@ -487,6 +512,18 @@ tests:
   cron: 0 0 1 1 *
   steps:
     cluster_profile: equinix-ocp-metal
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: baremetalds-e2e-ovn-dualstack
+- as: e2e-metal-ipi-ovn-dualstack-rhcos9
+  capabilities:
+  - intranet
+  interval: 168h
+  steps:
+    cluster_profile: equinix-ocp-metal
+    env:
+      OSSTREAM: rhel-9
     observers:
       enable:
       - observers-resource-watch
@@ -875,6 +912,19 @@ tests:
       TEST_SKIPS: 'In-tree Volumes \[Driver: vsphere\] \[Testpattern: Inline-volume\|
         In-tree Volumes \[Driver: vsphere\] \[Testpattern: Pre-provisioned PV'
     workflow: openshift-e2e-vsphere
+- as: e2e-vsphere-ovn-rhcos9-techpreview
+  interval: 168h
+  steps:
+    cluster_profile: vsphere-elastic
+    env:
+      FEATURE_SET: TechPreviewNoUpgrade
+      OS_IMAGE_STREAM: rhel-9
+      TEST_SKIPS: 'In-tree Volumes \[Driver: vsphere\] \[Testpattern: Inline-volume\|
+        In-tree Volumes \[Driver: vsphere\] \[Testpattern: Pre-provisioned PV'
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: openshift-e2e-vsphere
 - as: e2e-vsphere-ovn-rhcos10-techpreview
   cron: 1 18 * * 0
   steps:
@@ -917,6 +967,18 @@ tests:
       TEST_SKIPS: provisioning should mount multiple PV pointing to the same storage
         on the same node
     workflow: openshift-e2e-vsphere-ovn
+- as: e2e-vsphere-ovn-rhcos9
+  interval: 168h
+  steps:
+    cluster_profile: vsphere-elastic
+    env:
+      OS_IMAGE_STREAM: rhel-9
+      TEST_SKIPS: provisioning should mount multiple PV pointing to the same storage
+        on the same node
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: openshift-e2e-vsphere-ovn
 - as: e2e-vsphere-ovn-vcf9
   cron: 23,53 12,19 * * *
   steps:
@@ -951,6 +1013,18 @@ tests:
       TEST_SKIPS: provisioning should mount multiple PV pointing to the same storage
         on the same node
     workflow: openshift-e2e-vsphere-serial
+- as: e2e-vsphere-ovn-serial-rhcos9
+  interval: 168h
+  steps:
+    cluster_profile: vsphere-elastic
+    env:
+      OS_IMAGE_STREAM: rhel-9
+      TEST_SKIPS: provisioning should mount multiple PV pointing to the same storage
+        on the same node
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: openshift-e2e-vsphere-serial
 - as: e2e-vsphere-ovn-techpreview-serial
   cron: 40,55 2,9,10 * * *
   steps:
@@ -959,6 +1033,17 @@ tests:
       FEATURE_SET: TechPreviewNoUpgrade
     workflow: openshift-e2e-vsphere-serial
   timeout: 5h0m0s
+- as: e2e-vsphere-ovn-rhcos9-techpreview-serial
+  interval: 168h
+  steps:
+    cluster_profile: vsphere-elastic
+    env:
+      FEATURE_SET: TechPreviewNoUpgrade
+      OS_IMAGE_STREAM: rhel-9
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: openshift-e2e-vsphere-serial
 - as: e2e-vsphere-ovn-rhcos10-techpreview-serial
   cron: 3 4 * * 4
   steps:
@@ -1175,6 +1260,22 @@ tests:
     - chain: ipi-aws-pre-stableinitial
     - ref: fips-check
     workflow: openshift-upgrade-aws-ovn
+- as: e2e-aws-ovn-upgrade-fips-rhcos9
+  interval: 168h
+  steps:
+    cluster_profile: openshift-org-aws
+    env:
+      FAIL_ON_CORE_DUMP: "true"
+      FIPS_ENABLED: "true"
+      OS_IMAGE_STREAM: rhel-9
+      TEST_TYPE: upgrade-conformance
+    observers:
+      enable:
+      - observers-resource-watch
+    pre:
+    - chain: ipi-aws-pre-stableinitial
+    - ref: fips-check
+    workflow: openshift-upgrade-aws-ovn
 - as: e2e-aws-ovn-upgrade-fips-no-nat-instance
   interval: 168h
   steps:
@@ -1278,6 +1379,17 @@ tests:
   shard_count: 2
   steps:
     cluster_profile: openshift-org-aws
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: openshift-e2e-aws-ovn-serial
+- as: e2e-aws-ovn-serial-rhcos9
+  interval: 168h
+  shard_count: 2
+  steps:
+    cluster_profile: openshift-org-aws
+    env:
+      OS_IMAGE_STREAM: rhel-9
     observers:
       enable:
       - observers-resource-watch

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
@@ -331,7 +331,7 @@ tests:
 - as: e2e-metal-ipi-ovn-upgrade-rhcos9
   capabilities:
   - intranet
-  interval: 168h
+  interval: 12h
   steps:
     cluster_profile: equinix-ocp-metal
     env:
@@ -489,7 +489,7 @@ tests:
 - as: e2e-metal-ipi-ovn-ipv6-rhcos9
   capabilities:
   - intranet
-  interval: 168h
+  interval: 12h
   steps:
     cluster_profile: equinix-ocp-metal
     env:
@@ -524,7 +524,7 @@ tests:
 - as: e2e-metal-ipi-ovn-dualstack-rhcos9
   capabilities:
   - intranet
-  interval: 168h
+  interval: 12h
   steps:
     cluster_profile: equinix-ocp-metal
     env:
@@ -921,7 +921,7 @@ tests:
         In-tree Volumes \[Driver: vsphere\] \[Testpattern: Pre-provisioned PV'
     workflow: openshift-e2e-vsphere
 - as: e2e-vsphere-ovn-rhcos9-techpreview
-  interval: 168h
+  interval: 24h
   steps:
     cluster_profile: vsphere-elastic
     env:
@@ -976,7 +976,7 @@ tests:
         on the same node
     workflow: openshift-e2e-vsphere-ovn
 - as: e2e-vsphere-ovn-rhcos9
-  interval: 168h
+  interval: 24h
   steps:
     cluster_profile: vsphere-elastic
     env:
@@ -1023,7 +1023,7 @@ tests:
         on the same node
     workflow: openshift-e2e-vsphere-serial
 - as: e2e-vsphere-ovn-serial-rhcos9
-  interval: 168h
+  interval: 24h
   steps:
     cluster_profile: vsphere-elastic
     env:
@@ -1044,7 +1044,7 @@ tests:
     workflow: openshift-e2e-vsphere-serial
   timeout: 5h0m0s
 - as: e2e-vsphere-ovn-rhcos9-techpreview-serial
-  interval: 168h
+  interval: 24h
   steps:
     cluster_profile: vsphere-elastic
     env:
@@ -1271,7 +1271,7 @@ tests:
     - ref: fips-check
     workflow: openshift-upgrade-aws-ovn
 - as: e2e-aws-ovn-upgrade-fips-rhcos9
-  interval: 168h
+  interval: 12h
   steps:
     cluster_profile: openshift-org-aws
     env:
@@ -1395,7 +1395,7 @@ tests:
       - observers-resource-watch
     workflow: openshift-e2e-aws-ovn-serial
 - as: e2e-aws-ovn-serial-rhcos9
-  interval: 168h
+  interval: 12h
   shard_count: 2
   steps:
     cluster_profile: openshift-org-aws

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
@@ -337,7 +337,7 @@ tests:
     env:
       DEVSCRIPTS_CONFIG: |
         FEATURE_SET=TechPreviewNoUpgrade
-      OSSTREAM: rhel-9
+        OS_IMAGE_STREAM=rhel-9
       TEST_TYPE: upgrade-conformance
     observers:
       enable:
@@ -496,7 +496,7 @@ tests:
       DEVSCRIPTS_CONFIG: |
         IP_STACK=v6
         FEATURE_SET=TechPreviewNoUpgrade
-      OSSTREAM: rhel-9
+        OS_IMAGE_STREAM=rhel-9
     observers:
       enable:
       - observers-resource-watch
@@ -531,7 +531,7 @@ tests:
       DEVSCRIPTS_CONFIG: |
         IP_STACK=v4v6
         FEATURE_SET=TechPreviewNoUpgrade
-      OSSTREAM: rhel-9
+        OS_IMAGE_STREAM=rhel-9
     observers:
       enable:
       - observers-resource-watch

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
@@ -335,6 +335,8 @@ tests:
   steps:
     cluster_profile: equinix-ocp-metal
     env:
+      DEVSCRIPTS_CONFIG: |
+        FEATURE_SET=TechPreviewNoUpgrade
       OSSTREAM: rhel-9
       TEST_TYPE: upgrade-conformance
     observers:
@@ -491,6 +493,9 @@ tests:
   steps:
     cluster_profile: equinix-ocp-metal
     env:
+      DEVSCRIPTS_CONFIG: |
+        IP_STACK=v6
+        FEATURE_SET=TechPreviewNoUpgrade
       OSSTREAM: rhel-9
     observers:
       enable:
@@ -523,6 +528,9 @@ tests:
   steps:
     cluster_profile: equinix-ocp-metal
     env:
+      DEVSCRIPTS_CONFIG: |
+        IP_STACK=v4v6
+        FEATURE_SET=TechPreviewNoUpgrade
       OSSTREAM: rhel-9
     observers:
       enable:
@@ -972,6 +980,7 @@ tests:
   steps:
     cluster_profile: vsphere-elastic
     env:
+      FEATURE_SET: TechPreviewNoUpgrade
       OS_IMAGE_STREAM: rhel-9
       TEST_SKIPS: provisioning should mount multiple PV pointing to the same storage
         on the same node
@@ -1018,6 +1027,7 @@ tests:
   steps:
     cluster_profile: vsphere-elastic
     env:
+      FEATURE_SET: TechPreviewNoUpgrade
       OS_IMAGE_STREAM: rhel-9
       TEST_SKIPS: provisioning should mount multiple PV pointing to the same storage
         on the same node
@@ -1266,6 +1276,7 @@ tests:
     cluster_profile: openshift-org-aws
     env:
       FAIL_ON_CORE_DUMP: "true"
+      FEATURE_SET: TechPreviewNoUpgrade
       FIPS_ENABLED: "true"
       OS_IMAGE_STREAM: rhel-9
       TEST_TYPE: upgrade-conformance
@@ -1389,6 +1400,7 @@ tests:
   steps:
     cluster_profile: openshift-org-aws
     env:
+      FEATURE_SET: TechPreviewNoUpgrade
       OS_IMAGE_STREAM: rhel-9
     observers:
       enable:


### PR DESCRIPTION
With OCP 5.0 defaulting to RHCOS 10, a minimal set of RHCOS 9 jobs is needed to monitor RHCOS 9 specific regressions across core platforms.

CI stream (ci-5.0): e2e-aws-ovn, e2e-gcp-ovn, e2e-azure-ovn-serial, e2e-aws-ovn-techpreview, e2e-aws-ovn-techpreview-serial (sharded), e2e-azure-ovn-upgrade.

Nightly stream (nightly-5.0): e2e-vsphere-ovn, e2e-metal-ipi-ovn-ipv6, e2e-metal-ipi-ovn-dualstack, e2e-aws-ovn-serial (sharded), e2e-vsphere-ovn-serial, e2e-vsphere-ovn-techpreview, e2e-vsphere-ovn-techpreview-serial, e2e-aws-ovn-upgrade-fips, e2e-metal-ipi-ovn-upgrade.

All jobs use OS_IMAGE_STREAM=rhel-9 (or OSSTREAM=rhel-9 for metal) with interval: 168h scheduling to keep costs down.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded automated testing coverage for RHCOS 9 in tech preview mode across AWS, Azure, GCP, vSphere, and bare metal platforms.
  * Added new scheduled test jobs for upgrade scenarios and networking configurations with 12-hour test intervals.
  * Enables broader environment coverage to ensure stability across cloud and on-premises deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->