### PR TITLE
ShiftStack/Sync Tooling Migration: Added Rebasebot support for ShiftStack Jobs

### DIFF
--- a/ci-operator/config/openshift-eng/rebasebot/openshift-eng-rebasebot-main.yaml
+++ b/ci-operator/config/openshift-eng/rebasebot/openshift-eng-rebasebot-main.yaml
@@ -1132,6 +1132,503 @@ tests:
         requests:
           cpu: 100m
           memory: 200Mi
+- as: cluster-api-provider-openstack-main
+  cron: 0 10 * * Mon,Thu
+  steps:
+    test:
+    - as: cluster-api-provider-openstack-main
+      commands: |
+        rebasebot --source https://github.com/kubernetes-sigs/cluster-api-provider-openstack:release-0.14 \
+                  --dest openshift/cluster-api-provider-openstack:main \
+                  --rebase shiftstack/cluster-api-provider-openstack:rebase-bot-main \
+                  --update-go-modules \
+                  --git-username shiftstack-rebasebot \
+                  --git-email shiftstack-rebasebot@redhat.com \
+                  --github-app-id 118774 \
+                  --github-app-key /secrets/merge-bot/github_private_key \
+                  --github-cloner-id 121614 \
+                  --github-cloner-key /secrets/merge-bot/github_cloner_private_key \
+                  --slack-webhook /secrets/slack-hooks/forum-shiftstack
+      credentials:
+      - mount_path: /secrets/merge-bot
+        name: shiftstack-merge-bot
+        namespace: test-credentials
+      - mount_path: /secrets/slack-hooks
+        name: shiftstack-slack-hooks
+        namespace: test-credentials
+      from: rebasebot
+      resources:
+        limits:
+          memory: 4Gi
+        requests:
+          cpu: 100m
+          memory: 200Mi
+- as: cluster-api-provider-openstack-4-21
+  cron: 0 10 * * Mon,Thu
+  steps:
+    test:
+    - as: cluster-api-provider-openstack-4-21
+      commands: |
+        rebasebot --source https://github.com/kubernetes-sigs/cluster-api-provider-openstack:release-0.13 \
+                  --dest openshift/cluster-api-provider-openstack:release-4.21 \
+                  --rebase shiftstack/cluster-api-provider-openstack:rebase-bot-release-4.21 \
+                  --update-go-modules \
+                  --git-username shiftstack-rebasebot \
+                  --git-email shiftstack-rebasebot@redhat.com \
+                  --github-app-id 118774 \
+                  --github-app-key /secrets/merge-bot/github_private_key \
+                  --github-cloner-id 121614 \
+                  --github-cloner-key /secrets/merge-bot/github_cloner_private_key \
+                  --slack-webhook /secrets/slack-hooks/forum-shiftstack
+      credentials:
+      - mount_path: /secrets/merge-bot
+        name: shiftstack-merge-bot
+        namespace: test-credentials
+      - mount_path: /secrets/slack-hooks
+        name: shiftstack-slack-hooks
+        namespace: test-credentials
+      from: rebasebot
+      resources:
+        limits:
+          memory: 4Gi
+        requests:
+          cpu: 100m
+          memory: 200Mi
+- as: cluster-api-provider-openstack-4-20
+  cron: 0 10 * * Mon,Thu
+  steps:
+    test:
+    - as: cluster-api-provider-openstack-4-20
+      commands: |
+        rebasebot --source https://github.com/kubernetes-sigs/cluster-api-provider-openstack:release-0.12 \
+                  --dest openshift/cluster-api-provider-openstack:release-4.20 \
+                  --rebase shiftstack/cluster-api-provider-openstack:rebase-bot-release-4.20 \
+                  --update-go-modules \
+                  --git-username shiftstack-rebasebot \
+                  --git-email shiftstack-rebasebot@redhat.com \
+                  --github-app-id 118774 \
+                  --github-app-key /secrets/merge-bot/github_private_key \
+                  --github-cloner-id 121614 \
+                  --github-cloner-key /secrets/merge-bot/github_cloner_private_key \
+                  --slack-webhook /secrets/slack-hooks/forum-shiftstack
+      credentials:
+      - mount_path: /secrets/merge-bot
+        name: shiftstack-merge-bot
+        namespace: test-credentials
+      - mount_path: /secrets/slack-hooks
+        name: shiftstack-slack-hooks
+        namespace: test-credentials
+      from: rebasebot
+      resources:
+        limits:
+          memory: 4Gi
+        requests:
+          cpu: 100m
+          memory: 200Mi
+- as: cluster-api-provider-openstack-4-19
+  cron: 0 10 * * Mon,Thu
+  steps:
+    test:
+    - as: cluster-api-provider-openstack-4-19
+      commands: |
+        rebasebot --source https://github.com/kubernetes-sigs/cluster-api-provider-openstack:release-0.12 \
+                  --dest openshift/cluster-api-provider-openstack:release-4.19 \
+                  --rebase shiftstack/cluster-api-provider-openstack:rebase-bot-release-4.19 \
+                  --update-go-modules \
+                  --git-username shiftstack-rebasebot \
+                  --git-email shiftstack-rebasebot@redhat.com \
+                  --github-app-id 118774 \
+                  --github-app-key /secrets/merge-bot/github_private_key \
+                  --github-cloner-id 121614 \
+                  --github-cloner-key /secrets/merge-bot/github_cloner_private_key \
+                  --slack-webhook /secrets/slack-hooks/forum-shiftstack
+      credentials:
+      - mount_path: /secrets/merge-bot
+        name: shiftstack-merge-bot
+        namespace: test-credentials
+      - mount_path: /secrets/slack-hooks
+        name: shiftstack-slack-hooks
+        namespace: test-credentials
+      from: rebasebot
+      resources:
+        limits:
+          memory: 4Gi
+        requests:
+          cpu: 100m
+          memory: 200Mi
+- as: cluster-api-provider-openstack-4-18
+  cron: 0 10 * * Mon,Thu
+  steps:
+    test:
+    - as: cluster-api-provider-openstack-4-18
+      commands: |
+        rebasebot --source https://github.com/kubernetes-sigs/cluster-api-provider-openstack:release-0.11 \
+                  --dest openshift/cluster-api-provider-openstack:release-4.18 \
+                  --rebase shiftstack/cluster-api-provider-openstack:rebase-bot-release-4.18 \
+                  --update-go-modules \
+                  --git-username shiftstack-rebasebot \
+                  --git-email shiftstack-rebasebot@redhat.com \
+                  --github-app-id 118774 \
+                  --github-app-key /secrets/merge-bot/github_private_key \
+                  --github-cloner-id 121614 \
+                  --github-cloner-key /secrets/merge-bot/github_cloner_private_key \
+                  --slack-webhook /secrets/slack-hooks/forum-shiftstack
+      credentials:
+      - mount_path: /secrets/merge-bot
+        name: shiftstack-merge-bot
+        namespace: test-credentials
+      - mount_path: /secrets/slack-hooks
+        name: shiftstack-slack-hooks
+        namespace: test-credentials
+      from: rebasebot
+      resources:
+        limits:
+          memory: 4Gi
+        requests:
+          cpu: 100m
+          memory: 200Mi
+- as: cluster-api-provider-openstack-4-17
+  cron: 0 10 * * Mon,Thu
+  steps:
+    test:
+    - as: cluster-api-provider-openstack-4-17
+      commands: |
+        rebasebot --source https://github.com/kubernetes-sigs/cluster-api-provider-openstack:release-0.10 \
+                  --dest openshift/cluster-api-provider-openstack:release-4.17 \
+                  --rebase shiftstack/cluster-api-provider-openstack:rebase-bot-release-4.17 \
+                  --update-go-modules \
+                  --git-username shiftstack-rebasebot \
+                  --git-email shiftstack-rebasebot@redhat.com \
+                  --github-app-id 118774 \
+                  --github-app-key /secrets/merge-bot/github_private_key \
+                  --github-cloner-id 121614 \
+                  --github-cloner-key /secrets/merge-bot/github_cloner_private_key \
+                  --slack-webhook /secrets/slack-hooks/forum-shiftstack
+      credentials:
+      - mount_path: /secrets/merge-bot
+        name: shiftstack-merge-bot
+        namespace: test-credentials
+      - mount_path: /secrets/slack-hooks
+        name: shiftstack-slack-hooks
+        namespace: test-credentials
+      from: rebasebot
+      resources:
+        limits:
+          memory: 4Gi
+        requests:
+          cpu: 100m
+          memory: 200Mi
+- as: cluster-api-provider-openstack-4-16
+  cron: 0 10 * * Mon,Thu
+  steps:
+    test:
+    - as: cluster-api-provider-openstack-4-16
+      commands: |
+        rebasebot --source https://github.com/kubernetes-sigs/cluster-api-provider-openstack:release-0.10 \
+                  --dest openshift/cluster-api-provider-openstack:release-4.16 \
+                  --rebase shiftstack/cluster-api-provider-openstack:rebase-bot-release-4.16 \
+                  --update-go-modules \
+                  --git-username shiftstack-rebasebot \
+                  --git-email shiftstack-rebasebot@redhat.com \
+                  --github-app-id 118774 \
+                  --github-app-key /secrets/merge-bot/github_private_key \
+                  --github-cloner-id 121614 \
+                  --github-cloner-key /secrets/merge-bot/github_cloner_private_key \
+                  --slack-webhook /secrets/slack-hooks/forum-shiftstack
+      credentials:
+      - mount_path: /secrets/merge-bot
+        name: shiftstack-merge-bot
+        namespace: test-credentials
+      - mount_path: /secrets/slack-hooks
+        name: shiftstack-slack-hooks
+        namespace: test-credentials
+      from: rebasebot
+      resources:
+        limits:
+          memory: 4Gi
+        requests:
+          cpu: 100m
+          memory: 200Mi
+- as: cloud-provider-openstack-main
+  cron: 0 10 * * Mon,Thu
+  steps:
+    test:
+    - as: cloud-provider-openstack-main
+      commands: |
+        rebasebot --source https://github.com/kubernetes/cloud-provider-openstack:release-1.35 \
+                  --dest openshift/cloud-provider-openstack:main \
+                  --rebase shiftstack/cloud-provider-openstack:rebase-bot-main \
+                  --update-go-modules \
+                  --git-username shiftstack-rebasebot \
+                  --git-email shiftstack-rebasebot@redhat.com \
+                  --github-app-id 118774 \
+                  --github-app-key /secrets/merge-bot/github_private_key \
+                  --github-cloner-id 121614 \
+                  --github-cloner-key /secrets/merge-bot/github_cloner_private_key \
+                  --slack-webhook /secrets/slack-hooks/forum-shiftstack
+      credentials:
+      - mount_path: /secrets/merge-bot
+        name: shiftstack-merge-bot
+        namespace: test-credentials
+      - mount_path: /secrets/slack-hooks
+        name: shiftstack-slack-hooks
+        namespace: test-credentials
+      from: rebasebot
+      resources:
+        limits:
+          memory: 4Gi
+        requests:
+          cpu: 100m
+          memory: 200Mi
+- as: cloud-provider-openstack-4-21
+  cron: 0 10 * * Mon,Thu
+  steps:
+    test:
+    - as: cloud-provider-openstack-4-21
+      commands: |
+        rebasebot --source https://github.com/kubernetes/cloud-provider-openstack:release-1.34 \
+                  --dest openshift/cloud-provider-openstack:release-4.21 \
+                  --rebase shiftstack/cloud-provider-openstack:rebase-bot-release-4.21 \
+                  --update-go-modules \
+                  --git-username shiftstack-rebasebot \
+                  --git-email shiftstack-rebasebot@redhat.com \
+                  --github-app-id 118774 \
+                  --github-app-key /secrets/merge-bot/github_private_key \
+                  --github-cloner-id 121614 \
+                  --github-cloner-key /secrets/merge-bot/github_cloner_private_key \
+                  --slack-webhook /secrets/slack-hooks/forum-shiftstack
+      credentials:
+      - mount_path: /secrets/merge-bot
+        name: shiftstack-merge-bot
+        namespace: test-credentials
+      - mount_path: /secrets/slack-hooks
+        name: shiftstack-slack-hooks
+        namespace: test-credentials
+      from: rebasebot
+      resources:
+        limits:
+          memory: 4Gi
+        requests:
+          cpu: 100m
+          memory: 200Mi
+- as: cloud-provider-openstack-4-20
+  cron: 0 10 * * Mon,Thu
+  steps:
+    test:
+    - as: cloud-provider-openstack-4-20
+      commands: |
+        rebasebot --source https://github.com/kubernetes/cloud-provider-openstack:release-1.33 \
+                  --dest openshift/cloud-provider-openstack:release-4.20 \
+                  --rebase shiftstack/cloud-provider-openstack:rebase-bot-release-4.20 \
+                  --update-go-modules \
+                  --git-username shiftstack-rebasebot \
+                  --git-email shiftstack-rebasebot@redhat.com \
+                  --github-app-id 118774 \
+                  --github-app-key /secrets/merge-bot/github_private_key \
+                  --github-cloner-id 121614 \
+                  --github-cloner-key /secrets/merge-bot/github_cloner_private_key \
+                  --slack-webhook /secrets/slack-hooks/forum-shiftstack
+      credentials:
+      - mount_path: /secrets/merge-bot
+        name: shiftstack-merge-bot
+        namespace: test-credentials
+      - mount_path: /secrets/slack-hooks
+        name: shiftstack-slack-hooks
+        namespace: test-credentials
+      from: rebasebot
+      resources:
+        limits:
+          memory: 4Gi
+        requests:
+          cpu: 100m
+          memory: 200Mi
+- as: cloud-provider-openstack-4-19
+  cron: 0 10 * * Mon,Thu
+  steps:
+    test:
+    - as: cloud-provider-openstack-4-19
+      commands: |
+        rebasebot --source https://github.com/kubernetes/cloud-provider-openstack:release-1.31 \
+                  --dest openshift/cloud-provider-openstack:release-4.19 \
+                  --rebase shiftstack/cloud-provider-openstack:rebase-bot-release-4.19 \
+                  --update-go-modules \
+                  --git-username shiftstack-rebasebot \
+                  --git-email shiftstack-rebasebot@redhat.com \
+                  --github-app-id 118774 \
+                  --github-app-key /secrets/merge-bot/github_private_key \
+                  --github-cloner-id 121614 \
+                  --github-cloner-key /secrets/merge-bot/github_cloner_private_key \
+                  --slack-webhook /secrets/slack-hooks/forum-shiftstack
+      credentials:
+      - mount_path: /secrets/merge-bot
+        name: shiftstack-merge-bot
+        namespace: test-credentials
+      - mount_path: /secrets/slack-hooks
+        name: shiftstack-slack-hooks
+        namespace: test-credentials
+      from: rebasebot
+      resources:
+        limits:
+          memory: 4Gi
+        requests:
+          cpu: 100m
+          memory: 200Mi
+- as: cloud-provider-openstack-4-18
+  cron: 0 10 * * Mon,Thu
+  steps:
+    test:
+    - as: cloud-provider-openstack-4-18
+      commands: |
+        rebasebot --source https://github.com/kubernetes/cloud-provider-openstack:release-1.31 \
+                  --dest openshift/cloud-provider-openstack:release-4.18 \
+                  --rebase shiftstack/cloud-provider-openstack:rebase-bot-release-4.18 \
+                  --update-go-modules \
+                  --git-username shiftstack-rebasebot \
+                  --git-email shiftstack-rebasebot@redhat.com \
+                  --github-app-id 118774 \
+                  --github-app-key /secrets/merge-bot/github_private_key \
+                  --github-cloner-id 121614 \
+                  --github-cloner-key /secrets/merge-bot/github_cloner_private_key \
+                  --slack-webhook /secrets/slack-hooks/forum-shiftstack
+      credentials:
+      - mount_path: /secrets/merge-bot
+        name: shiftstack-merge-bot
+        namespace: test-credentials
+      - mount_path: /secrets/slack-hooks
+        name: shiftstack-slack-hooks
+        namespace: test-credentials
+      from: rebasebot
+      resources:
+        limits:
+          memory: 4Gi
+        requests:
+          cpu: 100m
+          memory: 200Mi
+- as: cloud-provider-openstack-4-17
+  cron: 0 10 * * Mon,Thu
+  steps:
+    test:
+    - as: cloud-provider-openstack-4-17
+      commands: |
+        rebasebot --source https://github.com/kubernetes/cloud-provider-openstack:release-1.30 \
+                  --dest openshift/cloud-provider-openstack:release-4.17 \
+                  --rebase shiftstack/cloud-provider-openstack:rebase-bot-release-4.17 \
+                  --update-go-modules \
+                  --git-username shiftstack-rebasebot \
+                  --git-email shiftstack-rebasebot@redhat.com \
+                  --github-app-id 118774 \
+                  --github-app-key /secrets/merge-bot/github_private_key \
+                  --github-cloner-id 121614 \
+                  --github-cloner-key /secrets/merge-bot/github_cloner_private_key \
+                  --slack-webhook /secrets/slack-hooks/forum-shiftstack
+      credentials:
+      - mount_path: /secrets/merge-bot
+        name: shiftstack-merge-bot
+        namespace: test-credentials
+      - mount_path: /secrets/slack-hooks
+        name: shiftstack-slack-hooks
+        namespace: test-credentials
+      from: rebasebot
+      resources:
+        limits:
+          memory: 4Gi
+        requests:
+          cpu: 100m
+          memory: 200Mi
+- as: cloud-provider-openstack-4-16
+  cron: 0 10 * * Mon,Thu
+  steps:
+    test:
+    - as: cloud-provider-openstack-4-16
+      commands: |
+        rebasebot --source https://github.com/kubernetes/cloud-provider-openstack:release-1.29 \
+                  --dest openshift/cloud-provider-openstack:release-4.16 \
+                  --rebase shiftstack/cloud-provider-openstack:rebase-bot-release-4.16 \
+                  --update-go-modules \
+                  --git-username shiftstack-rebasebot \
+                  --git-email shiftstack-rebasebot@redhat.com \
+                  --github-app-id 118774 \
+                  --github-app-key /secrets/merge-bot/github_private_key \
+                  --github-cloner-id 121614 \
+                  --github-cloner-key /secrets/merge-bot/github_cloner_private_key \
+                  --slack-webhook /secrets/slack-hooks/forum-shiftstack
+      credentials:
+      - mount_path: /secrets/merge-bot
+        name: shiftstack-merge-bot
+        namespace: test-credentials
+      - mount_path: /secrets/slack-hooks
+        name: shiftstack-slack-hooks
+        namespace: test-credentials
+      from: rebasebot
+      resources:
+        limits:
+          memory: 4Gi
+        requests:
+          cpu: 100m
+          memory: 200Mi
+- as: csi-driver-nfs-main
+  cron: 0 10 * * Mon,Thu
+  steps:
+    test:
+    - as: csi-driver-nfs-main
+      commands: |
+        # csi-driver-nfs doesn't do releases, so we always pull from master
+        rebasebot --source https://github.com/kubernetes-csi/csi-driver-nfs:master \
+                  --dest openshift/csi-driver-nfs:main \
+                  --rebase shiftstack/csi-driver-nfs:rebase-bot-main \
+                  --update-go-modules \
+                  --git-username shiftstack-rebasebot \
+                  --git-email shiftstack-rebasebot@redhat.com \
+                  --github-app-id 118774 \
+                  --github-app-key /secrets/merge-bot/github_private_key \
+                  --github-cloner-id 121614 \
+                  --github-cloner-key /secrets/merge-bot/github_cloner_private_key \
+                  --slack-webhook /secrets/slack-hooks/forum-shiftstack
+      credentials:
+      - mount_path: /secrets/merge-bot
+        name: shiftstack-merge-bot
+        namespace: test-credentials
+      - mount_path: /secrets/slack-hooks
+        name: shiftstack-slack-hooks
+        namespace: test-credentials
+      from: rebasebot
+      resources:
+        limits:
+          memory: 4Gi
+        requests:
+          cpu: 100m
+          memory: 200Mi
+- as: openstack-resource-controller-main
+  cron: 0 10 * * Mon,Thu
+  steps:
+    test:
+    - as: openstack-resource-controller-main
+      commands: |
+        rebasebot --source https://github.com/k-orc/openstack-resource-controller:release-1.0 \
+                  --dest openshift/openstack-resource-controller:main \
+                  --rebase shiftstack/openstack-resource-controller:rebase-bot-main \
+                  --update-go-modules \
+                  --git-username shiftstack-rebasebot \
+                  --git-email shiftstack-rebasebot@redhat.com \
+                  --github-app-id 118774 \
+                  --github-app-key /secrets/merge-bot/github_private_key \
+                  --github-cloner-id 121614 \
+                  --github-cloner-key /secrets/merge-bot/github_cloner_private_key \
+                  --slack-webhook /secrets/slack-hooks/forum-shiftstack
+      credentials:
+      - mount_path: /secrets/merge-bot
+        name: shiftstack-merge-bot
+        namespace: test-credentials
+      - mount_path: /secrets/slack-hooks
+        name: shiftstack-slack-hooks
+        namespace: test-credentials
+      from: rebasebot
+      resources:
+        limits:
+          memory: 4Gi
+        requests:
+          cpu: 100m
+          memory: 200Mi
 - as: unit
   commands: make deps && make unittests
   container:

