### PR TITLE
Scale down 4-22 clusters

### DIFF
--- a/clusters/hosted-mgmt/hive/pools/cvp/cvp-fips-ocp-4-22-amd64-aws-eu-central-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/cvp/cvp-fips-ocp-4-22-amd64-aws-eu-central-1_clusterpool.yaml
@@ -35,8 +35,8 @@ spec:
       region: eu-central-1
   pullSecretRef:
     name: pull-secret
-  runningCount: 8
-  size: 10
+  runningCount: 0
+  size: 0
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/cvp/cvp-ocp-4-22-amd64-aws-eu-central-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/cvp/cvp-ocp-4-22-amd64-aws-eu-central-1_clusterpool.yaml
@@ -34,8 +34,8 @@ spec:
       region: eu-central-1
   pullSecretRef:
     name: pull-secret
-  runningCount: 5
-  size: 5
+  runningCount: 0
+  size: 0
   skipMachinePools: true
 status:
   ready: 0


### PR DESCRIPTION
Scaled down CVP's v4.22 clusters until https://github.com/openshift/ci-tools/pull/5092 makes it into production.