### PR TITLE
AGENT-1486 AGENT-1487: Add generic iso-no-registry conformance workflow and test ref 

### DIFF
--- a/ci-operator/step-registry/agent/e2e/generic/conformance/iso-no-registry/OWNERS
+++ b/ci-operator/step-registry/agent/e2e/generic/conformance/iso-no-registry/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+- andfasano
+- bfournie
+- pamoedom
+- pawanpinjarkar
+- rwsu
+- zaneb

--- a/ci-operator/step-registry/agent/e2e/generic/conformance/iso-no-registry/agent-e2e-generic-conformance-iso-no-registry-workflow.metadata.json
+++ b/ci-operator/step-registry/agent/e2e/generic/conformance/iso-no-registry/agent-e2e-generic-conformance-iso-no-registry-workflow.metadata.json
@@ -1,0 +1,13 @@
+{
+	"path": "agent/e2e/generic/conformance/iso-no-registry/agent-e2e-generic-conformance-iso-no-registry-workflow.yaml",
+	"owners": {
+		"approvers": [
+			"andfasano",
+			"bfournie",
+			"pamoedom",
+			"pawanpinjarkar",
+			"rwsu",
+			"zaneb"
+		]
+	}
+}

--- a/ci-operator/step-registry/agent/e2e/generic/conformance/iso-no-registry/agent-e2e-generic-conformance-iso-no-registry-workflow.yaml
+++ b/ci-operator/step-registry/agent/e2e/generic/conformance/iso-no-registry/agent-e2e-generic-conformance-iso-no-registry-workflow.yaml
@@ -1,0 +1,16 @@
+workflow:
+  as: agent-e2e-generic-conformance-iso-no-registry
+  steps:
+    allow_best_effort_post_steps: true
+    allow_skip_on_success: true
+    env:
+      DEVSCRIPTS_TARGET: agent
+    pre:
+      - chain: agent-pre
+    test:
+      - chain: agent-test-conformance-iso-no-registry
+    post:
+      - chain: agent-post
+  documentation: |-
+    This workflow is a generic conformance one to deploy a no registry cluster provisioned by running agent installer, and it
+    will require to set the env variable DEVSCRIPTS_CONFIG to work properly.

--- a/ci-operator/step-registry/agent/e2e/test/OWNERS
+++ b/ci-operator/step-registry/agent/e2e/test/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+- andfasano
+- bfournie
+- pamoedom
+- pawanpinjarkar
+- rwsu
+- zaneb

--- a/ci-operator/step-registry/agent/e2e/test/iso-no-registry/OWNERS
+++ b/ci-operator/step-registry/agent/e2e/test/iso-no-registry/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+- andfasano
+- bfournie
+- pamoedom
+- pawanpinjarkar
+- rwsu
+- zaneb

--- a/ci-operator/step-registry/agent/e2e/test/iso-no-registry/agent-e2e-test-iso-no-registry-commands.sh
+++ b/ci-operator/step-registry/agent/e2e/test/iso-no-registry/agent-e2e-test-iso-no-registry-commands.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+export KUBECONFIG=${SHARED_DIR}/kubeconfig
+
+echo "$(date +%s)" > "${SHARED_DIR}/TEST_TIME_TEST_START"
+trap 'echo "$(date +%s)" > "${SHARED_DIR}/TEST_TIME_TEST_END"' EXIT
+
+TEST_ARGS=""
+
+if [[ -n "${TEST_SKIPS:-}" ]]; then
+    TESTS="$(openshift-tests run all --dry-run)"
+    echo "${TESTS}" | grep -v "${TEST_SKIPS}" >/tmp/tests
+    echo "Skipping tests:"
+    echo "${TESTS}" | grep "${TEST_SKIPS}" || true
+    TEST_ARGS="--file /tmp/tests"
+fi
+
+openshift-tests run all --run ".*NoRegistryClusterInstall.*" ${TEST_ARGS} \
+    -o "${ARTIFACT_DIR}/e2e.log" \
+    --junit-dir "${ARTIFACT_DIR}/junit"

--- a/ci-operator/step-registry/agent/e2e/test/iso-no-registry/agent-e2e-test-iso-no-registry-ref.metadata.json
+++ b/ci-operator/step-registry/agent/e2e/test/iso-no-registry/agent-e2e-test-iso-no-registry-ref.metadata.json
@@ -1,0 +1,13 @@
+{
+	"path": "agent/e2e/test/iso-no-registry/agent-e2e-test-iso-no-registry-ref.yaml",
+	"owners": {
+		"approvers": [
+			"andfasano",
+			"bfournie",
+			"pamoedom",
+			"pawanpinjarkar",
+			"rwsu",
+			"zaneb"
+		]
+	}
+}

