### PR TITLE
Add network-tests and other script updates

### DIFF
--- a/ci-operator/config/rh-ecosystem-edge/openshift-dpf/.config.prowgen
+++ b/ci-operator/config/rh-ecosystem-edge/openshift-dpf/.config.prowgen
@@ -16,3 +16,4 @@ slack_reporter:
   job_names:
   - sanity
   - deploy-cluster
+  - network-tests

--- a/ci-operator/config/rh-ecosystem-edge/openshift-dpf/rh-ecosystem-edge-openshift-dpf-main.yaml
+++ b/ci-operator/config/rh-ecosystem-edge/openshift-dpf/rh-ecosystem-edge-openshift-dpf-main.yaml
@@ -16,16 +16,6 @@ resources:
       memory: 1Gi
 tests:
 - always_run: false
-  as: sanity
-  capabilities:
-  - intranet
-  cluster: build05
-  restrict_network_access: false
-  steps:
-    test:
-    - ref: dpf-hypervisor-sanity-existing
-  timeout: 1h0m0s
-- always_run: false
   as: deploy-cluster
   capabilities:
   - intranet
@@ -35,6 +25,26 @@ tests:
     test:
     - ref: dpf-hypervisor-deploy-cluster
   timeout: 6h0m0s
+- always_run: false
+  as: sanity
+  capabilities:
+  - intranet
+  cluster: build05
+  restrict_network_access: false
+  steps:
+    test:
+    - ref: dpf-hypervisor-sanity-existing
+  timeout: 2h0m0s
+- always_run: false
+  as: network-tests
+  capabilities:
+  - intranet
+  cluster: build05
+  restrict_network_access: false
+  steps:
+    test:
+    - ref: dpf-hypervisor-network-tests
+  timeout: 2h0m0s
 zz_generated_metadata:
   branch: main
   org: rh-ecosystem-edge

--- a/ci-operator/jobs/rh-ecosystem-edge/openshift-dpf/rh-ecosystem-edge-openshift-dpf-main-presubmits.yaml
+++ b/ci-operator/jobs/rh-ecosystem-edge/openshift-dpf/rh-ecosystem-edge-openshift-dpf-main-presubmits.yaml
@@ -153,11 +153,103 @@ presubmits:
     - ^main$
     - ^main-
     cluster: build05
+    context: ci/prow/network-tests
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+      timeout: 2h0m0s
+    labels:
+      capability/intranet: intranet
+      ci-operator.openshift.io/cluster: build05
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-rh-ecosystem-edge-openshift-dpf-main-network-tests
+    reporter_config:
+      slack:
+        channel: '#wg-nvidia-dpf-ci'
+        job_states_to_report:
+        - failure
+        - error
+        - aborted
+        report_template: |
+          {{if eq .Status.State "success"}}
+            :white_check_mark: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :white_check_mark:
+          {{else}}
+            :warning: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :warning:
+            {{if eq .Status.State "aborted"}}
+              The job was aborted, check for orphaned cloud resources.
+            {{end}}
+          {{end}}
+    rerun_command: /test network-tests
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --target=network-tests
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )(network-tests|remaining-required),?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build05
     context: ci/prow/sanity
     decorate: true
     decoration_config:
       skip_cloning: true
-      timeout: 1h0m0s
+      timeout: 2h0m0s
     labels:
       capability/intranet: intranet
       ci-operator.openshift.io/cluster: build05

--- a/ci-operator/step-registry/dpf/hypervisor/deploy-cluster/dpf-hypervisor-deploy-cluster-commands.sh
+++ b/ci-operator/step-registry/dpf/hypervisor/deploy-cluster/dpf-hypervisor-deploy-cluster-commands.sh
@@ -90,7 +90,12 @@ echo "Remote deployment logs directory on hypervisor: ${DEPLOYMENT_LOG}"
 
 
 # Git clone the dpf-openshift repo on hypervisor