--- a/ci-operator/config/openshift/cloud-provider-openstack/openshift-cloud-provider-openstack-main__periodics.yaml
+++ b/ci-operator/config/openshift/cloud-provider-openstack/openshift-cloud-provider-openstack-main__periodics.yaml
@@ -1,0 +1,52 @@
+base_images:
+  rebasebot:
+    name: rebasebot
+    namespace: ci
+    tag: latest
+build_root:
+  from_repository: true
+resources:
+  '*':
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: rebasebot
+  cron: 0 10 * * Mon,Thu
+  steps:
+    test:
+    - as: rebasebot
+      commands: |
+        rebasebot --source https://github.com/kubernetes/cloud-provider-openstack:release-1.36 \
+                  --dest openshift/cloud-provider-openstack:main \
+                  --rebase shiftstack/cloud-provider-openstack:rebase-bot-main \
+                  --update-go-modules \
+                  --git-username shiftstack-rebasebot \
+                  --git-email shiftstack-rebasebot@redhat.com \
+                  --github-app-id 118774 \
+                  --github-app-key /secrets/merge-bot/github_private_key \
+                  --github-cloner-id 121614 \
+                  --github-cloner-key /secrets/merge-bot/github_cloner_private_key \
+                  --slack-webhook /secrets/slack-hooks/forum-shiftstack
+      credentials:
+      - mount_path: /secrets/merge-bot
+        name: shiftstack-merge-bot
+        namespace: test-credentials
+      - mount_path: /secrets/slack-hooks
+        name: shiftstack-slack-hooks
+        namespace: test-credentials
+      from_image:
+        name: rebasebot
+        namespace: ci
+        tag: latest
+      resources:
+        limits:
+          memory: 4Gi
+        requests:
+          cpu: 100m
+          memory: 200Mi
+zz_generated_metadata:
+  branch: main
+  org: openshift
+  repo: cloud-provider-openstack
+  variant: periodics

