### PR TITLE
Use aws-mco-qe profile for MCO FIPS proxy long-duration test

### DIFF
--- a/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-4.22__periodics.yaml
+++ b/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-4.22__periodics.yaml
@@ -219,7 +219,7 @@ tests:
 - as: e2e-aws-mco-fips-proxy-longduration
   interval: 168h
   steps:
-    cluster_profile: openshift-org-aws
+    cluster_profile: aws-mco-qe
     env:
       COMPUTE_NODE_REPLICAS: "2"
       FIPS_ENABLED: "true"

--- a/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-4.23__periodics.yaml
+++ b/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-4.23__periodics.yaml
@@ -219,7 +219,7 @@ tests:
 - as: e2e-aws-mco-fips-proxy-longduration
   interval: 168h
   steps:
-    cluster_profile: openshift-org-aws
+    cluster_profile: aws-mco-qe
     env:
       COMPUTE_NODE_REPLICAS: "2"
       FIPS_ENABLED: "true"

--- a/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-5.0__periodics.yaml
+++ b/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-5.0__periodics.yaml
@@ -219,7 +219,7 @@ tests:
 - as: e2e-aws-mco-fips-proxy-longduration
   interval: 168h
   steps:
-    cluster_profile: openshift-org-aws
+    cluster_profile: aws-mco-qe
     env:
       COMPUTE_NODE_REPLICAS: "2"
       FIPS_ENABLED: "true"

--- a/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-release-4.22-periodics.yaml
+++ b/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-release-4.22-periodics.yaml
@@ -1000,7 +1000,7 @@ periodics:
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: aws
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-mco-qe
     ci-operator.openshift.io/variant: periodics
     ci.openshift.io/generator: prowgen
     job-release: "4.22"

--- a/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-release-4.23-periodics.yaml
+++ b/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-release-4.23-periodics.yaml
@@ -754,7 +754,7 @@ periodics:
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: aws
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-mco-qe
     ci-operator.openshift.io/variant: periodics
     ci.openshift.io/generator: prowgen
     job-release: "4.23"

--- a/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-release-5.0-periodics.yaml
+++ b/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-release-5.0-periodics.yaml
@@ -754,7 +754,7 @@ periodics:
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: aws
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-mco-qe
     ci-operator.openshift.io/variant: periodics
     ci.openshift.io/generator: prowgen
     job-release: "5.0"


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                                                   
  - Updates the `e2e-aws-mco-fips-proxy-longduration` periodic jobs to use the `aws-mco-qe` cluster profile                                                                                                                                                    
  - Applies to releases **4.22**, **4.23**, and **5.0**                                                                                                                                                                                                        
  - This profile is specifically designed for MCO QE long-running tests (24hr+)                                                                                                                                                                                
  - Provides dedicated quota slices across multiple AWS regions                                                                                                                                                                                                
                                                                                                                                                                                                                                                               
  ## Changes                                                                                                                                                                                                                                                   
  - Modified `ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-4.22__periodics.yaml`                                                                                                                             
  - Modified `ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-4.23__periodics.yaml`                                                                                                                             
  - Modified `ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-5.0__periodics.yaml`                                                                                                                              
  - Changed `cluster_profile` from `openshift-org-aws` to `aws-mco-qe`                                                                                                                                                                                         
  - Regenerated Prow job configs for all three releases                                                                                                                                                                                                        
                                                                                                                                                                                                                                                               
  ## Rationale                                                                                                                                                                                                                                                 
  The `aws-mco-qe` profile provides dedicated resources for long-duration MCO tests, ensuring better isolation and resource availability for 24-hour test runs.     