### PR TITLE
ARO-HCP: Add 4h timeout to aro-hcp-test-persistent step ref

### DIFF
--- a/ci-operator/step-registry/aro-hcp/test/persistent/aro-hcp-test-persistent-ref.yaml
+++ b/ci-operator/step-registry/aro-hcp/test/persistent/aro-hcp-test-persistent-ref.yaml
@@ -6,6 +6,7 @@ ref:
     - namespace: test-credentials
       name: aro-hcp-qe-pull-secret
       mount_path: /var/run/aro-hcp-qe-pull-secret
+  timeout: 4h0m0s
   resources:
     requests:
       cpu: 1000m


### PR DESCRIPTION
### What

Add explicit `timeout: 4h0m0s` to the `aro-hcp-test-persistent` step ref, matching the Prow job-level timeout set in #77612.

### Why

There are **two independent timeout layers** in the Prow/ci-operator pipeline, and #77612 only fixed one:

**Layer 1: Prow job timeout (fixed by #77612)**
The `decoration_config.timeout` controls how long the entire Prow pod can run. This was bumped from 2h (default) to 4h.

**Layer 2: ci-operator step timeout (NOT fixed — what this PR addresses)**
Each step ref in the ci-operator step registry has its own timeout. When omitted, it defaults to 2 hours. The `aro-hcp-test-persistent-ref.yaml` step — which runs the actual e2e binary — has no `timeout` field, so ci-operator kills it at 2h regardless of the Prow job-level timeout.

**Evidence:** Both runs that started **after** #77612 was merged (Apr 9 19:28 UTC) still died at exactly ~128 min:

| Run | Started (UTC) | Duration | Result |
|-----|--------------|----------|--------|
| `2042557690818859008` | Apr 10 10:58 | 128 min | KILLED |
| `2042558518153711616` | Apr 10 11:01 | 127 min | KILLED |

Tests that were actively passing got `signal: killed` during cleanup — ci-operator terminating the step process, not individual test timeouts.

**In short:**
- **#77612** = "the Prow pod can run for 4h" ✅
- **This PR** = "the test step inside that pod can also run for 4h" ← missing piece

Without both, the step hits the 2h default and kills all running tests even though the pod has 2 more hours available.

### Testing

No tests needed — this is a ci-operator config change. Validation will be visible in the next periodic prod-e2e-parallel runs, which should no longer be killed at ~128 min.

### Changes

- `ci-operator/step-registry/aro-hcp/test/persistent/aro-hcp-test-persistent-ref.yaml`: Added `timeout: 4h0m0s`
