### PR TITLE
NO-ISSUE: Make ISO NO Registry job mandatory

### DIFF
--- a/ci-operator/config/openshift-assisted/assisted-installer-ui/openshift-assisted-assisted-installer-ui-master.yaml
+++ b/ci-operator/config/openshift-assisted/assisted-installer-ui/openshift-assisted-assisted-installer-ui-master.yaml
@@ -42,7 +42,6 @@ tests:
   as: e2e-agent-compact-ipv4-iso-no-registry
   capabilities:
   - intranet
-  optional: true
   steps:
     cluster_profile: equinix-ocp-metal
     dependencies:

--- a/ci-operator/config/openshift-assisted/assisted-installer-ui/openshift-assisted-assisted-installer-ui-release-4.21.yaml
+++ b/ci-operator/config/openshift-assisted/assisted-installer-ui/openshift-assisted-assisted-installer-ui-release-4.21.yaml
@@ -42,7 +42,6 @@ tests:
   as: e2e-agent-compact-ipv4-iso-no-registry
   capabilities:
   - intranet
-  optional: true
   steps:
     cluster_profile: equinix-ocp-metal
     dependencies:

--- a/ci-operator/config/openshift-assisted/assisted-installer-ui/openshift-assisted-assisted-installer-ui-release-4.22.yaml
+++ b/ci-operator/config/openshift-assisted/assisted-installer-ui/openshift-assisted-assisted-installer-ui-release-4.22.yaml
@@ -43,7 +43,6 @@ tests:
   as: e2e-agent-compact-ipv4-iso-no-registry
   capabilities:
   - intranet
-  optional: true
   steps:
     cluster_profile: equinix-ocp-metal
     dependencies:

--- a/ci-operator/config/openshift-assisted/assisted-installer-ui/openshift-assisted-assisted-installer-ui-release-4.23.yaml
+++ b/ci-operator/config/openshift-assisted/assisted-installer-ui/openshift-assisted-assisted-installer-ui-release-4.23.yaml
@@ -42,7 +42,6 @@ tests:
   as: e2e-agent-compact-ipv4-iso-no-registry
   capabilities:
   - intranet
-  optional: true
   steps:
     cluster_profile: equinix-ocp-metal
     dependencies:

--- a/ci-operator/config/openshift-assisted/assisted-installer-ui/openshift-assisted-assisted-installer-ui-release-5.0.yaml
+++ b/ci-operator/config/openshift-assisted/assisted-installer-ui/openshift-assisted-assisted-installer-ui-release-5.0.yaml
@@ -42,7 +42,6 @@ tests:
   as: e2e-agent-compact-ipv4-iso-no-registry
   capabilities:
   - intranet
-  optional: true
   steps:
     cluster_profile: equinix-ocp-metal
     dependencies:

--- a/ci-operator/jobs/openshift-assisted/assisted-installer-ui/openshift-assisted-assisted-installer-ui-master-presubmits.yaml
+++ b/ci-operator/jobs/openshift-assisted/assisted-installer-ui/openshift-assisted-assisted-installer-ui-master-presubmits.yaml
@@ -17,7 +17,6 @@ presubmits:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-assisted-assisted-installer-ui-master-e2e-agent-compact-ipv4-iso-no-registry
-    optional: true
     rerun_command: /test e2e-agent-compact-ipv4-iso-no-registry
     spec:
       containers:
@@ -83,7 +82,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-agent-compact-ipv4-iso-no-registry,?($|\s.*)
+    trigger: (?m)^/test( | .* )(e2e-agent-compact-ipv4-iso-no-registry|remaining-required),?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift-assisted/assisted-installer-ui/openshift-assisted-assisted-installer-ui-release-4.21-presubmits.yaml
+++ b/ci-operator/jobs/openshift-assisted/assisted-installer-ui/openshift-assisted-assisted-installer-ui-release-4.21-presubmits.yaml
@@ -17,7 +17,6 @@ presubmits:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-assisted-assisted-installer-ui-release-4.21-e2e-agent-compact-ipv4-iso-no-registry
-    optional: true
     rerun_command: /test e2e-agent-compact-ipv4-iso-no-registry
     spec:
       containers:
@@ -83,7 +82,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-agent-compact-ipv4-iso-no-registry,?($|\s.*)
+    trigger: (?m)^/test( | .* )(e2e-agent-compact-ipv4-iso-no-registry|remaining-required),?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift-assisted/assisted-installer-ui/openshift-assisted-assisted-installer-ui-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift-assisted/assisted-installer-ui/openshift-assisted-assisted-installer-ui-release-4.22-presubmits.yaml
@@ -17,7 +17,6 @@ presubmits:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-assisted-assisted-installer-ui-release-4.22-e2e-agent-compact-ipv4-iso-no-registry
-    optional: true
     rerun_command: /test e2e-agent-compact-ipv4-iso-no-registry
     spec:
       containers:
@@ -83,7 +82,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-agent-compact-ipv4-iso-no-registry,?($|\s.*)
+    trigger: (?m)^/test( | .* )(e2e-agent-compact-ipv4-iso-no-registry|remaining-required),?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift-assisted/assisted-installer-ui/openshift-assisted-assisted-installer-ui-release-4.23-presubmits.yaml
+++ b/ci-operator/jobs/openshift-assisted/assisted-installer-ui/openshift-assisted-assisted-installer-ui-release-4.23-presubmits.yaml
@@ -17,7 +17,6 @@ presubmits:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-assisted-assisted-installer-ui-release-4.23-e2e-agent-compact-ipv4-iso-no-registry
-    optional: true
     rerun_command: /test e2e-agent-compact-ipv4-iso-no-registry
     spec:
       containers:
@@ -83,7 +82,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-agent-compact-ipv4-iso-no-registry,?($|\s.*)
+    trigger: (?m)^/test( | .* )(e2e-agent-compact-ipv4-iso-no-registry|remaining-required),?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift-assisted/assisted-installer-ui/openshift-assisted-assisted-installer-ui-release-5.0-presubmits.yaml
+++ b/ci-operator/jobs/openshift-assisted/assisted-installer-ui/openshift-assisted-assisted-installer-ui-release-5.0-presubmits.yaml
@@ -17,7 +17,6 @@ presubmits:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-assisted-assisted-installer-ui-release-5.0-e2e-agent-compact-ipv4-iso-no-registry
-    optional: true
     rerun_command: /test e2e-agent-compact-ipv4-iso-no-registry
     spec:
       containers:
@@ -83,7 +82,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-agent-compact-ipv4-iso-no-registry,?($|\s.*)
+    trigger: (?m)^/test( | .* )(e2e-agent-compact-ipv4-iso-no-registry|remaining-required),?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:


### PR DESCRIPTION
The OVE local UI and the SaaS UI currently share a unified codebase in assisted-installer-ui. Because of this shared logic, UI updates intended for SaaS could inadvertently break the automation tools built for OVE use cases. This frequently impacts the ISO No Registry jobs, leading to regressions that are often caught too late in the cycle.

Currently, the ISO No Registry job is optional. This allows breaking changes to land, causing downstream failures in OVE integration testing and delaying feature delivery.

This PR makes the ISO No Registry job a required one for the assisted-service UI.