### PR TITLE
OCPBUGS-81561: graduate event-ttl

### DIFF
--- a/ci-operator/config/openshift/cluster-kube-apiserver-operator/openshift-cluster-kube-apiserver-operator-main__periodics.yaml
+++ b/ci-operator/config/openshift/cluster-kube-apiserver-operator/openshift-cluster-kube-apiserver-operator-main__periodics.yaml
@@ -35,45 +35,40 @@ resources:
 test_binary_build_commands: make build GO_BUILD_FLAGS:='-race' --warn-undefined-variables
 tests:
 - as: e2e-aws-event-ttl
-  interval: 12h
+  interval: 24h
   steps:
     cluster_profile: aws-3
     env:
-      FEATURE_SET: TechPreviewNoUpgrade
       TEST_SUITE: openshift/cluster-kube-apiserver-operator/event-ttl
     workflow: openshift-e2e-aws
 - as: e2e-azure-event-ttl
-  interval: 12h
+  interval: 48h
   steps:
     cluster_profile: azure4
     env:
-      FEATURE_SET: TechPreviewNoUpgrade
       TEST_SUITE: openshift/cluster-kube-apiserver-operator/event-ttl
     workflow: openshift-e2e-azure
 - as: e2e-gcp-event-ttl
-  interval: 12h
+  interval: 48h
   steps:
     cluster_profile: gcp
     env:
-      FEATURE_SET: TechPreviewNoUpgrade
       TEST_SUITE: openshift/cluster-kube-apiserver-operator/event-ttl
     workflow: openshift-e2e-gcp
 - as: e2e-vsphere-event-ttl
-  cron: 12 1 * * *
+  cron: 15 6 * * 5
   steps:
     cluster_profile: vsphere-elastic
     env:
-      FEATURE_SET: TechPreviewNoUpgrade
       TEST_SUITE: openshift/cluster-kube-apiserver-operator/event-ttl
     workflow: openshift-e2e-vsphere
 - as: e2e-metal-event-ttl
-  cron: 12 1 * * *
+  cron: 15 6 * * 5
   steps:
     cluster_profile: equinix-ocp-metal
     env:
       DEVSCRIPTS_CONFIG: |
         NETWORK_TYPE=OVNKubernetes
-        FEATURE_SET=TechPreviewNoUpgrade
       TEST_SUITE: openshift/cluster-kube-apiserver-operator/event-ttl
     workflow: baremetalds-e2e
 zz_generated_metadata:

--- a/ci-operator/config/openshift/cluster-kube-apiserver-operator/openshift-cluster-kube-apiserver-operator-release-4.22__periodics.yaml
+++ b/ci-operator/config/openshift/cluster-kube-apiserver-operator/openshift-cluster-kube-apiserver-operator-release-4.22__periodics.yaml
@@ -35,45 +35,40 @@ resources:
 test_binary_build_commands: make build GO_BUILD_FLAGS:='-race' --warn-undefined-variables
 tests:
 - as: e2e-aws-event-ttl
-  interval: 12h
+  interval: 24h
   steps:
     cluster_profile: aws-3
     env:
-      FEATURE_SET: TechPreviewNoUpgrade
       TEST_SUITE: openshift/cluster-kube-apiserver-operator/event-ttl
     workflow: openshift-e2e-aws
 - as: e2e-azure-event-ttl
-  interval: 12h
+  interval: 48h
   steps:
     cluster_profile: azure4
     env:
-      FEATURE_SET: TechPreviewNoUpgrade
       TEST_SUITE: openshift/cluster-kube-apiserver-operator/event-ttl
     workflow: openshift-e2e-azure
 - as: e2e-gcp-event-ttl
-  interval: 12h
+  interval: 48h
   steps:
     cluster_profile: gcp
     env:
-      FEATURE_SET: TechPreviewNoUpgrade
       TEST_SUITE: openshift/cluster-kube-apiserver-operator/event-ttl
     workflow: openshift-e2e-gcp
 - as: e2e-vsphere-event-ttl
-  cron: 12 3 * * *
+  cron: 15 6 * * 5
   steps:
     cluster_profile: vsphere-elastic
     env:
-      FEATURE_SET: TechPreviewNoUpgrade
       TEST_SUITE: openshift/cluster-kube-apiserver-operator/event-ttl
     workflow: openshift-e2e-vsphere
 - as: e2e-metal-event-ttl
-  cron: 12 3 * * *
+  cron: 15 6 * * 5
   steps:
     cluster_profile: equinix-ocp-metal
     env:
       DEVSCRIPTS_CONFIG: |
         NETWORK_TYPE=OVNKubernetes
-        FEATURE_SET=TechPreviewNoUpgrade
       TEST_SUITE: openshift/cluster-kube-apiserver-operator/event-ttl
     workflow: baremetalds-e2e
 zz_generated_metadata:

