### PR TITLE
Add triggers trusted_apps to openshift-priv repo-level pluginconfigs

### DIFF
--- a/core-services/prow/02_config/openshift-priv/agent-installer-utils/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/agent-installer-utils/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/agent-installer-utils
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/alibaba-cloud-csi-driver/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/alibaba-cloud-csi-driver/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/alibaba-cloud-csi-driver
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/alibaba-disk-csi-driver-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/alibaba-disk-csi-driver-operator/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/alibaba-disk-csi-driver-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/ansible-ocp-networking-migration-rollback/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/ansible-ocp-networking-migration-rollback/_pluginconfig.yaml
@@ -7,3 +7,8 @@ lgtm:
 - repos:
   - openshift-priv/ansible-ocp-networking-migration-rollback
   review_acts_as_lgtm: true
+triggers:
+- repos:
+  - openshift-priv/ansible-ocp-networking-migration-rollback
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/ansible-operator-plugins/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/ansible-operator-plugins/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/ansible-operator-plugins
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/ansible-service-broker/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/ansible-service-broker/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/ansible-service-broker
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/api/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/api/_pluginconfig.yaml
@@ -16,3 +16,8 @@ plugins:
     - sigmention
     - size
     - welcome
+triggers:
+- repos:
+  - openshift-priv/api
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/apiserver-library-go/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/apiserver-library-go/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/apiserver-library-go
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/apiserver-network-proxy/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/apiserver-network-proxy/_pluginconfig.yaml
@@ -18,3 +18,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/apiserver-network-proxy
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/app-netutil/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/app-netutil/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/app-netutil
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/appliance/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/appliance/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/appliance
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/assisted-installer-agent/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/assisted-installer-agent/_pluginconfig.yaml
@@ -18,3 +18,8 @@ plugins:
     - pony
     - sigmention
     - size
+triggers:
+- repos:
+  - openshift-priv/assisted-installer-agent
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/assisted-installer-ui/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/assisted-installer-ui/_pluginconfig.yaml
@@ -16,3 +16,8 @@ plugins:
     - owners-label
     - size
     - welcome
+triggers:
+- repos:
+  - openshift-priv/assisted-installer-ui
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/assisted-installer/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/assisted-installer/_pluginconfig.yaml
@@ -18,3 +18,8 @@ plugins:
     - pony
     - sigmention
     - size
+triggers:
+- repos:
+  - openshift-priv/assisted-installer
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/assisted-service/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/assisted-service/_pluginconfig.yaml
@@ -18,3 +18,8 @@ plugins:
     - pony
     - sigmention
     - size
+triggers:
+- repos:
+  - openshift-priv/assisted-service
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/assisted-test-infra/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/assisted-test-infra/_pluginconfig.yaml
@@ -7,3 +7,8 @@ lgtm:
 - repos:
   - openshift-priv/assisted-test-infra
   review_acts_as_lgtm: true
+triggers:
+- repos:
+  - openshift-priv/assisted-test-infra
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/aws-ebs-csi-driver-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/aws-ebs-csi-driver-operator/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/aws-ebs-csi-driver-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/aws-ebs-csi-driver/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/aws-ebs-csi-driver/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/aws-ebs-csi-driver
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/aws-efs-csi-driver-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/aws-efs-csi-driver-operator/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/aws-efs-csi-driver-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/aws-efs-csi-driver/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/aws-efs-csi-driver/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/aws-efs-csi-driver
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/aws-efs-utils/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/aws-efs-utils/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/aws-efs-utils
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/aws-encryption-provider/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/aws-encryption-provider/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/aws-encryption-provider
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/aws-karpenter-provider-aws/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/aws-karpenter-provider-aws/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/aws-karpenter-provider-aws
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/aws-node-termination-handler/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/aws-node-termination-handler/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/aws-node-termination-handler
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/aws-pod-identity-webhook/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/aws-pod-identity-webhook/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/aws-pod-identity-webhook
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/azure-disk-csi-driver-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/azure-disk-csi-driver-operator/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/azure-disk-csi-driver-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/azure-disk-csi-driver/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/azure-disk-csi-driver/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/azure-disk-csi-driver
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/azure-file-csi-driver-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/azure-file-csi-driver-operator/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/azure-file-csi-driver-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/azure-file-csi-driver/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/azure-file-csi-driver/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/azure-file-csi-driver
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/azure-kubernetes-kms/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/azure-kubernetes-kms/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/azure-kubernetes-kms
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/azure-service-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/azure-service-operator/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/azure-service-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/azure-storage-azcopy/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/azure-storage-azcopy/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/azure-storage-azcopy
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/azure-workload-identity/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/azure-workload-identity/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/azure-workload-identity
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/baremetal-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/baremetal-operator/_pluginconfig.yaml
@@ -13,3 +13,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/baremetal-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/baremetal-runtimecfg/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/baremetal-runtimecfg/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/baremetal-runtimecfg
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/bond-cni/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/bond-cni/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/bond-cni
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/bpfman-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/bpfman-operator/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/bpfman-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/bpfman/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/bpfman/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/bpfman
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/build-machinery-go/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/build-machinery-go/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/build-machinery-go
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/build-test-images/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/build-test-images/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/build-test-images
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/builder/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/builder/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/builder
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cert-manager-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cert-manager-operator/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cert-manager-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cincinnati/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cincinnati/_pluginconfig.yaml
@@ -2,3 +2,8 @@ plugins:
   openshift-priv/cincinnati:
     plugins:
     - approve
