### PR TITLE
Add profile setup for aws creds

### DIFF
--- a/ci-operator/config/openshift-online/rosa-regional-platform/openshift-online-rosa-regional-platform-main.yaml
+++ b/ci-operator/config/openshift-online/rosa-regional-platform/openshift-online-rosa-regional-platform-main.yaml
@@ -42,7 +42,9 @@ tests:
   steps:
     post:
     - as: teardown-ephemeral
-      commands: ./ci/nightly.sh --teardown
+      commands: |-
+        [[ -f ci/setup-aws-profiles.sh ]] && source ci/setup-aws-profiles.sh
+        ./ci/nightly.sh --teardown
       credentials:
       - mount_path: /var/run/rosa-credentials
         name: rosa-regional-platform-ephemeral-creds
@@ -54,7 +56,9 @@ tests:
           memory: 200Mi
     pre:
     - as: provision-ephemeral
-      commands: ./ci/nightly.sh
+      commands: |-
+        [[ -f ci/setup-aws-profiles.sh ]] && source ci/setup-aws-profiles.sh
+        ./ci/nightly.sh
       credentials:
       - mount_path: /var/run/rosa-credentials
         name: rosa-regional-platform-ephemeral-creds
@@ -66,7 +70,9 @@ tests:
           memory: 200Mi
     test:
     - as: e2e
-      commands: ./ci/e2e-tests.sh
+      commands: |-
+        [[ -f ci/setup-aws-profiles.sh ]] && source ci/setup-aws-profiles.sh
+        ./ci/e2e-tests.sh
       credentials:
       - mount_path: /var/run/rosa-credentials
         name: rosa-regional-platform-ephemeral-creds
@@ -81,7 +87,9 @@ tests:
   steps:
     test:
     - as: e2e
-      commands: ./ci/e2e-tests.sh
+      commands: |-
+        [[ -f ci/setup-aws-profiles.sh ]] && source ci/setup-aws-profiles.sh
+        ./ci/e2e-tests.sh
       credentials:
       - mount_path: /var/run/rosa-credentials
         name: rosa-regional-platform-integration-creds
@@ -97,6 +105,7 @@ tests:
     post:
     - as: teardown-ephemeral
       commands: |-
+        [[ -f ci/setup-aws-profiles.sh ]] && source ci/setup-aws-profiles.sh
         export REPOSITORY_URL=$(curl -s "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/pulls/${PULL_NUMBER}" | jq -r '.head.repo.clone_url')
         export REPOSITORY_BRANCH="${PULL_HEAD_REF}"
         ./ci/nightly.sh --teardown-fire-and-forget
@@ -112,6 +121,7 @@ tests:
     pre:
     - as: provision-ephemeral
       commands: |-
+        [[ -f ci/setup-aws-profiles.sh ]] && source ci/setup-aws-profiles.sh
         export REPOSITORY_URL=$(curl -s "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/pulls/${PULL_NUMBER}" | jq -r '.head.repo.clone_url')
         export REPOSITORY_BRANCH="${PULL_HEAD_REF}"
         ./ci/nightly.sh
@@ -126,7 +136,9 @@ tests:
           memory: 200Mi
     test:
     - as: e2e
-      commands: ./ci/e2e-tests.sh
+      commands: |-
+        [[ -f ci/setup-aws-profiles.sh ]] && source ci/setup-aws-profiles.sh
+        ./ci/e2e-tests.sh
       credentials:
       - mount_path: /var/run/rosa-credentials
         name: rosa-regional-platform-ephemeral-creds
@@ -141,7 +153,9 @@ tests:
   steps:
     test:
     - as: ephemeral-resources-janitor
-      commands: ./ci/ephemeral-resources-janitor.sh
+      commands: |-
+        [[ -f ci/setup-aws-profiles.sh ]] && source ci/setup-aws-profiles.sh
+        ./ci/ephemeral-resources-janitor.sh
       credentials:
       - mount_path: /var/run/rosa-credentials
         name: rosa-regional-platform-ephemeral-creds

--- a/ci-operator/step-registry/rosa-regional-platform/e2e/rosa-regional-platform-e2e-commands.sh
+++ b/ci-operator/step-registry/rosa-regional-platform/e2e/rosa-regional-platform-e2e-commands.sh
@@ -22,6 +22,9 @@ git clone https://github.com/openshift-online/rosa-regional-platform.git "${WORK
 cd "${WORK_DIR}/platform"
 git checkout "${CLONE_REF}"
 
+# Set up AWS profiles from mounted credentials (backwards-compatible)
+[[ -f ci/setup-aws-profiles.sh ]] && source ci/setup-aws-profiles.sh
+
 # ---------------------------------------------------------------------------
 # 2. Resolve which e2e test repo + ref to use
 # ---------------------------------------------------------------------------

--- a/ci-operator/step-registry/rosa-regional-platform/e2e/rosa-regional-platform-e2e-commands.sh
+++ b/ci-operator/step-registry/rosa-regional-platform/e2e/rosa-regional-platform-e2e-commands.sh
@@ -22,7 +22,7 @@ git clone https://github.com/openshift-online/rosa-regional-platform.git "${WORK
 cd "${WORK_DIR}/platform"
 git checkout "${CLONE_REF}"
 
