### PR TITLE
OCPEDGE-2490: feat: adding pacemaker and podman etcd logs in baremetalds-dev-scripts-gather

### DIFF
--- a/ci-operator/step-registry/baremetalds/devscripts/gather/baremetalds-devscripts-gather-commands.sh
+++ b/ci-operator/step-registry/baremetalds/devscripts/gather/baremetalds-devscripts-gather-commands.sh
@@ -69,9 +69,6 @@ then
   tar -czC "/tmp" -f "/tmp/artifacts/squid-logs-$NAMESPACE.tar.gz" squid-logs-$NAMESPACE/
 fi
 
-# Exit if we have access to the API, the other gather steps will get logs
-if [ "\$(cat logs/installer-status.txt)" == "0" ] ; then exit 0 ; fi
-
 # Pass master and workers IPs to installer-gather script to collect info from nodes which didn't join the cluster
 NODE_NAMES=()
 for (( n=0; n<\$NUM_MASTERS; n++ ))
@@ -93,6 +90,33 @@ do
   node_ip=\$(sudo virsh net-dumpxml \$BAREMETAL_NETWORK_NAME | xmllint --xpath "string(//host[@name='\$node_name']/@ip)" -)
     NODE_IPS+=("\$node_ip")
 done
+
+echo "Checking for pacemaker and podman etcd logs on master nodes..."
+for (( n=0; n<\$NUM_MASTERS; n++ ))
+do
+  HAS_PACEMAKER=\$(ssh "\${INTERNAL_SSH_OPTS[@]}" core@\${NODE_IPS[\$n]} sudo test -f /var/log/pacemaker/pacemaker.log && echo true || echo false)
+  HAS_ETCD=\$(ssh "\${INTERNAL_SSH_OPTS[@]}" core@\${NODE_IPS[\$n]} sudo podman container exists etcd && echo true || echo false)
+  if \$HAS_PACEMAKER; then
+    ssh "\${INTERNAL_SSH_OPTS[@]}" core@\${NODE_IPS[\$n]} \
+      sudo cat /var/log/pacemaker/pacemaker.log | \
+      sed -E 's/(name="(password|passwd|username)" value=")[^"]*/\1REDACTED/g' \
+      > /tmp/pacemaker_\${NODE_NAMES[\$n]//:/_}.log || true
+    tar -czf /tmp/artifacts/pacemaker_\${NODE_NAMES[\$n]//:/_}.tar.gz \
+      -C /tmp pacemaker_\${NODE_NAMES[\$n]//:/_}.log || true
+    rm -f /tmp/pacemaker_\${NODE_NAMES[\$n]//:/_}.log
+  fi
+  if \$HAS_ETCD; then
+    ssh "\${INTERNAL_SSH_OPTS[@]}" core@\${NODE_IPS[\$n]} \
+      sudo podman logs etcd > /tmp/podman-etcd_\${NODE_NAMES[\$n]//:/_}.log 2>&1 || true
+    tar -czf /tmp/artifacts/podman-etcd_\${NODE_NAMES[\$n]//:/_}.tar.gz \
+      -C /tmp podman-etcd_\${NODE_NAMES[\$n]//:/_}.log || true
+    rm -f /tmp/podman-etcd_\${NODE_NAMES[\$n]//:/_}.log
+  fi
+done
+
+
+# Exit if we have access to the API, the other gather steps will get logs
+if [ "\$(cat logs/installer-status.txt)" == "0" ] ; then exit 0 ; fi
 
 # Collect sos report from each known node
 for NODE_IP in \${NODE_IPS[@]}; do


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI diagnostic logging by automatically collecting additional per-node artifacts: temporary node log files, Pacemaker service logs, and container runtime (etcd) logs.  
  * Captured logs are stored as per-node artifacts and collection is tolerant of individual failures so overall runs are not blocked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->