### PR TITLE
build02/04/08: update RHCOS boot images

### DIFF
--- a/clusters/build-clusters/build02/ci-scheduling-webhook/ci-builds-worker-amd64.yaml
+++ b/clusters/build-clusters/build02/ci-scheduling-webhook/ci-builds-worker-amd64.yaml
@@ -37,7 +37,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-8-20260314-0-gcp-x86-64
             # 200 GB * 30 IOPS = 6000 IOPS
             sizeGb: 200
             type: pd-ssd
@@ -120,7 +120,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-8-20260314-0-gcp-x86-64
             # 200 GB * 30 IOPS = 6000 IOPS
             sizeGb: 200
             type: pd-ssd
@@ -203,7 +203,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-8-20260314-0-gcp-x86-64
             # 200 GB * 30 IOPS = 6000 IOPS
             sizeGb: 200
             type: pd-ssd

--- a/clusters/build-clusters/build02/ci-scheduling-webhook/ci-longtests-worker-amd64.yaml
+++ b/clusters/build-clusters/build02/ci-scheduling-webhook/ci-longtests-worker-amd64.yaml
@@ -37,7 +37,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-8-20260314-0-gcp-x86-64
             # 200 GB * 30 IOPS = 6000 IOPS
             sizeGb: 200
             type: pd-ssd
@@ -120,7 +120,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-8-20260314-0-gcp-x86-64
             # 200 GB * 30 IOPS = 6000 IOPS
             sizeGb: 200
             type: pd-ssd
@@ -203,7 +203,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-8-20260314-0-gcp-x86-64
             # 200 GB * 30 IOPS = 6000 IOPS
             sizeGb: 200
             type: pd-ssd

--- a/clusters/build-clusters/build02/ci-scheduling-webhook/ci-prowjobs-worker-amd64.yaml
+++ b/clusters/build-clusters/build02/ci-scheduling-webhook/ci-prowjobs-worker-amd64.yaml
@@ -37,7 +37,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-8-20260314-0-gcp-x86-64
             # 200 GB * 30 IOPS = 6000 IOPS
             sizeGb: 200
             type: pd-ssd
@@ -120,7 +120,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-8-20260314-0-gcp-x86-64
             # 200 GB * 30 IOPS = 6000 IOPS
             sizeGb: 200
             type: pd-ssd
@@ -203,7 +203,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-8-20260314-0-gcp-x86-64
             # 200 GB * 30 IOPS = 6000 IOPS
             sizeGb: 200
             type: pd-ssd

--- a/clusters/build-clusters/build02/ci-scheduling-webhook/ci-tests-worker-amd64.yaml
+++ b/clusters/build-clusters/build02/ci-scheduling-webhook/ci-tests-worker-amd64.yaml
@@ -37,7 +37,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-8-20260314-0-gcp-x86-64
             # 200 GB * 30 IOPS = 6000 IOPS
             sizeGb: 200
             type: pd-ssd
@@ -120,7 +120,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-8-20260314-0-gcp-x86-64
             # 200 GB * 30 IOPS = 6000 IOPS
             sizeGb: 200
             type: pd-ssd
@@ -203,7 +203,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-8-20260314-0-gcp-x86-64
             # 200 GB * 30 IOPS = 6000 IOPS
             sizeGb: 200
             type: pd-ssd

--- a/clusters/build-clusters/build02/machineset/infra-amd64.yaml
+++ b/clusters/build-clusters/build02/machineset/infra-amd64.yaml
@@ -50,7 +50,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-8-20260314-0-gcp-x86-64
             labels: null
             sizeGb: 300
             type: pd-ssd
@@ -125,7 +125,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-8-20260314-0-gcp-x86-64
             labels: null
             sizeGb: 300
             type: pd-ssd
@@ -200,7 +200,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-8-20260314-0-gcp-x86-64
             labels: null
             sizeGb: 300
             type: pd-ssd

--- a/clusters/build-clusters/build02/machineset/worker-amd64.yaml
+++ b/clusters/build-clusters/build02/machineset/worker-amd64.yaml
@@ -34,7 +34,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-8-20260314-0-gcp-x86-64
             labels: {}
             sizeGb: 128
             type: pd-ssd
@@ -104,7 +104,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-8-20260314-0-gcp-x86-64
             labels: {}
             sizeGb: 128
             type: pd-ssd
@@ -174,7 +174,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-8-20260314-0-gcp-x86-64
             labels: {}
             sizeGb: 128
             type: pd-ssd

--- a/clusters/build-clusters/build04/ci-scheduling-webhook/ci-builds-worker-amd64.yaml
+++ b/clusters/build-clusters/build04/ci-scheduling-webhook/ci-builds-worker-amd64.yaml
@@ -37,7 +37,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-6-20260401-0-gcp-x86-64
             # 200 GB * 30 IOPS = 6000 IOPS
             sizeGb: 200
             type: pd-ssd
