### PR TITLE
CNTRLPLANE-3278: Add Prow presubmit to enforce GitHub Actions workflow consistency for HyperShift

### DIFF
--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-main.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-main.yaml
@@ -468,6 +468,40 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-workflows
+  commands: |
+    set -euo pipefail
+    git fetch --unshallow 2>/dev/null || true
+    if ! git fetch https://github.com/openshift/hypershift.git main; then
+      echo "ERROR: Could not fetch main from GitHub."
+      exit 1
+    fi
+    MAIN_REF="FETCH_HEAD"
+    BASE=$(git merge-base HEAD "$MAIN_REF")
+    FAILED=0
+    while IFS= read -r file; do
+      [ -z "$file" ] && continue
+      main_hash=$(git rev-parse "${MAIN_REF}:${file}" 2>/dev/null) || continue
+      head_hash=$(git rev-parse "HEAD:${file}" 2>/dev/null) || head_hash=""
+      if [ -z "$head_hash" ]; then
+        echo "MISSING: $file exists on main but not on this branch."
+        FAILED=1
+      elif [ "$main_hash" != "$head_hash" ]; then
+        base_hash=$(git rev-parse "${BASE}:${file}" 2>/dev/null) || base_hash=""
+        if [ "$head_hash" = "$base_hash" ]; then
+          echo "OUTDATED: $file has been updated on main since this branch diverged."
+          FAILED=1
+        fi
+      fi
+    done < <(git ls-tree --name-only "${MAIN_REF}" -- .github/workflows/)
+    if [ "$FAILED" -eq 1 ]; then
+      echo ""
+      echo "Rebase your branch on main: git fetch upstream main && git rebase upstream/main"
+      exit 1
+    fi
+    echo "Workflow files are up to date."
+  container:
+    from: src
 - always_run: false
   as: reqserving-e2e-aws
   capabilities:

--- a/ci-operator/jobs/openshift/hypershift/openshift-hypershift-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/hypershift/openshift-hypershift-main-presubmits.yaml
@@ -2758,3 +2758,64 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build01
+    context: ci/prow/verify-workflows
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-hypershift-main-verify-workflows
+    rerun_command: /test verify-workflows
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=verify-workflows
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-workflows,?($|\s.*)

--- a/core-services/prow/02_config/openshift/hypershift/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/hypershift/_pluginconfig.yaml
@@ -15,5 +15,7 @@ plugins:
 triggers:
 - repos:
   - openshift/hypershift
+  trigger_github_workflows: true
   trusted_apps:
   - hypershift-jira-solve-ci
+  - openshift-merge-bot


### PR DESCRIPTION
## Summary

Adds a `verify-workflows` first-stage Prow presubmit to the HyperShift ci-operator config that ensures PR branches have up-to-date GitHub Actions workflow files, and enables `/retest` to re-trigger failed GitHub Actions workflows.

## Problem

GitHub Actions workflows only run if the workflow YAML file exists on the PR's head branch. PRs branched before a workflow was introduced or updated will never trigger those jobs, allowing them to merge without running the latest CI checks. Additionally, when GHA checks flake, Prow's `/retest` command does not re-trigger them by default.

## Solution

### 1. `verify-workflows` presubmit

A lightweight `container` test (`from: src`) that runs on every PR:

1. Fetches upstream `main` and computes the merge-base
2. Iterates each workflow file on `main`, comparing per-file blob hashes
3. For each file: if missing on the PR branch or outdated (matches merge-base but not main), the check fails
4. PRs that intentionally modify workflow files are allowed (hash differs from both main and merge-base)

Per-file comparison prevents bypassing the check by touching an unrelated workflow file.

### 2. `trigger_github_workflows` enablement

Enables the Prow trigger plugin's `trigger_github_workflows` flag for `openshift/hypershift`. This allows `/retest` and `/test all` comments to re-trigger failed GitHub Actions workflows alongside Prow jobs.

## Test plan

- [x] Tested locally: up-to-date branch passes
- [x] Tested locally: branch predating workflow files fails with clear per-file output
- [ ] Verify presubmit runs on a real HyperShift PR after merge
- [ ] Verify `/retest` re-triggers failed GHA workflows after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)