### PR TITLE
OU-1184: perses periodic and coo-0.5

### DIFF
--- a/ci-operator/config/openshift/monitoring-plugin/.config.prowgen
+++ b/ci-operator/config/openshift/monitoring-plugin/.config.prowgen
@@ -14,3 +14,5 @@ slack_reporter:
   - e2e-incidents
   - e2e-monitoring-dev
   - e2e-virtualization
+  - e2e-perses
+  - e2e-perses-dev

--- a/ci-operator/config/openshift/monitoring-plugin/openshift-monitoring-plugin-main.yaml
+++ b/ci-operator/config/openshift/monitoring-plugin/openshift-monitoring-plugin-main.yaml
@@ -229,6 +229,14 @@ tests:
     - ref: monitoring-plugin-tests-virtualization-ui
     workflow: generic-claim
 - always_run: false
+  as: e2e-perses
+  optional: true
+  steps:
+    cluster_profile: openshift-org-aws
+    test:
+    - ref: monitoring-plugin-tests-perses-ui
+    workflow: ipi-aws
+- always_run: false
   as: e2e-monitoring-dev
   optional: true
   steps:
@@ -237,12 +245,12 @@ tests:
     - ref: monitoring-plugin-tests-monitoring-dev-ui
     workflow: ipi-aws
 - always_run: false
-  as: e2e-perses
+  as: e2e-perses-dev
   optional: true
   steps:
     cluster_profile: openshift-org-aws
     test:
-    - ref: monitoring-plugin-tests-perses-ui
+    - ref: monitoring-plugin-tests-perses-dev-ui
     workflow: ipi-aws
 zz_generated_metadata:
   branch: main

--- a/ci-operator/config/openshift/monitoring-plugin/openshift-monitoring-plugin-main__periodics.yaml
+++ b/ci-operator/config/openshift/monitoring-plugin/openshift-monitoring-plugin-main__periodics.yaml
@@ -64,6 +64,20 @@ tests:
     test:
     - ref: monitoring-plugin-tests-virtualization-ui
     workflow: ipi-aws
+- as: e2e-perses
+  cron: 0 5 * * *
+  steps:
+    cluster_profile: openshift-org-aws
+    test:
+    - ref: monitoring-plugin-tests-perses-ui
+    workflow: ipi-aws
+- as: e2e-perses-dev
+  cron: 0 5 * * *
+  steps:
+    cluster_profile: openshift-org-aws
+    test:
+    - ref: monitoring-plugin-tests-perses-dev-ui
+    workflow: ipi-aws
 zz_generated_metadata:
   branch: main
   org: openshift

--- a/ci-operator/config/openshift/monitoring-plugin/openshift-monitoring-plugin-release-4.22.yaml
+++ b/ci-operator/config/openshift/monitoring-plugin/openshift-monitoring-plugin-release-4.22.yaml
@@ -229,6 +229,14 @@ tests:
     - ref: monitoring-plugin-tests-virtualization-ui
     workflow: generic-claim
 - always_run: false
+  as: e2e-perses
+  optional: true
+  steps:
+    cluster_profile: openshift-org-aws
+    test:
+    - ref: monitoring-plugin-tests-perses-ui
+    workflow: ipi-aws
+- always_run: false
   as: e2e-monitoring-dev
   optional: true
   steps:
@@ -237,12 +245,12 @@ tests:
     - ref: monitoring-plugin-tests-monitoring-dev-ui
     workflow: ipi-aws
 - always_run: false
-  as: e2e-perses
+  as: e2e-perses-dev
   optional: true
   steps:
     cluster_profile: openshift-org-aws
     test:
-    - ref: monitoring-plugin-tests-perses-ui
+    - ref: monitoring-plugin-tests-perses-dev-ui
     workflow: ipi-aws
 zz_generated_metadata:
   branch: release-4.22

