### PR TITLE
Update scanner prow jobs to apollo-ci 0.5.7

### DIFF
--- a/ci-operator/config/stackrox/scanner/stackrox-scanner-master.yaml
+++ b/ci-operator/config/stackrox/scanner/stackrox-scanner-master.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: scanner-test-0.4.9
+    tag: scanner-test-0.5.7
 resources:
   '*':
     requests:

--- a/ci-operator/config/stackrox/scanner/stackrox-scanner-release-2.34.yaml
+++ b/ci-operator/config/stackrox/scanner/stackrox-scanner-release-2.34.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: scanner-test-0.4.4
+    tag: scanner-test-0.5.7
 resources:
   '*':
     requests:

--- a/ci-operator/config/stackrox/scanner/stackrox-scanner-release-2.35.yaml
+++ b/ci-operator/config/stackrox/scanner/stackrox-scanner-release-2.35.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: scanner-test-0.4.4
+    tag: scanner-test-0.5.7
 resources:
   '*':
     requests:

--- a/ci-operator/config/stackrox/scanner/stackrox-scanner-release-2.36.yaml
+++ b/ci-operator/config/stackrox/scanner/stackrox-scanner-release-2.36.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: scanner-test-0.4.9
+    tag: scanner-test-0.5.7
 resources:
   '*':
     requests:

--- a/ci-operator/config/stackrox/scanner/stackrox-scanner-release-2.37.yaml
+++ b/ci-operator/config/stackrox/scanner/stackrox-scanner-release-2.37.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: scanner-test-0.4.9
+    tag: scanner-test-0.5.7
 resources:
   '*':
     requests:

--- a/ci-operator/config/stackrox/scanner/stackrox-scanner-release-2.38.yaml
+++ b/ci-operator/config/stackrox/scanner/stackrox-scanner-release-2.38.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: scanner-test-0.4.9
+    tag: scanner-test-0.5.7
 resources:
   '*':
     requests:

--- a/ci-operator/config/stackrox/scanner/stackrox-scanner-release-2.39.yaml
+++ b/ci-operator/config/stackrox/scanner/stackrox-scanner-release-2.39.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: scanner-test-0.4.9
+    tag: scanner-test-0.5.7
 resources:
   '*':
     requests:


### PR DESCRIPTION
## Summary
- Update scanner-test image from 0.4.4/0.4.9 to 0.5.7 across all scanner prow job configs
- This version includes the UBI 9 upgrade from [stackrox/rox-ci-image#234](https://github.com/stackrox/rox-ci-image/pull/234)
- Depends on [openshift/release#77568](https://github.com/openshift/release/pull/77568) for the 0.5.7 mirror entry

/hold
/uncc

🤖 Generated with [Claude Code](https://claude.com/claude-code)