### PR TITLE
Fix operator substitution image reference in 4.20-sbr-rename variant

### DIFF
--- a/ci-operator/config/medik8s/storage-based-remediation/medik8s-storage-based-remediation-main__4.20-sbr-rename.yaml
+++ b/ci-operator/config/medik8s/storage-based-remediation/medik8s-storage-based-remediation-main__4.20-sbr-rename.yaml
@@ -20,7 +20,7 @@ operator:
     skip_building_index: true
   substitutions:
   - pullspec: quay.io/medik8s/storage-based-remediation-operator:.*
-    with: pipeline:storage-based-remediation-operator
+    with: pipeline:storage-based-remediation
 releases:
   latest:
     candidate:


### PR DESCRIPTION
The substitution referenced pipeline:storage-based-remediation-operator but the image is built as pipeline:storage-based-remediation, causing a dependency resolution failure.
