### PR TITLE
hosted-mgmt: pin Hive to manual upgrades, add installAttemptsLimit, bump 4.21 imageset to 4.21.10

### DIFF
--- a/clusters/hosted-mgmt/hive/operator.yaml
+++ b/clusters/hosted-mgmt/hive/operator.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openshift-operators
 spec:
   channel: alpha
-  installPlanApproval: Automatic
+  installPlanApproval: Manual
   name: hive-operator
   source: community-operators
   sourceNamespace: openshift-marketplace

--- a/clusters/hosted-mgmt/hive/pools/ci-tools/fake-ocp-4-18-multi-aws_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/ci-tools/fake-ocp-4-18-multi-aws_clusterpool.yaml
@@ -20,6 +20,7 @@ spec:
   hibernationConfig: null
   imageSetRef:
     name: ocp-release-4.18.37-multi-for-4.18.0-0-to-4.19.0-0
+  installAttemptsLimit: 1
   installConfigSecretTemplateRef:
     name: fake-install-config
   labels:

--- a/clusters/hosted-mgmt/hive/pools/cvp/cvp-fips-ocp-4-21-amd64-aws-eu-west-3_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/cvp/cvp-fips-ocp-4-21-amd64-aws-eu-west-3_clusterpool.yaml
@@ -20,7 +20,7 @@ spec:
   hibernationConfig:
     resumeTimeout: 15m0s
   imageSetRef:
-    name: ocp-release-4.21.9-multi-for-4.21.0-0-to-4.22.0-0
+    name: ocp-release-4.21.10-multi-for-4.21.0-0-to-4.22.0-0
   installAttemptsLimit: 1
   installConfigSecretTemplateRef:
     name: fips-install-config-aws-eu-west-3

--- a/clusters/hosted-mgmt/hive/pools/cvp/cvp-ocp-4-21-amd64-aws-eu-west-3_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/cvp/cvp-ocp-4-21-amd64-aws-eu-west-3_clusterpool.yaml
@@ -19,7 +19,7 @@ spec:
   hibernationConfig:
     resumeTimeout: 15m0s
   imageSetRef:
-    name: ocp-release-4.21.9-multi-for-4.21.0-0-to-4.22.0-0
+    name: ocp-release-4.21.10-multi-for-4.21.0-0-to-4.22.0-0
   installAttemptsLimit: 1
   installConfigSecretTemplateRef:
     name: install-config-aws-eu-west-3

--- a/clusters/hosted-mgmt/hive/pools/ocp-release-4.21.10-multi-for-4.21.0-0-to-4.22.0-0_clusterimageset.yaml
+++ b/clusters/hosted-mgmt/hive/pools/ocp-release-4.21.10-multi-for-4.21.0-0-to-4.22.0-0_clusterimageset.yaml
@@ -6,7 +6,7 @@ metadata:
     version_stream: 4-stable
     version_upper: 4.22.0-0
   creationTimestamp: null
-  name: ocp-release-4.21.9-multi-for-4.21.0-0-to-4.22.0-0
+  name: ocp-release-4.21.10-multi-for-4.21.0-0-to-4.22.0-0
 spec:
-  releaseImage: quay.io/openshift-release-dev/ocp-release:4.21.9-multi
+  releaseImage: quay.io/openshift-release-dev/ocp-release:4.21.10-multi
 status: {}

--- a/clusters/hosted-mgmt/hive/pools/openshift-ci/ci-ocp-4-21-0-amd64-aws-us-east-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-ci/ci-ocp-4-21-0-amd64-aws-us-east-1_clusterpool.yaml
@@ -19,7 +19,7 @@ spec:
   hibernationConfig:
     resumeTimeout: 20m0s
   imageSetRef:
-    name: ocp-release-4.21.9-multi-for-4.21.0-0-to-4.22.0-0
+    name: ocp-release-4.21.10-multi-for-4.21.0-0-to-4.22.0-0
   installAttemptsLimit: 1
   installConfigSecretTemplateRef:
     name: install-config-aws-us-east-1

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-logging-ocp-4-21-amd64-aws-us-east-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-logging-ocp-4-21-amd64-aws-us-east-1_clusterpool.yaml
@@ -19,7 +19,7 @@ spec:
   hibernationConfig:
     resumeTimeout: 20m0s
   imageSetRef:
-    name: ocp-release-4.21.9-multi-for-4.21.0-0-to-4.22.0-0
+    name: ocp-release-4.21.10-multi-for-4.21.0-0-to-4.22.0-0
   installAttemptsLimit: 1
   installConfigSecretTemplateRef:
     name: install-config-aws-2xlarge-us-east-1

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-21-0-amd64-aws-us-east-2_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-21-0-amd64-aws-us-east-2_clusterpool.yaml
@@ -19,7 +19,7 @@ spec:
   hibernationConfig:
     resumeTimeout: 20m0s
   imageSetRef:
