### PR TITLE
aro-hcp: add app registration cleanup prow job

### DIFF
--- a/ci-operator/config/Azure/ARO-HCP/.config.prowgen
+++ b/ci-operator/config/Azure/ARO-HCP/.config.prowgen
@@ -6,6 +6,8 @@ slack_reporter:
   report_template: ':failed: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs>'
   job_names:
   - image-updater-tooling
+  - delete-expired-red-hat-tenant-app-registrations
+  - delete-expired-msft-test-tenant-app-registrations
 - channel: "#aro-hcp-failures-int"
   job_states_to_report:
   - failure

--- a/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__periodic.yaml
+++ b/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__periodic.yaml
@@ -18,6 +18,20 @@ tests:
   steps:
     test:
     - ref: aro-hcp-deprovision-kusto-role-assignments
+- as: delete-expired-red-hat-tenant-app-registrations
+  cron: 0 5 * * *
+  steps:
+    env:
+      VAULT_SECRET_PROFILE: red-hat-tenant
+    test:
+    - ref: aro-hcp-deprovision-expired-app-registrations
+- as: delete-expired-msft-test-tenant-app-registrations
+  cron: 0 5 * * *
+  steps:
+    env:
+      VAULT_SECRET_PROFILE: msft-test-tenant
+    test:
+    - ref: aro-hcp-deprovision-expired-app-registrations
 - as: delete-expired-dev-prow-resource-groups
   cron: 7,37 * * * *
   steps:

--- a/ci-operator/jobs/Azure/ARO-HCP/Azure-ARO-HCP-main-periodics.yaml
+++ b/ci-operator/jobs/Azure/ARO-HCP/Azure-ARO-HCP-main-periodics.yaml
@@ -528,6 +528,87 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build09
+  cron: 0 5 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: Azure
+    repo: ARO-HCP
+  labels:
+    ci-operator.openshift.io/variant: periodic
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-Azure-ARO-HCP-main-periodic-delete-expired-msft-test-tenant-app-registrations
+  reporter_config:
+    slack:
+      channel: '#aro-hcp-failures-dev'
+      job_states_to_report:
+      - failure
+      - error
+      report_template: ':failed: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*.
+        <{{.Status.URL}}|View logs>'
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --target=delete-expired-msft-test-tenant-app-registrations
+      - --variant=periodic
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build09
   cron: 7,37 * * * *
   decorate: true
   decoration_config:
@@ -557,6 +638,87 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --target=delete-expired-prod-resource-groups
+      - --variant=periodic
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build09
+  cron: 0 5 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: Azure
+    repo: ARO-HCP
+  labels:
+    ci-operator.openshift.io/variant: periodic
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-Azure-ARO-HCP-main-periodic-delete-expired-red-hat-tenant-app-registrations
+  reporter_config:
+    slack:
+      channel: '#aro-hcp-failures-dev'
+      job_states_to_report:
+      - failure
+      - error
+      report_template: ':failed: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*.
+        <{{.Status.URL}}|View logs>'
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --target=delete-expired-red-hat-tenant-app-registrations
       - --variant=periodic
       command:
       - ci-operator

--- a/ci-operator/step-registry/aro-hcp/deprovision/expired-app-registrations/OWNERS
+++ b/ci-operator/step-registry/aro-hcp/deprovision/expired-app-registrations/OWNERS
@@ -1,0 +1,14 @@
+approvers:
+- geoberle
+- jharrington22
+- mmazur
+- roivaz
+- venkateshsredhat
+- deads2k
+reviewers:
+- geoberle
+- jharrington22
+- mmazur
+- roivaz
+- venkateshsredhat
+- deads2k

