### PR TITLE
USHIFT-6847: Switch MicroShift CI doctor to use edge-tooling repository

### DIFF
--- a/ci-operator/step-registry/openshift/microshift/claude/ci-doctor/openshift-microshift-claude-ci-doctor-commands.sh
+++ b/ci-operator/step-registry/openshift/microshift/claude/ci-doctor/openshift-microshift-claude-ci-doctor-commands.sh
@@ -36,6 +36,12 @@ atexit_handler() {
         echo "ERROR: No HTML report was generated"
         return 1
     fi
+
+    # Check if Claude log contains tool errors
+    if grep -q '"is_error":\s*true' "${WORKDIR}/claude-output.log"; then
+        echo "ERROR: Claude log contains tool errors"
+        return 1
+    fi
 }
 
 load_secrets() {

--- a/ci-operator/step-registry/openshift/microshift/claude/ci-doctor/openshift-microshift-claude-ci-doctor-commands.sh
+++ b/ci-operator/step-registry/openshift/microshift/claude/ci-doctor/openshift-microshift-claude-ci-doctor-commands.sh
@@ -117,6 +117,11 @@ wait_for_mcp_status() {
 }
 
 configure_claude() {
+    # Disable command tracing to prevent leaking credentials in logs
+    # and restore it after the function is executed
+    trap 'set -x' RETURN
+    set +x
+
     echo "Configuring Claude..."
 
     # Create an empty configuration file to avoid the "Claude configuration file
@@ -161,18 +166,13 @@ EOF
         pip install uv --user --upgrade
         export PATH="${HOME}/.local/bin:${PATH}"
 
-        # Load secrets with command tracing disabled to prevent leaking credentials in logs
-        {
-          set +x
-          claude mcp add \
-              -e JIRA_URL="${JIRA_URL}" \
-              -e JIRA_API_TOKEN="${JIRA_API_TOKEN}" \
-              -e JIRA_USERNAME="${JIRA_USERNAME}" \
-              --scope user \
-              --transport stdio \
-              jira -- uvx mcp-atlassian@0.21.0
-          set -x
-        }
+        claude mcp add \
+            -e JIRA_URL="${JIRA_URL}" \
+            -e JIRA_API_TOKEN="${JIRA_API_TOKEN}" \
+            -e JIRA_USERNAME="${JIRA_USERNAME}" \
+            --scope user \
+            --transport stdio \
+            jira -- uvx mcp-atlassian@0.21.0
 
         echo "Waiting for JIRA MCP to become available..."
         wait_for_mcp_status "jira" "Connected"

--- a/ci-operator/step-registry/openshift/microshift/claude/ci-doctor/openshift-microshift-claude-ci-doctor-commands.sh
+++ b/ci-operator/step-registry/openshift/microshift/claude/ci-doctor/openshift-microshift-claude-ci-doctor-commands.sh
@@ -3,11 +3,40 @@ set -euo pipefail
 set -x
 
 # Set global variables
-WORKDIR="/tmp/analyze-ci-claude-workdir.$(date +%y%m%d)"
+WORKDIR="/tmp/microshift-ci-claude-workdir.$(date +%y%m%d)"
 mkdir -p "${WORKDIR}"
 
 CLAUDE_HOME="/home/claude/.claude"
 mkdir -p "${CLAUDE_HOME}"
+
+# The procedure to copy reports and session logs to artifacts, executed at exit
+atexit_handler() {
+    if [[ -d "${WORKDIR:-}" ]]; then
+        echo "Copying reports to artifact and shared directories..."
+        find "${WORKDIR}" -maxdepth 1 -name "*.html" -exec cp {} "${ARTIFACT_DIR}/" \; || true
+        find "${WORKDIR}" -maxdepth 1 -name "*.json" -exec cp {} "${ARTIFACT_DIR}/" \; || true
+        find "${WORKDIR}" -maxdepth 1 -name "*.txt"  -exec cp {} "${ARTIFACT_DIR}/" \; || true
+        find "${WORKDIR}" -maxdepth 1 -name "*.html" -exec cp {} "${SHARED_DIR}/"   \; || true
+    fi
+
+    # Archive the full Claude session directory (including subagent logs) for session continuation.
+    # These are used by the openshift-claude-post step to generate the continue-session page.
+    if [[ -d "${CLAUDE_HOME}/projects" ]]; then
+        echo "Archiving Claude session logs..."
+        if tar -czf "${ARTIFACT_DIR}/claude-sessions-$(date +%Y%m%d-%H%M%S).tar.gz" -C "${CLAUDE_HOME}" projects/ 2>/dev/null; then
+            touch "${SHARED_DIR}/claude-session-available"
+        fi
+    fi
+
+    # Check if the report was produced
+    if ls "${WORKDIR}"/*.html &>/dev/null; then
+        touch "${SHARED_DIR}/claude-report-available"
+        echo "Analysis complete"
+    else
+        echo "ERROR: No HTML report was generated"
+        return 1
+    fi
+}
 
 load_secrets() {
     # Disable command tracing to prevent leaking credentials in logs
@@ -69,25 +98,6 @@ install_prerequisites() {
     echo "gcloud CLI installed."
 }
 
-# Copy reports and session logs to artifacts
-copy_reports() {
-    if [[ -d "${WORKDIR:-}" ]]; then
-        echo "Copying reports to artifact and shared directories..."
-        find "${WORKDIR}" -maxdepth 1 -name "*.html" -exec cp {} "${ARTIFACT_DIR}/" \; || true
-        find "${WORKDIR}" -maxdepth 1 -name "*.html" -exec cp {} "${SHARED_DIR}/"   \; || true
-        find "${WORKDIR}" -maxdepth 1 -name "*.txt"  -exec cp {} "${ARTIFACT_DIR}/" \; || true
-    fi
-
-    # Archive the full Claude session directory (including subagent logs) for session continuation.
-    # These are used by the openshift-claude-post step to generate the continue-session page.
-    if [[ -d "${CLAUDE_HOME}/projects" ]]; then
-        echo "Archiving Claude session logs..."
-        if tar -czf "${ARTIFACT_DIR}/claude-sessions-$(date +%Y%m%d-%H%M%S).tar.gz" -C "${CLAUDE_HOME}" projects/ 2>/dev/null; then
-            touch "${SHARED_DIR}/claude-session-available"
-        fi
-    fi
-}
-
 wait_for_mcp_status() {
     local -r service="$1"
     local -r status="$2"
@@ -115,6 +125,34 @@ configure_claude() {
         echo "{}" > "${CLAUDE_HOME}/.claude.json"
     fi
 
+    # Configure Claude permission-related settings
+    cat > "${CLAUDE_HOME}/settings.json" <<'EOF'
+{
+  "permissions": {
+    "allow": [
+      "Read(//tmp/**)",
+      "Write(//tmp/**)",
+      "Bash(bash plugins/microshift-ci/scripts/*)",
+      "Bash(python3 plugins/microshift-ci/scripts/*)",
+      "Bash(curl:*)",
+      "Bash(date:*)",
+      "Bash(cat:*)",
+      "Bash(echo:*)",
+      "Bash(wc:*)",
+      "Bash(ls:*)",
+      "Bash(jq:*)",
+      "Skill(microshift-ci:create-bugs)",
+      "Skill(microshift-ci:doctor)",
+      "Skill(microshift-ci:prow-job)",
+      "Skill(microshift-ci:test-job)",
+      "Skill(microshift-ci:test-scenario)"
+    ]
+  }
+}
+EOF
+    echo "Claude permissions configured."
+    cat "${CLAUDE_HOME}/settings.json"
+
     # Configure JIRA MCP
     if [[ -n "${JIRA_API_TOKEN:-}" ]] && [[ -n "${JIRA_USERNAME:-}" ]]; then
         echo "Configuring JIRA MCP..."
@@ -130,6 +168,7 @@ configure_claude() {
               -e JIRA_URL="${JIRA_URL}" \
               -e JIRA_API_TOKEN="${JIRA_API_TOKEN}" \
               -e JIRA_USERNAME="${JIRA_USERNAME}" \
+              --scope user \
               --transport stdio \
               jira -- uvx mcp-atlassian@0.21.0
           set -x
@@ -155,17 +194,18 @@ if [[ "${JOB_NAME}" != *-main-ci-doctor ]]; then
 fi
 
 # Ensure reports and session logs are copied to artifacts
-trap copy_reports EXIT TERM INT
-
-# Clone the MicroShift repository from the main branch to get the latest
-# analyze-ci skills and run analysis on all releases and open pull requests
-SRC_DIR="/tmp/microshift"
-git clone -b main https://github.com/openshift/microshift.git "${SRC_DIR}"
-cd "${SRC_DIR}"
+trap atexit_handler EXIT TERM INT
 
 load_secrets
 install_prerequisites
 configure_claude
+
+# Clone the edge-tooling repository from the main branch to get the latest
+# microshift-ci skills and run analysis on all releases and open pull requests
+SRC_DIR="/tmp/edge-tooling"
+EXE_DIR="${SRC_DIR}/plugins/microshift-ci/scripts"
+gh repo clone openshift-eng/edge-tooling "${SRC_DIR}" -- --branch main
+cd "${SRC_DIR}"
 
 # Run analysis on all releases and open rebase PRs.
 # Time-box analysis and limit turns to avoid uncontrolled billable minutes.
@@ -174,12 +214,12 @@ timeout 3600 claude \
     --model "${CLAUDE_MODEL}" \
     --max-turns 50 \
     --output-format stream-json \
-    -p "/analyze-ci:doctor ${RELEASE_VERSIONS}" \
+    -p "/microshift-ci:doctor ${RELEASE_VERSIONS}" \
     --verbose 2>&1 | tee "${WORKDIR}/claude-output.log"
 
 # After the analysis, run automatic approval of rebase PRs with all tests passing
 echo "Running automatic approval of rebase PRs with all tests passing..."
-.claude/scripts/microshift-prow-jobs-for-pull-requests.sh \
+"${EXE_DIR}/prow-jobs-for-pull-requests.sh" \
     --mode approve \
     --author 'microshift-rebase-script[bot]'
 echo "Automatic approval of rebase PRs with all tests passing completed"
@@ -188,16 +228,7 @@ echo "Automatic approval of rebase PRs with all tests passing completed"
 # restarted tests complete successfully, the PR will be automatically
 # approved next time the analysis runs.
 echo "Running automatic restart of failed rebase PRs tests..."
-.claude/scripts/microshift-prow-jobs-for-pull-requests.sh \
+"${EXE_DIR}/prow-jobs-for-pull-requests.sh" \
     --mode restart \
     --author 'microshift-rebase-script[bot]'
 echo "Automatic restart of failed rebase PRs tests completed"
-
-# Check if the report was produced
-if ls "${WORKDIR}"/*.html &>/dev/null; then
-    touch "${SHARED_DIR}/claude-report-available"
-    echo "Analysis complete"
-else
-    echo "ERROR: No HTML report was generated"
-    exit 1
-fi

--- a/ci-operator/step-registry/openshift/microshift/claude/ci-doctor/openshift-microshift-claude-ci-doctor-commands.sh
+++ b/ci-operator/step-registry/openshift/microshift/claude/ci-doctor/openshift-microshift-claude-ci-doctor-commands.sh
@@ -221,6 +221,7 @@ timeout 3600 claude \
 echo "Running automatic approval of rebase PRs with all tests passing..."
 "${EXE_DIR}/prow-jobs-for-pull-requests.sh" \
     --mode approve \
+    --execute \
     --author 'microshift-rebase-script[bot]'
 echo "Automatic approval of rebase PRs with all tests passing completed"
 
@@ -230,5 +231,6 @@ echo "Automatic approval of rebase PRs with all tests passing completed"
 echo "Running automatic restart of failed rebase PRs tests..."
 "${EXE_DIR}/prow-jobs-for-pull-requests.sh" \
     --mode restart \
+    --execute \
     --author 'microshift-rebase-script[bot]'
 echo "Automatic restart of failed rebase PRs tests completed"

--- a/ci-operator/step-registry/openshift/microshift/claude/ci-doctor/openshift-microshift-claude-ci-doctor-ref.yaml
+++ b/ci-operator/step-registry/openshift/microshift/claude/ci-doctor/openshift-microshift-claude-ci-doctor-ref.yaml
@@ -25,7 +25,7 @@ ref:
   - name: GOOGLE_APPLICATION_CREDENTIALS
     default: "/var/run/claude-code-service-account/token"
   - name: CLAUDE_MODEL
-    default: "claude-opus-4-6[1m]"
+    default: "claude-opus-4-6"
   - name: GITHUB_APP_ID_PATH
     default: "/var/run/pr-creds/app_id"
   - name: GITHUB_KEY_PATH


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Renamed temp workdir prefix and added a centralized exit handler to consolidate artifact/report copying, archive session data, and signal availability only on success; handler now fails if no HTML report is produced.

* **Chores**
  * Updated CI tooling source and job invocation behavior, added execution flag for approve/restart runs, and tightened AI integration permissions via a settings allowlist.

* **Bug Fixes**
  * Normalized default AI model identifier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->