### PR TITLE
opendatahub: Increase 4.20 pool size from 6 to 12

### DIFF
--- a/clusters/hosted-mgmt/hive/pools/opendatahub/opendatahub-ocp-4-20-amd64-aws_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/opendatahub/opendatahub-ocp-4-20-amd64-aws_clusterpool.yaml
@@ -35,7 +35,7 @@ spec:
   pullSecretRef:
     name: pull-secret
   runningCount: 2
-  size: 6
+  size: 12
   skipMachinePools: true
 status:
   ready: 0


### PR DESCRIPTION
Increase odh-4-20-aws cluster pool size from 6 to 12 to provide more capacity for parallel CI workloads.

Changes:
- odh-4-20-aws: size 6 → 12
- Maintains runningCount: 2, maxConcurrent: 2

This doubles the pool capacity to better support concurrent E2E test runs while keeping the same number of running clusters.