### PR TITLE
migrating ols presubmits to gcp temporarily

### DIFF
--- a/ci-operator/config/openshift/lightspeed-operator/openshift-lightspeed-operator-main.yaml
+++ b/ci-operator/config/openshift/lightspeed-operator/openshift-lightspeed-operator-main.yaml
@@ -411,16 +411,7 @@ tests:
           cpu: 100m
     workflow: generic-claim
 - as: bundle-e2e-4-21
-  cluster_claim:
-    architecture: amd64
-    cloud: aws
-    labels:
-      region: us-east-1
-      variant: fips
-    owner: obs
-    product: ocp
-    timeout: 1h30m0s
-    version: "4.21"
+  cluster_profile: gcp-observability
   cron: 10 2 * * *
   presubmit: true
   skip_if_only_changed: ^docs/|\.md$|lightspeed-catalog.*|^renovate\.json|^\.golangci\.yaml|^\.tekton/|^\.github/|^hack/|^(?:.*/)?(?:\.gitignore|\.snyk|\.dockerignore|OWNERS|PROJECT|LICENSE)$
@@ -428,7 +419,6 @@ tests:
     pre:
     - ref: ipi-install-rbac
     test:
-    - ref: fips-check-fips-or-die
     - as: e2e-install
       cli: latest
       commands: |
@@ -479,7 +469,7 @@ tests:
       resources:
         requests:
           cpu: 100m
-    workflow: generic-claim
+    workflow: ipi-gcp
 - as: bundle-e2e-4-22
   cluster_claim:
     architecture: amd64

--- a/ci-operator/config/openshift/lightspeed-operator/openshift-lightspeed-operator-main.yaml
+++ b/ci-operator/config/openshift/lightspeed-operator/openshift-lightspeed-operator-main.yaml
@@ -42,10 +42,10 @@ promotion:
     tag: latest
 releases:
   latest:
-    release:
-      architecture: multi
-      channel: stable
-      version: "4.16"
+    integration:
+      include_built_images: true
+      name: "4.21"
+      namespace: ocp
 resources:
   '*':
     limits:
@@ -411,7 +411,6 @@ tests:
           cpu: 100m
     workflow: generic-claim
 - as: bundle-e2e-4-21
-  cluster_profile: gcp-observability
   cron: 10 2 * * *
   presubmit: true
   skip_if_only_changed: ^docs/|\.md$|lightspeed-catalog.*|^renovate\.json|^\.golangci\.yaml|^\.tekton/|^\.github/|^hack/|^(?:.*/)?(?:\.gitignore|\.snyk|\.dockerignore|OWNERS|PROJECT|LICENSE)$

--- a/ci-operator/config/openshift/lightspeed-service/openshift-lightspeed-service-main.yaml
+++ b/ci-operator/config/openshift/lightspeed-service/openshift-lightspeed-service-main.yaml
@@ -14,10 +14,10 @@ promotion:
     tag: latest
 releases:
   latest:
-    release:
-      architecture: amd64
-      channel: candidate
-      version: "4.21"
+    integration:
+      include_built_images: true
+      name: "4.21"
+      namespace: ocp
 resources:
   '*':
     limits:
@@ -63,7 +63,6 @@ tests:
     test:
     - ref: fips-check-image-scan
 - as: e2e-ols-cluster
-  cluster_profile: gcp-observability
   run_if_changed: ^(Containerfile.*|Makefile|manifests/.*|ols/.*|pyproject.toml|pdm.lock|scripts/.*|tests/.*)$
   steps:
     allow_skip_on_success: true
@@ -132,7 +131,6 @@ tests:
           cpu: 100m
     workflow: ipi-gcp
 - as: ols-evaluation
-  cluster_profile: gcp-observability
   run_if_changed: ^(Containerfile|tests/e2e/scripts/test-evaluation.sh|tests/e2e/scripts/utils.sh|Makefile|tests/e2e/evaluation/.*|ols/src/llms/providers/.*|ols/src/prompts/.*|ols/src/query_helpers/docs_summarizer.py|ols/src/rag_index/.*|ols/src/tools/.*|ols/utils/token_handler.py|ols/constants.py|scripts/evaluation/.*)$
   steps:
     allow_skip_on_success: true

--- a/ci-operator/config/openshift/lightspeed-service/openshift-lightspeed-service-main.yaml
+++ b/ci-operator/config/openshift/lightspeed-service/openshift-lightspeed-service-main.yaml
@@ -63,16 +63,7 @@ tests:
     test:
     - ref: fips-check-image-scan
 - as: e2e-ols-cluster
-  cluster_claim:
-    architecture: amd64
-    cloud: aws
-    labels:
-      region: us-east-1
-      variant: fips
-    owner: obs
-    product: ocp
-    timeout: 1h30m0s
-    version: "4.21"
+  cluster_profile: gcp-observability
   run_if_changed: ^(Containerfile.*|Makefile|manifests/.*|ols/.*|pyproject.toml|pdm.lock|scripts/.*|tests/.*)$
   steps:
     allow_skip_on_success: true
