### PR TITLE
Sync Serverless CI config/

### DIFF
--- a/ci-operator/config/openshift-knative/eventing-istio/.config.prowgen
+++ b/ci-operator/config/openshift-knative/eventing-istio/.config.prowgen
@@ -1,13 +1,15 @@
+rehearsals: {}
 slack_reporter:
 - channel: '#knative-eventing-ci'
+  excluded_variants:
+  - "421"
+  job_names:
+  - e2e-tests-c
   job_states_to_report:
   - success
   - failure
   - error
-  report_template: '{{if eq .Status.State "success"}} :rainbow: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
-    logs> :rainbow: {{else}} :volcano: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :volcano:
-    {{end}}'
-  job_names:
-  - e2e-tests-c
-  excluded_variants:
-  - '421'
+  report_template: '{{if eq .Status.State "success"}} :rainbow: Job *{{.Spec.Job}}*
+    ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :rainbow: {{else}}
+    :volcano: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+    logs> :volcano: {{end}}'

--- a/ci-operator/config/openshift-knative/eventing-kafka-broker/.config.prowgen
+++ b/ci-operator/config/openshift-knative/eventing-kafka-broker/.config.prowgen
@@ -1,17 +1,19 @@
+rehearsals: {}
 slack_reporter:
 - channel: '#knative-eventing-ci'
-  job_states_to_report:
-  - success
-  - failure
-  - error
-  report_template: '{{if eq .Status.State "success"}} :rainbow: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
-    logs> :rainbow: {{else}} :volcano: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :volcano:
-    {{end}}'
+  excluded_variants:
+  - "421"
   job_names:
   - test-conformance-c
   - test-e2e-c
   - test-reconciler-c
   - test-reconciler-encryption-auth-c
   - test-reconciler-keda-c
-  excluded_variants:
-  - '421'
+  job_states_to_report:
+  - success
+  - failure
+  - error
+  report_template: '{{if eq .Status.State "success"}} :rainbow: Job *{{.Spec.Job}}*
+    ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :rainbow: {{else}}
+    :volcano: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+    logs> :volcano: {{end}}'

--- a/ci-operator/config/openshift-knative/eventing/.config.prowgen
+++ b/ci-operator/config/openshift-knative/eventing/.config.prowgen
@@ -1,16 +1,18 @@
+rehearsals: {}
 slack_reporter:
 - channel: '#knative-eventing-ci'
-  job_states_to_report:
-  - success
-  - failure
-  - error
-  report_template: '{{if eq .Status.State "success"}} :rainbow: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
-    logs> :rainbow: {{else}} :volcano: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :volcano:
-    {{end}}'
+  excluded_variants:
+  - "421"
   job_names:
   - test-conformance-c
   - test-e2e-c
   - test-encryption-auth-e2e-c
   - test-reconciler-c
-  excluded_variants:
-  - '421'
+  job_states_to_report:
+  - success
+  - failure
+  - error
+  report_template: '{{if eq .Status.State "success"}} :rainbow: Job *{{.Spec.Job}}*
+    ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :rainbow: {{else}}
+    :volcano: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+    logs> :volcano: {{end}}'

--- a/ci-operator/config/openshift-knative/kn-plugin-event/.config.prowgen
+++ b/ci-operator/config/openshift-knative/kn-plugin-event/.config.prowgen
@@ -1,13 +1,16 @@
+rehearsals: {}
 slack_reporter:
 - channel: '#knative-client'
+  excluded_variants:
+  - "420"
+  - "421"
+  job_names:
+  - e2e-c
   job_states_to_report:
   - success
   - failure
   - error
-  report_template: '{{if eq .Status.State "success"}} :rainbow: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
-    logs> :rainbow: {{else}} :volcano: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :volcano:
-    {{end}}'
-  job_names:
-  - e2e-c
-  excluded_variants:
-  - '421'
+  report_template: '{{if eq .Status.State "success"}} :rainbow: Job *{{.Spec.Job}}*
+    ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :rainbow: {{else}}
+    :volcano: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+    logs> :volcano: {{end}}'

