### PR TITLE
SREP-4345: Skip flaky conformance tests, add daily status job, stagger nightly crons

### DIFF
--- a/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main.yaml
+++ b/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main.yaml
@@ -40,6 +40,33 @@ tests:
     make lint
   container:
     from: src
+- as: rosa-ci-daily-status
+  commands: |
+    #!/bin/bash
+    set -euo pipefail
+    SIPPY_API="https://sippy.dptools.openshift.org/api/jobs"
+    RELEASE="rosa-stage"
+    echo "Querying Sippy for ${RELEASE} job results..."
+    response=$(curl -sf "${SIPPY_API}?release=${RELEASE}&limit=100" 2>/dev/null) || {
+      echo "Warning: Failed to fetch data from Sippy API"
+      response="[]"
+    }
+    total=$(echo "${response}" | jq 'length')
+    if [[ "${total}" == "0" ]]; then
+      echo "No jobs found in Sippy for ${RELEASE}"
+      exit 1
+    fi
+    passing=$(echo "${response}" | jq '[.[] | select(.current_pass_percentage >= 80)] | length')
+    failing=$((total - passing))
+    echo "ROSA CI Status: ${passing}/${total} jobs healthy, ${failing} failing"
+    echo "${response}" | jq -r '.[] | "\(.name): \(.current_pass_percentage)%"' | sort
+    if [[ "${failing}" -gt 0 ]]; then
+      echo "Some jobs are below threshold"
+      exit 1
+    fi
+  container:
+    from: src
+  cron: 0 14 * * *
 zz_generated_metadata:
   branch: main
   org: openshift-online

--- a/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__periodics.yaml
+++ b/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__periodics.yaml
@@ -58,7 +58,7 @@ tests:
   - mount_path: /usr/local/cs-qe-credentials
     name: cs-qe-credentials
 - as: rosa-hcp-e2e-nightly-4-20
-  cron: 0 4 * * *
+  cron: 0 3 * * *
   steps:
     cluster_profile: rosa-e2e-01
     env:
@@ -70,7 +70,7 @@ tests:
       REPLICAS: "3"
     workflow: rosa-e2e
 - as: rosa-hcp-e2e-nightly-4-21
-  cron: 0 4 * * *
+  cron: 30 3 * * *
   steps:
     cluster_profile: rosa-e2e-01
     env:

--- a/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-periodics.yaml
@@ -73,7 +73,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build09
-  cron: 0 4 * * *
+  cron: 0 3 * * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -156,7 +156,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build09
-  cron: 0 4 * * *
+  cron: 30 3 * * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -311,6 +311,80 @@ periodics:
     - name: ci-pull-credentials
       secret:
         secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build05
+  cron: 0 14 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-online
+    repo: rosa-e2e
+  labels:
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-online-rosa-e2e-main-rosa-ci-daily-status
+  reporter_config:
+    slack:
+      channel: '#wg-rosa-ci-enhancement'
+      job_states_to_report:
+      - success
+      - failure
+      - error
+      report_template: '{{if eq .Status.State "success"}} :white_check_mark: ROSA
+        CI Daily Status: all jobs healthy. <{{.Status.URL}}|View logs> | <https://sippy.dptools.openshift.org/sippy-ng/release/rosa-stage|Sippy>
+        {{else}} :x: ROSA CI Daily Status: some jobs failing. <{{.Status.URL}}|View
+        logs> | <https://sippy.dptools.openshift.org/sippy-ng/release/rosa-stage|Sippy>
+        {{end}}'
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --report-credentials-file=/etc/report/credentials
+      - --target=rosa-ci-daily-status
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
     - name: manifest-tool-local-pusher
       secret:
         secretName: manifest-tool-local-pusher

--- a/ci-operator/step-registry/rosa/aws/hcp/conformance/rosa-aws-hcp-conformance-workflow.yaml
+++ b/ci-operator/step-registry/rosa/aws/hcp/conformance/rosa-aws-hcp-conformance-workflow.yaml
@@ -24,7 +24,11 @@ workflow:
         when installed on the cluster should have a AlertmanagerReceiversNotConfigured alert in firing state\|
         API LBs follow \/readyz of kube-apiserver and stop sending requests before server shutdowns for external clients\|
         Node Lifecycle should run through the lifecycle of a node\|
