### PR TITLE
Clean up storage before initial PV creation in kuttl jobs

### DIFF
--- a/ci-operator/step-registry/openstack-k8s-operators/kuttl/openstack-k8s-operators-kuttl-commands.sh
+++ b/ci-operator/step-registry/openstack-k8s-operators/kuttl/openstack-k8s-operators-kuttl-commands.sh
@@ -130,6 +130,9 @@ if [ -f "/go/src/github.com/${ORG}/${BASE_OP}/kuttl-test.yaml" ]; then
   # Create/enable openstack namespace
   make namespace
 
+  # Clean up storage before creating PVs to avoid stale data from a
+  # previous CI job (e.g. RabbitMQ mnesia from a different version)
+  storage_cleanup
   storage_create
 
   # perform a minor update if it is the openstack-operator


### PR DESCRIPTION
Add storage_cleanup before storage_create to wipe stale data from previous CI jobs on the same node. Without this, PV directories may contain leftover data (e.g. RabbitMQ mnesia from a different version) that causes boot failures during the minor update test.