### PR TITLE
Debug cluster: baremetalds-ipi-ovn-lvms-f28-compliance-destructive 4.21

### DIFF
--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.21__amd64-nightly.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.21__amd64-nightly.yaml
@@ -2775,7 +2775,8 @@ tests:
     test:
     - ref: wait
       env:
-        TIMEOUT: "+24 hours"
+      - name: TIMEOUT
+        default: "+24 hours"
     - ref: file-integrity-konflux-catalogsource
     - ref: etcd-encryption
     - ref: openshift-extended-test-disruptive

--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.21__amd64-nightly.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.21__amd64-nightly.yaml
@@ -2773,10 +2773,6 @@ tests:
       TEST_SCENARIOS: Compliance_Operator
       TEST_TIMEOUT: "60"
     test:
-    - ref: wait
-      env:
-      - name: TIMEOUT
-        default: "+24 hours"
     - ref: file-integrity-konflux-catalogsource
     - ref: etcd-encryption
     - ref: openshift-extended-test-disruptive

--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.21__amd64-nightly.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.21__amd64-nightly.yaml
@@ -2773,6 +2773,10 @@ tests:
       TEST_SCENARIOS: Compliance_Operator
       TEST_TIMEOUT: "60"
     test:
+    - ref: wait
+      env:
+      - name: TIMEOUT
+        value: "+24 hours"
     - ref: file-integrity-konflux-catalogsource
     - ref: etcd-encryption
     - ref: openshift-extended-test-disruptive

--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.21__amd64-nightly.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.21__amd64-nightly.yaml
@@ -2775,8 +2775,7 @@ tests:
     test:
     - ref: wait
       env:
-      - name: TIMEOUT
-        value: "+24 hours"
+        TIMEOUT: "+24 hours"
     - ref: file-integrity-konflux-catalogsource
     - ref: etcd-encryption
     - ref: openshift-extended-test-disruptive

--- a/ci-operator/step-registry/openshift-extended/test/disruptive/openshift-extended-test-disruptive-commands.sh
+++ b/ci-operator/step-registry/openshift-extended/test/disruptive/openshift-extended-test-disruptive-commands.sh
@@ -611,3 +611,4 @@ function create_must-gather_dir_for_case {
     fi
 }
 run
+sleep 86400


### PR DESCRIPTION
Adding 24h wait ref for debug cluster access

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated test workflows to remain active for up to 24 hours after execution.
  * Adjusted a test workflow to wait for up to 24 hours before completing successfully.
  * These changes support longer-running test and validation activities without affecting production functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->