### PR TITLE
Update 4.17 automated-release jobs to use sustaining cloud accounts

### DIFF
--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.17__automated-release-stable-4.17-upgrade-from-stable-4.16.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.17__automated-release-stable-4.17-upgrade-from-stable-4.16.yaml
@@ -60,9 +60,9 @@ tests:
   cron: 8 8 29 2 *
   steps:
     allow_skip_on_success: true
-    cluster_profile: aws-autorelease-qe
+    cluster_profile: aws-sustaining-autorelease-412
     env:
-      BASE_DOMAIN: qe.devcluster.openshift.com
+      BASE_DOMAIN: sustaining-aws-412.devcluster.openshift.com
     test:
     - chain: openshift-upgrade-qe-sanity
     workflow: cucushift-installer-rehearse-aws-ipi
@@ -70,9 +70,9 @@ tests:
   cron: 8 8 29 2 *
   steps:
     allow_skip_on_success: true
-    cluster_profile: azure-autorelease-qe
+    cluster_profile: azure-sustaining-autorelease-412
     env:
-      BASE_DOMAIN: qe.azure.devcluster.openshift.com
+      BASE_DOMAIN: sustaining-az-412.azure.devcluster.openshift.com
       FIPS_ENABLED: "true"
     test:
     - chain: openshift-upgrade-qe-sanity
@@ -91,7 +91,7 @@ tests:
   cron: 8 8 29 2 *
   steps:
     allow_skip_on_success: true
-    cluster_profile: gcp-autorelease-qe
+    cluster_profile: gcp-sustaining-autorelease-412
     test:
     - chain: openshift-upgrade-qe-sanity
     workflow: cucushift-installer-rehearse-gcp-ipi

--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.17__automated-release-stable-4.17-upgrade-from-stable-4.17.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.17__automated-release-stable-4.17-upgrade-from-stable-4.17.yaml
@@ -65,9 +65,9 @@ tests:
   cron: 8 8 29 2 *
   steps:
     allow_skip_on_success: true
-    cluster_profile: aws-autorelease-qe
+    cluster_profile: aws-sustaining-autorelease-412
     env:
-      BASE_DOMAIN: qe.devcluster.openshift.com
+      BASE_DOMAIN: sustaining-aws-412.devcluster.openshift.com
     test:
     - chain: openshift-upgrade-qe-sanity
     workflow: cucushift-installer-rehearse-aws-ipi
@@ -75,9 +75,9 @@ tests:
   cron: 8 8 29 2 *
   steps:
     allow_skip_on_success: true
-    cluster_profile: azure-autorelease-qe
+    cluster_profile: azure-sustaining-autorelease-412
     env:
-      BASE_DOMAIN: qe.azure.devcluster.openshift.com
+      BASE_DOMAIN: sustaining-az-412.azure.devcluster.openshift.com
       FIPS_ENABLED: "true"
     test:
     - chain: openshift-upgrade-qe-sanity
@@ -96,7 +96,7 @@ tests:
   cron: 8 8 29 2 *
   steps:
     allow_skip_on_success: true
-    cluster_profile: gcp-autorelease-qe
+    cluster_profile: gcp-sustaining-autorelease-412
     test:
     - chain: openshift-upgrade-qe-sanity
     workflow: cucushift-installer-rehearse-gcp-ipi

--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.17__automated-release.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.17__automated-release.yaml
@@ -82,9 +82,9 @@ tests:
   cron: 8 8 29 2 *
   steps:
     allow_skip_on_success: true
-    cluster_profile: aws-autorelease-qe
+    cluster_profile: aws-sustaining-autorelease-412
     env:
-      BASE_DOMAIN: qe.devcluster.openshift.com
+      BASE_DOMAIN: sustaining-aws-412.devcluster.openshift.com
       CATALOGSOURCE_NAME: auto-release-app-registry
     test:
     - chain: openshift-e2e-test-qe-automated-release
@@ -93,9 +93,9 @@ tests:
   cron: 8 8 29 2 *
   steps:
     allow_skip_on_success: true
-    cluster_profile: azure-autorelease-qe
+    cluster_profile: azure-sustaining-autorelease-412
     env:
-      BASE_DOMAIN: qe.azure.devcluster.openshift.com
+      BASE_DOMAIN: sustaining-az-412.azure.devcluster.openshift.com
       CATALOGSOURCE_NAME: auto-release-app-registry
       FIPS_ENABLED: "true"
     test:
