### PR TITLE
Use make lint for medik8s/node-remediation-console CI

### DIFF
--- a/ci-operator/config/medik8s/node-remediation-console/medik8s-node-remediation-console-main.yaml
+++ b/ci-operator/config/medik8s/node-remediation-console/medik8s-node-remediation-console-main.yaml
@@ -19,7 +19,7 @@ resources:
       memory: 200Mi
 tests:
 - as: lint
-  commands: yarn install --ignore-scripts && yarn run lint
+  commands: make lint
   container:
     from: src
   skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$

--- a/ci-operator/config/medik8s/node-remediation-console/medik8s-node-remediation-console-release-0.10.yaml
+++ b/ci-operator/config/medik8s/node-remediation-console/medik8s-node-remediation-console-release-0.10.yaml
@@ -19,7 +19,7 @@ resources:
       memory: 200Mi
 tests:
 - as: lint
-  commands: yarn install --ignore-scripts && yarn run lint
+  commands: make lint
   container:
     from: src
   skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$

--- a/ci-operator/config/medik8s/node-remediation-console/medik8s-node-remediation-console-release-0.11.yaml
+++ b/ci-operator/config/medik8s/node-remediation-console/medik8s-node-remediation-console-release-0.11.yaml
@@ -19,7 +19,7 @@ resources:
       memory: 200Mi
 tests:
 - as: lint
-  commands: yarn install --ignore-scripts && yarn run lint
+  commands: make lint
   container:
     from: src
   skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$

--- a/ci-operator/config/medik8s/node-remediation-console/medik8s-node-remediation-console-release-0.6.yaml
+++ b/ci-operator/config/medik8s/node-remediation-console/medik8s-node-remediation-console-release-0.6.yaml
@@ -19,7 +19,7 @@ resources:
       memory: 200Mi
 tests:
 - as: lint
-  commands: yarn install --ignore-scripts && yarn run lint
+  commands: make lint
   container:
     from: src
   skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$

--- a/ci-operator/config/medik8s/node-remediation-console/medik8s-node-remediation-console-release-0.8.yaml
+++ b/ci-operator/config/medik8s/node-remediation-console/medik8s-node-remediation-console-release-0.8.yaml
@@ -19,7 +19,7 @@ resources:
       memory: 200Mi
 tests:
 - as: lint
-  commands: yarn install --ignore-scripts && yarn run lint
+  commands: make lint
   container:
     from: src
   skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$

--- a/ci-operator/config/medik8s/node-remediation-console/medik8s-node-remediation-console-release-0.9.yaml
+++ b/ci-operator/config/medik8s/node-remediation-console/medik8s-node-remediation-console-release-0.9.yaml
@@ -19,7 +19,7 @@ resources:
       memory: 200Mi
 tests:
 - as: lint
-  commands: yarn install --ignore-scripts && yarn run lint
+  commands: make lint
   container:
     from: src
   skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$


### PR DESCRIPTION
#### Why we need this PR:
Follow-up to [#76655](https://github.com/openshift/release/pull/76655) per [review feedback](https://github.com/openshift/release/pull/76655#discussion_r3004707807): CI configs should delegate to `make lint` instead of inlining `yarn install --ignore-scripts && yarn run lint`. This way the same test runs locally and in CI without having to look at the CI config.

#### Changes made:
Replace `yarn install --ignore-scripts && yarn run lint` with `make lint` in all 6 ci-operator configs that define a lint test (main, release-0.6, 0.8, 0.9, 0.10, 0.11). The upstream [Makefile](https://github.com/medik8s/node-remediation-console/blob/main/Makefile) already has a `lint` target on all branches.

#### Which issue(s) this PR fixes:
Follow-up to [#76655](https://github.com/openshift/release/pull/76655)

#### Test plan:
- Verified all 6 branches (main, release-0.6 through 0.11) have a `make lint` target in their Makefile
- CI rehearsal jobs on this PR will validate the change