### PR TITLE
OCPBUGS-83718: add main branch config for openshift/etcd

### DIFF
--- a/ci-operator/config/openshift/etcd/OWNERS
+++ b/ci-operator/config/openshift/etcd/OWNERS
@@ -1,12 +1,11 @@
 approvers:
 - deads2k
 - dusk125
-- elbehery
 - hasbro17
 - tjungblu
 reviewers:
 - deads2k
 - dusk125
-- elbehery
 - hasbro17
+- jubittajohn
 - tjungblu

--- a/ci-operator/config/openshift/etcd/openshift-etcd-main.yaml
+++ b/ci-operator/config/openshift/etcd/openshift-etcd-main.yaml
@@ -19,8 +19,7 @@ images:
     to: installer-etcd-artifacts
 promotion:
   to:
-  - disabled: true
-    name: "5.0"
+  - name: "5.0"
     namespace: ocp
 releases:
   initial:
@@ -92,6 +91,6 @@ tests:
     - chain: openshift-qe-control-plane
     workflow: openshift-qe-installer-aws
 zz_generated_metadata:
-  branch: openshift-5.0
+  branch: main
   org: openshift
   repo: etcd

--- a/ci-operator/jobs/openshift/etcd/openshift-etcd-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/etcd/openshift-etcd-main-postsubmits.yaml
@@ -1,0 +1,61 @@
+postsubmits:
+  openshift/etcd:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    cluster: build01
+    decorate: true
+    labels:
+      ci-operator.openshift.io/is-promotion: "true"
+      ci.openshift.io/generator: prowgen
+    max_concurrency: 1
+    name: branch-ci-openshift-etcd-main-images
+    path_alias: go.etcd.io/etcd
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --image-mirror-push-secret=/etc/push-secret/.dockerconfigjson
+        - --promote
+        - --report-credentials-file=/etc/report/credentials
+        - --target=[images]
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/push-secret
+          name: push-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: push-secret
+        secret:
+          secretName: registry-push-credentials-ci-central
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator

--- a/ci-operator/jobs/openshift/etcd/openshift-etcd-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/etcd/openshift-etcd-main-presubmits.yaml
@@ -3,9 +3,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^openshift-5\.0$
-    - ^openshift-5\.0-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build06
     context: ci/prow/configmap-scale
     decorate: true
     labels:
@@ -13,7 +13,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-5.0-configmap-scale
+    name: pull-ci-openshift-etcd-main-configmap-scale
     path_alias: go.etcd.io/etcd
     rerun_command: /test configmap-scale
     spec:
@@ -84,9 +84,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^openshift-5\.0$
-    - ^openshift-5\.0-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build06
     context: ci/prow/e2e-aws-etcd-recovery
     decorate: true
     labels:
@@ -94,7 +94,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-5.0-e2e-aws-etcd-recovery
+    name: pull-ci-openshift-etcd-main-e2e-aws-etcd-recovery
     optional: true
     path_alias: go.etcd.io/etcd
     rerun_command: /test e2e-aws-etcd-recovery
@@ -166,9 +166,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^openshift-5\.0$
-    - ^openshift-5\.0-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build06
     context: ci/prow/e2e-aws-ovn
     decorate: true
     labels:
@@ -176,7 +176,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-5.0-e2e-aws-ovn
+    name: pull-ci-openshift-etcd-main-e2e-aws-ovn
     path_alias: go.etcd.io/etcd
     rerun_command: /test e2e-aws-ovn
     spec:
@@ -247,9 +247,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^openshift-5\.0$
-    - ^openshift-5\.0-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build06
     context: ci/prow/e2e-aws-ovn-serial
     decorate: true
     labels:
@@ -257,7 +257,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-5.0-e2e-aws-ovn-serial
+    name: pull-ci-openshift-etcd-main-e2e-aws-ovn-serial
     path_alias: go.etcd.io/etcd
     rerun_command: /test e2e-aws-ovn-serial
     spec:
