### PR TITLE
Add QE integration tests to lvm operator

### DIFF
--- a/ci-operator/config/openshift/lvm-operator/.config.prowgen
+++ b/ci-operator/config/openshift/lvm-operator/.config.prowgen
@@ -1,0 +1,14 @@
+slack_reporter:
+- channel: '#lvms-release-coordination'
+  job_states_to_report:
+  - error
+  - failure
+  - success
+  report_template: '{{if eq .Status.State "success"}} :large_green_circle: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+    logs> :large_green_circle: {{else}} :red_circle: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :red_circle:
+    {{end}}'
+  job_names:
+  - e2e-aws-mno-arm-qe-integration-tests
+  - e2e-aws-mno-qe-integration-tests
+  - e2e-aws-sno-arm-qe-integration-tests
+  - e2e-aws-sno-qe-integration-tests

--- a/ci-operator/config/openshift/lvm-operator/openshift-lvm-operator-main.yaml
+++ b/ci-operator/config/openshift/lvm-operator/openshift-lvm-operator-main.yaml
@@ -293,6 +293,92 @@ tests:
           cpu: 100m
           memory: 200Mi
     workflow: optional-operators-ci-operator-sdk-aws-sno
+- as: e2e-aws-sno-qe-integration-tests
+  cron: '@weekly'
+  steps:
+    cluster_profile: openshift-org-aws
+    env:
+      LVM_OPERATOR_SUB_INSTALL_NAMESPACE: openshift-lvm-storage
+      LVM_OPERATOR_SUB_SOURCE: lvm-catalogsource
+    test:
+    - as: lvms-sno-integration-test
+      cli: latest
+      commands: |
+        ./integration-test run-suite -c 1 --junit-path ${ARTIFACT_DIR}/junit_results.xml openshift/lvm-operator/test/integration/qe_tests/sno
+      from: lvm-operator-integration-test
+      resources:
+        requests:
+          cpu: 100m
+          memory: 200Mi
+      timeout: 4h0m0s
+    workflow: cucushift-installer-rehearse-aws-ipi-sno-lvms
+- as: e2e-aws-sno-arm-qe-integration-tests
+  cron: '@weekly'
+  steps:
+    cluster_profile: openshift-org-aws
+    dependencies:
+      OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: release:multi-latest
+    env:
+      COMPUTE_NODE_TYPE: m6g.4xlarge
+      CONTROL_PLANE_INSTANCE_TYPE: m6g.4xlarge
+      LVM_OPERATOR_SUB_INSTALL_NAMESPACE: openshift-lvm-storage
+      LVM_OPERATOR_SUB_SOURCE: lvm-catalogsource
+      OCP_ARCH: arm64
+    test:
+    - as: lvms-sno-integration-test
+      cli: latest
+      commands: |
+        ./integration-test run-suite -c 1 --junit-path ${ARTIFACT_DIR}/junit_results.xml openshift/lvm-operator/test/integration/qe_tests/sno
+      from: lvm-operator-integration-test
+      resources:
+        requests:
+          cpu: 100m
+          memory: 200Mi
+      timeout: 4h0m0s
+    workflow: cucushift-installer-rehearse-aws-ipi-sno-lvms
+- as: e2e-aws-mno-qe-integration-tests
+  cron: '@weekly'
+  steps:
+    cluster_profile: openshift-org-aws
+    env:
+      LVM_OPERATOR_SUB_INSTALL_NAMESPACE: openshift-lvm-storage
+      LVM_OPERATOR_SUB_SOURCE: lvm-catalogsource
+    test:
+    - as: lvms-mno-integration-test
+      cli: latest
+      commands: |
+        ./integration-test run-suite -c 1 --junit-path ${ARTIFACT_DIR}/junit_results.xml openshift/lvm-operator/test/integration/qe_tests/mno
+      from: lvm-operator-integration-test
+      resources:
+        requests:
+          cpu: 100m
+          memory: 200Mi
+      timeout: 4h0m0s
+    workflow: cucushift-installer-rehearse-aws-ipi-mno-lvms
+- as: e2e-aws-mno-arm-qe-integration-tests
+  cron: '@weekly'
+  steps:
+    cluster_profile: openshift-org-aws
+    dependencies:
+      OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: release:multi-latest
+    env:
+      COMPUTE_NODE_TYPE: m6g.4xlarge
+      CONTROL_PLANE_INSTANCE_TYPE: m6g.4xlarge
+      LVM_OPERATOR_SUB_INSTALL_NAMESPACE: openshift-lvm-storage
+      LVM_OPERATOR_SUB_SOURCE: lvm-catalogsource
+      OCP_ARCH: arm64
+    test:
+    - as: lvms-mno-integration-test
+      cli: latest
+      commands: |
+        ./integration-test run-suite -c 1 --junit-path ${ARTIFACT_DIR}/junit_results.xml openshift/lvm-operator/test/integration/qe_tests/mno
+      from: lvm-operator-integration-test
+      resources:
+        requests:
+          cpu: 100m
+          memory: 200Mi
+      timeout: 4h0m0s
+    workflow: cucushift-installer-rehearse-aws-ipi-mno-lvms
 zz_generated_metadata:
   branch: main
   org: openshift

