### PR TITLE
CNTRLPLANE-3222: Add e2e-azure-v2-self-managed CI job for HyperShift

### DIFF
--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-main.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-main.yaml
@@ -240,6 +240,15 @@ tests:
     - ref: hypershift-analyze-e2e-failure
     - chain: hypershift-destroy-nested-management-cluster
     workflow: hypershift-azure-e2e-self-managed
+- always_run: true
+  as: e2e-azure-v2-self-managed
+  optional: true
+  steps:
+    cluster_profile: hypershift-azure
+    env:
+      ENABLE_HYPERSHIFT_CERT_ROTATION_SCALE: "true"
+      HYPERSHIFT_AZURE_LOCATION: centralus
+    workflow: hypershift-azure-e2e-v2-self-managed
 - always_run: false
   as: e2e-aws-minimal
   optional: true

--- a/ci-operator/jobs/openshift/hypershift/openshift-hypershift-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/hypershift/openshift-hypershift-main-presubmits.yaml
@@ -1306,6 +1306,87 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-azure-self-managed,?($|\s.*)
   - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build01
+    context: ci/prow/e2e-azure-v2-self-managed
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: hypershift-azure
+      ci-operator.openshift.io/cloud-cluster-profile: hypershift-azure
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-hypershift-main-e2e-azure-v2-self-managed
+    optional: true
+    rerun_command: /test e2e-azure-v2-self-managed
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-azure-v2-self-managed
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-azure-v2-self-managed,?($|\s.*)
+  - agent: kubernetes
     always_run: false
     branches:
     - ^main$

--- a/ci-operator/step-registry/hypershift/azure/create-selfmanaged-guests/OWNERS
+++ b/ci-operator/step-registry/hypershift/azure/create-selfmanaged-guests/OWNERS
@@ -1,0 +1,11 @@
+approvers:
+- csrwng
+- enxebre
+- sjenning
+- bryan-cox
+options: {}
+reviewers:
+- csrwng
+- enxebre
+- sjenning
+- bryan-cox

--- a/ci-operator/step-registry/hypershift/azure/create-selfmanaged-guests/hypershift-azure-create-selfmanaged-guests-chain.metadata.json
+++ b/ci-operator/step-registry/hypershift/azure/create-selfmanaged-guests/hypershift-azure-create-selfmanaged-guests-chain.metadata.json
@@ -1,0 +1,17 @@
+{
+	"path": "hypershift/azure/create-selfmanaged-guests/hypershift-azure-create-selfmanaged-guests-chain.yaml",
+	"owners": {
+		"approvers": [
+			"csrwng",
+			"enxebre",
+			"sjenning",
+			"bryan-cox"
+		],
+		"reviewers": [
+			"csrwng",
+			"enxebre",
+			"sjenning",
+			"bryan-cox"
+		]
+	}
+}

--- a/ci-operator/step-registry/hypershift/azure/create-selfmanaged-guests/hypershift-azure-create-selfmanaged-guests-chain.yaml
+++ b/ci-operator/step-registry/hypershift/azure/create-selfmanaged-guests/hypershift-azure-create-selfmanaged-guests-chain.yaml
@@ -1,0 +1,4 @@
+chain:
+  as: hypershift-azure-create-selfmanaged-guests
+  steps:
+  - ref: hypershift-azure-create-selfmanaged-guests

