### PR TITLE
METAL-1751 baremetalds-devscripts-setup-commands without secret defined

### DIFF
--- a/ci-operator/step-registry/baremetalds/devscripts/setup/baremetalds-devscripts-setup-commands.sh
+++ b/ci-operator/step-registry/baremetalds/devscripts/setup/baremetalds-devscripts-setup-commands.sh
@@ -156,8 +156,8 @@ CIRFILE=$SHARED_DIR/cir
 EXTRAFILE=$SHARED_DIR/cir-extra
 NODESFILE=$SHARED_DIR/cir-nodes
 BMJSON=$SHARED_DIR/bm.json
-BMCUSER=$(cat "${CLUSTER_PROFILE_DIR}/bmcuser")
-BMCPASS=$(cat "${CLUSTER_PROFILE_DIR}/bmcpass")
+BMCUSER=$(cat "${CLUSTER_PROFILE_DIR}/bmcuser" || echo "NA")
+BMCPASS=$(cat "${CLUSTER_PROFILE_DIR}/bmcpass" || echo "NA")
 
 if [ -e "$CIRFILE" ] ; then
     # Get Extra data from CIR


### PR DESCRIPTION
Some teams use a different cluster secret and they don't have or need bmcuser and bmcpass defined.