### PR TITLE
OCM-22871 | fix: move ROSA CI build root to OpenShift 4.22

### DIFF
--- a/ci-operator/config/openshift/rosa/openshift-rosa-master.yaml
+++ b/ci-operator/config/openshift/rosa/openshift-rosa-master.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: builder
     namespace: ocp
-    tag: rhel-9-golang-1.25-openshift-4.21
+    tag: rhel-9-golang-1.25-openshift-4.22
 resources:
   '*':
     requests:


### PR DESCRIPTION
## Summary
- move the ROSA ci-operator build root from the OpenShift 4.21 Go 1.25 builder stream to the OpenShift 4.22 Go 1.25 builder stream
- keep ROSA on the Go 1.25.x line while picking up Go 1.25.8 for the CVE remediation
- avoid the stale 4.21 generic Go 1.25 stream, which still resolves to Go 1.25.7

## Test plan
- Verified `registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.21` reports `GO_VERSION=v1.25.7`
- Verified `registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22` reports `GO_VERSION=v1.25.8`
- Verified `registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.25-openshift-4.22` reports `GO_VERSION=v1.25.8`
- Rehearse jobs should confirm the ROSA presubmits pick up the new build root