--- a/ci-operator/step-registry/hypershift/azure/create-selfmanaged-guests/hypershift-azure-create-selfmanaged-guests-commands.sh
+++ b/ci-operator/step-registry/hypershift/azure/create-selfmanaged-guests/hypershift-azure-create-selfmanaged-guests-commands.sh
@@ -1,0 +1,243 @@
+#!/bin/bash
+
+set -exuo pipefail
+
+# Use the nested management cluster kubeconfig
+export KUBECONFIG="${SHARED_DIR}/management_cluster_kubeconfig"
+
+# Generate unique cluster names from job ID
+PUBLIC_NAME="$(echo -n "${PROW_JOB_ID}-pub"|sha256sum|cut -c-20)"
+PRIVATE_NAME="$(echo -n "${PROW_JOB_ID}-prv"|sha256sum|cut -c-20)"
+OAUTH_LB_NAME="$(echo -n "${PROW_JOB_ID}-oau"|sha256sum|cut -c-20)"
+
+# Self-managed Azure credentials
+AZURE_CREDS="/etc/hypershift-ci-jobs-self-managed-azure/credentials.json"
+AZURE_OIDC_ISSUER_URL="https://smazure.blob.core.windows.net/smazure"
+AZURE_SA_TOKEN_ISSUER_KEY_PATH="/etc/hypershift-ci-jobs-self-managed-azure-e2e/serviceaccount-signer.private"
+AZURE_WORKLOAD_IDENTITIES_FILE="/etc/hypershift-ci-jobs-self-managed-azure-e2e/workload-identities.json"
+
+PULL_SECRET_PATH="/etc/ci-pull-credentials/.dockerconfigjson"
+
+RELEASE_IMAGE="${RELEASE_IMAGE_LATEST}"
+HC_LOCATION="${HYPERSHIFT_AZURE_LOCATION:-centralus}"
+
+# Read private NAT subnet ID from SHARED_DIR (written by setup-private-link step)
+if [[ ! -s "${SHARED_DIR}/azure_private_nat_subnet_id" ]]; then
+  echo "$(date) ERROR: azure_private_nat_subnet_id is required for the private guest cluster"
+  exit 1
+fi
+AZURE_PRIVATE_NAT_SUBNET_ID="$(cat "${SHARED_DIR}/azure_private_nat_subnet_id")"
+
+# External DNS domain flag (required for correct service publishing strategy,
+# especially for Private topology clusters where the API server must use Route)
+EXTERNAL_DNS_ARGS=""
+if [[ -n "${HYPERSHIFT_EXTERNAL_DNS_DOMAIN:-}" ]]; then
+  EXTERNAL_DNS_ARGS="--external-dns-domain=${HYPERSHIFT_EXTERNAL_DNS_DOMAIN}"
+fi
+
+# Marketplace image flags
+ETCD_STORAGE_CLASS_ARGS=""
+if [[ -n "${HYPERSHIFT_ETCD_STORAGE_CLASS:-}" ]]; then
+  ETCD_STORAGE_CLASS_ARGS="--etcd-storage-class=${HYPERSHIFT_ETCD_STORAGE_CLASS}"
+fi
+
+MARKETPLACE_ARGS=""
+if [[ -n "${HYPERSHIFT_AZURE_MARKETPLACE_IMAGE_PUBLISHER:-}" ]]; then
+  MARKETPLACE_ARGS="--marketplace-publisher=${HYPERSHIFT_AZURE_MARKETPLACE_IMAGE_PUBLISHER} --marketplace-offer=${HYPERSHIFT_AZURE_MARKETPLACE_IMAGE_OFFER}"
+  if [[ -n "${HYPERSHIFT_AZURE_MARKETPLACE_IMAGE_SKU:-}" ]]; then
+    MARKETPLACE_ARGS="${MARKETPLACE_ARGS} --marketplace-sku=${HYPERSHIFT_AZURE_MARKETPLACE_IMAGE_SKU}"
+  elif [[ -f "${SHARED_DIR}/azure-marketplace-image-sku" ]]; then
+    MARKETPLACE_ARGS="${MARKETPLACE_ARGS} --marketplace-sku=$(cat "${SHARED_DIR}/azure-marketplace-image-sku")"
+  fi
+  if [[ -n "${HYPERSHIFT_AZURE_MARKETPLACE_IMAGE_VERSION:-}" ]]; then
+    MARKETPLACE_ARGS="${MARKETPLACE_ARGS} --marketplace-version=${HYPERSHIFT_AZURE_MARKETPLACE_IMAGE_VERSION}"
+  elif [[ -f "${SHARED_DIR}/azure-marketplace-image-version" ]]; then
+    MARKETPLACE_ARGS="${MARKETPLACE_ARGS} --marketplace-version=$(cat "${SHARED_DIR}/azure-marketplace-image-version")"
+  fi
+fi
+
+# Common flags for all self-managed clusters
+COMMON_FLAGS="--node-pool-replicas=${HYPERSHIFT_NODE_COUNT} \
+  --base-domain=${HYPERSHIFT_BASE_DOMAIN} \
+  --pull-secret=${PULL_SECRET_PATH} \
+  --azure-creds=${AZURE_CREDS} \
+  --location=${HC_LOCATION} \
+  --release-image=${RELEASE_IMAGE} \
+  --oidc-issuer-url=${AZURE_OIDC_ISSUER_URL} \
+  --sa-token-issuer-private-key-path=${AZURE_SA_TOKEN_ISSUER_KEY_PATH} \
+  --workload-identities-file=${AZURE_WORKLOAD_IDENTITIES_FILE} \
+  --assign-service-principal-roles \
+  --dns-zone-rg-name=os4-common \
+  --generate-ssh \
+  ${EXTERNAL_DNS_ARGS} \
+  ${MARKETPLACE_ARGS} \
+  ${ETCD_STORAGE_CLASS_ARGS}"
+
+# Create public cluster
+echo "$(date) Creating public self-managed cluster: ${PUBLIC_NAME}"
+/usr/bin/hypershift create cluster azure \
+  --name="${PUBLIC_NAME}" \
+  ${COMMON_FLAGS} &
+PUBLIC_PID=$!
+
+# Create private cluster
+PRIVATE_EXTRA="--endpoint-access-private-nat-subnet-id=${AZURE_PRIVATE_NAT_SUBNET_ID}"
+echo "$(date) Creating private self-managed cluster: ${PRIVATE_NAME}"
+/usr/bin/hypershift create cluster azure \
+  --name="${PRIVATE_NAME}" \
+  --endpoint-access=Private \
+  ${COMMON_FLAGS} \
+  ${PRIVATE_EXTRA} &
+PRIVATE_PID=$!
+
+# Create OAuth LoadBalancer cluster
+echo "$(date) Creating OAuth LB self-managed cluster: ${OAUTH_LB_NAME}"
+/usr/bin/hypershift create cluster azure \
+  --name="${OAUTH_LB_NAME}" \
+  --oauth-publishing-strategy=LoadBalancer \
+  ${COMMON_FLAGS} &
+OAUTH_LB_PID=$!
+
+# Wait for create commands to complete
+echo "$(date) Waiting for cluster create commands to finish..."
+FAILED=0
+wait ${PUBLIC_PID} || FAILED=1
+echo "$(date) Public cluster create command completed"
+wait ${PRIVATE_PID} || FAILED=1
+echo "$(date) Private cluster create command completed"
+wait ${OAUTH_LB_PID} || FAILED=1
+echo "$(date) OAuth LB cluster create command completed"
+if [[ ${FAILED} -ne 0 ]]; then
+  echo "$(date) ERROR: One or more cluster create commands failed"
+  exit 1
+fi
+
+# Patch the public cluster to set OperatorConfiguration for Ingress Operator.
+# The v2 e2e test ValidateIngressOperatorConfiguration expects this to be set on
+# public clusters (mirroring the BeforeApply hook used in the v1 CreateCluster test).
+echo "$(date) Patching public cluster ${PUBLIC_NAME} with OperatorConfiguration..."
+oc patch hostedcluster "${PUBLIC_NAME}" -n clusters --type=merge -p '
+{
+  "spec": {
+    "operatorConfiguration": {
+      "ingressOperator": {
+        "endpointPublishingStrategy": {
+          "type": "LoadBalancerService",
+          "loadBalancer": {
+            "scope": "Internal"
+          }
+        }
+      }
+    }
+  }
+}'
+echo "$(date) Public cluster ${PUBLIC_NAME} patched with OperatorConfiguration"
+
+# Wait for clusters to become available
+echo "$(date) Waiting for public cluster to become available..."
+oc wait --timeout=30m --for=condition=Available --namespace=clusters "hostedcluster/${PUBLIC_NAME}"
+echo "$(date) Public cluster is available"
+
+echo "$(date) Waiting for private cluster to become available..."
+oc wait --timeout=30m --for=condition=Available --namespace=clusters "hostedcluster/${PRIVATE_NAME}"
+echo "$(date) Private cluster is available"
+
+echo "$(date) Waiting for OAuth LB cluster to become available..."
+oc wait --timeout=30m --for=condition=Available --namespace=clusters "hostedcluster/${OAUTH_LB_NAME}"
+echo "$(date) OAuth LB cluster is available"
+
+# Wait for version rollout to complete on all clusters in parallel (via management API, same as AWS/GCP v2)
+echo "$(date) Starting parallel version rollout checks..."
+set +e
+
+echo "$(date) Waiting for version rollout on ${PUBLIC_NAME}..."
+CLUSTER_CHECK="${PUBLIC_NAME}" timeout 45m bash -c '
+  until [[ "$(oc get -n clusters hostedcluster/${CLUSTER_CHECK} -o jsonpath='"'"'{.status.version.history[?(@.state!="")].state}'"'"')" = "Completed" ]]; do
+    sleep 15
+  done
+' &
+ROLLOUT_PID_PUB=$!
+
+echo "$(date) Waiting for version rollout on ${PRIVATE_NAME}..."
+CLUSTER_CHECK="${PRIVATE_NAME}" timeout 45m bash -c '
+  until [[ "$(oc get -n clusters hostedcluster/${CLUSTER_CHECK} -o jsonpath='"'"'{.status.version.history[?(@.state!="")].state}'"'"')" = "Completed" ]]; do
+    sleep 15
+  done
+' &
+ROLLOUT_PID_PRV=$!
+
+echo "$(date) Waiting for version rollout on ${OAUTH_LB_NAME}..."
+CLUSTER_CHECK="${OAUTH_LB_NAME}" timeout 45m bash -c '
+  until [[ "$(oc get -n clusters hostedcluster/${CLUSTER_CHECK} -o jsonpath='"'"'{.status.version.history[?(@.state!="")].state}'"'"')" = "Completed" ]]; do
+    sleep 15
+  done
+' &
+ROLLOUT_PID_OAU=$!
+
+echo "$(date) Waiting for all version rollout checks to complete..."
+FAILED_READY=0
+for CLUSTER_PID in "${PUBLIC_NAME}:${ROLLOUT_PID_PUB}" "${PRIVATE_NAME}:${ROLLOUT_PID_PRV}" "${OAUTH_LB_NAME}:${ROLLOUT_PID_OAU}"; do
+  CLUSTER="${CLUSTER_PID%%:*}"
+  PID="${CLUSTER_PID##*:}"
+  wait ${PID}
+  ROLLOUT_RC=$?
+  if [[ ${ROLLOUT_RC} -ne 0 ]]; then
+    echo "$(date) ERROR: version rollout timed out for ${CLUSTER}"
+    echo "--- Diagnostic dump for ${CLUSTER} ---"
+    echo "HostedCluster conditions:"
+    oc get -n clusters hostedcluster/${CLUSTER} -o jsonpath='{range .status.conditions[*]}{.type}{"\t"}{.status}{"\t"}{.reason}{"\t"}{.message}{"\n"}{end}' || true
+    echo ""
+    echo "NodePool status:"
+    oc get -n clusters nodepool/${CLUSTER} -o jsonpath='{range .status.conditions[*]}{.type}{"\t"}{.status}{"\t"}{.reason}{"\t"}{.message}{"\n"}{end}' || true
+    echo ""
+    echo "Machines in clusters-${CLUSTER}:"
+    oc get machines.cluster.x-k8s.io -n "clusters-${CLUSTER}" -o wide 2>/dev/null || true
+    echo ""
+    echo "AzureMachines in clusters-${CLUSTER}:"
+    oc get azuremachines.infrastructure.cluster.x-k8s.io -n "clusters-${CLUSTER}" -o wide 2>/dev/null || true
+    echo ""
+    echo "Pods not ready in clusters-${CLUSTER}:"
+    oc get pods -n "clusters-${CLUSTER}" --field-selector=status.phase!=Running,status.phase!=Succeeded 2>/dev/null || true
+    echo "--- End diagnostic dump ---"
+    cat << EOF > "${ARTIFACT_DIR}/junit_hosted_cluster_${CLUSTER}.xml"
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="hypershift install ${CLUSTER}" tests="1" failures="1">
+  <testcase name="hosted cluster version rollout succeeds">
+    <failure message="hosted cluster version rollout never completed">
+      <![CDATA[
+error: hosted cluster version rollout never completed for ${CLUSTER}
+Degraded: $(oc get -n clusters hostedcluster/${CLUSTER} -o jsonpath='{.status.conditions[?(@.type=="Degraded")].message}')
+ClusterVersionSucceeding: $(oc get -n clusters hostedcluster/${CLUSTER} -o jsonpath='{.status.conditions[?(@.type=="ClusterVersionSucceeding")].message}')
+      ]]>
+    </failure>
+  </testcase>
+</testsuite>
+EOF
+    FAILED_READY=1
+  else
+    echo "$(date) Version rollout completed for ${CLUSTER}"
+    cat << EOF > "${ARTIFACT_DIR}/junit_hosted_cluster_${CLUSTER}.xml"
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="hypershift install ${CLUSTER}" tests="1" failures="0">
+  <testcase name="hosted cluster version rollout succeeds">
+    <system-out>
+      <![CDATA[
+info: hosted cluster version rollout completed successfully for ${CLUSTER}
+      ]]>
+    </system-out>
+  </testcase>
+</testsuite>
+EOF
+  fi
+done
+set -e
+if [[ ${FAILED_READY} -ne 0 ]]; then
+  exit 1
+fi
+
+# Write cluster names to shared dir
+echo "${PUBLIC_NAME}" > "${SHARED_DIR}/cluster-name-public"
+echo "${PRIVATE_NAME}" > "${SHARED_DIR}/cluster-name-private"
+echo "${OAUTH_LB_NAME}" > "${SHARED_DIR}/cluster-name-oauth-lb"
+
+echo "$(date) All self-managed guest clusters are ready"

