### PR TITLE
Configure cleanup-sweeper job for resource groups

### DIFF
--- a/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__periodic.yaml
+++ b/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__periodic.yaml
@@ -50,8 +50,10 @@ tests:
   cron: 5 * * * *
   steps:
     env:
-      CLEANUP_SWEEPER_ALL_SUBSCRIPTIONS: "true"
       CLEANUP_SWEEPER_POLICY: tooling/cleanup-sweeper/resourcegroups.policy.yaml
+      CLEANUP_SWEEPER_SUBSCRIPTION_NAMES: ARO HCP E2E Service Clusters (EA Subscription),
+        ARO HCP E2E Hosted Clusters (EA Subscription), ARO HCP E2E Management Clusters
+        (EA Subscription), ARO Hosted Control Planes (EA Subscription 1)
       CLEANUP_SWEEPER_WAIT: "false"
       CLEANUP_SWEEPER_WORKFLOW: rg-ordered
     test:

--- a/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__periodic.yaml
+++ b/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__periodic.yaml
@@ -46,6 +46,16 @@ tests:
       VAULT_SECRET_PROFILE: prod
     test:
     - ref: aro-hcp-deprovision-expired-resource-groups
+- as: cleanup-sweeper-rg-ordered
+  cron: 5 * * * *
+  steps:
+    env:
+      CLEANUP_SWEEPER_ALL_SUBSCRIPTIONS: "true"
+      CLEANUP_SWEEPER_POLICY: tooling/cleanup-sweeper/resourcegroups.policy.yaml
+      CLEANUP_SWEEPER_WAIT: "false"
+      CLEANUP_SWEEPER_WORKFLOW: rg-ordered
+    test:
+    - ref: aro-hcp-deprovision-cleanup-sweeper
 - as: integration-e2e-parallel
   cron: 0 0 1 1 *
   steps:

--- a/ci-operator/jobs/Azure/ARO-HCP/Azure-ARO-HCP-main-periodics.yaml
+++ b/ci-operator/jobs/Azure/ARO-HCP/Azure-ARO-HCP-main-periodics.yaml
@@ -82,6 +82,79 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build09
+  cron: 5 * * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: Azure
+    repo: ARO-HCP
+  labels:
+    ci-operator.openshift.io/variant: periodic
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-Azure-ARO-HCP-main-periodic-cleanup-sweeper-rg-ordered
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --target=cleanup-sweeper-rg-ordered
+      - --variant=periodic
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build09
   cron: 7,37 * * * *
   decorate: true
   decoration_config:

--- a/ci-operator/step-registry/aro-hcp/deprovision/cleanup-sweeper/OWNERS
+++ b/ci-operator/step-registry/aro-hcp/deprovision/cleanup-sweeper/OWNERS
@@ -1,0 +1,14 @@
+approvers:
+- geoberle
+- jharrington22
+- mmazur
+- roivaz
+- venkateshsredhat
+- deads2k
+reviewers:
+- geoberle
+- jharrington22
+- mmazur
+- roivaz
+- venkateshsredhat
+- deads2k

