### PR TITLE
CNTRLPLANE-3198: Extend Azure self-managed e2e test coverage

### DIFF
--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-main.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-main.yaml
@@ -219,7 +219,7 @@ tests:
       OCP_IMAGE_N1: release:n1minor
       OCP_IMAGE_N2: release:n2minor
     env:
-      CI_TESTS_RUN: ^(TestCreateCluster|TestAzurePrivateTopology|TestAzureOAuthLoadBalancer)$
+      CI_TESTS_RUN: ^(TestCreateCluster$|TestAutoscaling|TestNodePool|TestUpgradeControlPlane|TestHAEtcdChaos|TestAzureOAuthLoadBalancer|TestAzurePrivateTopology)$
       ENABLE_HYPERSHIFT_CERT_ROTATION_SCALE: "true"
       HYPERSHIFT_AZURE_LOCATION: centralus
     post:

--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.23.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.23.yaml
@@ -212,7 +212,7 @@ tests:
       OCP_IMAGE_N1: release:n1minor
       OCP_IMAGE_N2: release:n2minor
     env:
-      CI_TESTS_RUN: ^(TestCreateCluster|TestAzurePrivateTopology|TestAzureOAuthLoadBalancer)$
+      CI_TESTS_RUN: ^(TestCreateCluster$|TestAutoscaling|TestNodePool|TestUpgradeControlPlane|TestHAEtcdChaos|TestAzureOAuthLoadBalancer|TestAzurePrivateTopology)$
       ENABLE_HYPERSHIFT_CERT_ROTATION_SCALE: "true"
       HYPERSHIFT_AZURE_LOCATION: centralus
     post:

--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-release-5.0.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-release-5.0.yaml
@@ -212,7 +212,7 @@ tests:
       OCP_IMAGE_N1: release:n1minor
       OCP_IMAGE_N2: release:n2minor
     env:
-      CI_TESTS_RUN: ^(TestCreateCluster|TestAzurePrivateTopology|TestAzureOAuthLoadBalancer)$
+      CI_TESTS_RUN: ^(TestCreateCluster$|TestAutoscaling|TestNodePool|TestUpgradeControlPlane|TestHAEtcdChaos|TestAzureOAuthLoadBalancer|TestAzurePrivateTopology)$
       ENABLE_HYPERSHIFT_CERT_ROTATION_SCALE: "true"
       HYPERSHIFT_AZURE_LOCATION: centralus
     post:

--- a/ci-operator/step-registry/hypershift/setup-nested-management-cluster/hypershift-setup-nested-management-cluster-chain.yaml
+++ b/ci-operator/step-registry/hypershift/setup-nested-management-cluster/hypershift-setup-nested-management-cluster-chain.yaml
@@ -46,7 +46,7 @@ chain:
         export KUBECONFIG=/etc/hypershift-kubeconfig-azure/hypershift-ops-admin.kubeconfig
         AZURE_GUEST_INFRA_CREDENTIALS_FILE="/etc/hypershift-ci-jobs-self-managed-azure/credentials.json"
         DEFAULT_BASE_DOMAIN=hcp-sm-azure.azure.devcluster.openshift.com
-        HYPERSHIFT_INSTANCE_TYPE=Standard_D4s_v4
+        HYPERSHIFT_INSTANCE_TYPE=Standard_D16s_v3
         HYPERSHIFT_AZURE_LOCATION=${HYPERSHIFT_AZURE_LOCATION:-centralus}
       else
         AWS_GUEST_INFRA_CREDENTIALS_FILE="/etc/hypershift-ci-jobs-awscreds/credentials"
@@ -61,7 +61,7 @@ chain:
 
       DOMAIN=${HYPERSHIFT_BASE_DOMAIN:-$DEFAULT_BASE_DOMAIN}
       DEFAULT_RELEASE_STREAM=4-stable
-      HYPERSHIFT_HC_RELEASE_IMAGE=${HYPERSHIFT_HC_RELEASE_IMAGE:-quay.io/openshift-release-dev/ocp-release:4.22.0-ec.1-multi}
+      HYPERSHIFT_HC_RELEASE_IMAGE=${HYPERSHIFT_HC_RELEASE_IMAGE:-quay.io/openshift-release-dev/ocp-release:4.22.0-ec.3-multi}
 
       CLUSTER_NAME="$(echo -n $PROW_JOB_ID|sha256sum|cut -c-10)-mgmt"
 


### PR DESCRIPTION
## Summary
- Expand `CI_TESTS_RUN` for `e2e-azure-self-managed` to add 4 new tests beyond the original 3, extending parity with AWS self-managed (`e2e-aws`)
- Increase Azure mgmt cluster VM to `Standard_D16s_v3` (16 vCPUs) for capacity parity with AWS `m6i.4xlarge`
- Update nested management cluster release image to `4.22.0-ec.3-multi` (workload identity support)
- Applied to main, release-4.23, and release-5.0 configs

## Tests Now Covered
Previously only 3 tests ran. This PR adds 4 more:

| Test | Status |
|------|--------|
| TestCreateCluster | **existing** |
| TestAzureOAuthLoadBalancer | **existing** |
| TestAzurePrivateTopology | **existing** |
| TestAutoscaling | **new** |
| TestNodePool | **new** |
| TestUpgradeControlPlane | **new** |
| TestHAEtcdChaos | **new** |

## Known Failing Tests (tracked separately in [CNTRLPLANE-3198](https://redhat.atlassian.net/browse/CNTRLPLANE-3198))
- TestAzureScheduler/Main — scheduler test logic failure (HC validates successfully)
- TestCreateClusterDefaultSecurityContextUID — SCC UID annotation missing on namespace

## Test plan
- [x] Rehearsal job `pull-ci-openshift-hypershift-main-e2e-azure-self-managed` passes with all 7 tests
- [ ] Investigate TestAzureScheduler/Main failure separately
- [ ] Investigate TestCreateClusterDefaultSecurityContextUID failure separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CNTRLPLANE-3198]: https://redhat.atlassian.net/browse/CNTRLPLANE-3198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