### PR TITLE
opendatahub: Adjust pool sizes and running counts

### DIFF
--- a/clusters/hosted-mgmt/hive/pools/opendatahub/opendatahub-ocp-4-19-amd64-aws_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/opendatahub/opendatahub-ocp-4-19-amd64-aws_clusterpool.yaml
@@ -25,8 +25,7 @@ spec:
     name: opendatahub-install-config-aws
   labels:
     tp.openshift.io/owner: opendatahub
-  maxConcurrent: 5
-  maxSize: 40
+  maxSize: 6
   platform:
     aws:
       credentialsSecretRef:
@@ -34,8 +33,7 @@ spec:
       region: us-east-1
   pullSecretRef:
     name: pull-secret
-  runningCount: 2
-  size: 6
+  size: 2
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/opendatahub/opendatahub-ocp-4-20-amd64-aws_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/opendatahub/opendatahub-ocp-4-20-amd64-aws_clusterpool.yaml
@@ -25,7 +25,7 @@ spec:
     name: opendatahub-install-config-aws
   labels:
     tp.openshift.io/owner: opendatahub
-  maxConcurrent: 5
+  maxConcurrent: 6
   maxSize: 40
   platform:
     aws:
@@ -34,7 +34,7 @@ spec:
       region: us-east-1
   pullSecretRef:
     name: pull-secret
-  runningCount: 2
+  runningCount: 6
   size: 12
   skipMachinePools: true
 status:


### PR DESCRIPTION
Scale up 4.20 pool (primary) and scale down 4.19 pool (legacy):

4.20 pool (odh-4-20-aws):
- runningCount: 2 → 6 (more ready clusters for faster claims)
- size: 12 (unchanged)

4.19 pool (odh-4-19-aws):
- size: 6 → 2 (reduce legacy pool capacity)
- runningCount: removed (rely on standby mode only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted OpenDataHub cluster pool sizing for OCP 4.19: reduced overall pool capacity and lowered active instance targets to decrease resource usage.
  * Adjusted OpenDataHub cluster pool sizing for OCP 4.20: increased concurrency and active instance targets to improve availability and provisioning throughput.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->