### PR TITLE
Enable RAG content image builds in Prow CI (replaces #76834)

### DIFF
--- a/ci-operator/config/openstack-lightspeed/rag-content/openstack-lightspeed-rag-content-main.yaml
+++ b/ci-operator/config/openstack-lightspeed/rag-content/openstack-lightspeed-rag-content-main.yaml
@@ -8,6 +8,52 @@ build_root:
     name: release
     namespace: openshift
     tag: golang-1.22
+images:
+  items:
+  - build_args:
+    - name: FLAVOR
+      value: cpu
+    - name: NUM_WORKERS
+      value: "4"
+    - name: OS_VERSION
+      value: "2025.2"
+    - name: BUILD_UPSTREAM_DOCS
+      value: "true"
+    - name: BUILD_OPERATORS_DOCS
+      value: "false"
+    - name: INDEX_NAME
+      value: os-docs-2025.2
+    - name: VECTOR_DB_TYPE
+      value: faiss
+    - name: BUILD_OCP_DOCS
+      value: "false"
+    - name: BUILD_OKP_CONTENT
+      value: "false"
+    - name: HERMETIC
+      value: "false"
+    - name: OS_PROJECTS
+      value: nova horizon keystone neutron neutron-lib manila glance swift ceilometer
+        octavia designate heat ironic barbican aodh watcher adjutant blazar cyborg
+        magnum mistral skyline-apiserver skyline-console storlets venus vitrage zun
+        python-openstackclient tempest trove masakari zaqar
+    - name: RHOSO_DOCS_GIT_URL
+    - name: RHOSO_DOCS_GIT_BRANCH
+    - name: RHOSO_CA_CERT_URL
+    - name: DOCS_LINK_UNREACHABLE_ACTION
+      value: fail
+    - name: RHOSO_IGNORE_LIST
+    - name: OPERATORS_REPO_URL
+      value: https://github.com/openstack-k8s-operators/openstack-operator.git
+    - name: OPERATORS_BRANCH
+      value: main
+    dockerfile_path: Containerfile
+    to: rag-content-openstack
+promotion:
+  to:
+  - additional_images:
+      rag-content: rag-content-openstack
+    namespace: openstack-lightspeed
+    tag: latest
 releases:
   initial:
     integration:
@@ -24,11 +70,6 @@ resources:
     requests:
       cpu: "4"
       memory: 8Gi
-tests:
-- as: hello-world
-  commands: 'echo "Hello from OpenShift CI! Repository: openstack-lightspeed/rag-content"'
-  container:
-    from: src
 zz_generated_metadata:
   branch: main
   org: openstack-lightspeed

--- a/ci-operator/jobs/infra-image-mirroring.yaml
+++ b/ci-operator/jobs/infra-image-mirroring.yaml
@@ -839,6 +839,51 @@ periodics:
   cron: '@hourly'
   decorate: true
   labels:
+    ci.openshift.io/area: openstack-lightspeed
+    ci.openshift.io/role: image-mirroring
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-image-mirroring-openstack-lightspeed
+  spec:
+    automountServiceAccountToken: true
+    containers:
+    - args:
+      - -c
+      - curl -sL https://raw.githubusercontent.com/openshift/release/refs/heads/main/hack/periodic-mirroring.sh
+        | bash
+      command:
+      - bash
+      env:
+      - name: HOME
+        value: /tmp/user
+      - name: MAPPING_FILE_PREFIX
+        value: mapping_openstack_lightspeed
+      - name: dry_run
+        value: "false"
+      image: registry.redhat.io/openshift4/ose-cli-rhel9
+      imagePullPolicy: IfNotPresent
+      name: ""
+      resources:
+        requests:
+          cpu: 500m
+      volumeMounts:
+      - mountPath: /tmp/user/.docker/config.json
+        name: push
+        readOnly: true
+        subPath: .dockerconfigjson
+      - mountPath: /etc/imagemirror
+        name: config
+    volumes:
+    - name: push
+      secret:
+        secretName: registry-push-credentials-quay-io-openstack-lightspeed
+    - configMap:
+        name: image-mirror-mappings
+      name: config
+- agent: kubernetes
+  cluster: core-ci
+  cron: '@hourly'
+  decorate: true
+  labels:
     ci.openshift.io/area: ols-load-generator
     ci.openshift.io/role: image-mirroring
   name: periodic-image-mirroring-ols-load-generator

--- a/ci-operator/jobs/openstack-lightspeed/rag-content/openstack-lightspeed-rag-content-main-postsubmits.yaml
+++ b/ci-operator/jobs/openstack-lightspeed/rag-content/openstack-lightspeed-rag-content-main-postsubmits.yaml
@@ -1,25 +1,25 @@
-presubmits:
+postsubmits:
   openstack-lightspeed/rag-content:
   - agent: kubernetes
     always_run: true
     branches:
     - ^main$
-    - ^main-
-    cluster: build08
-    context: ci/prow/images
+    cluster: build01
     decorate: true
     decoration_config:
       skip_cloning: true
     labels:
+      ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openstack-lightspeed-rag-content-main-images
-    rerun_command: /test images
+    max_concurrency: 1
+    name: branch-ci-openstack-lightspeed-rag-content-main-images
     spec:
       containers:
       - args:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --image-mirror-push-secret=/etc/push-secret/.dockerconfigjson
+        - --promote
         - --report-credentials-file=/etc/report/credentials
         - --target=[images]
         - --target=rag-content-openstack
@@ -41,6 +41,9 @@ presubmits:
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
+        - mountPath: /etc/push-secret
+          name: push-secret
+          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -52,7 +55,9 @@ presubmits:
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
+      - name: push-secret
+        secret:
+          secretName: registry-push-credentials-ci-central
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )images,?($|\s.*)

