### PR TITLE
opendatahub: Increase maxConcurrent from 2 to 5

### DIFF
--- a/clusters/hosted-mgmt/hive/pools/opendatahub/opendatahub-ocp-4-19-amd64-aws_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/opendatahub/opendatahub-ocp-4-19-amd64-aws_clusterpool.yaml
@@ -25,7 +25,7 @@ spec:
     name: opendatahub-install-config-aws
   labels:
     tp.openshift.io/owner: opendatahub
-  maxConcurrent: 2
+  maxConcurrent: 5
   maxSize: 40
   platform:
     aws:

--- a/clusters/hosted-mgmt/hive/pools/opendatahub/opendatahub-ocp-4-20-amd64-aws_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/opendatahub/opendatahub-ocp-4-20-amd64-aws_clusterpool.yaml
@@ -25,7 +25,7 @@ spec:
     name: opendatahub-install-config-aws
   labels:
     tp.openshift.io/owner: opendatahub
-  maxConcurrent: 2
+  maxConcurrent: 5
   maxSize: 40
   platform:
     aws:


### PR DESCRIPTION
Increase maxConcurrent limit for both opendatahub cluster pools:
- odh-4-19-aws: maxConcurrent 2 → 5
- odh-4-20-aws: maxConcurrent 2 → 5

This allows up to 5 clusters to be provisioned simultaneously instead of 2, improving throughput for parallel CI workloads while still preventing excessive IAM resource accumulation.