### PR TITLE
oc-mirror: make integration tests aware of oc-mirror version

### DIFF
--- a/ci-operator/config/openshift/oc-mirror/openshift-oc-mirror-release-4.20.yaml
+++ b/ci-operator/config/openshift/oc-mirror/openshift-oc-mirror-release-4.20.yaml
@@ -71,7 +71,8 @@ tests:
     - ref: go-verify-deps
 - as: integration
   commands: |
-    ./scripts/flow-controller.sh all_happy_path
+    export OC_MIRROR_VERSION=4.20
+    cd /artifacts && ./integration.test
   container:
     from: oc-mirror-tests
   skip_if_only_changed: (^docs/)|((^|/)OWNERS(_ALIASES)?$)|((^|/)[A-Z]+\.md$)

--- a/ci-operator/config/openshift/oc-mirror/openshift-oc-mirror-release-4.21.yaml
+++ b/ci-operator/config/openshift/oc-mirror/openshift-oc-mirror-release-4.21.yaml
@@ -96,6 +96,7 @@ tests:
     - ref: go-verify-deps
 - as: integration
   commands: |
+    export OC_MIRROR_VERSION=4.21
     cd /artifacts && ./integration.test
   container:
     from: oc-mirror-tests

--- a/ci-operator/config/openshift/oc-mirror/openshift-oc-mirror-release-4.22.yaml
+++ b/ci-operator/config/openshift/oc-mirror/openshift-oc-mirror-release-4.22.yaml
@@ -86,6 +86,7 @@ tests:
     - ref: go-verify-deps
 - as: integration
   commands: |
+    export OC_MIRROR_VERSION=4.22
     cd /artifacts && ./integration.test
   container:
     from: oc-mirror-tests

--- a/ci-operator/config/openshift/oc-mirror/openshift-oc-mirror-release-4.23.yaml
+++ b/ci-operator/config/openshift/oc-mirror/openshift-oc-mirror-release-4.23.yaml
@@ -86,6 +86,7 @@ tests:
     - ref: go-verify-deps
 - as: integration
   commands: |
+    export OC_MIRROR_VERSION=4.23
     cd /artifacts && ./integration.test
   container:
     from: oc-mirror-tests

--- a/ci-operator/config/openshift/oc-mirror/openshift-oc-mirror-release-5.0.yaml
+++ b/ci-operator/config/openshift/oc-mirror/openshift-oc-mirror-release-5.0.yaml
@@ -87,6 +87,7 @@ tests:
     - ref: go-verify-deps
 - as: integration
   commands: |
+    export OC_MIRROR_VERSION=5.0
     cd /artifacts && ./integration.test
   container:
     from: oc-mirror-tests


### PR DESCRIPTION
This is useful to test features available only in certain releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Refactored integration test execution across OpenShift Mirror release versions 4.20–5.0 to explicitly set version parameters during test initialization. Version 4.20 now uses a direct integration test binary, while versions 4.21–5.0 include explicit version environment settings to ensure tests run with appropriate version context and improve testing consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->