+triggers:
+- repos:
+  - openshift-priv/cincinnati
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cli-manager-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cli-manager-operator/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cli-manager-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cli-manager/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cli-manager/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cli-manager
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/client-go/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/client-go/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/client-go
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cloud-credential-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cloud-credential-operator/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cloud-credential-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cloud-event-proxy/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cloud-event-proxy/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cloud-event-proxy
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cloud-network-config-controller/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cloud-network-config-controller/_pluginconfig.yaml
@@ -18,3 +18,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cloud-network-config-controller
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cloud-provider-alibaba-cloud/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cloud-provider-alibaba-cloud/_pluginconfig.yaml
@@ -16,3 +16,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cloud-provider-alibaba-cloud
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cloud-provider-aws/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cloud-provider-aws/_pluginconfig.yaml
@@ -16,3 +16,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cloud-provider-aws
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cloud-provider-azure/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cloud-provider-azure/_pluginconfig.yaml
@@ -16,3 +16,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cloud-provider-azure
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cloud-provider-gcp/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cloud-provider-gcp/_pluginconfig.yaml
@@ -16,3 +16,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cloud-provider-gcp
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cloud-provider-ibm/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cloud-provider-ibm/_pluginconfig.yaml
@@ -16,3 +16,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cloud-provider-ibm
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cloud-provider-kubevirt/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cloud-provider-kubevirt/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cloud-provider-kubevirt
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cloud-provider-nutanix/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cloud-provider-nutanix/_pluginconfig.yaml
@@ -16,3 +16,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cloud-provider-nutanix
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cloud-provider-openstack/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cloud-provider-openstack/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cloud-provider-openstack
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cloud-provider-powervs/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cloud-provider-powervs/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cloud-provider-powervs
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cloud-provider-vsphere/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cloud-provider-vsphere/_pluginconfig.yaml
@@ -16,3 +16,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cloud-provider-vsphere
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-api-actuator-pkg/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-api-actuator-pkg/_pluginconfig.yaml
@@ -14,3 +14,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-api-actuator-pkg
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-api-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-api-operator/_pluginconfig.yaml
@@ -16,3 +16,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-api-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-api-provider-alibaba/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-api-provider-alibaba/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-api-provider-alibaba
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-api-provider-aws/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-api-provider-aws/_pluginconfig.yaml
@@ -14,3 +14,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-api-provider-aws
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-api-provider-azure/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-api-provider-azure/_pluginconfig.yaml
@@ -14,3 +14,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-api-provider-azure
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-api-provider-baremetal/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-api-provider-baremetal/_pluginconfig.yaml
@@ -13,3 +13,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-api-provider-baremetal
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-api-provider-gcp/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-api-provider-gcp/_pluginconfig.yaml
@@ -14,3 +14,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-api-provider-gcp
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-api-provider-ibmcloud/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-api-provider-ibmcloud/_pluginconfig.yaml
@@ -14,3 +14,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-api-provider-ibmcloud
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-api-provider-kubemark/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-api-provider-kubemark/_pluginconfig.yaml
@@ -14,3 +14,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-api-provider-kubemark
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-api-provider-kubevirt/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-api-provider-kubevirt/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-api-provider-kubevirt
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-api-provider-libvirt/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-api-provider-libvirt/_pluginconfig.yaml
@@ -14,3 +14,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-api-provider-libvirt
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-api-provider-metal3/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-api-provider-metal3/_pluginconfig.yaml
@@ -13,3 +13,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-api-provider-metal3
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-api-provider-nutanix/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-api-provider-nutanix/_pluginconfig.yaml
@@ -14,3 +14,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-api-provider-nutanix
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-api-provider-openshift/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-api-provider-openshift/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - pony
     - sigmention
     - size
