### PR TITLE
Update osde2e nightly jobs to run daily with cron schedules (4.16-4.22)

### DIFF
--- a/ci-operator/config/openshift/osde2e/openshift-osde2e-main__nightly-4.16.yaml
+++ b/ci-operator/config/openshift/osde2e/openshift-osde2e-main__nightly-4.16.yaml
@@ -16,7 +16,7 @@ resources:
       memory: 200Mi
 tests:
 - as: rosa-classic-sts
-  cron: 0 0 1 1 *
+  cron: 0 2 * * *
   steps:
     env:
       CONFIGS: rosa,sts,stage,rosa-e2e-suite
@@ -29,7 +29,7 @@ tests:
     test:
     - ref: osde2e-test
 - as: osd-aws
-  cron: 0 0 1 1 *
+  cron: 0 6 * * *
   steps:
     env:
       CONFIGS: aws,stage,e2e-suite
@@ -42,7 +42,7 @@ tests:
     test:
     - ref: osde2e-test
 - as: osd-gcp
-  cron: 0 0 1 1 *
+  cron: 0 10 * * *
   steps:
     env:
       CONFIGS: gcp,stage,e2e-suite

--- a/ci-operator/config/openshift/osde2e/openshift-osde2e-main__nightly-4.17.yaml
+++ b/ci-operator/config/openshift/osde2e/openshift-osde2e-main__nightly-4.17.yaml
@@ -16,7 +16,7 @@ resources:
       memory: 200Mi
 tests:
 - as: rosa-classic-sts
-  cron: 0 0 1 1 *
+  cron: 0 3 * * *
   steps:
     env:
       CONFIGS: rosa,sts,stage,rosa-e2e-suite
@@ -29,7 +29,7 @@ tests:
     test:
     - ref: osde2e-test
 - as: osd-aws
-  cron: 0 0 1 1 *
+  cron: 0 7 * * *
   steps:
     env:
       CONFIGS: aws,stage,e2e-suite
@@ -42,7 +42,7 @@ tests:
     test:
     - ref: osde2e-test
 - as: osd-gcp
-  cron: 0 0 1 1 *
+  cron: 0 11 * * *
   steps:
     env:
       CONFIGS: gcp,stage,e2e-suite

--- a/ci-operator/config/openshift/osde2e/openshift-osde2e-main__nightly-4.18.yaml
+++ b/ci-operator/config/openshift/osde2e/openshift-osde2e-main__nightly-4.18.yaml
@@ -16,7 +16,7 @@ resources:
       memory: 200Mi
 tests:
 - as: rosa-classic-sts
-  cron: 0 0 1 1 *
+  cron: 0 4 * * *
   steps:
     env:
       CONFIGS: rosa,sts,stage,rosa-e2e-suite
@@ -29,7 +29,7 @@ tests:
     test:
     - ref: osde2e-test
 - as: osd-aws
-  cron: 0 0 1 1 *
+  cron: 0 8 * * *
   steps:
     env:
       CONFIGS: aws,stage,e2e-suite
@@ -42,7 +42,7 @@ tests:
     test:
     - ref: osde2e-test
 - as: osd-gcp
-  cron: 0 0 1 1 *
+  cron: 0 12 * * *
   steps:
     env:
       CONFIGS: gcp,stage,e2e-suite

--- a/ci-operator/config/openshift/osde2e/openshift-osde2e-main__nightly-4.19.yaml
+++ b/ci-operator/config/openshift/osde2e/openshift-osde2e-main__nightly-4.19.yaml
@@ -16,7 +16,7 @@ resources:
       memory: 200Mi
 tests:
 - as: rosa-classic-sts
-  cron: 0 0 1 1 *
+  cron: 0 5 * * *
   steps:
     env:
       CONFIGS: rosa,sts,stage,rosa-e2e-suite
@@ -29,7 +29,7 @@ tests:
     test:
     - ref: osde2e-test
 - as: osd-aws
-  cron: 8 12 * * 6
+  cron: 0 9 * * *
   steps:
     env:
       CONFIGS: aws,stage,e2e-suite
@@ -42,7 +42,7 @@ tests:
     test:
     - ref: osde2e-test
 - as: osd-gcp
-  cron: 0 0 1 1 *
+  cron: 0 13 * * *
   steps:
     env:
       CONFIGS: gcp,stage,e2e-suite

--- a/ci-operator/config/openshift/osde2e/openshift-osde2e-main__nightly-4.20.yaml
+++ b/ci-operator/config/openshift/osde2e/openshift-osde2e-main__nightly-4.20.yaml
@@ -16,7 +16,7 @@ resources:
       memory: 200Mi
 tests:
 - as: rosa-classic-sts
-  cron: 0 0 1 1 *
+  cron: 0 1 * * *
   steps:
     env:
       CONFIGS: rosa,sts,stage,rosa-e2e-suite
@@ -29,7 +29,7 @@ tests:
     test:
     - ref: osde2e-test
 - as: osd-aws