--- a/ci-operator/config/openshift/monitoring-plugin/openshift-monitoring-plugin-release-4.23.yaml
+++ b/ci-operator/config/openshift/monitoring-plugin/openshift-monitoring-plugin-release-4.23.yaml
@@ -229,6 +229,14 @@ tests:
     - ref: monitoring-plugin-tests-virtualization-ui
     workflow: generic-claim
 - always_run: false
+  as: e2e-perses
+  optional: true
+  steps:
+    cluster_profile: openshift-org-aws
+    test:
+    - ref: monitoring-plugin-tests-perses-ui
+    workflow: ipi-aws
+- always_run: false
   as: e2e-monitoring-dev
   optional: true
   steps:
@@ -237,12 +245,12 @@ tests:
     - ref: monitoring-plugin-tests-monitoring-dev-ui
     workflow: ipi-aws
 - always_run: false
-  as: e2e-perses
+  as: e2e-perses-dev
   optional: true
   steps:
     cluster_profile: openshift-org-aws
     test:
-    - ref: monitoring-plugin-tests-perses-ui
+    - ref: monitoring-plugin-tests-perses-dev-ui
     workflow: ipi-aws
 zz_generated_metadata:
   branch: release-4.23

--- a/ci-operator/config/openshift/monitoring-plugin/openshift-monitoring-plugin-release-5.0.yaml
+++ b/ci-operator/config/openshift/monitoring-plugin/openshift-monitoring-plugin-release-5.0.yaml
@@ -230,6 +230,14 @@ tests:
     - ref: monitoring-plugin-tests-virtualization-ui
     workflow: generic-claim
 - always_run: false
+  as: e2e-perses
+  optional: true
+  steps:
+    cluster_profile: openshift-org-aws
+    test:
+    - ref: monitoring-plugin-tests-perses-ui
+    workflow: ipi-aws
+- always_run: false
   as: e2e-monitoring-dev
   optional: true
   steps:
@@ -238,12 +246,12 @@ tests:
     - ref: monitoring-plugin-tests-monitoring-dev-ui
     workflow: ipi-aws
 - always_run: false
-  as: e2e-perses
+  as: e2e-perses-dev
   optional: true
   steps:
     cluster_profile: openshift-org-aws
     test:
-    - ref: monitoring-plugin-tests-perses-ui
+    - ref: monitoring-plugin-tests-perses-dev-ui
     workflow: ipi-aws
 zz_generated_metadata:
   branch: release-5.0

--- a/ci-operator/config/openshift/monitoring-plugin/openshift-monitoring-plugin-release-coo-0.5.yaml
+++ b/ci-operator/config/openshift/monitoring-plugin/openshift-monitoring-plugin-release-coo-0.5.yaml
@@ -195,12 +195,28 @@ tests:
     - ref: monitoring-plugin-tests-virtualization-ui
     workflow: generic-claim
 - always_run: false
+  as: e2e-perses
+  optional: true
+  steps:
+    cluster_profile: openshift-org-aws
+    test:
+    - ref: monitoring-plugin-tests-perses-ui
+    workflow: ipi-aws
+- always_run: false
   as: e2e-monitoring-dev
   optional: true
   steps:
     cluster_profile: openshift-org-aws
     test:
     - ref: monitoring-plugin-tests-monitoring-dev-ui
+    workflow: ipi-aws
+- always_run: false
+  as: e2e-perses-dev
+  optional: true
+  steps:
+    cluster_profile: openshift-org-aws
+    test:
+    - ref: monitoring-plugin-tests-perses-dev-ui
     workflow: ipi-aws
 zz_generated_metadata:
   branch: release-coo-0.5