+triggers:
+- repos:
+  - openshift-priv/cluster-api-provider-openshift
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-api-provider-openstack/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-api-provider-openstack/_pluginconfig.yaml
@@ -14,3 +14,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-api-provider-openstack
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-api-provider-ovirt/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-api-provider-ovirt/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-api-provider-ovirt
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-api-provider-powervs/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-api-provider-powervs/_pluginconfig.yaml
@@ -14,3 +14,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-api-provider-powervs
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-api-provider-vsphere/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-api-provider-vsphere/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-api-provider-vsphere
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-api/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-api/_pluginconfig.yaml
@@ -13,3 +13,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-api
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-authentication-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-authentication-operator/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-authentication-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-autoscaler-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-autoscaler-operator/_pluginconfig.yaml
@@ -14,3 +14,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-autoscaler-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-baremetal-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-baremetal-operator/_pluginconfig.yaml
@@ -13,3 +13,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-baremetal-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-bootstrap/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-bootstrap/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-bootstrap
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-capacity/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-capacity/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-capacity
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-capi-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-capi-operator/_pluginconfig.yaml
@@ -16,3 +16,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-capi-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-cloud-controller-manager-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-cloud-controller-manager-operator/_pluginconfig.yaml
@@ -13,3 +13,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-cloud-controller-manager-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-config-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-config-operator/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-config-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-control-plane-machine-set-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-control-plane-machine-set-operator/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - pony
     - sigmention
     - size
+triggers:
+- repos:
+  - openshift-priv/cluster-control-plane-machine-set-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-csi-snapshot-controller-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-csi-snapshot-controller-operator/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-csi-snapshot-controller-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-dns-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-dns-operator/_pluginconfig.yaml
@@ -14,3 +14,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-dns-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-etcd-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-etcd-operator/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-etcd-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-image-registry-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-image-registry-operator/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-image-registry-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-ingress-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-ingress-operator/_pluginconfig.yaml
@@ -14,3 +14,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-ingress-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-kube-apiserver-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-kube-apiserver-operator/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-kube-apiserver-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-kube-controller-manager-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-kube-controller-manager-operator/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-kube-controller-manager-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-kube-descheduler-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-kube-descheduler-operator/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-kube-descheduler-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-kube-scheduler-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-kube-scheduler-operator/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-kube-scheduler-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-kube-storage-version-migrator-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-kube-storage-version-migrator-operator/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-kube-storage-version-migrator-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-machine-approver/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-machine-approver/_pluginconfig.yaml
@@ -14,3 +14,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-machine-approver
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-monitoring-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-monitoring-operator/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-monitoring-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-network-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-network-operator/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-network-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-nfd-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-nfd-operator/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-nfd-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-node-tuning-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-node-tuning-operator/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-node-tuning-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-olm-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-olm-operator/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-olm-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-openshift-apiserver-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-openshift-apiserver-operator/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-openshift-apiserver-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-openshift-controller-manager-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-openshift-controller-manager-operator/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-openshift-controller-manager-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-policy-controller/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-policy-controller/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-policy-controller
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-resource-override-admission-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-resource-override-admission-operator/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-resource-override-admission-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-resource-override-admission/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-resource-override-admission/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-resource-override-admission
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-samples-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-samples-operator/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-samples-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-storage-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-storage-operator/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-storage-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-svcat-apiserver-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-svcat-apiserver-operator/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-svcat-apiserver-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-svcat-controller-manager-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-svcat-controller-manager-operator/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-svcat-controller-manager-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-update-keys/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-update-keys/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-update-keys
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cluster-version-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cluster-version-operator/_pluginconfig.yaml
@@ -12,3 +12,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cluster-version-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/community.okd/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/community.okd/_pluginconfig.yaml
@@ -7,3 +7,8 @@ lgtm:
 - repos:
   - openshift-priv/community.okd
   review_acts_as_lgtm: true
+triggers:
+- repos:
+  - openshift-priv/community.okd
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/configmap-reload/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/configmap-reload/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/configmap-reload
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/console-crontab-plugin/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/console-crontab-plugin/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/console-crontab-plugin
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/console-dashboards-plugin/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/console-dashboards-plugin/_pluginconfig.yaml
@@ -18,3 +18,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/console-dashboards-plugin
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/console-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/console-operator/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/console-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/console-plugin-template/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/console-plugin-template/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/console-plugin-template
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/console/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/console/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/console
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/containernetworking-plugins/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/containernetworking-plugins/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/containernetworking-plugins
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/contour-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/contour-operator/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/contour-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/contour/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/contour/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/contour
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/controller-runtime-common/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/controller-runtime-common/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/controller-runtime-common
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/coredns-ocp-dnsnameresolver/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/coredns-ocp-dnsnameresolver/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/coredns-ocp-dnsnameresolver
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/coredns/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/coredns/_pluginconfig.yaml
@@ -14,3 +14,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/coredns
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/crc/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/crc/_pluginconfig.yaml
@@ -7,3 +7,8 @@ lgtm:
 - repos:
   - openshift-priv/crc
   review_acts_as_lgtm: true