--- a/ci-operator/step-registry/hypershift/azure/create-selfmanaged-guests/hypershift-azure-create-selfmanaged-guests-ref.metadata.json
+++ b/ci-operator/step-registry/hypershift/azure/create-selfmanaged-guests/hypershift-azure-create-selfmanaged-guests-ref.metadata.json
@@ -1,0 +1,17 @@
+{
+	"path": "hypershift/azure/create-selfmanaged-guests/hypershift-azure-create-selfmanaged-guests-ref.yaml",
+	"owners": {
+		"approvers": [
+			"csrwng",
+			"enxebre",
+			"sjenning",
+			"bryan-cox"
+		],
+		"reviewers": [
+			"csrwng",
+			"enxebre",
+			"sjenning",
+			"bryan-cox"
+		]
+	}
+}

--- a/ci-operator/step-registry/hypershift/azure/create-selfmanaged-guests/hypershift-azure-create-selfmanaged-guests-ref.yaml
+++ b/ci-operator/step-registry/hypershift/azure/create-selfmanaged-guests/hypershift-azure-create-selfmanaged-guests-ref.yaml
@@ -1,0 +1,52 @@
+ref:
+  as: hypershift-azure-create-selfmanaged-guests
+  cli: latest
+  commands: hypershift-azure-create-selfmanaged-guests-commands.sh
+  credentials:
+  - mount_path: /etc/ci-pull-credentials
+    name: ci-pull-credentials
+    namespace: test-credentials
+  - mount_path: /etc/hypershift-ci-jobs-self-managed-azure
+    name: hypershift-ci-jobs-self-managed-azure
+    namespace: test-credentials
+  - mount_path: /etc/hypershift-ci-jobs-self-managed-azure-e2e
+    name: hypershift-ci-jobs-self-managed-azure-e2e
+    namespace: test-credentials
+  dependencies:
+  - name: "release:latest"
+    env: RELEASE_IMAGE_LATEST
+  env:
+  - name: HYPERSHIFT_NODE_COUNT
+    default: "3"
+    documentation: "The number of nodes per guest cluster."
+  - name: HYPERSHIFT_BASE_DOMAIN
+    default: "hcp-sm-azure.azure.devcluster.openshift.com"
+    documentation: "The cluster's FQDN will be a subdomain of the base domain."
+  - name: HYPERSHIFT_AZURE_LOCATION
+    default: "centralus"
+    documentation: "Specifies the Azure location of the clusters."
+  - name: HYPERSHIFT_EXTERNAL_DNS_DOMAIN
+    default: ""
+    documentation: "The external DNS domain for service publishing strategy hostnames. Required for Private topology clusters."
+  - name: HYPERSHIFT_AZURE_MARKETPLACE_IMAGE_PUBLISHER
+    default: ""
+    documentation: "The Azure Marketplace image publisher."
+  - name: HYPERSHIFT_AZURE_MARKETPLACE_IMAGE_OFFER
+    default: ""
+    documentation: "The Azure Marketplace image offer."
+  - name: HYPERSHIFT_AZURE_MARKETPLACE_IMAGE_SKU
+    default: ""
+    documentation: "The Azure Marketplace image SKU."
+  - name: HYPERSHIFT_AZURE_MARKETPLACE_IMAGE_VERSION
+    default: ""
+    documentation: "The Azure Marketplace image version."
+  - name: HYPERSHIFT_ETCD_STORAGE_CLASS
+    default: ""
+    documentation: "The persistent volume storage class for etcd data volumes."
+  from: hypershift-operator
+  grace_period: 5m0s
+  resources:
+    requests:
+      cpu: 100m
+      memory: 100Mi
+  timeout: 120m0s

