### PR TITLE
Add RHCOS 9+10 mixed cluster periodic CI jobs for OCP 5.0

### DIFF
--- a/ci-operator/config/openshift/release/openshift-release-main__ci-5.0.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__ci-5.0.yaml
@@ -316,7 +316,6 @@ tests:
       FEATURE_SET: TechPreviewNoUpgrade
       OS_IMAGE_STREAM: rhel-9
       OS_IMAGE_STREAM_MCP_WORKER: rhel-10
-      OSSTREAM: rhel-9
       TEST_TYPE: upgrade-conformance
     observers:
       enable:
@@ -418,7 +417,7 @@ tests:
 - as: e2e-gcp-ovn-rhcos9-10-techpreview
   interval: 12h
   steps:
-    cluster_profile: gcp-openshift-gce-devel-ci-2
+    cluster_profile: openshift-org-gcp
     env:
       FAIL_ON_CORE_DUMP: "true"
       FEATURE_SET: TechPreviewNoUpgrade

--- a/ci-operator/config/openshift/release/openshift-release-main__ci-5.0.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__ci-5.0.yaml
@@ -114,6 +114,7 @@ tests:
   steps:
     cluster_profile: openshift-org-aws
     env:
+      FEATURE_SET: TechPreviewNoUpgrade
       OS_IMAGE_STREAM: rhel-9
       OS_IMAGE_STREAM_MCP_WORKER: rhel-10
     observers:
@@ -264,6 +265,7 @@ tests:
   steps:
     cluster_profile: openshift-org-azure
     env:
+      FEATURE_SET: TechPreviewNoUpgrade
       OS_IMAGE_STREAM: rhel-9
       OS_IMAGE_STREAM_MCP_WORKER: rhel-10
     observers:
@@ -323,6 +325,7 @@ tests:
     cluster_profile: openshift-org-azure
     env:
       FAIL_ON_CORE_DUMP: "true"
+      FEATURE_SET: TechPreviewNoUpgrade
       OS_IMAGE_STREAM: rhel-9
       OS_IMAGE_STREAM_MCP_WORKER: rhel-10
       OSSTREAM: rhel-9
@@ -430,6 +433,7 @@ tests:
     cluster_profile: gcp-openshift-gce-devel-ci-2
     env:
       FAIL_ON_CORE_DUMP: "true"
+      FEATURE_SET: TechPreviewNoUpgrade
       OS_IMAGE_STREAM: rhel-9
       OS_IMAGE_STREAM_MCP_WORKER: rhel-10
     observers:

--- a/ci-operator/config/openshift/release/openshift-release-main__ci-5.0.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__ci-5.0.yaml
@@ -109,18 +109,6 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-aws-ovn
-- as: e2e-aws-ovn-rhcos9-10
-  interval: 12h
-  steps:
-    cluster_profile: openshift-org-aws
-    env:
-      FEATURE_SET: TechPreviewNoUpgrade
-      OS_IMAGE_STREAM: rhel-9
-      OS_IMAGE_STREAM_MCP_WORKER: rhel-10
-    observers:
-      enable:
-      - observers-resource-watch
-    workflow: openshift-e2e-aws-ovn
 - as: e2e-aws-ovn-proxy
   interval: 168h
   steps:
@@ -260,7 +248,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-azure-serial
-- as: e2e-azure-ovn-serial-rhcos9-10
+- as: e2e-azure-ovn-serial-rhcos9-10-techpreview
   interval: 12h
   steps:
     cluster_profile: openshift-org-azure
@@ -319,7 +307,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-upgrade-azure-ovn
-- as: e2e-azure-ovn-upgrade-rhcos9-10
+- as: e2e-azure-ovn-upgrade-rhcos9-10-techpreview
   interval: 12h
   steps:
     cluster_profile: openshift-org-azure
@@ -427,7 +415,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-gcp-ovn
-- as: e2e-gcp-ovn-rhcos9-10
+- as: e2e-gcp-ovn-rhcos9-10-techpreview
   interval: 12h
   steps:
     cluster_profile: gcp-openshift-gce-devel-ci-2

--- a/ci-operator/config/openshift/release/openshift-release-main__ci-5.0.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__ci-5.0.yaml
@@ -47,7 +47,7 @@ tests:
       - observers-resource-watch
     workflow: openshift-e2e-aws-ovn
 - as: e2e-aws-ovn-rhcos9-10-techpreview
-  interval: 168h
+  interval: 12h
   steps:
     cluster_profile: openshift-org-aws
     env:
@@ -110,7 +110,7 @@ tests:
       - observers-resource-watch
     workflow: openshift-e2e-aws-ovn
 - as: e2e-aws-ovn-rhcos9-10