@@ -328,9 +328,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^openshift-5\.0$
-    - ^openshift-5\.0-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build06
     context: ci/prow/e2e-aws-ovn-upgrade
     decorate: true
     labels:
@@ -338,7 +338,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-5.0-e2e-aws-ovn-upgrade
+    name: pull-ci-openshift-etcd-main-e2e-aws-ovn-upgrade
     path_alias: go.etcd.io/etcd
     rerun_command: /test e2e-aws-ovn-upgrade
     spec:
@@ -409,9 +409,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^openshift-5\.0$
-    - ^openshift-5\.0-
-    cluster: build06
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/e2e-hypershift
     decorate: true
     labels:
@@ -419,7 +419,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: hypershift-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-5.0-e2e-hypershift
+    name: pull-ci-openshift-etcd-main-e2e-hypershift
     optional: true
     path_alias: go.etcd.io/etcd
     rerun_command: /test e2e-hypershift
@@ -491,9 +491,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^openshift-5\.0$
-    - ^openshift-5\.0-
-    cluster: build06
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/e2e-hypershift-conformance
     decorate: true
     labels:
@@ -501,7 +501,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: hypershift-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-5.0-e2e-hypershift-conformance
+    name: pull-ci-openshift-etcd-main-e2e-hypershift-conformance
     optional: true
     path_alias: go.etcd.io/etcd
     rerun_command: /test e2e-hypershift-conformance
@@ -573,15 +573,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^openshift-5\.0$
-    - ^openshift-5\.0-
-    cluster: build06
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/images
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-5.0-images
+    name: pull-ci-openshift-etcd-main-images
     path_alias: go.etcd.io/etcd
     rerun_command: /test images
     spec:
@@ -591,6 +591,7 @@ presubmits:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --report-credentials-file=/etc/report/credentials
         - --target=[images]
+        - --target=[release:latest]
         command:
         - ci-operator
         image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
@@ -627,9 +628,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^openshift-5\.0$
-    - ^openshift-5\.0-
-    cluster: build07
+    - ^main$
+    - ^main-
+    cluster: build06
     context: ci/prow/perfscale-payload-control-plane-6nodes
     decorate: true
     labels:
@@ -637,7 +638,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-5.0-perfscale-payload-control-plane-6nodes
+    name: pull-ci-openshift-etcd-main-perfscale-payload-control-plane-6nodes
     optional: true
     path_alias: go.etcd.io/etcd
     rerun_command: /test perfscale-payload-control-plane-6nodes
@@ -709,15 +710,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^openshift-5\.0$
-    - ^openshift-5\.0-
-    cluster: build06
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/unit
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-5.0-unit
+    name: pull-ci-openshift-etcd-main-unit
     path_alias: go.etcd.io/etcd
     rerun_command: /test unit
     spec:

--- a/core-services/prow/02_config/openshift/etcd/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/etcd/_prowconfig.yaml
@@ -68,6 +68,23 @@ tide:
     - needs-rebase
     repos:
     - openshift/etcd
+  - includedBranches:
+    - main
+    labels:
+    - approved
+    - jira/valid-reference
+    - lgtm
+    - verified
+    missingLabels:
+    - backports/unvalidated-commits
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - jira/invalid-bug
+    - keep-main-query-separate
+    - needs-rebase
+    repos:
+    - openshift/etcd
   - excludedBranches:
     - main
     - master


### PR DESCRIPTION
Currently, openshift/etcd does not work like most other openshift repositories where the openshift release branches follow the main branch. This PR is starting to try to remedy this so that changes against main (and backports from main) can work properly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated maintainer roles: removed one user from approvers/reviewers and added a reviewer.
  * Added full CI configurations for the project: new build, promotion, presubmit and postsubmit jobs, resource defaults, and test workflows.
  * Adjusted promotion for the 5.0 release to mark the target as disabled.
  * Narrowed an images presubmit to only the images target.
  * Added a tide query for the main branch with updated required/missing labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->