### PR TITLE
Fix namespace for lcore-migration branch

### DIFF
--- a/ci-operator/config/openstack-lightspeed/operator/openstack-lightspeed-operator-lcore-migration.yaml
+++ b/ci-operator/config/openstack-lightspeed/operator/openstack-lightspeed-operator-lcore-migration.yaml
@@ -50,10 +50,10 @@ tests:
         apiVersion: v1
         kind: Namespace
         metadata:
-          name: openshift-lightspeed
+          name: openstack-lightspeed
         EOF
 
-        operator-sdk run bundle "$OO_BUNDLE" --namespace openshift-lightspeed
+        operator-sdk run bundle "$OO_BUNDLE" --namespace openstack-lightspeed
       dependencies:
       - env: OO_BUNDLE
         name: openstack-lightspeed-bundle


### PR DESCRIPTION
Update the job running on lcore-migration branch to create and deploy the operator in  the openstack-lightspeed namespace instead of openshift-lightspeed.

The OpenStack Lightspeed operator now runs in the openstack-lightspeed namespace by default. The KUTTL tests require this namespace to function correctly.