--- a/ci-operator/config/openshift-knative/net-istio/openshift-knative-net-istio-release-v1.15__414.yaml
+++ b/ci-operator/config/openshift-knative/net-istio/openshift-knative-net-istio-release-v1.15__414.yaml
@@ -3,10 +3,10 @@ base_images:
     name: ubi-minimal
     namespace: ocp
     tag: "8"
-  openshift_release_rhel-8-release-golang-1.22-openshift-4.17:
+  openshift_release_rhel-8-release-golang-1.25-openshift-4.21:
     name: release
     namespace: openshift
-    tag: rhel-8-release-golang-1.22-openshift-4.17
+    tag: rhel-8-release-golang-1.25-openshift-4.21
 build_root:
   project_image:
     dockerfile_path: openshift/ci-operator/build-image/Dockerfile
@@ -17,7 +17,7 @@ images:
       ocp_ubi-minimal_8:
         as:
         - $GO_RUNTIME
-      openshift_release_rhel-8-release-golang-1.22-openshift-4.17:
+      openshift_release_rhel-8-release-golang-1.25-openshift-4.21:
         as:
         - $GO_BUILDER
     to: net-istio-controller
@@ -26,7 +26,7 @@ images:
       ocp_ubi-minimal_8:
         as:
         - $GO_RUNTIME
-      openshift_release_rhel-8-release-golang-1.22-openshift-4.17:
+      openshift_release_rhel-8-release-golang-1.25-openshift-4.21:
         as:
         - $GO_BUILDER
     to: net-istio-webhook

--- a/ci-operator/config/openshift-knative/net-istio/openshift-knative-net-istio-release-v1.15__420.yaml
+++ b/ci-operator/config/openshift-knative/net-istio/openshift-knative-net-istio-release-v1.15__420.yaml
@@ -3,10 +3,10 @@ base_images:
     name: ubi-minimal
     namespace: ocp
     tag: "8"
-  openshift_release_rhel-8-release-golang-1.22-openshift-4.17:
+  openshift_release_rhel-8-release-golang-1.25-openshift-4.21:
     name: release
     namespace: openshift
-    tag: rhel-8-release-golang-1.22-openshift-4.17
+    tag: rhel-8-release-golang-1.25-openshift-4.21
 build_root:
   project_image:
     dockerfile_path: openshift/ci-operator/build-image/Dockerfile
@@ -17,7 +17,7 @@ images:
       ocp_ubi-minimal_8:
         as:
         - $GO_RUNTIME
-      openshift_release_rhel-8-release-golang-1.22-openshift-4.17:
+      openshift_release_rhel-8-release-golang-1.25-openshift-4.21:
         as:
         - $GO_BUILDER
     to: net-istio-controller
@@ -26,7 +26,7 @@ images:
       ocp_ubi-minimal_8:
         as:
         - $GO_RUNTIME
-      openshift_release_rhel-8-release-golang-1.22-openshift-4.17:
+      openshift_release_rhel-8-release-golang-1.25-openshift-4.21:
         as:
         - $GO_BUILDER
     to: net-istio-webhook

--- a/ci-operator/config/openshift-knative/net-istio/openshift-knative-net-istio-release-v1.16__414.yaml
+++ b/ci-operator/config/openshift-knative/net-istio/openshift-knative-net-istio-release-v1.16__414.yaml
@@ -3,10 +3,10 @@ base_images:
     name: ubi-minimal
     namespace: ocp
     tag: "8"
-  openshift_release_rhel-8-release-golang-1.22-openshift-4.17:
+  openshift_release_rhel-8-release-golang-1.25-openshift-4.21:
     name: release
     namespace: openshift
-    tag: rhel-8-release-golang-1.22-openshift-4.17
+    tag: rhel-8-release-golang-1.25-openshift-4.21
 build_root:
   project_image:
     dockerfile_path: openshift/ci-operator/build-image/Dockerfile
@@ -17,7 +17,7 @@ images:
       ocp_ubi-minimal_8:
         as:
         - $GO_RUNTIME
-      openshift_release_rhel-8-release-golang-1.22-openshift-4.17:
+      openshift_release_rhel-8-release-golang-1.25-openshift-4.21:
         as:
         - $GO_BUILDER
     to: net-istio-controller
@@ -26,7 +26,7 @@ images:
       ocp_ubi-minimal_8:
         as:
         - $GO_RUNTIME
