### PR TITLE
SPLAT-2668: hypershift/aws/ccm: enable optional managed security group conformance job

### DIFF
--- a/ci-operator/config/openshift/hypershift/.config.prowgen
+++ b/ci-operator/config/openshift/hypershift/.config.prowgen
@@ -1,0 +1,16 @@
+slack_reporter:
+- channel: '#forum-ocp-splat-alerts-aws'
+  job_states_to_report:
+  - failure
+  - error
+  report_template: ':red_jenkins_circle: :aws::edge: Periodical job *{{.Spec.Job}}* ended with *{{.Status.State}}*. (<{{.Status.URL}}|View
+    logs>) (<https://prow.ci.openshift.org/job-history/gs/test-platform-results/logs/{{.Spec.Job}}|View history>)
+
+    '
+  job_names:
+  - e2e-aws-ovn-conformance-ccm
+  - e2e-aws-ovn-conformance-ccm-techpreview
+  excluded_variants:
+  - equinix-cleanup
+  - mce-multi-version
+  - okd-scos

--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.23__periodics.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.23__periodics.yaml
@@ -157,6 +157,25 @@ tests:
     env:
       PUBLIC_ONLY: "true"
     workflow: hypershift-aws-conformance
+- as: e2e-aws-ovn-conformance-ccm
+  cron: '@monthly'
+  steps:
+    cluster_profile: hypershift-aws
+    env:
+      PUBLIC_ONLY: "true"
+      TEST_SKIPS: loadbalancer NLB should be reachable with target-node-labels\|loadbalancer
+        NLB internal should be reachable with hairpinning traffic
+    workflow: hypershift-aws-conformance
+- as: e2e-aws-ovn-conformance-ccm-techpreview
+  cron: '@monthly'
+  steps:
+    cluster_profile: hypershift-aws
+    env:
+      GUEST_FEATURE_SET: TechPreviewNoUpgrade
+      PUBLIC_ONLY: "true"
+      TEST_SKIPS: loadbalancer NLB should be reachable with target-node-labels\|loadbalancer
+        NLB internal should be reachable with hairpinning traffic
+    workflow: hypershift-aws-conformance
 - as: e2e-aws-ovn-proxy-conformance
   cron: 0 3 * * *
   steps:

--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-release-5.0.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-release-5.0.yaml
@@ -362,6 +362,25 @@ tests:
     env:
       PUBLIC_ONLY: "true"
     workflow: hypershift-aws-conformance
+- as: e2e-aws-ovn-conformance-ccm
+  cron: '@monthly'
+  steps:
+    cluster_profile: hypershift-aws
+    env:
+      PUBLIC_ONLY: "true"
+      TEST_SKIPS: loadbalancer NLB should be reachable with target-node-labels\|loadbalancer
+        NLB internal should be reachable with hairpinning traffic
+    workflow: hypershift-aws-conformance
+- as: e2e-aws-ovn-conformance-ccm-techpreview
+  cron: '@monthly'
+  steps:
+    cluster_profile: hypershift-aws
+    env:
+      GUEST_FEATURE_SET: TechPreviewNoUpgrade
+      PUBLIC_ONLY: "true"
+      TEST_SKIPS: loadbalancer NLB should be reachable with target-node-labels\|loadbalancer
+        NLB internal should be reachable with hairpinning traffic
+    workflow: hypershift-aws-conformance
 - always_run: false
   as: e2e-azure-kubevirt-ovn
   optional: true

--- a/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.23-periodics.yaml
+++ b/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.23-periodics.yaml
@@ -666,6 +666,188 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build07
+  cron: '@monthly'
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: release-4.23
+    org: openshift
+    repo: hypershift
+  labels:
+    ci-operator.openshift.io/cloud: hypershift-aws
+    ci-operator.openshift.io/cloud-cluster-profile: hypershift-aws
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "4.23"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-hypershift-release-4.23-periodics-e2e-aws-ovn-conformance-ccm
+  reporter_config:
+    slack:
+      channel: '#forum-ocp-splat-alerts-aws'
+      job_states_to_report:
+      - failure
+      - error
+      report_template: |
+        :red_jenkins_circle: :aws::edge: Periodical job *{{.Spec.Job}}* ended with *{{.Status.State}}*. (<{{.Status.URL}}|View logs>) (<https://prow.ci.openshift.org/job-history/gs/test-platform-results/logs/{{.Spec.Job}}|View history>)
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-aws-ovn-conformance-ccm
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build07
+  cron: '@monthly'
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: release-4.23
+    org: openshift
+    repo: hypershift
+  labels:
+    ci-operator.openshift.io/cloud: hypershift-aws
+    ci-operator.openshift.io/cloud-cluster-profile: hypershift-aws
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "4.23"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-hypershift-release-4.23-periodics-e2e-aws-ovn-conformance-ccm-techpreview
+  reporter_config:
+    slack:
+      channel: '#forum-ocp-splat-alerts-aws'
+      job_states_to_report:
+      - failure
+      - error
+      report_template: |
+        :red_jenkins_circle: :aws::edge: Periodical job *{{.Spec.Job}}* ended with *{{.Status.State}}*. (<{{.Status.URL}}|View logs>) (<https://prow.ci.openshift.org/job-history/gs/test-platform-results/logs/{{.Spec.Job}}|View history>)
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-aws-ovn-conformance-ccm-techpreview
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build07
   cron: 0 1 * * *
   decorate: true
   decoration_config:

--- a/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-5.0-periodics.yaml
+++ b/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-5.0-periodics.yaml
@@ -1,6 +1,200 @@
 periodics:
 - agent: kubernetes
   cluster: build07
+  cron: '@monthly'
+  decorate: true
+  decoration_config:
+    sparse_checkout_files:
+    - .ci-operator.yaml
+    - Dockerfile
+    - Dockerfile.control-plane
+    - Dockerfile.e2e
+  extra_refs:
+  - base_ref: release-5.0
+    org: openshift
+    repo: hypershift
+    sparse_checkout_files:
+    - .ci-operator.yaml
+    - Dockerfile
+    - Dockerfile.control-plane
+    - Dockerfile.e2e
+  labels:
+    ci-operator.openshift.io/cloud: hypershift-aws
+    ci-operator.openshift.io/cloud-cluster-profile: hypershift-aws
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-hypershift-release-5.0-e2e-aws-ovn-conformance-ccm
+  reporter_config:
+    slack:
+      channel: '#forum-ocp-splat-alerts-aws'
+      job_states_to_report:
+      - failure
+      - error
+      report_template: |
+        :red_jenkins_circle: :aws::edge: Periodical job *{{.Spec.Job}}* ended with *{{.Status.State}}*. (<{{.Status.URL}}|View logs>) (<https://prow.ci.openshift.org/job-history/gs/test-platform-results/logs/{{.Spec.Job}}|View history>)
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-aws-ovn-conformance-ccm
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build07
+  cron: '@monthly'
+  decorate: true
+  decoration_config:
+    sparse_checkout_files:
+    - .ci-operator.yaml
+    - Dockerfile
+    - Dockerfile.control-plane
+    - Dockerfile.e2e
+  extra_refs:
+  - base_ref: release-5.0
+    org: openshift
+    repo: hypershift
+    sparse_checkout_files:
+    - .ci-operator.yaml
+    - Dockerfile
+    - Dockerfile.control-plane
+    - Dockerfile.e2e
+  labels:
+    ci-operator.openshift.io/cloud: hypershift-aws
+    ci-operator.openshift.io/cloud-cluster-profile: hypershift-aws
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-hypershift-release-5.0-e2e-aws-ovn-conformance-ccm-techpreview
+  reporter_config:
+    slack:
+      channel: '#forum-ocp-splat-alerts-aws'
+      job_states_to_report:
+      - failure
+      - error
+      report_template: |
+        :red_jenkins_circle: :aws::edge: Periodical job *{{.Spec.Job}}* ended with *{{.Status.State}}*. (<{{.Status.URL}}|View logs>) (<https://prow.ci.openshift.org/job-history/gs/test-platform-results/logs/{{.Spec.Job}}|View history>)
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-aws-ovn-conformance-ccm-techpreview
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build07
   cron: 53 9,21 * * *
   decorate: true
   decoration_config:


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                                                                                
                            
  Add monthly periodic jobs to validate the AWS CCM managed security group feature                                                                                                                                                                                                          
  (`AWSServiceLBNetworkSecurityGroup`) on HyperShift for 4.23 and 5.0.
                                                                                                                                                                                                                                                                                            
  ## Changes                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                            
  - **Periodics (release-4.23 and release-5.0)**: Two monthly jobs each:                                                                                                                                                                                                                    
    - `e2e-aws-ovn-conformance-ccm` — conformance with managed SG enabled
    - `e2e-aws-ovn-conformance-ccm-techpreview` — same with `TechPreviewNoUpgrade`                                                                                                                                                                                                          
    - Both use `hypershift-aws-conformance` workflow with `TEST_SKIPS` adjusted                                                                                                                                                                                                             
      to include NLB security group tests                                                                                                                                                                                                                                                   
  - **Slack alerts**: Failure/error notifications to `#forum-ocp-splat-alerts-aws`                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                            
  ## Context                
                                                                                                                                                                                                                                                                                            
  Dedicated jobs to validate CCM managed SG on HyperShift without disrupting                                                                                                                                                                                                                
  existing monitoring. Once the feature is stable, these will be removed and the
  `AWSServiceLBNetworkSecurityGroup` skip reverted from baseline conformance.                                                                                                                                                                                                               
                                                                                                                                 