### PR TITLE
NO-ISSUE: Update cron and remove arm64 payload

### DIFF
--- a/ci-operator/config/openshift/insights-operator/openshift-insights-operator-release-4.22__periodics.yaml
+++ b/ci-operator/config/openshift/insights-operator/openshift-insights-operator-release-4.22__periodics.yaml
@@ -14,14 +14,9 @@ base_images:
 build_root:
   from_repository: true
 releases:
-  arm64-latest:
-    candidate:
-      architecture: arm64
-      product: ocp
-      stream: nightly
-      version: "4.22"
   latest:
     candidate:
+      architecture: amd64
       product: ocp
       stream: nightly
       version: "4.22"
@@ -365,7 +360,7 @@ tests:
 - as: e2e-metal-techpreview-ipv4-ipi
   capabilities:
   - intranet
-  cron: 0 0 * * *
+  cron: 30 4 * * *
   steps:
     cluster_profile: equinix-ocp-metal-qe
     env:

--- a/ci-operator/jobs/openshift/insights-operator/openshift-insights-operator-release-4.22-periodics.yaml
+++ b/ci-operator/jobs/openshift/insights-operator/openshift-insights-operator-release-4.22-periodics.yaml
@@ -649,7 +649,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 0 0 * * *
+  cron: 30 4 * * *
   decorate: true
   extra_refs:
   - base_ref: release-4.22


### PR DESCRIPTION
Changed the job execution time to make sure it runs when resources are expected to be available and removed arm64 payload as no job is requires it.