+triggers:
+- repos:
+  - openshift-priv/crc
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/crd-schema-checker/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/crd-schema-checker/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/crd-schema-checker
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/crd-schema-gen/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/crd-schema-gen/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/crd-schema-gen
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/cri-o/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/cri-o/_pluginconfig.yaml
@@ -7,3 +7,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/cri-o
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/csi-driver-manila-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/csi-driver-manila-operator/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/csi-driver-manila-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/csi-driver-nfs/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/csi-driver-nfs/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/csi-driver-nfs
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/csi-driver-shared-resource-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/csi-driver-shared-resource-operator/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/csi-driver-shared-resource-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/csi-driver-shared-resource/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/csi-driver-shared-resource/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/csi-driver-shared-resource
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/csi-driver-smb/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/csi-driver-smb/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/csi-driver-smb
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/csi-external-attacher/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/csi-external-attacher/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/csi-external-attacher
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/csi-external-provisioner/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/csi-external-provisioner/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/csi-external-provisioner
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/csi-external-resizer/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/csi-external-resizer/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/csi-external-resizer
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/csi-external-snapshot-metadata/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/csi-external-snapshot-metadata/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/csi-external-snapshot-metadata
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/csi-external-snapshotter/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/csi-external-snapshotter/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/csi-external-snapshotter
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/csi-livenessprobe/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/csi-livenessprobe/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/csi-livenessprobe
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/csi-node-driver-registrar/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/csi-node-driver-registrar/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/csi-node-driver-registrar
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/csi-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/csi-operator/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/csi-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/custom-metrics-autoscaler-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/custom-metrics-autoscaler-operator/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/custom-metrics-autoscaler-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/descheduler/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/descheduler/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/descheduler
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/dev-scripts/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/dev-scripts/_pluginconfig.yaml
@@ -4,3 +4,8 @@ approve:
   repos:
   - openshift-priv/dev-scripts
   require_self_approval: true
+triggers:
+- repos:
+  - openshift-priv/dev-scripts
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/dpu-network-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/dpu-network-operator/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/dpu-network-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/dpu-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/dpu-operator/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/dpu-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/driver-toolkit/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/driver-toolkit/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/driver-toolkit
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/egress-router-cni/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/egress-router-cni/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/egress-router-cni
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/etcd/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/etcd/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/etcd
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/external-dns-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/external-dns-operator/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/external-dns-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/external-dns/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/external-dns/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/external-dns
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/external-storage/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/external-storage/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/external-storage
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/federation-v2-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/federation-v2-operator/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/federation-v2-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/file-integrity-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/file-integrity-operator/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/file-integrity-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/frr/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/frr/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/frr
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/gatekeeper-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/gatekeeper-operator/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/gatekeeper-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/gatekeeper/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/gatekeeper/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/gatekeeper
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/gcp-filestore-csi-driver-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/gcp-filestore-csi-driver-operator/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/gcp-filestore-csi-driver-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/gcp-filestore-csi-driver/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/gcp-filestore-csi-driver/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/gcp-filestore-csi-driver
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/gcp-pd-csi-driver-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/gcp-pd-csi-driver-operator/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/gcp-pd-csi-driver-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/gcp-pd-csi-driver/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/gcp-pd-csi-driver/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/gcp-pd-csi-driver
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/gcp-workload-identity-federation-webhook/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/gcp-workload-identity-federation-webhook/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/gcp-workload-identity-federation-webhook
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/grafana/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/grafana/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/grafana
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/hypershift-oadp-plugin/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/hypershift-oadp-plugin/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/hypershift-oadp-plugin
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/hypershift/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/hypershift/_pluginconfig.yaml
@@ -18,3 +18,8 @@ plugins:
     - pony
     - require-matching-label
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/hypershift
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/ib-sriov-cni/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/ib-sriov-cni/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/ib-sriov-cni
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/ibm-powervs-block-csi-driver-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/ibm-powervs-block-csi-driver-operator/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/ibm-powervs-block-csi-driver-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/ibm-powervs-block-csi-driver/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/ibm-powervs-block-csi-driver/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/ibm-powervs-block-csi-driver
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/ibm-vpc-block-csi-driver-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/ibm-vpc-block-csi-driver-operator/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/ibm-vpc-block-csi-driver-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/ibm-vpc-block-csi-driver/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/ibm-vpc-block-csi-driver/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/ibm-vpc-block-csi-driver
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/ibm-vpc-node-label-updater/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/ibm-vpc-node-label-updater/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/ibm-vpc-node-label-updater
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/image-customization-controller/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/image-customization-controller/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/image-customization-controller
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/image-registry/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/image-registry/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/image-registry
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/images/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/images/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/images
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/ingress-node-firewall/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/ingress-node-firewall/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/ingress-node-firewall
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/insights-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/insights-operator/_pluginconfig.yaml
@@ -13,3 +13,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/insights-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/insights-runtime-extractor/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/insights-runtime-extractor/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/insights-runtime-extractor
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/installer-aro-wrapper/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/installer-aro-wrapper/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/installer-aro-wrapper
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/installer-aro/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/installer-aro/_pluginconfig.yaml
@@ -7,3 +7,8 @@ lgtm:
 - repos:
   - openshift-priv/installer-aro
   review_acts_as_lgtm: true