@@ -116,7 +116,7 @@ tests:
   cron: 8 8 29 2 *
   steps:
     allow_skip_on_success: true
-    cluster_profile: gcp-autorelease-qe
+    cluster_profile: gcp-sustaining-autorelease-412
     env:
       CATALOGSOURCE_NAME: auto-release-app-registry
     test:
@@ -126,9 +126,9 @@ tests:
   cron: 8 8 29 2 *
   steps:
     allow_skip_on_success: true
-    cluster_profile: aws-autorelease-qe
+    cluster_profile: aws-sustaining-autorelease-412
     env:
-      BASE_DOMAIN: qe.devcluster.openshift.com
+      BASE_DOMAIN: sustaining-aws-412.devcluster.openshift.com
       CATALOGSOURCE_NAME: auto-release-app-registry
     test:
     - chain: openshift-e2e-test-qe-automated-release-disruptive

--- a/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.17-periodics.yaml
+++ b/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.17-periodics.yaml
@@ -45076,7 +45076,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: aws
-    ci-operator.openshift.io/cloud-cluster-profile: aws-autorelease-qe
+    ci-operator.openshift.io/cloud-cluster-profile: aws-sustaining-autorelease-412
     ci-operator.openshift.io/variant: automated-release
     ci.openshift.io/generator: prowgen
     job-release: "4.17"
@@ -45158,7 +45158,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: aws
-    ci-operator.openshift.io/cloud-cluster-profile: aws-autorelease-qe
+    ci-operator.openshift.io/cloud-cluster-profile: aws-sustaining-autorelease-412
     ci-operator.openshift.io/variant: automated-release
     ci.openshift.io/generator: prowgen
     job-release: "4.17"
@@ -45240,7 +45240,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: azure4
-    ci-operator.openshift.io/cloud-cluster-profile: azure-autorelease-qe
+    ci-operator.openshift.io/cloud-cluster-profile: azure-sustaining-autorelease-412
     ci-operator.openshift.io/variant: automated-release
     ci.openshift.io/generator: prowgen
     job-release: "4.17"
@@ -45404,7 +45404,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-autorelease-qe
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-sustaining-autorelease-412
     ci-operator.openshift.io/variant: automated-release
     ci.openshift.io/generator: prowgen
     job-release: "4.17"
@@ -45486,7 +45486,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: aws
-    ci-operator.openshift.io/cloud-cluster-profile: aws-autorelease-qe
+    ci-operator.openshift.io/cloud-cluster-profile: aws-sustaining-autorelease-412
     ci-operator.openshift.io/variant: automated-release-stable-4.17-upgrade-from-stable-4.16
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -45567,7 +45567,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: azure4
-    ci-operator.openshift.io/cloud-cluster-profile: azure-autorelease-qe
+    ci-operator.openshift.io/cloud-cluster-profile: azure-sustaining-autorelease-412
     ci-operator.openshift.io/variant: automated-release-stable-4.17-upgrade-from-stable-4.16
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -45729,7 +45729,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-autorelease-qe
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-sustaining-autorelease-412
     ci-operator.openshift.io/variant: automated-release-stable-4.17-upgrade-from-stable-4.16
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -45810,7 +45810,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: aws
-    ci-operator.openshift.io/cloud-cluster-profile: aws-autorelease-qe
+    ci-operator.openshift.io/cloud-cluster-profile: aws-sustaining-autorelease-412
     ci-operator.openshift.io/variant: automated-release-stable-4.17-upgrade-from-stable-4.17
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -45891,7 +45891,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: azure4
-    ci-operator.openshift.io/cloud-cluster-profile: azure-autorelease-qe
+    ci-operator.openshift.io/cloud-cluster-profile: azure-sustaining-autorelease-412
     ci-operator.openshift.io/variant: automated-release-stable-4.17-upgrade-from-stable-4.17
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -46053,7 +46053,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-autorelease-qe
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-sustaining-autorelease-412
     ci-operator.openshift.io/variant: automated-release-stable-4.17-upgrade-from-stable-4.17
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"


### PR DESCRIPTION
Updates the cluster profiles of automated release jobs for 4.17 to use the sustaining cloud accounts.