### PR TITLE
Add apollo-ci 0.5.7 image mirrors for stackrox for UBI9

### DIFF
--- a/core-services/image-mirroring/_config.yaml
+++ b/core-services/image-mirroring/_config.yaml
@@ -727,6 +727,8 @@ supplementalCIImages:
     image: quay.io/stackrox-io/apollo-ci:scanner-test-0.5.5
   stackrox/apollo-ci:scanner-test-0.5.6:
     image: quay.io/stackrox-io/apollo-ci:scanner-test-0.5.6
+  stackrox/apollo-ci:scanner-test-0.5.7:
+    image: quay.io/stackrox-io/apollo-ci:scanner-test-0.5.7
   stackrox/apollo-ci:stackrox-test-0.3.57.1:
     image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.57.1
   stackrox/apollo-ci:stackrox-test-0.3.59.1:
@@ -763,6 +765,8 @@ supplementalCIImages:
     image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.5
   stackrox/apollo-ci:stackrox-test-0.5.6:
     image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.6
+  stackrox/apollo-ci:stackrox-test-0.5.7:
+    image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.7
   stackrox/apollo-ci:stackrox-ui-test-0.4.2:
     image: quay.io/stackrox-io/apollo-ci:stackrox-ui-test-0.4.2
   stackrox/apollo-ci:stackrox-ui-test-0.4.3:

--- a/core-services/image-mirroring/_config.yaml
+++ b/core-services/image-mirroring/_config.yaml
@@ -725,6 +725,8 @@ supplementalCIImages:
     image: quay.io/stackrox-io/apollo-ci:scanner-test-0.5.2
   stackrox/apollo-ci:scanner-test-0.5.5:
     image: quay.io/stackrox-io/apollo-ci:scanner-test-0.5.5
+  stackrox/apollo-ci:scanner-test-0.5.6:
+    image: quay.io/stackrox-io/apollo-ci:scanner-test-0.5.6
   stackrox/apollo-ci:stackrox-test-0.3.57.1:
     image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.57.1
   stackrox/apollo-ci:stackrox-test-0.3.59.1:
@@ -759,6 +761,8 @@ supplementalCIImages:
     image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.2
   stackrox/apollo-ci:stackrox-test-0.5.5:
     image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.5
+  stackrox/apollo-ci:stackrox-test-0.5.6:
+    image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.6
   stackrox/apollo-ci:stackrox-ui-test-0.4.2:
     image: quay.io/stackrox-io/apollo-ci:stackrox-ui-test-0.4.2
   stackrox/apollo-ci:stackrox-ui-test-0.4.3:
@@ -779,6 +783,8 @@ supplementalCIImages:
     image: quay.io/stackrox-io/apollo-ci:stackrox-ui-test-0.5.2
   stackrox/apollo-ci:stackrox-ui-test-0.5.5:
     image: quay.io/stackrox-io/apollo-ci:stackrox-ui-test-0.5.5
+  stackrox/apollo-ci:stackrox-ui-test-0.5.6:
+    image: quay.io/stackrox-io/apollo-ci:stackrox-ui-test-0.5.6
   stackrox/apollo-ci:stackrox-ui-test-0.5.7:
     image: quay.io/stackrox-io/apollo-ci:stackrox-ui-test-0.5.7
   coreos/stream-coreos-base:9:


### PR DESCRIPTION
## Summary
- Add mirror entries for `scanner-test-0.5.7` and `stackrox-test-0.5.7` apollo-ci images
- These images include the UBI 9 upgrade from [stackrox/rox-ci-image#234](https://github.com/stackrox/rox-ci-image/pull/234)

⭐ bumped to 0.5.7 to also include the helm update upgraded for stackrox-ui-test in https://github.com/openshift/release/pull/77580

🤖 Generated with [Claude Code](https://claude.com/claude-code)