+triggers:
+- repos:
+  - openshift-priv/installer-aro
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/installer/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/installer/_pluginconfig.yaml
@@ -14,3 +14,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/installer
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/instaslice-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/instaslice-operator/_pluginconfig.yaml
@@ -18,3 +18,8 @@ plugins:
     - pony
     - sigmention
     - size
+triggers:
+- repos:
+  - openshift-priv/instaslice-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/ironic-agent-image/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/ironic-agent-image/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/ironic-agent-image
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/ironic-hardware-inventory-recorder-image/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/ironic-hardware-inventory-recorder-image/_pluginconfig.yaml
@@ -13,3 +13,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/ironic-hardware-inventory-recorder-image
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/ironic-image/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/ironic-image/_pluginconfig.yaml
@@ -13,3 +13,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/ironic-image
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/ironic-inspector-image/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/ironic-inspector-image/_pluginconfig.yaml
@@ -13,3 +13,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/ironic-inspector-image
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/ironic-ipa-downloader/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/ironic-ipa-downloader/_pluginconfig.yaml
@@ -13,3 +13,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/ironic-ipa-downloader
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/ironic-rhcos-downloader/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/ironic-rhcos-downloader/_pluginconfig.yaml
@@ -13,3 +13,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/ironic-rhcos-downloader
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/ironic-standalone-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/ironic-standalone-operator/_pluginconfig.yaml
@@ -13,3 +13,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/ironic-standalone-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/ironic-static-ip-manager/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/ironic-static-ip-manager/_pluginconfig.yaml
@@ -13,3 +13,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/ironic-static-ip-manager
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/jenkins-client-plugin/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/jenkins-client-plugin/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/jenkins-client-plugin
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/jenkins-openshift-login-plugin/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/jenkins-openshift-login-plugin/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/jenkins-openshift-login-plugin
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/jenkins-sync-plugin/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/jenkins-sync-plugin/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/jenkins-sync-plugin
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/jenkins/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/jenkins/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/jenkins
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/jobset-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/jobset-operator/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/jobset-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/k8s-prometheus-adapter/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/k8s-prometheus-adapter/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/k8s-prometheus-adapter
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/karpenter-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/karpenter-operator/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/karpenter-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/kedacore-http-add-on/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/kedacore-http-add-on/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/kedacore-http-add-on
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/kedacore-keda/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/kedacore-keda/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/kedacore-keda
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/kube-compare/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/kube-compare/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/kube-compare
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/kube-rbac-proxy/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/kube-rbac-proxy/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/kube-rbac-proxy
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/kube-state-metrics/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/kube-state-metrics/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/kube-state-metrics
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/kubecsr/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/kubecsr/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/kubecsr
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/kubefed-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/kubefed-operator/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/kubefed-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/kubefed/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/kubefed/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/kubefed
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/kubernetes-autoscaler/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/kubernetes-autoscaler/_pluginconfig.yaml
@@ -14,3 +14,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/kubernetes-autoscaler
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/kubernetes-kube-storage-version-migrator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/kubernetes-kube-storage-version-migrator/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/kubernetes-kube-storage-version-migrator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/kubernetes-metrics-server/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/kubernetes-metrics-server/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/kubernetes-metrics-server
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/kubernetes-nmstate/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/kubernetes-nmstate/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/kubernetes-nmstate
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/kubernetes-sigs-jobset/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/kubernetes-sigs-jobset/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/kubernetes-sigs-jobset
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/kubernetes-sigs-karpenter/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/kubernetes-sigs-karpenter/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/kubernetes-sigs-karpenter
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/kubernetes-sigs-kueue/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/kubernetes-sigs-kueue/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/kubernetes-sigs-kueue
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/kubernetes-sigs-lws/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/kubernetes-sigs-lws/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/kubernetes-sigs-lws
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/kubernetes/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/kubernetes/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/kubernetes
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/kubevirt-csi-driver/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/kubevirt-csi-driver/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/kubevirt-csi-driver
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/kueue-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/kueue-operator/_pluginconfig.yaml
@@ -7,3 +7,8 @@ lgtm:
 - repos:
   - openshift-priv/kueue-operator
   review_acts_as_lgtm: true