--- a/ci-operator/jobs/openshift/monitoring-plugin/openshift-monitoring-plugin-main-periodics.yaml
+++ b/ci-operator/jobs/openshift/monitoring-plugin/openshift-monitoring-plugin-main-periodics.yaml
@@ -377,6 +377,188 @@ periodics:
     ci-operator.openshift.io/variant: periodics
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-monitoring-plugin-main-periodics-e2e-perses
+  reporter_config:
+    slack:
+      channel: '#observability-ui-qe'
+      job_states_to_report:
+      - success
+      - failure
+      - error
+      report_template: '{{if eq .Status.State "success"}} :rainbow: Job *{{.Spec.Job}}*
+        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :rainbow: {{else}}
+        :volcano: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+        logs> :volcano: {{end}}'
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-perses
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build11
+  cron: 0 5 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: monitoring-plugin
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-monitoring-plugin-main-periodics-e2e-perses-dev
+  reporter_config:
+    slack:
+      channel: '#observability-ui-qe'
+      job_states_to_report:
+      - success
+      - failure
+      - error
+      report_template: '{{if eq .Status.State "success"}} :rainbow: Job *{{.Spec.Job}}*
+        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :rainbow: {{else}}
+        :volcano: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+        logs> :volcano: {{end}}'
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-perses-dev
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build11
+  cron: 0 5 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: monitoring-plugin
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-monitoring-plugin-main-periodics-e2e-virtualization
   reporter_config:
     slack:

--- a/ci-operator/jobs/openshift/monitoring-plugin/openshift-monitoring-plugin-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/monitoring-plugin/openshift-monitoring-plugin-main-presubmits.yaml
@@ -1070,6 +1070,17 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-monitoring-plugin-main-e2e-perses
     optional: true
+    reporter_config:
+      slack:
+        channel: '#observability-ui-qe'
+        job_states_to_report:
+        - success
+        - failure
+        - error
+        report_template: '{{if eq .Status.State "success"}} :rainbow: Job *{{.Spec.Job}}*
+          ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :rainbow: {{else}}
+          :volcano: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+          logs> :volcano: {{end}}'
     rerun_command: /test e2e-perses
     spec:
       containers:
@@ -1136,6 +1147,98 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-perses,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build01
+    context: ci/prow/e2e-perses-dev
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-monitoring-plugin-main-e2e-perses-dev
+    optional: true
+    reporter_config:
+      slack:
+        channel: '#observability-ui-qe'
+        job_states_to_report:
+        - success
+        - failure
+        - error
+        report_template: '{{if eq .Status.State "success"}} :rainbow: Job *{{.Spec.Job}}*
+          ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :rainbow: {{else}}
+          :volcano: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+          logs> :volcano: {{end}}'
+    rerun_command: /test e2e-perses-dev
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-perses-dev
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-perses-dev,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:

--- a/ci-operator/jobs/openshift/monitoring-plugin/openshift-monitoring-plugin-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift/monitoring-plugin/openshift-monitoring-plugin-release-4.22-presubmits.yaml
@@ -1070,6 +1070,17 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-monitoring-plugin-release-4.22-e2e-perses
     optional: true
+    reporter_config:
+      slack:
+        channel: '#observability-ui-qe'
+        job_states_to_report:
+        - success
+        - failure
+        - error
+        report_template: '{{if eq .Status.State "success"}} :rainbow: Job *{{.Spec.Job}}*
+          ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :rainbow: {{else}}
+          :volcano: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+          logs> :volcano: {{end}}'
     rerun_command: /test e2e-perses
     spec:
       containers:
@@ -1136,6 +1147,98 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-perses,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.22$
+    - ^release-4\.22-
+    cluster: build01
+    context: ci/prow/e2e-perses-dev
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-monitoring-plugin-release-4.22-e2e-perses-dev
+    optional: true
+    reporter_config:
+      slack:
+        channel: '#observability-ui-qe'
+        job_states_to_report:
+        - success
+        - failure
+        - error
+        report_template: '{{if eq .Status.State "success"}} :rainbow: Job *{{.Spec.Job}}*
+          ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :rainbow: {{else}}
+          :volcano: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+          logs> :volcano: {{end}}'
+    rerun_command: /test e2e-perses-dev
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-perses-dev
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-perses-dev,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:

--- a/ci-operator/jobs/openshift/monitoring-plugin/openshift-monitoring-plugin-release-4.23-presubmits.yaml
+++ b/ci-operator/jobs/openshift/monitoring-plugin/openshift-monitoring-plugin-release-4.23-presubmits.yaml
@@ -1070,6 +1070,17 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-monitoring-plugin-release-4.23-e2e-perses
     optional: true
+    reporter_config:
+      slack:
+        channel: '#observability-ui-qe'
+        job_states_to_report:
+        - success
+        - failure
+        - error
+        report_template: '{{if eq .Status.State "success"}} :rainbow: Job *{{.Spec.Job}}*
+          ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :rainbow: {{else}}
+          :volcano: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+          logs> :volcano: {{end}}'
     rerun_command: /test e2e-perses
     spec:
       containers:
@@ -1136,6 +1147,98 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-perses,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.23$
+    - ^release-4\.23-
+    cluster: build01
+    context: ci/prow/e2e-perses-dev
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-monitoring-plugin-release-4.23-e2e-perses-dev
+    optional: true
+    reporter_config:
+      slack:
+        channel: '#observability-ui-qe'
+        job_states_to_report:
+        - success
+        - failure
+        - error
+        report_template: '{{if eq .Status.State "success"}} :rainbow: Job *{{.Spec.Job}}*
+          ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :rainbow: {{else}}
+          :volcano: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+          logs> :volcano: {{end}}'
+    rerun_command: /test e2e-perses-dev
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-perses-dev
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-perses-dev,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:

--- a/ci-operator/jobs/openshift/monitoring-plugin/openshift-monitoring-plugin-release-5.0-presubmits.yaml
+++ b/ci-operator/jobs/openshift/monitoring-plugin/openshift-monitoring-plugin-release-5.0-presubmits.yaml
@@ -1070,6 +1070,17 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-monitoring-plugin-release-5.0-e2e-perses
     optional: true
+    reporter_config:
+      slack:
+        channel: '#observability-ui-qe'
+        job_states_to_report:
+        - success
+        - failure
+        - error
+        report_template: '{{if eq .Status.State "success"}} :rainbow: Job *{{.Spec.Job}}*
+          ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :rainbow: {{else}}
+          :volcano: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+          logs> :volcano: {{end}}'
     rerun_command: /test e2e-perses
     spec:
       containers:
@@ -1136,6 +1147,98 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-perses,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-5\.0$
+    - ^release-5\.0-
+    cluster: build11
+    context: ci/prow/e2e-perses-dev
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-monitoring-plugin-release-5.0-e2e-perses-dev
+    optional: true
+    reporter_config:
+      slack:
+        channel: '#observability-ui-qe'
+        job_states_to_report:
+        - success
+        - failure
+        - error
+        report_template: '{{if eq .Status.State "success"}} :rainbow: Job *{{.Spec.Job}}*
+          ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :rainbow: {{else}}
+          :volcano: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+          logs> :volcano: {{end}}'
+    rerun_command: /test e2e-perses-dev
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-perses-dev
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-perses-dev,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:

--- a/ci-operator/jobs/openshift/monitoring-plugin/openshift-monitoring-plugin-release-5.1-presubmits.yaml
+++ b/ci-operator/jobs/openshift/monitoring-plugin/openshift-monitoring-plugin-release-5.1-presubmits.yaml
@@ -1070,6 +1070,17 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-monitoring-plugin-release-5.1-e2e-perses
     optional: true
+    reporter_config:
+      slack:
+        channel: '#observability-ui-qe'
+        job_states_to_report:
+        - success
+        - failure
+        - error
+        report_template: '{{if eq .Status.State "success"}} :rainbow: Job *{{.Spec.Job}}*
+          ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :rainbow: {{else}}
+          :volcano: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+          logs> :volcano: {{end}}'
     rerun_command: /test e2e-perses
     spec:
       containers:

