### PR TITLE
Add BASE_DOMAIN for aws-mco-qe cluster profile

### DIFF
--- a/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-4.22__periodics.yaml
+++ b/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-4.22__periodics.yaml
@@ -221,6 +221,7 @@ tests:
   steps:
     cluster_profile: aws-mco-qe
     env:
+      BASE_DOMAIN: ocp-mco-qe.devcluster.openshift.com
       COMPUTE_NODE_REPLICAS: "2"
       FIPS_ENABLED: "true"
       TEST_SKIPS: ""

--- a/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-4.23__periodics.yaml
+++ b/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-4.23__periodics.yaml
@@ -221,6 +221,7 @@ tests:
   steps:
     cluster_profile: aws-mco-qe
     env:
+      BASE_DOMAIN: ocp-mco-qe.devcluster.openshift.com
       COMPUTE_NODE_REPLICAS: "2"
       FIPS_ENABLED: "true"
       TEST_SKIPS: ""

--- a/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-5.0__periodics.yaml
+++ b/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-5.0__periodics.yaml
@@ -221,6 +221,7 @@ tests:
   steps:
     cluster_profile: aws-mco-qe
     env:
+      BASE_DOMAIN: ocp-mco-qe.devcluster.openshift.com
       COMPUTE_NODE_REPLICAS: "2"
       FIPS_ENABLED: "true"
       TEST_SKIPS: ""


### PR DESCRIPTION
Add BASE_DOMAIN environment variable for aws-mco-qe cluster profile to fix DNS lookup failures.
Issue: 
The aws-mco-qe cluster profile was missing the BASE_DOMAIN configuration, causing jobs to default to `origin-ci-int-aws.dev.rhcloud.com` which resulted in Route53 DNS lookup failures:
   ```
   failed to fetch Common Manifests: getting public zone for "origin-ci-int-aws.dev.rhcloud.com": no public route53 zone found
   ```
