### PR TITLE
Bump StackRox apollo-ci for stackrox master/nightlies to 0.5.7

### DIFF
--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master.yaml
@@ -31,7 +31,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: stackrox-ui-test-0.5.5
+    tag: stackrox-ui-test-0.5.6
 releases:
   latest:
     release:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master.yaml
@@ -31,7 +31,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: stackrox-ui-test-0.5.6
+    tag: stackrox-ui-test-0.5.7
 releases:
   latest:
     release:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4-12.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4-12.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: stackrox-ui-test-0.5.5
+    tag: stackrox-ui-test-0.5.6
 resources:
   '*':
     requests:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4-12.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4-12.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: stackrox-ui-test-0.5.6
+    tag: stackrox-ui-test-0.5.7
 resources:
   '*':
     requests:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4-14-lp-interop.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4-14-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: stackrox-ui-test-0.5.5
+    tag: stackrox-ui-test-0.5.6
 releases:
   latest:
     candidate:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4-14-lp-interop.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4-14-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: stackrox-ui-test-0.5.6
+    tag: stackrox-ui-test-0.5.7
 releases:
   latest:
     candidate:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4-15-lp-interop.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4-15-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: stackrox-ui-test-0.5.5
+    tag: stackrox-ui-test-0.5.6
 releases:
   latest:
     candidate:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4-15-lp-interop.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4-15-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: stackrox-ui-test-0.5.6
+    tag: stackrox-ui-test-0.5.7
 releases:
   latest:
     candidate:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4-16-lp-interop.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4-16-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: stackrox-ui-test-0.5.5
+    tag: stackrox-ui-test-0.5.6
 releases:
   latest:
     candidate:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4-16-lp-interop.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4-16-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: stackrox-ui-test-0.5.6
+    tag: stackrox-ui-test-0.5.7
 releases:
   latest:
     candidate:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4-17-lp-interop.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4-17-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: stackrox-ui-test-0.5.6
+    tag: stackrox-ui-test-0.5.7
 releases:
   latest:
     prerelease:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4-17-lp-interop.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4-17-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: stackrox-ui-test-0.5.5
+    tag: stackrox-ui-test-0.5.6
 releases:
   latest:
     prerelease:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4-18-lp-interop.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4-18-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: stackrox-ui-test-0.5.6
+    tag: stackrox-ui-test-0.5.7
 releases:
   latest:
     prerelease:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4-18-lp-interop.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4-18-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: stackrox-ui-test-0.5.5
+    tag: stackrox-ui-test-0.5.6
 releases:
   latest:
     prerelease:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4-19-lp-interop.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4-19-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: stackrox-ui-test-0.5.5
+    tag: stackrox-ui-test-0.5.6
 releases:
   latest:
     candidate:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4-19-lp-interop.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4-19-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: stackrox-ui-test-0.5.6
+    tag: stackrox-ui-test-0.5.7
 releases:
   latest:
     candidate:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4-20-lp-interop.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4-20-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: stackrox-ui-test-0.5.5
+    tag: stackrox-ui-test-0.5.6
 releases:
   latest:
     candidate:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4-20-lp-interop.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4-20-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: stackrox-ui-test-0.5.6
+    tag: stackrox-ui-test-0.5.7
 releases:
   latest:
     candidate:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4-21-lp-interop.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4-21-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: stackrox-ui-test-0.5.5
+    tag: stackrox-ui-test-0.5.6
 releases:
   latest:
     candidate:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4-21-lp-interop.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4-21-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: stackrox-ui-test-0.5.6
+    tag: stackrox-ui-test-0.5.7
 releases:
   latest:
     candidate:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4-21.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4-21.yaml
@@ -11,7 +11,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: stackrox-ui-test-0.5.5
+    tag: stackrox-ui-test-0.5.6
 resources:
   '*':
     requests:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4-21.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4-21.yaml
@@ -11,7 +11,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: stackrox-ui-test-0.5.6
+    tag: stackrox-ui-test-0.5.7
 resources:
   '*':
     requests:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4.21-lp-interop-cr-acs-latest.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4.21-lp-interop-cr-acs-latest.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: stackrox-ui-test-0.5.5