--- a/ci-operator/jobs/openshift/monitoring-plugin/openshift-monitoring-plugin-release-coo-0.5-presubmits.yaml
+++ b/ci-operator/jobs/openshift/monitoring-plugin/openshift-monitoring-plugin-release-coo-0.5-presubmits.yaml
@@ -899,6 +899,190 @@ presubmits:
     branches:
     - ^release-coo-0\.5$
     - ^release-coo-0\.5-
+    cluster: build06
+    context: ci/prow/e2e-perses
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-monitoring-plugin-release-coo-0.5-e2e-perses
+    optional: true
+    reporter_config:
+      slack:
+        channel: '#observability-ui-qe'
+        job_states_to_report:
+        - success
+        - failure
+        - error
+        report_template: '{{if eq .Status.State "success"}} :rainbow: Job *{{.Spec.Job}}*
+          ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :rainbow: {{else}}
+          :volcano: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+          logs> :volcano: {{end}}'
+    rerun_command: /test e2e-perses
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-perses
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-perses,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-coo-0\.5$
+    - ^release-coo-0\.5-
+    cluster: build06
+    context: ci/prow/e2e-perses-dev
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-monitoring-plugin-release-coo-0.5-e2e-perses-dev
+    optional: true
+    reporter_config:
+      slack:
+        channel: '#observability-ui-qe'
+        job_states_to_report:
+        - success
+        - failure
+        - error
+        report_template: '{{if eq .Status.State "success"}} :rainbow: Job *{{.Spec.Job}}*
+          ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :rainbow: {{else}}
+          :volcano: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+          logs> :volcano: {{end}}'
+    rerun_command: /test e2e-perses-dev
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-perses-dev
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-perses-dev,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-coo-0\.5$
+    - ^release-coo-0\.5-
     cluster: build04
     context: ci/prow/e2e-virtualization
     decorate: true

--- a/ci-operator/step-registry/monitoring-plugin/tests/coo-ui/monitoring-plugin-tests-coo-ui-ref.yaml
+++ b/ci-operator/step-registry/monitoring-plugin/tests/coo-ui/monitoring-plugin-tests-coo-ui-ref.yaml
@@ -7,9 +7,9 @@ ref:
   resources:
     requests:
       cpu: "1"
-      memory: 3Gi
+      memory: 8Gi
     limits:
-      memory: 4Gi
+      memory: 8Gi
   env:
   - name: CYPRESS_SKIP_COO_INSTALL
     default: ""

--- a/ci-operator/step-registry/monitoring-plugin/tests/perses-dev-ui/OWNERS
+++ b/ci-operator/step-registry/monitoring-plugin/tests/perses-dev-ui/OWNERS
@@ -1,0 +1,14 @@
+approvers:
+- etmurasaki
+- jan--f
+- jgbernalp
+- kyoto
+- peteryurkovich
+- zhuje
+options: {}
+reviewers:
+- etmurasaki
+- jgbernalp
+- kyoto
+- peteryurkovich
+- zhuje

