### PR TITLE
Add ship-help manifests to app.ci

### DIFF
--- a/clusters/app.ci/assets/ship-help_rbac.yaml
+++ b/clusters/app.ci/assets/ship-help_rbac.yaml
@@ -1,0 +1,28 @@
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: ship-help
+  namespace: ci
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ship-help-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-reader
+subjects:
+- kind: ServiceAccount
+  name: ship-help
+  namespace: ci
+---
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/service-account-token
+metadata:
+  name: ship-help-token
+  namespace: ci
+  annotations:
+    kubernetes.io/service-account.name: ship-help


### PR DESCRIPTION
Adding the manifests to app.ci specifically as https://github.com/openshift/release/pull/77639 didn't apply it.