--- a/ci-operator/jobs/openshift/lvm-operator/openshift-lvm-operator-main-periodics.yaml
+++ b/ci-operator/jobs/openshift/lvm-operator/openshift-lvm-operator-main-periodics.yaml
@@ -81,6 +81,188 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build05
+  cron: '@weekly'
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: lvm-operator
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-lvm-operator-main-e2e-aws-mno-arm-qe-integration-tests
+  reporter_config:
+    slack:
+      channel: '#lvms-release-coordination'
+      job_states_to_report:
+      - error
+      - failure
+      - success
+      report_template: '{{if eq .Status.State "success"}} :large_green_circle: Job
+        *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs>
+        :large_green_circle: {{else}} :red_circle: Job *{{.Spec.Job}}* ended with
+        *{{.Status.State}}*. <{{.Status.URL}}|View logs> :red_circle: {{end}}'
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-aws-mno-arm-qe-integration-tests
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build05
+  cron: '@weekly'
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: lvm-operator
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-lvm-operator-main-e2e-aws-mno-qe-integration-tests
+  reporter_config:
+    slack:
+      channel: '#lvms-release-coordination'
+      job_states_to_report:
+      - error
+      - failure
+      - success
+      report_template: '{{if eq .Status.State "success"}} :large_green_circle: Job
+        *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs>
+        :large_green_circle: {{else}} :red_circle: Job *{{.Spec.Job}}* ended with
+        *{{.Status.State}}*. <{{.Status.URL}}|View logs> :red_circle: {{end}}'
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-aws-mno-qe-integration-tests
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build05
   cron: 2 0 * * *
   decorate: true
   decoration_config:
@@ -184,6 +366,188 @@ periodics:
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
       - --target=e2e-aws-single-node-integration-tests
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build05
+  cron: '@weekly'
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: lvm-operator
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-lvm-operator-main-e2e-aws-sno-arm-qe-integration-tests
+  reporter_config:
+    slack:
+      channel: '#lvms-release-coordination'
+      job_states_to_report:
+      - error
+      - failure
+      - success
+      report_template: '{{if eq .Status.State "success"}} :large_green_circle: Job
+        *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs>
+        :large_green_circle: {{else}} :red_circle: Job *{{.Spec.Job}}* ended with
+        *{{.Status.State}}*. <{{.Status.URL}}|View logs> :red_circle: {{end}}'
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-aws-sno-arm-qe-integration-tests
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build05
+  cron: '@weekly'
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: lvm-operator
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-lvm-operator-main-e2e-aws-sno-qe-integration-tests
+  reporter_config:
+    slack:
+      channel: '#lvms-release-coordination'
+      job_states_to_report:
+      - error
+      - failure
+      - success
+      report_template: '{{if eq .Status.State "success"}} :large_green_circle: Job
+        *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs>
+        :large_green_circle: {{else}} :red_circle: Job *{{.Spec.Job}}* ended with
+        *{{.Status.State}}*. <{{.Status.URL}}|View logs> :red_circle: {{end}}'
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-aws-sno-qe-integration-tests
       command:
       - ci-operator
       env:

--- a/ci-operator/step-registry/storage/conf/csi-optional/topolvm/storage-conf-csi-optional-topolvm-chain.yaml
+++ b/ci-operator/step-registry/storage/conf/csi-optional/topolvm/storage-conf-csi-optional-topolvm-chain.yaml
@@ -6,6 +6,8 @@ chain:
     - ref: storage-create-lvm-cluster
     - ref: storage-conf-storageclass-set-default-storageclass
   env:
+  - name: LVM_SUB_TARGET_NAMESPACES
+    default: "!install"
   - name: REQUIRED_DEFAULT_STORAGECLASS
     default: "lvms-vg1"
   documentation: |-