--- a/ci-operator/step-registry/aro-hcp/deprovision/cleanup-sweeper/aro-hcp-deprovision-cleanup-sweeper-commands.sh
+++ b/ci-operator/step-registry/aro-hcp/deprovision/cleanup-sweeper/aro-hcp-deprovision-cleanup-sweeper-commands.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+export CLUSTER_PROFILE_DIR="/var/run/aro-hcp-${VAULT_SECRET_PROFILE}"
+
+export AZURE_CLIENT_ID; AZURE_CLIENT_ID=$(cat "${CLUSTER_PROFILE_DIR}/client-id")
+export AZURE_TENANT_ID; AZURE_TENANT_ID=$(cat "${CLUSTER_PROFILE_DIR}/tenant")
+export AZURE_CLIENT_SECRET; AZURE_CLIENT_SECRET=$(cat "${CLUSTER_PROFILE_DIR}/client-secret")
+export SUBSCRIPTION_ID; SUBSCRIPTION_ID=$(cat "${CLUSTER_PROFILE_DIR}/subscription-id")
+export AZURE_TOKEN_CREDENTIALS=prod
+
+az login --service-principal -u "${AZURE_CLIENT_ID}" -p "${AZURE_CLIENT_SECRET}" --tenant "${AZURE_TENANT_ID}" --output none
+az account set --subscription "${SUBSCRIPTION_ID}"
+
+go build -o /tmp/cleanup-sweeper ./tooling/cleanup-sweeper
+
+run_cleanup() {
+  local subscription_id="${1}"
+  local cmd=(
+    /tmp/cleanup-sweeper
+    --workflow "${CLEANUP_SWEEPER_WORKFLOW}"
+    --subscription-id "${subscription_id}"
+  )
+
+  if [[ -n "${CLEANUP_SWEEPER_POLICY}" ]]; then
+    cmd+=(--policy "${CLEANUP_SWEEPER_POLICY}")
+  fi
+
+  if [[ -n "${CLEANUP_SWEEPER_PARALLELISM}" ]]; then
+    cmd+=(--parallelism "${CLEANUP_SWEEPER_PARALLELISM}")
+  fi
+
+  if [[ -n "${CLEANUP_SWEEPER_WAIT}" ]]; then
+    cmd+=(--wait="${CLEANUP_SWEEPER_WAIT}")
+  fi
+
+  if [[ -n "${CLEANUP_SWEEPER_VERBOSITY}" ]]; then
+    cmd+=(--verbosity="${CLEANUP_SWEEPER_VERBOSITY}")
+  fi
+
+  if [[ -n "${CLEANUP_SWEEPER_EXTRA_ARGS}" ]]; then
+    # Intentional word splitting to support multiple CLI flags.
+    read -r -a extra_args <<< "${CLEANUP_SWEEPER_EXTRA_ARGS}"
+    cmd+=("${extra_args[@]}")
+  fi
+
+  printf 'Running:'
+  printf ' %q' "${cmd[@]}"
+  printf '\n'
+  "${cmd[@]}"
+}
+
+if [[ "${CLEANUP_SWEEPER_ALL_SUBSCRIPTIONS}" == "true" ]]; then
+  mapfile -t subscriptions < <(az account list --all --query "[?state=='Enabled'].[name,id]" -o tsv)
+  if [[ "${#subscriptions[@]}" -eq 0 ]]; then
+    echo "No enabled subscriptions discovered in tenant ${AZURE_TENANT_ID}"
+    exit 1
+  fi
+
+  failures=0
+  for subscription in "${subscriptions[@]}"; do
+    IFS=$'\t' read -r subscription_name subscription_id <<< "${subscription}"
+    echo "Starting cleanup for subscription name='${subscription_name}' id='${subscription_id}'"
+    if ! run_cleanup "${subscription_id}"; then
+      failures=$((failures + 1))
+      echo "Cleanup failed for subscription name='${subscription_name}' id='${subscription_id}'; continuing"
+    fi
+  done
+
+  if [[ "${failures}" -gt 0 ]]; then
+    echo "Cleanup failed for ${failures} subscription(s)"
+    exit 1
+  fi
+
+  exit 0
+fi
+
+current_subscription_id="$(az account show --query id -o tsv)"
+run_cleanup "${current_subscription_id}"

--- a/ci-operator/step-registry/aro-hcp/deprovision/cleanup-sweeper/aro-hcp-deprovision-cleanup-sweeper-commands.sh
+++ b/ci-operator/step-registry/aro-hcp/deprovision/cleanup-sweeper/aro-hcp-deprovision-cleanup-sweeper-commands.sh
@@ -16,6 +16,39 @@ az account set --subscription "${SUBSCRIPTION_ID}"
 
 go build -o /tmp/cleanup-sweeper ./tooling/cleanup-sweeper
 
