### PR TITLE
TELCOV10N-923 add day2 spoke worker

### DIFF
--- a/ci-operator/config/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main__cnf-ran-sno-day2-worker-4.20.yaml
+++ b/ci-operator/config/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main__cnf-ran-sno-day2-worker-4.20.yaml
@@ -46,11 +46,14 @@ tests:
         ]
       VERSION: "4.20"
       ZTP_GIT_BRANCH: sno_day2_worker
+      ZTP_GIT_BRANCH_DAY2_WORKER: sno_day2_worker_add_worker
+      ZTP_GIT_REPO: https://gitlab.cee.redhat.com/telcov10n/ztp-site-configs-ci.git
     pre:
     - ref: telcov10n-functional-cnf-ran-hub-deploy
     - ref: telcov10n-functional-cnf-ran-hub-config
     - ref: telcov10n-functional-cnf-ran-mirror-spoke-operators
     - ref: telcov10n-functional-cnf-ran-deploy-spoke-sno
+    - ref: telcov10n-functional-cnf-ran-deploy-spoke-sno-day2-worker
 zz_generated_metadata:
   branch: main
   org: openshift-kni

--- a/ci-operator/step-registry/telcov10n/functional/cnf-ran/deploy-spoke-sno-day2-worker/OWNERS
+++ b/ci-operator/step-registry/telcov10n/functional/cnf-ran/deploy-spoke-sno-day2-worker/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+- shaior
+- kononovn
+- eifrach
+- rdiscala

--- a/ci-operator/step-registry/telcov10n/functional/cnf-ran/deploy-spoke-sno-day2-worker/telcov10n-functional-cnf-ran-deploy-spoke-sno-day2-worker-commands.sh
+++ b/ci-operator/step-registry/telcov10n/functional/cnf-ran/deploy-spoke-sno-day2-worker/telcov10n-functional-cnf-ran-deploy-spoke-sno-day2-worker-commands.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+set -e
+set -o pipefail
+
+echo "Checking if the job should be skipped..."
+if [ -f "${SHARED_DIR}/skip.txt" ]; then
+  echo "Detected skip.txt file — skipping the job"
+  exit 0
+fi
+
+INVENTORY_PATH="/eco-ci-cd/inventories/ocp-deployment"
+MOUNTED_HOST_INVENTORY="/var/host_variables"
+
+process_inventory() {
+    local directory="$1"
+    local dest_file="$2"
+
+    if [ -z "$directory" ]; then
+        echo "Usage: process_inventory <directory> <dest_file>"
+        return 1
+    fi
+
+    if [ ! -d "$directory" ]; then
+        echo "Error: '$directory' is not a valid directory"
+        return 1
+    fi
+
+    find "$directory" -type f | while IFS= read -r filename; do
+        if [[ $filename == *"secretsync-vault-source-path"* ]]; then
+          continue
+        else
+          echo "$(basename "${filename}")": \'"$(cat "$filename")"\'
+        fi
+    done > "${dest_file}"
+
+    echo "Processing complete. Check \"${dest_file}\""
+}
+
+echo "CLUSTER_NAME=${CLUSTER_NAME}"
+
+if [ "${CLUSTER_NAME}" != "kni-qe-106" ]; then
+    echo "ERROR: Only CLUSTER_NAME=kni-qe-106 is supported by this step."
+    echo "This step mounts credentials specific to the kni-qe-106 hub."
+    exit 1
+fi
+
+echo "Create group_vars directory"
+mkdir -p ${INVENTORY_PATH}/group_vars
+
+echo "Process common group variables (all, bastions, hypervisors)"
+find /var/group_variables/common/ -mindepth 1 -type d 2>/dev/null | while read -r dir; do
+    echo "Process group inventory file: ${dir}"
+    process_inventory "$dir" ${INVENTORY_PATH}/group_vars/"$(basename "${dir}")"
+done
+
+echo "Process cluster group variables for ${CLUSTER_NAME}"
+find "/var/group_variables/${CLUSTER_NAME}/" -mindepth 1 -type d 2>/dev/null | while read -r dir; do
+    echo "Process group inventory file: ${dir}"
+    process_inventory "$dir" ${INVENTORY_PATH}/group_vars/"$(basename "${dir}")"
+done
+
+echo "Create host_vars directory"
+mkdir -p ${INVENTORY_PATH}/host_vars
+
+echo "Process host variables for ${CLUSTER_NAME}"
+find ${MOUNTED_HOST_INVENTORY}/"${CLUSTER_NAME}"/ -mindepth 1 -type d 2>/dev/null | while read -r dir; do
+    echo "Process host inventory file: ${dir}"
+    process_inventory "$dir" ${INVENTORY_PATH}/host_vars/"$(basename "${dir}")"
+done
+
+# Workaround: fthub-01 and kni-qe-106 share the same hypervisor (hv16), but
+# ci-operator cannot mount the same secret twice. Process the fthub-01 mount
+# as the kni-qe-106 hypervisor inventory.
+if [ "${CLUSTER_NAME}" = "kni-qe-106" ]; then
+    echo "Process shared hypervisor inventory for kni-qe-106 from fthub-01 mount"
+    process_inventory "${MOUNTED_HOST_INVENTORY}/fthub-01/hypervisor" \
+        ${INVENTORY_PATH}/host_vars/hypervisor
+fi
+
+# Set kubeconfig path
+KUBECONFIG_PATH="/home/telcov10n/project/generated/${CLUSTER_NAME}/auth/kubeconfig"
+
+# Parse first spoke cluster name from array format, e.g. "['kni-qe-107']" → "kni-qe-107"
+SPOKE_CLUSTER_NAME=$(echo "${SPOKE_CLUSTER}" | tr -d "[]' ")
+
+echo "Running day 2 worker expansion for SNO spoke cluster: ${SPOKE_CLUSTER_NAME}"
+ansible-playbook ./playbooks/deploy-ocp-sno-day2-worker.yml \
+    -i ./inventories/ocp-deployment/build-inventory.py \
+    --extra-vars "kubeconfig=${KUBECONFIG_PATH} \
+        spoke_cluster_name=${SPOKE_CLUSTER_NAME} \
+        day2_branch=${ZTP_GIT_BRANCH_DAY2_WORKER}"