@@ -139,18 +130,9 @@ tests:
       resources:
         requests:
           cpu: 100m
-    workflow: generic-claim
+    workflow: ipi-gcp
 - as: ols-evaluation
-  cluster_claim:
-    architecture: amd64
-    cloud: aws
-    labels:
-      region: us-east-1
-      variant: fips
-    owner: obs
-    product: ocp
-    timeout: 1h30m0s
-    version: "4.20"
+  cluster_profile: gcp-observability
   run_if_changed: ^(Containerfile|tests/e2e/scripts/test-evaluation.sh|tests/e2e/scripts/utils.sh|Makefile|tests/e2e/evaluation/.*|ols/src/llms/providers/.*|ols/src/prompts/.*|ols/src/query_helpers/docs_summarizer.py|ols/src/rag_index/.*|ols/src/tools/.*|ols/utils/token_handler.py|ols/constants.py|scripts/evaluation/.*)$
   steps:
     allow_skip_on_success: true
@@ -182,7 +164,7 @@ tests:
       resources:
         requests:
           cpu: 100m
-    workflow: generic-claim
+    workflow: ipi-gcp
 zz_generated_metadata:
   branch: main
   org: openshift

--- a/ci-operator/jobs/openshift/lightspeed-operator/openshift-lightspeed-operator-main-periodics.yaml
+++ b/ci-operator/jobs/openshift/lightspeed-operator/openshift-lightspeed-operator-main-periodics.yaml
@@ -430,7 +430,6 @@ periodics:
     containers:
     - args:
       - --gcs-upload-secret=/secrets/gcs/service-account.json
-      - --hive-kubeconfig=/secrets/hive-hive-credentials/kubeconfig
       - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
@@ -462,9 +461,6 @@ periodics:
       - mountPath: /secrets/gcs
         name: gcs-credentials
         readOnly: true
-      - mountPath: /secrets/hive-hive-credentials
-        name: hive-hive-credentials
-        readOnly: true
       - mountPath: /secrets/manifest-tool
         name: manifest-tool-local-pusher
         readOnly: true
@@ -485,9 +481,6 @@ periodics:
     - name: ci-pull-credentials
       secret:
         secretName: ci-pull-credentials
-    - name: hive-hive-credentials
-      secret:
-        secretName: hive-hive-credentials
     - name: manifest-tool-local-pusher
       secret:
         secretName: manifest-tool-local-pusher

--- a/ci-operator/jobs/openshift/lightspeed-operator/openshift-lightspeed-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/lightspeed-operator/openshift-lightspeed-operator-main-presubmits.yaml
@@ -18,7 +18,6 @@ presubmits:
       containers:
       - args:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --hive-kubeconfig=/secrets/hive-hive-credentials/kubeconfig
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
@@ -50,9 +49,6 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
-        - mountPath: /secrets/hive-hive-credentials
-          name: hive-hive-credentials
-          readOnly: true
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
@@ -73,9 +69,6 @@ presubmits:
       - name: ci-pull-credentials
         secret:
           secretName: ci-pull-credentials
-      - name: hive-hive-credentials
-        secret:
-          secretName: hive-hive-credentials
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher

--- a/ci-operator/jobs/openshift/lightspeed-service/openshift-lightspeed-service-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/lightspeed-service/openshift-lightspeed-service-main-presubmits.yaml
@@ -20,7 +20,6 @@ presubmits:
       containers:
       - args:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --hive-kubeconfig=/secrets/hive-hive-credentials/kubeconfig
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
@@ -52,9 +51,6 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
-        - mountPath: /secrets/hive-hive-credentials
-          name: hive-hive-credentials
-          readOnly: true
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
@@ -75,9 +71,6 @@ presubmits:
       - name: ci-pull-credentials
         secret:
           secretName: ci-pull-credentials
-      - name: hive-hive-credentials
-        secret:
-          secretName: hive-hive-credentials
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
@@ -315,7 +308,6 @@ presubmits:
       containers:
       - args:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --hive-kubeconfig=/secrets/hive-hive-credentials/kubeconfig
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
@@ -347,9 +339,6 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
-        - mountPath: /secrets/hive-hive-credentials
-          name: hive-hive-credentials
-          readOnly: true
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
@@ -370,9 +359,6 @@ presubmits:
       - name: ci-pull-credentials
         secret:
           secretName: ci-pull-credentials
-      - name: hive-hive-credentials
-        secret:
-          secretName: hive-hive-credentials
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher


### PR DESCRIPTION
Migrating OLS CI to GCP while https://redhat.enterprise.slack.com/archives/C0AS1DN0UMB does not have a solution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configurations for test environments and cluster provisioning strategies.
  * Removed deprecated Hive kubeconfig references from CI pipeline jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->