### PR TITLE
update vector CI for v0.47 to test against correct logging version

### DIFF
--- a/ci-operator/config/ViaQ/vector/ViaQ-vector-v0.47.0-rh.yaml
+++ b/ci-operator/config/ViaQ/vector/ViaQ-vector-v0.47.0-rh.yaml
@@ -4,19 +4,19 @@ base_images:
     namespace: ocp
     tag: "9"
   cluster-logging-operator:
-    name: 6.y
+    name: "6.5"
     namespace: logging
     tag: cluster-logging-operator
   cluster-logging-operator-e2e:
-    name: 6.y
+    name: "6.5"
     namespace: logging
     tag: cluster-logging-operator-e2e
   cluster-logging-operator-registry:
-    name: 6.y
+    name: "6.5"
     namespace: logging
     tag: cluster-logging-operator-registry
   log-file-metric-exporter:
-    name: 6.y
+    name: "6.5"
     namespace: logging
     tag: log-file-metric-exporter
   logging-eventrouter:
@@ -52,7 +52,7 @@ releases:
   latest:
     release:
       channel: stable
-      version: "4.18"
+      version: "4.20"
 resources:
   '*':
     limits:
@@ -92,7 +92,7 @@ tests:
     owner: obs-logging
     product: ocp
     timeout: 1h0m0s
-    version: "4.18"
+    version: "4.20"
   steps:
     test:
     - as: test


### PR DESCRIPTION
This PR:

* Updates CI for vector v0.47 to test against logging 6.4 and OCP 4.20

cc @vparfonov 