### PR TITLE
NO-ISSUE: core-services/prow/02_config/openshift: cluster-version-operator acknowledge-critical-fixes-only

### DIFF
--- a/core-services/prow/02_config/openshift/cincinnati-operator/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/cincinnati-operator/_prowconfig.yaml
@@ -1,6 +1,7 @@
 tide:
   queries:
   - labels:
+    - acknowledge-critical-fixes-only
     - approved
     - lgtm
     missingLabels:

--- a/core-services/prow/02_config/openshift/cincinnati/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/cincinnati/_prowconfig.yaml
@@ -1,6 +1,7 @@
 tide:
   queries:
   - labels:
+    - acknowledge-critical-fixes-only
     - approved
     - lgtm
     missingLabels:

--- a/core-services/prow/02_config/openshift/cluster-version-operator/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/cluster-version-operator/_prowconfig.yaml
@@ -1,6 +1,25 @@
 tide:
   queries:
   - includedBranches:
+    - main
+    - master
+    labels:
+    - acknowledge-critical-fixes-only
+    - approved
+    - jira/valid-reference
+    - lgtm
+    - verified
+    missingLabels:
+    - backports/unvalidated-commits
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - jira/invalid-bug
+    - keep-main-query-separate
+    - needs-rebase
+    repos:
+    - openshift/cluster-version-operator
+  - includedBranches:
     - openshift-4.22
     - release-4.22
     labels:
@@ -76,24 +95,6 @@ tide:
     - do-not-merge/invalid-owners-file
     - do-not-merge/work-in-progress
     - jira/invalid-bug
-    - needs-rebase
-    repos:
-    - openshift/cluster-version-operator
-  - includedBranches:
-    - main
-    - master
-    labels:
-    - approved
-    - jira/valid-reference
-    - lgtm
-    - verified
-    missingLabels:
-    - backports/unvalidated-commits
-    - do-not-merge/hold
-    - do-not-merge/invalid-owners-file
-    - do-not-merge/work-in-progress
-    - jira/invalid-bug
-    - keep-main-query-separate
     - needs-rebase
     repos:
     - openshift/cluster-version-operator


### PR DESCRIPTION
And the two Cincinnati repos that get quality-engineer review, while we focus on stability in the run up to 4.22.