--- a/ci-operator/step-registry/telcov10n/functional/cnf-ran/deploy-spoke-sno-day2-worker/telcov10n-functional-cnf-ran-deploy-spoke-sno-day2-worker-ref.metadata.json
+++ b/ci-operator/step-registry/telcov10n/functional/cnf-ran/deploy-spoke-sno-day2-worker/telcov10n-functional-cnf-ran-deploy-spoke-sno-day2-worker-ref.metadata.json
@@ -1,0 +1,11 @@
+{
+	"path": "telcov10n/functional/cnf-ran/deploy-spoke-sno-day2-worker/telcov10n-functional-cnf-ran-deploy-spoke-sno-day2-worker-ref.yaml",
+	"owners": {
+		"approvers": [
+			"shaior",
+			"kononovn",
+			"eifrach",
+			"rdiscala"
+		]
+	}
+}

--- a/ci-operator/step-registry/telcov10n/functional/cnf-ran/deploy-spoke-sno-day2-worker/telcov10n-functional-cnf-ran-deploy-spoke-sno-day2-worker-ref.yaml
+++ b/ci-operator/step-registry/telcov10n/functional/cnf-ran/deploy-spoke-sno-day2-worker/telcov10n-functional-cnf-ran-deploy-spoke-sno-day2-worker-ref.yaml
@@ -1,0 +1,57 @@
+ref:
+  as: telcov10n-functional-cnf-ran-deploy-spoke-sno-day2-worker
+  from_image:
+    namespace: telcov10n-ci
+    name: eco-ci-cd
+    tag: eco-ci-cd
+  commands: telcov10n-functional-cnf-ran-deploy-spoke-sno-day2-worker-commands.sh
+  documentation: |-
+    Expand a deployed SNO spoke cluster by switching the ZTP manifests branch
+    to provision an additional worker node via ArgoCD (day 2 operation)
+  timeout: 5h
+  resources:
+    requests:
+      cpu: 100m
+  env:
+    - name: VERSION
+      default: "4.20"
+      documentation: OCP version
+    - name: CLUSTER_NAME
+      default: "kni-qe-106"
+      documentation: |-
+        Hub cluster name. Only "kni-qe-106" is supported for now, because this step
+        mounts credentials specific to that hub (kni-qe-106 nodes, masters,
+        bastion, and shared fthub-01 hypervisor).
+    - name: SPOKE_CLUSTER
+      default: ""
+      documentation: |-
+        Spoke SNO cluster name (array format, e.g. \"['kni-qe-107']\")".
+        Only one spoke cluster is currently supported.
+    - name: ZTP_GIT_BRANCH_DAY2_WORKER
+      default: "day2-worker"
+      documentation: Git branch containing the worker node definition in the SiteConfig
+  credentials:
+    - namespace: test-credentials
+      name: telcov10n-ansible-group-all
+      mount_path: /var/group_variables/common/all
+    - namespace: test-credentials
+      name: telcov10n-ansible-group-bastions
+      mount_path: /var/group_variables/common/bastions
+    - namespace: test-credentials
+      name: telcov10n-ansible-group-hypervisors
+      mount_path: /var/group_variables/common/hypervisors
+    - namespace: test-credentials
+      name: telcov10n-ansible-group-kni-qe-106-nodes
+      mount_path: /var/group_variables/kni-qe-106/nodes
+    - namespace: test-credentials
+      name: telcov10n-ansible-group-kni-qe-106-masters
+      mount_path: /var/group_variables/kni-qe-106/masters
+    - namespace: test-credentials
+      name: telcov10n-ansible-kni-qe-106-bastion
+      mount_path: /var/host_variables/kni-qe-106/bastion
+    - namespace: test-credentials
+      name: telcov10n-ansible-kni-qe-106-master0
+      mount_path: /var/host_variables/kni-qe-106/master0
+    - namespace: test-credentials
+      name: telcov10n-ansible-hypervisors-hv16
+      mount_path: /var/host_variables/fthub-01/hypervisor


### PR DESCRIPTION
Add the step that adds a bare metal worker to the Spoke Single-Node OpenShift cluster, as a day 2 operation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new CI deployment step to perform day‑2 expansion of single‑node OpenShift clusters by provisioning an additional worker, with configurable cluster and branch options.

* **Chores**
  * Updated pipeline configuration with new environment variables, credentials/mounts, and orchestration to support the day‑2 worker provisioning workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->