+trim_whitespace() {
+  local value="${1}"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "${value}"
+}
+
+available_subscriptions=()
+
+load_enabled_subscriptions() {
+  mapfile -t available_subscriptions < <(az account list --all --query "[?state=='Enabled'].[name,id]" -o tsv)
+  if [[ "${#available_subscriptions[@]}" -eq 0 ]]; then
+    echo "No enabled subscriptions discovered in tenant ${AZURE_TENANT_ID}" >&2
+    return 1
+  fi
+}
+
+resolve_subscription_id() {
+  local wanted_name="${1}"
+  local entry subscription_name subscription_id
+
+  for entry in "${available_subscriptions[@]}"; do
+    IFS=$'\t' read -r subscription_name subscription_id <<< "${entry}"
+    if [[ "${subscription_name}" == "${wanted_name}" ]]; then
+      printf '%s\n' "${subscription_id}"
+      return 0
+    fi
+  done
+
+  echo "Configured subscription name '${wanted_name}' was not found among enabled subscriptions visible to this credential" >&2
+  return 1
+}
+
 run_cleanup() {
   local subscription_id="${1}"
   local cmd=(
@@ -52,16 +85,22 @@ run_cleanup() {
   "${cmd[@]}"
 }
 
-if [[ "${CLEANUP_SWEEPER_ALL_SUBSCRIPTIONS}" == "true" ]]; then
-  mapfile -t subscriptions < <(az account list --all --query "[?state=='Enabled'].[name,id]" -o tsv)
-  if [[ "${#subscriptions[@]}" -eq 0 ]]; then
-    echo "No enabled subscriptions discovered in tenant ${AZURE_TENANT_ID}"
-    exit 1
-  fi
+run_named_subscription_cleanups() {
+  local raw_name subscription_name subscription_id
+  local failures=0
+  local selected=0
+  local -a requested_names=()
 
-  failures=0
-  for subscription in "${subscriptions[@]}"; do
-    IFS=$'\t' read -r subscription_name subscription_id <<< "${subscription}"
+  IFS=',' read -r -a requested_names <<< "${CLEANUP_SWEEPER_SUBSCRIPTION_NAMES}"
+  load_enabled_subscriptions
+
+  for raw_name in "${requested_names[@]}"; do
+    subscription_name="$(trim_whitespace "${raw_name}")"
+    if [[ -z "${subscription_name}" ]]; then
+      continue
+    fi
+    selected=$((selected + 1))
+    subscription_id="$(resolve_subscription_id "${subscription_name}")"
     echo "Starting cleanup for subscription name='${subscription_name}' id='${subscription_id}'"
     if ! run_cleanup "${subscription_id}"; then
       failures=$((failures + 1))
@@ -69,11 +108,21 @@ if [[ "${CLEANUP_SWEEPER_ALL_SUBSCRIPTIONS}" == "true" ]]; then
     fi
   done
 
-  if [[ "${failures}" -gt 0 ]]; then
-    echo "Cleanup failed for ${failures} subscription(s)"
-    exit 1
+  if [[ "${selected}" -eq 0 ]]; then
+    echo "CLEANUP_SWEEPER_SUBSCRIPTION_NAMES was set but did not contain any subscription names" >&2
+    return 1
   fi
 
+  if [[ "${failures}" -gt 0 ]]; then
+    echo "Cleanup failed for ${failures} subscription(s)"
+    return 1
+  fi
+
+  return 0
+}
+
+if [[ -n "${CLEANUP_SWEEPER_SUBSCRIPTION_NAMES}" ]]; then
+  run_named_subscription_cleanups
   exit 0
 fi
 

--- a/ci-operator/step-registry/aro-hcp/deprovision/cleanup-sweeper/aro-hcp-deprovision-cleanup-sweeper-ref.metadata.json
+++ b/ci-operator/step-registry/aro-hcp/deprovision/cleanup-sweeper/aro-hcp-deprovision-cleanup-sweeper-ref.metadata.json
@@ -1,0 +1,21 @@
+{
+	"path": "aro-hcp/deprovision/cleanup-sweeper/aro-hcp-deprovision-cleanup-sweeper-ref.yaml",
+	"owners": {
+		"approvers": [
+			"geoberle",
+			"jharrington22",
+			"mmazur",
+			"roivaz",
+			"venkateshsredhat",
+			"deads2k"
+		],
+		"reviewers": [
+			"geoberle",
+			"jharrington22",
+			"mmazur",
+			"roivaz",
+			"venkateshsredhat",
+			"deads2k"
+		]
+	}
+}

--- a/ci-operator/step-registry/aro-hcp/deprovision/cleanup-sweeper/aro-hcp-deprovision-cleanup-sweeper-ref.yaml
+++ b/ci-operator/step-registry/aro-hcp/deprovision/cleanup-sweeper/aro-hcp-deprovision-cleanup-sweeper-ref.yaml
@@ -21,9 +21,9 @@ ref:
   - name: CLEANUP_SWEEPER_POLICY
     default: ""
     documentation: Optional policy file path for policy-driven workflows.
-  - name: CLEANUP_SWEEPER_ALL_SUBSCRIPTIONS
-    default: "false"
-    documentation: Run cleanup-sweeper for every enabled subscription visible to this credential (serial loop).
+  - name: CLEANUP_SWEEPER_SUBSCRIPTION_NAMES
+    default: ""
+    documentation: Comma-separated subscription display names to resolve and process serially. Empty string means use only the current subscription.
   - name: CLEANUP_SWEEPER_PARALLELISM
     default: "8"
     documentation: Optional cleanup-sweeper --parallelism value.
@@ -37,4 +37,4 @@ ref:
     default: ""
     documentation: Optional additional CLI arguments appended to cleanup-sweeper.
   documentation: |-
-    Run cleanup-sweeper with configurable workflow settings and optional serial all-subscription execution.
+    Run cleanup-sweeper with configurable workflow settings and optional serial execution over an explicit subscription-name allowlist.

--- a/ci-operator/step-registry/aro-hcp/deprovision/cleanup-sweeper/aro-hcp-deprovision-cleanup-sweeper-ref.yaml
+++ b/ci-operator/step-registry/aro-hcp/deprovision/cleanup-sweeper/aro-hcp-deprovision-cleanup-sweeper-ref.yaml
@@ -1,0 +1,40 @@
+ref:
+  as: aro-hcp-deprovision-cleanup-sweeper
+  from: aro-hcp-e2e-tools
+  commands: aro-hcp-deprovision-cleanup-sweeper-commands.sh
+  resources:
+    requests:
+      cpu: 100m
+      memory: 300Mi
+  credentials:
+    - namespace: test-credentials
+      name: cluster-secrets-aro-hcp-dev
+      mount_path: /var/run/aro-hcp-dev
+  env:
+  - name: VAULT_SECRET_PROFILE
+    default: "dev"
+    documentation: |-
+      Selects which environment's cluster secrets to use (dev, int, stg, prod).
+  - name: CLEANUP_SWEEPER_WORKFLOW
+    default: "shared-leftovers"
+    documentation: Cleanup workflow to execute (for example, "shared-leftovers" or "rg-ordered").
+  - name: CLEANUP_SWEEPER_POLICY
+    default: ""
+    documentation: Optional policy file path for policy-driven workflows.
+  - name: CLEANUP_SWEEPER_ALL_SUBSCRIPTIONS
+    default: "false"
+    documentation: Run cleanup-sweeper for every enabled subscription visible to this credential (serial loop).
+  - name: CLEANUP_SWEEPER_PARALLELISM
+    default: "8"
+    documentation: Optional cleanup-sweeper --parallelism value.
+  - name: CLEANUP_SWEEPER_WAIT
+    default: ""
+    documentation: Optional wait flag value passed as --wait=<value>.
+  - name: CLEANUP_SWEEPER_VERBOSITY
+    default: ""
+    documentation: Optional verbosity level passed as --verbosity=<value>.
+  - name: CLEANUP_SWEEPER_EXTRA_ARGS
+    default: ""
+    documentation: Optional additional CLI arguments appended to cleanup-sweeper.
+  documentation: |-
+    Run cleanup-sweeper with configurable workflow settings and optional serial all-subscription execution.


### PR DESCRIPTION
Add an hourly job to run cleaup-sweeper with the configured policy (https://github.com/Azure/ARO-HCP/blob/main/tooling/cleanup-sweeper/resourcegroups.policy.yaml).
The job walks all configured dev subscriptions and runs the tool.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated resource cleanup with scheduled execution and configurable policies.

* **Chores**
  * Configured CI/CD infrastructure and governance for the new cleanup automation system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->