### PR TITLE
Reduce ci-tools unit test count from 25 to 5

### DIFF
--- a/ci-operator/config/openshift/ci-tools/openshift-ci-tools-main.yaml
+++ b/ci-operator/config/openshift/ci-tools/openshift-ci-tools-main.yaml
@@ -893,7 +893,7 @@ resources:
 test_binary_build_commands: make race-install
 tests:
 - as: unit
-  commands: make test TESTFLAGS='-count=25 -coverprofile=cover.out'
+  commands: make test TESTFLAGS='-count=5 -coverprofile=cover.out'
   container:
     from: src
   node_architecture: arm64


### PR DESCRIPTION
## Summary
- Reduce `-count=25` to `-count=5` in ci-tools unit test presubmit

🤖 Generated with [Claude Code](https://claude.com/claude-code)