### PR TITLE
Add stackrox stable/latest tag mirrors

### DIFF
--- a/core-services/image-mirroring/_config.yaml
+++ b/core-services/image-mirroring/_config.yaml
@@ -701,10 +701,16 @@ supplementalCIImages:
     image: registry.access.redhat.com/ubi9/ubi-minimal:latest
   stackrox/apollo-ci:scanner-test-latest:
     image: quay.io/stackrox-io/apollo-ci:scanner-test-latest
+  stackrox/apollo-ci:scanner-test-stable:
+    image: quay.io/stackrox-io/apollo-ci:scanner-test-stable
   stackrox/apollo-ci:stackrox-test-latest:
     image: quay.io/stackrox-io/apollo-ci:stackrox-test-latest
+  stackrox/apollo-ci:stackrox-test-stable:
+    image: quay.io/stackrox-io/apollo-ci:stackrox-test-stable
   stackrox/apollo-ci:stackrox-ui-test-latest:
     image: quay.io/stackrox-io/apollo-ci:stackrox-ui-test-latest
+  stackrox/apollo-ci:stackrox-ui-test-stable:
+    image: quay.io/stackrox-io/apollo-ci:stackrox-ui-test-stable
   stackrox/apollo-ci:collector-0.3.44-1-gb00ffc52af:
     image: quay.io/stackrox-io/apollo-ci:collector-0.3.44-1-gb00ffc52af
   stackrox/apollo-ci:scanner-test-0.3.61:

--- a/core-services/image-mirroring/_config.yaml
+++ b/core-services/image-mirroring/_config.yaml
@@ -699,6 +699,12 @@ supplementalCIImages:
     image: quay.io/stackrox-io/ci:golang-1.18.4
   stackrox/ubi-minimal:9:
     image: registry.access.redhat.com/ubi9/ubi-minimal:latest
+  stackrox/apollo-ci:scanner-test-latest:
+    image: quay.io/stackrox-io/apollo-ci:scanner-test-latest
+  stackrox/apollo-ci:stackrox-test-latest:
+    image: quay.io/stackrox-io/apollo-ci:stackrox-test-latest
+  stackrox/apollo-ci:stackrox-ui-test-latest:
+    image: quay.io/stackrox-io/apollo-ci:stackrox-ui-test-latest
   stackrox/apollo-ci:collector-0.3.44-1-gb00ffc52af:
     image: quay.io/stackrox-io/apollo-ci:collector-0.3.44-1-gb00ffc52af
   stackrox/apollo-ci:scanner-test-0.3.61:


### PR DESCRIPTION
## Summary
- Add mirror entries for `scanner-test-stable`, `stackrox-test-stable`, and `stackrox-ui-test-stable` images (and "-latest" for each for staged testing)
The `latest` tagged images will be pushed by [rox-ci-image](https://github.com/stackrox/rox-ci-image) on every release.
The `stable` tagged images will be pushed on-demand by a stackrox engineer after verifying the latest images
> This change removes the need to request testplatform review for each version bump

Related to [stackrox/rox-ci-image#248](https://github.com/stackrox/rox-ci-image/pull/248) which adds the stable and latest image pushes

🤖 Generated with [Claude Code](https://claude.com/claude-code)