### PR TITLE
Add must-gather post step to amd-gpu-operator-e2e workflow

### DIFF
--- a/ci-operator/step-registry/amd-gpu-operator/e2e/amd-gpu-operator-e2e-workflow.yaml
+++ b/ci-operator/step-registry/amd-gpu-operator/e2e/amd-gpu-operator-e2e-workflow.yaml
@@ -10,5 +10,6 @@ workflow:
     test:
     - ref: amd-gpu-operator-test
     post:
+    - ref: amd-gpu-operator-must-gather
     - ref: amd-gpu-operator-deprovision
 

--- a/ci-operator/step-registry/amd-gpu-operator/must-gather/OWNERS
+++ b/ci-operator/step-registry/amd-gpu-operator/must-gather/OWNERS
@@ -1,0 +1,11 @@
+approvers:
+- aopincar
+- ggordanired
+- natalishemtov
+- tomernewman
+options: {}
+reviewers:
+- aopincar
+- ggordanired
+- natalishemtov
+- tomernewman

--- a/ci-operator/step-registry/amd-gpu-operator/must-gather/amd-gpu-operator-must-gather-commands.sh
+++ b/ci-operator/step-registry/amd-gpu-operator/must-gather/amd-gpu-operator-must-gather-commands.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+set -euo pipefail
+
+# Setup SSH key (add trailing newline if missing - Vault sync strips it)
+cat /var/run/amd-ci/id_rsa > /tmp/id_rsa
+echo "" >> /tmp/id_rsa
+chmod 600 /tmp/id_rsa
+mkdir -p ~/.ssh
+cat > ~/.ssh/config <<EOF
+Host ${REMOTE_HOST}
+    User root
+    IdentityFile /tmp/id_rsa
+    StrictHostKeyChecking no
+    UserKnownHostsFile /dev/null
+    LogLevel ERROR
+    ConnectTimeout 30
+    ServerAliveInterval 10
+    ServerAliveCountMax 3
+    BatchMode yes
+EOF
+chmod 600 ~/.ssh/config
+
+CONFIG_FILE=/tmp/cluster-config.yaml
+cat > "${CONFIG_FILE}" <<EOF
+ocp_version: "${OCP_CLUSTER_VERSION}"
+pull_secret_path: /var/run/amd-ci/pull-secret
+
+cluster_name: ${CLUSTER_NAME:-ocp}
+domain: ${CLUSTER_DOMAIN:-example.com}
+ctlplanes: ${CTLPLANES:-1}
+workers: ${WORKERS:-0}
+
+ctlplane:
+  numcpus: ${CTLPLANE_CPUS:-6}
+  memory: ${CTLPLANE_MEMORY:-18432}
+
+worker:
+  numcpus: ${WORKER_CPUS:-4}
+  memory: ${WORKER_MEMORY:-16384}
+
+disk_size: ${DISK_SIZE:-120}
+network: ${NETWORK:-default}
+api_ip: "${API_IP:-192.168.122.253}"
+
+remote:
+  host: "${REMOTE_HOST}"
+  user: root
+  ssh_key_path: /tmp/id_rsa
+
+pci_devices: []
+wait_timeout: ${WAIT_TIMEOUT:-3600}
+no_wait: false
+version_channel: ${VERSION_CHANNEL:-stable}
+
+operators:
+  install: false
+  gpu_operator_version: "${GPU_OPERATOR_VERSION:-1.4}"
+  machine_config_role: worker
+  driver_version: "30.20.1"
+  enable_metrics: true
+
+must_gather:
+  artifact_dir: "${ARTIFACT_DIR}/must-gather"
+EOF
+
+echo "Generated cluster config:"
+cat "${CONFIG_FILE}"
+
+echo "Running must-gather..."
+make must-gather CONFIG_FILE_PATH="${CONFIG_FILE}"

--- a/ci-operator/step-registry/amd-gpu-operator/must-gather/amd-gpu-operator-must-gather-ref.metadata.json
+++ b/ci-operator/step-registry/amd-gpu-operator/must-gather/amd-gpu-operator-must-gather-ref.metadata.json
@@ -1,0 +1,17 @@
+{
+	"path": "amd-gpu-operator/must-gather/amd-gpu-operator-must-gather-ref.yaml",
+	"owners": {
+		"approvers": [
+			"aopincar",
+			"ggordanired",
+			"natalishemtov",
+			"tomernewman"
+		],
+		"reviewers": [
+			"aopincar",
+			"ggordanired",
+			"natalishemtov",
+			"tomernewman"
+		]
+	}
+}

--- a/ci-operator/step-registry/amd-gpu-operator/must-gather/amd-gpu-operator-must-gather-ref.yaml
+++ b/ci-operator/step-registry/amd-gpu-operator/must-gather/amd-gpu-operator-must-gather-ref.yaml
@@ -1,0 +1,26 @@
+ref:
+  as: amd-gpu-operator-must-gather
+  from: amd-ci
+  best_effort: true
+  timeout: 900s
+  commands: amd-gpu-operator-must-gather-commands.sh
+  credentials:
+  - namespace: test-credentials
+    name: amd-ci-credentials
+    mount_path: /var/run/amd-ci
+  env:
+  - name: HOME
+    default: /alabama
+  - name: OCP_CLUSTER_VERSION
+    documentation: OpenShift version used for deployment
+  - name: GPU_OPERATOR_VERSION
+    default: "1.4"
+    documentation: AMD GPU Operator minor version (e.g. "1.3", "1.4"); resolves to latest patch via GitHub API
+  resources:
+    requests:
+      cpu: 2000m
+      memory: 2Gi
+  documentation: |-
+    Collects must-gather diagnostic data (NFD, AMD GPU Operator, KMM) from a
+    remote OpenShift cluster provisioned by the amd-ci provisioner. Results are
+    saved to $ARTIFACT_DIR for CI artifact archival.


### PR DESCRIPTION
Collect NFD, AMD GPU Operator, and KMM diagnostic data after each test run before the cluster is deprovisioned.
The step is marked best_effort so a gather failure does not block cleanup.

/cc @ggordaniRed 