-      openshift_release_rhel-8-release-golang-1.22-openshift-4.17:
+      openshift_release_rhel-8-release-golang-1.25-openshift-4.21:
         as:
         - $GO_BUILDER
     to: net-istio-webhook

--- a/ci-operator/config/openshift-knative/net-istio/openshift-knative-net-istio-release-v1.16__420.yaml
+++ b/ci-operator/config/openshift-knative/net-istio/openshift-knative-net-istio-release-v1.16__420.yaml
@@ -3,10 +3,10 @@ base_images:
     name: ubi-minimal
     namespace: ocp
     tag: "8"
-  openshift_release_rhel-8-release-golang-1.22-openshift-4.17:
+  openshift_release_rhel-8-release-golang-1.25-openshift-4.21:
     name: release
     namespace: openshift
-    tag: rhel-8-release-golang-1.22-openshift-4.17
+    tag: rhel-8-release-golang-1.25-openshift-4.21
 build_root:
   project_image:
     dockerfile_path: openshift/ci-operator/build-image/Dockerfile
@@ -17,7 +17,7 @@ images:
       ocp_ubi-minimal_8:
         as:
         - $GO_RUNTIME
-      openshift_release_rhel-8-release-golang-1.22-openshift-4.17:
+      openshift_release_rhel-8-release-golang-1.25-openshift-4.21:
         as:
         - $GO_BUILDER
     to: net-istio-controller
@@ -26,7 +26,7 @@ images:
       ocp_ubi-minimal_8:
         as:
         - $GO_RUNTIME
-      openshift_release_rhel-8-release-golang-1.22-openshift-4.17:
+      openshift_release_rhel-8-release-golang-1.25-openshift-4.21:
         as:
         - $GO_BUILDER
     to: net-istio-webhook

--- a/ci-operator/config/openshift-knative/net-istio/openshift-knative-net-istio-release-v1.16__421.yaml
+++ b/ci-operator/config/openshift-knative/net-istio/openshift-knative-net-istio-release-v1.16__421.yaml
@@ -3,10 +3,10 @@ base_images:
     name: ubi-minimal
     namespace: ocp
     tag: "8"
-  openshift_release_rhel-8-release-golang-1.22-openshift-4.17:
+  openshift_release_rhel-8-release-golang-1.25-openshift-4.21:
     name: release
     namespace: openshift
-    tag: rhel-8-release-golang-1.22-openshift-4.17
+    tag: rhel-8-release-golang-1.25-openshift-4.21
 build_root:
   project_image:
     dockerfile_path: openshift/ci-operator/build-image/Dockerfile
@@ -17,7 +17,7 @@ images:
       ocp_ubi-minimal_8:
         as:
         - $GO_RUNTIME
-      openshift_release_rhel-8-release-golang-1.22-openshift-4.17:
+      openshift_release_rhel-8-release-golang-1.25-openshift-4.21:
         as:
         - $GO_BUILDER
     to: net-istio-controller
@@ -26,7 +26,7 @@ images:
       ocp_ubi-minimal_8:
         as:
         - $GO_RUNTIME
-      openshift_release_rhel-8-release-golang-1.22-openshift-4.17:
+      openshift_release_rhel-8-release-golang-1.25-openshift-4.21:
         as:
         - $GO_BUILDER
     to: net-istio-webhook

--- a/ci-operator/config/openshift-knative/net-kourier/openshift-knative-net-kourier-release-v1.15__414.yaml
+++ b/ci-operator/config/openshift-knative/net-kourier/openshift-knative-net-kourier-release-v1.15__414.yaml
@@ -3,10 +3,10 @@ base_images:
     name: ubi-minimal
     namespace: ocp
     tag: "8"
-  openshift_release_rhel-8-release-golang-1.22-openshift-4.17:
+  openshift_release_rhel-8-release-golang-1.25-openshift-4.21:
     name: release
     namespace: openshift
-    tag: rhel-8-release-golang-1.22-openshift-4.17
+    tag: rhel-8-release-golang-1.25-openshift-4.21
 build_root:
   project_image:
     dockerfile_path: openshift/ci-operator/build-image/Dockerfile
@@ -17,7 +17,7 @@ images:
       ocp_ubi-minimal_8:
         as:
         - $GO_RUNTIME
