### PR TITLE
[Debug] Add wait step to aws-ipi-mno-lvms-arm-f7 for OCP 4.22

### DIFF
--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22__multi-nightly.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22__multi-nightly.yaml
@@ -1210,7 +1210,9 @@ tests:
       OCP_ARCH: arm64
       TEST_FILTERS: ~ChkUpgrade&;~DisconnectedOnly&;~HyperShiftMGMT&;~MicroShiftOnly&;~StagerunOnly;~LSO&;STORAGE&
       TEST_SCENARIOS: \[LVMS\]
+      TIMEOUT: +8 hours
     test:
+    - ref: wait
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-aws-ipi-mno-lvms
 - as: aws-upi-basecap-none-amd-f28-destructive


### PR DESCRIPTION
This adds a wait step with 8h timeout to enable debugging of test failures.

The wait step pauses the workflow before tests run, allowing QE to:
- SSH into the test environment
- Inspect system state and logs
- Debug configuration issues
- Investigate test failures

OCP Version: 4.22
Job: aws-ipi-mno-lvms-arm-f7