-  interval: 168h
+  interval: 12h
   steps:
     cluster_profile: openshift-org-aws
     env:
@@ -160,7 +160,7 @@ tests:
       - observers-resource-watch
     workflow: openshift-e2e-aws-ovn-serial
 - as: e2e-aws-ovn-rhcos9-10-techpreview-serial
-  interval: 168h
+  interval: 12h
   shard_count: 3
   steps:
     cluster_profile: openshift-org-aws
@@ -260,7 +260,7 @@ tests:
       - observers-resource-watch
     workflow: openshift-e2e-azure-serial
 - as: e2e-azure-ovn-serial-rhcos9-10
-  interval: 168h
+  interval: 12h
   steps:
     cluster_profile: openshift-org-azure
     env:
@@ -318,7 +318,7 @@ tests:
       - observers-resource-watch
     workflow: openshift-upgrade-azure-ovn
 - as: e2e-azure-ovn-upgrade-rhcos9-10
-  interval: 168h
+  interval: 12h
   steps:
     cluster_profile: openshift-org-azure
     env:
@@ -425,7 +425,7 @@ tests:
       - observers-resource-watch
     workflow: openshift-e2e-gcp-ovn
 - as: e2e-gcp-ovn-rhcos9-10
-  interval: 168h
+  interval: 12h
   steps:
     cluster_profile: gcp-openshift-gce-devel-ci-2
     env:

--- a/ci-operator/config/openshift/release/openshift-release-main__ci-5.0.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__ci-5.0.yaml
@@ -46,6 +46,18 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-aws-ovn
+- as: e2e-aws-ovn-rhcos9-10-techpreview
+  interval: 168h
+  steps:
+    cluster_profile: openshift-org-aws
+    env:
+      FEATURE_SET: TechPreviewNoUpgrade
+      OS_IMAGE_STREAM: rhel-9
+      OS_IMAGE_STREAM_MCP_WORKER: rhel-10
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: openshift-e2e-aws-ovn
 - as: e2e-aws-ovn-rhcos10-techpreview
   interval: 168h
   steps:
@@ -97,6 +109,17 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-aws-ovn
+- as: e2e-aws-ovn-rhcos9-10
+  interval: 168h
+  steps:
+    cluster_profile: openshift-org-aws
+    env:
+      OS_IMAGE_STREAM: rhel-9
+      OS_IMAGE_STREAM_MCP_WORKER: rhel-10
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: openshift-e2e-aws-ovn
 - as: e2e-aws-ovn-proxy
   interval: 168h
   steps:
@@ -132,6 +155,19 @@ tests:
     env:
       FEATURE_SET: TechPreviewNoUpgrade
       OS_IMAGE_STREAM: rhel-9
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: openshift-e2e-aws-ovn-serial
+- as: e2e-aws-ovn-rhcos9-10-techpreview-serial
+  interval: 168h
+  shard_count: 3
+  steps:
+    cluster_profile: openshift-org-aws
+    env:
+      FEATURE_SET: TechPreviewNoUpgrade
+      OS_IMAGE_STREAM: rhel-9
+      OS_IMAGE_STREAM_MCP_WORKER: rhel-10
     observers:
       enable:
       - observers-resource-watch
@@ -223,6 +259,17 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-azure-serial
+- as: e2e-azure-ovn-serial-rhcos9-10
+  interval: 168h
+  steps:
+    cluster_profile: openshift-org-azure
+    env:
+      OS_IMAGE_STREAM: rhel-9
+      OS_IMAGE_STREAM_MCP_WORKER: rhel-10
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: openshift-e2e-azure-serial
 - as: e2e-azure-ovn-techpreview-serial
   interval: 168h
   steps:
@@ -269,6 +316,26 @@ tests:
     observers:
       enable:
       - observers-resource-watch
+    workflow: openshift-upgrade-azure-ovn
+- as: e2e-azure-ovn-upgrade-rhcos9-10
+  interval: 168h
+  steps:
+    cluster_profile: openshift-org-azure
+    env:
+      FAIL_ON_CORE_DUMP: "true"
+      OS_IMAGE_STREAM: rhel-9
+      OS_IMAGE_STREAM_MCP_WORKER: rhel-10
+      OSSTREAM: rhel-9
+      TEST_TYPE: upgrade-conformance
+    observers:
+      enable:
+      - observers-resource-watch
+    pre:
+    - chain: ipi-conf-azure
+    - ref: ovn-conf
+    - ref: rhcos-conf-osstream
+    - chain: ipi-install-stableinitial
+    - ref: ipi-azure-rbac
     workflow: openshift-upgrade-azure-ovn
 - as: e2e-azure-ovn-techpreview-upgrade
   interval: 168h