-      openshift_release_rhel-8-release-golang-1.22-openshift-4.17:
+      openshift_release_rhel-8-release-golang-1.25-openshift-4.21:
         as:
         - $GO_BUILDER
     to: net-kourier-kourier

--- a/ci-operator/config/openshift-knative/net-kourier/openshift-knative-net-kourier-release-v1.15__420.yaml
+++ b/ci-operator/config/openshift-knative/net-kourier/openshift-knative-net-kourier-release-v1.15__420.yaml
@@ -3,10 +3,10 @@ base_images:
     name: ubi-minimal
     namespace: ocp
     tag: "8"
-  openshift_release_rhel-8-release-golang-1.22-openshift-4.17:
+  openshift_release_rhel-8-release-golang-1.25-openshift-4.21:
     name: release
     namespace: openshift
-    tag: rhel-8-release-golang-1.22-openshift-4.17
+    tag: rhel-8-release-golang-1.25-openshift-4.21
 build_root:
   project_image:
     dockerfile_path: openshift/ci-operator/build-image/Dockerfile
@@ -17,7 +17,7 @@ images:
       ocp_ubi-minimal_8:
         as:
         - $GO_RUNTIME
-      openshift_release_rhel-8-release-golang-1.22-openshift-4.17:
+      openshift_release_rhel-8-release-golang-1.25-openshift-4.21:
         as:
         - $GO_BUILDER
     to: net-kourier-kourier

--- a/ci-operator/config/openshift-knative/net-kourier/openshift-knative-net-kourier-release-v1.16__414.yaml
+++ b/ci-operator/config/openshift-knative/net-kourier/openshift-knative-net-kourier-release-v1.16__414.yaml
@@ -3,10 +3,10 @@ base_images:
     name: ubi-minimal
     namespace: ocp
     tag: "8"
-  openshift_release_rhel-8-release-golang-1.22-openshift-4.17:
+  openshift_release_rhel-8-release-golang-1.25-openshift-4.21:
     name: release
     namespace: openshift
-    tag: rhel-8-release-golang-1.22-openshift-4.17
+    tag: rhel-8-release-golang-1.25-openshift-4.21
 build_root:
   project_image:
     dockerfile_path: openshift/ci-operator/build-image/Dockerfile
@@ -17,7 +17,7 @@ images:
       ocp_ubi-minimal_8:
         as:
         - $GO_RUNTIME
-      openshift_release_rhel-8-release-golang-1.22-openshift-4.17:
+      openshift_release_rhel-8-release-golang-1.25-openshift-4.21:
         as:
         - $GO_BUILDER
     to: net-kourier-kourier

--- a/ci-operator/config/openshift-knative/net-kourier/openshift-knative-net-kourier-release-v1.16__420.yaml
+++ b/ci-operator/config/openshift-knative/net-kourier/openshift-knative-net-kourier-release-v1.16__420.yaml
@@ -3,10 +3,10 @@ base_images:
     name: ubi-minimal
     namespace: ocp
     tag: "8"
-  openshift_release_rhel-8-release-golang-1.22-openshift-4.17:
+  openshift_release_rhel-8-release-golang-1.25-openshift-4.21:
     name: release
     namespace: openshift
-    tag: rhel-8-release-golang-1.22-openshift-4.17
+    tag: rhel-8-release-golang-1.25-openshift-4.21
 build_root:
   project_image:
     dockerfile_path: openshift/ci-operator/build-image/Dockerfile
@@ -17,7 +17,7 @@ images:
       ocp_ubi-minimal_8:
         as:
         - $GO_RUNTIME
-      openshift_release_rhel-8-release-golang-1.22-openshift-4.17:
+      openshift_release_rhel-8-release-golang-1.25-openshift-4.21:
         as:
         - $GO_BUILDER
     to: net-kourier-kourier

--- a/ci-operator/config/openshift-knative/net-kourier/openshift-knative-net-kourier-release-v1.16__421.yaml
+++ b/ci-operator/config/openshift-knative/net-kourier/openshift-knative-net-kourier-release-v1.16__421.yaml
@@ -3,10 +3,10 @@ base_images:
     name: ubi-minimal
     namespace: ocp
     tag: "8"