--- a/ci-operator/step-registry/hypershift/azure/destroy-selfmanaged-guests/OWNERS
+++ b/ci-operator/step-registry/hypershift/azure/destroy-selfmanaged-guests/OWNERS
@@ -1,0 +1,11 @@
+approvers:
+- csrwng
+- enxebre
+- sjenning
+- bryan-cox
+options: {}
+reviewers:
+- csrwng
+- enxebre
+- sjenning
+- bryan-cox

--- a/ci-operator/step-registry/hypershift/azure/destroy-selfmanaged-guests/hypershift-azure-destroy-selfmanaged-guests-chain.metadata.json
+++ b/ci-operator/step-registry/hypershift/azure/destroy-selfmanaged-guests/hypershift-azure-destroy-selfmanaged-guests-chain.metadata.json
@@ -1,0 +1,17 @@
+{
+	"path": "hypershift/azure/destroy-selfmanaged-guests/hypershift-azure-destroy-selfmanaged-guests-chain.yaml",
+	"owners": {
+		"approvers": [
+			"csrwng",
+			"enxebre",
+			"sjenning",
+			"bryan-cox"
+		],
+		"reviewers": [
+			"csrwng",
+			"enxebre",
+			"sjenning",
+			"bryan-cox"
+		]
+	}
+}