--- a/ci-operator/step-registry/agent/e2e/test/iso-no-registry/agent-e2e-test-iso-no-registry-ref.yaml
+++ b/ci-operator/step-registry/agent/e2e/test/iso-no-registry/agent-e2e-test-iso-no-registry-ref.yaml
@@ -1,0 +1,22 @@
+ref:
+  as: agent-e2e-test-iso-no-registry
+  from: tests
+  grace_period: 10m
+  commands: agent-e2e-test-iso-no-registry-commands.sh
+  timeout: 5h0m0s
+  resources:
+    requests:
+      cpu: "3"
+      memory: 600Mi
+    limits:
+      memory: 12Gi
+  env:
+  - name: TEST_SKIPS
+    default: ""
+    documentation: |-
+      Regular expression (POSIX basic regular expression) of tests to skip.
+      If unset, all NoRegistryClusterInstall origin tests are run.
+  documentation: |-
+    Runs the NoRegistryClusterInstall origin tests for the agent installer ISO NO REGISTRY
+    scenario. Exports the kubeconfig and runs openshift-tests without image mirroring,
+    optionally filtering out tests matching TEST_SKIPS.

--- a/ci-operator/step-registry/agent/test/conformance/iso-no-registry/OWNERS
+++ b/ci-operator/step-registry/agent/test/conformance/iso-no-registry/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+- andfasano
+- bfournie
+- pamoedom
+- pawanpinjarkar
+- rwsu
+- zaneb

--- a/ci-operator/step-registry/agent/test/conformance/iso-no-registry/agent-test-conformance-iso-no-registry-chain.metadata.json
+++ b/ci-operator/step-registry/agent/test/conformance/iso-no-registry/agent-test-conformance-iso-no-registry-chain.metadata.json
@@ -1,0 +1,13 @@
+{
+	"path": "agent/test/conformance/iso-no-registry/agent-test-conformance-iso-no-registry-chain.yaml",
+	"owners": {
+		"approvers": [
+			"andfasano",
+			"bfournie",
+			"pamoedom",
+			"pawanpinjarkar",
+			"rwsu",
+			"zaneb"
+		]
+	}
+}

--- a/ci-operator/step-registry/agent/test/conformance/iso-no-registry/agent-test-conformance-iso-no-registry-chain.yaml
+++ b/ci-operator/step-registry/agent/test/conformance/iso-no-registry/agent-test-conformance-iso-no-registry-chain.yaml
@@ -1,0 +1,6 @@
+chain:
+  as: agent-test-conformance-iso-no-registry
+  steps:
+  - ref: baremetalds-e2e-test # this ref needs to be updated after AGENT-1487
+  documentation: |-
+    This chain encapsulates the e2e tests for the agent installer ISO No registry

--- a/ci-operator/step-registry/agent/test/conformance/iso-no-registry/agent-test-conformance-iso-no-registry-chain.yaml
+++ b/ci-operator/step-registry/agent/test/conformance/iso-no-registry/agent-test-conformance-iso-no-registry-chain.yaml
@@ -1,6 +1,6 @@
 chain:
   as: agent-test-conformance-iso-no-registry
   steps:
-  - ref: baremetalds-e2e-test # this ref needs to be updated after AGENT-1487
+  - ref: agent-e2e-test-iso-no-registry
   documentation: |-
     This chain encapsulates the e2e tests for the agent installer ISO No registry


### PR DESCRIPTION
- Add agent-e2e-generic-conformance-iso-no-registry workflow and agent-test-conformance-iso-no-registry chain as scaffolding for ISO NO REGISTRY conformance testing ([AGENT-1486](https://redhat.atlassian.net/browse/AGENT-1486), @pawanpinjarkar)                                                                                                
- Add agent-e2e-test-iso-no-registry ref with a simplified commands.sh that exports the kubeconfig and runs openshift-tests run all --run ".*NoRegistryClusterInstall.*" without image mirroring ([AGENT-1487](https://redhat.atlassian.net/browse/AGENT-1487))                                                                               
- Update the chain to use the new ref instead of the baremetalds-e2e-test placeholder
                                                                                             

[AGENT-1486]: https://redhat.atlassian.net/browse/AGENT-1486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AGENT-1487]: https://redhat.atlassian.net/browse/AGENT-1487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