### PR TITLE
TELCOV10N-923 - Add step for reporting and Slack

### DIFF
--- a/ci-operator/config/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main__cnf-ran-sno-day2-worker-4.20.yaml
+++ b/ci-operator/config/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main__cnf-ran-sno-day2-worker-4.20.yaml
@@ -39,7 +39,14 @@ tests:
           {"name":"topology-aware-lifecycle-manager","catalog":"topology-aware-lifecycle-manager-fbc","og_name":"global-operators","nsname":"openshift-operators","fbc_iib_repo":"latest","channel":"stable","deploy_default_config":false,"ocp_operator_mirror_fbc_image_base":"quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-fbc-4-20"},
           {"name":"cluster-logging","catalog":"redhat-operators","nsname":"openshift-logging","channel":"stable-6.2","default_channel":"stable-6.5","og_name":"cluster-logging","subscription_name":"cluster-logging","og_spec":{"targetNamespaces":[]}}
         ]
+      JOB_NAME: periodic-ci-openshift-kni-eco-ci-cd-main-cnf-ran-sno-day2-worker-4.20-cnf-ran-ztp-tests
+      JOB_TYPE: "1"
       MIRROR_REGISTRY: disconnected.registry.local:5000
+      RAN_METRICS_LIST: spoke_general_ocp,hub_general_ocp,sriov,sriov_fec,ptp,acm,talm,gitops,local_storage,logging
+      REPORTER_TEMPLATE_NAME: Telco 5G RAN Regression 4_20 - Telco 5G RAN Regression
+        - <build> - 4.20
+      REPORTPORTAL_FILES: .reportportal_url_Sno_Day2_Worker
+      REPORTS_PORTAL_ATTRIBUTES_ENV: ci-lane:telco-ft-ran-sno-day2-worker;spoke_ocp_version:4.20
       SPOKE_CLUSTER: '[''kni-qe-107'']'
       SPOKE_OPERATORS: |
         [
@@ -53,6 +60,11 @@ tests:
       ZTP_GIT_BRANCH: sno_day2_worker
       ZTP_GIT_BRANCH_DAY2_WORKER: sno_day2_worker_add_worker
       ZTP_GIT_REPO: https://gitlab.cee.redhat.com/telcov10n/ztp-site-configs-ci.git
+    post:
+    - ref: telcov10n-functional-cnf-ran-report-compact
+    - ref: telcov10n-functional-cnf-ran-send-slack-notification
+    - ref: telcov10n-functional-cnf-network-trigger-job
+    - ref: telcov10n-verify-junit-reports
     pre:
     - ref: telcov10n-functional-cnf-ran-hub-deploy
     - ref: telcov10n-functional-cnf-ran-hub-config

--- a/ci-operator/step-registry/telcov10n/functional/cnf-ran/report-compact/telcov10n-functional-cnf-ran-report-compact-ref.yaml
+++ b/ci-operator/step-registry/telcov10n/functional/cnf-ran/report-compact/telcov10n-functional-cnf-ran-report-compact-ref.yaml
@@ -49,3 +49,6 @@ ref:
   - namespace: test-credentials
     name: telcov10n-ansible-fthub-01-bastion
     mount_path: /var/host_variables/fthub-01/bastion
+  - namespace: test-credentials
+    name: telcov10n-ansible-kni-qe-106-bastion
+    mount_path: /var/host_variables/kni-qe-106/bastion

--- a/ci-operator/step-registry/telcov10n/functional/cnf-ran/send-slack-notification/telcov10n-functional-cnf-ran-send-slack-notification-ref.yaml
+++ b/ci-operator/step-registry/telcov10n/functional/cnf-ran/send-slack-notification/telcov10n-functional-cnf-ran-send-slack-notification-ref.yaml
@@ -31,6 +31,9 @@ ref:
       name: telcov10n-ansible-fthub-01-bastion
       mount_path: /var/host_variables/fthub-01/bastion
     - namespace: test-credentials
+      name: telcov10n-ansible-kni-qe-106-bastion
+      mount_path: /var/host_variables/kni-qe-106/bastion
+    - namespace: test-credentials
       name: vran-qe-ci-webhook
       mount_path: /var/run/slack-webhook-url
   documentation: |-


### PR DESCRIPTION
Modifies the step configuration to parametrize the bastion server where the report URLs are stored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR updates OpenShift CI configuration (openshift/release) for the TEL Connectivity Overlay (telcov10n) CNF RAN test pipeline to parameterize an additional bastion server used for storing report URLs and to extend reporting/notification behavior for the cnf-ran-sno-day2-worker-4.20 test variant.

## What changed in practical terms

- Repository affected: openshift/release — CI operator job and step-registry for telcov10n/cnf-ran tests.
- Purpose: allow reporting and Slack-notification steps to read host variables/configuration from an additional bastion (kni-qe-106) so report URLs and related artifacts can be retrieved from that host.

## Key changes

1. Step-registry credential additions
- Added a new credential entry `telcov10n-ansible-kni-qe-106-bastion` to two pipeline steps:
  - telcov10n/functional/cnf-ran/report-compact
  - telcov10n/functional/cnf-ran/send-slack-notification
- The credential is mounted at /var/host_variables/kni-qe-106/bastion so the reporting and Slack steps can access kni-qe-106 host variables alongside existing bastions.

2. CI job configuration (ci-operator config for cnf-ran-sno-day2-worker-4.20)
- Added periodic job metadata and an explicit MIRROR_REGISTRY override.
- Enabled/extended reporting configuration via REPORTER_TEMPLATE_NAME, REPORTPORTAL_FILES, REPORTS_PORTAL_ATTRIBUTES_ENV, and UPLOAD_TO_REPORT_PORTAL.
- Expanded RAN_METRICS_LIST to collect additional metrics (spoke_general_ocp, hub_general_ocp, sriov, sriov_fec, ptp, acm, talm, gitops, local_storage, logging).
- Post-test workflow extended to include compact report handling, Slack notifications, network-triggered job handling, and JUnit report verification.
- Test refs updated to include eco-gotests-sno-worker alongside cnf-gotests-sno-worker.

## Impact

- Reporting and Slack-notification steps can now pull report URLs/config from kni-qe-106, improving flexibility when reports are hosted on that bastion.
- The cnf-ran sno day2 worker job has expanded metrics and reporting integrations enabling richer telemetry and automated notifications.
- Changes are configuration-only (YAML); no code exports or public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->