@@ -120,7 +120,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-6-20260401-0-gcp-x86-64
             # 200 GB * 30 IOPS = 6000 IOPS
             sizeGb: 200
             type: pd-ssd
@@ -203,7 +203,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-6-20260401-0-gcp-x86-64
             # 200 GB * 30 IOPS = 6000 IOPS
             sizeGb: 200
             type: pd-ssd

--- a/clusters/build-clusters/build04/ci-scheduling-webhook/ci-longtests-worker-amd64.yaml
+++ b/clusters/build-clusters/build04/ci-scheduling-webhook/ci-longtests-worker-amd64.yaml
@@ -37,7 +37,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-6-20260401-0-gcp-x86-64
             # 200 GB * 30 IOPS = 6000 IOPS
             sizeGb: 200
             type: pd-ssd
@@ -120,7 +120,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-6-20260401-0-gcp-x86-64
             # 200 GB * 30 IOPS = 6000 IOPS
             sizeGb: 200
             type: pd-ssd
@@ -203,7 +203,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-6-20260401-0-gcp-x86-64
             # 200 GB * 30 IOPS = 6000 IOPS
             sizeGb: 200
             type: pd-ssd

--- a/clusters/build-clusters/build04/ci-scheduling-webhook/ci-prowjobs-worker-amd64.yaml
+++ b/clusters/build-clusters/build04/ci-scheduling-webhook/ci-prowjobs-worker-amd64.yaml
@@ -37,7 +37,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-6-20260401-0-gcp-x86-64
             # 200 GB * 30 IOPS = 6000 IOPS
             sizeGb: 200
             type: pd-ssd
@@ -120,7 +120,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-6-20260401-0-gcp-x86-64
             # 200 GB * 30 IOPS = 6000 IOPS
             sizeGb: 200
             type: pd-ssd
@@ -203,7 +203,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-6-20260401-0-gcp-x86-64
             # 200 GB * 30 IOPS = 6000 IOPS
             sizeGb: 200
             type: pd-ssd

--- a/clusters/build-clusters/build04/ci-scheduling-webhook/ci-tests-worker-amd64.yaml
+++ b/clusters/build-clusters/build04/ci-scheduling-webhook/ci-tests-worker-amd64.yaml
@@ -37,7 +37,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-6-20260401-0-gcp-x86-64
             # 200 GB * 30 IOPS = 6000 IOPS
             sizeGb: 200
             type: pd-ssd
@@ -120,7 +120,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-6-20260401-0-gcp-x86-64
             # 200 GB * 30 IOPS = 6000 IOPS
             sizeGb: 200
             type: pd-ssd
@@ -203,7 +203,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-6-20260401-0-gcp-x86-64
             # 200 GB * 30 IOPS = 6000 IOPS
             sizeGb: 200
             type: pd-ssd

--- a/clusters/build-clusters/build04/machineset/infra-amd64.yaml
+++ b/clusters/build-clusters/build04/machineset/infra-amd64.yaml
@@ -50,7 +50,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-6-20260401-0-gcp-x86-64
             labels: null
             sizeGb: 300
             type: pd-ssd
@@ -125,7 +125,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-6-20260401-0-gcp-x86-64
             labels: null
             sizeGb: 300
             type: pd-ssd
@@ -200,7 +200,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-6-20260401-0-gcp-x86-64
             labels: null
             sizeGb: 300
             type: pd-ssd

--- a/clusters/build-clusters/build04/machineset/worker-amd64.yaml
+++ b/clusters/build-clusters/build04/machineset/worker-amd64.yaml
@@ -34,7 +34,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-6-20260401-0-gcp-x86-64
             labels: {}
             sizeGb: 128
             type: pd-ssd
@@ -104,7 +104,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-6-20260401-0-gcp-x86-64
             labels: {}
             sizeGb: 128
             type: pd-ssd
@@ -174,7 +174,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-6-20260401-0-gcp-x86-64
             labels: {}
             sizeGb: 128
             type: pd-ssd

--- a/clusters/build-clusters/build08/ci-scheduling-webhook/ci-builds-worker-amd64.yaml
+++ b/clusters/build-clusters/build08/ci-scheduling-webhook/ci-builds-worker-amd64.yaml
@@ -37,7 +37,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-6-20260401-0-gcp-x86-64
             # 200 GB * 30 IOPS = 6000 IOPS
             sizeGb: 200
             type: pd-ssd
@@ -120,7 +120,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-6-20260401-0-gcp-x86-64
             # 200 GB * 30 IOPS = 6000 IOPS
             sizeGb: 200
             type: pd-ssd
@@ -203,7 +203,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-6-20260401-0-gcp-x86-64
             # 200 GB * 30 IOPS = 6000 IOPS
             sizeGb: 200
             type: pd-ssd