--- a/ci-operator/config/openshift/cloud-provider-openstack/openshift-cloud-provider-openstack-release-4.16__periodics.yaml
+++ b/ci-operator/config/openshift/cloud-provider-openstack/openshift-cloud-provider-openstack-release-4.16__periodics.yaml
@@ -1,0 +1,52 @@
+base_images:
+  rebasebot:
+    name: rebasebot
+    namespace: ci
+    tag: latest
+build_root:
+  from_repository: true
+resources:
+  '*':
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: rebasebot
+  cron: 0 10 * * Mon,Thu
+  steps:
+    test:
+    - as: rebasebot
+      commands: |
+        rebasebot --source https://github.com/kubernetes/cloud-provider-openstack:release-1.29 \
+                  --dest openshift/cloud-provider-openstack:release-4.16 \
+                  --rebase shiftstack/cloud-provider-openstack:rebase-bot-release-4.16 \
+                  --update-go-modules \
+                  --git-username shiftstack-rebasebot \
+                  --git-email shiftstack-rebasebot@redhat.com \
+                  --github-app-id 118774 \
+                  --github-app-key /secrets/merge-bot/github_private_key \
+                  --github-cloner-id 121614 \
+                  --github-cloner-key /secrets/merge-bot/github_cloner_private_key \
+                  --slack-webhook /secrets/slack-hooks/forum-shiftstack
+      credentials:
+      - mount_path: /secrets/merge-bot
+        name: shiftstack-merge-bot
+        namespace: test-credentials
+      - mount_path: /secrets/slack-hooks
+        name: shiftstack-slack-hooks
+        namespace: test-credentials
+      from_image:
+        name: rebasebot
+        namespace: ci
+        tag: latest
+      resources:
+        limits:
+          memory: 4Gi
+        requests:
+          cpu: 100m
+          memory: 200Mi
+zz_generated_metadata:
+  branch: release-4.16
+  org: openshift
+  repo: cloud-provider-openstack
+  variant: periodics

--- a/ci-operator/config/openshift/cloud-provider-openstack/openshift-cloud-provider-openstack-release-4.17__periodics.yaml
+++ b/ci-operator/config/openshift/cloud-provider-openstack/openshift-cloud-provider-openstack-release-4.17__periodics.yaml
@@ -1,0 +1,52 @@
+base_images:
+  rebasebot:
+    name: rebasebot
+    namespace: ci
+    tag: latest
+build_root:
+  from_repository: true
+resources:
+  '*':
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: rebasebot
+  cron: 0 10 * * Mon,Thu
+  steps:
+    test:
+    - as: rebasebot
+      commands: |
+        rebasebot --source https://github.com/kubernetes/cloud-provider-openstack:release-1.30 \
+                  --dest openshift/cloud-provider-openstack:release-4.17 \
+                  --rebase shiftstack/cloud-provider-openstack:rebase-bot-release-4.17 \
+                  --update-go-modules \
+                  --git-username shiftstack-rebasebot \
+                  --git-email shiftstack-rebasebot@redhat.com \
+                  --github-app-id 118774 \
+                  --github-app-key /secrets/merge-bot/github_private_key \
+                  --github-cloner-id 121614 \
+                  --github-cloner-key /secrets/merge-bot/github_cloner_private_key \
+                  --slack-webhook /secrets/slack-hooks/forum-shiftstack
+      credentials:
+      - mount_path: /secrets/merge-bot
+        name: shiftstack-merge-bot
+        namespace: test-credentials
+      - mount_path: /secrets/slack-hooks
+        name: shiftstack-slack-hooks
+        namespace: test-credentials
+      from_image:
+        name: rebasebot
+        namespace: ci
+        tag: latest
+      resources:
+        limits:
+          memory: 4Gi
+        requests:
+          cpu: 100m
+          memory: 200Mi
+zz_generated_metadata:
+  branch: release-4.17
+  org: openshift
+  repo: cloud-provider-openstack
+  variant: periodics

