### PR TITLE
clusters/app.ci/prow/03_deployment/gcsweb: Bump requests to 40 mCPU and 200 MiB

### DIFF
--- a/clusters/app.ci/prow/03_deployment/gcsweb.yaml
+++ b/clusters/app.ci/prow/03_deployment/gcsweb.yaml
@@ -42,11 +42,11 @@ spec:
             port: 8081
         resources:
           requests:
-            cpu: 10m
-            memory: 60Mi
-          limits:
             cpu: 40m
             memory: 200Mi
+          limits:
+            cpu: 400m
+            memory: 400Mi
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
    pod:container_cpu_usage:sum{pod="gcsweb-645cc65cfd-6h9wp"}

shows up to 35 vCPU and:

    container_memory_rss{pod="gcsweb-645cc65cfd-6h9wp",container="gcsweb"}

shows up to 170 MB, and the Pods are crash-looping:

```console
$ oc -n ci get pod gcsweb-645cc65cfd-6h9wp
NAME                      READY   STATUS             RESTARTS        AGE
gcsweb-645cc65cfd-6h9wp   0/1     CrashLoopBackOff   7 (4m32s ago)   24m
```

on what seems like CPU-throttled liveness probes that time out:

```console
$ oc -n ci get -o json events | jq -r '[.items[] | select(tostring | contains("gcsweb-645cc65cfd-6h9wp")) | (.firstTimestamp // .eventTime // .metadata.creationTimestamp) + " " + (.count | tostring) + " " + (.involvedObject | .kind + " " + .name) + " " + .reason + ": " + .message] | sort[]'
2026-04-10T04:57:36.694552Z null Pod gcsweb-645cc65cfd-6h9wp Scheduled: Successfully assigned ci/gcsweb-645cc65cfd-6h9wp to ip-10-0-139-76.ec2.internal
2026-04-10T04:57:36Z 1 ReplicaSet gcsweb-645cc65cfd SuccessfulCreate: Created pod: gcsweb-645cc65cfd-6h9wp
2026-04-10T04:57:37Z 1 Pod gcsweb-645cc65cfd-6h9wp AddedInterface: Add eth0 [10.129.8.67/23] from ovn-kubernetes
2026-04-10T04:57:37Z 2 Pod gcsweb-645cc65cfd-6h9wp Pulling: Pulling image "quay-proxy.ci.openshift.org/openshift/ci:ci_gcsweb_latest"
2026-04-10T04:57:39Z 1 Pod gcsweb-645cc65cfd-6h9wp Pulled: Successfully pulled image "quay-proxy.ci.openshift.org/openshift/ci:ci_gcsweb_latest" in 2.085s (2.085s including waiting). Image size: 154058086 bytes.
2026-04-10T04:57:40Z 2 Pod gcsweb-645cc65cfd-6h9wp Created: Created container: gcsweb
2026-04-10T04:57:40Z 2 Pod gcsweb-645cc65cfd-6h9wp Started: Started container gcsweb
2026-04-10T04:57:41Z 23 Pod gcsweb-645cc65cfd-6h9wp Unhealthy: Readiness probe failed: Get "http://10.129.8.67:8081/healthz/ready": dial tcp 10.129.8.67:8081: connect: connection refused
2026-04-10T04:58:05Z 35 Pod gcsweb-645cc65cfd-6h9wp Unhealthy: Liveness probe failed: Get "http://10.129.8.67:8081/healthz": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
2026-04-10T04:58:18Z 3 Pod gcsweb-645cc65cfd-6h9wp Unhealthy: Readiness probe failed: Get "http://10.129.8.67:8081/healthz/ready": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
2026-04-10T04:58:52Z 1 Pod gcsweb-645cc65cfd-6h9wp Unhealthy: Liveness probe failed: Get "http://10.129.8.67:8081/healthz": read tcp 10.129.8.2:45714->10.129.8.67:8081: read: connection reset by peer
2026-04-10T04:58:53Z 1 Pod gcsweb-645cc65cfd-6h9wp Pulled: Successfully pulled image "quay-proxy.ci.openshift.org/openshift/ci:ci_gcsweb_latest" in 338ms (338ms including waiting). Image size: 154058086 bytes.
2026-04-10T05:06:58Z 33 Pod gcsweb-645cc65cfd-6h9wp BackOff: Back-off restarting failed container gcsweb in pod gcsweb-645cc65cfd-6h9wp_ci(df9dfb1f-d8a8-45bc-94c1-6c0a7ff3cf7f)
```

leading to https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/... requests failing with messages like:

> Application is not available
>
> The application is currently not serving requests at this endpoint. It may not have been started or is still starting.

Like 40156497aa (#77012), bring the requests in line with actual usage, so the scheduler has a chance at finding a workable packing, and so configured-limit or noisy-neighbor contention is less likely to take down this important workload.