-  openshift_release_rhel-8-release-golang-1.22-openshift-4.17:
+  openshift_release_rhel-8-release-golang-1.25-openshift-4.21:
     name: release
     namespace: openshift
-    tag: rhel-8-release-golang-1.22-openshift-4.17
+    tag: rhel-8-release-golang-1.25-openshift-4.21
 build_root:
   project_image:
     dockerfile_path: openshift/ci-operator/build-image/Dockerfile
@@ -17,7 +17,7 @@ images:
       ocp_ubi-minimal_8:
         as:
         - $GO_RUNTIME
-      openshift_release_rhel-8-release-golang-1.22-openshift-4.17:
+      openshift_release_rhel-8-release-golang-1.25-openshift-4.21:
         as:
         - $GO_BUILDER
     to: net-kourier-kourier

--- a/ci-operator/config/openshift-knative/serverless-operator/.config.prowgen
+++ b/ci-operator/config/openshift-knative/serverless-operator/.config.prowgen
@@ -1,13 +1,15 @@
+rehearsals: {}
 slack_reporter:
 - channel: '#serverless-ci'
-  job_states_to_report:
-  - success
-  - failure
-  - error
-  report_template: '{{if eq .Status.State "success"}} :rainbow: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
-    logs> :rainbow: {{else}} :volcano: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :volcano:
-    {{end}}'
+  excluded_variants:
+  - "413"
+  - "414"
+  - "420"
+  - "421"
+  - "422"
   job_names:
+  - aws-fips
+  - cr-operator-e2e-aws
   - e2e-aws-ovn-continuous
   - e2e-azure-continuous
   - e2e-gcp-continuous
@@ -17,14 +19,17 @@ slack_reporter:
   - kitchensink-e2e-c
   - kitchensink-upgrade-c
   - mesh-e2e-c
+  - olmv1-operator-e2e
   - operator-e2e-c
-  - operator-e2e-interop-aws-ocp422
   - test-soak-c
   - test-upgrade-c
   - ui-e2e-c
   - upstream-e2e-kafka-c
-  excluded_variants:
-  - '413'
-  - '421'
-  - '422'
-  - ocp-4.23-lp-interop-cr
+  job_states_to_report:
+  - success
+  - failure
+  - error
+  report_template: '{{if eq .Status.State "success"}} :rainbow: Job *{{.Spec.Job}}*
+    ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :rainbow: {{else}}
+    :volcano: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+    logs> :volcano: {{end}}'

--- a/ci-operator/config/openshift-knative/serverless-operator/openshift-knative-serverless-operator-main__420-vsphere.yaml
+++ b/ci-operator/config/openshift-knative/serverless-operator/openshift-knative-serverless-operator-main__420-vsphere.yaml
@@ -141,6 +141,8 @@ tests:
   cron: 26 4 * * 3
   steps:
     cluster_profile: vsphere-elastic
+    env:
+      COMPUTE_NODE_REPLICAS: "3"
     test:
     - as: operator-e2e
       commands: HA=false GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin make test-e2e-with-kafka

--- a/ci-operator/config/openshift-knative/serving/.config.prowgen
+++ b/ci-operator/config/openshift-knative/serving/.config.prowgen
@@ -1,14 +1,16 @@
+rehearsals: {}
 slack_reporter:
 - channel: '#knative-serving-ci'
+  excluded_variants:
+  - "421"
+  job_names:
+  - test-e2e-c
+  - test-e2e-tls-c
   job_states_to_report:
   - success
   - failure
   - error
-  report_template: '{{if eq .Status.State "success"}} :rainbow: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
-    logs> :rainbow: {{else}} :volcano: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :volcano:
-    {{end}}'
-  job_names:
-  - test-e2e-c
-  - test-e2e-tls-c
-  excluded_variants:
-  - '421'
+  report_template: '{{if eq .Status.State "success"}} :rainbow: Job *{{.Spec.Job}}*
+    ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :rainbow: {{else}}
+    :volcano: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+    logs> :volcano: {{end}}'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build environments for net-istio and net-kourier (release v1.15 and v1.16) to use Go 1.25 instead of Go 1.22 for image builds.
  * Configuration-only updates to CI/build image references; no changes to runtime behavior, public interfaces, or functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->