### PR TITLE
[INTEROP-8998] Correct crontab value for cr job; shorten job names.

### DIFF
--- a/ci-operator/config/redhat-developer/gitops-operator/.config.prowgen
+++ b/ci-operator/config/redhat-developer/gitops-operator/.config.prowgen
@@ -9,5 +9,5 @@ slack_reporter:
                     Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
                     logs> {{end}}'
   job_names: 
-  - redhat-openshift-gitops-interop-aws
-  - redhat-openshift-gitops-interop-aws-fips
+  - cr-gitops-aws
+  - gitops-aws-fips

--- a/ci-operator/config/redhat-developer/gitops-operator/redhat-developer-gitops-operator-v1.20__gitops-ocp-4.22-lp-interop.yaml
+++ b/ci-operator/config/redhat-developer/gitops-operator/redhat-developer-gitops-operator-v1.20__gitops-ocp-4.22-lp-interop.yaml
@@ -28,8 +28,8 @@ resources:
       cpu: 100m
       memory: 200Mi
 tests:
-- as: cr-redhat-openshift-gitops-interop-aws
-  cron: 0 23 31 2 *
+- as: cr-gitops-aws
+  cron: 0 3,15 * * *
   steps:
     cluster_profile: aws-cspi-qe
     env:
@@ -60,7 +60,7 @@ tests:
     - ref: gitops-operator-tests
     workflow: firewatch-ipi-aws-cr
   timeout: 3h30m0s
-- as: redhat-openshift-gitops-interop-aws-fips
+- as: gitops-aws-fips
   cron: 0 23 31 2 *
   steps:
     cluster_profile: aws-cspi-qe

--- a/ci-operator/jobs/redhat-developer/gitops-operator/redhat-developer-gitops-operator-v1.20-periodics.yaml
+++ b/ci-operator/jobs/redhat-developer/gitops-operator/redhat-developer-gitops-operator-v1.20-periodics.yaml
@@ -1,7 +1,7 @@
 periodics:
 - agent: kubernetes
   cluster: build09
-  cron: 0 23 31 2 *
+  cron: 0 3,15 * * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -17,7 +17,18 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-redhat-developer-gitops-operator-v1.20-gitops-ocp-4.22-lp-interop-cr-redhat-openshift-gitops-interop-aws
+  name: periodic-ci-redhat-developer-gitops-operator-v1.20-gitops-ocp-4.22-lp-interop-cr-gitops-aws
+  reporter_config:
+    slack:
+      channel: '#gitops-interop-qe'
+      job_states_to_report:
+      - success
+      - failure
+      - error
+      report_template: '{{if eq .Status.State "success"}} :slack-green: Job *{{.Spec.Job}}*
+        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> {{else}} :failed:
+        Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+        logs> {{end}}'
   spec:
     containers:
     - args:
@@ -26,7 +37,7 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=cr-redhat-openshift-gitops-interop-aws
+      - --target=cr-gitops-aws
       - --variant=gitops-ocp-4.22-lp-interop
       command:
       - ci-operator
@@ -100,7 +111,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-redhat-developer-gitops-operator-v1.20-gitops-ocp-4.22-lp-interop-redhat-openshift-gitops-interop-aws-fips
+  name: periodic-ci-redhat-developer-gitops-operator-v1.20-gitops-ocp-4.22-lp-interop-gitops-aws-fips
   reporter_config:
     slack:
       channel: '#gitops-interop-qe'
@@ -120,7 +131,7 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=redhat-openshift-gitops-interop-aws-fips
+      - --target=gitops-aws-fips
       - --variant=gitops-ocp-4.22-lp-interop
       command:
       - ci-operator


### PR DESCRIPTION
- Correct crontab value for the `cr-gitops-aws` job.
- Shorten both job names in config to shorten the periodic job names.