--- a/ci-operator/config/openshift/cluster-kube-apiserver-operator/openshift-cluster-kube-apiserver-operator-release-4.23__periodics.yaml
+++ b/ci-operator/config/openshift/cluster-kube-apiserver-operator/openshift-cluster-kube-apiserver-operator-release-4.23__periodics.yaml
@@ -35,45 +35,40 @@ resources:
 test_binary_build_commands: make build GO_BUILD_FLAGS:='-race' --warn-undefined-variables
 tests:
 - as: e2e-aws-event-ttl
-  interval: 12h
+  interval: 24h
   steps:
     cluster_profile: aws-3
     env:
-      FEATURE_SET: TechPreviewNoUpgrade
       TEST_SUITE: openshift/cluster-kube-apiserver-operator/event-ttl
     workflow: openshift-e2e-aws
 - as: e2e-azure-event-ttl
-  interval: 12h
+  interval: 48h
   steps:
     cluster_profile: azure4
     env:
-      FEATURE_SET: TechPreviewNoUpgrade
       TEST_SUITE: openshift/cluster-kube-apiserver-operator/event-ttl
     workflow: openshift-e2e-azure
 - as: e2e-gcp-event-ttl
-  interval: 12h
+  interval: 48h
   steps:
     cluster_profile: gcp
     env:
-      FEATURE_SET: TechPreviewNoUpgrade
       TEST_SUITE: openshift/cluster-kube-apiserver-operator/event-ttl
     workflow: openshift-e2e-gcp
 - as: e2e-vsphere-event-ttl
-  cron: 12 4 * * *
+  cron: 15 6 * * 5
   steps:
     cluster_profile: vsphere-elastic
     env:
-      FEATURE_SET: TechPreviewNoUpgrade
       TEST_SUITE: openshift/cluster-kube-apiserver-operator/event-ttl
     workflow: openshift-e2e-vsphere
 - as: e2e-metal-event-ttl
-  cron: 12 4 * * *
+  cron: 15 6 * * 5
   steps:
     cluster_profile: equinix-ocp-metal
     env:
       DEVSCRIPTS_CONFIG: |
         NETWORK_TYPE=OVNKubernetes
-        FEATURE_SET=TechPreviewNoUpgrade
       TEST_SUITE: openshift/cluster-kube-apiserver-operator/event-ttl
     workflow: baremetalds-e2e
 zz_generated_metadata:

--- a/ci-operator/config/openshift/cluster-kube-apiserver-operator/openshift-cluster-kube-apiserver-operator-release-5.0__periodics.yaml
+++ b/ci-operator/config/openshift/cluster-kube-apiserver-operator/openshift-cluster-kube-apiserver-operator-release-5.0__periodics.yaml
@@ -35,45 +35,40 @@ resources:
 test_binary_build_commands: make build GO_BUILD_FLAGS:='-race' --warn-undefined-variables
 tests:
 - as: e2e-aws-event-ttl
-  interval: 12h
+  interval: 24h
   steps:
     cluster_profile: aws-3
     env:
-      FEATURE_SET: TechPreviewNoUpgrade
       TEST_SUITE: openshift/cluster-kube-apiserver-operator/event-ttl
     workflow: openshift-e2e-aws
 - as: e2e-azure-event-ttl
-  interval: 12h
+  interval: 48h
   steps:
     cluster_profile: azure4
     env:
-      FEATURE_SET: TechPreviewNoUpgrade
       TEST_SUITE: openshift/cluster-kube-apiserver-operator/event-ttl
     workflow: openshift-e2e-azure
 - as: e2e-gcp-event-ttl
-  interval: 12h
+  interval: 48h
   steps:
     cluster_profile: gcp
     env:
-      FEATURE_SET: TechPreviewNoUpgrade
       TEST_SUITE: openshift/cluster-kube-apiserver-operator/event-ttl
     workflow: openshift-e2e-gcp
 - as: e2e-vsphere-event-ttl
-  cron: 12 5 * * *
+  cron: 15 6 * * 5
   steps:
     cluster_profile: vsphere-elastic
     env:
-      FEATURE_SET: TechPreviewNoUpgrade
       TEST_SUITE: openshift/cluster-kube-apiserver-operator/event-ttl
     workflow: openshift-e2e-vsphere
 - as: e2e-metal-event-ttl
-  cron: 12 5 * * *
+  cron: 15 6 * * 5
   steps:
     cluster_profile: equinix-ocp-metal
     env:
       DEVSCRIPTS_CONFIG: |
         NETWORK_TYPE=OVNKubernetes
-        FEATURE_SET=TechPreviewNoUpgrade
       TEST_SUITE: openshift/cluster-kube-apiserver-operator/event-ttl
     workflow: baremetalds-e2e
 zz_generated_metadata:


### PR DESCRIPTION
* Removes the feature gating
* Moves the BM/vsphere variants to once a week, all others to every 48h

Keeping the existing configs for 4.21 because we're going to backport and need to continue to gather data.

/hold waiting for the api and apiserver code to merge first