### PR TITLE
Remove fixed region in Kserve jobs to reduce quota failures

### DIFF
--- a/ci-operator/config/opendatahub-io/kserve/opendatahub-io-kserve-master.yaml
+++ b/ci-operator/config/opendatahub-io/kserve/opendatahub-io-kserve-master.yaml
@@ -106,7 +106,6 @@ tests:
     env:
       BASE_DOMAIN: openshift-ci-aws.rhaiseng.com
       COMPUTE_NODE_TYPE: m5.2xlarge
-      HYPERSHIFT_AWS_REGION: us-west-2
       HYPERSHIFT_NODE_COUNT: "3"
     post:
     - as: testlog-gather
@@ -174,7 +173,6 @@ tests:
     env:
       BASE_DOMAIN: openshift-ci-aws.rhaiseng.com
       COMPUTE_NODE_TYPE: m5.2xlarge
-      HYPERSHIFT_AWS_REGION: us-west-2
       HYPERSHIFT_NODE_COUNT: "3"
     post:
     - as: testlog-gather
@@ -245,7 +243,6 @@ tests:
     env:
       BASE_DOMAIN: openshift-ci-aws.rhaiseng.com
       COMPUTE_NODE_TYPE: m5.2xlarge
-      HYPERSHIFT_AWS_REGION: us-west-2
       HYPERSHIFT_NODE_COUNT: "3"
     post:
     - as: testlog-gather
@@ -308,7 +305,6 @@ tests:
     env:
       BASE_DOMAIN: openshift-ci-aws.rhaiseng.com
       COMPUTE_NODE_TYPE: m5.2xlarge
-      HYPERSHIFT_AWS_REGION: us-west-2
       HYPERSHIFT_NODE_COUNT: "3"
     post:
     - as: testlog-gather

--- a/ci-operator/config/opendatahub-io/kserve/opendatahub-io-kserve-release-v0.17.yaml
+++ b/ci-operator/config/opendatahub-io/kserve/opendatahub-io-kserve-release-v0.17.yaml
@@ -84,7 +84,6 @@ tests:
     env:
       BASE_DOMAIN: openshift-ci-aws.rhaiseng.com
       COMPUTE_NODE_TYPE: m5.2xlarge
-      HYPERSHIFT_AWS_REGION: us-west-2
       HYPERSHIFT_NODE_COUNT: "3"
     post:
     - as: testlog-gather
@@ -152,7 +151,6 @@ tests:
     env:
       BASE_DOMAIN: openshift-ci-aws.rhaiseng.com
       COMPUTE_NODE_TYPE: m5.2xlarge
-      HYPERSHIFT_AWS_REGION: us-west-2
       HYPERSHIFT_NODE_COUNT: "3"
     post:
     - as: testlog-gather
@@ -214,7 +212,6 @@ tests:
     env:
       BASE_DOMAIN: openshift-ci-aws.rhaiseng.com
       COMPUTE_NODE_TYPE: m5.2xlarge
-      HYPERSHIFT_AWS_REGION: us-west-2
       HYPERSHIFT_NODE_COUNT: "3"
     post:
     - as: testlog-gather
@@ -285,7 +282,6 @@ tests:
     env:
       BASE_DOMAIN: openshift-ci-aws.rhaiseng.com
       COMPUTE_NODE_TYPE: m5.2xlarge
-      HYPERSHIFT_AWS_REGION: us-west-2
       HYPERSHIFT_NODE_COUNT: "3"
     post:
     - as: testlog-gather


### PR DESCRIPTION
jobs can use slices in other regions too. The profile has 120 more slices in us-east-1, us-east-2, and us-west-1