### PR TITLE
Add temporary 4.20-sbr-rename variant for medik8s/storage-based-remediation

### DIFF
--- a/ci-operator/config/medik8s/storage-based-remediation/medik8s-storage-based-remediation-main__4.20-sbr-rename.yaml
+++ b/ci-operator/config/medik8s/storage-based-remediation/medik8s-storage-based-remediation-main__4.20-sbr-rename.yaml
@@ -1,0 +1,132 @@
+base_images:
+  os:
+    name: centos
+    namespace: openshift
+    tag: stream9
+binary_build_commands: make build
+build_root:
+  from_repository: true
+images:
+  items:
+  - dockerfile_path: Dockerfile
+    from: os
+    to: storage-based-remediation
+  - dockerfile_path: cmd/sbr-agent/Dockerfile
+    to: sbr-agent
+operator:
+  bundles:
+  - as: my-bundle
+    dockerfile_path: bundle.Dockerfile
+    skip_building_index: true
+  substitutions:
+  - pullspec: quay.io/medik8s/storage-based-remediation-operator:.*
+    with: pipeline:storage-based-remediation-operator
+releases:
+  latest:
+    candidate:
+      product: ocp
+      stream: ci
+      version: "4.20"
+resources:
+  '*':
+    requests:
+      cpu: 500m
+      memory: 1000Mi
+tests:
+- as: openshift-e2e
+  run_if_changed: ^$
+  steps:
+    cluster_profile: medik8s-aws
+    env:
+      BASE_DOMAIN: ocp-ci.medik8s-ci.devcluster.openshift.com
+      COMPUTE_NODE_TYPE: m5.4xlarge
+      OPERATOR_NAMESPACE: sbr-operator-system
+      OPERATOR_RELEASED_VERSION: 0.2.0
+    test:
+    - as: install-last-operator-version
+      cli: latest
+      commands: |
+        make create-ns
+
+        # workaround for OLM pod not running with restricted PSA
+        oc label --overwrite ns "$OPERATOR_NAMESPACE" security.openshift.io/scc.podSecurityLabelSync=false
+        oc label --overwrite ns "$OPERATOR_NAMESPACE" pod-security.kubernetes.io/enforce=privileged
+
+        # OPERATOR_NAMESPACE variable is used by bundle-run and bundle-run-update
+        BUNDLE_IMG=quay.io/medik8s/storage-based-remediation-operator-bundle:v"$OPERATOR_RELEASED_VERSION" make bundle-run
+      env:
+      - name: OPERATOR_NAMESPACE
+      - name: OPERATOR_RELEASED_VERSION
+      from: src
+      resources:
+        requests:
+          cpu: 100m
+          memory: 200Mi
+    - as: set-odf-on-cluster
+      cli: latest
+      commands: |
+        # Force ODF setup binary to use test-cluster admin kubeconfig (it prefers
+        # InClusterConfig() otherwise, which may not have namespace create permission).
+        export KUBECONFIG="${SHARED_DIR}/kubeconfig"
+        unset KUBERNETES_SERVICE_HOST KUBERNETES_SERVICE_PORT
+
+        make setup-odf-storage
+        make run-setup-odf-storage-retry
+      from: src
+      resources:
+        requests:
+          cpu: 100m
+          memory: 200Mi
+    - as: upgrade-operator-latest
+      cli: latest
+      commands: |
+        BUNDLE_IMG="$OO_BUNDLE" make bundle-run-update
+
+        # Inject CI-built agent image into the CSV so OLM propagates it to the deployment
+        CSV_NAME=$(oc get csv -n "$OPERATOR_NAMESPACE" -o jsonpath='{.items[0].metadata.name}')
+        oc -n "$OPERATOR_NAMESPACE" patch csv "$CSV_NAME" --type=json -p '[
+          {"op":"add","path":"/spec/install/spec/deployments/0/spec/template/spec/containers/0/env/-","value":{"name":"RELATED_IMAGE_SBR_AGENT","value":"'"${SBR_AGENT_IMAGE}"'"}}
+        ]'
+        echo "CSV patched, waiting for OLM to process and trigger rollout..."
+        sleep 30
+        oc rollout status deployment/sbr-operator-controller-manager \
+          -n "$OPERATOR_NAMESPACE" --timeout=120s
+      dependencies:
+      - env: OO_BUNDLE
+        name: my-bundle
+      - env: SBR_AGENT_IMAGE
+        name: sbr-agent
+      env:
+      - name: OPERATOR_NAMESPACE
+      from: src
+      resources:
+        requests:
+          cpu: 100m
+          memory: 200Mi
+    - as: test-command
+      cli: latest
+      commands: |
+        # kubectl is not available in the CI test pod; create a symlink to oc which is a superset
+        which kubectl || { mkdir -p /tmp/bin && ln -s "$(which oc)" /tmp/bin/kubectl && export PATH="/tmp/bin:${PATH}"; }
+        export OPERATOR_NS="$OPERATOR_NAMESPACE"
+        # Use cluster profile AWS credentials so e2e tests can make EC2 API calls (e.g. ec2:DescribeInstances, ec2:RebootInstances)
+        # The node's IAM role alone doesn't have these permissions
+        export AWS_SHARED_CREDENTIALS_FILE="${CLUSTER_PROFILE_DIR}/.awscred"
+        make test-e2e && TEST_EXIT_CODE=0 || TEST_EXIT_CODE=$? # TEST_EXIT_CODE=$? always returns true, preventing set -e from aborting the script, while still capturing the real exit code
+        # Copy test artifacts (logs, junit report) to CI artifact directory regardless of test outcome
+        cp -r .tests/* "$ARTIFACT_DIR/" 2>/dev/null || echo "WARNING: cp failed (no artifacts to copy?)"
+        # Agents logs expected at <test-number>/artifacts/openshift-e2e/test-command/artifacts/<unique identifier>/
+        exit $TEST_EXIT_CODE
+      env:
+      - name: OPERATOR_NAMESPACE
+      from: src
+      resources:
+        requests:
+          cpu: 100m
+          memory: 200Mi
+    workflow: ipi-aws
+zz_generated_metadata:
+  branch: main
+  org: medik8s
+  repo: storage-based-remediation
+  variant: 4.20-sbr-rename

--- a/ci-operator/jobs/medik8s/storage-based-remediation/medik8s-storage-based-remediation-main-presubmits.yaml
+++ b/ci-operator/jobs/medik8s/storage-based-remediation/medik8s-storage-based-remediation-main-presubmits.yaml
@@ -196,3 +196,199 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )4.20-openshift-e2e,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build06
+    context: ci/prow/4.20-sbr-rename-ci-bundle-my-bundle
+    decorate: true
+    labels:
+      ci-operator.openshift.io/variant: 4.20-sbr-rename
+      ci.openshift.io/generator: prowgen
+      job-release: "4.20"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-medik8s-storage-based-remediation-main-4.20-sbr-rename-ci-bundle-my-bundle
+    rerun_command: /test 4.20-sbr-rename-ci-bundle-my-bundle
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=my-bundle
+        - --variant=4.20-sbr-rename
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )4.20-sbr-rename-ci-bundle-my-bundle,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build06
+    context: ci/prow/4.20-sbr-rename-images
+    decorate: true
+    labels:
+      ci-operator.openshift.io/variant: 4.20-sbr-rename
+      ci.openshift.io/generator: prowgen
+      job-release: "4.20"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-medik8s-storage-based-remediation-main-4.20-sbr-rename-images
+    rerun_command: /test 4.20-sbr-rename-images
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=[images]
+        - --variant=4.20-sbr-rename
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )4.20-sbr-rename-images,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build10
+    context: ci/prow/4.20-sbr-rename-openshift-e2e
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: medik8s-aws
+      ci-operator.openshift.io/variant: 4.20-sbr-rename
+      ci.openshift.io/generator: prowgen
+      job-release: "4.20"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-medik8s-storage-based-remediation-main-4.20-sbr-rename-openshift-e2e
+    rerun_command: /test 4.20-sbr-rename-openshift-e2e
+    run_if_changed: ^$
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=openshift-e2e
+        - --variant=4.20-sbr-rename
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )4.20-sbr-rename-openshift-e2e,?($|\s.*)


### PR DESCRIPTION
Temporary CI config variant to test the SBR rename changes against OCP 4.20.
The openshift-e2e presubmit has `run_if_changed: ^$` so it only runs when explicitly triggered with /test.
