### PR TITLE
[release-4.20] Test PR 7953: OCPBUGS-78474 custom kubeconfig deadlock fix

### DIFF
--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.20__amd64-nightly.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.20__amd64-nightly.yaml
@@ -948,6 +948,7 @@ tests:
   steps:
     cluster_profile: aws-qe
     env:
+      EXTRA_ARGS: "--annotations=hypershift.openshift.io/control-plane-operator-image=quay.io/heli/hypershift-control-plane:7953"
       ADDITIONAL_HYPERSHIFT_INSTANCE_TYPE: m5.large
       ADDITIONAL_HYPERSHIFT_NODE_ARCH: amd64
       BASE_DOMAIN: qe.devcluster.openshift.com
@@ -956,8 +957,7 @@ tests:
       HYPERSHIFT_DYNAMIC_DNS: hypershift-qe-dns.qe.devcluster.openshift.com
       HYPERSHIFT_FEATURE_SET: TechPreviewNoUpgrade
       HYPERSHIFT_NODE_COUNT: "1"
-      NODEPOOL_CAPACITY_RESERVATION: OnDemand
-      NODEPOOL_CAPACITY_RESERVATION_ZONE: us-east-1a
+      CUSTOM_OPERATOR_IMAGE: "quay.io/heli/hypershift-operator:7953"
       PUBLIC_ONLY: "true"
       TEST_FILTERS: ~ChkUpgrade&;~DisconnectedOnly&;~NonPreRelease&;~HyperShiftMGMT&;~MicroShiftOnly&;~NonHyperShiftHOST&;~Serial&;~Disruptive&
       TEST_TIMEOUT: "30"

--- a/ci-operator/step-registry/cucushift/hypershift-extended/install-private/cucushift-hypershift-extended-install-private-commands.sh
+++ b/ci-operator/step-registry/cucushift/hypershift-extended/install-private/cucushift-hypershift-extended-install-private-commands.sh
@@ -14,6 +14,11 @@ if [[ $HO_MULTI == "true" ]]; then
   HCP_CLI="/tmp/hs-cli/hypershift"
 fi
 