-        check registry.redhat.io is available and samples operator can import sample imagestreams
+        check registry.redhat.io is available and samples operator can import sample imagestreams\|
+        NetworkPolicy between server and client should allow ingress access from updated pod\|
+        In-tree Volumes.*local.*blockfs.*subPath should support file as subpath\|
+        DRA.*kubelet.*DynamicResourceAllocation\|
+        CSI Mock volume expansion Expansion with recovery recovery should not be possible
     pre:
       - chain: rosa-aws-sts-hcp-provision
       - ref: osd-ccs-conf-idp-htpasswd-multi-users

--- a/ci-operator/step-registry/rosa/aws/sts/conformance/rosa-aws-sts-conformance-workflow.yaml
+++ b/ci-operator/step-registry/rosa/aws/sts/conformance/rosa-aws-sts-conformance-workflow.yaml
@@ -16,7 +16,11 @@ workflow:
         when installed on the cluster should have a AlertmanagerReceiversNotConfigured alert in firing state\|
         API LBs follow \/readyz of kube-apiserver and stop sending requests before server shutdowns for external clients\|
         Node Lifecycle should run through the lifecycle of a node\|
-        CSI Mock volume expansion Expansion with recovery should allow recovery if controller expansion fails with infeasible error
+        CSI Mock volume expansion Expansion with recovery should allow recovery if controller expansion fails with infeasible error\|
+        NetworkPolicy between server and client should allow ingress access from updated pod\|
+        CPU Partitioning cluster infrastructure should be configured correctly\|
+        Managed cluster should set requests but not limits\|
+        Managed cluster should ensure platform components have system-\* priority class associated
     pre:
       - chain: rosa-aws-sts-provision
       - ref: osd-ccs-conf-idp-htpasswd-multi-users

--- a/ci-operator/step-registry/rosa/sts/account-roles/create/rosa-sts-account-roles-create-commands.sh
+++ b/ci-operator/step-registry/rosa/sts/account-roles/create/rosa-sts-account-roles-create-commands.sh
@@ -72,6 +72,12 @@ if [[ "$CHANNEL_GROUP" != "stable" ]]; then
 
   OPENSHIFT_VERSION=$(echo "${OPENSHIFT_VERSION}" | cut -d '.' -f 1,2)
 
+  # Determine cluster type switch early so the version fallback can use it
+  CLUSTER_SWITCH="--classic"
+  if [[ "$HOSTED_CP" == "true" ]]; then
+    CLUSTER_SWITCH="--hosted-cp"
+  fi
+
   # Verify the version has published policies. If not, fall back to the latest
   # available version. This handles cases where nightly builds for unreleased
   # versions (e.g., 4.23, 5.0) don't have IAM policies published yet.


### PR DESCRIPTION
## Summary

**1. Skip flaky conformance tests**

HCP conformance:
- NetworkPolicy ingress from updated pod (4.20 flake)
- In-tree Volumes local blockfs subPath (4.21 flake)
- DRA kubelet DynamicResourceAllocation (new 4.21, needs kubelet 1.33)
- CSI Mock volume expansion recovery

Classic STS conformance:
- CSI Mock volume expansion recovery
- NetworkPolicy ingress from updated pod
- CPU Partitioning (not applicable to non-partitioned clusters)
- Managed cluster set requests but not limits
- Managed cluster platform components priority class

**2. Add daily CI status aggregation job**

New `rosa-ci-daily-status` periodic runs at 14:00 UTC, queries the Sippy API for all rosa-stage job pass rates, and reports healthy/failing via Prow's Slack reporter to `#wg-rosa-ci-enhancement`.

**3. Redirect Slack reporter to #wg-rosa-ci-enhancement**

Update rosa-e2e repo-level `slack_reporter_config` from `#ocm-fvt-prow` to `#wg-rosa-ci-enhancement` with improved formatting and Sippy link.

**4. Stagger versioned nightly crons**

Stagger the 3 versioned rosa-e2e nightly jobs (from PR #77880) to avoid Boskos quota contention:
- 4.20: 3:00 UTC
- 4.21: 3:30 UTC
- 4.22: 4:00 UTC

Jira: https://redhat.atlassian.net/browse/SREP-4345

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added daily scheduled ROSA status check test to monitor quality metrics

* **Chores**
  * Updated periodic test job schedules with adjusted cron timings
  * Enhanced Slack notifications with conditional status templates and reporting links
  * Added conformance test skip entries for improved test stability
  * Improved cluster account roles creation logic and version handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->