### PR TITLE
cloud-bulldozer/orion to squash merge by default

### DIFF
--- a/core-services/prow/02_config/cloud-bulldozer/orion/_prowconfig.yaml
+++ b/core-services/prow/02_config/cloud-bulldozer/orion/_prowconfig.yaml
@@ -6,6 +6,8 @@ branch-protection:
           required_pull_request_reviews:
             required_approving_review_count: 2
 tide:
+  merge_method:
+    cloud-bulldozer/orion: squash
   queries:
   - labels:
     - approved


### PR DESCRIPTION
tide by default merges PRs as a 'merge', which leaves the git history cluttered with development branch commits.

This allows tide to use 'squash' merge type, so that all commits are squashed into a single commit and merged cleanly into the main branch.

See docs here: https://docs.prow.k8s.io/docs/components/core/tide/config/#general-configuration