@@ -353,6 +420,18 @@ tests:
       FAIL_ON_CORE_DUMP: "true"
       FEATURE_SET: TechPreviewNoUpgrade
       OS_IMAGE_STREAM: rhel-9
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: openshift-e2e-gcp-ovn
+- as: e2e-gcp-ovn-rhcos9-10
+  interval: 168h
+  steps:
+    cluster_profile: gcp-openshift-gce-devel-ci-2
+    env:
+      FAIL_ON_CORE_DUMP: "true"
+      OS_IMAGE_STREAM: rhel-9
+      OS_IMAGE_STREAM_MCP_WORKER: rhel-10
     observers:
       enable:
       - observers-resource-watch

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
@@ -343,7 +343,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: baremetalds-e2e-upgrade-ovn-ipv4
-- as: e2e-metal-ipi-ovn-upgrade-rhcos9-10
+- as: e2e-metal-ipi-ovn-upgrade-rhcos9-10-techpreview
   capabilities:
   - intranet
   interval: 12h
@@ -517,7 +517,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: baremetalds-e2e-ovn-ipv6
-- as: e2e-metal-ipi-ovn-ipv6-rhcos9-10
+- as: e2e-metal-ipi-ovn-ipv6-rhcos9-10-techpreview
   capabilities:
   - intranet
   interval: 12h
@@ -568,7 +568,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: baremetalds-e2e-ovn-dualstack
-- as: e2e-metal-ipi-ovn-dualstack-rhcos9-10
+- as: e2e-metal-ipi-ovn-dualstack-rhcos9-10-techpreview
   capabilities:
   - intranet
   interval: 12h
@@ -1050,7 +1050,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-vsphere-ovn
-- as: e2e-vsphere-ovn-rhcos9-10
+- as: e2e-vsphere-ovn-rhcos9-10-techpreview-ovn
   interval: 24h
   steps:
     cluster_profile: vsphere-elastic
@@ -1117,7 +1117,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-vsphere-serial
-- as: e2e-vsphere-ovn-serial-rhcos9-10
+- as: e2e-vsphere-ovn-serial-rhcos9-10-techpreview
   interval: 24h
   steps:
     cluster_profile: vsphere-elastic
@@ -1395,7 +1395,7 @@ tests:
     - chain: ipi-aws-pre-stableinitial
     - ref: fips-check
     workflow: openshift-upgrade-aws-ovn
-- as: e2e-aws-ovn-upgrade-fips-rhcos9-10
+- as: e2e-aws-ovn-upgrade-fips-rhcos9-10-techpreview
   interval: 12h
   steps:
     cluster_profile: openshift-org-aws
@@ -1535,7 +1535,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-aws-ovn-serial
-- as: e2e-aws-ovn-serial-rhcos9-10
+- as: e2e-aws-ovn-serial-rhcos9-10-techpreview
   interval: 12h
   shard_count: 2
   steps:

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
@@ -352,8 +352,8 @@ tests:
     env:
       DEVSCRIPTS_CONFIG: |
         FEATURE_SET=TechPreviewNoUpgrade
+        OS_IMAGE_STREAM=rhel-9
       OS_IMAGE_STREAM_MCP_WORKER: rhel-10
-      OSSTREAM: rhel-9
       TEST_TYPE: upgrade-conformance
     observers:
       enable:
@@ -527,8 +527,8 @@ tests:
       DEVSCRIPTS_CONFIG: |
         IP_STACK=v6
         FEATURE_SET=TechPreviewNoUpgrade
+        OS_IMAGE_STREAM=rhel-9
       OS_IMAGE_STREAM_MCP_WORKER: rhel-10
-      OSSTREAM: rhel-9
     observers:
       enable:
       - observers-resource-watch
@@ -578,8 +578,8 @@ tests:
       DEVSCRIPTS_CONFIG: |
         IP_STACK=v4v6
         FEATURE_SET=TechPreviewNoUpgrade
+        OS_IMAGE_STREAM=rhel-9
       OS_IMAGE_STREAM_MCP_WORKER: rhel-10
-      OSSTREAM: rhel-9
     observers:
       enable:
       - observers-resource-watch
@@ -1058,7 +1058,6 @@ tests:
       FEATURE_SET: TechPreviewNoUpgrade
       OS_IMAGE_STREAM: rhel-9
       OS_IMAGE_STREAM_MCP_WORKER: rhel-10
-      OSSTREAM: rhel-9
       TEST_SKIPS: provisioning should mount multiple PV pointing to the same storage
         on the same node
     observers:
@@ -1405,7 +1404,6 @@ tests:
       FIPS_ENABLED: "true"
       OS_IMAGE_STREAM: rhel-9
       OS_IMAGE_STREAM_MCP_WORKER: rhel-10
