### PR TITLE
Setting default e2e test run using OLM true for OSSM Sail opeartor e2e

### DIFF
--- a/ci-operator/step-registry/servicemesh/sail-operator/e2e-ocp/servicemesh-sail-operator-e2e-ocp-commands.sh
+++ b/ci-operator/step-registry/servicemesh/sail-operator/e2e-ocp/servicemesh-sail-operator-e2e-ocp-commands.sh
@@ -129,6 +129,22 @@ execute_and_collect_artifacts() {
   test_rc=$?
   echo "Test run (attempt ${attempt}) completed with exit code ${test_rc}"
 
+  if [ "${test_rc}" -ne 0 ] && [ "${OLM:-true}" = "true" ]; then
+    echo "=== OLM Diagnostic Information ==="
+    oc rsh -n "${MAISTRA_NAMESPACE}" "${MAISTRA_SC_POD}" sh -c "
+      export KUBECONFIG=/work/ci-kubeconfig
+      echo '--- Pods in sail-operator namespace ---'
+      oc get pods -n sail-operator -o wide 2>/dev/null || true
+      echo '--- CatalogSource status ---'
+      oc get catalogsource -n sail-operator -o yaml 2>/dev/null || true
+      echo '--- Subscription status ---'
+      oc get subscription -n sail-operator -o yaml 2>/dev/null || true
+      echo '--- Events (sail-operator namespace) ---'
+      oc get events -n sail-operator --sort-by='.lastTimestamp' 2>/dev/null || true
+    " 2>/dev/null || true
+    echo "=== End OLM Diagnostic ==="
+  fi
+
   echo "Copying artifacts from test pod after attempt ${attempt}..."
   oc cp "${MAISTRA_NAMESPACE}"/"${MAISTRA_SC_POD}":"${ARTIFACT_DIR}"/. "${ARTIFACT_DIR}"
 

--- a/ci-operator/step-registry/servicemesh/sail-operator/e2e-ocp/servicemesh-sail-operator-e2e-ocp-commands.sh
+++ b/ci-operator/step-registry/servicemesh/sail-operator/e2e-ocp/servicemesh-sail-operator-e2e-ocp-commands.sh
@@ -21,6 +21,7 @@
 #   - MAISTRA_NAMESPACE: The namespace where the test pod is running.
 #   - MAISTRA_SC_POD: The name of the test pod.
 #   - ARTIFACT_DIR: The local directory to store test artifacts.
+#   - OLM (optional): Set to "false" to avoid creating and deploying the operator using the OLM bundle.
 #   - VERSIONS_YAML_CONFIG (optional): Path to versions YAML config.
 #   - E2E_COMMAND (optional): Replace with the specific test command to run.
 # ==============================================================================
@@ -99,6 +100,7 @@ run_tests() {
     export HUB=\"${HUB:-quay.io/sail-dev}\"
     export USE_INTERNAL_REGISTRY=\"false\"
     export PR_NUMBER=\"${PULL_NUMBER:-}\"
+    export OLM=\"${OLM:-true}\"
     ${VERSIONS_YAML_CONFIG:-}
     oc version
     cd /work

--- a/ci-operator/step-registry/servicemesh/sail-operator/e2e-ocp/servicemesh-sail-operator-e2e-ocp-ref.yaml
+++ b/ci-operator/step-registry/servicemesh/sail-operator/e2e-ocp/servicemesh-sail-operator-e2e-ocp-ref.yaml
@@ -25,6 +25,10 @@ ref:
     default: ""
     documentation: |-
       Optional environment variable to set VERSIONS_YAML_FILE. For 4.19 use 'export VERSIONS_YAML_FILE=versions.yaml && ' to be prepended to the make command
+  - name: OLM
+    default: "true"
+    documentation: |-
+      Set to "false" to avoid creating and deploying the operator using the OLM bundle. By default, the operator will be created and deployed using the OLM bundle. Setting to "false" will cause the operator to be deployed using helm after building the operator image.
   - name: E2E_COMMAND
     default: "make test.e2e.ocp"
     documentation: |-

--- a/ci-operator/step-registry/servicemesh/sail-operator/e2e-ocp/servicemesh-sail-operator-e2e-ocp-ref.yaml
+++ b/ci-operator/step-registry/servicemesh/sail-operator/e2e-ocp/servicemesh-sail-operator-e2e-ocp-ref.yaml
@@ -33,6 +33,10 @@ ref:
     default: "make test.e2e.ocp"
     documentation: |-
       The make command to execute for e2e tests
+  - name: EXPECTED_REGISTRY
+    default: '^docker\.io|^gcr\.io|^registry\.istio\.io|^registry\.redhat\.io'
+    documentation: |-
+      Which registry should be expected in tests for checking correct images. Adding the default ones + registry.redhat.io for OCP tests when OLM is used
   - name: CI
     default: "true"
     documentation: |-


### PR DESCRIPTION
Jira: https://redhat.atlassian.net/browse/OSSM-7993

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable `OLM` environment variable (enabled by default) to control Sail Operator deployment methodology, supporting both OLM bundle-based and Helm-based installation approaches.

* **Chores**
  * Enhanced test failure diagnostics with automatic collection of detailed cluster information, including pod status, catalog sources, subscriptions, and event logs from the operator namespace to aid troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->