### PR TITLE
remove sjenning from pr-reminder

### DIFF
--- a/core-services/pr-reminder/_config.yaml
+++ b/core-services/pr-reminder/_config.yaml
@@ -156,7 +156,6 @@ teams:
   - rhobs/observability-operator
   - rhobs/obo-prometheus-operator/
 - teamMembers:
-  - sjenning
   - asegurap
   - agarcial
   - jparrill

--- a/core-services/pr-reminder/_config.yaml
+++ b/core-services/pr-reminder/_config.yaml
@@ -11,7 +11,6 @@ teams:
   - prucek
   - dmistry
   - pruan
-  - lxia
   - hvidosil
   teamNames:
   - test-platform
@@ -22,15 +21,9 @@ teams:
   - kubernetes/test-infra
   - kubernetes-sigs/prow
 - teamMembers:
-  - lxia
   - dis
-  - liqcui
-  - pewang
   - jiezhao
   - jechen
-  - qili
-  - jhou
-  - jianl
   - pruan
   repos:
   - openshift/cucushift
@@ -189,8 +182,6 @@ teams:
   - lgarciaa
   - mbiarnes
   - sidsharm
-  - ximhan
-  - yuxzhu
   teamNames:
   - openshift-team-automated-release
   - openshift-team-automated-release-maintainers


### PR DESCRIPTION
This is redundant with other workflows I have personally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed several team members from the PR reminder configuration, updating who receives automated reminders. No other configuration keys or settings were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->