--- a/ci-operator/step-registry/hypershift/azure/destroy-selfmanaged-guests/hypershift-azure-destroy-selfmanaged-guests-chain.yaml
+++ b/ci-operator/step-registry/hypershift/azure/destroy-selfmanaged-guests/hypershift-azure-destroy-selfmanaged-guests-chain.yaml
@@ -1,0 +1,51 @@
+chain:
+  as: hypershift-azure-destroy-selfmanaged-guests
+  steps:
+  - as: destroy-guests
+    best_effort: true
+    cli: latest
+    env:
+    - name: HYPERSHIFT_AZURE_LOCATION
+      default: "centralus"
+      documentation: "Specifies the Azure location of the clusters."
+    commands: |-
+      set -xuo pipefail
+
+      # Use the nested management cluster kubeconfig
+      export KUBECONFIG="${SHARED_DIR}/management_cluster_kubeconfig"
+
+      AZURE_CREDS="/etc/hypershift-ci-jobs-self-managed-azure/credentials.json"
+      HC_LOCATION="${HYPERSHIFT_AZURE_LOCATION:-centralus}"
+
+      # Re-derive cluster names from job ID (same logic as create step)
+      PUBLIC_NAME="$(echo -n "${PROW_JOB_ID}-pub"|sha256sum|cut -c-20)"
+      PRIVATE_NAME="$(echo -n "${PROW_JOB_ID}-prv"|sha256sum|cut -c-20)"
+      OAUTH_LB_NAME="$(echo -n "${PROW_JOB_ID}-oau"|sha256sum|cut -c-20)"
+
+      # Destroy all clusters, continue per-cluster, but preserve failure signal
+      FAILED=0
+      for CLUSTER in "${PUBLIC_NAME}" "${PRIVATE_NAME}" "${OAUTH_LB_NAME}"; do
+        echo "$(date) Destroying self-managed cluster: ${CLUSTER}"
+        if ! /usr/bin/hypershift destroy cluster azure \
+          --azure-creds="${AZURE_CREDS}" \
+          --name="${CLUSTER}" \
+          --location="${HC_LOCATION}" \
+          --dns-zone-rg-name=os4-common \
+          --cluster-grace-period=40m; then
+          echo "$(date) WARNING: Failed to destroy cluster ${CLUSTER}" >&2
+          FAILED=1
+        fi
+        echo "$(date) Finished destroying cluster ${CLUSTER}"
+      done
+      exit "${FAILED}"
+    from: hypershift-operator
+    grace_period: 5m0s
+    resources:
+      requests:
+        cpu: 100m
+        memory: 100Mi
+    timeout: 2h0m0s
+    credentials:
+    - mount_path: /etc/hypershift-ci-jobs-self-managed-azure
+      name: hypershift-ci-jobs-self-managed-azure
+      namespace: test-credentials

--- a/ci-operator/step-registry/hypershift/azure/dump-selfmanaged-guests/OWNERS
+++ b/ci-operator/step-registry/hypershift/azure/dump-selfmanaged-guests/OWNERS
@@ -1,0 +1,11 @@
+approvers:
+- csrwng
+- enxebre
+- sjenning
+- bryan-cox
+options: {}
+reviewers:
+- csrwng
+- enxebre
+- sjenning
+- bryan-cox

