### PR TITLE
feat: add ability to deploy plugin integration pieces alongside rhdh

### DIFF
--- a/ci-operator/step-registry/redhat-developer/rhdh-test-instance/redhat-developer-rhdh-test-instance-commands.sh
+++ b/ci-operator/step-registry/redhat-developer/rhdh-test-instance/redhat-developer-rhdh-test-instance-commands.sh
@@ -118,25 +118,64 @@ echo "Found comment: $comment_body"
 
 if [[ -n "$comment_body" && "$comment_body" != "null" ]]; then
     read -r -a comment_parts <<< "$comment_body"
-    
-    if [ ${#comment_parts[@]} -ge 4 ] && [[ "${comment_parts[2]}" == "helm" || "${comment_parts[2]}" == "operator" ]]; then
-        # Extract install.sh arguments (skip /pj-rehearse or /test and job_name)
+
+    action="${comment_parts[1]}"
+
+    if [ ${#comment_parts[@]} -ge 4 ] && [[ "${comment_parts[2]}" == "helm" || "${comment_parts[2]}" == "operator" ]] && [[ "$action" == "deploy" || "$action" == "redeploy" ]]; then
+        # Extract deploy arguments (skip /pj-rehearse or /test and action)
         install_type="${comment_parts[2]}"
         rhdh_version="${comment_parts[3]}"
-        
-        # Check if duration is provided (5th argument), otherwise default to 3h
-        if [ ${#comment_parts[@]} -ge 5 ]; then
+
+        # Check if duration is provided (5th argument) and is not a flag, otherwise default to 3h
+        if [ ${#comment_parts[@]} -ge 5 ] && [[ "${comment_parts[4]}" != "--plugins" ]]; then
             time="${comment_parts[4]}"
         else
             time="3h"
         fi
-        
+
+        # Parse optional --plugins flag anywhere after the required arguments
+        plugins_args=()
+        for (( i=4; i<${#comment_parts[@]}; i++ )); do
+            if [[ "${comment_parts[$i]}" == "--plugins" ]] && [[ $(( i + 1 )) -lt ${#comment_parts[@]} ]]; then
+                plugins_args=("--plugins" "${comment_parts[$((i+1))]}")
+                break
+            fi
+        done
+
         echo "Parsed arguments: $install_type $rhdh_version"
         echo "Time duration: $time"
-        
-        source ./deploy.sh "$install_type" "$rhdh_version"
+        [[ ${#plugins_args[@]} -gt 0 ]] && echo "Plugins: ${plugins_args[*]}"
+
+        if [[ "$action" == "redeploy" ]]; then
+            echo "Running teardown before redeployment..."
+
+            # Teardown must use the plugins from the PREVIOUS deploy, not the current redeploy.
+            # Passing the new plugin list would leave any previously-deployed-but-now-removed
+            # plugins (e.g. lighthouse) still running in the cluster.
+            prev_deploy_comment=$(gh pr view "$GIT_PR_NUMBER" --repo "$REPO" --json comments |
+                jq -r '.comments | reverse | map(select(.body | test("^(/pj-rehearse|/test) deploy "))) | .[0].body')
+            echo "Previous deploy comment: $prev_deploy_comment"
+
+            teardown_plugins_args=()
+            if [[ -n "$prev_deploy_comment" && "$prev_deploy_comment" != "null" ]]; then
+                read -r -a prev_parts <<< "$prev_deploy_comment"
+                for (( i=4; i<${#prev_parts[@]}; i++ )); do
+                    if [[ "${prev_parts[$i]}" == "--plugins" ]] && [[ $(( i + 1 )) -lt ${#prev_parts[@]} ]]; then
+                        teardown_plugins_args=("--plugins" "${prev_parts[$((i+1))]}")
+                        break
+                    fi
+                done
+            fi
+
+            echo "Tearing down previously deployed plugins: ${teardown_plugins_args[*]:-none}"
+            source ./teardown.sh "$install_type" "${teardown_plugins_args[@]}"
+        fi
+
+        # deploy.sh mirrors the deploy.sh script from the rhdh-test-instance repo
+        source ./deploy.sh "$install_type" "$rhdh_version" "${plugins_args[@]}"
     else
-        echo "❌ Error: Unable to trigger deployment command format is incorrect. Expected: /test deploy (helm or operator) (1.7-98-CI or next or 1.7) 3h"
+        echo "❌ Error: Unable to trigger deployment - command format is incorrect."
+        echo "Expected: /test deploy|redeploy (helm or operator) (1.7-98-CI or next or 1.7) [duration] [--plugins keycloak,lighthouse]"
         echo "Example: /test deploy helm 1.7 3h"
         echo "Received comment: $comment_body"
         gh_comment "## ❌ Deployment Command Error
@@ -145,13 +184,15 @@ if [[ -n "$comment_body" && "$comment_body" != "null" ]]; then
 
 ### 📋 Expected Format:
 \`\`\`
-/test deploy [helm or operator] [Helm chart or Operator version] [duration]
+/test deploy|redeploy [helm or operator] [Helm chart or Operator version] [duration] [--plugins plugin1,plugin2]
 \`\`\`
 
 ### ✨ Examples:
 - \`/test deploy helm 1.7 3h\`
 - \`/test deploy operator 1.6 2h\`
 - \`/test deploy helm 1.7-98-CI\` (defaults to 3h)
+- \`/test deploy helm 1.7 3h --plugins keycloak,lighthouse\`
+- \`/test redeploy helm 1.7 3h --plugins keycloak\` (tears down first, then redeploys)
 
 Please correct the command format and try again! 🚀"
         exit 1
@@ -184,7 +225,13 @@ else
     echo "Sleeping for $time"
 fi
 
-comment="🚀 Deployed RHDH version: $rhdh_version using $install_type
+plugins_info=""
+if [[ ${#plugins_args[@]} -gt 0 ]]; then
+    plugins_info="
+🔌 **Plugins:** \`${plugins_args[1]}\`"
+fi
+
+comment="🚀 Deployed RHDH version: $rhdh_version using $install_type${plugins_info}
 
 🌐 **RHDH URL:** $RHDH_BASE_URL
 

--- a/ci-operator/step-registry/redhat-developer/rhdh-test-instance/redhat-developer-rhdh-test-instance-commands.sh
+++ b/ci-operator/step-registry/redhat-developer/rhdh-test-instance/redhat-developer-rhdh-test-instance-commands.sh
@@ -146,32 +146,7 @@ if [[ -n "$comment_body" && "$comment_body" != "null" ]]; then
         echo "Time duration: $time"
         [[ ${#plugins_args[@]} -gt 0 ]] && echo "Plugins: ${plugins_args[*]}"
 
-        if [[ "$action" == "redeploy" ]]; then
-            echo "Running teardown before redeployment..."
-
-            # Teardown must use the plugins from the PREVIOUS deploy, not the current redeploy.
-            # Passing the new plugin list would leave any previously-deployed-but-now-removed
-            # plugins (e.g. lighthouse) still running in the cluster.
-            prev_deploy_comment=$(gh pr view "$GIT_PR_NUMBER" --repo "$REPO" --json comments |
-                jq -r '.comments | reverse | map(select(.body | test("^(/pj-rehearse|/test) deploy "))) | .[0].body')
-            echo "Previous deploy comment: $prev_deploy_comment"
-
-            teardown_plugins_args=()
-            if [[ -n "$prev_deploy_comment" && "$prev_deploy_comment" != "null" ]]; then
-                read -r -a prev_parts <<< "$prev_deploy_comment"
-                for (( i=4; i<${#prev_parts[@]}; i++ )); do
-                    if [[ "${prev_parts[$i]}" == "--plugins" ]] && [[ $(( i + 1 )) -lt ${#prev_parts[@]} ]]; then
-                        teardown_plugins_args=("--plugins" "${prev_parts[$((i+1))]}")
-                        break
-                    fi
-                done
-            fi
-
-            echo "Tearing down previously deployed plugins: ${teardown_plugins_args[*]:-none}"
-            source ./teardown.sh "$install_type" "${teardown_plugins_args[@]}"
-        fi
-
-        # deploy.sh mirrors the deploy.sh script from the rhdh-test-instance repo
+        # deploy.sh mirrors the rhdh-test-instance repo; redeploy uses the same path (fresh CI cluster each run).
         source ./deploy.sh "$install_type" "$rhdh_version" "${plugins_args[@]}"
     else
         echo "❌ Error: Unable to trigger deployment - command format is incorrect."
@@ -192,7 +167,7 @@ if [[ -n "$comment_body" && "$comment_body" != "null" ]]; then
 - \`/test deploy operator 1.6 2h\`
 - \`/test deploy helm 1.7-98-CI\` (defaults to 3h)
 - \`/test deploy helm 1.7 3h --plugins keycloak,lighthouse\`
-- \`/test redeploy helm 1.7 3h --plugins keycloak\` (tears down first, then redeploys)
+- \`/test redeploy helm 1.7 3h --plugins keycloak\`
 
 Please correct the command format and try again! 🚀"
         exit 1


### PR DESCRIPTION
## Description 

Adds support for the `--plugins` flag being introduced in the companion [PR #30](https://github.com/redhat-developer/rhdh-test-instance/pull/30), which deploys optional plugin integrations alongside an RHDH test instance. This allows users to deploy an RHDH instance with whichever plugins they want to test against.

Also included is a `redeploy` action, which allows users to switch to a new set of plugins without manually tearing down the cluster first. Under the hood, it looks up the previously deployed plugins, calls `teardown.sh` to cleanly remove those plugin integrations and the existing RHDH instance, and then redeploys fresh with the new plugin configuration.

Made with [Cursor](https://cursor.com/)

/cc @subhashkhileri 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds CI infrastructure support for deploying optional plugin integrations alongside RHDH (Red Hat Developer Hub) test instances in the OpenShift CI pipeline.

### Changes

The PR modifies the RHDH test instance CI step registry to enhance the deployment command parser and execution flow:

**Enhanced Deployment Command Recognition**
- The test deployment trigger command now accepts both `/test deploy` and `/test redeploy` formats (previously only `/test deploy`)
- Supports configurable deployment duration (defaults to 3 hours if not specified)
- Recognizes a new optional `--plugins` argument that accepts a comma-separated list of plugin names to deploy alongside the RHDH instance

**Redeploy Capability**
- Enables users to redeploy RHDH instances with different plugin configurations without manual cluster teardown
- The redeploy action internally manages plugin cleanup and redeployment by invoking teardown and redeploy workflows

**Updated Messaging**
- Error messages and inline documentation updated to reflect the new `redeploy` and `--plugins` command syntax
- Success comment generation now includes a "Plugins" section when plugins are specified in the deployment

### Impact

This enhances the RHDH test instance CI configuration to provide more flexible testing scenarios, allowing developers to easily test RHDH with different plugin combinations through simple comment-based CI triggers on pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->