-  cron: 0 0 1 1 *
+  cron: 0 14 * * *
   steps:
     env:
       CONFIGS: aws,stage,e2e-suite
@@ -42,7 +42,7 @@ tests:
     test:
     - ref: osde2e-test
 - as: osd-gcp
-  cron: 0 0 1 1 *
+  cron: 0 15 * * *
   steps:
     env:
       CONFIGS: gcp,stage,e2e-suite

--- a/ci-operator/config/openshift/osde2e/openshift-osde2e-main__nightly-4.21.yaml
+++ b/ci-operator/config/openshift/osde2e/openshift-osde2e-main__nightly-4.21.yaml
@@ -16,7 +16,7 @@ resources:
       memory: 200Mi
 tests:
 - as: rosa-classic-sts
-  cron: 0 0 1 1 *
+  cron: 0 0 * * *
   steps:
     env:
       CONFIGS: rosa,sts,stage,rosa-e2e-suite
@@ -42,7 +42,7 @@ tests:
     test:
     - ref: osde2e-test
 - as: osd-aws
-  cron: 0 0 1 1 *
+  cron: 0 16 * * *
   steps:
     env:
       CONFIGS: aws,stage,e2e-suite
@@ -54,7 +54,7 @@ tests:
     test:
     - ref: osde2e-test
 - as: osd-gcp
-  cron: 0 0 1 1 *
+  cron: 0 17 * * *
   steps:
     env:
       CONFIGS: gcp,stage,e2e-suite

--- a/ci-operator/config/openshift/osde2e/openshift-osde2e-main__nightly-4.22.yaml
+++ b/ci-operator/config/openshift/osde2e/openshift-osde2e-main__nightly-4.22.yaml
@@ -16,7 +16,7 @@ resources:
       memory: 200Mi
 tests:
 - as: rosa-classic-sts
-  cron: 0 0 1 1 *
+  cron: 0 18 * * *
   steps:
     env:
       CONFIGS: rosa,sts,stage,rosa-e2e-suite
@@ -42,7 +42,7 @@ tests:
     test:
     - ref: osde2e-test
 - as: osd-aws
-  cron: 0 0 1 1 *
+  cron: 0 21 * * *
   steps:
     env:
       CONFIGS: aws,stage,e2e-suite
@@ -55,7 +55,7 @@ tests:
     test:
     - ref: osde2e-test
 - as: osd-gcp
-  cron: 0 0 1 1 *
+  cron: 0 23 * * *
   steps:
     env:
       CONFIGS: gcp,stage,e2e-suite

--- a/ci-operator/jobs/openshift/osde2e/openshift-osde2e-main-periodics.yaml
+++ b/ci-operator/jobs/openshift/osde2e/openshift-osde2e-main-periodics.yaml
@@ -623,7 +623,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 0 0 1 1 *
+  cron: 0 6 * * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -704,7 +704,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 0 0 1 1 *
+  cron: 0 10 * * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -785,7 +785,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 0 0 1 1 *
+  cron: 0 2 * * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -866,7 +866,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 0 0 1 1 *
+  cron: 0 7 * * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -947,7 +947,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 0 0 1 1 *
+  cron: 0 11 * * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -1028,7 +1028,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 0 0 1 1 *
+  cron: 0 3 * * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -1109,7 +1109,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 0 0 1 1 *
+  cron: 0 8 * * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -1190,7 +1190,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 0 0 1 1 *
+  cron: 0 12 * * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -1271,7 +1271,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 0 0 1 1 *
+  cron: 0 4 * * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -1352,7 +1352,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 8 12 * * 6
+  cron: 0 9 * * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -1433,7 +1433,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 0 0 1 1 *
+  cron: 0 13 * * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -1514,7 +1514,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 0 0 1 1 *
+  cron: 0 5 * * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -1595,7 +1595,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 0 0 1 1 *
+  cron: 0 14 * * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -1676,7 +1676,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 0 0 1 1 *
+  cron: 0 15 * * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -1757,7 +1757,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 0 0 1 1 *
+  cron: 0 1 * * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -1838,7 +1838,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 0 0 1 1 *
+  cron: 0 16 * * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -1919,7 +1919,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 0 0 1 1 *
+  cron: 0 17 * * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -2000,7 +2000,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 0 0 1 1 *
+  cron: 0 0 * * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -2162,7 +2162,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 0 0 1 1 *
+  cron: 0 21 * * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -2243,7 +2243,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 0 0 1 1 *
+  cron: 0 23 * * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -2324,7 +2324,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 0 0 1 1 *
+  cron: 0 18 * * *
   decorate: true
   decoration_config:
     skip_cloning: true


### PR DESCRIPTION
Changed osde2e nightly variant configurations from annual/weekly schedules to daily cron schedules with distributed execution times for production-ready versions.

Modified versions: 4.16, 4.17, 4.18, 4.19, 4.20, 4.21, 4.22
