### PR TITLE
multiarch: run nightly-4.16 s390x libvirt jobs on VPN

### DIFF
--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.16.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.16.yaml
@@ -437,6 +437,8 @@ tests:
   cron: 0 0 28 1 *
   steps:
     cluster_profile: libvirt-s390x-vpn
+    dependencies:
+      OPENSHIFT_INSTALL_TARGET: release:multi-latest
     env:
       ARCH: s390x
       BRANCH: "4.16"
@@ -449,6 +451,8 @@ tests:
   cron: 0 0 29 1 *
   steps:
     cluster_profile: libvirt-s390x-vpn
+    dependencies:
+      OPENSHIFT_INSTALL_TARGET: release:multi-latest
     env:
       ARCH: s390x
       BRANCH: "4.16"
@@ -461,6 +465,8 @@ tests:
   cron: 0 0 30 1 *
   steps:
     cluster_profile: libvirt-s390x-vpn
+    dependencies:
+      OPENSHIFT_INSTALL_TARGET: release:s390x-latest
     env:
       ARCH: s390x
       BRANCH: "4.16"
@@ -473,6 +479,8 @@ tests:
   cron: 0 16 * * 5
   steps:
     cluster_profile: libvirt-s390x-vpn
+    dependencies:
+      OPENSHIFT_INSTALL_TARGET: release:s390x-latest
     env:
       ARCH: s390x
       BRANCH: "4.16"

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.16.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.16.yaml
@@ -372,10 +372,10 @@ tests:
     workflow: openshift-upgrade-azure
 - as: ocp-e2e-ovn-remote-libvirt-s390x
   capabilities:
-  - sshd-bastion
+  - intranet
   cron: 0 12 * * 5
   steps:
-    cluster_profile: libvirt-s390x-1
+    cluster_profile: libvirt-s390x-vpn
     dependencies:
       OPENSHIFT_INSTALL_TARGET: release:s390x-latest
     env:
@@ -383,13 +383,14 @@ tests:
       BRANCH: "4.16"
       NODE_TUNING: "true"
       TEST_TYPE: conformance-parallel
-    workflow: openshift-e2e-libvirt-upi
+      USE_EXTERNAL_DNS: "true"
+    workflow: openshift-e2e-libvirt-vpn
 - as: ocp-e2e-ovn-agent-remote-libvirt-s390x
   capabilities:
-  - sshd-bastion
+  - intranet
   cron: 0 0 2 2 *
   steps:
-    cluster_profile: libvirt-s390x-1
+    cluster_profile: libvirt-s390x-vpn
     dependencies:
       OPENSHIFT_INSTALL_TARGET: release:s390x-latest
     env:
@@ -398,8 +399,9 @@ tests:
       INSTALLER_TYPE: agent
       NODE_TUNING: "true"
       TEST_TYPE: conformance-parallel
+      USE_EXTERNAL_DNS: "true"
       VOLUME_CAPACITY: 120G
-    workflow: openshift-e2e-libvirt-upi
+    workflow: openshift-e2e-libvirt-vpn
 - as: ocp-e2e-ovn-remote-libvirt-s390x-heterogeneous
   capabilities:
   - sshd-bastion
@@ -416,10 +418,10 @@ tests:
     workflow: openshift-e2e-libvirt-upi-heterogeneous
 - as: ocp-heavy-build-ovn-remote-libvirt-s390x
   capabilities:
-  - sshd-bastion
+  - intranet
   cron: 0 0 26 1 *
   steps:
-    cluster_profile: libvirt-s390x-1
+    cluster_profile: libvirt-s390x-vpn
     dependencies:
       OPENSHIFT_INSTALL_TARGET: release:s390x-latest
     env:
@@ -427,61 +429,58 @@ tests:
       BRANCH: "4.16"
       NODE_TUNING: "true"
       TEST_TYPE: heavy-build
-    workflow: openshift-e2e-libvirt-upi
+      USE_EXTERNAL_DNS: "true"
+    workflow: openshift-e2e-libvirt-vpn
 - as: ocp-image-ecosystem-ovn-remote-libvirt-s390x
   capabilities:
-  - sshd-bastion
+  - intranet
   cron: 0 0 28 1 *
   steps:
-    cluster_profile: libvirt-s390x-1
-    dependencies:
-      OPENSHIFT_INSTALL_TARGET: release:multi-latest
+    cluster_profile: libvirt-s390x-vpn
     env:
       ARCH: s390x
       BRANCH: "4.16"
       TEST_TYPE: image-ecosystem
-    workflow: openshift-e2e-libvirt-upi
+      USE_EXTERNAL_DNS: "true"
+    workflow: openshift-e2e-libvirt-vpn
 - as: ocp-jenkins-e2e-ovn-remote-libvirt-s390x
   capabilities:
