### PR TITLE
PTP: Remove dualnicbc test mode from 4.12

### DIFF
--- a/ci-operator/step-registry/telco5g/ptp/tests/telco5g-ptp-tests-commands.sh
+++ b/ci-operator/step-registry/telco5g/ptp/tests/telco5g-ptp-tests-commands.sh
@@ -352,6 +352,13 @@ if [[ "$T5CI_VERSION" =~ 4.1[2-8]+ ]]; then
   if [[ "$T5CI_VERSION" =~ 4.1[2-5] ]]; then
     TEST_MODES=("${TEST_MODES[@]/dualnicbcha}")
   fi
+
+  # DualNICBoundaryClock test mode is only supported from 4.13 onwards,
+  # so if the version is less than 4.13, remove it from the list
+  if [[ "$T5CI_VERSION" == 4.12 ]]; then
+    TEST_MODES=("${TEST_MODES[@]/dualnicbc}")
+  fi
+
 else
   echo "Version is 4.19 or greater"
   export CONSUMER_IMG="quay.io/redhat-cne/cloud-event-consumer:latest"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration logic to handle version-specific test mode selection for telemetry and timing protocol testing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->