### PR TITLE
CNTRLPLANE-3197 (hypershift): fix image refs in 4.22 presubmits

### DIFF
--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.22.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.22.yaml
@@ -35,11 +35,7 @@ images:
     to: hypershift-tests
 promotion:
   to:
-  - disabled: true
-    excluded_images:
-    - hypershift-operator
-    - hypershift-tests
-    name: "4.22"
+  - name: "4.22"
     namespace: ocp
 releases:
   initial:
@@ -63,47 +59,47 @@ releases:
     candidate:
       product: ocp
       stream: ci
-      version: "4.22"
+      version: "4.17"
   latest-418:
     candidate:
       product: ocp
       stream: ci
-      version: "4.22"
+      version: "4.18"
   latest-419:
     candidate:
       product: ocp
       stream: ci
-      version: "4.22"
+      version: "4.19"
   latest-420:
     candidate:
       product: ocp
       stream: ci
-      version: "4.22"
+      version: "4.20"
   latest-421:
     candidate:
       product: ocp
       stream: ci
-      version: "4.22"
+      version: "4.21"
   n1minor:
     candidate:
       product: ocp
       stream: ci
-      version: "4.22"
+      version: "4.21"
   n2minor:
     candidate:
       product: ocp
       stream: ci
-      version: "4.22"
+      version: "4.20"
   n3minor:
     candidate:
       product: ocp
       stream: ci
-      version: "4.22"
+      version: "4.19"
   n4minor:
     candidate:
       product: ocp
       stream: ci
-      version: "4.22"
+      version: "4.18"
 resources:
   '*':
     limits:


### PR DESCRIPTION
Correct all the back-release refs to be appropriate for 4.22.