--- a/ci-operator/step-registry/monitoring-plugin/tests/perses-dev-ui/monitoring-plugin-tests-perses-dev-ui-commands.sh
+++ b/ci-operator/step-registry/monitoring-plugin/tests/perses-dev-ui/monitoring-plugin-tests-perses-dev-ui-commands.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+# List of variables to check.
+vars=(
+  CYPRESS_SKIP_COO_INSTALL
+  CYPRESS_COO_UI_INSTALL
+  CYPRESS_KONFLUX_COO_BUNDLE_IMAGE
+  CYPRESS_CUSTOM_COO_BUNDLE_IMAGE
+  CYPRESS_MCP_CONSOLE_IMAGE
+  CYPRESS_MP_IMAGE
+  CYPRESS_FBC_STAGE_COO_IMAGE
+  CYPRESS_TIMEZONE
+  CYPRESS_SESSION
+  CYPRESS_DEBUG
+  CYPRESS_SKIP_KBV_INSTALL
+  CYPRESS_KBV_UI_INSTALL
+  CYPRESS_KONFLUX_KBV_BUNDLE_IMAGE
+  CYPRESS_CUSTOM_KBV_BUNDLE_IMAGE
+  CYPRESS_FBC_STAGE_KBV_IMAGE
+)
+
+# Loop through each variable.
+for var in "${vars[@]}"; do
+  if [[ -z "${!var:-}" ]]; then
+    unset "$var"
+    echo "Unset variable: $var"
+  else
+    echo "$var is set to '${!var}'"
+  fi
+done
+
+# Read kubeadmin password from file
+if [[ -z "${KUBEADMIN_PASSWORD_FILE:-}" ]]; then
+  echo "Error: KUBEADMIN_PASSWORD_FILE variable is not set"
+  exit 0
+fi
+
+if [[ ! -f "${KUBEADMIN_PASSWORD_FILE}" ]]; then
+  echo "Error: Kubeadmin password file ${KUBEADMIN_PASSWORD_FILE} does not exist"
+  exit 0
+fi
+
+kubeadmin_password=$(cat "${KUBEADMIN_PASSWORD_FILE}")
+echo "Successfully read kubeadmin password from ${KUBEADMIN_PASSWORD_FILE}"
+
+# Set proxy vars.
+if [ -f "${SHARED_DIR}/proxy-conf.sh" ] ; then
+  source "${SHARED_DIR}/proxy-conf.sh"
+fi
+
+## skip all tests when console is not installed.
+if ! (oc get clusteroperator console --kubeconfig=${KUBECONFIG}) ; then
+  echo "console is not installed, skipping all console tests."
+  exit 0
+fi
+
+# Function to copy artifacts to the artifact directory after test run.
+function copyArtifacts {
+  if [ -d "/tmp/monitoring-plugin/web/cypress/screenshots/" ]; then
+    cp -r /tmp/monitoring-plugin/web/cypress/screenshots/ "${ARTIFACT_DIR}/screenshots"
+    echo "Screenshots copied successfully."
+  else
+    echo "Directory screenshots does not exist. Nothing to copy."
+  fi
+  if [ -d "/tmp/monitoring-plugin/web/cypress/videos/" ]; then
+    cp -r /tmp/monitoring-plugin/web/cypress/videos/ "${ARTIFACT_DIR}/videos"
+    echo "Videos copied successfully."
+  else
+    echo "Directory videos does not exist. Nothing to copy."
+  fi
+}
+
+## Add IDP for testing
+# prepare users
+users=""
+htpass_file=/tmp/users.htpasswd
+
+for i in $(seq 1 5); do
+    username="uiauto-test-${i}"
+    password=$(tr </dev/urandom -dc 'a-z0-9' | fold -w 12 | head -n 1 || true)
+    users+="${username}:${password},"
+    if [ -f "${htpass_file}" ]; then
+        htpasswd -B -b ${htpass_file} "${username}" "${password}"
+    else
+        htpasswd -c -B -b ${htpass_file} "${username}" "${password}"
+    fi
+done
+
+# remove trailing ',' for case parsing
+users=${users%?}
+
+# add users to cluster
+oc create secret generic uiauto-htpass-secret --from-file=htpasswd=${htpass_file} -n openshift-config
+oc patch oauth cluster --type='json' -p='[{"op": "add", "path": "/spec/identityProviders", "value": [{"type": "HTPasswd", "name": "uiauto-htpasswd-idp", "mappingMethod": "claim", "htpasswd":{"fileData":{"name": "uiauto-htpass-secret"}}}]}]'
+
+## wait for oauth-openshift to rollout
+oc rollout status deployment/oauth-openshift -n openshift-authentication --timeout=10m
+echo "authentication operator finished updating"
+
+# Copy the artifacts to the aritfact directory at the end of the test run.
+trap copyArtifacts EXIT
+
+# Set Kubeconfig var for Cypress.
+cp -L $KUBECONFIG /tmp/kubeconfig && export CYPRESS_KUBECONFIG_PATH=/tmp/kubeconfig
+
+# Set Cypress base URL var.
+console_route=$(oc get route console -n openshift-console -o jsonpath='{.spec.host}')
+export CYPRESS_BASE_URL=https://$console_route
+
+# Set Cypress authentication username and password.
+# Use the IDP once issue https://issues.redhat.com/browse/OCPBUGS-59366 is fixed.
+export CYPRESS_LOGIN_IDP_DEV_USER=uiauto-htpasswd-idp
+export CYPRESS_LOGIN_IDP=kube:admin
+export CYPRESS_LOGIN_USERS=kubeadmin:${kubeadmin_password},${users}
+
+# Run the Cypress tests.
+export NO_COLOR=1
+export CYPRESS_CACHE_FOLDER=/tmp/Cypress
+
+# Install npm modules
+ls -ltr
+npm install
+
+# Run the Cypress tests
+npm run test-cypress-perses-dev