-    name: ocp-release-4.21.9-multi-for-4.21.0-0-to-4.22.0-0
+    name: ocp-release-4.21.10-multi-for-4.21.0-0-to-4.22.0-0
   installAttemptsLimit: 1
   installConfigSecretTemplateRef:
     name: install-config-aws-us-east-2

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-21-0-fips-amd64-aws-us-east-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-21-0-fips-amd64-aws-us-east-1_clusterpool.yaml
@@ -20,7 +20,7 @@ spec:
   hibernationConfig:
     resumeTimeout: 20m0s
   imageSetRef:
-    name: ocp-release-4.21.9-multi-for-4.21.0-0-to-4.22.0-0
+    name: ocp-release-4.21.10-multi-for-4.21.0-0-to-4.22.0-0
   installAttemptsLimit: 1
   installConfigSecretTemplateRef:
     name: fips-install-config-aws-us-east-1

--- a/clusters/hosted-mgmt/hive/pools/rh-openshift-ecosystem/rhoe-ocp-4-21-amd64-aws-us-east-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/rh-openshift-ecosystem/rhoe-ocp-4-21-amd64-aws-us-east-1_clusterpool.yaml
@@ -18,7 +18,7 @@ spec:
   hibernationConfig:
     resumeTimeout: 20m0s
   imageSetRef:
-    name: ocp-release-4.21.9-multi-for-4.21.0-0-to-4.22.0-0
+    name: ocp-release-4.21.10-multi-for-4.21.0-0-to-4.22.0-0
   installAttemptsLimit: 1
   installConfigSecretTemplateRef:
     name: install-config-4-21-amd64-aws-us-east-1

--- a/clusters/hosted-mgmt/hive/pools/rh-openshift-ecosystem/rhoe-ocp-4-21-amd64-aws-us-east-2_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/rh-openshift-ecosystem/rhoe-ocp-4-21-amd64-aws-us-east-2_clusterpool.yaml
@@ -18,7 +18,7 @@ spec:
   hibernationConfig:
     resumeTimeout: 20m0s
   imageSetRef:
-    name: ocp-release-4.21.9-multi-for-4.21.0-0-to-4.22.0-0
+    name: ocp-release-4.21.10-multi-for-4.21.0-0-to-4.22.0-0
   installAttemptsLimit: 1
   installConfigSecretTemplateRef:
     name: install-config-4-21-amd64-aws-us-east-2

--- a/clusters/hosted-mgmt/hive/pools/rhdh/rhdh-ocp-4-21-0-amd64-aws-us-east-2_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/rhdh/rhdh-ocp-4-21-0-amd64-aws-us-east-2_clusterpool.yaml
@@ -19,7 +19,7 @@ spec:
   hibernationConfig:
     resumeTimeout: 30m0s
   imageSetRef:
-    name: ocp-release-4.21.9-multi-for-4.21.0-0-to-4.22.0-0
+    name: ocp-release-4.21.10-multi-for-4.21.0-0-to-4.22.0-0
   installAttemptsLimit: 1
   installConfigSecretTemplateRef:
     name: rhdh-aws-us-east-2

--- a/clusters/hosted-mgmt/hive/pools/serverless/serverless-ocp-4-21-amd64-aws-us-east-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/serverless/serverless-ocp-4-21-amd64-aws-us-east-1_clusterpool.yaml
@@ -19,7 +19,7 @@ spec:
   hibernationConfig:
     resumeTimeout: 20m0s
   imageSetRef:
-    name: ocp-release-4.21.9-multi-for-4.21.0-0-to-4.22.0-0
+    name: ocp-release-4.21.10-multi-for-4.21.0-0-to-4.22.0-0
   installAttemptsLimit: 1
   installConfigSecretTemplateRef:
     name: install-config-aws-us-east-1

--- a/clusters/hosted-mgmt/hive/pools/stackrox/ocp-4.12_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/stackrox/ocp-4.12_clusterpool.yaml
@@ -19,6 +19,7 @@ spec:
     resumeTimeout: 15m0s
   imageSetRef:
     name: ocp-release-4.12.61-multi-for-4.12.0-0-to-4.13.0-0
+  installAttemptsLimit: 1
   installConfigSecretTemplateRef:
     name: stackrox-ocp-4-13-install-config
   labels:


### PR DESCRIPTION
## Summary

- Set `installPlanApproval: Manual` on the Hive operator subscription to prevent uncontrolled upgrades; pins at `hive-operator.v1.2.5060-b061ef0` which includes the deprovisioning fix
- Add `installAttemptsLimit: 1` to `ci-tools/fake-ocp-4-18-multi-aws` and `stackrox/ocp-4.12` ClusterPools to prevent infinite retry loops on install failure
- Bump the 4.21 ClusterImageSet from `4.21.9-multi` → `4.21.10-multi` across all referencing pools; 4.21.10 includes the AWS SDK v2 EC2 not-found error handling fix (openshift/installer#10340)

## Test plan

- [ ] Verify Hive subscription on hosted-mgmt no longer auto-approves InstallPlans after merge
- [ ] Confirm 4.21 cluster pools reference the updated imageset

Assisted with [Cursor](https://cursor.com)