-      OSSTREAM: rhel-9
       TEST_TYPE: upgrade-conformance
     observers:
       enable:

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
@@ -343,6 +343,20 @@ tests:
       enable:
       - observers-resource-watch
     workflow: baremetalds-e2e-upgrade-ovn-ipv4
+- as: e2e-metal-ipi-ovn-upgrade-rhcos9-10
+  capabilities:
+  - intranet
+  interval: 168h
+  steps:
+    cluster_profile: equinix-ocp-metal
+    env:
+      OS_IMAGE_STREAM_MCP_WORKER: rhel-10
+      OSSTREAM: rhel-9
+      TEST_TYPE: upgrade-conformance
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: baremetalds-e2e-upgrade-ovn-ipv4
 - as: e2e-metal-ipi-upgrade-ovn-ipv6
   capabilities:
   - intranet
@@ -501,6 +515,19 @@ tests:
       enable:
       - observers-resource-watch
     workflow: baremetalds-e2e-ovn-ipv6
+- as: e2e-metal-ipi-ovn-ipv6-rhcos9-10
+  capabilities:
+  - intranet
+  interval: 168h
+  steps:
+    cluster_profile: equinix-ocp-metal
+    env:
+      OS_IMAGE_STREAM_MCP_WORKER: rhel-10
+      OSSTREAM: rhel-9
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: baremetalds-e2e-ovn-ipv6
 - as: e2e-metal-ipi-ovn-ipv6-runc
   capabilities:
   - intranet
@@ -532,6 +559,19 @@ tests:
         IP_STACK=v4v6
         FEATURE_SET=TechPreviewNoUpgrade
         OS_IMAGE_STREAM=rhel-9
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: baremetalds-e2e-ovn-dualstack
+- as: e2e-metal-ipi-ovn-dualstack-rhcos9-10
+  capabilities:
+  - intranet
+  interval: 168h
+  steps:
+    cluster_profile: equinix-ocp-metal
+    env:
+      OS_IMAGE_STREAM_MCP_WORKER: rhel-10
+      OSSTREAM: rhel-9
     observers:
       enable:
       - observers-resource-watch