-  - sshd-bastion
+  - intranet
   cron: 0 0 29 1 *
   steps:
-    cluster_profile: libvirt-s390x-1
-    dependencies:
-      OPENSHIFT_INSTALL_TARGET: release:multi-latest
+    cluster_profile: libvirt-s390x-vpn
     env:
       ARCH: s390x
       BRANCH: "4.16"
       TEST_TYPE: jenkins-e2e-rhel-only
-    workflow: openshift-e2e-libvirt-upi
+      USE_EXTERNAL_DNS: "true"
+    workflow: openshift-e2e-libvirt-vpn
 - as: ocp-e2e-serial-ovn-remote-libvirt-s390x
   capabilities:
-  - sshd-bastion
+  - intranet
   cron: 0 0 30 1 *
   steps:
-    cluster_profile: libvirt-s390x-1
-    dependencies:
-      OPENSHIFT_INSTALL_TARGET: release:s390x-latest
+    cluster_profile: libvirt-s390x-vpn
     env:
       ARCH: s390x
       BRANCH: "4.16"
       TEST_TYPE: conformance-serial
-    workflow: openshift-e2e-libvirt-upi
+      USE_EXTERNAL_DNS: "true"
+    workflow: openshift-e2e-libvirt-vpn
 - as: ocp-fips-ovn-remote-libvirt-s390x
   capabilities:
-  - sshd-bastion
+  - intranet
   cron: 0 16 * * 5
   steps:
-    cluster_profile: libvirt-s390x-1
-    dependencies:
-      OPENSHIFT_INSTALL_TARGET: release:s390x-latest
+    cluster_profile: libvirt-s390x-vpn
     env:
       ARCH: s390x
       BRANCH: "4.16"
       FIPS_ENABLED: "true"
       NODE_TUNING: "true"
       TEST_TYPE: conformance-parallel
-    workflow: openshift-e2e-libvirt-upi-fips
+      USE_EXTERNAL_DNS: "true"
+    workflow: openshift-e2e-libvirt-vpn-fips
 - as: ocp-e2e-ovn-remote-s2s-libvirt-ppc64le
   capabilities:
   - power-s2s-dns

--- a/ci-operator/jobs/openshift/multiarch/openshift-multiarch-main-periodics.yaml
+++ b/ci-operator/jobs/openshift/multiarch/openshift-multiarch-main-periodics.yaml
@@ -18745,7 +18745,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
+  cluster: build09
   cron: 0 0 2 2 *
   decorate: true
   decoration_config:
@@ -18755,9 +18755,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-1
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-1
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-4.16
     ci.openshift.io/generator: prowgen
     job-release: "4.16"
@@ -18997,7 +18997,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
+  cluster: build09
   cron: 0 12 * * 5
   decorate: true
   decoration_config:
@@ -19007,9 +19007,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-1
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-1
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-4.16
     ci.openshift.io/generator: prowgen
     job-release: "4.16"
@@ -19498,7 +19498,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
+  cluster: build09
   cron: 0 0 30 1 *
   decorate: true
   decoration_config:
@@ -19508,9 +19508,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-1
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-1
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-4.16
     ci.openshift.io/generator: prowgen
     job-release: "4.16"
@@ -20164,7 +20164,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
+  cluster: build09
   cron: 0 16 * * 5
   decorate: true
   decoration_config:
@@ -20174,9 +20174,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-1
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-1
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-4.16
     ci.openshift.io/generator: prowgen
     job-release: "4.16"
@@ -20332,7 +20332,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
+  cluster: build09
   cron: 0 0 26 1 *
   decorate: true
   decoration_config:
@@ -20342,9 +20342,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-1
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-1
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-4.16
     ci.openshift.io/generator: prowgen
     job-release: "4.16"
@@ -20499,7 +20499,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
+  cluster: build09
   cron: 0 0 28 1 *
   decorate: true
   decoration_config:
@@ -20509,9 +20509,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-1
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-1
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-4.16
     ci.openshift.io/generator: prowgen
     job-release: "4.16"
@@ -20750,7 +20750,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
+  cluster: build09
   cron: 0 0 29 1 *
   decorate: true
   decoration_config:
@@ -20760,9 +20760,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-1
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-1
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-4.16
     ci.openshift.io/generator: prowgen
     job-release: "4.16"


### PR DESCRIPTION
Move homogeneous s390x periodics to libvirt-s390x-vpn, intranet, openshift-e2e-libvirt-vpn (vpn-fips for FIPS), ETCD_DISK_SPEED and USE_EXTERNAL_DNS to align with nightly-4.17+. Schedule on build09.

Jobs: ocp-e2e-ovn-remote-libvirt-s390x, agent, heavy-build, image-ecosystem, jenkins, serial, fips.