### PR TITLE
platform-externa/aws/opct: add "None" workflow to cover VCSP

### DIFF
--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22.yaml
@@ -2157,6 +2157,14 @@ tests:
       PLATFORM_EXTERNAL_CCM_ENABLED: "yes"
     workflow: opct-conformance-external-aws
   timeout: 6h0m0s
+- as: opct-external-aws
+  cron: '@weekly'
+  steps:
+    cluster_profile: openshift-org-aws
+    env:
+      PLATFORM_EXTERNAL_CCM_ENABLED: "no"
+    workflow: opct-conformance-external-aws
+  timeout: 6h0m0s
 - as: e2e-aws-ovn-kube-apiserver-rollout
   interval: 168h
   steps:

--- a/ci-operator/step-registry/platform-external/DIAGNOSTIC_IMPROVEMENTS.md
+++ b/ci-operator/step-registry/platform-external/DIAGNOSTIC_IMPROVEMENTS.md
@@ -1,0 +1,366 @@
+# Platform-External Diagnostic Collection Improvements
+
+## Overview
+
+This document describes the diagnostic collection improvements made to the platform-external workflow to better debug installation failures, particularly for bootstrap and control plane issues.
+
+## Problem Statement
+
+The platform-external workflow was experiencing failures with minimal diagnostic information:
+1. **No bootstrap logs collected** when installation fails
+2. **No EC2 console logs** to debug instance boot/ignition failures
+3. **No load balancer health diagnostics** to identify API connectivity issues
+4. **Limited control plane diagnostics** when waiting for masters times out
+5. **No AWS infrastructure state** captured on failure
+
+## Solution Overview
+
+Implemented comprehensive diagnostic collection through two main improvements:
+
+### 1. New Post-Gather Step: `platform-external-post-gather-aws`
+
+**Location**: `ci-operator/step-registry/platform-external/post/gather-aws/`
+
+**Purpose**: Collect AWS-specific diagnostics on failure only (best-effort, optional on success)
+
+**Capabilities**:
+
+#### A. Bootstrap Logs Collection
+- Uses `openshift-install gather bootstrap` to collect comprehensive bootstrap logs
+- Requires: `BOOTSTRAP_IP` in SHARED_DIR, SSH private key in CLUSTER_PROFILE_DIR
+- Output: `log-bundle-*.tar.gz` in ARTIFACT_DIR
+- Contains: journal logs, service status, container logs from bootstrap node
+
+#### B. EC2 Instance Console Logs
+- Extracts instance IDs from CloudFormation stacks
+- Queries EC2 API for all cluster instances by tag
+- Collects console output for each instance (bootstrap, masters, workers)
+- Output: `ec2-console-logs/<instance-id>-<name>.log`
+- Use cases: Boot failures, kernel panics, ignition errors, systemd failures
+
+#### C. Load Balancer Diagnostics
+- Discovers all ELBv2 load balancers for the cluster
+- Lists all target groups (API, service endpoints)
+- Collects target health status for each target
+- Output: `load-balancer-diagnostics/target-health-*.json`
+- Shows: Which targets are healthy/unhealthy, health check failures, reasons
+
+#### D. CloudFormation Stack Events
+- Collects events for all cluster-related stacks
+- Shows resource creation timeline
+- Identifies provisioning failures
+- Output: `cloudformation-events/<stack-name>-events.json`
+
+#### E. Instance Metadata
+- Collects EC2 instance details for all cluster instances
+- Includes: state, type, security groups, network interfaces, tags
+- Output: `ec2-console-logs/<instance-id>-metadata.json`
+
+#### F. Summary Report
+- Human-readable summary of all collected diagnostics
+- Shows: region, infra ID, bootstrap status, instance count, LB status
+- Output: `aws-diagnostics-summary.txt`
+
+**Configuration**:
+- `timeout: 20m` - allows time for bootstrap log gathering over SSH
+- `grace_period: 10m` - extra time for cleanup
+- `best_effort: true` - continues even if some operations fail
+- `optional_on_success: true` - **only runs on failure** to protect sensitive data
+
+### 2. Enhanced Control Plane Wait Step
+
+**Location**: `ci-operator/step-registry/platform-external/cluster/wait-for/ready/control/`
+
+**Improvements**:
+
+#### A. Configurable Timeout
+- Environment variable: `CONTROL_PLANE_WAIT_MAX_ITERATIONS` (default: 60)
+- Total wait time: 60 iterations × 30 seconds = 30 minutes
+- Progress tracking with iteration counter
+
+#### B. Periodic Diagnostic Collection
+- Collects diagnostics every 5 iterations (2.5 minutes)
+- Snapshot includes:
+  - Node status and details
+  - Pod status in critical namespaces (kube-system, apiserver, etcd)
+  - Recent events
+  - Machine API resources
+  - Cluster operator status
+- Output: `control-plane-diagnostics/iteration-NNN/`
+
+#### C. Progress Indicators
+- Shows master ready count every iteration
+- Detailed status every 5 minutes
+- Displays pod status in kube-system
+
+#### D. Comprehensive Final Diagnostics on Timeout
+- Full cluster state capture
+- Detailed pod information across all critical namespaces
+- Complete event history
+- Cluster operators and version info
+- Machine API state
+- Summary report with timeline
+- Output: `control-plane-final-state/`
+
+## Integration
+
+### Workflow Changes
+
+**Updated**: `platform-external-cluster-aws-post-chain.yaml`
+```yaml
+chain:
+  as: platform-external-cluster-aws-post
+  steps:
+  - ref: platform-external-post-gather-aws  # NEW - runs first, on failure only
+  - ref: platform-external-cluster-aws-destroy
+```
+
+The new gather step runs **before** destroy, ensuring diagnostics are collected even if destroy fails.
+
+### Files Created
+
+```
+platform-external/
+├── post/
+│   └── gather-aws/
+│       ├── platform-external-post-gather-aws-commands.sh  (NEW)
+│       ├── platform-external-post-gather-aws-ref.yaml     (NEW)
+│       └── OWNERS                                          (NEW)
+└── cluster/
+    └── wait-for/
+        └── ready/
+            └── control/
+                ├── platform-external-cluster-wait-for-ready-control-commands.sh  (ENHANCED)
+                └── platform-external-cluster-wait-for-ready-control-ref.yaml      (ENHANCED)
+```
+
+### Files Modified
+
+1. `platform-external-cluster-aws-post-chain.yaml` - Added gather-aws step
+2. `platform-external-cluster-wait-for-ready-control-commands.sh` - Enhanced diagnostics
+3. `platform-external-cluster-wait-for-ready-control-ref.yaml` - Added configuration
+
+## Usage Examples
+
+### Successful Run (No Extra Diagnostics)
+```
+1. Installation proceeds normally
+2. Control plane nodes become ready (periodic snapshots collected)
+3. Installation completes
+4. platform-external-post-gather-aws SKIPPED (optional_on_success: true)
+5. Infrastructure destroyed
+```
+
+### Failed Run (Full Diagnostics)
+```
+1. Installation starts
+2. Control plane wait begins
+3. Periodic diagnostics collected every 2.5 minutes
+4. Timeout after 30 minutes
+5. Final control plane diagnostics collected
+6. platform-external-post-gather-aws runs:
+   - Connects to bootstrap via SSH
+   - Collects log-bundle-*.tar.gz
+   - Queries CloudFormation for instance IDs
+   - Downloads console logs for all instances
+   - Checks load balancer target health
+   - Gathers CloudFormation events
+   - Creates summary report
+7. Infrastructure destroyed
+```
+
+### Artifacts on Failure
+```
+artifacts/
+├── log-bundle-20260407-120000.tar.gz           # Bootstrap logs
+├── bootstrap-gather.log                         # Gather operation log
+├── aws-diagnostics-summary.txt                  # Summary report
+├── aws-instance-ids.txt                         # All instance IDs
+├── ec2-console-logs/
+│   ├── i-0abc123-bootstrap.log
+│   ├── i-0abc123-bootstrap-metadata.json
+│   ├── i-0def456-master-0.log
+│   ├── i-0def456-master-0-metadata.json
+│   └── ...
+├── load-balancer-diagnostics/
+│   ├── load-balancers.json
+│   ├── target-groups.json
+│   ├── target-health-api-ext.json
+│   ├── target-health-api-ext.txt
+│   └── ...
+├── cloudformation-events/
+│   ├── infra-bootstrap-events.json
+│   ├── infra-bootstrap-events.txt
+│   └── ...
+├── control-plane-diagnostics/
+│   ├── iteration-005/
+│   ├── iteration-010/
+│   └── ...
+└── control-plane-final-state/
+    ├── summary.txt
+    ├── nodes.yaml
+    ├── pods-all.txt
+    ├── namespace-kube-system/
+    └── ...
+```
+
+## Debugging Workflows
+
+### Scenario 1: Bootstrap Failure
+**Symptoms**: Installation hangs during bootstrap, API never becomes available
+
+**Diagnostics to Check**:
+1. `log-bundle-*.tar.gz` - Complete bootstrap logs
+   - Extract: `tar -xzf log-bundle-*.tar.gz`
+   - Check: `bootstrap/journals/bootkube.service.log`
+   - Check: `bootstrap/containers/`
+2. `ec2-console-logs/i-*-bootstrap.log` - Boot process, ignition
+   - Look for: ignition errors, failed systemd units, kernel panics
+3. `load-balancer-diagnostics/target-health-api-ext.json`
+   - Check if bootstrap registered as target
+   - Check health check failures
+
+### Scenario 2: Master Nodes Not Booting
+**Symptoms**: Masters stuck in Pending or never appear
+
+**Diagnostics to Check**:
+1. `ec2-console-logs/i-*-master-*.log` - Boot logs
+   - Look for: ignition failures, disk issues, network problems
+2. `ec2-console-logs/i-*-master-*-metadata.json` - Instance state
+   - Check: instance state, security groups, network interfaces
+3. `cloudformation-events/*-master-events.json` - Provisioning
+   - Look for: CloudFormation resource failures
+4. `control-plane-final-state/machines.yaml` - Machine API
+   - Check: machine provisioning status, errors
+
+### Scenario 3: API Not Healthy
+**Symptoms**: Masters boot but API health checks fail
+
+**Diagnostics to Check**:
+1. `load-balancer-diagnostics/target-health-api-*.json`
+   - Check target states: healthy, unhealthy, initial, draining
+   - Check reasons: connection refused, timeout, unhealthy threshold
+2. `control-plane-final-state/namespace-openshift-kube-apiserver/`
+   - Check apiserver pod status
+   - Check pod logs for startup errors
+3. `log-bundle-*/master-*/journals/kubelet.service.log`
+   - Check kubelet connecting to API
+
+### Scenario 4: Etcd Issues
+**Symptoms**: Control plane partially ready, etcd problems
+
+**Diagnostics to Check**:
+1. `control-plane-final-state/namespace-openshift-etcd/`
+   - Check etcd pod status
+   - Check events for etcd errors
+2. `log-bundle-*/master-*/containers/etcd-*`
+   - Etcd logs from bootstrap perspective
+3. `control-plane-diagnostics/iteration-NNN/events-recent.txt`
+   - Timeline of etcd-related events
+
+## Testing Strategy
+
+### Unit Testing
+- [x] Script syntax validation: `bash -n *.sh`
+- [ ] Test with missing BOOTSTRAP_IP (should gracefully skip)
+- [ ] Test with missing metadata.json (should use LEASED_RESOURCE)
+- [ ] Test with no CloudFormation stacks (should handle gracefully)
+
+### Integration Testing
+- [ ] Run on successful installation (should skip gather-aws)
+- [ ] Run on bootstrap failure (should collect all diagnostics)
+- [ ] Run on control plane timeout (should collect control plane diagnostics)
+- [ ] Run on network failure (should collect partial diagnostics)
+
+### Verification Checklist
+- [ ] Bootstrap logs collected in log-bundle-*.tar.gz
+- [ ] Console logs for all instances present
+- [ ] Load balancer health status captured
+- [ ] CloudFormation events collected
+- [ ] Summary report generated
+- [ ] Control plane diagnostics collected periodically
+- [ ] Final state captured on timeout
+- [ ] Step completes successfully even with partial failures
+- [ ] Step skipped on successful runs
+
+## Performance Considerations
+
+### Resource Usage
+- **CPU**: 100m (lightweight, mostly API calls)
+- **Memory**: 300Mi (sufficient for log downloads)
+- **Timeout**: 20 minutes (allows SSH bootstrap gather)
+- **Network**: Moderate (downloads console logs, ~1-5MB per instance)
+
+### Time Impact
+- **Success case**: 0 seconds (step skipped)
+- **Failure case**: 5-15 minutes depending on:
+  - Bootstrap SSH connectivity (5-10 min)
+  - Number of instances (1-3 min)
+  - Network latency (varies)
+
+### Cost Impact
+- **AWS API calls**: ~50-100 calls per failure (negligible cost)
+- **Data transfer**: Minimal (console logs, CloudFormation events)
+- **Storage**: 50-200MB in artifacts (typical failure)
+
+## Security Considerations
+
+### Sensitive Data Protection
+1. **Only runs on failure**: `optional_on_success: true` prevents collection from successful runs
+2. **No credentials in logs**: Bootstrap logs may contain token references but not values
+3. **No kubeconfig exposure**: Kubeconfig handled internally, not exposed
+4. **Instance metadata**: Public data only (IDs, states, not credentials)
+
+### Access Control
+- Requires AWS credentials (provided by CI infrastructure)
+- Requires SSH key (provided by cluster profile)
+- All artifacts stored in CI-controlled artifact bucket
+
+## Future Enhancements
+
+### Potential Improvements
+1. **Automated analysis**: Parse bootstrap logs for common failure patterns
+2. **Smart filtering**: Only collect console logs for failed instances
+3. **Compression**: Compress console logs before upload
+4. **Parallel collection**: Gather bootstrap and console logs concurrently
+5. **Platform abstraction**: Extend to Azure, GCP with similar diagnostics
+6. **Metric collection**: CloudWatch metrics for instances and load balancers
+
+### Additional Diagnostics
+1. **VPC flow logs**: Network traffic analysis
+2. **Route53 health checks**: DNS resolution verification
+3. **Security group analysis**: Firewall rule validation
+4. **S3 bucket logs**: Ignition download verification
+5. **CloudTrail events**: API call history
+
+## References
+
+### Existing Patterns
+- `openstack/gather/openstack-gather-commands.sh` - Platform-specific gathering
+- `gather/aws-console/gather-aws-console-commands.sh` - Console log collection
+- `platform-external/cluster/wait-for/ccm-nodes-initialized/` - Wait with diagnostics
+
+### Documentation
+- [OpenShift Install Gather Bootstrap](https://docs.openshift.com/container-platform/4.13/installing/installing-troubleshooting.html#installation-bootstrap-gather_installing-troubleshooting)
+- [AWS EC2 Console Output](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-console.html)
+- [ELBv2 Target Health](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/target-group-health-checks.html)
+
+## Maintenance
+
+### Ownership
+- **Team**: Platform External / UPI
+- **Reviewers**: See `OWNERS` files in each directory
+- **Contact**: #forum-platform-external
+
+### Update Process
+1. Test changes in rehearsal jobs
+2. Update documentation (this file)
+3. Get review from OWNERS
+4. Merge to release repository
+5. Monitor periodic jobs for regressions
+
+---
+
+**Last Updated**: 2026-04-07
+**Author**: Claude Code + mtulio
+**Status**: Implemented, pending testing

--- a/ci-operator/step-registry/platform-external/ccm/deploy/platform-external-ccm-deploy-commands.sh
+++ b/ci-operator/step-registry/platform-external/ccm/deploy/platform-external-ccm-deploy-commands.sh
@@ -73,7 +73,7 @@ do
   oc create -f "${SHARED_DIR}"/"${manifest}" || true
 done <<< "$(cat "${SHARED_DIR}/deploy-ccm-manifests.txt")"
 
-## What will be an standard method?
+## What will be a standard method?
 # For AWS:
 #CCM_STATUS_KEY=.status.availableReplicas
 # For OCI:
@@ -81,10 +81,235 @@ done <<< "$(cat "${SHARED_DIR}/deploy-ccm-manifests.txt")"
 if [[ -z "${CCM_STATUS_KEY}" ]]; then
   export CCM_STATUS_KEY=.status.availableReplicas
 fi
-until  oc wait --for=jsonpath="{${CCM_STATUS_KEY}}"=${CCM_REPLICAS_COUNT} ${CCM_RESOURCE} -n ${CCM_NAMESPACE} --timeout=10m &> /dev/null
-do
-  log "Waiting for minimum replicas avaialble..."
-  sleep 10
+
+# Configuration for intelligent wait loop with timeout and exponential backoff
+CCM_DEPLOY_TIMEOUT_MINUTES=${CCM_DEPLOY_TIMEOUT_MINUTES:-25}
+CCM_DEPLOY_DIAGNOSTIC_INTERVAL=${CCM_DEPLOY_DIAGNOSTIC_INTERVAL:-60}
+CCM_DEPLOY_FAIL_FAST_IMAGE_PULL_THRESHOLD=${CCM_DEPLOY_FAIL_FAST_IMAGE_PULL_THRESHOLD:-3}
+
+TIMEOUT_SECONDS=$((CCM_DEPLOY_TIMEOUT_MINUTES * 60))
+START_TIME=$(date +%s)
+ITERATION=0
+CURRENT_WAIT=10
+MAX_WAIT=120
+BACKOFF_FACTOR=1.5
+LAST_REPLICAS_COUNT=0
+IMAGE_PULL_BACKOFF_COUNT=0
+LAST_DIAGNOSTIC_TIME=$START_TIME
+NO_PODS_ITERATIONS=0
+
+# Create diagnostic directory
+DIAGNOSTIC_DIR="${ARTIFACT_DIR}/ccm-deployment-diagnostics"
+mkdir -p "${DIAGNOSTIC_DIR}"
+
+# Verbose log file
+VERBOSE_LOG="${ARTIFACT_DIR}/ccm-wait-summary.log"
+touch "${VERBOSE_LOG}"
+
+# Helper function: Get deployment status
+function get_deployment_status() {
+  local current_replicas
+  current_replicas=$(oc get ${CCM_RESOURCE} -n ${CCM_NAMESPACE} -o jsonpath="{${CCM_STATUS_KEY}}" 2>/dev/null || echo "0")
+  echo "${current_replicas}/${CCM_REPLICAS_COUNT}"
+}
+
+# Helper function: Get pod status summary
+function get_pod_status_summary() {
+  local pods_output
+  pods_output=$(oc get pods -n ${CCM_NAMESPACE} --no-headers 2>/dev/null || echo "")
+
+  if [ -z "$pods_output" ]; then
+    echo "0 pods"
+    return
+  fi
+
+  local running=$(echo "$pods_output" | grep -c "Running" || echo "0")
+  local pending=$(echo "$pods_output" | grep -c "Pending" || echo "0")
+  local container_creating=$(echo "$pods_output" | grep -c "ContainerCreating" || echo "0")
+  local error=$(echo "$pods_output" | grep -cE "Error|CrashLoopBackOff|ImagePullBackOff|ErrImagePull" || echo "0")
+
+  local summary=""
+  [ "$running" -gt 0 ] && summary="${summary}${running} Running, "
+  [ "$pending" -gt 0 ] && summary="${summary}${pending} Pending, "
+  [ "$container_creating" -gt 0 ] && summary="${summary}${container_creating} ContainerCreating, "
+  [ "$error" -gt 0 ] && summary="${summary}${error} Error, "
+
+  summary=${summary%, }  # Remove trailing comma
+  [ -z "$summary" ] && summary="Unknown status"
+
+  echo "$summary"
+}
+
+# Helper function: Collect diagnostic snapshot
+function collect_diagnostic_snapshot() {
+  local iteration=$1
+  local snapshot_dir="${DIAGNOSTIC_DIR}/iteration-$(printf "%03d" $iteration)"
+  mkdir -p "${snapshot_dir}"
+
+  oc get ${CCM_RESOURCE} -n ${CCM_NAMESPACE} -o yaml > "${snapshot_dir}/deployment.yaml" 2>&1 || true
+  oc get pods -n ${CCM_NAMESPACE} -o yaml > "${snapshot_dir}/pods.yaml" 2>&1 || true
+  oc describe pods -n ${CCM_NAMESPACE} > "${snapshot_dir}/pods-describe.txt" 2>&1 || true
+  oc get events -n ${CCM_NAMESPACE} --sort-by='.lastTimestamp' > "${snapshot_dir}/events.txt" 2>&1 || true
+  oc get replicasets -n ${CCM_NAMESPACE} -o yaml > "${snapshot_dir}/replicasets.yaml" 2>&1 || true
+}
+
+# Helper function: Perform fail-fast checks
+function perform_fail_fast_checks() {
+  local elapsed=$1
+
+  # Check if deployment exists (fail after 2 minutes if not found)
+  if [ $elapsed -gt 120 ]; then
+    if ! oc get ${CCM_RESOURCE} -n ${CCM_NAMESPACE} &>/dev/null; then
+      log "ERROR: Deployment ${CCM_RESOURCE} not found in namespace ${CCM_NAMESPACE} after 2 minutes"
+      echo "ERROR: Deployment not found after 2 minutes" >> "${VERBOSE_LOG}"
+      return 1
+    fi
+  fi
+
+  # Check for no pods created (fail after 5 iterations)
+  local pod_count=$(oc get pods -n ${CCM_NAMESPACE} --no-headers 2>/dev/null | wc -l)
+  if [ "$pod_count" -eq 0 ]; then
+    NO_PODS_ITERATIONS=$((NO_PODS_ITERATIONS + 1))
+    if [ $NO_PODS_ITERATIONS -ge 5 ]; then
+      log "ERROR: No pods created after 5 iterations (~50 seconds)"
+      echo "ERROR: No pods created after 5 iterations" >> "${VERBOSE_LOG}"
+      return 1
+    fi
+  else
+    NO_PODS_ITERATIONS=0
+  fi
+
+  # Check for CrashLoopBackOff (fail immediately)
+  if oc get pods -n ${CCM_NAMESPACE} -o jsonpath='{.items[*].status.containerStatuses[*].state.waiting.reason}' 2>/dev/null | grep -q "CrashLoopBackOff"; then
+    log "ERROR: Pod in CrashLoopBackOff - indicates config/compatibility issue"
+    echo "ERROR: CrashLoopBackOff detected" >> "${VERBOSE_LOG}"
+    oc get pods -n ${CCM_NAMESPACE} >> "${VERBOSE_LOG}" 2>&1 || true
+    return 1
+  fi
+
+  # Check for ImagePullBackOff (fail after 3 consecutive detections)
+  if oc get pods -n ${CCM_NAMESPACE} -o jsonpath='{.items[*].status.containerStatuses[*].state.waiting.reason}' 2>/dev/null | grep -qE "ImagePullBackOff|ErrImagePull"; then
+    IMAGE_PULL_BACKOFF_COUNT=$((IMAGE_PULL_BACKOFF_COUNT + 1))
+    if [ $IMAGE_PULL_BACKOFF_COUNT -ge $CCM_DEPLOY_FAIL_FAST_IMAGE_PULL_THRESHOLD ]; then
+      log "ERROR: ImagePullBackOff detected $IMAGE_PULL_BACKOFF_COUNT consecutive times"
+      echo "ERROR: ImagePullBackOff threshold exceeded" >> "${VERBOSE_LOG}"
+      oc get pods -n ${CCM_NAMESPACE} >> "${VERBOSE_LOG}" 2>&1 || true
+      return 1
+    fi
+  else
+    IMAGE_PULL_BACKOFF_COUNT=0
+  fi
+
+  return 0
+}
+
+# Helper function: Collect final diagnostics
+function collect_final_diagnostics() {
+  local reason=$1
+  local final_dir="${ARTIFACT_DIR}/ccm-deployment-final-state"
+  mkdir -p "${final_dir}"
+
+  log "Collecting final diagnostics to ${final_dir}..."
+
+  oc get ${CCM_RESOURCE} -n ${CCM_NAMESPACE} -o yaml > "${final_dir}/deployment.yaml" 2>&1 || true
+  oc get pods -n ${CCM_NAMESPACE} -o yaml > "${final_dir}/pods.yaml" 2>&1 || true
+  oc describe pods -n ${CCM_NAMESPACE} > "${final_dir}/pods-describe.txt" 2>&1 || true
+  oc get events -n ${CCM_NAMESPACE} --sort-by='.lastTimestamp' > "${final_dir}/events.txt" 2>&1 || true
+  oc get replicasets -n ${CCM_NAMESPACE} -o yaml > "${final_dir}/replicasets.yaml" 2>&1 || true
+  oc get nodes -o yaml > "${final_dir}/nodes.yaml" 2>&1 || true
+
+  # Create summary report
+  cat > "${final_dir}/summary.txt" << EOF
+CCM Deployment Failure Summary
+==============================
+Failure Reason: ${reason}
+Elapsed Time: $(($(date +%s) - START_TIME)) seconds
+Total Iterations: ${ITERATION}
+
+Final Status:
+$(oc get ${CCM_RESOURCE} -n ${CCM_NAMESPACE} 2>&1 || echo "Deployment not found")
+
+Final Pods:
+$(oc get pods -n ${CCM_NAMESPACE} 2>&1 || echo "No pods found")
+
+Recent Events:
+$(oc get events -n ${CCM_NAMESPACE} --sort-by='.lastTimestamp' | tail -20 2>&1 || echo "Could not fetch events")
+EOF
+}
+
+log "Starting CCM deployment wait (timeout: ${CCM_DEPLOY_TIMEOUT_MINUTES}m)"
+echo "$(date -u --rfc-3339=seconds) - Starting CCM deployment wait (timeout: ${CCM_DEPLOY_TIMEOUT_MINUTES}m)" >> "${VERBOSE_LOG}"
+
+# Main wait loop with timeout, exponential backoff, and fail-fast checks
+while true; do
+  CURRENT_TIME=$(date +%s)
+  ELAPSED=$((CURRENT_TIME - START_TIME))
+
+  # Check overall timeout
+  if [ $ELAPSED -ge $TIMEOUT_SECONDS ]; then
+    log "TIMEOUT: CCM deployment failed to become ready within ${CCM_DEPLOY_TIMEOUT_MINUTES} minutes"
+    echo "TIMEOUT: Exceeded ${CCM_DEPLOY_TIMEOUT_MINUTES} minutes" >> "${VERBOSE_LOG}"
+    collect_final_diagnostics "Timeout after ${CCM_DEPLOY_TIMEOUT_MINUTES} minutes"
+    exit 1
+  fi
+
+  ITERATION=$((ITERATION + 1))
+
+  # Perform fail-fast checks
+  if ! perform_fail_fast_checks $ELAPSED; then
+    collect_final_diagnostics "Fail-fast check failed"
+    exit 1
+  fi
+
+  # Get current replica count
+  CURRENT_REPLICAS=$(oc get ${CCM_RESOURCE} -n ${CCM_NAMESPACE} -o jsonpath="{${CCM_STATUS_KEY}}" 2>/dev/null || echo "0")
+
+  # Check if deployment is ready
+  if [ "${CURRENT_REPLICAS}" -ge "${CCM_REPLICAS_COUNT}" ]; then
+    log "CCM Ready! (took $(date -u -d @${ELAPSED} +%Mm%Ss))"
+    echo "SUCCESS: CCM deployment ready after ${ELAPSED} seconds" >> "${VERBOSE_LOG}"
+    break
+  fi
+
+  # Collect diagnostics periodically
+  if [ $((CURRENT_TIME - LAST_DIAGNOSTIC_TIME)) -ge $CCM_DEPLOY_DIAGNOSTIC_INTERVAL ]; then
+    collect_diagnostic_snapshot $ITERATION
+    LAST_DIAGNOSTIC_TIME=$CURRENT_TIME
+  fi
+
+  # Get status summaries
+  DEPLOYMENT_STATUS=$(get_deployment_status)
+  POD_STATUS=$(get_pod_status_summary)
+
+  # Calculate remaining time
+  REMAINING=$((TIMEOUT_SECONDS - ELAPSED))
+  REMAINING_MIN=$((REMAINING / 60))
+
+  # Log to verbose file
+  echo "$(date -u --rfc-3339=seconds) - [${ITERATION}] Deployment: ${DEPLOYMENT_STATUS} | Pods: ${POD_STATUS} | Next check: ${CURRENT_WAIT}s | Remaining: ${REMAINING_MIN}m" >> "${VERBOSE_LOG}"
+
+  # Log to stdout (minute markers only to avoid clutter)
+  if [ $((ELAPSED % 60)) -lt $CURRENT_WAIT ]; then
+    log "[Minute $((ELAPSED / 60))] Deployment: ${DEPLOYMENT_STATUS} | Pods: ${POD_STATUS}"
+  elif [ $ITERATION -eq 1 ]; then
+    log "[1/~$((TIMEOUT_SECONDS / 15))] Deployment: ${DEPLOYMENT_STATUS} | Pods: ${POD_STATUS} | Next check: ${CURRENT_WAIT}s"
+  fi
+
+  # Check for progress (if replicas increased, reset backoff)
+  if [ "$CURRENT_REPLICAS" -gt "$LAST_REPLICAS_COUNT" ]; then
+    CURRENT_WAIT=10
+    echo "Progress detected: replicas increased from ${LAST_REPLICAS_COUNT} to ${CURRENT_REPLICAS}, resetting backoff to 10s" >> "${VERBOSE_LOG}"
+  else
+    # Apply exponential backoff
+    CURRENT_WAIT=$(awk "BEGIN {print int($CURRENT_WAIT * $BACKOFF_FACTOR)}")
+    if [ $CURRENT_WAIT -gt $MAX_WAIT ]; then
+      CURRENT_WAIT=$MAX_WAIT
+    fi
+  fi
+
+  LAST_REPLICAS_COUNT=$CURRENT_REPLICAS
+
+  sleep $CURRENT_WAIT
 done
 
 log "CCM Ready!"

--- a/ci-operator/step-registry/platform-external/ccm/deploy/platform-external-ccm-deploy-ref.yaml
+++ b/ci-operator/step-registry/platform-external/ccm/deploy/platform-external-ccm-deploy-ref.yaml
@@ -14,3 +14,21 @@ ref:
     default: "no"
     documentation: |-
       When set to "yes" the CCM manifests provided by prior steps will be applyed to the cluster.
+  - name: CCM_DEPLOY_TIMEOUT_MINUTES
+    default: "25"
+    documentation: |-
+      Overall timeout in minutes for CCM deployment to become ready. Default: 25 minutes.
+      This allows time for API server stabilization during bootstrap (can take 15+ minutes)
+      while preventing infinite retry loops. Successful deployments typically complete in ~1 minute.
+  - name: CCM_DEPLOY_DIAGNOSTIC_INTERVAL
+    default: "60"
+    documentation: |-
+      Interval in seconds between diagnostic snapshots collected to ARTIFACT_DIR.
+      Default: 60 seconds. Diagnostics include deployment status, pod details, events, and replicasets.
+      Reduces API load during bootstrap while providing sufficient debugging information.
+  - name: CCM_DEPLOY_FAIL_FAST_IMAGE_PULL_THRESHOLD
+    default: "3"
+    documentation: |-
+      Number of consecutive ImagePullBackOff/ErrImagePull detections before failing fast.
+      Default: 3. Prevents timeout on obvious image pull failures while tolerating transient errors.
+      CrashLoopBackOff triggers immediate failure as it indicates config/compatibility issues.

--- a/ci-operator/step-registry/platform-external/cluster/aws/post/platform-external-cluster-aws-post-chain.yaml
+++ b/ci-operator/step-registry/platform-external/cluster/aws/post/platform-external-cluster-aws-post-chain.yaml
@@ -1,6 +1,8 @@
 chain:
   as: platform-external-cluster-aws-post
   steps:
+  - ref: platform-external-post-gather-aws
   - ref: platform-external-cluster-aws-destroy
   documentation: >-
-    This chain contains all of the steps to provision an OpenShift cluster using the AWS UPI workflow.
+    This chain contains all post-steps for platform-external AWS clusters.
+    Includes AWS-specific diagnostic gathering and infrastructure cleanup.

--- a/ci-operator/step-registry/platform-external/cluster/wait-for/ready/control/platform-external-cluster-wait-for-ready-control-commands.sh
+++ b/ci-operator/step-registry/platform-external/cluster/wait-for/ready/control/platform-external-cluster-wait-for-ready-control-commands.sh
@@ -14,25 +14,155 @@ export KUBECONFIG=${SHARED_DIR}/kubeconfig
 
 source "${SHARED_DIR}/init-fn.sh" || true
 
+# Configuration
+MAX_ITERATIONS=${CONTROL_PLANE_WAIT_MAX_ITERATIONS:-60}  # 60 iterations * 30s = 30 minutes
+ITERATION=0
+DIAGNOSTIC_INTERVAL=5  # Collect diagnostics every 5 iterations (2.5 minutes)
+
+# Helper function: Collect diagnostic snapshot
+function collect_diagnostic_snapshot() {
+  local iteration=$1
+  local diagnostic_dir="${ARTIFACT_DIR}/control-plane-diagnostics/iteration-$(printf "%03d" $iteration)"
+  mkdir -p "${diagnostic_dir}"
+
+  log "Collecting diagnostic snapshot to ${diagnostic_dir}"
+
+  # Node status
+  oc get nodes -o wide > "${diagnostic_dir}/nodes.txt" 2>&1 || true
+  oc get nodes -o yaml > "${diagnostic_dir}/nodes.yaml" 2>&1 || true
+
+  # Master node details
+  oc get nodes -l node-role.kubernetes.io/master -o yaml > "${diagnostic_dir}/master-nodes.yaml" 2>&1 || true
+  oc describe nodes -l node-role.kubernetes.io/master > "${diagnostic_dir}/master-nodes-describe.txt" 2>&1 || true
+
+  # Pod status in critical namespaces
+  for ns in kube-system openshift-kube-apiserver openshift-etcd openshift-machine-api; do
+    oc get pods -n ${ns} -o wide > "${diagnostic_dir}/pods-${ns}.txt" 2>&1 || true
+  done
+
+  # Events
+  oc get events -A --sort-by='.lastTimestamp' | tail -50 > "${diagnostic_dir}/events-recent.txt" 2>&1 || true
+
+  # Machine API (if available)
+  oc get machines -n openshift-machine-api -o yaml > "${diagnostic_dir}/machines.yaml" 2>&1 || true
+  oc get machinesets -n openshift-machine-api -o yaml > "${diagnostic_dir}/machinesets.yaml" 2>&1 || true
+
+  # Cluster operators status
+  oc get clusteroperators > "${diagnostic_dir}/clusteroperators.txt" 2>&1 || true
+}
+
+# Helper function: Collect final diagnostics on failure
+function collect_final_diagnostics() {
+  local final_dir="${ARTIFACT_DIR}/control-plane-final-state"
+  mkdir -p "${final_dir}"
+
+  log "Collecting final diagnostics to ${final_dir}"
+
+  oc get nodes -o wide > "${final_dir}/nodes.txt" 2>&1 || true
+  oc get nodes -o yaml > "${final_dir}/nodes.yaml" 2>&1 || true
+  oc describe nodes > "${final_dir}/nodes-describe.txt" 2>&1 || true
+
+  # Pod status across all namespaces
+  oc get pods -A -o wide > "${final_dir}/pods-all.txt" 2>&1 || true
+
+  # Critical namespace details
+  for ns in kube-system openshift-kube-apiserver openshift-etcd openshift-machine-api openshift-cloud-controller-manager; do
+    mkdir -p "${final_dir}/namespace-${ns}"
+    oc get all -n ${ns} -o yaml > "${final_dir}/namespace-${ns}/resources.yaml" 2>&1 || true
+    oc describe pods -n ${ns} > "${final_dir}/namespace-${ns}/pods-describe.txt" 2>&1 || true
+    oc get events -n ${ns} --sort-by='.lastTimestamp' > "${final_dir}/namespace-${ns}/events.txt" 2>&1 || true
+  done
+
+  # Cluster state
+  oc get clusteroperators -o yaml > "${final_dir}/clusteroperators.yaml" 2>&1 || true
+  oc get clusterversion -o yaml > "${final_dir}/clusterversion.yaml" 2>&1 || true
+
+  # Machine API
+  oc get machines,machinesets -n openshift-machine-api -o yaml > "${final_dir}/machines.yaml" 2>&1 || true
+
+  # Create summary
+  cat > "${final_dir}/summary.txt" << EOF
+Control Plane Wait Timeout Summary
+===================================
+Date: $(date -u --rfc-3339=seconds)
+Iterations: ${ITERATION}/${MAX_ITERATIONS}
+Duration: ~$((ITERATION * 30 / 60)) minutes
+
+Node Status:
+$(oc get nodes 2>&1 || echo "Unable to get nodes")
+
+Master Nodes:
+$(oc get nodes -l node-role.kubernetes.io/master 2>&1 || echo "Unable to get master nodes")
+
+Critical Pods Status:
+$(oc get pods -n kube-system 2>&1 || echo "Unable to get kube-system pods")
+$(oc get pods -n openshift-kube-apiserver 2>&1 || echo "Unable to get apiserver pods")
+$(oc get pods -n openshift-etcd 2>&1 || echo "Unable to get etcd pods")
+
+Recent Events:
+$(oc get events -A --sort-by='.lastTimestamp' | tail -20 2>&1 || echo "Unable to get events")
+EOF
+
+  log "Final diagnostics summary:"
+  cat "${final_dir}/summary.txt"
+}
+
 function wait_for_masters() {
-  log "0/ wait_for_masters()"
+  log "Waiting for control plane nodes to become ready (max ${MAX_ITERATIONS} iterations, ~30 minutes)"
   set +e
-  until oc wait node --selector='node-role.kubernetes.io/master' --for condition=Ready --timeout=30s; do
-    log "Checking masters..."
-    oc get nodes -l node-role.kubernetes.io/master
-    if [[ "$(oc get nodes --selector='node-role.kubernetes.io/master' --no-headers 2>/dev/null | wc -l)" -eq 3 ]] ; then
-      log "Found 3 masters nodes, exiting..."
-      break
+
+  while [ $ITERATION -lt $MAX_ITERATIONS ]; do
+    ITERATION=$((ITERATION + 1))
+
+    # Try to wait for masters with short timeout
+    if oc wait node --selector='node-role.kubernetes.io/master' --for condition=Ready --timeout=30s 2>/dev/null; then
+      log "SUCCESS: All master nodes are ready!"
+      oc get nodes -l node-role.kubernetes.io/master
+      return 0
     fi
+
+    # Check current state
+    MASTER_COUNT=$(oc get nodes --selector='node-role.kubernetes.io/master' --no-headers 2>/dev/null | wc -l || echo "0")
+    READY_COUNT=$(oc get nodes --selector='node-role.kubernetes.io/master' --no-headers 2>/dev/null | grep " Ready " | wc -l || echo "0")
+
+    log "[${ITERATION}/${MAX_ITERATIONS}] Masters: ${READY_COUNT}/${MASTER_COUNT} ready"
+
+    # Show current status
+    oc get nodes -l node-role.kubernetes.io/master 2>&1 || log "Unable to get master nodes"
+
+    # If we have 3 masters and they're all ready, we're done
+    if [[ "${MASTER_COUNT}" -eq 3 ]] && [[ "${READY_COUNT}" -eq 3 ]]; then
+      log "Found 3 ready master nodes, exiting..."
+      return 0
+    fi
+
+    # Collect diagnostics periodically
+    if [ $((ITERATION % DIAGNOSTIC_INTERVAL)) -eq 0 ]; then
+      collect_diagnostic_snapshot "${ITERATION}"
+    fi
+
+    # Show progress markers every 5 minutes
+    if [ $((ITERATION % 10)) -eq 0 ]; then
+      log "[$(((ITERATION * 30) / 60)) minutes] Still waiting for masters..."
+      log "Current pod status in kube-system:"
+      oc get pods -n kube-system 2>&1 | head -10 || true
+    fi
+
     sleep 30
   done
-  log "1/ wait_for_masters() done"
-  oc get nodes -l node-role.kubernetes.io/master=''
+
+  # Timeout reached
+  log "ERROR: Timeout waiting for control plane nodes after ${MAX_ITERATIONS} iterations (~$((MAX_ITERATIONS * 30 / 60)) minutes)"
+  collect_final_diagnostics
+  return 1
 }
 
 log "=> Waiting for Control Plane nodes"
 
-wait_for_masters &
-wait "$!"
+if ! wait_for_masters; then
+  log "ERROR: Failed to wait for control plane nodes"
+  exit 1
+fi
 
+log "Control plane nodes are ready!"
 oc get nodes

--- a/ci-operator/step-registry/platform-external/cluster/wait-for/ready/control/platform-external-cluster-wait-for-ready-control-ref.yaml
+++ b/ci-operator/step-registry/platform-external/cluster/wait-for/ready/control/platform-external-cluster-wait-for-ready-control-ref.yaml
@@ -7,5 +7,27 @@ ref:
     requests:
       cpu: 300m
       memory: 300Mi
+  env:
+  - name: CONTROL_PLANE_WAIT_MAX_ITERATIONS
+    default: "60"
+    documentation: |-
+      Maximum number of 30-second iterations to wait for control plane nodes.
+      Default: 60 iterations = 30 minutes total wait time.
+      Each iteration checks if all master nodes are Ready.
   documentation: |-
-    Platform agnostic check waiting for control plane nodes stayed in Ready phase.
+    Platform agnostic check waiting for control plane nodes to become Ready.
+
+    This step waits for all master nodes (typically 3) to reach Ready state with:
+    - 30-minute total timeout (60 iterations * 30 seconds, configurable)
+    - Periodic diagnostic collection every 2.5 minutes (5 iterations)
+    - Progress markers every 5 minutes showing pod and node status
+    - Comprehensive final diagnostics on timeout
+
+    Diagnostic Collection:
+    - Periodic snapshots: Node status, pod status, events, machines (every 2.5min)
+    - Final state on failure: Complete cluster state, all namespaces, events
+    - Artifacts saved to: control-plane-diagnostics/ and control-plane-final-state/
+
+    Success Criteria:
+    - All master nodes have "Ready" condition
+    - 3 master nodes discovered (for standard HA deployments)

--- a/ci-operator/step-registry/platform-external/post/gather-aws/OWNERS
+++ b/ci-operator/step-registry/platform-external/post/gather-aws/OWNERS
@@ -1,0 +1,12 @@
+approvers:
+- elmiko
+- jcpowermac
+- mtulio
+- rvanderp3
+- vr4manta
+reviewers:
+- elmiko
+- jcpowermac
+- mtulio
+- rvanderp3
+- vr4manta

--- a/ci-operator/step-registry/platform-external/post/gather-aws/platform-external-post-gather-aws-commands.sh
+++ b/ci-operator/step-registry/platform-external/post/gather-aws/platform-external-post-gather-aws-commands.sh
@@ -1,0 +1,378 @@
+#!/bin/bash
+
+#
+# Gather AWS-specific diagnostics for platform-external installations on failure.
+# This step collects:
+# - Bootstrap logs via openshift-install gather bootstrap
+# - EC2 instance console logs (bootstrap, masters, workers)
+# - Load balancer target group health status
+# - CloudFormation stack events (if not already collected)
+#
+
+set -o nounset
+set -o pipefail
+
+# Don't exit on error - we want to collect as much as possible
+set +o errexit
+
+source "${SHARED_DIR}/init-fn.sh" || true
+
+log "Starting AWS-specific diagnostic collection for platform-external"
+
+export AWS_SHARED_CREDENTIALS_FILE="${CLUSTER_PROFILE_DIR}/.awscred"
+
+# Determine AWS region
+if [ ! -f "${SHARED_DIR}/metadata.json" ]; then
+  log "WARNING: No metadata.json found, attempting to extract region from other sources"
+  if [ -f "${SHARED_DIR}/terraform.tfvars.json" ]; then
+    AWS_REGION=$(jq -r '.aws_region // empty' "${SHARED_DIR}/terraform.tfvars.json" 2>/dev/null || echo "")
+  fi
+  if [ -z "${AWS_REGION}" ] && [ -n "${LEASED_RESOURCE:-}" ]; then
+    AWS_REGION="${LEASED_RESOURCE}"
+  fi
+  if [ -z "${AWS_REGION}" ]; then
+    log "ERROR: Unable to determine AWS region, skipping AWS diagnostics"
+    exit 0
+  fi
+else
+  AWS_REGION="$(jq -r .aws.region "${SHARED_DIR}/metadata.json")"
+fi
+
+export AWS_DEFAULT_REGION="${AWS_REGION}"
+log "AWS Region: ${AWS_REGION}"
+
+# Get infrastructure ID
+if [ -f "${SHARED_DIR}/metadata.json" ]; then
+  INFRA_ID="$(jq -r .infraID "${SHARED_DIR}/metadata.json")"
+elif [ -f "${SHARED_DIR}/terraform.tfvars.json" ]; then
+  INFRA_ID="$(jq -r .cluster_id "${SHARED_DIR}/terraform.tfvars.json")"
+else
+  log "WARNING: Unable to determine infrastructure ID, will skip some diagnostics"
+  INFRA_ID=""
+fi
+
+log "Infrastructure ID: ${INFRA_ID}"
+
+#
+# 1. Collect Bootstrap Logs
+#
+log "=========================================="
+log "1. Collecting Bootstrap Logs"
+log "=========================================="
+
+if [ -f "${SHARED_DIR}/BOOTSTRAP_IP" ]; then
+  BOOTSTRAP_IP=$(<"${SHARED_DIR}/BOOTSTRAP_IP")
+  log "Bootstrap IP: ${BOOTSTRAP_IP}"
+
+  SSH_PRIV_KEY_PATH="${CLUSTER_PROFILE_DIR}/ssh-privatekey"
+
+  if [ -f "${SSH_PRIV_KEY_PATH}" ]; then
+    log "Attempting to gather bootstrap logs via openshift-install..."
+
+    # Create temporary install directory with kubeconfig
+    TEMP_INSTALL_DIR="${ARTIFACT_DIR}/bootstrap-gather-install-dir"
+    mkdir -p "${TEMP_INSTALL_DIR}/auth"
+
+    if [ -f "${SHARED_DIR}/kubeconfig" ]; then
+      cp "${SHARED_DIR}/kubeconfig" "${TEMP_INSTALL_DIR}/auth/kubeconfig" 2>/dev/null || true
+    fi
+
+    # Try to gather bootstrap logs
+    if command -v openshift-install &> /dev/null; then
+      log "Running: openshift-install gather bootstrap --bootstrap ${BOOTSTRAP_IP} --key ${SSH_PRIV_KEY_PATH}"
+
+      cd "${TEMP_INSTALL_DIR}" || exit 1
+      timeout 600 openshift-install gather bootstrap \
+        --bootstrap "${BOOTSTRAP_IP}" \
+        --key "${SSH_PRIV_KEY_PATH}" \
+        --log-level debug 2>&1 | tee "${ARTIFACT_DIR}/bootstrap-gather.log" || {
+        log "WARNING: openshift-install gather bootstrap failed or timed out"
+      }
+
+      # Copy any log bundles to artifacts
+      if ls log-bundle-*.tar.gz 1> /dev/null 2>&1; then
+        cp -v log-bundle-*.tar.gz "${ARTIFACT_DIR}/" || true
+        log "Bootstrap logs collected successfully"
+      else
+        log "WARNING: No bootstrap log bundle created"
+      fi
+
+      cd - || exit 1
+    else
+      log "WARNING: openshift-install command not found, cannot gather bootstrap logs"
+    fi
+  else
+    log "WARNING: SSH private key not found at ${SSH_PRIV_KEY_PATH}"
+  fi
+else
+  log "WARNING: BOOTSTRAP_IP file not found, skipping bootstrap log collection"
+fi
+
+#
+# 2. Extract Instance IDs from CloudFormation Stacks
+#
+log "=========================================="
+log "2. Extracting Instance IDs from CloudFormation"
+log "=========================================="
+
+INSTANCE_IDS_FILE="${ARTIFACT_DIR}/aws-instance-ids.txt"
+touch "${INSTANCE_IDS_FILE}"
+
+# Function to extract instance IDs from CloudFormation stack
+extract_instances_from_stack() {
+  local stack_name=$1
+  log "Extracting instances from stack: ${stack_name}"
+
+  aws --region "${AWS_REGION}" cloudformation describe-stack-resources \
+    --stack-name "${stack_name}" \
+    --query 'StackResources[?ResourceType==`AWS::EC2::Instance`].PhysicalResourceId' \
+    --output text 2>/dev/null | tr '\t' '\n' >> "${INSTANCE_IDS_FILE}" || {
+    log "WARNING: Failed to extract instances from stack ${stack_name}"
+  }
+}
+
+# Extract from known stack files
+if [ -f "${SHARED_DIR}/STACK_NAME_BOOTSTRAP" ]; then
+  BOOTSTRAP_STACK=$(<"${SHARED_DIR}/STACK_NAME_BOOTSTRAP")
+  extract_instances_from_stack "${BOOTSTRAP_STACK}"
+fi
+
+# Try to find all cluster stacks by infrastructure ID
+if [ -n "${INFRA_ID}" ]; then
+  log "Searching for all CloudFormation stacks with InfrastructureName=${INFRA_ID}"
+
+  aws --region "${AWS_REGION}" cloudformation describe-stacks \
+    --query "Stacks[?Tags[?Key=='Name'&&contains(Value,'${INFRA_ID}')]].StackName" \
+    --output text 2>/dev/null | tr '\t' '\n' | while read -r stack_name; do
+    if [ -n "${stack_name}" ]; then
+      extract_instances_from_stack "${stack_name}"
+    fi
+  done
+fi
+
+# Also try to find instances directly by tag
+if [ -n "${INFRA_ID}" ]; then
+  log "Searching for EC2 instances with tag kubernetes.io/cluster/${INFRA_ID}=owned"
+
+  aws --region "${AWS_REGION}" ec2 describe-instances \
+    --filters "Name=tag:kubernetes.io/cluster/${INFRA_ID},Values=owned" \
+    --query 'Reservations[].Instances[].InstanceId' \
+    --output text 2>/dev/null | tr '\t' '\n' >> "${INSTANCE_IDS_FILE}" || {
+    log "WARNING: Failed to query instances by tag"
+  }
+fi
+
+# Remove duplicates
+if [ -f "${INSTANCE_IDS_FILE}" ]; then
+  sort -u "${INSTANCE_IDS_FILE}" -o "${INSTANCE_IDS_FILE}"
+  INSTANCE_COUNT=$(wc -l < "${INSTANCE_IDS_FILE}")
+  log "Found ${INSTANCE_COUNT} unique instance(s)"
+
+  if [ "${INSTANCE_COUNT}" -gt 0 ]; then
+    log "Instance IDs:"
+    cat "${INSTANCE_IDS_FILE}" | while read -r instance_id; do
+      log "  - ${instance_id}"
+    done
+  fi
+fi
+
+#
+# 3. Collect EC2 Console Logs
+#
+log "=========================================="
+log "3. Collecting EC2 Instance Console Logs"
+log "=========================================="
+
+if [ -f "${INSTANCE_IDS_FILE}" ] && [ -s "${INSTANCE_IDS_FILE}" ]; then
+  mkdir -p "${ARTIFACT_DIR}/ec2-console-logs"
+
+  cat "${INSTANCE_IDS_FILE}" | while read -r instance_id; do
+    if [ -n "${instance_id}" ]; then
+      log "Gathering console log for instance ${instance_id}"
+
+      # Get instance name tag for better file naming
+      INSTANCE_NAME=$(aws --region "${AWS_REGION}" ec2 describe-instances \
+        --instance-ids "${instance_id}" \
+        --query 'Reservations[0].Instances[0].Tags[?Key==`Name`].Value' \
+        --output text 2>/dev/null || echo "unknown")
+
+      INSTANCE_NAME=$(echo "${INSTANCE_NAME}" | tr '/' '-' | tr ' ' '-')
+
+      # Get console output
+      LC_ALL=C.utf8 aws --region "${AWS_REGION}" ec2 get-console-output \
+        --instance-id "${instance_id}" \
+        --output text > "${ARTIFACT_DIR}/ec2-console-logs/${instance_id}-${INSTANCE_NAME}.log" 2>&1 || {
+        log "WARNING: Failed to get console output for ${instance_id}"
+      }
+
+      # Also save instance metadata
+      aws --region "${AWS_REGION}" ec2 describe-instances \
+        --instance-ids "${instance_id}" \
+        --output json > "${ARTIFACT_DIR}/ec2-console-logs/${instance_id}-${INSTANCE_NAME}-metadata.json" 2>&1 || {
+        log "WARNING: Failed to get instance metadata for ${instance_id}"
+      }
+    fi
+  done
+
+  log "EC2 console logs collected to ${ARTIFACT_DIR}/ec2-console-logs/"
+else
+  log "WARNING: No instance IDs found, skipping console log collection"
+fi
+
+#
+# 4. Collect Load Balancer Target Group Health
+#
+log "=========================================="
+log "4. Collecting Load Balancer Diagnostics"
+log "=========================================="
+
+if [ -n "${INFRA_ID}" ]; then
+  mkdir -p "${ARTIFACT_DIR}/load-balancer-diagnostics"
+
+  # Find all load balancers for this cluster
+  log "Searching for load balancers..."
+  aws --region "${AWS_REGION}" elbv2 describe-load-balancers \
+    --query "LoadBalancers[?contains(LoadBalancerName,'${INFRA_ID}')]" \
+    --output json > "${ARTIFACT_DIR}/load-balancer-diagnostics/load-balancers.json" 2>&1 || {
+    log "WARNING: Failed to describe load balancers"
+  }
+
+  # Find all target groups for this cluster
+  log "Searching for target groups..."
+  aws --region "${AWS_REGION}" elbv2 describe-target-groups \
+    --query "TargetGroups[?contains(TargetGroupName,'${INFRA_ID}')]" \
+    --output json > "${ARTIFACT_DIR}/load-balancer-diagnostics/target-groups.json" 2>&1 || {
+    log "WARNING: Failed to describe target groups"
+  }
+
+  # Get target health for each target group
+  if [ -f "${ARTIFACT_DIR}/load-balancer-diagnostics/target-groups.json" ]; then
+    jq -r '.TargetGroups[].TargetGroupArn' "${ARTIFACT_DIR}/load-balancer-diagnostics/target-groups.json" 2>/dev/null | while read -r tg_arn; do
+      if [ -n "${tg_arn}" ]; then
+        TG_NAME=$(echo "${tg_arn}" | awk -F: '{print $NF}' | sed 's/targetgroup\///')
+        log "Checking target health for: ${TG_NAME}"
+
+        aws --region "${AWS_REGION}" elbv2 describe-target-health \
+          --target-group-arn "${tg_arn}" \
+          --output json > "${ARTIFACT_DIR}/load-balancer-diagnostics/target-health-${TG_NAME}.json" 2>&1 || {
+          log "WARNING: Failed to describe target health for ${TG_NAME}"
+        }
+
+        # Also create a human-readable summary
+        aws --region "${AWS_REGION}" elbv2 describe-target-health \
+          --target-group-arn "${tg_arn}" \
+          --query 'TargetHealthDescriptions[].{Target:Target.Id,Port:Target.Port,State:TargetHealth.State,Reason:TargetHealth.Reason,Description:TargetHealth.Description}' \
+          --output table > "${ARTIFACT_DIR}/load-balancer-diagnostics/target-health-${TG_NAME}.txt" 2>&1 || true
+      fi
+    done
+  fi
+
+  log "Load balancer diagnostics collected to ${ARTIFACT_DIR}/load-balancer-diagnostics/"
+else
+  log "WARNING: No infrastructure ID available, skipping load balancer diagnostics"
+fi
+
+#
+# 5. Collect CloudFormation Stack Events (if not already collected)
+#
+log "=========================================="
+log "5. Collecting CloudFormation Stack Events"
+log "=========================================="
+
+if [ -n "${INFRA_ID}" ]; then
+  mkdir -p "${ARTIFACT_DIR}/cloudformation-events"
+
+  # Find all stacks for this cluster
+  aws --region "${AWS_REGION}" cloudformation describe-stacks \
+    --query "Stacks[?Tags[?Key=='Name'&&contains(Value,'${INFRA_ID}')]].StackName" \
+    --output text 2>/dev/null | tr '\t' '\n' | while read -r stack_name; do
+    if [ -n "${stack_name}" ]; then
+      log "Collecting events for stack: ${stack_name}"
+
+      aws --region "${AWS_REGION}" cloudformation describe-stack-events \
+        --stack-name "${stack_name}" \
+        --output json > "${ARTIFACT_DIR}/cloudformation-events/${stack_name}-events.json" 2>&1 || {
+        log "WARNING: Failed to get events for stack ${stack_name}"
+      }
+
+      # Also create human-readable table
+      aws --region "${AWS_REGION}" cloudformation describe-stack-events \
+        --stack-name "${stack_name}" \
+        --query 'StackEvents[0:50].[Timestamp,ResourceStatus,ResourceType,LogicalResourceId,ResourceStatusReason]' \
+        --output table > "${ARTIFACT_DIR}/cloudformation-events/${stack_name}-events.txt" 2>&1 || true
+    fi
+  done
+
+  log "CloudFormation events collected to ${ARTIFACT_DIR}/cloudformation-events/"
+fi
+
+#
+# 6. Create Summary Report
+#
+log "=========================================="
+log "6. Creating Diagnostic Summary"
+log "=========================================="
+
+SUMMARY_FILE="${ARTIFACT_DIR}/aws-diagnostics-summary.txt"
+
+cat > "${SUMMARY_FILE}" << EOF
+AWS Platform-External Diagnostic Collection Summary
+====================================================
+Date: $(date -u --rfc-3339=seconds)
+Region: ${AWS_REGION}
+Infrastructure ID: ${INFRA_ID}
+
+Bootstrap Information:
+----------------------
+$(if [ -f "${SHARED_DIR}/BOOTSTRAP_IP" ]; then
+  echo "Bootstrap IP: $(<"${SHARED_DIR}/BOOTSTRAP_IP")"
+  echo "Bootstrap logs: $(if [ -f "${ARTIFACT_DIR}"/log-bundle-*.tar.gz ]; then echo "Collected"; else echo "Not available"; fi)"
+else
+  echo "Bootstrap IP: Not available"
+fi)
+
+Instance Information:
+---------------------
+Total instances found: $(if [ -f "${INSTANCE_IDS_FILE}" ]; then wc -l < "${INSTANCE_IDS_FILE}"; else echo "0"; fi)
+$(if [ -f "${INSTANCE_IDS_FILE}" ] && [ -s "${INSTANCE_IDS_FILE}" ]; then
+  echo "Instance IDs:"
+  cat "${INSTANCE_IDS_FILE}" | while read -r id; do echo "  - ${id}"; done
+fi)
+
+Console logs collected: $(if [ -d "${ARTIFACT_DIR}/ec2-console-logs" ]; then ls -1 "${ARTIFACT_DIR}/ec2-console-logs"/*.log 2>/dev/null | wc -l; else echo "0"; fi)
+
+Load Balancer Information:
+---------------------------
+$(if [ -f "${ARTIFACT_DIR}/load-balancer-diagnostics/target-groups.json" ]; then
+  echo "Target Groups:"
+  jq -r '.TargetGroups[] | "  - \(.TargetGroupName) (\(.Protocol):\(.Port))"' "${ARTIFACT_DIR}/load-balancer-diagnostics/target-groups.json" 2>/dev/null || echo "  Unable to parse"
+else
+  echo "  No target groups found"
+fi)
+
+CloudFormation Stacks:
+----------------------
+$(if [ -d "${ARTIFACT_DIR}/cloudformation-events" ]; then
+  echo "Stack events collected:"
+  ls -1 "${ARTIFACT_DIR}/cloudformation-events"/*-events.json 2>/dev/null | while read -r f; do
+    basename "$f" | sed 's/-events.json//'
+  done | sed 's/^/  - /'
+else
+  echo "  No stack events collected"
+fi)
+
+Collected Artifacts:
+--------------------
+$(ls -lh "${ARTIFACT_DIR}" | tail -n +2 | awk '{print $9, $5}' | sed 's/^/  /')
+
+EOF
+
+log "Summary report created: ${SUMMARY_FILE}"
+cat "${SUMMARY_FILE}"
+
+log "=========================================="
+log "AWS diagnostic collection completed"
+log "=========================================="
+
+# Exit successfully - this is a best-effort gather step
+exit 0

--- a/ci-operator/step-registry/platform-external/post/gather-aws/platform-external-post-gather-aws-ref.yaml
+++ b/ci-operator/step-registry/platform-external/post/gather-aws/platform-external-post-gather-aws-ref.yaml
@@ -1,0 +1,50 @@
+ref:
+  as: platform-external-post-gather-aws
+  from: cli
+  commands: platform-external-post-gather-aws-commands.sh
+  grace_period: 10m
+  timeout: 20m
+  best_effort: true
+  optional_on_success: true
+  resources:
+    requests:
+      cpu: 100m
+      memory: 300Mi
+  documentation: |-
+    Gather AWS-specific diagnostics for platform-external installations on failure.
+
+    This step collects comprehensive diagnostic information from AWS to help debug
+    installation failures in platform-external workflows:
+
+    1. **Bootstrap Logs**: Uses openshift-install gather bootstrap to collect logs
+       from the bootstrap node via SSH. Creates log-bundle-*.tar.gz in artifacts.
+
+    2. **EC2 Console Logs**: Extracts instance IDs from CloudFormation stacks and
+       collects console output for all instances (bootstrap, masters, workers).
+       Useful for diagnosing boot failures, kernel panics, ignition issues.
+
+    3. **Load Balancer Diagnostics**: Collects target group health status for all
+       cluster load balancers. Shows which targets are healthy/unhealthy and why.
+       Critical for diagnosing API connectivity issues.
+
+    4. **CloudFormation Events**: Gathers stack events showing resource creation
+       timeline and any failures. Helps identify infrastructure provisioning issues.
+
+    5. **Instance Metadata**: Collects EC2 instance details including state, type,
+       security groups, network interfaces for all cluster instances.
+
+    All diagnostics are collected to ARTIFACT_DIR with organized subdirectories:
+    - ec2-console-logs/: Console output for each instance
+    - load-balancer-diagnostics/: Target group health and LB details
+    - cloudformation-events/: Stack events for all cluster stacks
+    - aws-diagnostics-summary.txt: Human-readable summary of collected data
+
+    This step is best-effort and will collect as much data as possible even if
+    some operations fail. It only runs on failure (optional_on_success: true) to
+    avoid collecting sensitive data from successful runs.
+
+    **Prerequisites**:
+    - AWS credentials in CLUSTER_PROFILE_DIR
+    - metadata.json or LEASED_RESOURCE for region detection
+    - BOOTSTRAP_IP in SHARED_DIR (if bootstrap logs needed)
+    - SSH private key in CLUSTER_PROFILE_DIR (if bootstrap logs needed)

--- a/ci-operator/step-registry/platform-external/pre/conf/manifests/platform-external-pre-conf-manifests-ref.yaml
+++ b/ci-operator/step-registry/platform-external/pre/conf/manifests/platform-external-pre-conf-manifests-ref.yaml
@@ -29,3 +29,6 @@ ref:
     default: ""
     documentation: |-
       Override release image.
+  - name: OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY
+    default: "true"
+    documentation: "Set to true to disable the Sigstore image signature policy to allow the installation of an unsigned release image. This is for internal CI testing only"


### PR DESCRIPTION
Introducing the job validate OCP install with configuration Platform Type `External` without CCM on AWS provider, running VCSP conformance workflow deployed by OPCT