### PR TITLE
Fix censoring exclude_directories glob for ARO-HCP (take 2)

### DIFF
--- a/core-services/prow/02_config/_config.yaml
+++ b/core-services/prow/02_config/_config.yaml
@@ -359,7 +359,7 @@ plank:
   - config:
       censoring_options:
         exclude_directories:
-        - '**/aro-hcp-gather-custom-link-tools/**/*.html'
+        - '**/custom-link-tools*.html'
     repo: Azure/ARO-HCP
   - config:
       gcs_configuration:


### PR DESCRIPTION
The previous glob `**/aro-hcp-gather-custom-link-tools/**/*.html` still never matched. Try matching on the actual file names instead, which are what the sidecar sees: `custom-link-tools*.html`.