### PR TITLE
Update Group Aliases for MPEX Integrity Engineering Teams.

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -331,7 +331,6 @@ aliases:
   - danalanerh
   - sg-rh
   - etirta
-  - tanfengshuang
   openstack-k8s-operators-approvers:
   - abays
   - arxcruz
@@ -524,8 +523,6 @@ aliases:
   - tonyxrmdavidson
   ieng-chaos:
   - etirta
-  - LibinLiu
-  - Userweiwei
   perfscale-ocp-reviewers:
   - afcollins
   - akrzos


### PR DESCRIPTION
## Description
Due to cease of China engineering operation, the China associates IDs need to be removed from Group Aliases:
  - ieng-chaos
  - cspi-qe-ocp-lp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal team member lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->