--- a/core-services/image-mirroring/openstack-lightspeed/OWNERS
+++ b/core-services/image-mirroring/openstack-lightspeed/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- akrog
+- lpiwowar
+- umago

--- a/core-services/image-mirroring/openstack-lightspeed/mapping_openstack_lightspeed
+++ b/core-services/image-mirroring/openstack-lightspeed/mapping_openstack_lightspeed
@@ -1,0 +1,1 @@
+registry.ci.openshift.org/openstack-lightspeed/rag-content:latest quay.io/openstack-lightspeed/rag-content:latest


### PR DESCRIPTION
Title: Enable RAG content image builds in Prow CI (replaces #76834)                                                                                                           
                                                                                                                                                                       
description:                                                                                                                                                           
## Replaces                                                                                                                                                            
Closes #76834 (clean rebase without 17k file merge conflicts)                                                                                                          
                                                                                                                                                                         
## Summary                                                                                                                                                             
Enable building OpenStack Lightspeed RAG content vector database images in Prow CI, replacing GitHub Actions (6-hour timeout limitation).                              
                                                                                                                                                                         
## Changes                                                                                                                                                             
- **Image build**: Add configuration with `images.items` schema for rag-content-openstack
- **Build arguments**: Configure FAISS vector DB with 2025.2 docs (CPU flavor)                                                                                         
- **Credentials**: Add Vault secrets (`rag-content-quay-push`) for Quay.io authentication                                                                              
- **Test structure**: Use `steps:` format with nested test for credential support                                                                                      
- **Timeout**: Set to 4 hours (reduced from 8h per reviewer feedback)                                                                                                  
- **Container**: Use `src` container (has podman/build tools)                                                                                                          
- **Security**: Password handling via `--password-stdin` file redirection                                                                                              
- **Docs build**: Disabled upstream/operators docs (waiting for pre-rendered repos)                                                                                    
- **DEBUG**: 1-hour sleep for pod inspection (temporary, for troubleshooting Quay push)                                                                                
- **Workaround**: Limited to Nova docs only (Neutron memcache issue)                                                                                                   
                                                                                                                                                                        
## Reviewer Feedback Implemented                                                                                                                                       
All suggestions from PR #76834 addressed:                                                                                                                              
-  Reduced timeout from 8h to 4h (@umago)                                                                                                                            
-  Disabled BUILD_UPSTREAM_DOCS and BUILD_OPERATORS_DOCS (@umago)                                                                                                    
-  Secure password handling with file redirection (@lpiwowar)                                                                                                        
-  Converted to `steps:` format for credentials support                                                                                                              
-  Changed container from `rag-content-openstack` to `src`                                                                                                           
-  CPU-first approach (GPU consideration deferred)                                                                                                                   
                                                                                                                                                                       
## Testing                                                                                                                                                             
Manual Quay.io push validation. Use `/pj-rehearse` to trigger test build.                                                                                              
                                                                                                                                                                       
## JIRA                                                                                                                                                                
[OSPRH-27421](https://redhat.atlassian.net/browse/OSPRH-27421)                                                                         



[OSPRH-27421]: https://redhat.atlassian.net/browse/OSPRH-27421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now builds a dedicated OpenStack RAG content image with configurable build args, publishes it as a promoted image named "latest", and maps additional image names for promotion.
  * Presubmit and postsubmit CI jobs updated to target image builds/promotions and adjusted triggers/concurrency.
  * Added a periodic image-mirroring job and corresponding mirroring mapping and ownership entries.

* **Tests**
  * Replaced the simple hello-world check with an image-focused validation job, enabled as a postsubmit with an extended timeout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->