--- a/ci-operator/step-registry/storage/conf/storageclass/set-default-storageclass/storage-conf-storageclass-set-default-storageclass-commands.sh
+++ b/ci-operator/step-registry/storage/conf/storageclass/set-default-storageclass/storage-conf-storageclass-set-default-storageclass-commands.sh
@@ -48,9 +48,46 @@ function set_required_sc_as_default () {
   run_command "oc annotate sc ${REQUIRED_DEFAULT_STORAGECLASS} storageclass.kubernetes.io/is-default-class=true --overwrite"
 }
 
+function wait_for_default_sc () {
+  for i in $(seq 1 12); do
+      get_default_sc
+      if [ "${CURRENT_DEFAULT_SC}" == "${REQUIRED_DEFAULT_STORAGECLASS}" ]; then
+          echo "${REQUIRED_DEFAULT_STORAGECLASS} is the default storageclass"
+          return 0
+      fi
+      echo "Waiting for operator to set ${REQUIRED_DEFAULT_STORAGECLASS} as default (attempt ${i}/12)..."
+      sleep 10
+  done
+  echo "ERROR: ${REQUIRED_DEFAULT_STORAGECLASS} did not become the default storageclass" && exit 1
+}
+
 set_proxy
 get_default_sc
-remove_all_default_sc_annotations
-set_required_sc_as_default
+
+function version_ge() {
+  # Returns 0 (true) if $1 >= $2
+  [[ "$1" == "$2" ]] && return 0
+  [[ "$(printf '%s\n' "$2" "$1" | sort -V | head -n1)" == "$2" ]]
+}
+
+OCP_VERSION=$(oc get clusterversion version -o jsonpath='{.status.desired.version}' 2>/dev/null | cut -d'.' -f1,2 || echo "0.0")
+
+# On OCP 4.22+, the LVMS operator manages the default SC annotation via
+# Server-Side Apply with ForceOwnership. Removing the annotation from the
+# operator-managed SC causes a race — the operator immediately restores it.
+# Instead, remove all default annotations and wait for the operator to
+# reconcile its SC as the default.
+# Only apply this path when LVMS operator is actually installed.
+LVMS_INSTALLED=$(oc get csv -A 2>/dev/null | grep -c "lvms-operator" || true)
+
+if version_ge "${OCP_VERSION}" "4.22" && [ "${LVMS_INSTALLED}" -gt 0 ] && oc get sc "${REQUIRED_DEFAULT_STORAGECLASS}" &>/dev/null; then
+    echo "OCP ${OCP_VERSION}: Removing default annotation from all storageclasses, operator will reconcile ${REQUIRED_DEFAULT_STORAGECLASS}"
+    run_command "oc annotate sc storageclass.kubernetes.io/is-default-class=false --all --overwrite"
+    wait_for_default_sc
+else
+    remove_all_default_sc_annotations
+    set_required_sc_as_default
+fi
+
 # For debugging
 get_current_sc


### PR DESCRIPTION
## Summary                                                                                                                                                                 
  - Add QE integration tests for the LVMS operator on AWS for both SNO and MNO configurations
  - Support x86 and arm64 architectures with dedicated jobs for each                                                                                                         
  - Add `storage-conf-csi-optional-topolvm` chain that subscribes the LVMS operator, creates lvmcluster, and sets the default storageclass to `lvms-vg1`                     
  - Fix default storageclass handling for OCP 4.22+ where the LVMS operator manages the default SC annotation via Server-Side Apply with ForceOwnership                      
  - Configure Slack reporting to `#lvms-release-coordination` for all QE integration test jobs
  -  Runs  migrated tests from lvm operator repo                                                                               
                                                                                                                                                                             
  ## New Jobs                                                                                                                                                                
  | Job | Platform | Arch | Schedule |                                                                                                                                       
  |-----|----------|------|----------|                                                                                                                                       
  | `e2e-aws-sno-qe-integration-tests` | AWS | x86 | Weekly |
  | `e2e-aws-sno-arm-qe-integration-tests` | AWS | arm64 | Weekly |                                                                                                          
  | `e2e-aws-mno-qe-integration-tests` | AWS | x86 | Weekly |                                                                                                                
  | `e2e-aws-mno-arm-qe-integration-tests` | AWS | arm64 | Weekly |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added weekly E2E integration jobs for single-node and multi-node workflows, including ARM variants, and corresponding periodic CI entries.
  * Configured Slack notifications to the release coordination channel with tailored success vs non-success message templates for those jobs.
  * Introduced an explicit test phase with an 8‑hour wait into relevant rehearsal workflows.

* **Bug Fixes**
  * Made default storage class selection more robust on newer OpenShift minor versions by avoiding unnecessary clears and polling until the required class becomes default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->