### PR TITLE
Make CodeRabbit a required check for openshift/origin

### DIFF
--- a/core-services/prow/02_config/openshift/origin/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/origin/_prowconfig.yaml
@@ -1,3 +1,14 @@
+branch-protection:
+  orgs:
+    openshift:
+      repos:
+        origin:
+          branches:
+            main:
+              protect: true
+              required_status_checks:
+                contexts:
+                - CodeRabbit
 tide:
   queries:
   - includedBranches:


### PR DESCRIPTION
## Summary
- Adds branch-protection configuration to require the `CodeRabbit` status check on the `main` branch of `openshift/origin` before merging
- Uses the same pattern as `openshift-eng/ai-helpers` for requiring external GitHub Action checks
- Tide picks this up automatically via `from-branch-protection: true`

## Test plan
- [ ] Verify prow config validation passes
- [ ] Confirm CodeRabbit check appears as required on a test PR to openshift/origin main

🤖 Generated with [Claude Code](https://claude.com/claude-code)