--- a/ci-operator/step-registry/hypershift/azure/dump-selfmanaged-guests/hypershift-azure-dump-selfmanaged-guests-chain.metadata.json
+++ b/ci-operator/step-registry/hypershift/azure/dump-selfmanaged-guests/hypershift-azure-dump-selfmanaged-guests-chain.metadata.json
@@ -1,0 +1,17 @@
+{
+	"path": "hypershift/azure/dump-selfmanaged-guests/hypershift-azure-dump-selfmanaged-guests-chain.yaml",
+	"owners": {
+		"approvers": [
+			"csrwng",
+			"enxebre",
+			"sjenning",
+			"bryan-cox"
+		],
+		"reviewers": [
+			"csrwng",
+			"enxebre",
+			"sjenning",
+			"bryan-cox"
+		]
+	}
+}

--- a/ci-operator/step-registry/hypershift/azure/dump-selfmanaged-guests/hypershift-azure-dump-selfmanaged-guests-chain.yaml
+++ b/ci-operator/step-registry/hypershift/azure/dump-selfmanaged-guests/hypershift-azure-dump-selfmanaged-guests-chain.yaml
@@ -1,0 +1,36 @@
+chain:
+  as: hypershift-azure-dump-selfmanaged-guests
+  steps:
+  - as: dump
+    cli: latest
+    commands: |-
+      set -xuo pipefail
+
+      # Use the nested management cluster kubeconfig
+      export KUBECONFIG="${SHARED_DIR}/management_cluster_kubeconfig"
+
+      if [ -f "${SHARED_DIR}/proxy-conf.sh" ] ; then
+        source "${SHARED_DIR}/proxy-conf.sh"
+      fi
+
+      # Re-derive cluster names from job ID (same logic as create/destroy steps)
+      PUBLIC_NAME="$(echo -n "${PROW_JOB_ID}-pub"|sha256sum|cut -c-20)"
+      PRIVATE_NAME="$(echo -n "${PROW_JOB_ID}-prv"|sha256sum|cut -c-20)"
+      OAUTH_LB_NAME="$(echo -n "${PROW_JOB_ID}-oau"|sha256sum|cut -c-20)"
+
+      for CLUSTER in "${PUBLIC_NAME}" "${PRIVATE_NAME}" "${OAUTH_LB_NAME}"; do
+        echo "$(date) Dumping self-managed guest cluster: ${CLUSTER}"
+        DUMP_DIR="${ARTIFACT_DIR}/${CLUSTER}"
+        mkdir -p "${DUMP_DIR}"
+        bin/hypershift dump cluster \
+          --artifact-dir="${DUMP_DIR}" \
+          --dump-guest-cluster=true \
+          --name="${CLUSTER}" || echo "$(date) WARNING: Failed to dump cluster ${CLUSTER}"
+      done
+    from: hypershift-operator
+    resources:
+      requests:
+        cpu: 100m
+    timeout: 15m0s
+  - ref: hypershift-debug
+  - ref: hypershift-k8sgpt

--- a/ci-operator/step-registry/hypershift/azure/e2e/v2-self-managed/OWNERS
+++ b/ci-operator/step-registry/hypershift/azure/e2e/v2-self-managed/OWNERS
@@ -1,0 +1,11 @@
+approvers:
+- csrwng
+- enxebre
+- sjenning
+- bryan-cox
+options: {}
+reviewers:
+- csrwng
+- enxebre
+- sjenning
+- bryan-cox

--- a/ci-operator/step-registry/hypershift/azure/e2e/v2-self-managed/hypershift-azure-e2e-v2-self-managed-workflow.metadata.json
+++ b/ci-operator/step-registry/hypershift/azure/e2e/v2-self-managed/hypershift-azure-e2e-v2-self-managed-workflow.metadata.json
@@ -1,0 +1,17 @@
+{
+	"path": "hypershift/azure/e2e/v2-self-managed/hypershift-azure-e2e-v2-self-managed-workflow.yaml",
+	"owners": {
+		"approvers": [
+			"csrwng",
+			"enxebre",
+			"sjenning",
+			"bryan-cox"
+		],
+		"reviewers": [
+			"csrwng",
+			"enxebre",
+			"sjenning",
+			"bryan-cox"
+		]
+	}
+}

--- a/ci-operator/step-registry/hypershift/azure/e2e/v2-self-managed/hypershift-azure-e2e-v2-self-managed-workflow.yaml
+++ b/ci-operator/step-registry/hypershift/azure/e2e/v2-self-managed/hypershift-azure-e2e-v2-self-managed-workflow.yaml
@@ -1,0 +1,40 @@
+workflow:
+  as: hypershift-azure-e2e-v2-self-managed
+  documentation: |-
+    The HyperShift Azure e2e v2 self-managed workflow provisions a nested management
+    cluster on self-managed Azure infrastructure, installs the HyperShift operator, creates
+    three self-managed Azure guest clusters (public, private, OAuth LoadBalancer), and runs
+    the v2 Ginkgo test suite against each. Each test spec produces a separate JUnit XML
+    entry for Sippy.
+
+    The HyperShift launch capability is currently supported by the HyperShift
+    team. For now, please direct all questions and comments to:
+
+    - Alberto Lamela (agarcial@redhat.com)
+    - Seth Jennings (sjenning@redhat.com)
+    - Cesar Wong (cewong@redhat.com)
+    - Bryan Cox (brcox@redhat.com)
+
+    Learn more about HyperShift here: https://github.com/openshift/hypershift
+
+    Track HyperShift's development here: https://issues.redhat.com/projects/CNTRLPLANE/summary
+  steps:
+    pre:
+    - ref: ipi-install-rbac
+    - chain: hypershift-setup-nested-management-cluster
+    - ref: hypershift-azure-setup-private-link
+    - ref: hypershift-install
+    - chain: hypershift-azure-create-selfmanaged-guests
+    test:
+    - chain: hypershift-azure-run-e2e-v2-selfmanaged
+    post:
+    - chain: hypershift-azure-dump-selfmanaged-guests
+    - chain: hypershift-azure-destroy-selfmanaged-guests
+    - chain: hypershift-destroy-nested-management-cluster
+    env:
+      CLOUD_PROVIDER: "Azure"
+      HYPERSHIFT_NODE_COUNT: "6"
+      HYPERSHIFT_AZURE_LOCATION: "centralus"
+      AZURE_SELF_MANAGED: "true"
+      HYPERSHIFT_EXTERNAL_DNS_DOMAIN: "sm.hcp-sm-azure.azure.devcluster.openshift.com"
+      HYPERSHIFT_ETCD_STORAGE_CLASS: "managed-csi-premium-v2"

