### PR TITLE
NO-ISSUE: Added perodic job for longrunning testsuite for 4.21

### DIFF
--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.21.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.21.yaml
@@ -2160,6 +2160,18 @@ tests:
   steps:
     cluster_profile: openshift-org-azure
     workflow: openshift-e2e-cert-rotation-short-azure
+- as: e2e-aws-disruptive-longrunning
+  cron: 0 12 * * *
+  steps:
+    cluster_profile: openshift-org-aws
+    env:
+      TEST_REQUIRES_SSH: "yes"
+      TEST_SUITE: openshift/disruptive-longrunning
+      TEST_TYPE: suite
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: openshift-e2e-aws-disruption
 zz_generated_metadata:
   branch: main
   org: openshift


### PR DESCRIPTION
The PR adds a periodic job that runs once in 24 hours.
Its configured to be informing
The test suite was added in https://github.com/openshift/origin/pull/30976

Note: pj-rehearse validation will fail because no tests are tagged with this suite yet in release-4.21. Tests are being added via openshift/origin#30973, but that PR depends on merging this CI job configuration first so the tests have a job to run in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Added new periodic test job for AWS disruptive long-running test scenarios in OpenShift nightly 4.21 release validation. This job executes daily at 12:00 UTC using AWS infrastructure with SSH-enabled remote access capabilities and includes system resource monitoring and observer functionality to track system behavior during extended test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->