--- a/ci-operator/step-registry/monitoring-plugin/tests/perses-dev-ui/monitoring-plugin-tests-perses-dev-ui-ref.metadata.json
+++ b/ci-operator/step-registry/monitoring-plugin/tests/perses-dev-ui/monitoring-plugin-tests-perses-dev-ui-ref.metadata.json
@@ -1,0 +1,20 @@
+{
+	"path": "monitoring-plugin/tests/perses-dev-ui/monitoring-plugin-tests-perses-dev-ui-ref.yaml",
+	"owners": {
+		"approvers": [
+			"etmurasaki",
+			"jan--f",
+			"jgbernalp",
+			"kyoto",
+			"peteryurkovich",
+			"zhuje"
+		],
+		"reviewers": [
+			"etmurasaki",
+			"jgbernalp",
+			"kyoto",
+			"peteryurkovich",
+			"zhuje"
+		]
+	}
+}

--- a/ci-operator/step-registry/monitoring-plugin/tests/perses-dev-ui/monitoring-plugin-tests-perses-dev-ui-ref.yaml
+++ b/ci-operator/step-registry/monitoring-plugin/tests/perses-dev-ui/monitoring-plugin-tests-perses-dev-ui-ref.yaml
@@ -1,15 +1,15 @@
 ref:
-  as: monitoring-plugin-tests-perses-ui
+  as: monitoring-plugin-tests-perses-dev-ui
   from: monitoring-ui-tests-runner
-  commands: monitoring-plugin-tests-perses-ui-commands.sh
+  commands: monitoring-plugin-tests-perses-dev-ui-commands.sh
   timeout: 2h0m0s
   grace_period: 60s
   resources:
     requests:
       cpu: "1"
-      memory: 8Gi
+      memory: 3Gi
     limits:
-      memory: 8Gi
+      memory: 4Gi
   env:
   - name: CYPRESS_SKIP_COO_INSTALL
     default: ""

--- a/ci-operator/step-registry/monitoring-plugin/tests/virtualization-ui/monitoring-plugin-tests-virtualization-ui-ref.yaml
+++ b/ci-operator/step-registry/monitoring-plugin/tests/virtualization-ui/monitoring-plugin-tests-virtualization-ui-ref.yaml
@@ -7,9 +7,9 @@ ref:
   resources:
     requests:
       cpu: "1"
-      memory: 3Gi
+      memory: 8Gi
     limits:
-      memory: 4Gi
+      memory: 8Gi
   env:
   - name: CYPRESS_SKIP_ALL_INSTALL
     default: ""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added end-to-end Perses UI tests plus a separate "dev" variant across branches, releases, and periodic schedules.
  * Added presubmit and periodic jobs for both Perses variants with rerun/trigger commands and Slack notifications to the observability channel.
  * Extended Slack reporter to include the new Perses job names.
  * Introduced CI step refs, test runner script, OWNERS/metadata for the Perses dev UI.
  * Increased memory for multiple UI test jobs for improved reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->