-if ssh ${SSH_OPTS} root@${REMOTE_HOST} "ls -ltr; env; cd ${REMOTE_MAIN_WORK_DIR}; mkdir -p openshift-dpf-${datetime_string}; cd openshift-dpf-${datetime_string}; git clone -b ${OPENSHIFT_DPF_BRANCH} ${OPENSHIFT_DPF_GITHUB_REPO_URL}"; then
+if ssh ${SSH_OPTS} root@${REMOTE_HOST} "ls -ltr; \
+  env; \
+  cd ${REMOTE_MAIN_WORK_DIR}; \
+  mkdir -p openshift-dpf-${datetime_string}; \
+  cd openshift-dpf-${datetime_string}; \
+  git clone -b ${OPENSHIFT_DPF_BRANCH} ${OPENSHIFT_DPF_GITHUB_REPO_URL}"; then
   # need more checks to ensure repo was git cloned successfully
   echo "Git clone openshift-dpf repo was successful"
 else
@@ -102,11 +107,34 @@ REMOTE_WORK_DIR="${REMOTE_MAIN_WORK_DIR}/openshift-dpf-${datetime_string}"
 echo "Remote Working directory on hypervisor: ${REMOTE_WORK_DIR}"
 
 echo "Checking if github repo branch was cloned successfully"
-if ssh ${SSH_OPTS} root@${REMOTE_HOST} "ls -ltr; env; cd ${REMOTE_WORK_DIR}/openshift-dpf; git status"; then
+if ssh ${SSH_OPTS} root@${REMOTE_HOST} "ls -ltr; \
+   env; \
+   cd ${REMOTE_WORK_DIR}/openshift-dpf; \
+   git status; \
+   git log -1"; then
   echo "Git repository verified successfully"
 else
   echo "ERROR: Failed to verify git repository at ${REMOTE_WORK_DIR}/openshift-dpf"
   exit 1
+fi
+
+echo "Verify last-openshift-dpf-dir.sh file exists..."
+if ! ssh ${SSH_OPTS} root@${REMOTE_HOST} "test -f ${REMOTE_LAST_OPENSHIFT_DPF_DIR_LOCATION}"; then
+  echo "WARNING: File ${REMOTE_LAST_OPENSHIFT_DPF_DIR_LOCATION} does not exist, creating it..."
+  if ! ssh ${SSH_OPTS} root@${REMOTE_HOST} "echo 'LAST_OPENSHIFT_DPF=${REMOTE_WORK_DIR}/openshift-dpf' > ${REMOTE_LAST_OPENSHIFT_DPF_DIR_LOCATION}"; then
+    echo "ERROR: Failed to create ${REMOTE_LAST_OPENSHIFT_DPF_DIR_LOCATION}"
+    exit 1
+  fi
+  echo "File created successfully"
+else
+  echo "Update hypervisor file ${REMOTE_LAST_OPENSHIFT_DPF_DIR_LOCATION} with path to latest openshift-dpf install dir"
+  if ssh ${SSH_OPTS} root@${REMOTE_HOST} "cd ${REMOTE_MAIN_WORK_DIR}; \
+    sed -i 's|LAST_OPENSHIFT_DPF=.*|LAST_OPENSHIFT_DPF=${REMOTE_WORK_DIR}/openshift-dpf|' last-openshift-dpf-dir.sh"; then
+    echo "Updated variable LAST_OPENSHIFT_DPF with path '${REMOTE_WORK_DIR}/openshift-dpf' in hypervisor file '${REMOTE_LAST_OPENSHIFT_DPF_DIR_LOCATION}'"
+  else
+    echo "ERROR: Failed to update variable LAST_OPENSHIFT_DPF in hypervisor file '${REMOTE_LAST_OPENSHIFT_DPF_DIR_LOCATION}'"
+    exit 1
+  fi
 fi
 
 # Generate the .env file using the env.user file on hypervisor
@@ -201,24 +229,8 @@ else
   exit 1
 fi
 