--- a/ci-operator/config/openshift/cloud-provider-openstack/openshift-cloud-provider-openstack-release-4.18__periodics.yaml
+++ b/ci-operator/config/openshift/cloud-provider-openstack/openshift-cloud-provider-openstack-release-4.18__periodics.yaml
@@ -1,0 +1,52 @@
+base_images:
+  rebasebot:
+    name: rebasebot
+    namespace: ci
+    tag: latest
+build_root:
+  from_repository: true
+resources:
+  '*':
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: rebasebot
+  cron: 0 10 * * Mon,Thu
+  steps:
+    test:
+    - as: rebasebot
+      commands: |
+        rebasebot --source https://github.com/kubernetes/cloud-provider-openstack:release-1.31 \
+                  --dest openshift/cloud-provider-openstack:release-4.18 \
+                  --rebase shiftstack/cloud-provider-openstack:rebase-bot-release-4.18 \
+                  --update-go-modules \
+                  --git-username shiftstack-rebasebot \
+                  --git-email shiftstack-rebasebot@redhat.com \
+                  --github-app-id 118774 \
+                  --github-app-key /secrets/merge-bot/github_private_key \
+                  --github-cloner-id 121614 \
+                  --github-cloner-key /secrets/merge-bot/github_cloner_private_key \
+                  --slack-webhook /secrets/slack-hooks/forum-shiftstack
+      credentials:
+      - mount_path: /secrets/merge-bot
+        name: shiftstack-merge-bot
+        namespace: test-credentials
+      - mount_path: /secrets/slack-hooks
+        name: shiftstack-slack-hooks
+        namespace: test-credentials
+      from_image:
+        name: rebasebot
+        namespace: ci
+        tag: latest
+      resources:
+        limits:
+          memory: 4Gi
+        requests:
+          cpu: 100m
+          memory: 200Mi
+zz_generated_metadata:
+  branch: release-4.18
+  org: openshift
+  repo: cloud-provider-openstack
+  variant: periodics

--- a/ci-operator/config/openshift/cloud-provider-openstack/openshift-cloud-provider-openstack-release-4.19__periodics.yaml
+++ b/ci-operator/config/openshift/cloud-provider-openstack/openshift-cloud-provider-openstack-release-4.19__periodics.yaml
@@ -1,0 +1,52 @@
+base_images:
+  rebasebot:
+    name: rebasebot
+    namespace: ci
+    tag: latest
+build_root:
+  from_repository: true
+resources:
+  '*':
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: rebasebot
+  cron: 0 10 * * Mon,Thu
+  steps:
+    test:
+    - as: rebasebot
+      commands: |
+        rebasebot --source https://github.com/kubernetes/cloud-provider-openstack:release-1.31 \
+                  --dest openshift/cloud-provider-openstack:release-4.19 \
+                  --rebase shiftstack/cloud-provider-openstack:rebase-bot-release-4.19 \
+                  --update-go-modules \
+                  --git-username shiftstack-rebasebot \
+                  --git-email shiftstack-rebasebot@redhat.com \
+                  --github-app-id 118774 \
+                  --github-app-key /secrets/merge-bot/github_private_key \
+                  --github-cloner-id 121614 \
+                  --github-cloner-key /secrets/merge-bot/github_cloner_private_key \
+                  --slack-webhook /secrets/slack-hooks/forum-shiftstack
+      credentials:
+      - mount_path: /secrets/merge-bot
+        name: shiftstack-merge-bot
+        namespace: test-credentials
+      - mount_path: /secrets/slack-hooks
+        name: shiftstack-slack-hooks
+        namespace: test-credentials
+      from_image:
+        name: rebasebot
+        namespace: ci
+        tag: latest
+      resources:
+        limits:
+          memory: 4Gi
+        requests:
+          cpu: 100m
+          memory: 200Mi
+zz_generated_metadata:
+  branch: release-4.19
+  org: openshift
+  repo: cloud-provider-openstack
+  variant: periodics

--- a/ci-operator/config/openshift/cloud-provider-openstack/openshift-cloud-provider-openstack-release-4.20__periodics.yaml
+++ b/ci-operator/config/openshift/cloud-provider-openstack/openshift-cloud-provider-openstack-release-4.20__periodics.yaml
@@ -1,0 +1,52 @@
+base_images:
+  rebasebot:
+    name: rebasebot
+    namespace: ci
+    tag: latest
+build_root:
+  from_repository: true
+resources:
+  '*':
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: rebasebot
+  cron: 0 10 * * Mon,Thu
+  steps:
+    test:
+    - as: rebasebot
+      commands: |
+        rebasebot --source https://github.com/kubernetes/cloud-provider-openstack:release-1.33 \
+                  --dest openshift/cloud-provider-openstack:release-4.20 \
+                  --rebase shiftstack/cloud-provider-openstack:rebase-bot-release-4.20 \
+                  --update-go-modules \
+                  --git-username shiftstack-rebasebot \
+                  --git-email shiftstack-rebasebot@redhat.com \
+                  --github-app-id 118774 \
+                  --github-app-key /secrets/merge-bot/github_private_key \
+                  --github-cloner-id 121614 \
+                  --github-cloner-key /secrets/merge-bot/github_cloner_private_key \
+                  --slack-webhook /secrets/slack-hooks/forum-shiftstack
+      credentials:
+      - mount_path: /secrets/merge-bot
+        name: shiftstack-merge-bot
+        namespace: test-credentials
+      - mount_path: /secrets/slack-hooks
+        name: shiftstack-slack-hooks
+        namespace: test-credentials
+      from_image:
+        name: rebasebot
+        namespace: ci
+        tag: latest
+      resources:
+        limits:
+          memory: 4Gi
+        requests:
+          cpu: 100m
+          memory: 200Mi
+zz_generated_metadata:
+  branch: release-4.20
+  org: openshift
+  repo: cloud-provider-openstack
+  variant: periodics

--- a/ci-operator/config/openshift/cloud-provider-openstack/openshift-cloud-provider-openstack-release-4.21__periodics.yaml
+++ b/ci-operator/config/openshift/cloud-provider-openstack/openshift-cloud-provider-openstack-release-4.21__periodics.yaml
@@ -1,0 +1,52 @@
+base_images:
+  rebasebot:
+    name: rebasebot
+    namespace: ci
+    tag: latest
+build_root:
+  from_repository: true
+resources:
+  '*':
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: rebasebot
+  cron: 0 10 * * Mon,Thu
+  steps:
+    test:
+    - as: rebasebot
+      commands: |
+        rebasebot --source https://github.com/kubernetes/cloud-provider-openstack:release-1.34 \
+                  --dest openshift/cloud-provider-openstack:release-4.21 \
+                  --rebase shiftstack/cloud-provider-openstack:rebase-bot-release-4.21 \
+                  --update-go-modules \
+                  --git-username shiftstack-rebasebot \
+                  --git-email shiftstack-rebasebot@redhat.com \
+                  --github-app-id 118774 \
+                  --github-app-key /secrets/merge-bot/github_private_key \
+                  --github-cloner-id 121614 \
+                  --github-cloner-key /secrets/merge-bot/github_cloner_private_key \
+                  --slack-webhook /secrets/slack-hooks/forum-shiftstack
+      credentials:
+      - mount_path: /secrets/merge-bot
+        name: shiftstack-merge-bot
+        namespace: test-credentials
+      - mount_path: /secrets/slack-hooks
+        name: shiftstack-slack-hooks
+        namespace: test-credentials
+      from_image:
+        name: rebasebot
+        namespace: ci
+        tag: latest
+      resources:
+        limits:
+          memory: 4Gi
+        requests:
+          cpu: 100m
+          memory: 200Mi
+zz_generated_metadata:
+  branch: release-4.21
+  org: openshift
+  repo: cloud-provider-openstack
+  variant: periodics

--- a/ci-operator/config/openshift/cloud-provider-openstack/openshift-cloud-provider-openstack-release-4.22__periodics.yaml
+++ b/ci-operator/config/openshift/cloud-provider-openstack/openshift-cloud-provider-openstack-release-4.22__periodics.yaml
@@ -1,0 +1,52 @@
+base_images:
+  rebasebot:
+    name: rebasebot
+    namespace: ci
+    tag: latest
+build_root:
+  from_repository: true
+resources:
+  '*':
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: rebasebot
+  cron: 0 10 * * Mon,Thu
+  steps:
+    test:
+    - as: rebasebot
+      commands: |
+        rebasebot --source https://github.com/kubernetes/cloud-provider-openstack:release-1.35 \
+                  --dest openshift/cloud-provider-openstack:release-4.22 \
+                  --rebase shiftstack/cloud-provider-openstack:rebase-bot-release-4.22 \
+                  --update-go-modules \
+                  --git-username shiftstack-rebasebot \
+                  --git-email shiftstack-rebasebot@redhat.com \
+                  --github-app-id 118774 \
+                  --github-app-key /secrets/merge-bot/github_private_key \
+                  --github-cloner-id 121614 \
+                  --github-cloner-key /secrets/merge-bot/github_cloner_private_key \
+                  --slack-webhook /secrets/slack-hooks/forum-shiftstack
+      credentials:
+      - mount_path: /secrets/merge-bot
+        name: shiftstack-merge-bot
+        namespace: test-credentials
+      - mount_path: /secrets/slack-hooks
+        name: shiftstack-slack-hooks
+        namespace: test-credentials
+      from_image:
+        name: rebasebot
+        namespace: ci
+        tag: latest
+      resources:
+        limits:
+          memory: 4Gi
+        requests:
+          cpu: 100m
+          memory: 200Mi
+zz_generated_metadata:
+  branch: release-4.22
+  org: openshift
+  repo: cloud-provider-openstack
+  variant: periodics

