### PR TITLE
ARO HCP Execute baseimage-generator presubmit job only if Dockerfile changed

### DIFF
--- a/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__baseimage-generator.yaml
+++ b/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__baseimage-generator.yaml
@@ -8,6 +8,7 @@ images:
   - dockerfile_path: dev-infrastructure/openshift-ci/Dockerfile
     from: src
     to: aro-hcp-e2e-base-ci
+  run_if_changed: ^dev-infrastructure/openshift-ci/Dockerfile$
 promotion:
   to:
   - name: aro-hcp-ci-images

--- a/ci-operator/jobs/Azure/ARO-HCP/Azure-ARO-HCP-main-presubmits.yaml
+++ b/ci-operator/jobs/Azure/ARO-HCP/Azure-ARO-HCP-main-presubmits.yaml
@@ -82,7 +82,7 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )api-validation,?($|\s.*)
   - agent: kubernetes
-    always_run: true
+    always_run: false
     branches:
     - ^main$
     - ^main-
@@ -97,6 +97,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-Azure-ARO-HCP-main-baseimage-generator-images
     rerun_command: /test baseimage-generator-images
+    run_if_changed: ^dev-infrastructure/openshift-ci/Dockerfile$
     spec:
       containers:
       - args:


### PR DESCRIPTION
The config syntax of images has changed and the conditional execution was removed. Adding the condition back with proper configuration.