--- a/ci-operator/step-registry/aro-hcp/deprovision/expired-app-registrations/aro-hcp-deprovision-expired-app-registrations-commands.sh
+++ b/ci-operator/step-registry/aro-hcp/deprovision/expired-app-registrations/aro-hcp-deprovision-expired-app-registrations-commands.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+export CLUSTER_PROFILE_DIR="/var/run/aro-hcp-${VAULT_SECRET_PROFILE}"
+
+# Disable tracing due to credential handling
+export AZURE_CLIENT_ID; AZURE_CLIENT_ID=$(cat "${CLUSTER_PROFILE_DIR}/client-id")
+export AZURE_TENANT_ID; AZURE_TENANT_ID=$(cat "${CLUSTER_PROFILE_DIR}/tenant")
+export AZURE_CLIENT_SECRET; AZURE_CLIENT_SECRET=$(cat "${CLUSTER_PROFILE_DIR}/client-secret")
+export AZURE_TOKEN_CREDENTIALS=prod
+
+set -o xtrace
+
+./test/aro-hcp-tests cleanup app-registrations

--- a/ci-operator/step-registry/aro-hcp/deprovision/expired-app-registrations/aro-hcp-deprovision-expired-app-registrations-ref.metadata.json
+++ b/ci-operator/step-registry/aro-hcp/deprovision/expired-app-registrations/aro-hcp-deprovision-expired-app-registrations-ref.metadata.json
@@ -1,0 +1,21 @@
+{
+	"path": "aro-hcp/deprovision/expired-app-registrations/aro-hcp-deprovision-expired-app-registrations-ref.yaml",
+	"owners": {
+		"approvers": [
+			"geoberle",
+			"jharrington22",
+			"mmazur",
+			"roivaz",
+			"venkateshsredhat",
+			"deads2k"
+		],
+		"reviewers": [
+			"geoberle",
+			"jharrington22",
+			"mmazur",
+			"roivaz",
+			"venkateshsredhat",
+			"deads2k"
+		]
+	}
+}

--- a/ci-operator/step-registry/aro-hcp/deprovision/expired-app-registrations/aro-hcp-deprovision-expired-app-registrations-ref.yaml
+++ b/ci-operator/step-registry/aro-hcp/deprovision/expired-app-registrations/aro-hcp-deprovision-expired-app-registrations-ref.yaml
@@ -1,0 +1,22 @@
+ref:
+  as: aro-hcp-deprovision-expired-app-registrations
+  from: aro-hcp-e2e-tools
+  commands: aro-hcp-deprovision-expired-app-registrations-commands.sh
+  resources:
+    requests:
+      cpu: 100m
+      memory: 300Mi
+  credentials:
+    - namespace: test-credentials
+      name: cluster-secrets-aro-hcp-red-hat-tenant
+      mount_path: /var/run/aro-hcp-red-hat-tenant
+    - namespace: test-credentials
+      name: cluster-secrets-aro-hcp-msft-test-tenant
+      mount_path: /var/run/aro-hcp-msft-test-tenant
+  env:
+    - name: VAULT_SECRET_PROFILE
+      default: "red-hat-tenant"
+      documentation: |-
+        Selects which environment's cluster secrets to use (red-hat-tenant, msft-test-tenant).
+  documentation: |-
+    Clean up expired e2e app registrations that were left by test runs.


### PR DESCRIPTION
[ARO-25877](https://redhat.atlassian.net/browse/ARO-25877)

Add new cluster profiles (aro-hcp-red-hat-tenant, aro-hcp-msft-test-tenant) and a periodic job to clean up orphaned app registrations with expired credentials left by e2e test runs.

Depends on 
- openshift/ci-tools#5097 for cluster profile registration.
- [Azure/ARO-HCP#4813](https://github.com/Azure/ARO-HCP#4813) for functionality

[ARO-25877]: https://redhat.atlassian.net/browse/ARO-25877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added daily automated cleanup for expired app registrations in two Azure tenant environments: Red Hat and MSFT test tenants.

* **Chores**
  * Updated CI/CD to schedule the new daily maintenance jobs and removed the older resource-group cleanup task.
  * Updated failure reporting configuration to include the new cleanup jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->