### PR TITLE
ARO-HCP: add manual vault secret mounting to gather-observability step

### DIFF
--- a/ci-operator/step-registry/aro-hcp/gather/observability/aro-hcp-gather-observability-commands.sh
+++ b/ci-operator/step-registry/aro-hcp/gather/observability/aro-hcp-gather-observability-commands.sh
@@ -4,6 +4,8 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
+export CLUSTER_PROFILE_DIR="/var/run/aro-hcp-${VAULT_SECRET_PROFILE}"
+
 export AZURE_CLIENT_ID; AZURE_CLIENT_ID=$(cat "${CLUSTER_PROFILE_DIR}/client-id")
 export AZURE_TENANT_ID; AZURE_TENANT_ID=$(cat "${CLUSTER_PROFILE_DIR}/tenant")
 export AZURE_CLIENT_SECRET; AZURE_CLIENT_SECRET=$(cat "${CLUSTER_PROFILE_DIR}/client-secret")

--- a/ci-operator/step-registry/aro-hcp/gather/observability/aro-hcp-gather-observability-ref.yaml
+++ b/ci-operator/step-registry/aro-hcp/gather/observability/aro-hcp-gather-observability-ref.yaml
@@ -6,7 +6,15 @@ ref:
     requests:
       cpu: 10m
       memory: 200Mi
+  credentials:
+    - namespace: test-credentials
+      name: cluster-secrets-aro-hcp-dev
+      mount_path: /var/run/aro-hcp-dev
   env:
+    - name: VAULT_SECRET_PROFILE
+      default: "dev"
+      documentation: |-
+        Selects which environment's cluster secrets to use (dev, int, stg, prod).
     - name: COMPRESS_TIMING_METADATA
       default: "true"
       documentation: Whether to compress timing metadata files with gzip.


### PR DESCRIPTION
The gather-observability step was added in #77572 but relied on CLUSTER_PROFILE_DIR being set by ci-operator via cluster_profile. Since #76075 dropped cluster profiles in favor of manual vault and lease management, this step needs the same treatment: mount credential secrets and derive CLUSTER_PROFILE_DIR from VAULT_SECRET_PROFILE.