### PR TITLE
SSCSI-274: Add tokenRequests to CSIDriver for AWS secrets-store e2e tests

### DIFF
--- a/ci-operator/step-registry/openshift/e2e/aws/csi/secrets-store/test/openshift-e2e-aws-csi-secrets-store-test-commands.sh
+++ b/ci-operator/step-registry/openshift/e2e/aws/csi/secrets-store/test/openshift-e2e-aws-csi-secrets-store-test-commands.sh
@@ -21,5 +21,8 @@ fi
 aws_region=${REGION:-$LEASED_RESOURCE}
 export REGION=$aws_region
 
+# audience needed to be added for token to be retrieved by the aws provider
+oc patch csidriver secrets-store.csi.k8s.io --type='merge' -p '{"spec":{"tokenRequests":[{"audience": "sts.amazonaws.com"}]}}'
+
 # Run aws end-to-end tests
 make e2e-aws


### PR DESCRIPTION
## Summary
- The upstream AWS provider ([aws/secrets-store-csi-driver-provider-aws#561](https://github.com/aws/secrets-store-csi-driver-provider-aws/pull/561), merged Mar 27 2026) now requires `spec.tokenRequests` on the CSIDriver object.
- Without it, AWS e2e tests 4-8 (`test/bats/aws.bats`) fail with: `"CSI token error: serviceAccount.tokens not provided - ensure tokenRequests is configured in CSIDriver spec"`
- This adds an `oc patch` to set `tokenRequests` with audience `sts.amazonaws.com` before running `make e2e-aws`, matching the existing Azure pattern (`api://AzureADTokenExchange`). Both the operand (`e2e-aws`) and operator (`operator-e2e-aws`) workflows share this test step.

## Test plan
- [ ] Verify `operator-e2e-aws` job passes (secrets-store-csi-driver-operator)
- [x] Verify `e2e-aws` job passes (secrets-store-csi-driver)

Made with [Cursor](https://cursor.com)