--- a/ci-operator/config/openshift/cluster-api-provider-openstack/openshift-cluster-api-provider-openstack-main__periodics.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-openstack/openshift-cluster-api-provider-openstack-main__periodics.yaml
@@ -1,0 +1,52 @@
+base_images:
+  rebasebot:
+    name: rebasebot
+    namespace: ci
+    tag: latest
+build_root:
+  from_repository: true
+resources:
+  '*':
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: rebasebot
+  cron: 0 10 * * Mon,Thu
+  steps:
+    test:
+    - as: rebasebot
+      commands: |
+        rebasebot --source https://github.com/kubernetes-sigs/cluster-api-provider-openstack:release-0.14 \
+                  --dest openshift/cluster-api-provider-openstack:main \
+                  --rebase shiftstack/cluster-api-provider-openstack:rebase-bot-main \
+                  --update-go-modules \
+                  --git-username shiftstack-rebasebot \
+                  --git-email shiftstack-rebasebot@redhat.com \
+                  --github-app-id 118774 \
+                  --github-app-key /secrets/merge-bot/github_private_key \
+                  --github-cloner-id 121614 \
+                  --github-cloner-key /secrets/merge-bot/github_cloner_private_key \
+                  --slack-webhook /secrets/slack-hooks/forum-shiftstack
+      credentials:
+      - mount_path: /secrets/merge-bot
+        name: shiftstack-merge-bot
+        namespace: test-credentials
+      - mount_path: /secrets/slack-hooks
+        name: shiftstack-slack-hooks
+        namespace: test-credentials
+      from_image:
+        name: rebasebot
+        namespace: ci
+        tag: latest
+      resources:
+        limits:
+          memory: 4Gi
+        requests:
+          cpu: 100m
+          memory: 200Mi
+zz_generated_metadata:
+  branch: main
+  org: openshift
+  repo: cluster-api-provider-openstack
+  variant: periodics

--- a/ci-operator/config/openshift/cluster-api-provider-openstack/openshift-cluster-api-provider-openstack-release-4.16__periodics.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-openstack/openshift-cluster-api-provider-openstack-release-4.16__periodics.yaml
@@ -1,0 +1,52 @@
+base_images:
+  rebasebot:
+    name: rebasebot
+    namespace: ci
+    tag: latest
+build_root:
+  from_repository: true
+resources:
+  '*':
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: rebasebot
+  cron: 0 10 * * Mon,Thu
+  steps:
+    test:
+    - as: rebasebot
+      commands: |
+        rebasebot --source https://github.com/kubernetes-sigs/cluster-api-provider-openstack:release-0.10 \
+                  --dest openshift/cluster-api-provider-openstack:release-4.16 \
+                  --rebase shiftstack/cluster-api-provider-openstack:rebase-bot-release-4.16 \
+                  --update-go-modules \
+                  --git-username shiftstack-rebasebot \
+                  --git-email shiftstack-rebasebot@redhat.com \
+                  --github-app-id 118774 \
+                  --github-app-key /secrets/merge-bot/github_private_key \
+                  --github-cloner-id 121614 \
+                  --github-cloner-key /secrets/merge-bot/github_cloner_private_key \
+                  --slack-webhook /secrets/slack-hooks/forum-shiftstack
+      credentials:
+      - mount_path: /secrets/merge-bot
+        name: shiftstack-merge-bot
+        namespace: test-credentials
+      - mount_path: /secrets/slack-hooks
+        name: shiftstack-slack-hooks
+        namespace: test-credentials
+      from_image:
+        name: rebasebot
+        namespace: ci
+        tag: latest
+      resources:
+        limits:
+          memory: 4Gi
+        requests:
+          cpu: 100m
+          memory: 200Mi
+zz_generated_metadata:
+  branch: release-4.16
+  org: openshift
+  repo: cluster-api-provider-openstack
+  variant: periodics

--- a/ci-operator/config/openshift/cluster-api-provider-openstack/openshift-cluster-api-provider-openstack-release-4.17__periodics.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-openstack/openshift-cluster-api-provider-openstack-release-4.17__periodics.yaml
@@ -1,0 +1,52 @@
+base_images:
+  rebasebot:
+    name: rebasebot
+    namespace: ci
+    tag: latest
+build_root:
+  from_repository: true
+resources:
+  '*':
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: rebasebot
+  cron: 0 10 * * Mon,Thu
+  steps:
+    test:
+    - as: rebasebot
+      commands: |
+        rebasebot --source https://github.com/kubernetes-sigs/cluster-api-provider-openstack:release-0.10 \
+                  --dest openshift/cluster-api-provider-openstack:release-4.17 \
+                  --rebase shiftstack/cluster-api-provider-openstack:rebase-bot-release-4.17 \
+                  --update-go-modules \
+                  --git-username shiftstack-rebasebot \
+                  --git-email shiftstack-rebasebot@redhat.com \
+                  --github-app-id 118774 \
+                  --github-app-key /secrets/merge-bot/github_private_key \
+                  --github-cloner-id 121614 \
+                  --github-cloner-key /secrets/merge-bot/github_cloner_private_key \
+                  --slack-webhook /secrets/slack-hooks/forum-shiftstack
+      credentials:
+      - mount_path: /secrets/merge-bot
+        name: shiftstack-merge-bot
+        namespace: test-credentials
+      - mount_path: /secrets/slack-hooks
+        name: shiftstack-slack-hooks
+        namespace: test-credentials
+      from_image:
+        name: rebasebot
+        namespace: ci
+        tag: latest
+      resources:
+        limits:
+          memory: 4Gi
+        requests:
+          cpu: 100m
+          memory: 200Mi
+zz_generated_metadata:
+  branch: release-4.17
+  org: openshift
+  repo: cluster-api-provider-openstack
+  variant: periodics

--- a/ci-operator/config/openshift/cluster-api-provider-openstack/openshift-cluster-api-provider-openstack-release-4.18__periodics.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-openstack/openshift-cluster-api-provider-openstack-release-4.18__periodics.yaml
@@ -1,0 +1,52 @@
+base_images:
+  rebasebot:
+    name: rebasebot
+    namespace: ci
+    tag: latest
+build_root:
+  from_repository: true
+resources:
+  '*':
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: rebasebot
+  cron: 0 10 * * Mon,Thu
+  steps:
+    test:
+    - as: rebasebot
+      commands: |
+        rebasebot --source https://github.com/kubernetes-sigs/cluster-api-provider-openstack:release-0.11 \
+                  --dest openshift/cluster-api-provider-openstack:release-4.18 \
+                  --rebase shiftstack/cluster-api-provider-openstack:rebase-bot-release-4.18 \
+                  --update-go-modules \
+                  --git-username shiftstack-rebasebot \
+                  --git-email shiftstack-rebasebot@redhat.com \
+                  --github-app-id 118774 \
+                  --github-app-key /secrets/merge-bot/github_private_key \
+                  --github-cloner-id 121614 \
+                  --github-cloner-key /secrets/merge-bot/github_cloner_private_key \
+                  --slack-webhook /secrets/slack-hooks/forum-shiftstack
+      credentials:
+      - mount_path: /secrets/merge-bot
+        name: shiftstack-merge-bot
+        namespace: test-credentials
+      - mount_path: /secrets/slack-hooks
+        name: shiftstack-slack-hooks
+        namespace: test-credentials
+      from_image:
+        name: rebasebot
+        namespace: ci
+        tag: latest
+      resources:
+        limits:
+          memory: 4Gi
+        requests:
+          cpu: 100m
+          memory: 200Mi
+zz_generated_metadata:
+  branch: release-4.18
+  org: openshift
+  repo: cluster-api-provider-openstack
+  variant: periodics

--- a/ci-operator/config/openshift/cluster-api-provider-openstack/openshift-cluster-api-provider-openstack-release-4.19__periodics.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-openstack/openshift-cluster-api-provider-openstack-release-4.19__periodics.yaml
@@ -1,0 +1,52 @@
+base_images:
+  rebasebot:
+    name: rebasebot
+    namespace: ci
+    tag: latest
+build_root:
+  from_repository: true
+resources:
+  '*':
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: rebasebot
+  cron: 0 10 * * Mon,Thu
+  steps:
+    test:
+    - as: rebasebot
+      commands: |
+        rebasebot --source https://github.com/kubernetes-sigs/cluster-api-provider-openstack:release-0.12 \
+                  --dest openshift/cluster-api-provider-openstack:release-4.19 \
+                  --rebase shiftstack/cluster-api-provider-openstack:rebase-bot-release-4.19 \
+                  --update-go-modules \
+                  --git-username shiftstack-rebasebot \
+                  --git-email shiftstack-rebasebot@redhat.com \
+                  --github-app-id 118774 \
+                  --github-app-key /secrets/merge-bot/github_private_key \
+                  --github-cloner-id 121614 \
+                  --github-cloner-key /secrets/merge-bot/github_cloner_private_key \
+                  --slack-webhook /secrets/slack-hooks/forum-shiftstack
+      credentials:
+      - mount_path: /secrets/merge-bot
+        name: shiftstack-merge-bot
+        namespace: test-credentials
+      - mount_path: /secrets/slack-hooks
+        name: shiftstack-slack-hooks
+        namespace: test-credentials
+      from_image:
+        name: rebasebot
+        namespace: ci
+        tag: latest
+      resources:
+        limits:
+          memory: 4Gi
+        requests:
+          cpu: 100m
+          memory: 200Mi
+zz_generated_metadata:
+  branch: release-4.19
+  org: openshift
+  repo: cluster-api-provider-openstack
+  variant: periodics