+triggers:
+- repos:
+  - openshift-priv/kueue-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/kuryr-kubernetes/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/kuryr-kubernetes/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/kuryr-kubernetes
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/leader-elector/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/leader-elector/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/leader-elector
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/library-go/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/library-go/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/library-go
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/lightspeed-service/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/lightspeed-service/_pluginconfig.yaml
@@ -7,3 +7,8 @@ lgtm:
 - repos:
   - openshift-priv/lightspeed-service
   review_acts_as_lgtm: true
+triggers:
+- repos:
+  - openshift-priv/lightspeed-service
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/linuxptp-daemon/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/linuxptp-daemon/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/linuxptp-daemon
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/local-storage-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/local-storage-operator/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/local-storage-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/loki/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/loki/_pluginconfig.yaml
@@ -2,3 +2,8 @@ plugins:
   openshift-priv/loki:
     plugins:
     - approve
+triggers:
+- repos:
+  - openshift-priv/loki
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/lvm-driver/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/lvm-driver/_pluginconfig.yaml
@@ -3,3 +3,8 @@ approve:
   repos:
   - openshift-priv/lvm-driver
   require_self_approval: false
+triggers:
+- repos:
+  - openshift-priv/lvm-driver
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/lvm-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/lvm-operator/_pluginconfig.yaml
@@ -15,3 +15,8 @@ plugins:
     - sigmention
     - size
     - welcome
