### PR TITLE
feat(GCP-431): pass network service account to hypershift GCP e2e tests

### DIFF
--- a/ci-operator/step-registry/hypershift/gcp/hosted-cluster-setup/hypershift-gcp-hosted-cluster-setup-commands.sh
+++ b/ci-operator/step-registry/hypershift/gcp/hosted-cluster-setup/hypershift-gcp-hosted-cluster-setup-commands.sh
@@ -115,8 +115,9 @@ NODEPOOL_SA=$(awk -F'"' '/"nodepool-mgmt"/{print $4}' "${IAM_OUTPUT}")
 CLOUDCONTROLLER_SA=$(awk -F'"' '/"cloud-controller"/{print $4}' "${IAM_OUTPUT}")
 STORAGE_SA=$(awk -F'"' '/"gcp-pd-csi"/{print $4}' "${IAM_OUTPUT}")
 IMAGEREGISTRY_SA=$(awk -F'"' '/"image-registry"/{print $4}' "${IAM_OUTPUT}")
+NETWORK_SA=$(awk -F'"' '/"cloud-network"/{print $4}' "${IAM_OUTPUT}")
 
-if [[ -z "${PROJECT_NUMBER}" || -z "${POOL_ID}" || -z "${PROVIDER_ID}" || -z "${CONTROLPLANE_SA}" || -z "${NODEPOOL_SA}" || -z "${CLOUDCONTROLLER_SA}" || -z "${STORAGE_SA}" || -z "${IMAGEREGISTRY_SA}" ]]; then
+if [[ -z "${PROJECT_NUMBER}" || -z "${POOL_ID}" || -z "${PROVIDER_ID}" || -z "${CONTROLPLANE_SA}" || -z "${NODEPOOL_SA}" || -z "${CLOUDCONTROLLER_SA}" || -z "${STORAGE_SA}" || -z "${IMAGEREGISTRY_SA}" || -z "${NETWORK_SA}" ]]; then
     echo "ERROR: Failed to parse WIF configuration from IAM output"
     cat "${IAM_OUTPUT}"
     exit 1
@@ -131,6 +132,7 @@ echo "${NODEPOOL_SA}" > "${SHARED_DIR}/nodepool-sa"
 echo "${CLOUDCONTROLLER_SA}" > "${SHARED_DIR}/cloudcontroller-sa"
 echo "${STORAGE_SA}" > "${SHARED_DIR}/storage-sa"
 echo "${IMAGEREGISTRY_SA}" > "${SHARED_DIR}/imageregistry-sa"
+echo "${NETWORK_SA}" > "${SHARED_DIR}/network-sa"
 
 echo "WIF configuration saved to SHARED_DIR"
 
@@ -181,6 +183,7 @@ echo "  Provider ID: ${PROVIDER_ID}"
 echo "  Control Plane SA: ${CONTROLPLANE_SA}"
 echo "  NodePool SA: ${NODEPOOL_SA}"
 echo "  Cloud Controller SA: ${CLOUDCONTROLLER_SA}"
+echo "  Network SA: ${NETWORK_SA}"
 echo ""
 echo "Network Configuration:"
 echo "  VPC: ${HC_VPC_NAME}"

--- a/ci-operator/step-registry/hypershift/gcp/run-e2e/hypershift-gcp-run-e2e-commands.sh
+++ b/ci-operator/step-registry/hypershift/gcp/run-e2e/hypershift-gcp-run-e2e-commands.sh
@@ -45,6 +45,7 @@ CONTROLPLANE_SA=""
 CLOUDCONTROLLER_SA=""
 STORAGE_SA=""
 IMAGEREGISTRY_SA=""
+NETWORK_SA=""
 SA_SIGNING_KEY_PATH=""
 
 if [[ -f "${SHARED_DIR}/wif-project-number" ]]; then
@@ -70,6 +71,9 @@ if [[ -f "${SHARED_DIR}/storage-sa" ]]; then
 fi
 if [[ -f "${SHARED_DIR}/imageregistry-sa" ]]; then
     IMAGEREGISTRY_SA="$(<"${SHARED_DIR}/imageregistry-sa")"
+fi
+if [[ -f "${SHARED_DIR}/network-sa" ]]; then
+    NETWORK_SA="$(<"${SHARED_DIR}/network-sa")"
 fi
 if [[ -f "${SHARED_DIR}/sa-signing-key-path" ]]; then
     SA_SIGNING_KEY_PATH="$(<"${SHARED_DIR}/sa-signing-key-path")"
@@ -153,6 +157,7 @@ hack/ci-test-e2e.sh -test.v \
   --e2e.gcp-cloudcontroller-sa="${CLOUDCONTROLLER_SA}" \
   --e2e.gcp-storage-sa="${STORAGE_SA}" \
   --e2e.gcp-imageregistry-sa="${IMAGEREGISTRY_SA}" \
+  --e2e.gcp-network-sa="${NETWORK_SA}" \
   --e2e.gcp-sa-signing-key-path="${SA_SIGNING_KEY_PATH}" \
   --e2e.gcp-oidc-issuer-url="${OIDC_ISSUER_URL}" \
   --e2e.gcp-boot-image="${GCP_BOOT_IMAGE}" \


### PR DESCRIPTION
## Summary
- Extract the `cloud-network` service account created by `hypershift create iam gcp` and pass it as `--e2e.gcp-network-sa` to the e2e test binary so the cloud-network-config-controller pod gets WIF credentials.
- Follows the same pattern as all other service accounts (controlplane, nodepool, cloudcontroller, storage, imageregistry).

## Dependencies
> **⚠️ /hold** — This PR depends on https://github.com/openshift/hypershift/pull/7824 ([GCP-431](https://redhat.atlassian.net/browse/GCP-431): CNCC WIF support).
> Rehearsal jobs are expected to fail until that PR merges and images rebuild.
> Remove hold after hypershift#7824 merges.

## Changes
- `ci-operator/step-registry/hypershift/gcp/hosted-cluster-setup/hypershift-gcp-hosted-cluster-setup-commands.sh`: Extract `NETWORK_SA` from IAM output and save to `${SHARED_DIR}/network-sa`
- `ci-operator/step-registry/hypershift/gcp/run-e2e/hypershift-gcp-run-e2e-commands.sh`: Read `network-sa` and pass `--e2e.gcp-network-sa` to e2e binary

## Test plan
- [ ] Wait for openshift/hypershift#7824 to merge
- [ ] Verify `hypershift-operator` and `hypershift-tests` images rebuild with CNCC support
- [ ] Remove `/hold` and let CI rehearsal jobs pass
- [ ] Confirm e2e GKE workflow picks up the new network SA correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[GCP-431]: https://redhat.atlassian.net/browse/GCP-431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