--- a/ci-operator/config/openshift/cluster-api-provider-openstack/openshift-cluster-api-provider-openstack-release-4.20__periodics.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-openstack/openshift-cluster-api-provider-openstack-release-4.20__periodics.yaml
@@ -1,0 +1,52 @@
+base_images:
+  rebasebot:
+    name: rebasebot
+    namespace: ci
+    tag: latest
+build_root:
+  from_repository: true
+resources:
+  '*':
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: rebasebot
+  cron: 0 10 * * Mon,Thu
+  steps:
+    test:
+    - as: rebasebot
+      commands: |
+        rebasebot --source https://github.com/kubernetes-sigs/cluster-api-provider-openstack:release-0.12 \
+                  --dest openshift/cluster-api-provider-openstack:release-4.20 \
+                  --rebase shiftstack/cluster-api-provider-openstack:rebase-bot-release-4.20 \
+                  --update-go-modules \
+                  --git-username shiftstack-rebasebot \
+                  --git-email shiftstack-rebasebot@redhat.com \
+                  --github-app-id 118774 \
+                  --github-app-key /secrets/merge-bot/github_private_key \
+                  --github-cloner-id 121614 \
+                  --github-cloner-key /secrets/merge-bot/github_cloner_private_key \
+                  --slack-webhook /secrets/slack-hooks/forum-shiftstack
+      credentials:
+      - mount_path: /secrets/merge-bot
+        name: shiftstack-merge-bot
+        namespace: test-credentials
+      - mount_path: /secrets/slack-hooks
+        name: shiftstack-slack-hooks
+        namespace: test-credentials
+      from_image:
+        name: rebasebot
+        namespace: ci
+        tag: latest
+      resources:
+        limits:
+          memory: 4Gi
+        requests:
+          cpu: 100m
+          memory: 200Mi
+zz_generated_metadata:
+  branch: release-4.20
+  org: openshift
+  repo: cluster-api-provider-openstack
+  variant: periodics

--- a/ci-operator/config/openshift/cluster-api-provider-openstack/openshift-cluster-api-provider-openstack-release-4.21__periodics.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-openstack/openshift-cluster-api-provider-openstack-release-4.21__periodics.yaml
@@ -1,0 +1,52 @@
+base_images:
+  rebasebot:
+    name: rebasebot
+    namespace: ci
+    tag: latest
+build_root:
+  from_repository: true
+resources:
+  '*':
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: rebasebot
+  cron: 0 10 * * Mon,Thu
+  steps:
+    test:
+    - as: rebasebot
+      commands: |
+        rebasebot --source https://github.com/kubernetes-sigs/cluster-api-provider-openstack:release-0.13 \
+                  --dest openshift/cluster-api-provider-openstack:release-4.21 \
+                  --rebase shiftstack/cluster-api-provider-openstack:rebase-bot-release-4.21 \
+                  --update-go-modules \
+                  --git-username shiftstack-rebasebot \
+                  --git-email shiftstack-rebasebot@redhat.com \
+                  --github-app-id 118774 \
+                  --github-app-key /secrets/merge-bot/github_private_key \
+                  --github-cloner-id 121614 \
+                  --github-cloner-key /secrets/merge-bot/github_cloner_private_key \
+                  --slack-webhook /secrets/slack-hooks/forum-shiftstack
+      credentials:
+      - mount_path: /secrets/merge-bot
+        name: shiftstack-merge-bot
+        namespace: test-credentials
+      - mount_path: /secrets/slack-hooks
+        name: shiftstack-slack-hooks
+        namespace: test-credentials
+      from_image:
+        name: rebasebot
+        namespace: ci
+        tag: latest
+      resources:
+        limits:
+          memory: 4Gi
+        requests:
+          cpu: 100m
+          memory: 200Mi
+zz_generated_metadata:
+  branch: release-4.21
+  org: openshift
+  repo: cluster-api-provider-openstack
+  variant: periodics

--- a/ci-operator/config/openshift/cluster-api-provider-openstack/openshift-cluster-api-provider-openstack-release-4.22__periodics.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-openstack/openshift-cluster-api-provider-openstack-release-4.22__periodics.yaml
@@ -1,0 +1,52 @@
+base_images:
+  rebasebot:
+    name: rebasebot
+    namespace: ci
+    tag: latest
+build_root:
+  from_repository: true
+resources:
+  '*':
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: rebasebot
+  cron: 0 10 * * Mon,Thu
+  steps:
+    test:
+    - as: rebasebot
+      commands: |
+        rebasebot --source https://github.com/kubernetes-sigs/cluster-api-provider-openstack:release-0.14 \
+                  --dest openshift/cluster-api-provider-openstack:release-4.22 \
+                  --rebase shiftstack/cluster-api-provider-openstack:rebase-bot-release-4.22 \
+                  --update-go-modules \
+                  --git-username shiftstack-rebasebot \
+                  --git-email shiftstack-rebasebot@redhat.com \
+                  --github-app-id 118774 \
+                  --github-app-key /secrets/merge-bot/github_private_key \
+                  --github-cloner-id 121614 \
+                  --github-cloner-key /secrets/merge-bot/github_cloner_private_key \
+                  --slack-webhook /secrets/slack-hooks/forum-shiftstack
+      credentials:
+      - mount_path: /secrets/merge-bot
+        name: shiftstack-merge-bot
+        namespace: test-credentials
+      - mount_path: /secrets/slack-hooks
+        name: shiftstack-slack-hooks
+        namespace: test-credentials
+      from_image:
+        name: rebasebot
+        namespace: ci
+        tag: latest
+      resources:
+        limits:
+          memory: 4Gi
+        requests:
+          cpu: 100m
+          memory: 200Mi
+zz_generated_metadata:
+  branch: release-4.22
+  org: openshift
+  repo: cluster-api-provider-openstack
+  variant: periodics

--- a/ci-operator/config/openshift/csi-driver-nfs/openshift-csi-driver-nfs-main__periodics.yaml
+++ b/ci-operator/config/openshift/csi-driver-nfs/openshift-csi-driver-nfs-main__periodics.yaml
@@ -1,0 +1,52 @@
+base_images:
+  rebasebot:
+    name: rebasebot
+    namespace: ci
+    tag: latest
+build_root:
+  from_repository: true
+resources:
+  '*':
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: rebasebot
+  cron: 0 10 * * Mon,Thu
+  steps:
+    test:
+    - as: rebasebot
+      commands: |
+        rebasebot --source https://github.com/kubernetes-csi/csi-driver-nfs:master \
+                  --dest openshift/csi-driver-nfs:main \
+                  --rebase shiftstack/csi-driver-nfs:rebase-bot-main \
+                  --update-go-modules \
+                  --git-username shiftstack-rebasebot \
+                  --git-email shiftstack-rebasebot@redhat.com \
+                  --github-app-id 118774 \
+                  --github-app-key /secrets/merge-bot/github_private_key \
+                  --github-cloner-id 121614 \
+                  --github-cloner-key /secrets/merge-bot/github_cloner_private_key \
+                  --slack-webhook /secrets/slack-hooks/forum-shiftstack
+      credentials:
+      - mount_path: /secrets/merge-bot
+        name: shiftstack-merge-bot
+        namespace: test-credentials
+      - mount_path: /secrets/slack-hooks
+        name: shiftstack-slack-hooks
+        namespace: test-credentials
+      from_image:
+        name: rebasebot
+        namespace: ci
+        tag: latest
+      resources:
+        limits:
+          memory: 4Gi
+        requests:
+          cpu: 100m
+          memory: 200Mi
+zz_generated_metadata:
+  branch: main
+  org: openshift
+  repo: csi-driver-nfs
+  variant: periodics

--- a/ci-operator/config/openshift/openstack-resource-controller/openshift-openstack-resource-controller-main__periodics.yaml
+++ b/ci-operator/config/openshift/openstack-resource-controller/openshift-openstack-resource-controller-main__periodics.yaml
@@ -1,0 +1,52 @@
+base_images:
+  rebasebot:
+    name: rebasebot
+    namespace: ci
+    tag: latest
+build_root:
+  from_repository: true
+resources:
+  '*':
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: rebasebot
+  cron: 0 10 * * Mon,Thu
+  steps:
+    test:
+    - as: rebasebot
+      commands: |
+        rebasebot --source https://github.com/k-orc/openstack-resource-controller:release-1.0 \
+                  --dest openshift/openstack-resource-controller:main \
+                  --rebase shiftstack/openstack-resource-controller:rebase-bot-main \
+                  --update-go-modules \
+                  --git-username shiftstack-rebasebot \
+                  --git-email shiftstack-rebasebot@redhat.com \
+                  --github-app-id 118774 \
+                  --github-app-key /secrets/merge-bot/github_private_key \
+                  --github-cloner-id 121614 \
+                  --github-cloner-key /secrets/merge-bot/github_cloner_private_key \
+                  --slack-webhook /secrets/slack-hooks/forum-shiftstack
+      credentials:
+      - mount_path: /secrets/merge-bot
+        name: shiftstack-merge-bot
+        namespace: test-credentials
+      - mount_path: /secrets/slack-hooks
+        name: shiftstack-slack-hooks
+        namespace: test-credentials
+      from_image:
+        name: rebasebot
+        namespace: ci
+        tag: latest
+      resources:
+        limits:
+          memory: 4Gi
+        requests:
+          cpu: 100m
+          memory: 200Mi
+zz_generated_metadata:
+  branch: main
+  org: openshift
+  repo: openstack-resource-controller
+  variant: periodics