+    tag: stackrox-ui-test-0.5.6
 releases:
   latest:
     candidate:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4.21-lp-interop-cr-acs-latest.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4.21-lp-interop-cr-acs-latest.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: stackrox-ui-test-0.5.6
+    tag: stackrox-ui-test-0.5.7
 releases:
   latest:
     candidate:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4.22-lp-interop-acs-latest.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4.22-lp-interop-acs-latest.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: stackrox-ui-test-0.5.5
+    tag: stackrox-ui-test-0.5.6
 releases:
   latest:
     candidate:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4.22-lp-interop-acs-latest.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4.22-lp-interop-acs-latest.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: stackrox-ui-test-0.5.6
+    tag: stackrox-ui-test-0.5.7
 releases:
   latest:
     candidate:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-dev-preview.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-dev-preview.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: stackrox-ui-test-0.5.5
+    tag: stackrox-ui-test-0.5.6
 resources:
   '*':
     requests:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-dev-preview.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-dev-preview.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: stackrox-ui-test-0.5.6
+    tag: stackrox-ui-test-0.5.7
 resources:
   '*':
     requests:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-next-candidate.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-next-candidate.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: stackrox-ui-test-0.5.5
+    tag: stackrox-ui-test-0.5.6
 resources:
   '*':
     requests:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-next-candidate.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-next-candidate.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: stackrox-ui-test-0.5.6
+    tag: stackrox-ui-test-0.5.7
 resources:
   '*':
     requests:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-stable-scanner-v4-install.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-stable-scanner-v4-install.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: stackrox-ui-test-0.5.5
+    tag: stackrox-ui-test-0.5.6
 resources:
   '*':
     requests:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-stable-scanner-v4-install.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-stable-scanner-v4-install.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: stackrox-ui-test-0.5.6
+    tag: stackrox-ui-test-0.5.7
 resources:
   '*':
     requests:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-nightlies.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-nightlies.yaml
@@ -27,7 +27,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: stackrox-ui-test-0.5.6
+    tag: stackrox-ui-test-0.5.7
 resources:
   '*':
     requests:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-nightlies.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-nightlies.yaml
@@ -27,7 +27,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: stackrox-ui-test-0.5.5
+    tag: stackrox-ui-test-0.5.6
 resources:
   '*':
     requests:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-nightlies__ocp-4-12.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-nightlies__ocp-4-12.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: stackrox-ui-test-0.5.5
+    tag: stackrox-ui-test-0.5.6
 resources:
   '*':
     requests:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-nightlies__ocp-4-12.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-nightlies__ocp-4-12.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: stackrox-ui-test-0.5.6
+    tag: stackrox-ui-test-0.5.7
 resources:
   '*':
     requests:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-nightlies__ocp-4-19.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-nightlies__ocp-4-19.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: stackrox-ui-test-0.5.5
+    tag: stackrox-ui-test-0.5.6
 releases:
   latest:
     candidate:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-nightlies__ocp-4-19.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-nightlies__ocp-4-19.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: stackrox-ui-test-0.5.6
+    tag: stackrox-ui-test-0.5.7
 releases:
   latest:
     candidate:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-nightlies__ocp-4-21.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-nightlies__ocp-4-21.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: stackrox-ui-test-0.5.5
+    tag: stackrox-ui-test-0.5.6
 resources:
   '*':
     requests:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-nightlies__ocp-4-21.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-nightlies__ocp-4-21.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: stackrox-ui-test-0.5.6
+    tag: stackrox-ui-test-0.5.7
 resources:
   '*':
     requests:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-nightlies__perf-scale.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-nightlies__perf-scale.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: stackrox-ui-test-0.5.5
+    tag: stackrox-ui-test-0.5.6
 releases:
   latest:
     release:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-nightlies__perf-scale.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-nightlies__perf-scale.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: stackrox-ui-test-0.5.6
+    tag: stackrox-ui-test-0.5.7
 releases:
   latest:
     release:


### PR DESCRIPTION
Blocked by:
- https://github.com/openshift/release/pull/77580