+if [[ -n "$CUSTOM_OPERATOR_IMAGE" ]] ; then
+  OPERATOR_IMAGE=$CUSTOM_OPERATOR_IMAGE
+fi
+
+
 # Build up the hypershift install command
 COMMAND=(
     "${HCP_CLI}" install

--- a/ci-operator/step-registry/cucushift/hypershift-extended/install-private/cucushift-hypershift-extended-install-private-ref.yaml
+++ b/ci-operator/step-registry/cucushift/hypershift-extended/install-private/cucushift-hypershift-extended-install-private-ref.yaml
@@ -32,6 +32,9 @@ ref:
   - name: HO_MULTI
     default: "false"
     documentation: "If true, HyperShift Operator image will be multi"
+  - name: CUSTOM_OPERATOR_IMAGE
+    default: ""
+    documentation: "It is used to set custom HO image"
   - name: ENABLE_PRIVATE
     default: "true"
     documentation: |

--- a/ci-operator/step-registry/cucushift/installer/rehearse/aws/ipi/ovn/hypershift/guest/advanced/cucushift-installer-rehearse-aws-ipi-ovn-hypershift-guest-advanced-workflow.yaml
+++ b/ci-operator/step-registry/cucushift/installer/rehearse/aws/ipi/ovn/hypershift/guest/advanced/cucushift-installer-rehearse-aws-ipi-ovn-hypershift-guest-advanced-workflow.yaml
@@ -2,6 +2,8 @@ workflow:
   as: cucushift-installer-rehearse-aws-ipi-ovn-hypershift-guest-advanced
   steps:
     env:
+      ADDITIONAL_HYPERSHIFT_NODE_COUNT: "0"
+      ENABLE_ICSP: "false"
       REGION: us-east-1
       HYPERSHIFT_AWS_REGION: us-east-1
       HYPERSHIFT_HC_ZONES: us-east-1a,us-east-1b,us-east-1c
@@ -14,8 +16,8 @@ workflow:
       - ref: cucushift-hypershift-extended-enable-dns
       - ref: cucushift-hypershift-extended-capacity-reservation-create
       - ref: hypershift-aws-create-nodepool
-      - chain: cucushift-hypershift-extended-enable-qe-catalogsource
       - ref: cucushift-hypershift-extended-ovn-ipv4
+      - ref: cucushift-hypershift-extended-debug
       - ref: cucushift-hypershift-extended-enable-guest
       - ref: cucushift-installer-reportportal-marker
     post:

--- a/ci-operator/step-registry/hypershift/aws/create/nodepool/hypershift-aws-create-nodepool-commands.sh
+++ b/ci-operator/step-registry/hypershift/aws/create/nodepool/hypershift-aws-create-nodepool-commands.sh
@@ -33,8 +33,13 @@ function config_nodepool() {
     if [[ -n "${NODEPOOL_TENANCY}" || -n "${NODEPOOL_CAPACITY_RESERVATION}" ]]; then
       EXTRA_FLARGS+=" && oc apply -f /tmp/np.yaml"
     fi
-    echo "$EXTRA_FLARGS"  
+    echo "$EXTRA_FLARGS"
 }
+
+if [[ -z "${ADDITIONAL_HYPERSHIFT_NODE_COUNT}" || "${ADDITIONAL_HYPERSHIFT_NODE_COUNT}" == "0" ]]; then
+  echo "Skip: no additional hypershift nodes requested"
+  exit 0
+fi
 
 eval "/usr/bin/hypershift create nodepool aws \
   --cluster-name  ${CLUSTER_NAME} \


### PR DESCRIPTION
## Purpose

Regression testing for openshift/hypershift#7953 - OCPBUGS-78474 deadlock fix.

## Changes

Modified `aws-ipi-ovn-hypershift-guest-dynamic-dns-ondemand-adv-f14` job to use custom images from PR 7953:

- **HyperShift Operator:** `quay.io/heli/hypershift-operator:7953`
- **Control Plane Operator:** `quay.io/heli/hypershift-control-plane:7953`

## Testing Scope

This tests the deadlock scenario fix where:
1. HostedCluster created with `KubeAPIServerDNSName` (custom kubeconfig)
2. CPO sets status before secret exists  
3. HC controller must tolerate NotFound and continue reconciliation
4. CPO deployment gets updated and creates secret
5. Secret successfully copied to HC namespace

## Files Modified

1. `ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.20__amd64-nightly.yaml`
   - Added `EXTRA_ARGS` for CPO image override
   - Added `CUSTOM_OPERATOR_IMAGE` for HO image override
   - Removed `NODEPOOL_CAPACITY_RESERVATION` settings

2. `ci-operator/step-registry/cucushift/hypershift-extended/install-private/cucushift-hypershift-extended-install-private-commands.sh`
   - Added logic to use `CUSTOM_OPERATOR_IMAGE` if provided

3. `ci-operator/step-registry/cucushift/hypershift-extended/install-private/cucushift-hypershift-extended-install-private-ref.yaml`
   - Added `CUSTOM_OPERATOR_IMAGE` environment variable

4. `ci-operator/step-registry/cucushift/installer/rehearse/aws/ipi/ovn/hypershift/guest/advanced/cucushift-installer-rehearse-aws-ipi-ovn-hypershift-guest-advanced-workflow.yaml`
   - Added `ADDITIONAL_HYPERSHIFT_NODE_COUNT: "0"` to skip additional nodepool
   - Added `ENABLE_ICSP: "false"`
   - Removed `cucushift-hypershift-extended-enable-qe-catalogsource`
   - Added `cucushift-hypershift-extended-debug`

5. `ci-operator/step-registry/hypershift/aws/create/nodepool/hypershift-aws-create-nodepool-commands.sh`
   - Added check to skip nodepool creation if count is 0

## Reference

Based on https://github.com/openshift/release/pull/76067 (4.22 testing pattern)

## Next Steps

1. Wait for CI checks (rehearsal)
2. Trigger job: `/pj-rehearse aws-ipi-ovn-hypershift-guest-dynamic-dns-ondemand-adv-f14`
3. Verify no deadlock during cluster provisioning
4. Monitor logs for NotFound handling

/cc @heliubj18