--- a/ci-operator/jobs/openshift-eng/rebasebot/openshift-eng-rebasebot-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-eng/rebasebot/openshift-eng-rebasebot-main-periodics.yaml
@@ -498,6 +498,503 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
+  cron: 0 10 * * Mon,Thu
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-eng
+    repo: rebasebot
+  labels:
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-eng-rebasebot-main-cloud-provider-openstack-4-16
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --target=cloud-provider-openstack-4-16
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build08
+  cron: 0 10 * * Mon,Thu
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-eng
+    repo: rebasebot
+  labels:
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-eng-rebasebot-main-cloud-provider-openstack-4-17
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --target=cloud-provider-openstack-4-17
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build08
+  cron: 0 10 * * Mon,Thu
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-eng
+    repo: rebasebot
+  labels:
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-eng-rebasebot-main-cloud-provider-openstack-4-18
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --target=cloud-provider-openstack-4-18
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build08
+  cron: 0 10 * * Mon,Thu
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-eng
+    repo: rebasebot
+  labels:
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-eng-rebasebot-main-cloud-provider-openstack-4-19
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --target=cloud-provider-openstack-4-19
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build08
+  cron: 0 10 * * Mon,Thu
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-eng
+    repo: rebasebot
+  labels:
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-eng-rebasebot-main-cloud-provider-openstack-4-20
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --target=cloud-provider-openstack-4-20
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build08
+  cron: 0 10 * * Mon,Thu
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-eng
+    repo: rebasebot
+  labels:
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-eng-rebasebot-main-cloud-provider-openstack-4-21
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --target=cloud-provider-openstack-4-21
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build08
+  cron: 0 10 * * Mon,Thu
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-eng
+    repo: rebasebot
+  labels:
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-eng-rebasebot-main-cloud-provider-openstack-main
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --target=cloud-provider-openstack-main
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build08
   cron: 10 12 * * Mon,Thu
   decorate: true
   decoration_config:
@@ -1136,6 +1633,503 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
+  cluster: build08
+  cron: 0 10 * * Mon,Thu
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-eng
+    repo: rebasebot
+  labels:
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-eng-rebasebot-main-cluster-api-provider-openstack-4-16
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --target=cluster-api-provider-openstack-4-16
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build08
+  cron: 0 10 * * Mon,Thu
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-eng
+    repo: rebasebot
+  labels:
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-eng-rebasebot-main-cluster-api-provider-openstack-4-17
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --target=cluster-api-provider-openstack-4-17
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build08
+  cron: 0 10 * * Mon,Thu
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-eng
+    repo: rebasebot
+  labels:
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-eng-rebasebot-main-cluster-api-provider-openstack-4-18
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --target=cluster-api-provider-openstack-4-18
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build08
+  cron: 0 10 * * Mon,Thu
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-eng
+    repo: rebasebot
+  labels:
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-eng-rebasebot-main-cluster-api-provider-openstack-4-19
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --target=cluster-api-provider-openstack-4-19
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build08
+  cron: 0 10 * * Mon,Thu
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-eng
+    repo: rebasebot
+  labels:
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-eng-rebasebot-main-cluster-api-provider-openstack-4-20
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --target=cluster-api-provider-openstack-4-20
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build08
+  cron: 0 10 * * Mon,Thu
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-eng
+    repo: rebasebot
+  labels:
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-eng-rebasebot-main-cluster-api-provider-openstack-4-21
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --target=cluster-api-provider-openstack-4-21
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build08
+  cron: 0 10 * * Mon,Thu
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-eng
+    repo: rebasebot
+  labels:
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-eng-rebasebot-main-cluster-api-provider-openstack-main
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --target=cluster-api-provider-openstack-main
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
   cluster: vsphere02
   cron: 0 12 * * Mon,Thu
   decorate: true
@@ -1157,6 +2151,77 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --target=cluster-api-provider-vsphere
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build08
+  cron: 0 10 * * Mon,Thu
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-eng
+    repo: rebasebot
+  labels:
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-eng-rebasebot-main-csi-driver-nfs-main
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --target=csi-driver-nfs-main
       command:
       - ci-operator
       env:
@@ -2364,6 +3429,77 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --target=openstack-ironic-python-agent
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build08
+  cron: 0 10 * * Mon,Thu
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-eng
+    repo: rebasebot
+  labels:
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-eng-rebasebot-main-openstack-resource-controller-main
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --target=openstack-resource-controller-main
       command:
       - ci-operator
       env:

--- a/ci-operator/jobs/openshift/cloud-provider-openstack/openshift-cloud-provider-openstack-main-periodics.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-openstack/openshift-cloud-provider-openstack-main-periodics.yaml
@@ -1,0 +1,77 @@
+periodics:
+- agent: kubernetes
+  cluster: build01
+  cron: 0 10 * * Mon,Thu
+  decorate: true
+  decoration_config:
+    sparse_checkout_files:
+    - .ci-operator.yaml
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: cloud-provider-openstack
+    sparse_checkout_files:
+    - .ci-operator.yaml
+  labels:
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-cloud-provider-openstack-main-periodics-rebasebot
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --target=rebasebot
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator

--- a/ci-operator/jobs/openshift/cloud-provider-openstack/openshift-cloud-provider-openstack-release-4.16-periodics.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-openstack/openshift-cloud-provider-openstack-release-4.16-periodics.yaml
@@ -1,0 +1,77 @@
+periodics:
+- agent: kubernetes
+  cluster: build01
+  cron: 0 10 * * Mon,Thu
+  decorate: true
+  decoration_config:
+    sparse_checkout_files:
+    - .ci-operator.yaml
+  extra_refs:
+  - base_ref: release-4.16
+    org: openshift
+    repo: cloud-provider-openstack
+    sparse_checkout_files:
+    - .ci-operator.yaml
+  labels:
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-cloud-provider-openstack-release-4.16-periodics-rebasebot
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --target=rebasebot
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator

--- a/ci-operator/jobs/openshift/cloud-provider-openstack/openshift-cloud-provider-openstack-release-4.17-periodics.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-openstack/openshift-cloud-provider-openstack-release-4.17-periodics.yaml
@@ -1,0 +1,77 @@
+periodics:
+- agent: kubernetes
+  cluster: build01
+  cron: 0 10 * * Mon,Thu
+  decorate: true
+  decoration_config:
+    sparse_checkout_files:
+    - .ci-operator.yaml
+  extra_refs:
+  - base_ref: release-4.17
+    org: openshift
+    repo: cloud-provider-openstack
+    sparse_checkout_files:
+    - .ci-operator.yaml
+  labels:
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-cloud-provider-openstack-release-4.17-periodics-rebasebot
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --target=rebasebot
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator

--- a/ci-operator/jobs/openshift/cloud-provider-openstack/openshift-cloud-provider-openstack-release-4.18-periodics.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-openstack/openshift-cloud-provider-openstack-release-4.18-periodics.yaml
@@ -1,0 +1,77 @@
+periodics:
+- agent: kubernetes
+  cluster: build01
+  cron: 0 10 * * Mon,Thu
+  decorate: true
+  decoration_config:
+    sparse_checkout_files:
+    - .ci-operator.yaml
+  extra_refs:
+  - base_ref: release-4.18
+    org: openshift
+    repo: cloud-provider-openstack
+    sparse_checkout_files:
+    - .ci-operator.yaml
+  labels:
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-cloud-provider-openstack-release-4.18-periodics-rebasebot
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --target=rebasebot
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator

--- a/ci-operator/jobs/openshift/cloud-provider-openstack/openshift-cloud-provider-openstack-release-4.19-periodics.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-openstack/openshift-cloud-provider-openstack-release-4.19-periodics.yaml
@@ -1,0 +1,77 @@
+periodics:
+- agent: kubernetes
+  cluster: build01
+  cron: 0 10 * * Mon,Thu
+  decorate: true
+  decoration_config:
+    sparse_checkout_files:
+    - .ci-operator.yaml
+  extra_refs:
+  - base_ref: release-4.19
+    org: openshift
+    repo: cloud-provider-openstack
+    sparse_checkout_files:
+    - .ci-operator.yaml
+  labels:
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-cloud-provider-openstack-release-4.19-periodics-rebasebot
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --target=rebasebot
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator

--- a/ci-operator/jobs/openshift/cloud-provider-openstack/openshift-cloud-provider-openstack-release-4.20-periodics.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-openstack/openshift-cloud-provider-openstack-release-4.20-periodics.yaml
@@ -1,0 +1,77 @@
+periodics:
+- agent: kubernetes
+  cluster: build01
+  cron: 0 10 * * Mon,Thu
+  decorate: true
+  decoration_config:
+    sparse_checkout_files:
+    - .ci-operator.yaml
+  extra_refs:
+  - base_ref: release-4.20
+    org: openshift
+    repo: cloud-provider-openstack
+    sparse_checkout_files:
+    - .ci-operator.yaml
+  labels:
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-cloud-provider-openstack-release-4.20-periodics-rebasebot
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --target=rebasebot
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator

--- a/ci-operator/jobs/openshift/cloud-provider-openstack/openshift-cloud-provider-openstack-release-4.21-periodics.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-openstack/openshift-cloud-provider-openstack-release-4.21-periodics.yaml
@@ -1,0 +1,77 @@
+periodics:
+- agent: kubernetes
+  cluster: build01
+  cron: 0 10 * * Mon,Thu
+  decorate: true
+  decoration_config:
+    sparse_checkout_files:
+    - .ci-operator.yaml
+  extra_refs:
+  - base_ref: release-4.21
+    org: openshift
+    repo: cloud-provider-openstack
+    sparse_checkout_files:
+    - .ci-operator.yaml
+  labels:
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-cloud-provider-openstack-release-4.21-periodics-rebasebot
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --target=rebasebot
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator

--- a/ci-operator/jobs/openshift/cloud-provider-openstack/openshift-cloud-provider-openstack-release-4.22-periodics.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-openstack/openshift-cloud-provider-openstack-release-4.22-periodics.yaml
@@ -1,0 +1,77 @@
+periodics:
+- agent: kubernetes
+  cluster: build01
+  cron: 0 10 * * Mon,Thu
+  decorate: true
+  decoration_config:
+    sparse_checkout_files:
+    - .ci-operator.yaml
+  extra_refs:
+  - base_ref: release-4.22
+    org: openshift
+    repo: cloud-provider-openstack
+    sparse_checkout_files:
+    - .ci-operator.yaml
+  labels:
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-cloud-provider-openstack-release-4.22-periodics-rebasebot
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --target=rebasebot
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator

--- a/ci-operator/jobs/openshift/cluster-api-provider-openstack/openshift-cluster-api-provider-openstack-main-periodics.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-openstack/openshift-cluster-api-provider-openstack-main-periodics.yaml
@@ -1,0 +1,77 @@
+periodics:
+- agent: kubernetes
+  cluster: build01
+  cron: 0 10 * * Mon,Thu
+  decorate: true
+  decoration_config:
+    sparse_checkout_files:
+    - .ci-operator.yaml
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: cluster-api-provider-openstack
+    sparse_checkout_files:
+    - .ci-operator.yaml
+  labels:
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-cluster-api-provider-openstack-main-periodics-rebasebot
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --target=rebasebot
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator

--- a/ci-operator/jobs/openshift/cluster-api-provider-openstack/openshift-cluster-api-provider-openstack-release-4.16-periodics.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-openstack/openshift-cluster-api-provider-openstack-release-4.16-periodics.yaml
@@ -1,0 +1,77 @@
+periodics:
+- agent: kubernetes
+  cluster: build01
+  cron: 0 10 * * Mon,Thu
+  decorate: true
+  decoration_config:
+    sparse_checkout_files:
+    - .ci-operator.yaml
+  extra_refs:
+  - base_ref: release-4.16
+    org: openshift
+    repo: cluster-api-provider-openstack
+    sparse_checkout_files:
+    - .ci-operator.yaml
+  labels:
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-cluster-api-provider-openstack-release-4.16-periodics-rebasebot
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --target=rebasebot
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator

--- a/ci-operator/jobs/openshift/cluster-api-provider-openstack/openshift-cluster-api-provider-openstack-release-4.17-periodics.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-openstack/openshift-cluster-api-provider-openstack-release-4.17-periodics.yaml
@@ -1,0 +1,77 @@
+periodics:
+- agent: kubernetes
+  cluster: build01
+  cron: 0 10 * * Mon,Thu
+  decorate: true
+  decoration_config:
+    sparse_checkout_files:
+    - .ci-operator.yaml
+  extra_refs:
+  - base_ref: release-4.17
+    org: openshift
+    repo: cluster-api-provider-openstack
+    sparse_checkout_files:
+    - .ci-operator.yaml
+  labels:
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-cluster-api-provider-openstack-release-4.17-periodics-rebasebot
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --target=rebasebot
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator

--- a/ci-operator/jobs/openshift/cluster-api-provider-openstack/openshift-cluster-api-provider-openstack-release-4.18-periodics.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-openstack/openshift-cluster-api-provider-openstack-release-4.18-periodics.yaml
@@ -1,0 +1,77 @@
+periodics:
+- agent: kubernetes
+  cluster: build01
+  cron: 0 10 * * Mon,Thu
+  decorate: true
+  decoration_config:
+    sparse_checkout_files:
+    - .ci-operator.yaml
+  extra_refs:
+  - base_ref: release-4.18
+    org: openshift
+    repo: cluster-api-provider-openstack
+    sparse_checkout_files:
+    - .ci-operator.yaml
+  labels:
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-cluster-api-provider-openstack-release-4.18-periodics-rebasebot
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --target=rebasebot
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator

--- a/ci-operator/jobs/openshift/cluster-api-provider-openstack/openshift-cluster-api-provider-openstack-release-4.19-periodics.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-openstack/openshift-cluster-api-provider-openstack-release-4.19-periodics.yaml
@@ -1,0 +1,77 @@
+periodics:
+- agent: kubernetes
+  cluster: build01
+  cron: 0 10 * * Mon,Thu
+  decorate: true
+  decoration_config:
+    sparse_checkout_files:
+    - .ci-operator.yaml
+  extra_refs:
+  - base_ref: release-4.19
+    org: openshift
+    repo: cluster-api-provider-openstack
+    sparse_checkout_files:
+    - .ci-operator.yaml
+  labels:
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-cluster-api-provider-openstack-release-4.19-periodics-rebasebot
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --target=rebasebot
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator

--- a/ci-operator/jobs/openshift/cluster-api-provider-openstack/openshift-cluster-api-provider-openstack-release-4.20-periodics.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-openstack/openshift-cluster-api-provider-openstack-release-4.20-periodics.yaml
@@ -1,0 +1,77 @@
+periodics:
+- agent: kubernetes
+  cluster: build01
+  cron: 0 10 * * Mon,Thu
+  decorate: true
+  decoration_config:
+    sparse_checkout_files:
+    - .ci-operator.yaml
+  extra_refs:
+  - base_ref: release-4.20
+    org: openshift
+    repo: cluster-api-provider-openstack
+    sparse_checkout_files:
+    - .ci-operator.yaml
+  labels:
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-cluster-api-provider-openstack-release-4.20-periodics-rebasebot
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --target=rebasebot
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator

--- a/ci-operator/jobs/openshift/cluster-api-provider-openstack/openshift-cluster-api-provider-openstack-release-4.21-periodics.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-openstack/openshift-cluster-api-provider-openstack-release-4.21-periodics.yaml
@@ -1,0 +1,77 @@
+periodics:
+- agent: kubernetes
+  cluster: build01
+  cron: 0 10 * * Mon,Thu
+  decorate: true
+  decoration_config:
+    sparse_checkout_files:
+    - .ci-operator.yaml
+  extra_refs:
+  - base_ref: release-4.21
+    org: openshift
+    repo: cluster-api-provider-openstack
+    sparse_checkout_files:
+    - .ci-operator.yaml
+  labels:
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-cluster-api-provider-openstack-release-4.21-periodics-rebasebot
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --target=rebasebot
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator

--- a/ci-operator/jobs/openshift/cluster-api-provider-openstack/openshift-cluster-api-provider-openstack-release-4.22-periodics.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-openstack/openshift-cluster-api-provider-openstack-release-4.22-periodics.yaml
@@ -1,0 +1,77 @@
+periodics:
+- agent: kubernetes
+  cluster: build01
+  cron: 0 10 * * Mon,Thu
+  decorate: true
+  decoration_config:
+    sparse_checkout_files:
+    - .ci-operator.yaml
+  extra_refs:
+  - base_ref: release-4.22
+    org: openshift
+    repo: cluster-api-provider-openstack
+    sparse_checkout_files:
+    - .ci-operator.yaml
+  labels:
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-cluster-api-provider-openstack-release-4.22-periodics-rebasebot
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --target=rebasebot
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator

--- a/ci-operator/jobs/openshift/csi-driver-nfs/openshift-csi-driver-nfs-main-periodics.yaml
+++ b/ci-operator/jobs/openshift/csi-driver-nfs/openshift-csi-driver-nfs-main-periodics.yaml
@@ -1,0 +1,77 @@
+periodics:
+- agent: kubernetes
+  cluster: build01
+  cron: 0 10 * * Mon,Thu
+  decorate: true
+  decoration_config:
+    sparse_checkout_files:
+    - .ci-operator.yaml
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: csi-driver-nfs
+    sparse_checkout_files:
+    - .ci-operator.yaml
+  labels:
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-csi-driver-nfs-main-periodics-rebasebot
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --target=rebasebot
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator

--- a/ci-operator/jobs/openshift/openstack-resource-controller/openshift-openstack-resource-controller-main-periodics.yaml
+++ b/ci-operator/jobs/openshift/openstack-resource-controller/openshift-openstack-resource-controller-main-periodics.yaml
@@ -1,0 +1,77 @@
+periodics:
+- agent: kubernetes
+  cluster: build01
+  cron: 0 10 * * Mon,Thu
+  decorate: true
+  decoration_config:
+    sparse_checkout_files:
+    - .ci-operator.yaml
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: openstack-resource-controller
+    sparse_checkout_files:
+    - .ci-operator.yaml
+  labels:
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-openstack-resource-controller-main-periodics-rebasebot
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --target=rebasebot
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator


### PR DESCRIPTION
The goal is to see a successful migration for all of ShiftStack's synchronization jobs to use rebasebot

This will be useful as `merge-bot` was forked a few years ago by openshift-eng team, and the resulting tool, [rebasebot](https://github.com/openshift-eng/rebasebot/), is significantly more advanced.

- Reuses existing credentials from `merge-bot` (FTM)
- `cron` schedule changed will occur 2 hours earlier to not overlap

Equivalent `merge-bot` backup will be removed when `rebasebot` is verified to work successfully in this PR.