+triggers:
+- repos:
+  - openshift-priv/lvm-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/lws-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/lws-operator/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/lws-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/machine-api-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/machine-api-operator/_pluginconfig.yaml
@@ -14,3 +14,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/machine-api-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/machine-api-provider-aws/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/machine-api-provider-aws/_pluginconfig.yaml
@@ -14,3 +14,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/machine-api-provider-aws
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/machine-api-provider-azure/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/machine-api-provider-azure/_pluginconfig.yaml
@@ -14,3 +14,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/machine-api-provider-azure
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/machine-api-provider-gcp/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/machine-api-provider-gcp/_pluginconfig.yaml
@@ -14,3 +14,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/machine-api-provider-gcp
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/machine-api-provider-ibmcloud/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/machine-api-provider-ibmcloud/_pluginconfig.yaml
@@ -14,3 +14,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/machine-api-provider-ibmcloud
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/machine-api-provider-nutanix/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/machine-api-provider-nutanix/_pluginconfig.yaml
@@ -14,3 +14,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/machine-api-provider-nutanix
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/machine-api-provider-openstack/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/machine-api-provider-openstack/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/machine-api-provider-openstack
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/machine-api-provider-powervs/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/machine-api-provider-powervs/_pluginconfig.yaml
@@ -18,3 +18,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/machine-api-provider-powervs
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/machine-config-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/machine-config-operator/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/machine-config-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/machine-os-images/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/machine-os-images/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/machine-os-images
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/managed-release-bundle-osd/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/managed-release-bundle-osd/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/managed-release-bundle-osd
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/mcp-lifecycle-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/mcp-lifecycle-operator/_pluginconfig.yaml
@@ -7,3 +7,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/mcp-lifecycle-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/mdns-publisher/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/mdns-publisher/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/mdns-publisher
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/metal3-smart-exporter/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/metal3-smart-exporter/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/metal3-smart-exporter
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/metallb-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/metallb-operator/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/metallb-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/metallb/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/metallb/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/metallb
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/microshift/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/microshift/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/microshift
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/monitoring-plugin/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/monitoring-plugin/_pluginconfig.yaml
@@ -18,3 +18,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/monitoring-plugin
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/multi-operator-manager/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/multi-operator-manager/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/multi-operator-manager
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/multiarch-tuning-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/multiarch-tuning-operator/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/multiarch-tuning-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/multus-admission-controller/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/multus-admission-controller/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/multus-admission-controller
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/multus-cni/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/multus-cni/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/multus-cni
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/multus-networkpolicy/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/multus-networkpolicy/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/multus-networkpolicy
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/must-gather-clean/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/must-gather-clean/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/must-gather-clean
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/must-gather-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/must-gather-operator/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/must-gather-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/must-gather/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/must-gather/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/must-gather
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/nbde-tang-server/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/nbde-tang-server/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/nbde-tang-server
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/network-metrics-daemon/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/network-metrics-daemon/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/network-metrics-daemon
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/network-tools/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/network-tools/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/network-tools
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/network.offline_migration_sdn_to_ovnk/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/network.offline_migration_sdn_to_ovnk/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/network.offline_migration_sdn_to_ovnk
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/networking-console-plugin/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/networking-console-plugin/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/networking-console-plugin
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/nmstate-console-plugin/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/nmstate-console-plugin/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/nmstate-console-plugin
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/node-feature-discovery/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/node-feature-discovery/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/node-feature-discovery
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/node-observability-agent/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/node-observability-agent/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/node-observability-agent
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/node-observability-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/node-observability-operator/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/node-observability-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/node-problem-detector-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/node-problem-detector-operator/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/node-problem-detector-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/node-problem-detector/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/node-problem-detector/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/node-problem-detector
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/node_exporter/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/node_exporter/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/node_exporter
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/oauth-apiserver/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/oauth-apiserver/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/oauth-apiserver
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/oauth-proxy/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/oauth-proxy/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/oauth-proxy
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/oauth-server/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/oauth-server/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/oauth-server
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/oc-mirror/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/oc-mirror/_pluginconfig.yaml
@@ -13,3 +13,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/oc-mirror
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/oc/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/oc/_pluginconfig.yaml
@@ -12,3 +12,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/oc
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/ocp-release-operator-sdk/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/ocp-release-operator-sdk/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/ocp-release-operator-sdk
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/openldap/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/openldap/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/openldap
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/openshift-ansible/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/openshift-ansible/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/openshift-ansible
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/openshift-apiserver/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/openshift-apiserver/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/openshift-apiserver
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/openshift-controller-manager/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/openshift-controller-manager/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/openshift-controller-manager
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/openshift-mcp-server/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/openshift-mcp-server/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/openshift-mcp-server
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/openshift-state-metrics/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/openshift-state-metrics/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/openshift-state-metrics
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/openshift-tests-private/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/openshift-tests-private/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/openshift-tests-private
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/openshift-tuned/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/openshift-tuned/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/openshift-tuned
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/openstack-cinder-csi-driver-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/openstack-cinder-csi-driver-operator/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/openstack-cinder-csi-driver-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/openstack-ironic-inspector/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/openstack-ironic-inspector/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/openstack-ironic-inspector
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/openstack-ironic-lib/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/openstack-ironic-lib/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/openstack-ironic-lib
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/openstack-ironic-prometheus-exporter/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/openstack-ironic-prometheus-exporter/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/openstack-ironic-prometheus-exporter
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/openstack-ironic-python-agent/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/openstack-ironic-python-agent/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/openstack-ironic-python-agent
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/openstack-ironic/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/openstack-ironic/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/openstack-ironic
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/openstack-resource-controller/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/openstack-resource-controller/_pluginconfig.yaml
@@ -14,3 +14,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/openstack-resource-controller
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/openstack-sushy/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/openstack-sushy/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/openstack-sushy
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/openstack-test/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/openstack-test/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/openstack-test
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/operator-framework-catalogd/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/operator-framework-catalogd/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/operator-framework-catalogd
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/operator-framework-olm/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/operator-framework-olm/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/operator-framework-olm
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/operator-framework-operator-controller/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/operator-framework-operator-controller/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/operator-framework-operator-controller
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/operator-framework-rukpak/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/operator-framework-rukpak/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/operator-framework-rukpak
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/operator-lifecycle-manager/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/operator-lifecycle-manager/_pluginconfig.yaml
@@ -13,3 +13,8 @@ plugins:
     - approve
     - golint
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/operator-lifecycle-manager
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/operator-marketplace/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/operator-marketplace/_pluginconfig.yaml
@@ -13,3 +13,8 @@ plugins:
     - approve
     - golint
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/operator-marketplace
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/operator-registry/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/operator-registry/_pluginconfig.yaml
@@ -13,3 +13,8 @@ plugins:
     - approve
     - golint
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/operator-registry
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/origin-aggregated-logging/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/origin-aggregated-logging/_pluginconfig.yaml
@@ -13,3 +13,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/origin-aggregated-logging
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/origin/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/origin/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/origin
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/os/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/os/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/os
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/osd-example-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/osd-example-operator/_pluginconfig.yaml
@@ -7,3 +7,8 @@ lgtm:
 - repos:
   - openshift-priv/osd-example-operator
   review_acts_as_lgtm: true
