### PR TITLE
aro hcp: add boskos lease for image push and cspr cd

### DIFF
--- a/core-services/prow/02_config/_boskos.yaml
+++ b/core-services/prow/02_config/_boskos.yaml
@@ -63,6 +63,10 @@ resources:
   min-count: 1
   state: free
   type: aro-hcp-dev-global-pipeline-quota-slice
+- max-count: 1
+  min-count: 1
+  state: free
+  type: aro-hcp-dev-image-push-quota-slice
 - max-count: 15
   min-count: 15
   state: free

--- a/core-services/prow/02_config/_boskos.yaml
+++ b/core-services/prow/02_config/_boskos.yaml
@@ -58,6 +58,10 @@ resources:
 - max-count: 1
   min-count: 1
   state: free
+  type: aro-hcp-dev-cd-quota-slice
+- max-count: 1
+  min-count: 1
+  state: free
   type: aro-hcp-dev-global-pipeline-quota-slice
 - max-count: 15
   min-count: 15

--- a/core-services/prow/02_config/_boskos.yaml
+++ b/core-services/prow/02_config/_boskos.yaml
@@ -58,7 +58,7 @@ resources:
 - max-count: 1
   min-count: 1
   state: free
-  type: aro-hcp-dev-cd-quota-slice
+  type: aro-hcp-dev-cspr-pipeline-quota-slice
 - max-count: 1
   min-count: 1
   state: free

--- a/core-services/prow/02_config/generate-boskos.py
+++ b/core-services/prow/02_config/generate-boskos.py
@@ -291,6 +291,9 @@ CONFIG = {
     'aro-hcp-dev-global-pipeline-quota-slice': {
         'default': 1,
     },
+    'aro-hcp-dev-cd-quota-slice': {
+        'default': 1,
+    },
     'aro-hcp-test-msi-containers-dev': {},
     'aro-hcp-test-msi-containers-int': {},
     'aro-hcp-test-msi-containers-stg': {},

--- a/core-services/prow/02_config/generate-boskos.py
+++ b/core-services/prow/02_config/generate-boskos.py
@@ -294,6 +294,9 @@ CONFIG = {
     'aro-hcp-dev-cd-quota-slice': {
         'default': 1,
     },
+    'aro-hcp-dev-image-push-quota-slice': {
+        'default': 1,
+    },
     'aro-hcp-test-msi-containers-dev': {},
     'aro-hcp-test-msi-containers-int': {},
     'aro-hcp-test-msi-containers-stg': {},

--- a/core-services/prow/02_config/generate-boskos.py
+++ b/core-services/prow/02_config/generate-boskos.py
@@ -291,7 +291,7 @@ CONFIG = {
     'aro-hcp-dev-global-pipeline-quota-slice': {
         'default': 1,
     },
-    'aro-hcp-dev-cd-quota-slice': {
+    'aro-hcp-dev-cspr-pipeline-quota-slice': {
         'default': 1,
     },
     'aro-hcp-dev-image-push-quota-slice': {


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-524
Prevents concurrent execution of image push and cspr CD step

To be used by https://github.com/openshift/release/pull/76898

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added two new quota slice resources for development CD operations and image push management to the resource configuration system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->