-echo "Verify last-openshift-dpf-dir.sh file exists..."
-if ! ssh ${SSH_OPTS} root@${REMOTE_HOST} "test -f ${REMOTE_LAST_OPENSHIFT_DPF_DIR_LOCATION}"; then
-  echo "WARNING: File ${REMOTE_LAST_OPENSHIFT_DPF_DIR_LOCATION} does not exist, creating it..."
-  if ! ssh ${SSH_OPTS} root@${REMOTE_HOST} "echo 'LAST_OPENSHIFT_DPF=${REMOTE_WORK_DIR}/openshift-dpf' > ${REMOTE_LAST_OPENSHIFT_DPF_DIR_LOCATION}"; then
-    echo "ERROR: Failed to create ${REMOTE_LAST_OPENSHIFT_DPF_DIR_LOCATION}"
-    exit 1
-  fi
-  echo "File created successfully"
-else
-  echo "Update hypervisor file ${REMOTE_LAST_OPENSHIFT_DPF_DIR_LOCATION} with path to latest openshift-dpf install dir"
-  if ssh ${SSH_OPTS} root@${REMOTE_HOST} "cd ${REMOTE_MAIN_WORK_DIR}; \
-    sed -i 's|LAST_OPENSHIFT_DPF=.*|LAST_OPENSHIFT_DPF=${REMOTE_WORK_DIR}/openshift-dpf|' last-openshift-dpf-dir.sh"; then
-    echo "Updated variable LAST_OPENSHIFT_DPF with path '${REMOTE_WORK_DIR}/openshift-dpf' in hypervisor file '${REMOTE_LAST_OPENSHIFT_DPF_DIR_LOCATION}'"
-  else
-    echo "ERROR: Failed to update variable LAST_OPENSHIFT_DPF in hypervisor file '${REMOTE_LAST_OPENSHIFT_DPF_DIR_LOCATION}'"
-    exit 1
-  fi
-fi
+# Need basic oc commands to verify make all step passed
+
 
 #### Global comment:
 : <<'GLOBALCOMMENT'

--- a/ci-operator/step-registry/dpf/hypervisor/network-tests/OWNERS
+++ b/ci-operator/step-registry/dpf/hypervisor/network-tests/OWNERS
@@ -1,0 +1,11 @@
+approvers:
+- szigmon
+- tsorya
+- wabouhamad
+- linoyaslan
+options: {}
+reviewers:
+- szigmon
+- tsorya
+- wabouhamad
+- linoyaslan

