### PR TITLE
MPIIT: Add support for skipJobTriggers switch for triggered job lists

### DIFF
--- a/ci-operator/config/rhpit/interop-tests/rhpit-interop-tests-main__weekly_trigger.yaml
+++ b/ci-operator/config/rhpit/interop-tests/rhpit-interop-tests-main__weekly_trigger.yaml
@@ -142,6 +142,16 @@ tests:
     - ref: trigger-jobs-trig-check-resource-owner
     test:
     - ref: trigger-jobs
+- as: tmp-interop-jobs-trigger
+  cron: 0 20 * * 0
+  steps:
+    cluster_profile: aws-cspi-qe
+    env:
+      JT__POST_TASK_EXEC_FLGS: "0"
+      JT__TRIG_COND_EXEC_FLGS: "1"
+      JT__TRIG_JOB_LIST: tmp-test-jobs-list
+    test:
+    - ref: trigger-jobs
 zz_generated_metadata:
   branch: main
   org: rhpit

--- a/ci-operator/jobs/rhpit/interop-tests/rhpit-interop-tests-main-periodics.yaml
+++ b/ci-operator/jobs/rhpit/interop-tests/rhpit-interop-tests-main-periodics.yaml
@@ -790,3 +790,86 @@ periodics:
     - name: result-aggregator
       secret:
         secretName: result-aggregator
+- agent: kubernetes
+  cluster: build03
+  cron: 0 20 * * 0
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: rhpit
+    repo: interop-tests
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-cspi-qe
+    ci-operator.openshift.io/variant: weekly_trigger
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-rhpit-interop-tests-main-weekly_trigger-tmp-interop-jobs-trigger
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=tmp-interop-jobs-trigger
+      - --variant=weekly_trigger
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator

--- a/ci-operator/step-registry/trigger-jobs/README.md
+++ b/ci-operator/step-registry/trigger-jobs/README.md
@@ -19,6 +19,7 @@ The two sources of data are:
       ```json
       [
         {
+          "skipJobTriggers": false,
           "trigCond": [
             {
               "trigCondFlgs": 1,
@@ -285,7 +286,8 @@ This Step will do the following:
     the bitwise mask `(trigCondFlgs & JT__TRIG_COND_EXEC_FLGS)` evaluates to non-0. If any checked trigger condition is not met, the rest
     of the processing is skipped.
  4. **(If applicable)** Loop through the jobs-to-trigger JSON and trigger each Job that has `active: true` and matches the set trigger condition, if any.
-    This Step is skipped if `JT__SKIP_TRIG_MAIN_JOBS` is non-zero.
+    For each JSON list object, its `jobList` block is skipped when `skipJobTriggers` key is set to true.
+    If the step env `JT__SKIP_TRIG_MAIN_JOBS` is non-zero (set in the `ci-operator` config), every `jobList` item is skipped the same way.
  5. **(If applicable)** Set execution markers so the downstream processes can determine whether to execute post-Steps. Markers are only set when
     the bitwise mask `(postTaskFlgs & JT__POST_TASK_EXEC_FLGS)` evaluates to non-0.
  6. Continue processing until all Jobs have been processed.

--- a/ci-operator/step-registry/trigger-jobs/trigger-jobs-commands.sh
+++ b/ci-operator/step-registry/trigger-jobs/trigger-jobs-commands.sh
@@ -8,6 +8,7 @@ typeset jobList='' jobType='' jobName='' stepName=''
 typeset postTask='' postTaskStep='' postTaskPars=''
 typeset rsp=''
 typeset -i trigCondFlgs=0 postTaskFlgs=0 jobExecType=0
+typeset -i skipJobTriggers=0
 typeset -i dryRun=0 tryLeft=0 retryWait=60
 typeset -a failedJobs=()
 #   https://github.com/kubernetes-sigs/prow/blob/95b2a34128de51a4f618c8d6bb9d0c6b587fd29c/pkg/gangway/gangway.proto#L108
@@ -94,8 +95,8 @@ cmd1EOF
   ((rsp == 200)) || { echo "Endpoint is still not available after 60 retries. Aborting." 1>&2; exit 1; }
 fi
 
-while IFS=$'\t' read -r trigCond jobList postTask; do
-    : "Processing: ${trigCond@Q} ${jobList@Q} ${postTask@Q}"
+while IFS=$'\t' read -r trigCond jobList postTask skipJobTriggers; do
+    : "Processing: ${trigCond@Q} ${jobList@Q} ${postTask@Q} skipJobTriggers=${skipJobTriggers@Q}"
     # Trigger Conditions Check.
     while IFS=$'\t' read -r trigCondFlgs trigCondStep trigCondPars; do
         : "Processing: ${trigCondFlgs@Q} ${trigCondStep@Q} ${trigCondPars@Q}"
@@ -181,7 +182,14 @@ cmd1EOF
         done
         ((rsp == 200)) || failedJobs+=("${jobName}")
     done 0< <(
-        ((JT__SKIP_TRIG_MAIN_JOBS)) && exit
+        ((JT__SKIP_TRIG_MAIN_JOBS)) && {
+            echo 'Skipping job list: JT__SKIP_TRIG_MAIN_JOBS is non-zero in this run.' >&2
+            exit
+        }
+        ((skipJobTriggers)) && {
+            echo 'Skipping job list: skipJobTriggers is true for this JSON element.' >&2
+            exit
+        }
         jq -cr '
             .[] |
             select(.active == true) |
@@ -243,7 +251,12 @@ done 0< <(jq -cr '
         else
             .
         end
-    ) | [(.trigCond//[] | @json), (.jobList//[] | @json), (.postTask//[] | @json)] | @tsv
+    ) | [
+        (.trigCond//[] | @json),
+        (.jobList//[] | @json),
+        (.postTask//[] | @json),
+        (if (.skipJobTriggers // false) then 1 else 0 end | tostring)
+    ] | @tsv
 ' "${jobDescFile}")
 
 # Print the list of failed jobs after the loop completes.

--- a/ci-operator/step-registry/trigger-jobs/trigger-jobs-ref.yaml
+++ b/ci-operator/step-registry/trigger-jobs/trigger-jobs-ref.yaml
@@ -21,6 +21,8 @@ ref:
       ```json
       [
         {
+          "skipJobTriggers": <true|false>,                                      # Optional. Master switch: if true,
+                                                                                # skip all `jobList` triggers; `postTask` still runs.
           "trigCond": [                                                         # Optional.
             {
               "trigCondFlgs": <ci-operator-step-trigger-condition-execution-flags>,


### PR DESCRIPTION
This PR adds an optional top-level boolean `skipJobTriggers` on each job list Json object.

When set to true, Gangway-API job triggering is skipped for that object’s entire `jobList`; post tasks still run. 
Omitted or false preserves existing behavior.

`trigCondFlgs` masks only control which trigger-condition steps run; they do not turn off the whole block. 
This gives an explicit vault-driven switch for “disable all jobs in this group” without misusing trigCond or toggling every active field.

Will be verified using the following `jobList`:
```
{"jobType": "periodic", "jobName": "periodic-ci-CSPI-QE-MSI-openshift-ci-trigger-poc-test-fail-setup", "active": true}
```
This job is failing on setup, so if triggered, nothing happens.