### PR TITLE
OU-1260: use npm instead of yarn for monitoring plugin

### DIFF
--- a/ci-operator/config/openshift/monitoring-plugin/openshift-monitoring-plugin-release-4.14.yaml
+++ b/ci-operator/config/openshift/monitoring-plugin/openshift-monitoring-plugin-release-4.14.yaml
@@ -33,7 +33,7 @@ resources:
       memory: 200Mi
 tests:
 - as: lint
-  commands: yarn lint
+  commands: npm run lint
   container:
     from: monitoring-plugin-test
 zz_generated_metadata:

--- a/ci-operator/config/openshift/monitoring-plugin/openshift-monitoring-plugin-release-4.15.yaml
+++ b/ci-operator/config/openshift/monitoring-plugin/openshift-monitoring-plugin-release-4.15.yaml
@@ -33,7 +33,7 @@ resources:
       memory: 200Mi
 tests:
 - as: lint
-  commands: yarn lint
+  commands: npm run lint
   container:
     from: monitoring-plugin-test
 zz_generated_metadata:

--- a/ci-operator/config/openshift/monitoring-plugin/openshift-monitoring-plugin-release-4.16.yaml
+++ b/ci-operator/config/openshift/monitoring-plugin/openshift-monitoring-plugin-release-4.16.yaml
@@ -42,7 +42,7 @@ resources:
       memory: 200Mi
 tests:
 - as: lint
-  commands: yarn lint
+  commands: npm run lint
   container:
     from: monitoring-plugin-test
 zz_generated_metadata:

--- a/ci-operator/config/openshift/monitoring-plugin/openshift-monitoring-plugin-release-4.17.yaml
+++ b/ci-operator/config/openshift/monitoring-plugin/openshift-monitoring-plugin-release-4.17.yaml
@@ -42,7 +42,7 @@ resources:
       memory: 200Mi
 tests:
 - as: lint
-  commands: yarn lint
+  commands: npm run lint
   container:
     from: monitoring-plugin-test
 zz_generated_metadata:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configuration to standardize the linting command across release branches (versions 4.14-4.17), switching from yarn to npm package manager for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->