--- a/clusters/build-clusters/build08/ci-scheduling-webhook/ci-longtests-worker-amd64.yaml
+++ b/clusters/build-clusters/build08/ci-scheduling-webhook/ci-longtests-worker-amd64.yaml
@@ -37,7 +37,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-6-20260401-0-gcp-x86-64
             # 200 GB * 30 IOPS = 6000 IOPS
             sizeGb: 200
             type: pd-ssd
@@ -120,7 +120,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-6-20260401-0-gcp-x86-64
             # 200 GB * 30 IOPS = 6000 IOPS
             sizeGb: 200
             type: pd-ssd
@@ -203,7 +203,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-6-20260401-0-gcp-x86-64
             # 200 GB * 30 IOPS = 6000 IOPS
             sizeGb: 200
             type: pd-ssd

--- a/clusters/build-clusters/build08/ci-scheduling-webhook/ci-prowjobs-worker-amd64.yaml
+++ b/clusters/build-clusters/build08/ci-scheduling-webhook/ci-prowjobs-worker-amd64.yaml
@@ -37,7 +37,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-6-20260401-0-gcp-x86-64
             # 200 GB * 30 IOPS = 6000 IOPS
             sizeGb: 200
             type: pd-ssd
@@ -120,7 +120,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-6-20260401-0-gcp-x86-64
             # 200 GB * 30 IOPS = 6000 IOPS
             sizeGb: 200
             type: pd-ssd
@@ -203,7 +203,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-6-20260401-0-gcp-x86-64
             # 200 GB * 30 IOPS = 6000 IOPS
             sizeGb: 200
             type: pd-ssd

--- a/clusters/build-clusters/build08/ci-scheduling-webhook/ci-tests-worker-amd64.yaml
+++ b/clusters/build-clusters/build08/ci-scheduling-webhook/ci-tests-worker-amd64.yaml
@@ -37,7 +37,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-6-20260401-0-gcp-x86-64
             # 200 GB * 30 IOPS = 6000 IOPS
             sizeGb: 200
             type: pd-ssd
@@ -120,7 +120,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-6-20260401-0-gcp-x86-64
             # 200 GB * 30 IOPS = 6000 IOPS
             sizeGb: 200
             type: pd-ssd
@@ -203,7 +203,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-6-20260401-0-gcp-x86-64
             # 200 GB * 30 IOPS = 6000 IOPS
             sizeGb: 200
             type: pd-ssd

--- a/clusters/build-clusters/build08/machineset/infra-amd64.yaml
+++ b/clusters/build-clusters/build08/machineset/infra-amd64.yaml
@@ -50,7 +50,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-6-20260401-0-gcp-x86-64
             labels: null
             sizeGb: 300
             type: pd-ssd
@@ -125,7 +125,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-6-20260401-0-gcp-x86-64
             labels: null
             sizeGb: 300
             type: pd-ssd
@@ -200,7 +200,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250826-1-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-6-20260401-0-gcp-x86-64
             labels: null
             sizeGb: 300
             type: pd-ssd

--- a/clusters/build-clusters/build08/machineset/worker-amd64.yaml
+++ b/clusters/build-clusters/build08/machineset/worker-amd64.yaml
@@ -34,7 +34,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20251023-0-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-6-20260401-0-gcp-x86-64
             labels: {}
             sizeGb: 128
             type: pd-ssd
@@ -104,7 +104,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20251023-0-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-6-20260401-0-gcp-x86-64
             labels: {}
             sizeGb: 128
             type: pd-ssd
@@ -174,7 +174,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20251023-0-gcp-x86-64
+            image: projects/rhcos-cloud/global/images/rhcos-9-6-20260401-0-gcp-x86-64
             labels: {}
             sizeGb: 128
             type: pd-ssd


### PR DESCRIPTION
## Summary
- **build02**: Update boot image from `rhcos-9-6-20250826-1` to `rhcos-9-8-20260314-0` (cluster runs OCP 4.22 / RHCOS 9.8)
- **build04**: Update boot image from `rhcos-9-6-20250826-1` to `rhcos-9-6-20260401-0` (cluster runs OCP 4.20 / RHCOS 9.6)
- **build08**: Update boot images from `rhcos-9-6-20250826-1` and `rhcos-9-6-20251023-0` to `rhcos-9-6-20260401-0` (cluster runs OCP 4.20 / RHCOS 9.6)

New worker VMs fail to bootstrap on build02: the MCD firstboot pull hangs on the old RHCOS 9.6 image when the cluster expects 9.8, preventing kubelet from starting and leaving machines stuck in `Provisioned` phase. build04 already has a stuck machine with the same symptoms.


🤖 Generated with [Claude Code](https://claude.com/claude-code)