### PR TITLE
verification-tests: add 4.22 installer-rehearse AWS with 8h hold

### DIFF
--- a/ci-operator/config/openshift/verification-tests/openshift-verification-tests-main__installer-rehearse-4.22.yaml
+++ b/ci-operator/config/openshift/verification-tests/openshift-verification-tests-main__installer-rehearse-4.22.yaml
@@ -78,6 +78,20 @@ tests:
     - ref: gcp-deprovision-public-dns-zone-record-sets
     - ref: send-results-to-reportportal
     workflow: cucushift-installer-rehearse-aws-ipi-custom-dns
+- as: installer-rehearse-aws-tp
+  cron: '@yearly'
+  steps:
+    allow_skip_on_success: true
+    cluster_profile: aws-qe
+    env:
+      BASE_DOMAIN: qe.devcluster.openshift.com
+      FEATURE_SET: TechPreviewNoUpgrade
+      SLEEP_DURATION: 10h
+    post:
+    - ref: cucushift-installer-wait
+    - chain: cucushift-installer-rehearse-aws-ipi-deprovision
+    - ref: send-results-to-reportportal
+    workflow: cucushift-installer-rehearse-aws-ipi
 - as: installer-rehearse-vsphere-dis
   cron: '@yearly'
   steps:

--- a/ci-operator/config/openshift/verification-tests/openshift-verification-tests-main__installer-rehearse-4.22.yaml
+++ b/ci-operator/config/openshift/verification-tests/openshift-verification-tests-main__installer-rehearse-4.22.yaml
@@ -70,6 +70,13 @@ tests:
       FEATURE_GATES: '["AWSClusterHostedDNSInstall=true"]'
       FEATURE_SET: CustomNoUpgrade
       GCP_NEW_PUBLIC_DNS_RECORD_WAITING_TIME: "600"
+      SLEEP_DURATION: 8h
+    post:
+    - ref: cucushift-installer-wait
+    - ref: aws-provision-public-custom-dns-post
+    - chain: cucushift-installer-rehearse-aws-ipi-deprovision
+    - ref: gcp-deprovision-public-dns-zone-record-sets
+    - ref: send-results-to-reportportal
     workflow: cucushift-installer-rehearse-aws-ipi-custom-dns
 - as: installer-rehearse-vsphere-dis
   cron: '@yearly'

--- a/ci-operator/jobs/openshift/verification-tests/openshift-verification-tests-main-periodics.yaml
+++ b/ci-operator/jobs/openshift/verification-tests/openshift-verification-tests-main-periodics.yaml
@@ -75824,6 +75824,89 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
+  cluster: build01
+  cron: '@yearly'
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: verification-tests
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-qe
+    ci-operator.openshift.io/variant: installer-rehearse-4.22
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-verification-tests-main-installer-rehearse-4.22-installer-rehearse-aws-tp
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=installer-rehearse-aws-tp
+      - --variant=installer-rehearse-4.22
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
   cluster: build08
   cron: '@yearly'
   decorate: true


### PR DESCRIPTION
Add openshift-verification-tests-main__installer-rehearse-4.22.yaml including installer-rehearse-aws with SLEEP_DURATION 8h and cucushift-installer-wait before teardown (pj-rehearse / manual use).

Made-with: Cursor