--- a/ci-operator/step-registry/dpf/hypervisor/network-tests/dpf-hypervisor-network-tests-commands.sh
+++ b/ci-operator/step-registry/dpf/hypervisor/network-tests/dpf-hypervisor-network-tests-commands.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+set -euo pipefail
+
+# Configuration
+REMOTE_HOST="${REMOTE_HOST:-10.6.135.45}"
+
+echo "Setting up SSH access to DPF hypervisor: ${REMOTE_HOST}"
+
+# Prepare SSH key from Vault (add trailing newline if missing)
+echo "Configuring SSH private key..."
+cat /var/run/dpf-ci/private-key | base64 -d > /tmp/id_rsa
+echo "" >> /tmp/id_rsa
+chmod 600 /tmp/id_rsa
+
+# Define SSH command with explicit options (don't rely on ~/.ssh/config)
+SSH_OPTS="-i /tmp/id_rsa -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -o ConnectTimeout=30 -o ServerAliveInterval=10 -o ServerAliveCountMax=3 -o BatchMode=yes"
+
+# Test SSH connection
+echo "Testing SSH connection to ${REMOTE_HOST}..."
+if ssh ${SSH_OPTS} root@${REMOTE_HOST} echo 'SSH connection successful'; then
+    echo "SSH setup complete and tested successfully"
+else
+    echo "ERROR: Failed to connect to hypervisor ${REMOTE_HOST}"
+    echo "Debug information:"
+    echo "- Checking if SSH key exists:"
+    ls -la /tmp/id_rsa
+    echo "- Testing SSH connectivity with verbose output:"
+    ssh -v ${SSH_OPTS} root@${REMOTE_HOST} echo 'test' || true
+    exit 1
+fi
+
+# Export SSH settings for subsequent steps
+echo "REMOTE_HOST=${REMOTE_HOST}" >> ${SHARED_DIR}/dpf-env
+echo "SSH_OPTS=${SSH_OPTS}" >> ${SHARED_DIR}/dpf-env
+echo "SSH setup completed successfully for ${REMOTE_HOST}"
+
+echo "Remote host: ${REMOTE_HOST}"
+
+datetime_string=$(date +"%Y-%m-%d_%H-%M-%S")
+NETWORK_TESTS_RESULT=""
+
+# Run dpf make target checks test
+REMOTE_LAST_OPENSHIFT_DPF_DIR_LOCATION="/root/doca8/ci/last-openshift-dpf-dir.sh"
+
+echo "=== DPF Make Target checks on Existing Cluster ==="
+echo "Using openshift-dpf dir from last cluster-deploy: '${REMOTE_LAST_OPENSHIFT_DPF_DIR_LOCATION}'"
+
+echo "Updating VERIFY_DEPLOYMENT, VERIFY_MAX_RETRIES and VERIFY_SLEEP_SECONDS variable values to true, 4 and 3 respectively in .env file"
+# Using delimiter '|' since we have '/' in the patterns
+if ssh ${SSH_OPTS} root@${REMOTE_HOST} "set -e; \
+    test -f ${REMOTE_LAST_OPENSHIFT_DPF_DIR_LOCATION}; \
+    source ${REMOTE_LAST_OPENSHIFT_DPF_DIR_LOCATION}; \
+    echo \${LAST_OPENSHIFT_DPF}; \
+    cd \${LAST_OPENSHIFT_DPF}; \
+    pwd ; \
+    set -e; \
+    test -f .env ; \
+    cat .env | grep VERIFY ; \
+    cp .env .env_orig ; \
+    sed -i 's|VERIFY_DEPLOYMENT=.*|VERIFY_DEPLOYMENT=true|' .env ; \
+    sed -i 's|VERIFY_MAX_RETRIES=.*|VERIFY_MAX_RETRIES=4|' .env ; \
+    sed -i 's|VERIFY_SLEEP_SECONDS=.*|VERIFY_SLEEP_SECONDS=3|' .env ; \
+    cat .env | grep VERIFY"; then
+  echo "VERIFY_DEPLOYMENT, VERIFY_MAX_RETRIES and VERIFY_SLEEP_SECONDS variables updated successfully in .env file"
+else
+  echo "ERROR: Failed to update VERIFY_DEPLOYMENT, VERIFY_MAX_RETRIES and VERIFY_SLEEP_SECONDS variables in .env file"
+  exit 1
+fi
+
+##if ssh ${SSH_OPTS} root@${REMOTE_HOST} "
+
+if ssh ${SSH_OPTS} root@${REMOTE_HOST} "set -a; \
+    pwd; \
+    ls -ltr; \
+    env; \
+    source ${REMOTE_LAST_OPENSHIFT_DPF_DIR_LOCATION}; \
+    echo \${LAST_OPENSHIFT_DPF}; \
+    env; \
+    cd \${LAST_OPENSHIFT_DPF}; \
+    pwd; \
+    set -e;\
+    export KUBECONFIG=\${LAST_OPENSHIFT_DPF}/kubeconfig.doca8; \
+    oc get co; \
+    oc get nodes; \
+    oc get dpu -A; \
+    oc get application -A; \
+    echo \${KUBECONFIG}; \
+    ls -ltr ; \
+    make verify-workers; \
+    make verify-dpu-nodes; \
+    make verify-deployment; \
+    make verify-dpudeployment; \
+    echo \$? > verification-result"; then
+
+  echo "DPF spot check tests Passed"; 
+
+else 
+  echo "DPF spot checks tests Failed"; 
+  exit 1
+fi
+
+
+
+echo "=== Run DPF Kubernetes Traffic Flow Tests on Existing Cluster ==="
+# Run kubernetes traffic flow test
+# Need to run cmds or script on hypervisor to discover worker node names after being renamed
+if ssh ${SSH_OPTS} root@${REMOTE_HOST} "set -euo pipefail; \
+  ls -ltr; \
+  env; \
+  source ${REMOTE_LAST_OPENSHIFT_DPF_DIR_LOCATION}; \
+  echo \${LAST_OPENSHIFT_DPF}; \
+  env; \
+  cd \${LAST_OPENSHIFT_DPF}; \
+  cat .env; \
+  export TFT_SERVER_NODE=worker-303ea712f414; \
+  export TFT_CLIENT_NODE=worker-303ea712f378; \
+  make run-traffic-flow-tests 2>&1 | tee log-traffic-flow-tests-${datetime_string}"; then
+
+  echo "Kubernetes Network Traffic Flow Iperf Tests Passed";
+  NETWORK_TESTS_RESULT="PASS"
+
+else 
+  echo "Kubernetes Network Traffic Flow Iperf Tests Failed";
+
+fi
+
+echo "====== Output DPF Kubernetes Traffic Flow Tests Log file:"
+if ssh ${SSH_OPTS} root@${REMOTE_HOST} "source ${REMOTE_LAST_OPENSHIFT_DPF_DIR_LOCATION}; \
+  echo \${LAST_OPENSHIFT_DPF}; \
+  env; \
+  cd \${LAST_OPENSHIFT_DPF}; \
+  cat log-traffic-flow-tests-${datetime_string}"; then
+
+  echo "Successfully output Kubernetes Network Traffic Flow Iperf Tests logs"; 
+
+else 
+  echo "Failed to output DPF kubernetes Traffic Flow Iperf Tests logs";
+
+fi
+
+# Parse the log files, may need to scp to container running ssh cmds and process the 
+# output file and exit accordingly
+
+if [ "${NETWORK_TESTS_RESULT}" == "PASS" ]; then
+  exit 0
+fi
+
+exit 1
+