--- a/ci-operator/step-registry/hypershift/azure/run-e2e-v2-selfmanaged/OWNERS
+++ b/ci-operator/step-registry/hypershift/azure/run-e2e-v2-selfmanaged/OWNERS
@@ -1,0 +1,11 @@
+approvers:
+- csrwng
+- enxebre
+- sjenning
+- bryan-cox
+options: {}
+reviewers:
+- csrwng
+- enxebre
+- sjenning
+- bryan-cox

--- a/ci-operator/step-registry/hypershift/azure/run-e2e-v2-selfmanaged/hypershift-azure-run-e2e-v2-selfmanaged-chain.metadata.json
+++ b/ci-operator/step-registry/hypershift/azure/run-e2e-v2-selfmanaged/hypershift-azure-run-e2e-v2-selfmanaged-chain.metadata.json
@@ -1,0 +1,17 @@
+{
+	"path": "hypershift/azure/run-e2e-v2-selfmanaged/hypershift-azure-run-e2e-v2-selfmanaged-chain.yaml",
+	"owners": {
+		"approvers": [
+			"csrwng",
+			"enxebre",
+			"sjenning",
+			"bryan-cox"
+		],
+		"reviewers": [
+			"csrwng",
+			"enxebre",
+			"sjenning",
+			"bryan-cox"
+		]
+	}
+}

--- a/ci-operator/step-registry/hypershift/azure/run-e2e-v2-selfmanaged/hypershift-azure-run-e2e-v2-selfmanaged-chain.yaml
+++ b/ci-operator/step-registry/hypershift/azure/run-e2e-v2-selfmanaged/hypershift-azure-run-e2e-v2-selfmanaged-chain.yaml
@@ -1,0 +1,69 @@
+chain:
+  as: hypershift-azure-run-e2e-v2-selfmanaged
+  steps:
+  - as: tests
+    cli: latest
+    commands: |-
+      set -xuo pipefail
+
+      # Use the nested management cluster kubeconfig
+      export KUBECONFIG="${SHARED_DIR}/management_cluster_kubeconfig"
+      export EVENTUALLY_VERBOSE="false"
+
+      # Export private NAT subnet ID for private topology tests
+      AZURE_PRIVATE_NAT_SUBNET_ID=""
+      if [[ -f "${SHARED_DIR}/azure_private_nat_subnet_id" ]]; then
+        AZURE_PRIVATE_NAT_SUBNET_ID="$(cat "${SHARED_DIR}/azure_private_nat_subnet_id")"
+      fi
+      export AZURE_PRIVATE_NAT_SUBNET_ID
+
+      PUBLIC_NAME="$(cat "${SHARED_DIR}/cluster-name-public")"
+      PRIVATE_NAME="$(cat "${SHARED_DIR}/cluster-name-private")"
+      OAUTH_LB_NAME="$(cat "${SHARED_DIR}/cluster-name-oauth-lb")"
+
+      # Run all 3 test suites in parallel (clusters are independent)
+      echo "$(date) Running public cluster tests against ${PUBLIC_NAME}..."
+      E2E_HOSTED_CLUSTER_NAME="${PUBLIC_NAME}" \
+      E2E_HOSTED_CLUSTER_NAMESPACE=clusters \
+      bin/test-e2e-v2 \
+        --ginkgo.label-filter="self-managed-azure-public" \
+        --ginkgo.skip="KAS allowed CIDRs" \
+        --ginkgo.junit-report="${ARTIFACT_DIR}/junit_self_managed_azure_public.xml" \
+        --ginkgo.v &
+      PID_PUB=$!
+
+      echo "$(date) Running private topology tests against ${PRIVATE_NAME}..."
+      E2E_HOSTED_CLUSTER_NAME="${PRIVATE_NAME}" \
+      E2E_HOSTED_CLUSTER_NAMESPACE=clusters \
+      bin/test-e2e-v2 \
+        --ginkgo.label-filter="self-managed-azure-private" \
+        --ginkgo.junit-report="${ARTIFACT_DIR}/junit_self_managed_azure_private.xml" \
+        --ginkgo.v &
+      PID_PRV=$!
+
+      echo "$(date) Running OAuth LB tests against ${OAUTH_LB_NAME}..."
+      E2E_HOSTED_CLUSTER_NAME="${OAUTH_LB_NAME}" \
+      E2E_HOSTED_CLUSTER_NAMESPACE=clusters \
+      bin/test-e2e-v2 \
+        --ginkgo.label-filter="self-managed-azure-oauth-lb" \
+        --ginkgo.junit-report="${ARTIFACT_DIR}/junit_self_managed_azure_oauth_lb.xml" \
+        --ginkgo.v &
+      PID_OAU=$!
+
+      echo "$(date) Waiting for all test suites to complete..."
+      OVERALL_EXIT=0
+      wait ${PID_PUB} || OVERALL_EXIT=1
+      echo "$(date) Public cluster tests finished (exit=$?)"
+      wait ${PID_PRV} || OVERALL_EXIT=1
+      echo "$(date) Private topology tests finished (exit=$?)"
+      wait ${PID_OAU} || OVERALL_EXIT=1
+      echo "$(date) OAuth LB tests finished (exit=$?)"
+
+      exit ${OVERALL_EXIT}
+    timeout: 45m
+    grace_period: 5m
+    from: hypershift-tests
+    resources:
+      requests:
+        cpu: "1"
+        memory: 200Mi

