### PR TITLE
AGENT-1487: add baremetalds-e2e-test-iso-no-registry ref

### DIFF
--- a/ci-operator/step-registry/baremetalds/e2e/test/iso-no-registry/OWNERS
+++ b/ci-operator/step-registry/baremetalds/e2e/test/iso-no-registry/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+- andfasano
+- bfournie
+- pamoedom
+- pawanpinjarkar
+- rwsu
+- zaneb

--- a/ci-operator/step-registry/baremetalds/e2e/test/iso-no-registry/baremetalds-e2e-test-iso-no-registry-commands.sh
+++ b/ci-operator/step-registry/baremetalds/e2e/test/iso-no-registry/baremetalds-e2e-test-iso-no-registry-commands.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+export KUBECONFIG=${SHARED_DIR}/kubeconfig
+
+echo "$(date +%s)" > "${SHARED_DIR}/TEST_TIME_TEST_START"
+trap 'echo "$(date +%s)" > "${SHARED_DIR}/TEST_TIME_TEST_END"' EXIT
+
+TEST_ARGS=""
+
+if [[ -n "${TEST_SKIPS:-}" ]]; then
+    TESTS="$(openshift-tests run all --dry-run)"
+    echo "${TESTS}" | grep -v "${TEST_SKIPS}" >/tmp/tests
+    echo "Skipping tests:"
+    echo "${TESTS}" | grep "${TEST_SKIPS}" || true
+    TEST_ARGS="--file /tmp/tests"
+fi
+
+openshift-tests run all ${TEST_ARGS} \
+    -o "${ARTIFACT_DIR}/e2e.log" \
+    --junit-dir "${ARTIFACT_DIR}/junit"

--- a/ci-operator/step-registry/baremetalds/e2e/test/iso-no-registry/baremetalds-e2e-test-iso-no-registry-ref.metadata.json
+++ b/ci-operator/step-registry/baremetalds/e2e/test/iso-no-registry/baremetalds-e2e-test-iso-no-registry-ref.metadata.json
@@ -1,0 +1,13 @@
+{
+	"path": "baremetalds/e2e/test/iso-no-registry/baremetalds-e2e-test-iso-no-registry-ref.yaml",
+	"owners": {
+		"approvers": [
+			"andfasano",
+			"bfournie",
+			"pamoedom",
+			"pawanpinjarkar",
+			"rwsu",
+			"zaneb"
+		]
+	}
+}

--- a/ci-operator/step-registry/baremetalds/e2e/test/iso-no-registry/baremetalds-e2e-test-iso-no-registry-ref.yaml
+++ b/ci-operator/step-registry/baremetalds/e2e/test/iso-no-registry/baremetalds-e2e-test-iso-no-registry-ref.yaml
@@ -1,0 +1,22 @@
+ref:
+  as: baremetalds-e2e-test-iso-no-registry
+  from: tests
+  grace_period: 10m
+  commands: baremetalds-e2e-test-iso-no-registry-commands.sh
+  timeout: 5h0m0s
+  resources:
+    requests:
+      cpu: "3"
+      memory: 600Mi
+    limits:
+      memory: 12Gi
+  env:
+  - name: TEST_SKIPS
+    default: ""
+    documentation: |-
+      Regular expression (POSIX basic regular expression) of tests to skip.
+      If unset, all origin tests are run.
+  documentation: |-
+    The Baremetal DS E2E step for ISO NO REGISTRY executes the full end-to-end test suite
+    without image mirroring. It exports the kubeconfig and runs all origin tests, optionally
+    filtering out tests matching TEST_SKIPS.


### PR DESCRIPTION
Add a new ref for the ISO NO REGISTRY scenario that runs all origin tests without image mirroring. Unlike the existing baremetalds-e2e-test ref, the commands.sh simply exports the kubeconfig and runs openshift-tests run all, optionally filtering via TEST_SKIPS.