-# Set up AWS profiles from mounted credentials (backwards-compatible)
+# Set up AWS profiles from mounted credentials
 [[ -f ci/setup-aws-profiles.sh ]] && source ci/setup-aws-profiles.sh
 
 # ---------------------------------------------------------------------------

--- a/ci-operator/step-registry/rosa-regional-platform/provision/rosa-regional-platform-provision-commands.sh
+++ b/ci-operator/step-registry/rosa-regional-platform/provision/rosa-regional-platform-provision-commands.sh
@@ -9,6 +9,9 @@ git clone --depth 1 --branch "${ROSA_REGIONAL_PLATFORM_REF}" \
   https://github.com/openshift-online/rosa-regional-platform.git "${WORK_DIR}/platform"
 cd "${WORK_DIR}/platform"
 
+# Set up AWS profiles from mounted credentials (backwards-compatible)
+[[ -f ci/setup-aws-profiles.sh ]] && source ci/setup-aws-profiles.sh
+
 # Pin the exact commit SHA so e2e and teardown use the same code
 PINNED_SHA="$(git rev-parse HEAD)"
 echo "${PINNED_SHA}" > "${SHARED_DIR}/rosa-regional-platform-sha"

--- a/ci-operator/step-registry/rosa-regional-platform/provision/rosa-regional-platform-provision-commands.sh
+++ b/ci-operator/step-registry/rosa-regional-platform/provision/rosa-regional-platform-provision-commands.sh
@@ -9,7 +9,7 @@ git clone --depth 1 --branch "${ROSA_REGIONAL_PLATFORM_REF}" \
   https://github.com/openshift-online/rosa-regional-platform.git "${WORK_DIR}/platform"
 cd "${WORK_DIR}/platform"
 
-# Set up AWS profiles from mounted credentials (backwards-compatible)
+# Set up AWS profiles from mounted credentials
 [[ -f ci/setup-aws-profiles.sh ]] && source ci/setup-aws-profiles.sh
 
 # Pin the exact commit SHA so e2e and teardown use the same code

--- a/ci-operator/step-registry/rosa-regional-platform/teardown/rosa-regional-platform-teardown-commands.sh
+++ b/ci-operator/step-registry/rosa-regional-platform/teardown/rosa-regional-platform-teardown-commands.sh
@@ -18,7 +18,7 @@ git clone https://github.com/openshift-online/rosa-regional-platform.git "${WORK
 cd "${WORK_DIR}/platform"
 git checkout "${CLONE_REF}"
 
-# Set up AWS profiles from mounted credentials (backwards-compatible)
+# Set up AWS profiles from mounted credentials
 [[ -f ci/setup-aws-profiles.sh ]] && source ci/setup-aws-profiles.sh
 
 echo "Starting ephemeral teardown (fire-and-forget)..."

--- a/ci-operator/step-registry/rosa-regional-platform/teardown/rosa-regional-platform-teardown-commands.sh
+++ b/ci-operator/step-registry/rosa-regional-platform/teardown/rosa-regional-platform-teardown-commands.sh
@@ -18,5 +18,8 @@ git clone https://github.com/openshift-online/rosa-regional-platform.git "${WORK
 cd "${WORK_DIR}/platform"
 git checkout "${CLONE_REF}"
 
+# Set up AWS profiles from mounted credentials (backwards-compatible)
+[[ -f ci/setup-aws-profiles.sh ]] && source ci/setup-aws-profiles.sh
+
 echo "Starting ephemeral teardown (fire-and-forget)..."
 uv run --no-cache ci/ephemeral-provider/main.py --teardown-fire-and-forget


### PR DESCRIPTION
## Summary
  - Add `source ci/setup-aws-profiles.sh` to all CI steps that use AWS credentials
  - Backwards-compatible: guarded with `[[ -f ci/setup-aws-profiles.sh ]]` so older refs still work

  ## Context

  openshift-online/rosa-regional-platform is moving to AWS profiles as the single credential interface . Scripts no longer read raw
  credential files from `/var/run/rosa-credentials/` directly — they expect profiles (`rrp-rc`, `rrp-mc`, `rrp-central`) to be configured via `AWS_CONFIG_FILE`.

  A new `ci/setup-aws-profiles.sh` script in the platform repo reads the Prow-mounted secrets and writes the AWS config. This PR sources that script at the start of every CI step
   that uses credentials.

  ## Changes

  **Step registry** (used by cross-repo workflow, e.g. rosa-regional-platform-api):
  - `provision-commands.sh` — source after cloning platform repo
  - `e2e-commands.sh` — source after checkout
  - `teardown-commands.sh` — source after checkout

  **ci-operator config** (inline steps):
  - nightly-ephemeral: provision, e2e, teardown
  - nightly-integration: e2e
  - on-demand-e2e: provision, e2e, teardown
  - ephemeral-resources-janitor