--- a/ci-operator/step-registry/hypershift/install/hypershift-install-commands.sh
+++ b/ci-operator/step-registry/hypershift/install/hypershift-install-commands.sh
@@ -97,7 +97,11 @@ case "${CLOUD_PROVIDER}" in
 
     if [ "${AZURE_SELF_MANAGED}" == "true" ]; then
       AZURE_MANAGED_SERVICE_ARGS=""
-      # Keep external DNS enabled - domain filter is set via HYPERSHIFT_EXTERNAL_DNS_DOMAIN env var
+      if [[ "${AZURE_EXTERNAL_DNS_DOMAIN}" != *"aks-e2e"* ]] && [ -f "/etc/hypershift-ci-jobs-self-managed-azure-e2e/dns-creds.json" ]; then
+        AZURE_EXTERNAL_DNS_ARGS="--external-dns-provider=azure \
+          --external-dns-credentials=/etc/hypershift-ci-jobs-self-managed-azure-e2e/dns-creds.json \
+          --external-dns-domain-filter=${AZURE_EXTERNAL_DNS_DOMAIN}"
+      fi
 
       # Enable Azure private platform support (Private Link Services) if credentials and resource group are provided.
       # Values can come from env vars or from SHARED_DIR files written by the

--- a/ci-operator/step-registry/hypershift/install/hypershift-install-ref.yaml
+++ b/ci-operator/step-registry/hypershift/install/hypershift-install-ref.yaml
@@ -70,6 +70,9 @@ ref:
   - mount_path: /etc/hypershift-ci-jobs-self-managed-azure
     name: hypershift-ci-jobs-self-managed-azure
     namespace: test-credentials
+  - mount_path: /etc/hypershift-ci-jobs-self-managed-azure-e2e
+    name: hypershift-ci-jobs-self-managed-azure-e2e
+    namespace: test-credentials
   grace_period: 1m0s
   resources:
     requests:


### PR DESCRIPTION
## Summary

- Add a new v2 Ginkgo-based CI workflow for self-managed Azure HyperShift e2e tests
- The workflow uses the nested management cluster pattern: provisions an Azure HCP management cluster, installs HyperShift with self-managed Azure support, creates three guest clusters, runs the v2 test suite, and tears everything down
- Each test spec produces a separate JUnit XML entry for individual Sippy test case reporting

### New step registry components

- **`hypershift-azure-e2e-v2-self-managed`** — workflow: RBAC → nested mgmt cluster → private link setup → HyperShift install → create guests → run tests → destroy guests → destroy mgmt cluster
- **`hypershift-azure-create-selfmanaged-guests`** — creates 3 guest clusters in parallel (public, private w/ PLS, OAuth LB) on the nested management cluster
- **`hypershift-azure-run-e2e-v2-selfmanaged`** — runs `bin/test-e2e-self-managed-azure` 3x with `--ginkgo.label-filter` per cluster, producing 3 JUnit XML files
- **`hypershift-azure-destroy-selfmanaged-guests`** — destroys all 3 guest clusters (best_effort)

### New CI job

- **`e2e-azure-v2-self-managed`** — optional, triggers on changes to `test/e2e/v2/selfmanagedazure` or `test/e2e/util`
- Uses `cluster_profile: hypershift-azure` with self-managed Azure credentials

### Depends on

- openshift/hypershift#8204 (adds the test binary and `selfmanaged-azure-e2e` Makefile target)

Ref: [CNTRLPLANE-3222](https://redhat.atlassian.net/browse/CNTRLPLANE-3222)

Generated with [Claude Code](https://claude.com/claude-code)

[CNTRLPLANE-3222]: https://redhat.atlassian.net/browse/CNTRLPLANE-3222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional Azure self-managed e2e test to CI (gated, opt-in).

* **Tests**
  * New workflow runs v2 E2E suites across public, private, and OAuth‑LB guest clusters, producing separate test reports per suite and coordinating creation/destruction of guest clusters.

* **Chores**
  * Added CI chains/steps, a gated presubmit job to trigger the tests, and ownership/metadata files to support the workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->