### PR TITLE
OCPBUGS-80930: Add explicit cachingMode for UltraSSD StorageClass

### DIFF
--- a/ci-operator/step-registry/openshift/e2e/azure/csi/ultrassd/openshift-e2e-azure-csi-ultrassd-workflow.yaml
+++ b/ci-operator/step-registry/openshift/e2e/azure/csi/ultrassd/openshift-e2e-azure-csi-ultrassd-workflow.yaml
@@ -25,6 +25,10 @@ workflow:
     env:
       AZURE_DISK_SKU: UltraSSD_LRS
       CLUSTERCSIDRIVER: disk.csi.azure.com
+      # UltraSSD capability is only available in some regions, westus2 is the recommended region for testing
+      # Although it should be available on all zones but we meet some issues on zone 1 and 2 in westus2, 
+      # so we only use zone 3 for both control plane and compute nodes to make the test more stable.
+      # ref: https://learn.microsoft.com/en-us/azure/virtual-machines/disks-enable-ultra-ssd?tabs=azure-portal
       COMPUTE_CUSTOM_AZURE_AZ: "['3']"
       CP_CUSTOM_AZURE_AZ: "['3']"
       CUSTOM_AZURE_REGION: westus2

--- a/ci-operator/step-registry/openshift/e2e/azure/csi/ultrassd/openshift-e2e-azure-csi-ultrassd-workflow.yaml
+++ b/ci-operator/step-registry/openshift/e2e/azure/csi/ultrassd/openshift-e2e-azure-csi-ultrassd-workflow.yaml
@@ -2,7 +2,11 @@ workflow:
   as: openshift-e2e-azure-csi-ultrassd
   steps:
     pre:
-    - chain: ipi-conf-azure
+    - ref: ipi-conf
+    - ref: ipi-conf-telemetry
+    - ref: ipi-conf-azure
+    - ref: ipi-conf-azure-custom-region
+    - ref: ipi-conf-azure-custom-az
     - ref: ipi-conf-azure-ultrassd
     - chain: azure-provision-service-principal-minimal-permission
     - ref: rhcos-conf-osstream
@@ -21,6 +25,9 @@ workflow:
     env:
       AZURE_DISK_SKU: UltraSSD_LRS
       CLUSTERCSIDRIVER: disk.csi.azure.com
+      COMPUTE_CUSTOM_AZURE_AZ: "['3']"
+      CP_CUSTOM_AZURE_AZ: "['3']"
+      CUSTOM_AZURE_REGION: westus2
       TRUECONDITIONS: AzureDiskDriverControllerServiceControllerAvailable AzureDiskDriverNodeServiceControllerAvailable
       TEST_CSI_DRIVER_MANIFEST: manifest-azure-disk.yaml
       TEST_OCP_CSI_DRIVER_MANIFEST: ocp-manifest-azure-disk.yaml

--- a/ci-operator/step-registry/storage/conf/storageclass/add-azure-disk-ultrassd/storage-conf-storageclass-add-azure-disk-ultrassd-commands.sh
+++ b/ci-operator/step-registry/storage/conf/storageclass/add-azure-disk-ultrassd/storage-conf-storageclass-add-azure-disk-ultrassd-commands.sh
@@ -11,6 +11,8 @@ metadata:
 provisioner: disk.csi.azure.com
 parameters:
   skuName: UltraSSD_LRS
+  # UltraSSD_LRS only support None caching mode
+  cachingMode: None
 volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true
 reclaimPolicy: Delete


### PR DESCRIPTION
- UltraSSD_LRS only support None caching mode, in vac test jobs we must add explicit cachingMode for UltraSSD StorageClass.
   xref: https://github.com/openshift/azure-disk-csi-driver/blob/master/docs/driver-parameters.md
**[Failure record](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_csi-operator/538/pull-ci-openshift-csi-operator-main-e2e-azure-csi-volumeattributesclass/2039876436482854912)**
- Using the UltraSSD_LRS supported zone instead.
```console
...
2026-04-03T02:30:16.010555510Z E0403 02:30:16.010526       1 utils.go:110] GRPC error: rpc error: code = Internal desc = Attach volume pvc-c815310f-5489-4680-abf4-a6bbb84ace72 to instance ci-op-pb7r2m8f-ccb8f-tbtr9-worker-eastus2-xgxk2 failed with PUT https://management.azure.com/subscriptions/d38f1e38-4bed-438e-b227-833f997adf6a/resourceGroups/ci-op-pb7r2m8f-ccb8f-tbtr9-rg/providers/Microsoft.Compute/virtualMachines/ci-op-pb7r2m8f-ccb8f-tbtr9-worker-eastus2-xgxk2
2026-04-03T02:30:16.010555510Z --------------------------------------------------------------------------------
2026-04-03T02:30:16.010555510Z RESPONSE 400: 400 Bad Request
2026-04-03T02:30:16.010555510Z ERROR CODE: InvalidParameter
2026-04-03T02:30:16.010555510Z --------------------------------------------------------------------------------
2026-04-03T02:30:16.010555510Z {
2026-04-03T02:30:16.010555510Z   "error": {
2026-04-03T02:30:16.010555510Z     "code": "InvalidParameter",
2026-04-03T02:30:16.010555510Z     "message": "Storage Account type UltraSSD_LRS is not supported with caching type ReadOnly. Please use caching type None.",
2026-04-03T02:30:16.010555510Z     "target": "dataDisk.caching"
2026-04-03T02:30:16.010555510Z   }
2026-04-03T02:30:16.010555510Z }
2026-04-03T02:30:16.010555510Z --------------------------------------------------------------------------------
...
```