### PR TITLE
Add one-click "Open in Claude Code" button to continue-session page

### DIFF
--- a/ci-operator/step-registry/openshift/claude/post/openshift-claude-post-commands.sh
+++ b/ci-operator/step-registry/openshift/claude/post/openshift-claude-post-commands.sh
@@ -18,6 +18,13 @@ else
     PROW_URL="https://prow.ci.openshift.org/view/gs/test-platform-results/logs/${JOB_NAME}/${BUILD_ID}"
 fi
 
+CONTINUE_CMD="/ci:continue-session ${PROW_URL}"
+# The claude-cli:// link needs to cd into a temp dir first so Claude Code
+# doesn't open in $HOME with all its files in context.
+OPEN_CMD="cd \$(mktemp -d) && ${CONTINUE_CMD}"
+ENCODED_CMD=$(python3 -c "import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1]))" "${OPEN_CMD}")
+CLAUDE_CLI_URL="claude-cli://open?q=${ENCODED_CMD}"
+
 cat > "${ARTIFACT_DIR}/continue-session-summary.html" <<HTMLEOF
 <!DOCTYPE html>
 <html lang="en">
@@ -28,8 +35,12 @@ cat > "${ARTIFACT_DIR}/continue-session-summary.html" <<HTMLEOF
   body { font-family: system-ui, sans-serif; background: #1a1a2e; color: #e0e0e0; max-width: 960px; margin: 0 auto; padding: 3rem 2rem; }
   h1 { text-align: center; }
   .subtitle { text-align: center; color: #888; margin-bottom: 2rem; }
+  .open-btn { display: block; width: fit-content; margin: 1.5rem auto; padding: 0.75rem 2rem; background: #7c4dff; color: #fff; text-decoration: none; border-radius: 8px; font-size: 1.1rem; font-weight: 600; transition: background 0.2s; }
+  .open-btn:hover { background: #651fff; }
+  .or-divider { text-align: center; color: #666; margin: 1.5rem 0; font-size: 0.9rem; }
   pre { background: #111; border: 1px solid #333; border-radius: 8px; padding: 1rem; color: #b39ddb; word-break: break-all; white-space: pre-wrap; cursor: pointer; position: relative; }
   pre:hover { border-color: #7c4dff; }
+  .copied-msg { text-align: center; color: #4caf50; font-size: 0.85rem; height: 1.2em; margin-top: 0.5rem; }
   ol { color: #aaa; margin: 2rem 0; padding-left: 1.5rem; }
   li { padding: 0.25rem 0; }
   a { color: #b39ddb; }
@@ -37,18 +48,16 @@ cat > "${ARTIFACT_DIR}/continue-session-summary.html" <<HTMLEOF
 </head>
 <body>
 <h1>Continue This Claude Session Locally ✨</h1>
-<p class="subtitle">Pick up right where the CI agent left off. Click below to copy.</p>
-<pre id="cmd" onclick="navigator.clipboard.writeText(this.textContent).then(()=>{this.style.borderColor='#4caf50';setTimeout(()=>this.style.borderColor='',1500)})">/ci:continue-session ${PROW_URL}</pre>
+<p class="subtitle">Pick up right where the CI agent left off.</p>
+<a class="open-btn" href="${CLAUDE_CLI_URL}">Open in Claude Code</a>
+<p class="or-divider">— or copy the command manually —</p>
+<pre id="cmd" onclick="navigator.clipboard.writeText(this.textContent).then(()=>{document.getElementById('copied').textContent='Copied!';this.style.borderColor='#4caf50';setTimeout(()=>{this.style.borderColor='';document.getElementById('copied').textContent=''},1500)})">${CONTINUE_CMD}</pre>
+<p class="copied-msg" id="copied"></p>
 <ol>
   <li>Install the <a href="https://github.com/openshift-eng/ai-helpers" target="_blank"><strong>ai-helpers</strong></a> marketplace</li>
-  <li>Open Claude Code in your terminal</li>
-  <li>Paste the command above and press Enter</li>
+  <li>Click <strong>Open in Claude Code</strong> above, or copy the command and paste it into Claude Code</li>
   <li>Claude will download the session and help you resume the conversation</li>
 </ol>
-<p>&nbsp;</p>
-<p>&nbsp;</p>
-<p>&nbsp;</p>
-<p>&nbsp;</p>
 </body>
 </html>
 HTMLEOF


### PR DESCRIPTION
## Summary
- Adds a `claude-cli://open?q=...` deep link button ("Open in Claude Code") to the continue-session HTML artifact page
- The link opens Claude Code in a temp directory (`cd $(mktemp -d)`) to avoid loading `$HOME` context
- Keeps the existing click-to-copy command as a manual fallback with improved "Copied!" feedback

## Test plan
- [x] Rendered page locally and verified layout, button styling, and copy behavior
- [x] Verify `claude-cli://` link opens Claude Code with the command pre-populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)