### PR TITLE
opendatahub: Rename pools to fix 21-char cluster name limit

### DIFF
--- a/clusters/hosted-mgmt/hive/pools/opendatahub/opendatahub-ocp-4-19-amd64-aws_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/opendatahub/opendatahub-ocp-4-19-amd64-aws_clusterpool.yaml
@@ -12,7 +12,7 @@ metadata:
     version_lower: 4.19.0-0
     version_stream: 4-stable
     version_upper: 4.20.0-0
-  name: opendatahub-ocp-4-19-amd64-aws
+  name: odh-4-19-aws
   namespace: opendatahub-cluster-pool
 spec:
   baseDomain: openshift-ci-aws.rhaiseng.com
@@ -25,6 +25,7 @@ spec:
     name: opendatahub-install-config-aws
   labels:
     tp.openshift.io/owner: opendatahub
+  maxConcurrent: 2
   maxSize: 40
   platform:
     aws:

--- a/clusters/hosted-mgmt/hive/pools/opendatahub/opendatahub-ocp-4-20-amd64-aws_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/opendatahub/opendatahub-ocp-4-20-amd64-aws_clusterpool.yaml
@@ -12,7 +12,7 @@ metadata:
     version_lower: 4.20.0-0
     version_stream: 4-stable
     version_upper: 4.21.0-0
-  name: opendatahub-ocp-4-20-amd64-aws
+  name: odh-4-20-aws
   namespace: opendatahub-cluster-pool
 spec:
   baseDomain: openshift-ci-aws.rhaiseng.com
@@ -25,6 +25,7 @@ spec:
     name: opendatahub-install-config-aws
   labels:
     tp.openshift.io/owner: opendatahub
+  maxConcurrent: 2
   maxSize: 40
   platform:
     aws:


### PR DESCRIPTION
Rename pools to short names to fix bootstrap DNS failures:
- opendatahub-ocp-4-19-amd64-aws → odh-4-19-aws (30 → 12 chars)
- opendatahub-ocp-4-20-amd64-aws → odh-4-20-aws (30 → 12 chars)

Root cause: Pool names >21 chars generate cluster names that exceed DNS label length limits, causing bootstrap failures. With old names, generated cluster names were 35+ characters. With short names, cluster names will be ~17 chars (odh-4-19-aws-xxxxx).

Changes:
- Renamed both pools to short names (in-place rename)
- Added maxConcurrent: 2 to prevent future resource accumulation
- Both pools maintained at size: 6, runningCount: 2
- Kept current imagesets (4.19.28, 4.20.18)

When this PR merges, Hive will delete the old pools and create new ones with the short names. CI configs unchanged (use cluster_claim labels, not pool names).