--- a/ci-operator/step-registry/dpf/hypervisor/network-tests/dpf-hypervisor-network-tests-ref.metadata.json
+++ b/ci-operator/step-registry/dpf/hypervisor/network-tests/dpf-hypervisor-network-tests-ref.metadata.json
@@ -1,0 +1,17 @@
+{
+	"path": "dpf/hypervisor/network-tests/dpf-hypervisor-network-tests-ref.yaml",
+	"owners": {
+		"approvers": [
+			"szigmon",
+			"tsorya",
+			"wabouhamad",
+			"linoyaslan"
+		],
+		"reviewers": [
+			"szigmon",
+			"tsorya",
+			"wabouhamad",
+			"linoyaslan"
+		]
+	}
+}

--- a/ci-operator/step-registry/dpf/hypervisor/network-tests/dpf-hypervisor-network-tests-ref.yaml
+++ b/ci-operator/step-registry/dpf/hypervisor/network-tests/dpf-hypervisor-network-tests-ref.yaml
@@ -1,0 +1,32 @@
+ref:
+  as: dpf-hypervisor-network-tests
+  commands: dpf-hypervisor-network-tests-commands.sh
+  credentials:
+  - mount_path: /var/run/dpf-ci
+    name: dpf-ci
+    namespace: test-credentials
+  documentation: |-
+    Run Kubernetes Network Flow tests on an EXISTING cluster without provisioning.
+
+    This step:
+    1. Sets up SSH access to hypervisor
+    2. Finds the last DPF cluster install openshift-dpf dir
+    3. Runs 'make run-traffic-flow-tests' on hypervisor
+    4. Collect and output logs from hypervisor
+
+    Use this for quick validation on doca8 or other existing clusters.
+    Does NOT create or destroy any cluster resources.
+
+    Required Vault secrets:
+    - private-key: SSH key for hypervisor
+
+    Expected duration: 60-120 minutes
+  env:
+  - default: "10.6.135.45"
+    name: REMOTE_HOST
+  from: dpf-ci
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+  timeout: 2h0m0s

--- a/ci-operator/step-registry/dpf/hypervisor/sanity-existing/dpf-hypervisor-sanity-existing-commands.sh
+++ b/ci-operator/step-registry/dpf/hypervisor/sanity-existing/dpf-hypervisor-sanity-existing-commands.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 # Configuration
 REMOTE_HOST="${REMOTE_HOST:-10.6.135.45}"
 
+# $ host api.doca8.nvidia.eng.rdu2.dc.redhat.com
+# api.doca8.nvidia.eng.rdu2.dc.redhat.com has address 10.6.135.33
+echo "Setting DOCA8 CLUSTER_API_IP to 10.6.135.33"
+CLUSTER_API_IP="10.6.135.33"
+
 echo "Setting up SSH access to DPF hypervisor: ${REMOTE_HOST}"
 
 # Prepare SSH key from Vault (add trailing newline if missing)
@@ -41,15 +46,93 @@ echo "SSH setup completed successfully for ${REMOTE_HOST}"
 echo "Remote host: ${REMOTE_HOST}"
 
 datetime_string=$(date +"%Y-%m-%d_%H-%M-%S")