+triggers:
+- repos:
+  - openshift-priv/osd-example-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/osd-metrics-exporter/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/osd-metrics-exporter/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/osd-metrics-exporter
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/osin/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/osin/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/osin
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/ovirt-csi-driver-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/ovirt-csi-driver-operator/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/ovirt-csi-driver-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/ovirt-csi-driver/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/ovirt-csi-driver/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/ovirt-csi-driver
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/ovn-kubernetes/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/ovn-kubernetes/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/ovn-kubernetes
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/ovs-cni/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/ovs-cni/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/ovs-cni
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/pf-status-relay-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/pf-status-relay-operator/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/pf-status-relay-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/pf-status-relay/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/pf-status-relay/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/pf-status-relay
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/platform-operators/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/platform-operators/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/platform-operators
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/project-request-limit/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/project-request-limit/_pluginconfig.yaml
@@ -7,3 +7,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/project-request-limit
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/prom-label-proxy/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/prom-label-proxy/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/prom-label-proxy
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/prometheus-alertmanager/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/prometheus-alertmanager/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/prometheus-alertmanager
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/prometheus-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/prometheus-operator/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/prometheus-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/prometheus/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/prometheus/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/prometheus
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/ptp-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/ptp-operator/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/ptp-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/rdma-cni/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/rdma-cni/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/rdma-cni
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/redhat-subscription-injection-webhook/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/redhat-subscription-injection-webhook/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/redhat-subscription-injection-webhook
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/route-controller-manager/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/route-controller-manager/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/route-controller-manager
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/route-override-cni/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/route-override-cni/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/route-override-cni
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/router/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/router/_pluginconfig.yaml
@@ -29,3 +29,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/router
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/run-once-duration-override-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/run-once-duration-override-operator/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/run-once-duration-override-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/run-once-duration-override/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/run-once-duration-override/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/run-once-duration-override
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/runtime-utils/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/runtime-utils/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/runtime-utils
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/sdn/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/sdn/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/sdn
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/secondary-scheduler-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/secondary-scheduler-operator/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/secondary-scheduler-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/secrets-store-csi-driver-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/secrets-store-csi-driver-operator/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/secrets-store-csi-driver-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/secrets-store-csi-driver/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/secrets-store-csi-driver/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/secrets-store-csi-driver
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/service-ca-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/service-ca-operator/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/service-ca-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/service-catalog/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/service-catalog/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/service-catalog
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/sig-storage-local-static-provisioner/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/sig-storage-local-static-provisioner/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/sig-storage-local-static-provisioner
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/special-resource-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/special-resource-operator/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/special-resource-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/sriov-cni/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/sriov-cni/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/sriov-cni
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/sriov-dp-admission-controller/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/sriov-dp-admission-controller/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/sriov-dp-admission-controller
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/sriov-network-device-plugin/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/sriov-network-device-plugin/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/sriov-network-device-plugin
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/sriov-network-metrics-exporter/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/sriov-network-metrics-exporter/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/sriov-network-metrics-exporter
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/sriov-network-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/sriov-network-operator/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/sriov-network-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/telemeter/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/telemeter/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/telemeter
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/template-service-broker-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/template-service-broker-operator/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/template-service-broker-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/template-service-broker/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/template-service-broker/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/template-service-broker
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/thanos/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/thanos/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/thanos
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/tls-scanner/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/tls-scanner/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/tls-scanner
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/vcf-migration-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/vcf-migration-operator/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/vcf-migration-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/vertical-pod-autoscaler-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/vertical-pod-autoscaler-operator/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/vertical-pod-autoscaler-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/vmware-vsphere-csi-driver-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/vmware-vsphere-csi-driver-operator/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/vmware-vsphere-csi-driver-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/vmware-vsphere-csi-driver/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/vmware-vsphere-csi-driver/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/vmware-vsphere-csi-driver
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/volume-data-source-validator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/volume-data-source-validator/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/volume-data-source-validator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/vsphere-problem-detector/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/vsphere-problem-detector/_pluginconfig.yaml
@@ -17,3 +17,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/vsphere-problem-detector
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/whereabouts-cni/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/whereabouts-cni/_pluginconfig.yaml
@@ -8,3 +8,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/whereabouts-cni
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-priv/windows-machine-config-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-priv/windows-machine-config-operator/_pluginconfig.yaml
@@ -13,3 +13,8 @@ plugins:
     - owners-label
     - pony
     - sigmention
+triggers:
+- repos:
+  - openshift-priv/windows-machine-config-operator
+  trusted_apps:
+  - openshift-merge-bot


### PR DESCRIPTION
Each openshift-priv repo with a repo-level _pluginconfig.yaml needs its own triggers entry with trusted_apps for the trigger plugin validation to pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configuration to authorize automated merge operations across repositories. This enables trusted bot-driven workflow automation while maintaining security controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->