### PR TITLE
opendatahub: Switch CI to use 4.20 cluster pool

### DIFF
--- a/ci-operator/config/opendatahub-io/opendatahub-operator/opendatahub-io-opendatahub-operator-main.yaml
+++ b/ci-operator/config/opendatahub-io/opendatahub-operator/opendatahub-io-opendatahub-operator-main.yaml
@@ -47,7 +47,7 @@ releases:
     release:
       architecture: multi
       channel: stable
-      version: "4.19"
+      version: "4.20"
 resources:
   '*':
     requests:
@@ -61,7 +61,7 @@ tests:
     owner: opendatahub
     product: ocp
     timeout: 2h0m0s
-    version: "4.19"
+    version: "4.20"
   skip_if_only_changed: ^\.github/|^docs/|\.[mM][dD]$|^.gitignore$|^golangci|^crd-ref-docs\.config|^OWNERS$|^PROJECT$|^LICENSE$|^OWNERS_ALIASES$|^cmd/[^/]+/|^[^/]+\.(yaml|yml)$|^.gitleaksignore$|^.yamllint$
   steps:
     allow_best_effort_post_steps: true
@@ -110,7 +110,7 @@ tests:
     owner: opendatahub
     product: ocp
     timeout: 2h0m0s
-    version: "4.19"
+    version: "4.20"
   skip_if_only_changed: ^\.github/|^docs/|\.[mM][dD]$|^.gitignore$|^golangci|^crd-ref-docs\.config|^OWNERS$|^PROJECT$|^LICENSE$|^OWNERS_ALIASES$|^cmd/[^/]+/|^[^/]+\.(yaml|yml)$|^.gitleaksignore$|^.yamllint$
   steps:
     allow_best_effort_post_steps: true


### PR DESCRIPTION
Migrate opendatahub-operator CI jobs from 4.19 to 4.20 cluster pool:
- releases.latest.version: 4.19 → 4.20
- opendatahub-operator-e2e cluster_claim.version: 4.19 → 4.20
- opendatahub-operator-rhoai-e2e cluster_claim.version: 4.20 → 4.20