### PR TITLE
Add TEST_FILTERS to create-prowjob-commands

### DIFF
--- a/ci-operator/step-registry/sandboxed-containers-operator/create-prowjob/sandboxed-containers-operator-create-prowjob-commands.sh
+++ b/ci-operator/step-registry/sandboxed-containers-operator/create-prowjob/sandboxed-containers-operator-create-prowjob-commands.sh
@@ -144,6 +144,27 @@ validate_and_set_defaults() {
     # Allow override of test scenarios
     TEST_SCENARIOS="${TEST_SCENARIOS:-sig-kata.*Kata Author}"
 
+    TEST_FILTERS="${TEST_FILTERS:-~DisconnectedOnly&;~Disruptive&}"
+    local -a _test_filter_segments
+    local _test_filter_seg
+    local _test_filter_re='^~?[a-zA-Z0-9_]+&?$'
+    IFS=';' read -ra _test_filter_segments <<< "${TEST_FILTERS}"
+    for _test_filter_seg in "${_test_filter_segments[@]}"; do
+        [[ -z "${_test_filter_seg}" ]] && continue
+        if [[ ! "${_test_filter_seg}" =~ ${_test_filter_re} ]]; then
+            echo "ERROR: Invalid TEST_FILTERS segment '${_test_filter_seg}'."
+            echo "Each non-empty segment must match ${_test_filter_re} (openshift-extended-test)."
+            echo "Example skipping Polarion cases C00317 and C00133:"
+            echo ""
+            echo "export TEST_FILTERS='~DisconnectedOnly&;~Disruptive&;~C00317&;~C00133&'"
+            echo ""
+            echo '* leading "~" excludes any selected dry-run line matching that token (grep -v -E)'
+            echo '* ";" separates filters'
+            echo '* trailing "&" means AND-combined'
+            exit 1
+        fi
+    done
+
     # Let the tests run for this many minutes before killing the cluster and interupting the test
     TEST_TIMEOUT="${TEST_TIMEOUT:-90}"
     # Validate TEST_TIMEOUT is numeric
@@ -217,6 +238,8 @@ show_usage() {
     echo "  KATA_RPM_VERSION               - Kata RPM version (default: 3.17.0-3.rhaos4.19.el9)"
     echo "  SLEEP_DURATION                 - Sleep duration after tests (default: 0h)"
     echo "  TEST_SCENARIOS                 - Test scenarios filter (default: sig-kata.*Kata Author)"
+    echo "  TEST_FILTERS                   - openshift-extended-test filters (default: ~DisconnectedOnly&;~Disruptive&)"
+    echo "                                   Append ;~Cnnnnn& to skip a Polarion-style id appearing in case lines"
     echo "  TEST_TIMEOUT                   - Test timeout in minutes (default: 90)"
     echo "  ENABLE_MUST_GATHER             - Enable must-gather: true or false (default: true)"
     echo "  MUST_GATHER_IMAGE              - Must-gather image (default: registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel9:latest)"
@@ -307,7 +330,7 @@ generate_workflow() {
     "MUST_GATHER_IMAGE: ${MUST_GATHER_IMAGE}"
     "MUST_GATHER_ON_FAILURE_ONLY: \"${MUST_GATHER_ON_FAILURE_ONLY}\""
     "SLEEP_DURATION: ${SLEEP_DURATION}"
-    "TEST_FILTERS: ~DisconnectedOnly&;~Disruptive&"
+    "TEST_FILTERS: ${TEST_FILTERS}"
     "TEST_RELEASE_TYPE: ${TEST_RELEASE_TYPE}"
     "TEST_SCENARIOS: ${TEST_SCENARIOS}"
     "TEST_TIMEOUT: \"${TEST_TIMEOUT}\""
@@ -433,6 +456,7 @@ EOF
     echo "  • Kata RPM: ${INSTALL_KATA_RPM} (${KATA_RPM_VERSION})"
     echo "  • Sleep Duration: ${SLEEP_DURATION}"
     echo "  • Test Timeout: ${TEST_TIMEOUT}"
+    echo "  • TEST_FILTERS: ${TEST_FILTERS}"
 
     if [[ "${TEST_RELEASE_TYPE}" == "Pre-GA" ]]; then
         echo "  • Catalog Source: ${CATALOG_SOURCE_NAME} (${CATALOG_SOURCE_IMAGE})"


### PR DESCRIPTION
Setting TEST_FILTERS will override the previously hard coded value

ex: TEST_FILTERS='~C00133&;C00317&' will skip those 2 test cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TEST_FILTERS environment variable to control test filtering with built-in syntax validation.

* **Improvements**
  * Configuration output now displays the resolved TEST_FILTERS value.

* **Documentation**
  * Updated usage documentation with TEST_FILTERS semantics and examples for test filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->