-
-# Run dpf make target checks test
+SANITY_TESTS_RESULT=""
 REMOTE_LAST_OPENSHIFT_DPF_DIR_LOCATION="/root/doca8/ci/last-openshift-dpf-dir.sh"
+
+### Debug: testing scp:
+# Extract the kubeconfig from the last DPF openshift-dpf install dir on hypervisor
+echo "=== SCP the kubeconfig from the last DPF openshift-dpf install dir on hypervisor ==="
+### debug:
+
+scp ${SSH_OPTS} root@${REMOTE_HOST}:${REMOTE_LAST_OPENSHIFT_DPF_DIR_LOCATION} /tmp
+
+ls -ltr /tmp
+
+if [ -f /tmp/last-openshift-dpf-dir.sh ] ; then
+  cat /tmp/last-openshift-dpf-dir.sh
+  set -a
+  source /tmp/last-openshift-dpf-dir.sh 
+  echo "last DPF openshift-dpf dir is: '${LAST_OPENSHIFT_DPF}'"
+else
+  echo "Failed to find scp-ed file '/tmp/last-openshift-dpf-dir.sh'"
+  exit 1
+fi
+
+# scp DPF managment cluster kubeconfig from last dpf install dir
+echo "SCP DPF managment cluster kubeconfig from last dpf install dir to /tmp locally"
+
+scp ${SSH_OPTS} root@${REMOTE_HOST}:${LAST_OPENSHIFT_DPF}/kubeconfig.doca8 /tmp
+
+ls -ltr /tmp
+cp /tmp/kubeconfig.doca8 /tmp/kubeconfig.doca8_ORIG
+
+echo " Substitute the hypervisor domain name 'api.doca8.nvidia.eng.rdu2.dc.redhat.com' for cluster api ip address '${CLUSTER_API_IP}'"
+
+sed -i "s|server: https://api.doca8.nvidia.eng.rdu2.dc.redhat.com:6443|server: https://${CLUSTER_API_IP}:6443|" /tmp/kubeconfig.doca8
+
+cat /tmp/kubeconfig.doca8 | grep 6443
+
+export KUBECONFIG=/tmp/kubeconfig.doca8
+
+
+
+# Containerfile is updated in openshift-dpf to dnf install oc client, and the openshift-dpf 
+# latest main clone should be mounted in /root/dpf-ci
+echo "=== Checking if the openshift-dpf latest PR clone is mounted in /root/dpf-ci dir on this running pod"
+ls -ltr /root/dpf-ci
+
+####### Debug:
+echo "=== DEBUG:  sleeping for 20 mins in case we need to oc rhs to this pod remotely"
+sleep 1200
+
+which oc
+echo "=== Running oc commands on the DPF cluster from extracted kubeconfig"
+
+oc --insecure-skip-tls-verify=true get co
+oc --insecure-skip-tls-verify=true get nodes -o wide
+oc --insecure-skip-tls-verify=true get dpu -A
+oc --insecure-skip-tls-verify=true get dpuservice -A
+oc --insecure-skip-tls-verify=true get application -A
 
 echo "=== DPF Make Target checks on Existing Cluster ==="
 echo "Using openshift-dpf dir from last cluster-deploy: '${REMOTE_LAST_OPENSHIFT_DPF_DIR_LOCATION}'"
 
-##if ssh ${SSH_OPTS} root@${REMOTE_HOST} "
+# update the .env file to shorten the VERIFY_MAX_RETRIES and VERIFY_SLEEP_SECONDS var values
+echo "Updating VERIFY_DEPLOYMENT, VERIFY_MAX_RETRIES and VERIFY_SLEEP_SECONDS variable values to true, 4 and 3 respectively in .env file"
+# Using delimiter '|' since we have '/' in the patterns
+if ssh ${SSH_OPTS} root@${REMOTE_HOST} "set -e;\
+    source ${REMOTE_LAST_OPENSHIFT_DPF_DIR_LOCATION}; \
+    echo \${LAST_OPENSHIFT_DPF}; \
+    cd \${LAST_OPENSHIFT_DPF}; \
+    pwd ; \
+    set -e; \
+    test -f .env ; \
+    cat .env | grep VERIFY ; \
+    cp .env .env_orig ; \
+    sed -i -E 's|^VERIFY_DEPLOYMENT=.*$|VERIFY_DEPLOYMENT=true|' .env ; \
+    sed -i -E 's|^VERIFY_MAX_RETRIES=.*$|VERIFY_MAX_RETRIES=4|' .env ; \
+    sed -i -E 's|^VERIFY_SLEEP_SECONDS=.*$|VERIFY_SLEEP_SECONDS=3|' .env ; \
+    grep -qx 'VERIFY_DEPLOYMENT=true' .env ; \
+    grep -qx 'VERIFY_MAX_RETRIES=4' .env ; \
+    grep -qx 'VERIFY_SLEEP_SECONDS=3' .env ; \
+    cat .env | grep VERIFY "; then
+  echo "VERIFY_DEPLOYMENT, VERIFY_MAX_RETRIES and VERIFY_SLEEP_SECONDS variables updated successfully in .env file"
+else
+  echo "ERROR: Failed to update VERIFY_DEPLOYMENT, VERIFY_MAX_RETRIES and VERIFY_SLEEP_SECONDS variables in .env file"
+  exit 1
+fi
 
