### PR TITLE
Drop pull secret syncing into aro hcp jobs

### DIFF
--- a/core-services/ci-secret-bootstrap/_config.yaml
+++ b/core-services/ci-secret-bootstrap/_config.yaml
@@ -1168,22 +1168,6 @@ secret_configs:
     namespace: ci
   - cluster_groups:
     - non_app_ci
-    name: cluster-secrets-aro-hcp-int
-    namespace: ci
-  - cluster_groups:
-    - non_app_ci
-    name: cluster-secrets-aro-hcp-stg
-    namespace: ci
-  - cluster_groups:
-    - non_app_ci
-    name: cluster-secrets-aro-hcp-prod
-    namespace: ci
-  - cluster_groups:
-    - non_app_ci
-    name: cluster-secrets-aro-hcp-dev
-    namespace: ci
-  - cluster_groups:
-    - non_app_ci
     name: cluster-secrets-rosa-regional-platform-int
     namespace: ci
 - from:


### PR DESCRIPTION
Once #76075 merges, we will no longer be utilizing pull secrets in our jobs. And therefore we don't need the pull secret syncing config bit.

(I was initially confused by what this thing does, it became clear only once I scrolled up the file to line 884 and noticed that it starts with `from: pull-secret` and what this is removing is a few items from the `to:` counterpart to that `from:`.)

https://issues.redhat.com/browse/AROSLSRE-555