### PR TITLE
migrate auto-config-brancher to openshift-merge-bot GitHub App

### DIFF
--- a/ci-operator/jobs/infra-periodics.yaml
+++ b/ci-operator/jobs/infra-periodics.yaml
@@ -784,13 +784,14 @@ periodics:
   spec:
     containers:
     - args:
-      - --github-token-path=/etc/github/oauth
+      - --github-app-id=$(GITHUB_APP_ID)
+      - --github-app-private-key-path=/etc/github/cert
       - --github-endpoint=http://ghproxy
       - --github-endpoint=https://api.github.com
       - --github-graphql-endpoint=http://ghproxy/graphql
       - --confirm=true
-      - --git-name=openshift-bot
-      - --git-email=openshift-bot@redhat.com
+      - --git-name=openshift-merge-bot[bot]
+      - --git-email=148852131+openshift-merge-bot[bot]@users.noreply.github.com
       - --target-dir=.
       - --config-dir=./ci-operator/config
       - --current-release=4.22
@@ -802,6 +803,12 @@ periodics:
       - --whitelist-file=./core-services/openshift-priv/_whitelist.yaml
       command:
       - /usr/bin/auto-config-brancher
+      env:
+      - name: GITHUB_APP_ID
+        valueFrom:
+          secretKeyRef:
+            key: appid
+            name: openshift-merge-bot
       image: quay.io/openshift/ci-public:ci_auto-config-brancher_latest
       imagePullPolicy: Always
       name: auto-config-brancher
@@ -810,15 +817,15 @@ periodics:
           cpu: 500m
       volumeMounts:
       - mountPath: /etc/github
-        name: token
+        name: github-app-credentials
         readOnly: true
       - mountPath: /etc/prometheus
         name: prometheus
         readOnly: true
     volumes:
-    - name: token
+    - name: github-app-credentials
       secret:
-        secretName: github-credentials-openshift-bot
+        secretName: openshift-merge-bot
     - name: prometheus
       secret:
         items:

--- a/ci-operator/jobs/infra-periodics.yaml
+++ b/ci-operator/jobs/infra-periodics.yaml
@@ -799,7 +799,6 @@ periodics:
       - --future-release=5.0
       - --self-approve=true
       - --assign=openshift/test-platform
-      - --rebalancer-cron=0 0 * * 2,5
       - --whitelist-file=./core-services/openshift-priv/_whitelist.yaml
       command:
       - /usr/bin/auto-config-brancher

--- a/core-services/prow/02_config/openshift/release/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/release/_prowconfig.yaml
@@ -12,6 +12,16 @@ tide:
     - needs-rebase
     repos:
     - openshift/release
+  - author: openshift-merge-bot[bot]
+    labels:
+    - rehearsals-ack
+    missingLabels:
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - needs-rebase
+    repos:
+    - openshift/release
   - labels:
     - approved
     - lgtm


### PR DESCRIPTION
Switch periodic-prow-auto-config-brancher from openshift-bot token auth to openshift-merge-bot app auth. Add tide query for openshift-merge-bot[bot] to allow auto-merge of app-authored PRs.