+# Run dpf make target checks test
 if ssh ${SSH_OPTS} root@${REMOTE_HOST} "set -a; \
     pwd; \
     ls -ltr; \
@@ -60,14 +143,19 @@ if ssh ${SSH_OPTS} root@${REMOTE_HOST} "set -a; \
     cd \${LAST_OPENSHIFT_DPF}; \
     pwd; \
     export KUBECONFIG=\${LAST_OPENSHIFT_DPF}/kubeconfig.doca8; \
+    oc get co; \
+    oc get nodes; \
     oc get dpu -A; \
+    oc get application -A; \
     echo \${KUBECONFIG}; \
     ls -ltr ; \
-    export VERIFY_DEPLOYMENT=true; \
+    cat .env | grep VERIFY ; \
+    set -e; \
     make verify-workers; \
     make verify-dpu-nodes; \
     make verify-deployment; \
-    make verify-dpudeployment"; then
+    make verify-dpudeployment; \
+    echo \$? > verification-result"; then
 
   echo "DPF spot check tests Passed"; 
 
@@ -76,12 +164,12 @@ else
   exit 1
 fi
 
-
 # Run dpf-sanity-checks sanity test
 echo "=== DPF Sanity Test on last Existing Cluster ==="
 echo "log file on hypervisor: log-dpf-sanity-checks-${datetime_string}"
 
-if ssh ${SSH_OPTS} root@${REMOTE_HOST} "ls -ltr; \
+if ssh ${SSH_OPTS} root@${REMOTE_HOST} "set -euo pipefail; \
+  ls -ltr; \
   env; \
   source ${REMOTE_LAST_OPENSHIFT_DPF_DIR_LOCATION}; \
   echo \${LAST_OPENSHIFT_DPF}; \
@@ -89,47 +177,49 @@ if ssh ${SSH_OPTS} root@${REMOTE_HOST} "ls -ltr; \
   cd \${LAST_OPENSHIFT_DPF}; \
   pwd; \
   cat .env; \
+  cat verification-result; \
   make run-dpf-sanity 2>&1 | tee log-dpf-sanity-checks-${datetime_string}"; then 
   
-  echo "Sanity Test Passed"; 
-  
+  # Note the above statement will return true if it get executed and even if it sanity fails
+  # Need to try a different approach to check pass/fail for sanity test
+
+  echo "Sanity Test Passed on hypervisor"; 
+  SANITY_TESTS_RESULT="PASS";
 else 
-  echo "Sanity Test Failed";
+  echo "Sanity Test Failed on hypervisor";
 
 fi
 
-## echo "====== DPF Sanity Test Log file:"
-ssh ${SSH_OPTS} root@${REMOTE_HOST} "source ${REMOTE_LAST_OPENSHIFT_DPF_DIR_LOCATION}; \
+# if this does not work, try to scp the log file to the pod and store in the $SHARED_DIR/logs or /tmp
+echo "====== Retrieving DPF Sanity Test Log file:"
+if ssh ${SSH_OPTS} root@${REMOTE_HOST} "source ${REMOTE_LAST_OPENSHIFT_DPF_DIR_LOCATION}; \
   echo \${LAST_OPENSHIFT_DPF}; \
   env; \
   cd \${LAST_OPENSHIFT_DPF}; \
-  cat log-dpf-sanity-checks-${datetime_string}"
+  cat log-dpf-sanity-checks-${datetime_string}"; then
 