@@ -933,6 +973,20 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-vsphere
+- as: e2e-vsphere-ovn-rhcos9-10-techpreview
+  interval: 168h
+  steps:
+    cluster_profile: vsphere-elastic
+    env:
+      FEATURE_SET: TechPreviewNoUpgrade
+      OS_IMAGE_STREAM: rhel-9
+      OS_IMAGE_STREAM_MCP_WORKER: rhel-10
+      TEST_SKIPS: 'In-tree Volumes \[Driver: vsphere\] \[Testpattern: Inline-volume\|
+        In-tree Volumes \[Driver: vsphere\] \[Testpattern: Pre-provisioned PV'
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: openshift-e2e-vsphere
 - as: e2e-vsphere-ovn-rhcos10-techpreview
   cron: 1 18 * * 0
   steps:
@@ -988,6 +1042,25 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-vsphere-ovn
+- as: e2e-vsphere-ovn-rhcos9-10
+  interval: 168h
+  steps:
+    cluster_profile: vsphere-elastic
+    env:
+      OS_IMAGE_STREAM: rhel-9
+      OS_IMAGE_STREAM_MCP_WORKER: rhel-10
+      OSSTREAM: rhel-9
+      TEST_SKIPS: provisioning should mount multiple PV pointing to the same storage
+        on the same node
+    observers:
+      enable:
+      - observers-resource-watch
+    pre:
+    - chain: ipi-conf-vsphere
+    - ref: ovn-conf
+    - ref: rhcos-conf-osstream
+    - chain: ipi-install-vsphere
+    workflow: openshift-e2e-vsphere-ovn
 - as: e2e-vsphere-ovn-vcf9
   cron: 23,53 12,19 * * *
   steps:
@@ -1035,6 +1108,19 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-vsphere-serial
+- as: e2e-vsphere-ovn-serial-rhcos9-10
+  interval: 168h
+  steps:
+    cluster_profile: vsphere-elastic
+    env:
+      OS_IMAGE_STREAM: rhel-9
+      OS_IMAGE_STREAM_MCP_WORKER: rhel-10
+      TEST_SKIPS: provisioning should mount multiple PV pointing to the same storage
+        on the same node
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: openshift-e2e-vsphere-serial
 - as: e2e-vsphere-ovn-techpreview-serial
   cron: 40,55 2,9,10 * * *
   steps:
@@ -1050,6 +1136,18 @@ tests:
     env:
       FEATURE_SET: TechPreviewNoUpgrade
       OS_IMAGE_STREAM: rhel-9
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: openshift-e2e-vsphere-serial
+- as: e2e-vsphere-ovn-rhcos9-10-techpreview-serial
+  interval: 168h
+  steps:
+    cluster_profile: vsphere-elastic
+    env:
+      FEATURE_SET: TechPreviewNoUpgrade
+      OS_IMAGE_STREAM: rhel-9
+      OS_IMAGE_STREAM_MCP_WORKER: rhel-10
     observers:
       enable:
       - observers-resource-watch
@@ -1287,6 +1385,26 @@ tests:
     - chain: ipi-aws-pre-stableinitial
     - ref: fips-check
     workflow: openshift-upgrade-aws-ovn
+- as: e2e-aws-ovn-upgrade-fips-rhcos9-10
+  interval: 168h
+  steps:
+    cluster_profile: openshift-org-aws
+    env:
+      FAIL_ON_CORE_DUMP: "true"
+      FIPS_ENABLED: "true"
+      OS_IMAGE_STREAM: rhel-9
+      OS_IMAGE_STREAM_MCP_WORKER: rhel-10
+      OSSTREAM: rhel-9
+      TEST_TYPE: upgrade-conformance
+    observers:
+      enable:
+      - observers-resource-watch
+    pre:
+    - chain: ipi-conf-aws
+    - ref: rhcos-conf-osstream
+    - chain: ipi-install-stableinitial
+    - ref: fips-check
+    workflow: openshift-upgrade-aws-ovn
 - as: e2e-aws-ovn-upgrade-fips-no-nat-instance
   interval: 168h
   steps:
@@ -1402,6 +1520,18 @@ tests:
     env:
       FEATURE_SET: TechPreviewNoUpgrade
       OS_IMAGE_STREAM: rhel-9
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: openshift-e2e-aws-ovn-serial
+- as: e2e-aws-ovn-serial-rhcos9-10
+  interval: 168h
+  shard_count: 2
+  steps:
+    cluster_profile: openshift-org-aws
+    env:
+      OS_IMAGE_STREAM: rhel-9
+      OS_IMAGE_STREAM_MCP_WORKER: rhel-10
     observers:
       enable:
       - observers-resource-watch

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
@@ -346,7 +346,7 @@ tests:
 - as: e2e-metal-ipi-ovn-upgrade-rhcos9-10
   capabilities:
   - intranet
-  interval: 168h
+  interval: 12h
   steps:
     cluster_profile: equinix-ocp-metal
     env:
@@ -518,7 +518,7 @@ tests:
 - as: e2e-metal-ipi-ovn-ipv6-rhcos9-10
   capabilities:
   - intranet
-  interval: 168h
+  interval: 12h
   steps:
     cluster_profile: equinix-ocp-metal
     env:
@@ -566,7 +566,7 @@ tests:
 - as: e2e-metal-ipi-ovn-dualstack-rhcos9-10
   capabilities:
   - intranet
-  interval: 168h
+  interval: 12h
   steps:
     cluster_profile: equinix-ocp-metal
     env:
@@ -974,7 +974,7 @@ tests:
       - observers-resource-watch
     workflow: openshift-e2e-vsphere
 - as: e2e-vsphere-ovn-rhcos9-10-techpreview
-  interval: 168h
+  interval: 24h
   steps:
     cluster_profile: vsphere-elastic
     env:
@@ -1043,7 +1043,7 @@ tests:
       - observers-resource-watch
     workflow: openshift-e2e-vsphere-ovn
 - as: e2e-vsphere-ovn-rhcos9-10
-  interval: 168h
+  interval: 24h
   steps:
     cluster_profile: vsphere-elastic
     env:
@@ -1109,7 +1109,7 @@ tests:
       - observers-resource-watch
     workflow: openshift-e2e-vsphere-serial
 - as: e2e-vsphere-ovn-serial-rhcos9-10
-  interval: 168h
+  interval: 24h
   steps:
     cluster_profile: vsphere-elastic
     env:
@@ -1141,7 +1141,7 @@ tests:
       - observers-resource-watch
     workflow: openshift-e2e-vsphere-serial
 - as: e2e-vsphere-ovn-rhcos9-10-techpreview-serial
-  interval: 168h
+  interval: 24h
   steps:
     cluster_profile: vsphere-elastic
     env:
@@ -1386,7 +1386,7 @@ tests:
     - ref: fips-check
     workflow: openshift-upgrade-aws-ovn
 - as: e2e-aws-ovn-upgrade-fips-rhcos9-10
-  interval: 168h
+  interval: 12h
   steps:
     cluster_profile: openshift-org-aws
     env:
@@ -1525,7 +1525,7 @@ tests:
       - observers-resource-watch
     workflow: openshift-e2e-aws-ovn-serial
 - as: e2e-aws-ovn-serial-rhcos9-10
-  interval: 168h
+  interval: 12h
   shard_count: 2
   steps:
     cluster_profile: openshift-org-aws

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
@@ -350,6 +350,8 @@ tests:
   steps:
     cluster_profile: equinix-ocp-metal
     env:
+      DEVSCRIPTS_CONFIG: |
+        FEATURE_SET=TechPreviewNoUpgrade
       OS_IMAGE_STREAM_MCP_WORKER: rhel-10
       OSSTREAM: rhel-9
       TEST_TYPE: upgrade-conformance
@@ -522,6 +524,9 @@ tests:
   steps:
     cluster_profile: equinix-ocp-metal
     env:
+      DEVSCRIPTS_CONFIG: |
+        IP_STACK=v6
+        FEATURE_SET=TechPreviewNoUpgrade
       OS_IMAGE_STREAM_MCP_WORKER: rhel-10
       OSSTREAM: rhel-9
     observers:
@@ -570,6 +575,9 @@ tests:
   steps:
     cluster_profile: equinix-ocp-metal
     env:
+      DEVSCRIPTS_CONFIG: |
+        IP_STACK=v4v6
+        FEATURE_SET=TechPreviewNoUpgrade
       OS_IMAGE_STREAM_MCP_WORKER: rhel-10
       OSSTREAM: rhel-9
     observers:
@@ -1047,6 +1055,7 @@ tests:
   steps:
     cluster_profile: vsphere-elastic
     env:
+      FEATURE_SET: TechPreviewNoUpgrade
       OS_IMAGE_STREAM: rhel-9
       OS_IMAGE_STREAM_MCP_WORKER: rhel-10
       OSSTREAM: rhel-9
@@ -1113,6 +1122,7 @@ tests:
   steps:
     cluster_profile: vsphere-elastic
     env:
+      FEATURE_SET: TechPreviewNoUpgrade
       OS_IMAGE_STREAM: rhel-9
       OS_IMAGE_STREAM_MCP_WORKER: rhel-10
       TEST_SKIPS: provisioning should mount multiple PV pointing to the same storage
@@ -1391,6 +1401,7 @@ tests:
     cluster_profile: openshift-org-aws
     env:
       FAIL_ON_CORE_DUMP: "true"
+      FEATURE_SET: TechPreviewNoUpgrade
       FIPS_ENABLED: "true"
       OS_IMAGE_STREAM: rhel-9
       OS_IMAGE_STREAM_MCP_WORKER: rhel-10
@@ -1530,6 +1541,7 @@ tests:
   steps:
     cluster_profile: openshift-org-aws
     env:
+      FEATURE_SET: TechPreviewNoUpgrade
       OS_IMAGE_STREAM: rhel-9
       OS_IMAGE_STREAM_MCP_WORKER: rhel-10
     observers:

--- a/ci-operator/step-registry/rhcos/conf/osstream/rhcos-conf-osstream-commands.sh
+++ b/ci-operator/step-registry/rhcos/conf/osstream/rhcos-conf-osstream-commands.sh
@@ -20,7 +20,7 @@ WORKER_STREAM="${OS_IMAGE_STREAM_MCP_WORKER:-${OSSTREAM:-}}"
 
 # If neither pool has a stream configured, skip
 if [[ -z "${MASTER_STREAM}" && -z "${WORKER_STREAM}" ]]; then
-  echo "No OS image stream configured for any pool, skipping MachineConfigPool osImageStream configuration"
+  echo "No OS Image Stream configured for any pool, skipping MachineConfigPool osImageStream configuration"
   exit 0
 fi
 

--- a/ci-operator/step-registry/rhcos/conf/osstream/rhcos-conf-osstream-commands.sh
+++ b/ci-operator/step-registry/rhcos/conf/osstream/rhcos-conf-osstream-commands.sh
@@ -24,15 +24,6 @@ if [[ -z "${MASTER_STREAM}" && -z "${WORKER_STREAM}" ]]; then
   exit 0
 fi
 
-# Validate stream values
-for stream_var in MASTER_STREAM WORKER_STREAM; do
-  stream_val="${!stream_var}"
-  if [[ -n "${stream_val}" && "${stream_val}" != "rhel-9" && "${stream_val}" != "rhel-10" ]]; then
-    echo "Error: ${stream_var} must be either 'rhel-9' or 'rhel-10', got: '${stream_val}'"
-    exit 1
-  fi
-done
-
 # Generate master MCP manifest if stream is configured
 if [[ -n "${MASTER_STREAM}" ]]; then
   echo "Configuring the master MCP for ${MASTER_STREAM} osImageStream"

--- a/ci-operator/step-registry/rhcos/conf/osstream/rhcos-conf-osstream-commands.sh
+++ b/ci-operator/step-registry/rhcos/conf/osstream/rhcos-conf-osstream-commands.sh
@@ -5,7 +5,7 @@ set -o nounset
 set -o pipefail
 
 # Info output
-echo "Info: rhcos-conf-osstream running, OSSTREAM='${OSSTREAM:-<unset>}'"
+echo "Info: rhcos-conf-osstream running, OSSTREAM='${OSSTREAM:-<unset>}', OS_IMAGE_STREAM_MCP_MASTER='${OS_IMAGE_STREAM_MCP_MASTER:-<unset>}', OS_IMAGE_STREAM_MCP_WORKER='${OS_IMAGE_STREAM_MCP_WORKER:-<unset>}'"
 
 # Validation that SHARED_DIR exists
 if [[ ! -d "${SHARED_DIR}" ]]; then
@@ -13,21 +13,32 @@ if [[ ! -d "${SHARED_DIR}" ]]; then
   exit 1
 fi
 
-# Check if OSSTREAM is set and validate it
-if [[ -z "${OSSTREAM:-}" ]]; then
-  echo "OSSTREAM is not set, skipping MachineConfigPool osImageStream configuration"
+# Resolve the effective stream for each pool:
+# Per-pool override takes precedence, then falls back to OSSTREAM
+MASTER_STREAM="${OS_IMAGE_STREAM_MCP_MASTER:-${OSSTREAM:-}}"
+WORKER_STREAM="${OS_IMAGE_STREAM_MCP_WORKER:-${OSSTREAM:-}}"
+
+# If neither pool has a stream configured, skip
+if [[ -z "${MASTER_STREAM}" && -z "${WORKER_STREAM}" ]]; then
+  echo "No OS image stream configured for any pool, skipping MachineConfigPool osImageStream configuration"
   exit 0
 fi
 
-if [[ "${OSSTREAM}" != "rhel-9" && "${OSSTREAM}" != "rhel-10" ]]; then
-  echo "Error: OSSTREAM must be either 'rhel-9' or 'rhel-10', got: '${OSSTREAM}'"
-  exit 1
-fi
+# Validate stream values
+for stream_var in MASTER_STREAM WORKER_STREAM; do
+  stream_val="${!stream_var}"
+  if [[ -n "${stream_val}" && "${stream_val}" != "rhel-9" && "${stream_val}" != "rhel-10" ]]; then
+    echo "Error: ${stream_var} must be either 'rhel-9' or 'rhel-10', got: '${stream_val}'"
+    exit 1
+  fi
+done
 
-echo "Configuring the MCPs for ${OSSTREAM} osImageStream"
-# these haven't changed in six years so lets assume for now they're stable
-# source https://github.com/openshift/machine-config-operator/tree/main/manifests
-cat > "${SHARED_DIR}/manifest_master.machineconfigpool.yaml" <<EOF
+# Generate master MCP manifest if stream is configured
+if [[ -n "${MASTER_STREAM}" ]]; then
+  echo "Configuring the master MCP for ${MASTER_STREAM} osImageStream"
+  # these haven't changed in six years so lets assume for now they're stable
+  # source https://github.com/openshift/machine-config-operator/tree/main/manifests
+  cat > "${SHARED_DIR}/manifest_master.machineconfigpool.yaml" <<EOF
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfigPool
 metadata:
@@ -44,11 +55,15 @@ spec:
     matchLabels:
       node-role.kubernetes.io/master: ""
   osImageStream:
-    name: ${OSSTREAM}
+    name: ${MASTER_STREAM}
 
 EOF
+fi
 
-cat > "${SHARED_DIR}/manifest_worker.machineconfigpool.yaml" <<EOF
+# Generate worker MCP manifest if stream is configured
+if [[ -n "${WORKER_STREAM}" ]]; then
+  echo "Configuring the worker MCP for ${WORKER_STREAM} osImageStream"
+  cat > "${SHARED_DIR}/manifest_worker.machineconfigpool.yaml" <<EOF
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfigPool
 metadata:
@@ -64,6 +79,7 @@ spec:
     matchLabels:
       node-role.kubernetes.io/worker: ""
   osImageStream:
-    name: ${OSSTREAM}
+    name: ${WORKER_STREAM}
 
 EOF
+fi

--- a/ci-operator/step-registry/rhcos/conf/osstream/rhcos-conf-osstream-ref.yaml
+++ b/ci-operator/step-registry/rhcos/conf/osstream/rhcos-conf-osstream-ref.yaml
@@ -9,6 +9,12 @@ ref:
   env:
   - name: OSSTREAM
     default: ""
-    documentation: The OS image stream to configure for master and worker MachineConfigPools. Valid values are "rhel-9" or "rhel-10". If empty, no configuration is applied.
+    documentation: The OS image stream to configure for master and worker MachineConfigPools. Valid values are "rhel-9" or "rhel-10". If empty, no configuration is applied. Can be overridden per pool by OS_IMAGE_STREAM_MCP_MASTER and OS_IMAGE_STREAM_MCP_WORKER.
+  - name: OS_IMAGE_STREAM_MCP_MASTER
+    default: ""
+    documentation: The OS image stream for the master MachineConfigPool. Overrides OSSTREAM for masters only. Valid values are "rhel-9" or "rhel-10". If empty, falls back to OSSTREAM.
+  - name: OS_IMAGE_STREAM_MCP_WORKER
+    default: ""
+    documentation: The OS image stream for the worker MachineConfigPool. Overrides OSSTREAM for workers only. Valid values are "rhel-9" or "rhel-10". If empty, falls back to OSSTREAM.
   documentation: |-
-    Creates manifests for worker and master to set osImageStream to the specified RHCOS version. Only applies configuration if OSSTREAM is set to "rhel-9" or "rhel-10".
+    Creates manifests for worker and master to set osImageStream to the specified RHCOS version. Only applies configuration if OSSTREAM is set to "rhel-9" or "rhel-10". Supports per-pool overrides via OS_IMAGE_STREAM_MCP_MASTER and OS_IMAGE_STREAM_MCP_WORKER for mixed OS clusters.

--- a/ci-operator/step-registry/rhcos/conf/osstream/rhcos-conf-osstream-ref.yaml
+++ b/ci-operator/step-registry/rhcos/conf/osstream/rhcos-conf-osstream-ref.yaml
@@ -9,12 +9,12 @@ ref:
   env:
   - name: OSSTREAM
     default: ""
-    documentation: The OS image stream to configure for master and worker MachineConfigPools. Valid values are "rhel-9" or "rhel-10". If empty, no configuration is applied. Can be overridden per pool by OS_IMAGE_STREAM_MCP_MASTER and OS_IMAGE_STREAM_MCP_WORKER.
+    documentation: The OS Image Stream to configure for master and worker MachineConfigPools. Valid values are "rhel-9" or "rhel-10". If empty, no configuration is applied. Can be overridden per pool by OS_IMAGE_STREAM_MCP_MASTER and OS_IMAGE_STREAM_MCP_WORKER.
   - name: OS_IMAGE_STREAM_MCP_MASTER
     default: ""
-    documentation: The OS image stream for the master MachineConfigPool. Overrides OSSTREAM for masters only. Valid values are "rhel-9" or "rhel-10". If empty, falls back to OSSTREAM.
+    documentation: The OS Image Stream for the master MachineConfigPool. Overrides OSSTREAM for masters only. Valid values are "rhel-9" or "rhel-10". If empty, falls back to OSSTREAM.
   - name: OS_IMAGE_STREAM_MCP_WORKER
     default: ""
-    documentation: The OS image stream for the worker MachineConfigPool. Overrides OSSTREAM for workers only. Valid values are "rhel-9" or "rhel-10". If empty, falls back to OSSTREAM.
+    documentation: The OS Image Stream for the worker MachineConfigPool. Overrides OSSTREAM for workers only. Valid values are "rhel-9" or "rhel-10". If empty, falls back to OSSTREAM.
   documentation: |-
     Creates manifests for worker and master to set osImageStream to the specified RHCOS version. Only applies configuration if OSSTREAM is set to "rhel-9" or "rhel-10". Supports per-pool overrides via OS_IMAGE_STREAM_MCP_MASTER and OS_IMAGE_STREAM_MCP_WORKER for mixed OS clusters.


### PR DESCRIPTION
Modify the rhcos-conf-osstream step to support per-pool OS stream configuration via new env vars OS_IMAGE_STREAM_MCP_MASTER and OS_IMAGE_STREAM_MCP_WORKER, enabling mixed RHCOS 9+10 clusters where masters run RHCOS 9 and workers run RHCOS 10.

Add 15 mixed cluster jobs (rhcos9-10) across CI and nightly 5.0 configs, mirroring the same minimal set of platforms and test suites.

For workflows without rhcos-conf-osstream in their chains (upgrade and vsphere-ovn workflows), the step is injected explicitly via pre overrides.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added OVN end-to-end and upgrade/conformance tests across AWS, Azure, GCP, bare metal, and vSphere using mixed RHEL 9 (control plane) and RHEL 10 (workers); includes tech-preview, serial, FIPS/upgrade variants, shard splits, and observer/resource-watch enabled.
* **New Features**
  * Support for per-pool OS image stream selection to enable mixed-OS cluster testing.
* **Documentation**
  * Documented per-pool OS image stream overrides and mixed-OS cluster behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->