### PR TITLE
[WIP] DEBUG PR: get a 4.22 Powervs ipi cluster for debugging deployments

### DIFF
--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.22.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.22.yaml
@@ -713,7 +713,7 @@ tests:
   - sshd-bastion
   cron: 0 4,16 * * *
   steps:
-    cluster_profile: powervs-8
+    cluster_profile: powervs-7
     env:
       ARCH: ppc64le
       BRANCH: "4.22"

--- a/ci-operator/jobs/openshift/multiarch/openshift-multiarch-main-periodics.yaml
+++ b/ci-operator/jobs/openshift/multiarch/openshift-multiarch-main-periodics.yaml
@@ -49512,8 +49512,8 @@ periodics:
     repo: multiarch
   labels:
     capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: powervs-8
-    ci-operator.openshift.io/cloud-cluster-profile: powervs-8
+    ci-operator.openshift.io/cloud: powervs-7
+    ci-operator.openshift.io/cloud-cluster-profile: powervs-7
     ci-operator.openshift.io/variant: nightly-4.22
     ci.openshift.io/generator: prowgen
     job-release: "4.22"

--- a/ci-operator/step-registry/ipi/deprovision/deprovision/powervs/ipi-deprovision-deprovision-powervs-chain.yaml
+++ b/ci-operator/step-registry/ipi/deprovision/deprovision/powervs/ipi-deprovision-deprovision-powervs-chain.yaml
@@ -2,6 +2,5 @@ chain:
   as: ipi-deprovision-deprovision-powervs
   steps:
   - chain: gather-powervs
-  - ref: ipi-deprovision-deprovision-powervs-deprovision
   documentation: |-
     The IPI deprovision step chain contains all the individual steps necessary to gather and deprovision an OpenShift cluster.


### PR DESCRIPTION
Debug PR.
Using cluster profile powervs-7 to run these in lon06, to avoid resource contention in Frankfurt.
Removed deprovision step, so that we have cluster for some time till they are routinely cleaned up.