-echo "=== DPF Kubernetes Traffic Flow Tests on Existing Cluster ==="
-# Run kubernetes traffic flow test
-# Need to discover worker node names after being renamed
-if ssh ${SSH_OPTS} root@${REMOTE_HOST} "ls -ltr; \
-  env; \
-  source ${REMOTE_LAST_OPENSHIFT_DPF_DIR_LOCATION}; \
-  echo \${LAST_OPENSHIFT_DPF}; \
-  env; \
-  cd \${LAST_OPENSHIFT_DPF}; \
-  cat .env; \
-  export TFT_SERVER_NODE=worker-303ea712f378 ; \
-  export TFT_CLIENT_NODE=worker-303ea712f378; \
-  make run-traffic-flow-tests 2>&1 | tee log-traffic-flow-tests-${datetime_string}"; then
-
-  echo "Kubernetes Network Traffic Flow Iperf Tests Passed"; 
-
+  echo "Successfully output Sanity Test log file"; 
+  
 else 
-  echo "Kubernetes Network Traffic Flow Iperf Tests Failed";
+  echo "Failed to output Sanity Test log file";
 
 fi
 
-echo "====== DPF Kubernetes Traffic Flow Tests Log file:"
-ssh ${SSH_OPTS} root@${REMOTE_HOST} "source ${REMOTE_LAST_OPENSHIFT_DPF_DIR_LOCATION}; \
-  echo \${LAST_OPENSHIFT_DPF}; \
-  env; \
-  cd \${LAST_OPENSHIFT_DPF}; \
-  cat log-traffic-flow-tests-${datetime_string}"
-  
+# parse sanity test file and return pass/fail
+# Add code here
+
+scp ${SSH_OPTS} root@${REMOTE_HOST}:${LAST_OPENSHIFT_DPF}/log-dpf-sanity-checks-${datetime_string} /tmp
+
+if [ -f "/tmp/log-dpf-sanity-checks-${datetime_string}" ] ; then
+  cat /tmp/log-dpf-sanity-checks-${datetime_string}
+  # add parsing logic here, look for error messages, etc.
+else
+  echo "Failed to find scp-ed file /tmp/tmp/log-dpf-sanity-checks-${datetime_string}"
+
+fi
+
+if [ "${SANITY_TESTS_RESULT}" == "PASS" ]; then
+  exit 0
+fi
+
+exit 1


### PR DESCRIPTION
Adedd network-tests and other script updates:
-  modified:   ci-operator/config/rh-ecosystem-edge/openshift-dpf/rh-ecosystem-edge-openshift-dpf-main.yaml
-  modified:   ci-operator/jobs/rh-ecosystem-edge/openshift-dpf/rh-ecosystem-edge-openshift-dpf-main-presubmits.yaml
-  modified:   ci-operator/step-registry/dpf/hypervisor/deploy-cluster/dpf-hypervisor-deploy-cluster-commands.sh
-  new file:   ci-operator/step-registry/dpf/hypervisor/network-tests/OWNERS
-  new file:   ci-operator/step-registry/dpf/hypervisor/network-tests/dpf-hypervisor-network-tests-commands.sh
-  new file:   ci-operator/step-registry/dpf/hypervisor/network-tests/dpf-hypervisor-network-tests-ref.metadata.json
-  new file:   ci-operator/step-registry/dpf/hypervisor/network-tests/dpf-hypervisor-network-tests-ref.yaml
-  modified:   ci-operator/step-registry/dpf/hypervisor/sanity-existing/dpf-hypervisor-sanity-existing-commands.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a network-tests CI job with presubmit trigger to run Kubernetes Network Flow tests and collect logs.
  * Added a deploy-cluster CI job for full cluster deployment runs.

* **Chores**
  * Slack reporting now includes network-tests alongside sanity and deploy-cluster.
  * Increased sanity timeout to 2h; set deploy-cluster timeout to 6h.
  * Added ownership/metadata for the new network-tests step.

* **Refactor**
  * Improved test sequencing and pre-checks in deployment and sanity scripts for more reliable verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->