### PR TITLE
[DEBUG] [DO NOT MERGE]

### DIFF
--- a/ci-operator/config/openshift/sandboxed-containers-operator/openshift-sandboxed-containers-operator-devel__downstream-candidate418.yaml
+++ b/ci-operator/config/openshift/sandboxed-containers-operator/openshift-sandboxed-containers-operator-devel__downstream-candidate418.yaml
@@ -23,7 +23,7 @@ tests:
   capabilities:
   - intranet
   cron: 0 0 31 2 1
-  restrict_network_access: false
+  restrict_network_access: true
   steps:
     cluster_profile: azure-qe
     env:
@@ -32,24 +32,24 @@ tests:
       CATALOG_SOURCE_NAME: brew-catalog
       CUSTOM_AZURE_REGION: eastus
       ENABLE_MUST_GATHER: "true"
-      INITDATA: ""
-      INSTALL_KATA_RPM: "false"
-      KATA_RPM_VERSION: ""
+      INITDATA: H4sICMrPymkAA2luaXRkYXRhLnRvbWwA7Vhbc6pIF33nV1i8ZL7KUdR4TdV54KZiREXwllQq1UILyKWxuxHxVP77NJo5kzlzTOZh5ns6pAyy9+q19+7L6kYQugj71ItKX0s88UC92eK5A8TER3FhqlZqlSrPcU8OoOCZ4wGoUBSFPPPd3NxwTxQFMH6xUbz1XfL8w3PFRjZ6Acye4rBg8yhNyL0gBBtSJhAffBuWKU4JhbCMEogBRbhMcvYcVUCSkApNNhVwSjGsEBA7G3SEDuOmwI9Ziow+KlL7a0zG/Z/GsyGmBTfPl4tLUvvauCSrM0vrabJoqWcrp2uaoiiyLG5NV8w0SXTZxxLHkhvsvcDvd7OqJBqkJypipJtGprlrZWEYiiKxFCIn5x5X49No2c0eV0PP6XdzQ1HvxiejMbH02sQSs4Fnj/XdOtNPeqZbNrPNj8uzzWU2rcm9GfPl7ucRPgvAua7q62K1L5v7vqlt7hRDZSnPRbGhSUomZsz/ICJWliEf4rvTLdjB2mPuOXIYHtb2SeI667rXImMPNWTbM6OqoU3SZNheBM1GLRoq8pY0T52Vn6q90ZYx1IAbTkeHeKLcrgPtIItcGw/BIqNdSLDltp2meacKrbroaN18MW+r69EDULubjur2HX22rNZOc6dl1tv5Wp0fd/uhyinVdOz3h484WSEBrv3p0Yurh1XLjNps2iup6q5H3TzDx0WWCIGt9a3qvrfcSnpvFHTGU8wdHSrVDW2pW/HKyQctiQyNIRYWI6LBvLumD22j2tLrjV1wSIa4Xkferb9qjucd27MbxzriTpsJCMhkC0l7P50N72StjYXV0hgbYzBu7rPa40NQW9sA+aPbiWssoSbOPDxfKIdosa+DEye6uiSK/d3MkhRdbPTF2txRMlUSMkNlE0tOFNGU3PFiMGO4bUeVFbEvGgNBdFVRl6p97tyAMUuSGTw6fgAMq6sfXT2G8PG0bWU9T+2Bn81McSKLLAZnKN1jN0eDfG9syEaeILo+0tqsK+63yWRiDzeLaXXtriYPdltYtcOepYdYC8PG3JrMDdcQOOm0bnZ0sFqn2/HEMat++2jf1fT0JO7uIpp3FkeL6IcukObDk+Avpvlg8BCtRseJ7tRmWevEDWQnq4l1I5nLaCLvGjUPPm7a1ioc7DsPwxy3u2q/P9wA1W+bt6ekQw19hnvJXU/KcGvaMzg2/rnVP6zifWsc1h7rMnrY7PtCMzjIE4cs9E3j1B60gtTR7KM6nFUzBw8EpWm1JW8axvGGi/JafdepCb7emI677QSk3X693tChkO3pAg0dzTm0DqtmZEXVuSOlo+xAccO8HZvtkdXUhtwwqObdHphj9SSru7vZNlB6M+PrV+4sF+pY+ZuEMIHhConleNvx3kT3TXUJsgNYiNBNGvtHpm8CTmPhLIAOjKkPwvKfqiUUzYsWN5yN4ZufsMZPz0w7g439zMUggoWk2fYLe+b/S/VkXC+/FPSXgv5S0F8K+v9QUO7Jj4ALn7nz7YVAO2XH3fwlQaFv54WEfuMduAVpSPn7p288zRPI3/MY7qBN+dfnLzzFICYJwpTw9wxbSC8uvrmejSs+uiq7FBL653P5HL+MyfsohJ1XmYZC03dj6PBf+ADmU0A95mI6Wej6W2osCMPGZeYnAvtXrrLUXl9fb952iEs1FQxd9MfJPAF2wCKW2Cemb+VyrBeKSkrblBYqzZgyhB1S8eOrnu01D2RvCYzxLcOS6DjibDqGvuttECYzuE9ZB5Tuv5bYlgHfw8wMJNfccogINKnjx1cRKMl7fgiv+jEEFMp/9PvHMPOyTV0DKcyIUf4Jqg+pDin27atFM8RkoqsHNhJXIYVVgSzp8CrNyCdUiynEW2DDD1EzlNLrCB1GA0STMHWlfIrR5mpfTuKQ9aE8nbMW1zBTkJLPu3uahqFWrIBrgBkEjknZoLwPtGUHlfeQCB0+D3WBmRSEcOFj6qMtMT2AoY7SmF7tkxkkEDozNtIoUuDhA1gafZ6DCellQNkcs/zoatXFwgchGwM2nldTY6Vg+nnIAmVhYPux+wGGkn/AhJJPiCyaL4slSvzT1drmifNPFuIFpiYejNiJMvx4lC7g72vgY9jHi2AJfPpJx6tHaP8d8tdJyUZ6etbWq3HYdgOvzGzuJxH8bekbV2KXHycpfWGH5ohNSibqbCuxAf2NL/FfLr5KcmlZEbFL/nduQxA7yIMwRBl0vjf149JF/l+K33AqP7jJz4J9/ZGEe+W4dyRFCUWW/I9k/H3p6UxYXLxdvEgUbxFsK6vV25Uq+6vdd6rVVvFSImBIUIpt+H2XA7TYNAFbs3G5uKdEuNz4L/8qKT4vc55xPrPCit3yd1BoWKEHEwAA
+      INSTALL_KATA_RPM: "true"
+      KATA_RPM_VERSION: 3.25.0-5.rhaos4.18.el9
       MUST_GATHER_IMAGE: registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel9:latest
-      MUST_GATHER_ON_FAILURE_ONLY: "true"
-      SLEEP_DURATION: 0h
+      MUST_GATHER_ON_FAILURE_ONLY: "false"
+      SLEEP_DURATION: 6h
       TEST_FILTERS: ~DisconnectedOnly&;~Disruptive&
       TEST_RELEASE_TYPE: Pre-GA
       TEST_SCENARIOS: sig-kata.*Kata Author
-      TEST_TIMEOUT: "90"
-      TRUSTEE_URL: ""
+      TEST_TIMEOUT: "120"
+      TRUSTEE_URL: http://kbs-service-trustee-operator-system.apps.tpb.azure.sandboxedcontainers.com
     workflow: sandboxed-containers-operator-e2e-azure
   timeout: 24h0m0s
 - as: azure-ipi-peerpods
   capabilities:
   - intranet
   cron: 0 0 31 2 1
-  restrict_network_access: false
+  restrict_network_access: true
   steps:
     cluster_profile: azure-qe
     env:
@@ -59,18 +59,18 @@ tests:
       CUSTOM_AZURE_REGION: eastus
       ENABLE_MUST_GATHER: "true"
       ENABLEPEERPODS: "true"
-      INITDATA: ""
-      INSTALL_KATA_RPM: "false"
-      KATA_RPM_VERSION: ""
+      INITDATA: H4sICMrPymkAA2luaXRkYXRhLnRvbWwA7Vhbc6pIF33nV1i8ZL7KUdR4TdV54KZiREXwllQq1UILyKWxuxHxVP77NJo5kzlzTOZh5ns6pAyy9+q19+7L6kYQugj71ItKX0s88UC92eK5A8TER3FhqlZqlSrPcU8OoOCZ4wGoUBSFPPPd3NxwTxQFMH6xUbz1XfL8w3PFRjZ6Acye4rBg8yhNyL0gBBtSJhAffBuWKU4JhbCMEogBRbhMcvYcVUCSkApNNhVwSjGsEBA7G3SEDuOmwI9Ziow+KlL7a0zG/Z/GsyGmBTfPl4tLUvvauCSrM0vrabJoqWcrp2uaoiiyLG5NV8w0SXTZxxLHkhvsvcDvd7OqJBqkJypipJtGprlrZWEYiiKxFCIn5x5X49No2c0eV0PP6XdzQ1HvxiejMbH02sQSs4Fnj/XdOtNPeqZbNrPNj8uzzWU2rcm9GfPl7ucRPgvAua7q62K1L5v7vqlt7hRDZSnPRbGhSUomZsz/ICJWliEf4rvTLdjB2mPuOXIYHtb2SeI667rXImMPNWTbM6OqoU3SZNheBM1GLRoq8pY0T52Vn6q90ZYx1IAbTkeHeKLcrgPtIItcGw/BIqNdSLDltp2meacKrbroaN18MW+r69EDULubjur2HX22rNZOc6dl1tv5Wp0fd/uhyinVdOz3h484WSEBrv3p0Yurh1XLjNps2iup6q5H3TzDx0WWCIGt9a3qvrfcSnpvFHTGU8wdHSrVDW2pW/HKyQctiQyNIRYWI6LBvLumD22j2tLrjV1wSIa4Xkferb9qjucd27MbxzriTpsJCMhkC0l7P50N72StjYXV0hgbYzBu7rPa40NQW9sA+aPbiWssoSbOPDxfKIdosa+DEye6uiSK/d3MkhRdbPTF2txRMlUSMkNlE0tOFNGU3PFiMGO4bUeVFbEvGgNBdFVRl6p97tyAMUuSGTw6fgAMq6sfXT2G8PG0bWU9T+2Bn81McSKLLAZnKN1jN0eDfG9syEaeILo+0tqsK+63yWRiDzeLaXXtriYPdltYtcOepYdYC8PG3JrMDdcQOOm0bnZ0sFqn2/HEMat++2jf1fT0JO7uIpp3FkeL6IcukObDk+Avpvlg8BCtRseJ7tRmWevEDWQnq4l1I5nLaCLvGjUPPm7a1ioc7DsPwxy3u2q/P9wA1W+bt6ekQw19hnvJXU/KcGvaMzg2/rnVP6zifWsc1h7rMnrY7PtCMzjIE4cs9E3j1B60gtTR7KM6nFUzBw8EpWm1JW8axvGGi/JafdepCb7emI677QSk3X693tChkO3pAg0dzTm0DqtmZEXVuSOlo+xAccO8HZvtkdXUhtwwqObdHphj9SSru7vZNlB6M+PrV+4sF+pY+ZuEMIHhConleNvx3kT3TXUJsgNYiNBNGvtHpm8CTmPhLIAOjKkPwvKfqiUUzYsWN5yN4ZufsMZPz0w7g439zMUggoWk2fYLe+b/S/VkXC+/FPSXgv5S0F8K+v9QUO7Jj4ALn7nz7YVAO2XH3fwlQaFv54WEfuMduAVpSPn7p288zRPI3/MY7qBN+dfnLzzFICYJwpTw9wxbSC8uvrmejSs+uiq7FBL653P5HL+MyfsohJ1XmYZC03dj6PBf+ADmU0A95mI6Wej6W2osCMPGZeYnAvtXrrLUXl9fb952iEs1FQxd9MfJPAF2wCKW2Cemb+VyrBeKSkrblBYqzZgyhB1S8eOrnu01D2RvCYzxLcOS6DjibDqGvuttECYzuE9ZB5Tuv5bYlgHfw8wMJNfccogINKnjx1cRKMl7fgiv+jEEFMp/9PvHMPOyTV0DKcyIUf4Jqg+pDin27atFM8RkoqsHNhJXIYVVgSzp8CrNyCdUiynEW2DDD1EzlNLrCB1GA0STMHWlfIrR5mpfTuKQ9aE8nbMW1zBTkJLPu3uahqFWrIBrgBkEjknZoLwPtGUHlfeQCB0+D3WBmRSEcOFj6qMtMT2AoY7SmF7tkxkkEDozNtIoUuDhA1gafZ6DCellQNkcs/zoatXFwgchGwM2nldTY6Vg+nnIAmVhYPux+wGGkn/AhJJPiCyaL4slSvzT1drmifNPFuIFpiYejNiJMvx4lC7g72vgY9jHi2AJfPpJx6tHaP8d8tdJyUZ6etbWq3HYdgOvzGzuJxH8bekbV2KXHycpfWGH5ohNSibqbCuxAf2NL/FfLr5KcmlZEbFL/nduQxA7yIMwRBl0vjf149JF/l+K33AqP7jJz4J9/ZGEe+W4dyRFCUWW/I9k/H3p6UxYXLxdvEgUbxFsK6vV25Uq+6vdd6rVVvFSImBIUIpt+H2XA7TYNAFbs3G5uKdEuNz4L/8qKT4vc55xPrPCit3yd1BoWKEHEwAA
+      INSTALL_KATA_RPM: "true"
+      KATA_RPM_VERSION: 3.25.0-5.rhaos4.18.el9
       MUST_GATHER_IMAGE: registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel9:latest
-      MUST_GATHER_ON_FAILURE_ONLY: "true"
+      MUST_GATHER_ON_FAILURE_ONLY: "false"
       RUNTIMECLASS: kata-remote
-      SLEEP_DURATION: 0h
+      SLEEP_DURATION: 6h
       TEST_FILTERS: ~DisconnectedOnly&;~Disruptive&
       TEST_RELEASE_TYPE: Pre-GA
       TEST_SCENARIOS: sig-kata.*Kata Author
-      TEST_TIMEOUT: "90"
-      TRUSTEE_URL: ""
+      TEST_TIMEOUT: "120"
+      TRUSTEE_URL: http://kbs-service-trustee-operator-system.apps.tpb.azure.sandboxedcontainers.com
       WORKLOAD_TO_TEST: peer-pods
     workflow: sandboxed-containers-operator-e2e-azure
   timeout: 24h0m0s
@@ -78,7 +78,7 @@ tests:
   capabilities:
   - intranet
   cron: 0 0 31 2 1
-  restrict_network_access: false
+  restrict_network_access: true
   steps:
     cluster_profile: azure-qe
     env:
@@ -88,18 +88,18 @@ tests:
       CUSTOM_AZURE_REGION: eastus
       ENABLE_MUST_GATHER: "true"
       ENABLEPEERPODS: "true"
-      INITDATA: ""
-      INSTALL_KATA_RPM: "false"
-      KATA_RPM_VERSION: ""
+      INITDATA: H4sICMrPymkAA2luaXRkYXRhLnRvbWwA7Vhbc6pIF33nV1i8ZL7KUdR4TdV54KZiREXwllQq1UILyKWxuxHxVP77NJo5kzlzTOZh5ns6pAyy9+q19+7L6kYQugj71ItKX0s88UC92eK5A8TER3FhqlZqlSrPcU8OoOCZ4wGoUBSFPPPd3NxwTxQFMH6xUbz1XfL8w3PFRjZ6Acye4rBg8yhNyL0gBBtSJhAffBuWKU4JhbCMEogBRbhMcvYcVUCSkApNNhVwSjGsEBA7G3SEDuOmwI9Ziow+KlL7a0zG/Z/GsyGmBTfPl4tLUvvauCSrM0vrabJoqWcrp2uaoiiyLG5NV8w0SXTZxxLHkhvsvcDvd7OqJBqkJypipJtGprlrZWEYiiKxFCIn5x5X49No2c0eV0PP6XdzQ1HvxiejMbH02sQSs4Fnj/XdOtNPeqZbNrPNj8uzzWU2rcm9GfPl7ucRPgvAua7q62K1L5v7vqlt7hRDZSnPRbGhSUomZsz/ICJWliEf4rvTLdjB2mPuOXIYHtb2SeI667rXImMPNWTbM6OqoU3SZNheBM1GLRoq8pY0T52Vn6q90ZYx1IAbTkeHeKLcrgPtIItcGw/BIqNdSLDltp2meacKrbroaN18MW+r69EDULubjur2HX22rNZOc6dl1tv5Wp0fd/uhyinVdOz3h484WSEBrv3p0Yurh1XLjNps2iup6q5H3TzDx0WWCIGt9a3qvrfcSnpvFHTGU8wdHSrVDW2pW/HKyQctiQyNIRYWI6LBvLumD22j2tLrjV1wSIa4Xkferb9qjucd27MbxzriTpsJCMhkC0l7P50N72StjYXV0hgbYzBu7rPa40NQW9sA+aPbiWssoSbOPDxfKIdosa+DEye6uiSK/d3MkhRdbPTF2txRMlUSMkNlE0tOFNGU3PFiMGO4bUeVFbEvGgNBdFVRl6p97tyAMUuSGTw6fgAMq6sfXT2G8PG0bWU9T+2Bn81McSKLLAZnKN1jN0eDfG9syEaeILo+0tqsK+63yWRiDzeLaXXtriYPdltYtcOepYdYC8PG3JrMDdcQOOm0bnZ0sFqn2/HEMat++2jf1fT0JO7uIpp3FkeL6IcukObDk+Avpvlg8BCtRseJ7tRmWevEDWQnq4l1I5nLaCLvGjUPPm7a1ioc7DsPwxy3u2q/P9wA1W+bt6ekQw19hnvJXU/KcGvaMzg2/rnVP6zifWsc1h7rMnrY7PtCMzjIE4cs9E3j1B60gtTR7KM6nFUzBw8EpWm1JW8axvGGi/JafdepCb7emI677QSk3X693tChkO3pAg0dzTm0DqtmZEXVuSOlo+xAccO8HZvtkdXUhtwwqObdHphj9SSru7vZNlB6M+PrV+4sF+pY+ZuEMIHhConleNvx3kT3TXUJsgNYiNBNGvtHpm8CTmPhLIAOjKkPwvKfqiUUzYsWN5yN4ZufsMZPz0w7g439zMUggoWk2fYLe+b/S/VkXC+/FPSXgv5S0F8K+v9QUO7Jj4ALn7nz7YVAO2XH3fwlQaFv54WEfuMduAVpSPn7p288zRPI3/MY7qBN+dfnLzzFICYJwpTw9wxbSC8uvrmejSs+uiq7FBL653P5HL+MyfsohJ1XmYZC03dj6PBf+ADmU0A95mI6Wej6W2osCMPGZeYnAvtXrrLUXl9fb952iEs1FQxd9MfJPAF2wCKW2Cemb+VyrBeKSkrblBYqzZgyhB1S8eOrnu01D2RvCYzxLcOS6DjibDqGvuttECYzuE9ZB5Tuv5bYlgHfw8wMJNfccogINKnjx1cRKMl7fgiv+jEEFMp/9PvHMPOyTV0DKcyIUf4Jqg+pDin27atFM8RkoqsHNhJXIYVVgSzp8CrNyCdUiynEW2DDD1EzlNLrCB1GA0STMHWlfIrR5mpfTuKQ9aE8nbMW1zBTkJLPu3uahqFWrIBrgBkEjknZoLwPtGUHlfeQCB0+D3WBmRSEcOFj6qMtMT2AoY7SmF7tkxkkEDozNtIoUuDhA1gafZ6DCellQNkcs/zoatXFwgchGwM2nldTY6Vg+nnIAmVhYPux+wGGkn/AhJJPiCyaL4slSvzT1drmifNPFuIFpiYejNiJMvx4lC7g72vgY9jHi2AJfPpJx6tHaP8d8tdJyUZ6etbWq3HYdgOvzGzuJxH8bekbV2KXHycpfWGH5ohNSibqbCuxAf2NL/FfLr5KcmlZEbFL/nduQxA7yIMwRBl0vjf149JF/l+K33AqP7jJz4J9/ZGEe+W4dyRFCUWW/I9k/H3p6UxYXLxdvEgUbxFsK6vV25Uq+6vdd6rVVvFSImBIUIpt+H2XA7TYNAFbs3G5uKdEuNz4L/8qKT4vc55xPrPCit3yd1BoWKEHEwAA
+      INSTALL_KATA_RPM: "true"
+      KATA_RPM_VERSION: 3.25.0-5.rhaos4.18.el9
       MUST_GATHER_IMAGE: registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel9:latest
-      MUST_GATHER_ON_FAILURE_ONLY: "true"
+      MUST_GATHER_ON_FAILURE_ONLY: "false"
       RUNTIMECLASS: kata-remote
-      SLEEP_DURATION: 0h
+      SLEEP_DURATION: 6h
       TEST_FILTERS: ~DisconnectedOnly&;~Disruptive&
       TEST_RELEASE_TYPE: Pre-GA
       TEST_SCENARIOS: sig-kata.*Kata Author
-      TEST_TIMEOUT: "90"
-      TRUSTEE_URL: ""
+      TEST_TIMEOUT: "120"
+      TRUSTEE_URL: http://kbs-service-trustee-operator-system.apps.tpb.azure.sandboxedcontainers.com
       WORKLOAD_TO_TEST: coco
     workflow: sandboxed-containers-operator-e2e-azure
   timeout: 24h0m0s
@@ -107,7 +107,7 @@ tests:
   capabilities:
   - intranet
   cron: 0 0 31 2 1
-  restrict_network_access: false
+  restrict_network_access: true
   steps:
     cluster_profile: azure-qe
     env:
@@ -117,19 +117,19 @@ tests:
       ENABLE_MUST_GATHER: "true"
       ENABLEPEERPODS: "true"
       HYPERSHIFT_AZURE_LOCATION: eastus
-      INITDATA: ""
-      INSTALL_KATA_RPM: "false"
-      KATA_RPM_VERSION: ""
+      INITDATA: H4sICMrPymkAA2luaXRkYXRhLnRvbWwA7Vhbc6pIF33nV1i8ZL7KUdR4TdV54KZiREXwllQq1UILyKWxuxHxVP77NJo5kzlzTOZh5ns6pAyy9+q19+7L6kYQugj71ItKX0s88UC92eK5A8TER3FhqlZqlSrPcU8OoOCZ4wGoUBSFPPPd3NxwTxQFMH6xUbz1XfL8w3PFRjZ6Acye4rBg8yhNyL0gBBtSJhAffBuWKU4JhbCMEogBRbhMcvYcVUCSkApNNhVwSjGsEBA7G3SEDuOmwI9Ziow+KlL7a0zG/Z/GsyGmBTfPl4tLUvvauCSrM0vrabJoqWcrp2uaoiiyLG5NV8w0SXTZxxLHkhvsvcDvd7OqJBqkJypipJtGprlrZWEYiiKxFCIn5x5X49No2c0eV0PP6XdzQ1HvxiejMbH02sQSs4Fnj/XdOtNPeqZbNrPNj8uzzWU2rcm9GfPl7ucRPgvAua7q62K1L5v7vqlt7hRDZSnPRbGhSUomZsz/ICJWliEf4rvTLdjB2mPuOXIYHtb2SeI667rXImMPNWTbM6OqoU3SZNheBM1GLRoq8pY0T52Vn6q90ZYx1IAbTkeHeKLcrgPtIItcGw/BIqNdSLDltp2meacKrbroaN18MW+r69EDULubjur2HX22rNZOc6dl1tv5Wp0fd/uhyinVdOz3h484WSEBrv3p0Yurh1XLjNps2iup6q5H3TzDx0WWCIGt9a3qvrfcSnpvFHTGU8wdHSrVDW2pW/HKyQctiQyNIRYWI6LBvLumD22j2tLrjV1wSIa4Xkferb9qjucd27MbxzriTpsJCMhkC0l7P50N72StjYXV0hgbYzBu7rPa40NQW9sA+aPbiWssoSbOPDxfKIdosa+DEye6uiSK/d3MkhRdbPTF2txRMlUSMkNlE0tOFNGU3PFiMGO4bUeVFbEvGgNBdFVRl6p97tyAMUuSGTw6fgAMq6sfXT2G8PG0bWU9T+2Bn81McSKLLAZnKN1jN0eDfG9syEaeILo+0tqsK+63yWRiDzeLaXXtriYPdltYtcOepYdYC8PG3JrMDdcQOOm0bnZ0sFqn2/HEMat++2jf1fT0JO7uIpp3FkeL6IcukObDk+Avpvlg8BCtRseJ7tRmWevEDWQnq4l1I5nLaCLvGjUPPm7a1ioc7DsPwxy3u2q/P9wA1W+bt6ekQw19hnvJXU/KcGvaMzg2/rnVP6zifWsc1h7rMnrY7PtCMzjIE4cs9E3j1B60gtTR7KM6nFUzBw8EpWm1JW8axvGGi/JafdepCb7emI677QSk3X693tChkO3pAg0dzTm0DqtmZEXVuSOlo+xAccO8HZvtkdXUhtwwqObdHphj9SSru7vZNlB6M+PrV+4sF+pY+ZuEMIHhConleNvx3kT3TXUJsgNYiNBNGvtHpm8CTmPhLIAOjKkPwvKfqiUUzYsWN5yN4ZufsMZPz0w7g439zMUggoWk2fYLe+b/S/VkXC+/FPSXgv5S0F8K+v9QUO7Jj4ALn7nz7YVAO2XH3fwlQaFv54WEfuMduAVpSPn7p288zRPI3/MY7qBN+dfnLzzFICYJwpTw9wxbSC8uvrmejSs+uiq7FBL653P5HL+MyfsohJ1XmYZC03dj6PBf+ADmU0A95mI6Wej6W2osCMPGZeYnAvtXrrLUXl9fb952iEs1FQxd9MfJPAF2wCKW2Cemb+VyrBeKSkrblBYqzZgyhB1S8eOrnu01D2RvCYzxLcOS6DjibDqGvuttECYzuE9ZB5Tuv5bYlgHfw8wMJNfccogINKnjx1cRKMl7fgiv+jEEFMp/9PvHMPOyTV0DKcyIUf4Jqg+pDin27atFM8RkoqsHNhJXIYVVgSzp8CrNyCdUiynEW2DDD1EzlNLrCB1GA0STMHWlfIrR5mpfTuKQ9aE8nbMW1zBTkJLPu3uahqFWrIBrgBkEjknZoLwPtGUHlfeQCB0+D3WBmRSEcOFj6qMtMT2AoY7SmF7tkxkkEDozNtIoUuDhA1gafZ6DCellQNkcs/zoatXFwgchGwM2nldTY6Vg+nnIAmVhYPux+wGGkn/AhJJPiCyaL4slSvzT1drmifNPFuIFpiYejNiJMvx4lC7g72vgY9jHi2AJfPpJx6tHaP8d8tdJyUZ6etbWq3HYdgOvzGzuJxH8bekbV2KXHycpfWGH5ohNSibqbCuxAf2NL/FfLr5KcmlZEbFL/nduQxA7yIMwRBl0vjf149JF/l+K33AqP7jJz4J9/ZGEe+W4dyRFCUWW/I9k/H3p6UxYXLxdvEgUbxFsK6vV25Uq+6vdd6rVVvFSImBIUIpt+H2XA7TYNAFbs3G5uKdEuNz4L/8qKT4vc55xPrPCit3yd1BoWKEHEwAA
+      INSTALL_KATA_RPM: "true"
+      KATA_RPM_VERSION: 3.25.0-5.rhaos4.17.el9
       LOCATION: eastus
       MUST_GATHER_IMAGE: registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel9:latest
-      MUST_GATHER_ON_FAILURE_ONLY: "true"
+      MUST_GATHER_ON_FAILURE_ONLY: "false"
       RUNTIMECLASS: kata-remote
-      SLEEP_DURATION: 0h
+      SLEEP_DURATION: 6h
       TEST_FILTERS: ~DisconnectedOnly&;~Disruptive&
       TEST_RELEASE_TYPE: Pre-GA
       TEST_SCENARIOS: sig-kata.*Kata Author
-      TEST_TIMEOUT: "90"
-      TRUSTEE_URL: ""
+      TEST_TIMEOUT: "120"
+      TRUSTEE_URL: http://kbs-service-trustee-operator-system.apps.tpb.azure.sandboxedcontainers.com
       WORKLOAD_TO_TEST: peer-pods
     workflow: sandboxed-containers-operator-e2e-aro
   timeout: 24h0m0s
@@ -137,7 +137,7 @@ tests:
   capabilities:
   - intranet
   cron: 0 0 31 2 1
-  restrict_network_access: false
+  restrict_network_access: true
   steps:
     cluster_profile: azure-qe
     env:
@@ -147,19 +147,19 @@ tests:
       ENABLE_MUST_GATHER: "true"
       ENABLEPEERPODS: "true"
       HYPERSHIFT_AZURE_LOCATION: eastus
-      INITDATA: ""
-      INSTALL_KATA_RPM: "false"
-      KATA_RPM_VERSION: ""
+      INITDATA: H4sICMrPymkAA2luaXRkYXRhLnRvbWwA7Vhbc6pIF33nV1i8ZL7KUdR4TdV54KZiREXwllQq1UILyKWxuxHxVP77NJo5kzlzTOZh5ns6pAyy9+q19+7L6kYQugj71ItKX0s88UC92eK5A8TER3FhqlZqlSrPcU8OoOCZ4wGoUBSFPPPd3NxwTxQFMH6xUbz1XfL8w3PFRjZ6Acye4rBg8yhNyL0gBBtSJhAffBuWKU4JhbCMEogBRbhMcvYcVUCSkApNNhVwSjGsEBA7G3SEDuOmwI9Ziow+KlL7a0zG/Z/GsyGmBTfPl4tLUvvauCSrM0vrabJoqWcrp2uaoiiyLG5NV8w0SXTZxxLHkhvsvcDvd7OqJBqkJypipJtGprlrZWEYiiKxFCIn5x5X49No2c0eV0PP6XdzQ1HvxiejMbH02sQSs4Fnj/XdOtNPeqZbNrPNj8uzzWU2rcm9GfPl7ucRPgvAua7q62K1L5v7vqlt7hRDZSnPRbGhSUomZsz/ICJWliEf4rvTLdjB2mPuOXIYHtb2SeI667rXImMPNWTbM6OqoU3SZNheBM1GLRoq8pY0T52Vn6q90ZYx1IAbTkeHeKLcrgPtIItcGw/BIqNdSLDltp2meacKrbroaN18MW+r69EDULubjur2HX22rNZOc6dl1tv5Wp0fd/uhyinVdOz3h484WSEBrv3p0Yurh1XLjNps2iup6q5H3TzDx0WWCIGt9a3qvrfcSnpvFHTGU8wdHSrVDW2pW/HKyQctiQyNIRYWI6LBvLumD22j2tLrjV1wSIa4Xkferb9qjucd27MbxzriTpsJCMhkC0l7P50N72StjYXV0hgbYzBu7rPa40NQW9sA+aPbiWssoSbOPDxfKIdosa+DEye6uiSK/d3MkhRdbPTF2txRMlUSMkNlE0tOFNGU3PFiMGO4bUeVFbEvGgNBdFVRl6p97tyAMUuSGTw6fgAMq6sfXT2G8PG0bWU9T+2Bn81McSKLLAZnKN1jN0eDfG9syEaeILo+0tqsK+63yWRiDzeLaXXtriYPdltYtcOepYdYC8PG3JrMDdcQOOm0bnZ0sFqn2/HEMat++2jf1fT0JO7uIpp3FkeL6IcukObDk+Avpvlg8BCtRseJ7tRmWevEDWQnq4l1I5nLaCLvGjUPPm7a1ioc7DsPwxy3u2q/P9wA1W+bt6ekQw19hnvJXU/KcGvaMzg2/rnVP6zifWsc1h7rMnrY7PtCMzjIE4cs9E3j1B60gtTR7KM6nFUzBw8EpWm1JW8axvGGi/JafdepCb7emI677QSk3X693tChkO3pAg0dzTm0DqtmZEXVuSOlo+xAccO8HZvtkdXUhtwwqObdHphj9SSru7vZNlB6M+PrV+4sF+pY+ZuEMIHhConleNvx3kT3TXUJsgNYiNBNGvtHpm8CTmPhLIAOjKkPwvKfqiUUzYsWN5yN4ZufsMZPz0w7g439zMUggoWk2fYLe+b/S/VkXC+/FPSXgv5S0F8K+v9QUO7Jj4ALn7nz7YVAO2XH3fwlQaFv54WEfuMduAVpSPn7p288zRPI3/MY7qBN+dfnLzzFICYJwpTw9wxbSC8uvrmejSs+uiq7FBL653P5HL+MyfsohJ1XmYZC03dj6PBf+ADmU0A95mI6Wej6W2osCMPGZeYnAvtXrrLUXl9fb952iEs1FQxd9MfJPAF2wCKW2Cemb+VyrBeKSkrblBYqzZgyhB1S8eOrnu01D2RvCYzxLcOS6DjibDqGvuttECYzuE9ZB5Tuv5bYlgHfw8wMJNfccogINKnjx1cRKMl7fgiv+jEEFMp/9PvHMPOyTV0DKcyIUf4Jqg+pDin27atFM8RkoqsHNhJXIYVVgSzp8CrNyCdUiynEW2DDD1EzlNLrCB1GA0STMHWlfIrR5mpfTuKQ9aE8nbMW1zBTkJLPu3uahqFWrIBrgBkEjknZoLwPtGUHlfeQCB0+D3WBmRSEcOFj6qMtMT2AoY7SmF7tkxkkEDozNtIoUuDhA1gafZ6DCellQNkcs/zoatXFwgchGwM2nldTY6Vg+nnIAmVhYPux+wGGkn/AhJJPiCyaL4slSvzT1drmifNPFuIFpiYejNiJMvx4lC7g72vgY9jHi2AJfPpJx6tHaP8d8tdJyUZ6etbWq3HYdgOvzGzuJxH8bekbV2KXHycpfWGH5ohNSibqbCuxAf2NL/FfLr5KcmlZEbFL/nduQxA7yIMwRBl0vjf149JF/l+K33AqP7jJz4J9/ZGEe+W4dyRFCUWW/I9k/H3p6UxYXLxdvEgUbxFsK6vV25Uq+6vdd6rVVvFSImBIUIpt+H2XA7TYNAFbs3G5uKdEuNz4L/8qKT4vc55xPrPCit3yd1BoWKEHEwAA
+      INSTALL_KATA_RPM: "true"
+      KATA_RPM_VERSION: 3.25.0-5.rhaos4.17.el9
       LOCATION: eastus
       MUST_GATHER_IMAGE: registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel9:latest
-      MUST_GATHER_ON_FAILURE_ONLY: "true"
+      MUST_GATHER_ON_FAILURE_ONLY: "false"
       RUNTIMECLASS: kata-remote
-      SLEEP_DURATION: 0h
+      SLEEP_DURATION: 6h
       TEST_FILTERS: ~DisconnectedOnly&;~Disruptive&
       TEST_RELEASE_TYPE: Pre-GA
       TEST_SCENARIOS: sig-kata.*Kata Author
-      TEST_TIMEOUT: "90"
-      TRUSTEE_URL: ""
+      TEST_TIMEOUT: "120"
+      TRUSTEE_URL: http://kbs-service-trustee-operator-system.apps.tpb.azure.sandboxedcontainers.com
       WORKLOAD_TO_TEST: coco
     workflow: sandboxed-containers-operator-e2e-aro
   timeout: 24h0m0s
@@ -167,7 +167,7 @@ tests:
   capabilities:
   - intranet
   cron: 0 0 31 2 1
-  restrict_network_access: false
+  restrict_network_access: true
   steps:
     cluster_profile: aws-sandboxed-containers-operator
     env:
@@ -176,18 +176,18 @@ tests:
       CATALOG_SOURCE_NAME: brew-catalog
       ENABLE_MUST_GATHER: "true"
       ENABLEPEERPODS: "true"
-      INITDATA: ""
-      INSTALL_KATA_RPM: "false"
-      KATA_RPM_VERSION: ""
+      INITDATA: H4sICMrPymkAA2luaXRkYXRhLnRvbWwA7Vhbc6pIF33nV1i8ZL7KUdR4TdV54KZiREXwllQq1UILyKWxuxHxVP77NJo5kzlzTOZh5ns6pAyy9+q19+7L6kYQugj71ItKX0s88UC92eK5A8TER3FhqlZqlSrPcU8OoOCZ4wGoUBSFPPPd3NxwTxQFMH6xUbz1XfL8w3PFRjZ6Acye4rBg8yhNyL0gBBtSJhAffBuWKU4JhbCMEogBRbhMcvYcVUCSkApNNhVwSjGsEBA7G3SEDuOmwI9Ziow+KlL7a0zG/Z/GsyGmBTfPl4tLUvvauCSrM0vrabJoqWcrp2uaoiiyLG5NV8w0SXTZxxLHkhvsvcDvd7OqJBqkJypipJtGprlrZWEYiiKxFCIn5x5X49No2c0eV0PP6XdzQ1HvxiejMbH02sQSs4Fnj/XdOtNPeqZbNrPNj8uzzWU2rcm9GfPl7ucRPgvAua7q62K1L5v7vqlt7hRDZSnPRbGhSUomZsz/ICJWliEf4rvTLdjB2mPuOXIYHtb2SeI667rXImMPNWTbM6OqoU3SZNheBM1GLRoq8pY0T52Vn6q90ZYx1IAbTkeHeKLcrgPtIItcGw/BIqNdSLDltp2meacKrbroaN18MW+r69EDULubjur2HX22rNZOc6dl1tv5Wp0fd/uhyinVdOz3h484WSEBrv3p0Yurh1XLjNps2iup6q5H3TzDx0WWCIGt9a3qvrfcSnpvFHTGU8wdHSrVDW2pW/HKyQctiQyNIRYWI6LBvLumD22j2tLrjV1wSIa4Xkferb9qjucd27MbxzriTpsJCMhkC0l7P50N72StjYXV0hgbYzBu7rPa40NQW9sA+aPbiWssoSbOPDxfKIdosa+DEye6uiSK/d3MkhRdbPTF2txRMlUSMkNlE0tOFNGU3PFiMGO4bUeVFbEvGgNBdFVRl6p97tyAMUuSGTw6fgAMq6sfXT2G8PG0bWU9T+2Bn81McSKLLAZnKN1jN0eDfG9syEaeILo+0tqsK+63yWRiDzeLaXXtriYPdltYtcOepYdYC8PG3JrMDdcQOOm0bnZ0sFqn2/HEMat++2jf1fT0JO7uIpp3FkeL6IcukObDk+Avpvlg8BCtRseJ7tRmWevEDWQnq4l1I5nLaCLvGjUPPm7a1ioc7DsPwxy3u2q/P9wA1W+bt6ekQw19hnvJXU/KcGvaMzg2/rnVP6zifWsc1h7rMnrY7PtCMzjIE4cs9E3j1B60gtTR7KM6nFUzBw8EpWm1JW8axvGGi/JafdepCb7emI677QSk3X693tChkO3pAg0dzTm0DqtmZEXVuSOlo+xAccO8HZvtkdXUhtwwqObdHphj9SSru7vZNlB6M+PrV+4sF+pY+ZuEMIHhConleNvx3kT3TXUJsgNYiNBNGvtHpm8CTmPhLIAOjKkPwvKfqiUUzYsWN5yN4ZufsMZPz0w7g439zMUggoWk2fYLe+b/S/VkXC+/FPSXgv5S0F8K+v9QUO7Jj4ALn7nz7YVAO2XH3fwlQaFv54WEfuMduAVpSPn7p288zRPI3/MY7qBN+dfnLzzFICYJwpTw9wxbSC8uvrmejSs+uiq7FBL653P5HL+MyfsohJ1XmYZC03dj6PBf+ADmU0A95mI6Wej6W2osCMPGZeYnAvtXrrLUXl9fb952iEs1FQxd9MfJPAF2wCKW2Cemb+VyrBeKSkrblBYqzZgyhB1S8eOrnu01D2RvCYzxLcOS6DjibDqGvuttECYzuE9ZB5Tuv5bYlgHfw8wMJNfccogINKnjx1cRKMl7fgiv+jEEFMp/9PvHMPOyTV0DKcyIUf4Jqg+pDin27atFM8RkoqsHNhJXIYVVgSzp8CrNyCdUiynEW2DDD1EzlNLrCB1GA0STMHWlfIrR5mpfTuKQ9aE8nbMW1zBTkJLPu3uahqFWrIBrgBkEjknZoLwPtGUHlfeQCB0+D3WBmRSEcOFj6qMtMT2AoY7SmF7tkxkkEDozNtIoUuDhA1gafZ6DCellQNkcs/zoatXFwgchGwM2nldTY6Vg+nnIAmVhYPux+wGGkn/AhJJPiCyaL4slSvzT1drmifNPFuIFpiYejNiJMvx4lC7g72vgY9jHi2AJfPpJx6tHaP8d8tdJyUZ6etbWq3HYdgOvzGzuJxH8bekbV2KXHycpfWGH5ohNSibqbCuxAf2NL/FfLr5KcmlZEbFL/nduQxA7yIMwRBl0vjf149JF/l+K33AqP7jJz4J9/ZGEe+W4dyRFCUWW/I9k/H3p6UxYXLxdvEgUbxFsK6vV25Uq+6vdd6rVVvFSImBIUIpt+H2XA7TYNAFbs3G5uKdEuNz4L/8qKT4vc55xPrPCit3yd1BoWKEHEwAA
+      INSTALL_KATA_RPM: "true"
+      KATA_RPM_VERSION: 3.25.0-5.rhaos4.18.el9
       MUST_GATHER_IMAGE: registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel9:latest
-      MUST_GATHER_ON_FAILURE_ONLY: "true"
+      MUST_GATHER_ON_FAILURE_ONLY: "false"
       RUNTIMECLASS: kata-remote
-      SLEEP_DURATION: 0h
+      SLEEP_DURATION: 6h
       TEST_FILTERS: ~DisconnectedOnly&;~Disruptive&
       TEST_RELEASE_TYPE: Pre-GA
       TEST_SCENARIOS: sig-kata.*Kata Author
-      TEST_TIMEOUT: "90"
-      TRUSTEE_URL: ""
+      TEST_TIMEOUT: "120"
+      TRUSTEE_URL: http://kbs-service-trustee-operator-system.apps.tpb.azure.sandboxedcontainers.com
       WORKLOAD_TO_TEST: peer-pods
     workflow: sandboxed-containers-operator-e2e-aws
   timeout: 24h0m0s
@@ -195,7 +195,7 @@ tests:
   capabilities:
   - intranet
   cron: 0 0 31 2 1
-  restrict_network_access: false
+  restrict_network_access: true
   steps:
     cluster_profile: aws-sandboxed-containers-operator
     env:
@@ -204,18 +204,18 @@ tests:
       CATALOG_SOURCE_NAME: brew-catalog
       ENABLE_MUST_GATHER: "true"
       ENABLEPEERPODS: "true"
-      INITDATA: ""
-      INSTALL_KATA_RPM: "false"
-      KATA_RPM_VERSION: ""
+      INITDATA: H4sICMrPymkAA2luaXRkYXRhLnRvbWwA7Vhbc6pIF33nV1i8ZL7KUdR4TdV54KZiREXwllQq1UILyKWxuxHxVP77NJo5kzlzTOZh5ns6pAyy9+q19+7L6kYQugj71ItKX0s88UC92eK5A8TER3FhqlZqlSrPcU8OoOCZ4wGoUBSFPPPd3NxwTxQFMH6xUbz1XfL8w3PFRjZ6Acye4rBg8yhNyL0gBBtSJhAffBuWKU4JhbCMEogBRbhMcvYcVUCSkApNNhVwSjGsEBA7G3SEDuOmwI9Ziow+KlL7a0zG/Z/GsyGmBTfPl4tLUvvauCSrM0vrabJoqWcrp2uaoiiyLG5NV8w0SXTZxxLHkhvsvcDvd7OqJBqkJypipJtGprlrZWEYiiKxFCIn5x5X49No2c0eV0PP6XdzQ1HvxiejMbH02sQSs4Fnj/XdOtNPeqZbNrPNj8uzzWU2rcm9GfPl7ucRPgvAua7q62K1L5v7vqlt7hRDZSnPRbGhSUomZsz/ICJWliEf4rvTLdjB2mPuOXIYHtb2SeI667rXImMPNWTbM6OqoU3SZNheBM1GLRoq8pY0T52Vn6q90ZYx1IAbTkeHeKLcrgPtIItcGw/BIqNdSLDltp2meacKrbroaN18MW+r69EDULubjur2HX22rNZOc6dl1tv5Wp0fd/uhyinVdOz3h484WSEBrv3p0Yurh1XLjNps2iup6q5H3TzDx0WWCIGt9a3qvrfcSnpvFHTGU8wdHSrVDW2pW/HKyQctiQyNIRYWI6LBvLumD22j2tLrjV1wSIa4Xkferb9qjucd27MbxzriTpsJCMhkC0l7P50N72StjYXV0hgbYzBu7rPa40NQW9sA+aPbiWssoSbOPDxfKIdosa+DEye6uiSK/d3MkhRdbPTF2txRMlUSMkNlE0tOFNGU3PFiMGO4bUeVFbEvGgNBdFVRl6p97tyAMUuSGTw6fgAMq6sfXT2G8PG0bWU9T+2Bn81McSKLLAZnKN1jN0eDfG9syEaeILo+0tqsK+63yWRiDzeLaXXtriYPdltYtcOepYdYC8PG3JrMDdcQOOm0bnZ0sFqn2/HEMat++2jf1fT0JO7uIpp3FkeL6IcukObDk+Avpvlg8BCtRseJ7tRmWevEDWQnq4l1I5nLaCLvGjUPPm7a1ioc7DsPwxy3u2q/P9wA1W+bt6ekQw19hnvJXU/KcGvaMzg2/rnVP6zifWsc1h7rMnrY7PtCMzjIE4cs9E3j1B60gtTR7KM6nFUzBw8EpWm1JW8axvGGi/JafdepCb7emI677QSk3X693tChkO3pAg0dzTm0DqtmZEXVuSOlo+xAccO8HZvtkdXUhtwwqObdHphj9SSru7vZNlB6M+PrV+4sF+pY+ZuEMIHhConleNvx3kT3TXUJsgNYiNBNGvtHpm8CTmPhLIAOjKkPwvKfqiUUzYsWN5yN4ZufsMZPz0w7g439zMUggoWk2fYLe+b/S/VkXC+/FPSXgv5S0F8K+v9QUO7Jj4ALn7nz7YVAO2XH3fwlQaFv54WEfuMduAVpSPn7p288zRPI3/MY7qBN+dfnLzzFICYJwpTw9wxbSC8uvrmejSs+uiq7FBL653P5HL+MyfsohJ1XmYZC03dj6PBf+ADmU0A95mI6Wej6W2osCMPGZeYnAvtXrrLUXl9fb952iEs1FQxd9MfJPAF2wCKW2Cemb+VyrBeKSkrblBYqzZgyhB1S8eOrnu01D2RvCYzxLcOS6DjibDqGvuttECYzuE9ZB5Tuv5bYlgHfw8wMJNfccogINKnjx1cRKMl7fgiv+jEEFMp/9PvHMPOyTV0DKcyIUf4Jqg+pDin27atFM8RkoqsHNhJXIYVVgSzp8CrNyCdUiynEW2DDD1EzlNLrCB1GA0STMHWlfIrR5mpfTuKQ9aE8nbMW1zBTkJLPu3uahqFWrIBrgBkEjknZoLwPtGUHlfeQCB0+D3WBmRSEcOFj6qMtMT2AoY7SmF7tkxkkEDozNtIoUuDhA1gafZ6DCellQNkcs/zoatXFwgchGwM2nldTY6Vg+nnIAmVhYPux+wGGkn/AhJJPiCyaL4slSvzT1drmifNPFuIFpiYejNiJMvx4lC7g72vgY9jHi2AJfPpJx6tHaP8d8tdJyUZ6etbWq3HYdgOvzGzuJxH8bekbV2KXHycpfWGH5ohNSibqbCuxAf2NL/FfLr5KcmlZEbFL/nduQxA7yIMwRBl0vjf149JF/l+K33AqP7jJz4J9/ZGEe+W4dyRFCUWW/I9k/H3p6UxYXLxdvEgUbxFsK6vV25Uq+6vdd6rVVvFSImBIUIpt+H2XA7TYNAFbs3G5uKdEuNz4L/8qKT4vc55xPrPCit3yd1BoWKEHEwAA
+      INSTALL_KATA_RPM: "true"
+      KATA_RPM_VERSION: 3.25.0-5.rhaos4.18.el9
       MUST_GATHER_IMAGE: registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel9:latest
-      MUST_GATHER_ON_FAILURE_ONLY: "true"
+      MUST_GATHER_ON_FAILURE_ONLY: "false"
       RUNTIMECLASS: kata-remote
-      SLEEP_DURATION: 0h
+      SLEEP_DURATION: 6h
       TEST_FILTERS: ~DisconnectedOnly&;~Disruptive&
       TEST_RELEASE_TYPE: Pre-GA
       TEST_SCENARIOS: sig-kata.*Kata Author
-      TEST_TIMEOUT: "90"
-      TRUSTEE_URL: ""
+      TEST_TIMEOUT: "120"
+      TRUSTEE_URL: http://kbs-service-trustee-operator-system.apps.tpb.azure.sandboxedcontainers.com
       WORKLOAD_TO_TEST: coco
     workflow: sandboxed-containers-operator-e2e-aws
   timeout: 24h0m0s

--- a/ci-operator/config/openshift/sandboxed-containers-operator/openshift-sandboxed-containers-operator-devel__downstream-candidate420.yaml
+++ b/ci-operator/config/openshift/sandboxed-containers-operator/openshift-sandboxed-containers-operator-devel__downstream-candidate420.yaml
@@ -23,7 +23,7 @@ tests:
   capabilities:
   - intranet
   cron: 0 0 31 2 1
-  restrict_network_access: false
+  restrict_network_access: true
   steps:
     cluster_profile: azure-qe
     env:
@@ -32,24 +32,24 @@ tests:
       CATALOG_SOURCE_NAME: brew-catalog
       CUSTOM_AZURE_REGION: eastus
       ENABLE_MUST_GATHER: "true"
-      INITDATA: ""
-      INSTALL_KATA_RPM: "false"
-      KATA_RPM_VERSION: ""
+      INITDATA: H4sICMrPymkAA2luaXRkYXRhLnRvbWwA7Vhbc6pIF33nV1i8ZL7KUdR4TdV54KZiREXwllQq1UILyKWxuxHxVP77NJo5kzlzTOZh5ns6pAyy9+q19+7L6kYQugj71ItKX0s88UC92eK5A8TER3FhqlZqlSrPcU8OoOCZ4wGoUBSFPPPd3NxwTxQFMH6xUbz1XfL8w3PFRjZ6Acye4rBg8yhNyL0gBBtSJhAffBuWKU4JhbCMEogBRbhMcvYcVUCSkApNNhVwSjGsEBA7G3SEDuOmwI9Ziow+KlL7a0zG/Z/GsyGmBTfPl4tLUvvauCSrM0vrabJoqWcrp2uaoiiyLG5NV8w0SXTZxxLHkhvsvcDvd7OqJBqkJypipJtGprlrZWEYiiKxFCIn5x5X49No2c0eV0PP6XdzQ1HvxiejMbH02sQSs4Fnj/XdOtNPeqZbNrPNj8uzzWU2rcm9GfPl7ucRPgvAua7q62K1L5v7vqlt7hRDZSnPRbGhSUomZsz/ICJWliEf4rvTLdjB2mPuOXIYHtb2SeI667rXImMPNWTbM6OqoU3SZNheBM1GLRoq8pY0T52Vn6q90ZYx1IAbTkeHeKLcrgPtIItcGw/BIqNdSLDltp2meacKrbroaN18MW+r69EDULubjur2HX22rNZOc6dl1tv5Wp0fd/uhyinVdOz3h484WSEBrv3p0Yurh1XLjNps2iup6q5H3TzDx0WWCIGt9a3qvrfcSnpvFHTGU8wdHSrVDW2pW/HKyQctiQyNIRYWI6LBvLumD22j2tLrjV1wSIa4Xkferb9qjucd27MbxzriTpsJCMhkC0l7P50N72StjYXV0hgbYzBu7rPa40NQW9sA+aPbiWssoSbOPDxfKIdosa+DEye6uiSK/d3MkhRdbPTF2txRMlUSMkNlE0tOFNGU3PFiMGO4bUeVFbEvGgNBdFVRl6p97tyAMUuSGTw6fgAMq6sfXT2G8PG0bWU9T+2Bn81McSKLLAZnKN1jN0eDfG9syEaeILo+0tqsK+63yWRiDzeLaXXtriYPdltYtcOepYdYC8PG3JrMDdcQOOm0bnZ0sFqn2/HEMat++2jf1fT0JO7uIpp3FkeL6IcukObDk+Avpvlg8BCtRseJ7tRmWevEDWQnq4l1I5nLaCLvGjUPPm7a1ioc7DsPwxy3u2q/P9wA1W+bt6ekQw19hnvJXU/KcGvaMzg2/rnVP6zifWsc1h7rMnrY7PtCMzjIE4cs9E3j1B60gtTR7KM6nFUzBw8EpWm1JW8axvGGi/JafdepCb7emI677QSk3X693tChkO3pAg0dzTm0DqtmZEXVuSOlo+xAccO8HZvtkdXUhtwwqObdHphj9SSru7vZNlB6M+PrV+4sF+pY+ZuEMIHhConleNvx3kT3TXUJsgNYiNBNGvtHpm8CTmPhLIAOjKkPwvKfqiUUzYsWN5yN4ZufsMZPz0w7g439zMUggoWk2fYLe+b/S/VkXC+/FPSXgv5S0F8K+v9QUO7Jj4ALn7nz7YVAO2XH3fwlQaFv54WEfuMduAVpSPn7p288zRPI3/MY7qBN+dfnLzzFICYJwpTw9wxbSC8uvrmejSs+uiq7FBL653P5HL+MyfsohJ1XmYZC03dj6PBf+ADmU0A95mI6Wej6W2osCMPGZeYnAvtXrrLUXl9fb952iEs1FQxd9MfJPAF2wCKW2Cemb+VyrBeKSkrblBYqzZgyhB1S8eOrnu01D2RvCYzxLcOS6DjibDqGvuttECYzuE9ZB5Tuv5bYlgHfw8wMJNfccogINKnjx1cRKMl7fgiv+jEEFMp/9PvHMPOyTV0DKcyIUf4Jqg+pDin27atFM8RkoqsHNhJXIYVVgSzp8CrNyCdUiynEW2DDD1EzlNLrCB1GA0STMHWlfIrR5mpfTuKQ9aE8nbMW1zBTkJLPu3uahqFWrIBrgBkEjknZoLwPtGUHlfeQCB0+D3WBmRSEcOFj6qMtMT2AoY7SmF7tkxkkEDozNtIoUuDhA1gafZ6DCellQNkcs/zoatXFwgchGwM2nldTY6Vg+nnIAmVhYPux+wGGkn/AhJJPiCyaL4slSvzT1drmifNPFuIFpiYejNiJMvx4lC7g72vgY9jHi2AJfPpJx6tHaP8d8tdJyUZ6etbWq3HYdgOvzGzuJxH8bekbV2KXHycpfWGH5ohNSibqbCuxAf2NL/FfLr5KcmlZEbFL/nduQxA7yIMwRBl0vjf149JF/l+K33AqP7jJz4J9/ZGEe+W4dyRFCUWW/I9k/H3p6UxYXLxdvEgUbxFsK6vV25Uq+6vdd6rVVvFSImBIUIpt+H2XA7TYNAFbs3G5uKdEuNz4L/8qKT4vc55xPrPCit3yd1BoWKEHEwAA
+      INSTALL_KATA_RPM: "true"
+      KATA_RPM_VERSION: 3.25.0-5.rhaos4.20.el9
       MUST_GATHER_IMAGE: registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel9:latest
-      MUST_GATHER_ON_FAILURE_ONLY: "true"
-      SLEEP_DURATION: 0h
+      MUST_GATHER_ON_FAILURE_ONLY: "false"
+      SLEEP_DURATION: 6h
       TEST_FILTERS: ~DisconnectedOnly&;~Disruptive&
       TEST_RELEASE_TYPE: Pre-GA
       TEST_SCENARIOS: sig-kata.*Kata Author
-      TEST_TIMEOUT: "90"
-      TRUSTEE_URL: ""
+      TEST_TIMEOUT: "120"
+      TRUSTEE_URL: http://kbs-service-trustee-operator-system.apps.tpb.azure.sandboxedcontainers.com
     workflow: sandboxed-containers-operator-e2e-azure
   timeout: 24h0m0s
 - as: azure-ipi-peerpods
   capabilities:
   - intranet
   cron: 0 0 31 2 1
-  restrict_network_access: false
+  restrict_network_access: true
   steps:
     cluster_profile: azure-qe
     env:
@@ -59,18 +59,18 @@ tests:
       CUSTOM_AZURE_REGION: eastus
       ENABLE_MUST_GATHER: "true"
       ENABLEPEERPODS: "true"
-      INITDATA: ""
-      INSTALL_KATA_RPM: "false"
-      KATA_RPM_VERSION: ""
+      INITDATA: H4sICMrPymkAA2luaXRkYXRhLnRvbWwA7Vhbc6pIF33nV1i8ZL7KUdR4TdV54KZiREXwllQq1UILyKWxuxHxVP77NJo5kzlzTOZh5ns6pAyy9+q19+7L6kYQugj71ItKX0s88UC92eK5A8TER3FhqlZqlSrPcU8OoOCZ4wGoUBSFPPPd3NxwTxQFMH6xUbz1XfL8w3PFRjZ6Acye4rBg8yhNyL0gBBtSJhAffBuWKU4JhbCMEogBRbhMcvYcVUCSkApNNhVwSjGsEBA7G3SEDuOmwI9Ziow+KlL7a0zG/Z/GsyGmBTfPl4tLUvvauCSrM0vrabJoqWcrp2uaoiiyLG5NV8w0SXTZxxLHkhvsvcDvd7OqJBqkJypipJtGprlrZWEYiiKxFCIn5x5X49No2c0eV0PP6XdzQ1HvxiejMbH02sQSs4Fnj/XdOtNPeqZbNrPNj8uzzWU2rcm9GfPl7ucRPgvAua7q62K1L5v7vqlt7hRDZSnPRbGhSUomZsz/ICJWliEf4rvTLdjB2mPuOXIYHtb2SeI667rXImMPNWTbM6OqoU3SZNheBM1GLRoq8pY0T52Vn6q90ZYx1IAbTkeHeKLcrgPtIItcGw/BIqNdSLDltp2meacKrbroaN18MW+r69EDULubjur2HX22rNZOc6dl1tv5Wp0fd/uhyinVdOz3h484WSEBrv3p0Yurh1XLjNps2iup6q5H3TzDx0WWCIGt9a3qvrfcSnpvFHTGU8wdHSrVDW2pW/HKyQctiQyNIRYWI6LBvLumD22j2tLrjV1wSIa4Xkferb9qjucd27MbxzriTpsJCMhkC0l7P50N72StjYXV0hgbYzBu7rPa40NQW9sA+aPbiWssoSbOPDxfKIdosa+DEye6uiSK/d3MkhRdbPTF2txRMlUSMkNlE0tOFNGU3PFiMGO4bUeVFbEvGgNBdFVRl6p97tyAMUuSGTw6fgAMq6sfXT2G8PG0bWU9T+2Bn81McSKLLAZnKN1jN0eDfG9syEaeILo+0tqsK+63yWRiDzeLaXXtriYPdltYtcOepYdYC8PG3JrMDdcQOOm0bnZ0sFqn2/HEMat++2jf1fT0JO7uIpp3FkeL6IcukObDk+Avpvlg8BCtRseJ7tRmWevEDWQnq4l1I5nLaCLvGjUPPm7a1ioc7DsPwxy3u2q/P9wA1W+bt6ekQw19hnvJXU/KcGvaMzg2/rnVP6zifWsc1h7rMnrY7PtCMzjIE4cs9E3j1B60gtTR7KM6nFUzBw8EpWm1JW8axvGGi/JafdepCb7emI677QSk3X693tChkO3pAg0dzTm0DqtmZEXVuSOlo+xAccO8HZvtkdXUhtwwqObdHphj9SSru7vZNlB6M+PrV+4sF+pY+ZuEMIHhConleNvx3kT3TXUJsgNYiNBNGvtHpm8CTmPhLIAOjKkPwvKfqiUUzYsWN5yN4ZufsMZPz0w7g439zMUggoWk2fYLe+b/S/VkXC+/FPSXgv5S0F8K+v9QUO7Jj4ALn7nz7YVAO2XH3fwlQaFv54WEfuMduAVpSPn7p288zRPI3/MY7qBN+dfnLzzFICYJwpTw9wxbSC8uvrmejSs+uiq7FBL653P5HL+MyfsohJ1XmYZC03dj6PBf+ADmU0A95mI6Wej6W2osCMPGZeYnAvtXrrLUXl9fb952iEs1FQxd9MfJPAF2wCKW2Cemb+VyrBeKSkrblBYqzZgyhB1S8eOrnu01D2RvCYzxLcOS6DjibDqGvuttECYzuE9ZB5Tuv5bYlgHfw8wMJNfccogINKnjx1cRKMl7fgiv+jEEFMp/9PvHMPOyTV0DKcyIUf4Jqg+pDin27atFM8RkoqsHNhJXIYVVgSzp8CrNyCdUiynEW2DDD1EzlNLrCB1GA0STMHWlfIrR5mpfTuKQ9aE8nbMW1zBTkJLPu3uahqFWrIBrgBkEjknZoLwPtGUHlfeQCB0+D3WBmRSEcOFj6qMtMT2AoY7SmF7tkxkkEDozNtIoUuDhA1gafZ6DCellQNkcs/zoatXFwgchGwM2nldTY6Vg+nnIAmVhYPux+wGGkn/AhJJPiCyaL4slSvzT1drmifNPFuIFpiYejNiJMvx4lC7g72vgY9jHi2AJfPpJx6tHaP8d8tdJyUZ6etbWq3HYdgOvzGzuJxH8bekbV2KXHycpfWGH5ohNSibqbCuxAf2NL/FfLr5KcmlZEbFL/nduQxA7yIMwRBl0vjf149JF/l+K33AqP7jJz4J9/ZGEe+W4dyRFCUWW/I9k/H3p6UxYXLxdvEgUbxFsK6vV25Uq+6vdd6rVVvFSImBIUIpt+H2XA7TYNAFbs3G5uKdEuNz4L/8qKT4vc55xPrPCit3yd1BoWKEHEwAA
+      INSTALL_KATA_RPM: "true"
+      KATA_RPM_VERSION: 3.25.0-5.rhaos4.20.el9
       MUST_GATHER_IMAGE: registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel9:latest
-      MUST_GATHER_ON_FAILURE_ONLY: "true"
+      MUST_GATHER_ON_FAILURE_ONLY: "false"
       RUNTIMECLASS: kata-remote
-      SLEEP_DURATION: 0h
+      SLEEP_DURATION: 6h
       TEST_FILTERS: ~DisconnectedOnly&;~Disruptive&
       TEST_RELEASE_TYPE: Pre-GA
       TEST_SCENARIOS: sig-kata.*Kata Author
-      TEST_TIMEOUT: "90"
-      TRUSTEE_URL: ""
+      TEST_TIMEOUT: "120"
+      TRUSTEE_URL: http://kbs-service-trustee-operator-system.apps.tpb.azure.sandboxedcontainers.com
       WORKLOAD_TO_TEST: peer-pods
     workflow: sandboxed-containers-operator-e2e-azure
   timeout: 24h0m0s
@@ -78,7 +78,7 @@ tests:
   capabilities:
   - intranet
   cron: 0 0 31 2 1
-  restrict_network_access: false
+  restrict_network_access: true
   steps:
     cluster_profile: azure-qe
     env:
@@ -88,18 +88,18 @@ tests:
       CUSTOM_AZURE_REGION: eastus
       ENABLE_MUST_GATHER: "true"
       ENABLEPEERPODS: "true"
-      INITDATA: ""
-      INSTALL_KATA_RPM: "false"
-      KATA_RPM_VERSION: ""
+      INITDATA: H4sICMrPymkAA2luaXRkYXRhLnRvbWwA7Vhbc6pIF33nV1i8ZL7KUdR4TdV54KZiREXwllQq1UILyKWxuxHxVP77NJo5kzlzTOZh5ns6pAyy9+q19+7L6kYQugj71ItKX0s88UC92eK5A8TER3FhqlZqlSrPcU8OoOCZ4wGoUBSFPPPd3NxwTxQFMH6xUbz1XfL8w3PFRjZ6Acye4rBg8yhNyL0gBBtSJhAffBuWKU4JhbCMEogBRbhMcvYcVUCSkApNNhVwSjGsEBA7G3SEDuOmwI9Ziow+KlL7a0zG/Z/GsyGmBTfPl4tLUvvauCSrM0vrabJoqWcrp2uaoiiyLG5NV8w0SXTZxxLHkhvsvcDvd7OqJBqkJypipJtGprlrZWEYiiKxFCIn5x5X49No2c0eV0PP6XdzQ1HvxiejMbH02sQSs4Fnj/XdOtNPeqZbNrPNj8uzzWU2rcm9GfPl7ucRPgvAua7q62K1L5v7vqlt7hRDZSnPRbGhSUomZsz/ICJWliEf4rvTLdjB2mPuOXIYHtb2SeI667rXImMPNWTbM6OqoU3SZNheBM1GLRoq8pY0T52Vn6q90ZYx1IAbTkeHeKLcrgPtIItcGw/BIqNdSLDltp2meacKrbroaN18MW+r69EDULubjur2HX22rNZOc6dl1tv5Wp0fd/uhyinVdOz3h484WSEBrv3p0Yurh1XLjNps2iup6q5H3TzDx0WWCIGt9a3qvrfcSnpvFHTGU8wdHSrVDW2pW/HKyQctiQyNIRYWI6LBvLumD22j2tLrjV1wSIa4Xkferb9qjucd27MbxzriTpsJCMhkC0l7P50N72StjYXV0hgbYzBu7rPa40NQW9sA+aPbiWssoSbOPDxfKIdosa+DEye6uiSK/d3MkhRdbPTF2txRMlUSMkNlE0tOFNGU3PFiMGO4bUeVFbEvGgNBdFVRl6p97tyAMUuSGTw6fgAMq6sfXT2G8PG0bWU9T+2Bn81McSKLLAZnKN1jN0eDfG9syEaeILo+0tqsK+63yWRiDzeLaXXtriYPdltYtcOepYdYC8PG3JrMDdcQOOm0bnZ0sFqn2/HEMat++2jf1fT0JO7uIpp3FkeL6IcukObDk+Avpvlg8BCtRseJ7tRmWevEDWQnq4l1I5nLaCLvGjUPPm7a1ioc7DsPwxy3u2q/P9wA1W+bt6ekQw19hnvJXU/KcGvaMzg2/rnVP6zifWsc1h7rMnrY7PtCMzjIE4cs9E3j1B60gtTR7KM6nFUzBw8EpWm1JW8axvGGi/JafdepCb7emI677QSk3X693tChkO3pAg0dzTm0DqtmZEXVuSOlo+xAccO8HZvtkdXUhtwwqObdHphj9SSru7vZNlB6M+PrV+4sF+pY+ZuEMIHhConleNvx3kT3TXUJsgNYiNBNGvtHpm8CTmPhLIAOjKkPwvKfqiUUzYsWN5yN4ZufsMZPz0w7g439zMUggoWk2fYLe+b/S/VkXC+/FPSXgv5S0F8K+v9QUO7Jj4ALn7nz7YVAO2XH3fwlQaFv54WEfuMduAVpSPn7p288zRPI3/MY7qBN+dfnLzzFICYJwpTw9wxbSC8uvrmejSs+uiq7FBL653P5HL+MyfsohJ1XmYZC03dj6PBf+ADmU0A95mI6Wej6W2osCMPGZeYnAvtXrrLUXl9fb952iEs1FQxd9MfJPAF2wCKW2Cemb+VyrBeKSkrblBYqzZgyhB1S8eOrnu01D2RvCYzxLcOS6DjibDqGvuttECYzuE9ZB5Tuv5bYlgHfw8wMJNfccogINKnjx1cRKMl7fgiv+jEEFMp/9PvHMPOyTV0DKcyIUf4Jqg+pDin27atFM8RkoqsHNhJXIYVVgSzp8CrNyCdUiynEW2DDD1EzlNLrCB1GA0STMHWlfIrR5mpfTuKQ9aE8nbMW1zBTkJLPu3uahqFWrIBrgBkEjknZoLwPtGUHlfeQCB0+D3WBmRSEcOFj6qMtMT2AoY7SmF7tkxkkEDozNtIoUuDhA1gafZ6DCellQNkcs/zoatXFwgchGwM2nldTY6Vg+nnIAmVhYPux+wGGkn/AhJJPiCyaL4slSvzT1drmifNPFuIFpiYejNiJMvx4lC7g72vgY9jHi2AJfPpJx6tHaP8d8tdJyUZ6etbWq3HYdgOvzGzuJxH8bekbV2KXHycpfWGH5ohNSibqbCuxAf2NL/FfLr5KcmlZEbFL/nduQxA7yIMwRBl0vjf149JF/l+K33AqP7jJz4J9/ZGEe+W4dyRFCUWW/I9k/H3p6UxYXLxdvEgUbxFsK6vV25Uq+6vdd6rVVvFSImBIUIpt+H2XA7TYNAFbs3G5uKdEuNz4L/8qKT4vc55xPrPCit3yd1BoWKEHEwAA
+      INSTALL_KATA_RPM: "true"
+      KATA_RPM_VERSION: 3.25.0-5.rhaos4.20.el9
       MUST_GATHER_IMAGE: registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel9:latest
-      MUST_GATHER_ON_FAILURE_ONLY: "true"
+      MUST_GATHER_ON_FAILURE_ONLY: "false"
       RUNTIMECLASS: kata-remote
-      SLEEP_DURATION: 0h
+      SLEEP_DURATION: 6h
       TEST_FILTERS: ~DisconnectedOnly&;~Disruptive&
       TEST_RELEASE_TYPE: Pre-GA
       TEST_SCENARIOS: sig-kata.*Kata Author
-      TEST_TIMEOUT: "90"
-      TRUSTEE_URL: ""
+      TEST_TIMEOUT: "120"
+      TRUSTEE_URL: http://kbs-service-trustee-operator-system.apps.tpb.azure.sandboxedcontainers.com
       WORKLOAD_TO_TEST: coco
     workflow: sandboxed-containers-operator-e2e-azure
   timeout: 24h0m0s
@@ -107,7 +107,7 @@ tests:
   capabilities:
   - intranet
   cron: 0 0 31 2 1
-  restrict_network_access: false
+  restrict_network_access: true
   steps:
     cluster_profile: azure-qe
     env:
@@ -117,19 +117,19 @@ tests:
       ENABLE_MUST_GATHER: "true"
       ENABLEPEERPODS: "true"
       HYPERSHIFT_AZURE_LOCATION: eastus
-      INITDATA: ""
-      INSTALL_KATA_RPM: "false"
-      KATA_RPM_VERSION: ""
+      INITDATA: H4sICMrPymkAA2luaXRkYXRhLnRvbWwA7Vhbc6pIF33nV1i8ZL7KUdR4TdV54KZiREXwllQq1UILyKWxuxHxVP77NJo5kzlzTOZh5ns6pAyy9+q19+7L6kYQugj71ItKX0s88UC92eK5A8TER3FhqlZqlSrPcU8OoOCZ4wGoUBSFPPPd3NxwTxQFMH6xUbz1XfL8w3PFRjZ6Acye4rBg8yhNyL0gBBtSJhAffBuWKU4JhbCMEogBRbhMcvYcVUCSkApNNhVwSjGsEBA7G3SEDuOmwI9Ziow+KlL7a0zG/Z/GsyGmBTfPl4tLUvvauCSrM0vrabJoqWcrp2uaoiiyLG5NV8w0SXTZxxLHkhvsvcDvd7OqJBqkJypipJtGprlrZWEYiiKxFCIn5x5X49No2c0eV0PP6XdzQ1HvxiejMbH02sQSs4Fnj/XdOtNPeqZbNrPNj8uzzWU2rcm9GfPl7ucRPgvAua7q62K1L5v7vqlt7hRDZSnPRbGhSUomZsz/ICJWliEf4rvTLdjB2mPuOXIYHtb2SeI667rXImMPNWTbM6OqoU3SZNheBM1GLRoq8pY0T52Vn6q90ZYx1IAbTkeHeKLcrgPtIItcGw/BIqNdSLDltp2meacKrbroaN18MW+r69EDULubjur2HX22rNZOc6dl1tv5Wp0fd/uhyinVdOz3h484WSEBrv3p0Yurh1XLjNps2iup6q5H3TzDx0WWCIGt9a3qvrfcSnpvFHTGU8wdHSrVDW2pW/HKyQctiQyNIRYWI6LBvLumD22j2tLrjV1wSIa4Xkferb9qjucd27MbxzriTpsJCMhkC0l7P50N72StjYXV0hgbYzBu7rPa40NQW9sA+aPbiWssoSbOPDxfKIdosa+DEye6uiSK/d3MkhRdbPTF2txRMlUSMkNlE0tOFNGU3PFiMGO4bUeVFbEvGgNBdFVRl6p97tyAMUuSGTw6fgAMq6sfXT2G8PG0bWU9T+2Bn81McSKLLAZnKN1jN0eDfG9syEaeILo+0tqsK+63yWRiDzeLaXXtriYPdltYtcOepYdYC8PG3JrMDdcQOOm0bnZ0sFqn2/HEMat++2jf1fT0JO7uIpp3FkeL6IcukObDk+Avpvlg8BCtRseJ7tRmWevEDWQnq4l1I5nLaCLvGjUPPm7a1ioc7DsPwxy3u2q/P9wA1W+bt6ekQw19hnvJXU/KcGvaMzg2/rnVP6zifWsc1h7rMnrY7PtCMzjIE4cs9E3j1B60gtTR7KM6nFUzBw8EpWm1JW8axvGGi/JafdepCb7emI677QSk3X693tChkO3pAg0dzTm0DqtmZEXVuSOlo+xAccO8HZvtkdXUhtwwqObdHphj9SSru7vZNlB6M+PrV+4sF+pY+ZuEMIHhConleNvx3kT3TXUJsgNYiNBNGvtHpm8CTmPhLIAOjKkPwvKfqiUUzYsWN5yN4ZufsMZPz0w7g439zMUggoWk2fYLe+b/S/VkXC+/FPSXgv5S0F8K+v9QUO7Jj4ALn7nz7YVAO2XH3fwlQaFv54WEfuMduAVpSPn7p288zRPI3/MY7qBN+dfnLzzFICYJwpTw9wxbSC8uvrmejSs+uiq7FBL653P5HL+MyfsohJ1XmYZC03dj6PBf+ADmU0A95mI6Wej6W2osCMPGZeYnAvtXrrLUXl9fb952iEs1FQxd9MfJPAF2wCKW2Cemb+VyrBeKSkrblBYqzZgyhB1S8eOrnu01D2RvCYzxLcOS6DjibDqGvuttECYzuE9ZB5Tuv5bYlgHfw8wMJNfccogINKnjx1cRKMl7fgiv+jEEFMp/9PvHMPOyTV0DKcyIUf4Jqg+pDin27atFM8RkoqsHNhJXIYVVgSzp8CrNyCdUiynEW2DDD1EzlNLrCB1GA0STMHWlfIrR5mpfTuKQ9aE8nbMW1zBTkJLPu3uahqFWrIBrgBkEjknZoLwPtGUHlfeQCB0+D3WBmRSEcOFj6qMtMT2AoY7SmF7tkxkkEDozNtIoUuDhA1gafZ6DCellQNkcs/zoatXFwgchGwM2nldTY6Vg+nnIAmVhYPux+wGGkn/AhJJPiCyaL4slSvzT1drmifNPFuIFpiYejNiJMvx4lC7g72vgY9jHi2AJfPpJx6tHaP8d8tdJyUZ6etbWq3HYdgOvzGzuJxH8bekbV2KXHycpfWGH5ohNSibqbCuxAf2NL/FfLr5KcmlZEbFL/nduQxA7yIMwRBl0vjf149JF/l+K33AqP7jJz4J9/ZGEe+W4dyRFCUWW/I9k/H3p6UxYXLxdvEgUbxFsK6vV25Uq+6vdd6rVVvFSImBIUIpt+H2XA7TYNAFbs3G5uKdEuNz4L/8qKT4vc55xPrPCit3yd1BoWKEHEwAA
+      INSTALL_KATA_RPM: "true"
+      KATA_RPM_VERSION: 3.25.0-5.rhaos4.17.el9
       LOCATION: eastus
       MUST_GATHER_IMAGE: registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel9:latest
-      MUST_GATHER_ON_FAILURE_ONLY: "true"
+      MUST_GATHER_ON_FAILURE_ONLY: "false"
       RUNTIMECLASS: kata-remote
-      SLEEP_DURATION: 0h
+      SLEEP_DURATION: 6h
       TEST_FILTERS: ~DisconnectedOnly&;~Disruptive&
       TEST_RELEASE_TYPE: Pre-GA
       TEST_SCENARIOS: sig-kata.*Kata Author
-      TEST_TIMEOUT: "90"
-      TRUSTEE_URL: ""
+      TEST_TIMEOUT: "120"
+      TRUSTEE_URL: http://kbs-service-trustee-operator-system.apps.tpb.azure.sandboxedcontainers.com
       WORKLOAD_TO_TEST: peer-pods
     workflow: sandboxed-containers-operator-e2e-aro
   timeout: 24h0m0s
@@ -137,7 +137,7 @@ tests:
   capabilities:
   - intranet
   cron: 0 0 31 2 1
-  restrict_network_access: false
+  restrict_network_access: true
   steps:
     cluster_profile: azure-qe
     env:
@@ -147,19 +147,19 @@ tests:
       ENABLE_MUST_GATHER: "true"
       ENABLEPEERPODS: "true"
       HYPERSHIFT_AZURE_LOCATION: eastus
-      INITDATA: ""
-      INSTALL_KATA_RPM: "false"
-      KATA_RPM_VERSION: ""
+      INITDATA: H4sICMrPymkAA2luaXRkYXRhLnRvbWwA7Vhbc6pIF33nV1i8ZL7KUdR4TdV54KZiREXwllQq1UILyKWxuxHxVP77NJo5kzlzTOZh5ns6pAyy9+q19+7L6kYQugj71ItKX0s88UC92eK5A8TER3FhqlZqlSrPcU8OoOCZ4wGoUBSFPPPd3NxwTxQFMH6xUbz1XfL8w3PFRjZ6Acye4rBg8yhNyL0gBBtSJhAffBuWKU4JhbCMEogBRbhMcvYcVUCSkApNNhVwSjGsEBA7G3SEDuOmwI9Ziow+KlL7a0zG/Z/GsyGmBTfPl4tLUvvauCSrM0vrabJoqWcrp2uaoiiyLG5NV8w0SXTZxxLHkhvsvcDvd7OqJBqkJypipJtGprlrZWEYiiKxFCIn5x5X49No2c0eV0PP6XdzQ1HvxiejMbH02sQSs4Fnj/XdOtNPeqZbNrPNj8uzzWU2rcm9GfPl7ucRPgvAua7q62K1L5v7vqlt7hRDZSnPRbGhSUomZsz/ICJWliEf4rvTLdjB2mPuOXIYHtb2SeI667rXImMPNWTbM6OqoU3SZNheBM1GLRoq8pY0T52Vn6q90ZYx1IAbTkeHeKLcrgPtIItcGw/BIqNdSLDltp2meacKrbroaN18MW+r69EDULubjur2HX22rNZOc6dl1tv5Wp0fd/uhyinVdOz3h484WSEBrv3p0Yurh1XLjNps2iup6q5H3TzDx0WWCIGt9a3qvrfcSnpvFHTGU8wdHSrVDW2pW/HKyQctiQyNIRYWI6LBvLumD22j2tLrjV1wSIa4Xkferb9qjucd27MbxzriTpsJCMhkC0l7P50N72StjYXV0hgbYzBu7rPa40NQW9sA+aPbiWssoSbOPDxfKIdosa+DEye6uiSK/d3MkhRdbPTF2txRMlUSMkNlE0tOFNGU3PFiMGO4bUeVFbEvGgNBdFVRl6p97tyAMUuSGTw6fgAMq6sfXT2G8PG0bWU9T+2Bn81McSKLLAZnKN1jN0eDfG9syEaeILo+0tqsK+63yWRiDzeLaXXtriYPdltYtcOepYdYC8PG3JrMDdcQOOm0bnZ0sFqn2/HEMat++2jf1fT0JO7uIpp3FkeL6IcukObDk+Avpvlg8BCtRseJ7tRmWevEDWQnq4l1I5nLaCLvGjUPPm7a1ioc7DsPwxy3u2q/P9wA1W+bt6ekQw19hnvJXU/KcGvaMzg2/rnVP6zifWsc1h7rMnrY7PtCMzjIE4cs9E3j1B60gtTR7KM6nFUzBw8EpWm1JW8axvGGi/JafdepCb7emI677QSk3X693tChkO3pAg0dzTm0DqtmZEXVuSOlo+xAccO8HZvtkdXUhtwwqObdHphj9SSru7vZNlB6M+PrV+4sF+pY+ZuEMIHhConleNvx3kT3TXUJsgNYiNBNGvtHpm8CTmPhLIAOjKkPwvKfqiUUzYsWN5yN4ZufsMZPz0w7g439zMUggoWk2fYLe+b/S/VkXC+/FPSXgv5S0F8K+v9QUO7Jj4ALn7nz7YVAO2XH3fwlQaFv54WEfuMduAVpSPn7p288zRPI3/MY7qBN+dfnLzzFICYJwpTw9wxbSC8uvrmejSs+uiq7FBL653P5HL+MyfsohJ1XmYZC03dj6PBf+ADmU0A95mI6Wej6W2osCMPGZeYnAvtXrrLUXl9fb952iEs1FQxd9MfJPAF2wCKW2Cemb+VyrBeKSkrblBYqzZgyhB1S8eOrnu01D2RvCYzxLcOS6DjibDqGvuttECYzuE9ZB5Tuv5bYlgHfw8wMJNfccogINKnjx1cRKMl7fgiv+jEEFMp/9PvHMPOyTV0DKcyIUf4Jqg+pDin27atFM8RkoqsHNhJXIYVVgSzp8CrNyCdUiynEW2DDD1EzlNLrCB1GA0STMHWlfIrR5mpfTuKQ9aE8nbMW1zBTkJLPu3uahqFWrIBrgBkEjknZoLwPtGUHlfeQCB0+D3WBmRSEcOFj6qMtMT2AoY7SmF7tkxkkEDozNtIoUuDhA1gafZ6DCellQNkcs/zoatXFwgchGwM2nldTY6Vg+nnIAmVhYPux+wGGkn/AhJJPiCyaL4slSvzT1drmifNPFuIFpiYejNiJMvx4lC7g72vgY9jHi2AJfPpJx6tHaP8d8tdJyUZ6etbWq3HYdgOvzGzuJxH8bekbV2KXHycpfWGH5ohNSibqbCuxAf2NL/FfLr5KcmlZEbFL/nduQxA7yIMwRBl0vjf149JF/l+K33AqP7jJz4J9/ZGEe+W4dyRFCUWW/I9k/H3p6UxYXLxdvEgUbxFsK6vV25Uq+6vdd6rVVvFSImBIUIpt+H2XA7TYNAFbs3G5uKdEuNz4L/8qKT4vc55xPrPCit3yd1BoWKEHEwAA
+      INSTALL_KATA_RPM: "true"
+      KATA_RPM_VERSION: 3.25.0-5.rhaos4.17.el9
       LOCATION: eastus
       MUST_GATHER_IMAGE: registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel9:latest
-      MUST_GATHER_ON_FAILURE_ONLY: "true"
+      MUST_GATHER_ON_FAILURE_ONLY: "false"
       RUNTIMECLASS: kata-remote
-      SLEEP_DURATION: 0h
+      SLEEP_DURATION: 6h
       TEST_FILTERS: ~DisconnectedOnly&;~Disruptive&
       TEST_RELEASE_TYPE: Pre-GA
       TEST_SCENARIOS: sig-kata.*Kata Author
-      TEST_TIMEOUT: "90"
-      TRUSTEE_URL: ""
+      TEST_TIMEOUT: "120"
+      TRUSTEE_URL: http://kbs-service-trustee-operator-system.apps.tpb.azure.sandboxedcontainers.com
       WORKLOAD_TO_TEST: coco
     workflow: sandboxed-containers-operator-e2e-aro
   timeout: 24h0m0s
@@ -167,7 +167,7 @@ tests:
   capabilities:
   - intranet
   cron: 0 0 31 2 1
-  restrict_network_access: false
+  restrict_network_access: true
   steps:
     cluster_profile: aws-sandboxed-containers-operator
     env:
@@ -176,18 +176,18 @@ tests:
       CATALOG_SOURCE_NAME: brew-catalog
       ENABLE_MUST_GATHER: "true"
       ENABLEPEERPODS: "true"
-      INITDATA: ""
-      INSTALL_KATA_RPM: "false"
-      KATA_RPM_VERSION: ""
+      INITDATA: H4sICMrPymkAA2luaXRkYXRhLnRvbWwA7Vhbc6pIF33nV1i8ZL7KUdR4TdV54KZiREXwllQq1UILyKWxuxHxVP77NJo5kzlzTOZh5ns6pAyy9+q19+7L6kYQugj71ItKX0s88UC92eK5A8TER3FhqlZqlSrPcU8OoOCZ4wGoUBSFPPPd3NxwTxQFMH6xUbz1XfL8w3PFRjZ6Acye4rBg8yhNyL0gBBtSJhAffBuWKU4JhbCMEogBRbhMcvYcVUCSkApNNhVwSjGsEBA7G3SEDuOmwI9Ziow+KlL7a0zG/Z/GsyGmBTfPl4tLUvvauCSrM0vrabJoqWcrp2uaoiiyLG5NV8w0SXTZxxLHkhvsvcDvd7OqJBqkJypipJtGprlrZWEYiiKxFCIn5x5X49No2c0eV0PP6XdzQ1HvxiejMbH02sQSs4Fnj/XdOtNPeqZbNrPNj8uzzWU2rcm9GfPl7ucRPgvAua7q62K1L5v7vqlt7hRDZSnPRbGhSUomZsz/ICJWliEf4rvTLdjB2mPuOXIYHtb2SeI667rXImMPNWTbM6OqoU3SZNheBM1GLRoq8pY0T52Vn6q90ZYx1IAbTkeHeKLcrgPtIItcGw/BIqNdSLDltp2meacKrbroaN18MW+r69EDULubjur2HX22rNZOc6dl1tv5Wp0fd/uhyinVdOz3h484WSEBrv3p0Yurh1XLjNps2iup6q5H3TzDx0WWCIGt9a3qvrfcSnpvFHTGU8wdHSrVDW2pW/HKyQctiQyNIRYWI6LBvLumD22j2tLrjV1wSIa4Xkferb9qjucd27MbxzriTpsJCMhkC0l7P50N72StjYXV0hgbYzBu7rPa40NQW9sA+aPbiWssoSbOPDxfKIdosa+DEye6uiSK/d3MkhRdbPTF2txRMlUSMkNlE0tOFNGU3PFiMGO4bUeVFbEvGgNBdFVRl6p97tyAMUuSGTw6fgAMq6sfXT2G8PG0bWU9T+2Bn81McSKLLAZnKN1jN0eDfG9syEaeILo+0tqsK+63yWRiDzeLaXXtriYPdltYtcOepYdYC8PG3JrMDdcQOOm0bnZ0sFqn2/HEMat++2jf1fT0JO7uIpp3FkeL6IcukObDk+Avpvlg8BCtRseJ7tRmWevEDWQnq4l1I5nLaCLvGjUPPm7a1ioc7DsPwxy3u2q/P9wA1W+bt6ekQw19hnvJXU/KcGvaMzg2/rnVP6zifWsc1h7rMnrY7PtCMzjIE4cs9E3j1B60gtTR7KM6nFUzBw8EpWm1JW8axvGGi/JafdepCb7emI677QSk3X693tChkO3pAg0dzTm0DqtmZEXVuSOlo+xAccO8HZvtkdXUhtwwqObdHphj9SSru7vZNlB6M+PrV+4sF+pY+ZuEMIHhConleNvx3kT3TXUJsgNYiNBNGvtHpm8CTmPhLIAOjKkPwvKfqiUUzYsWN5yN4ZufsMZPz0w7g439zMUggoWk2fYLe+b/S/VkXC+/FPSXgv5S0F8K+v9QUO7Jj4ALn7nz7YVAO2XH3fwlQaFv54WEfuMduAVpSPn7p288zRPI3/MY7qBN+dfnLzzFICYJwpTw9wxbSC8uvrmejSs+uiq7FBL653P5HL+MyfsohJ1XmYZC03dj6PBf+ADmU0A95mI6Wej6W2osCMPGZeYnAvtXrrLUXl9fb952iEs1FQxd9MfJPAF2wCKW2Cemb+VyrBeKSkrblBYqzZgyhB1S8eOrnu01D2RvCYzxLcOS6DjibDqGvuttECYzuE9ZB5Tuv5bYlgHfw8wMJNfccogINKnjx1cRKMl7fgiv+jEEFMp/9PvHMPOyTV0DKcyIUf4Jqg+pDin27atFM8RkoqsHNhJXIYVVgSzp8CrNyCdUiynEW2DDD1EzlNLrCB1GA0STMHWlfIrR5mpfTuKQ9aE8nbMW1zBTkJLPu3uahqFWrIBrgBkEjknZoLwPtGUHlfeQCB0+D3WBmRSEcOFj6qMtMT2AoY7SmF7tkxkkEDozNtIoUuDhA1gafZ6DCellQNkcs/zoatXFwgchGwM2nldTY6Vg+nnIAmVhYPux+wGGkn/AhJJPiCyaL4slSvzT1drmifNPFuIFpiYejNiJMvx4lC7g72vgY9jHi2AJfPpJx6tHaP8d8tdJyUZ6etbWq3HYdgOvzGzuJxH8bekbV2KXHycpfWGH5ohNSibqbCuxAf2NL/FfLr5KcmlZEbFL/nduQxA7yIMwRBl0vjf149JF/l+K33AqP7jJz4J9/ZGEe+W4dyRFCUWW/I9k/H3p6UxYXLxdvEgUbxFsK6vV25Uq+6vdd6rVVvFSImBIUIpt+H2XA7TYNAFbs3G5uKdEuNz4L/8qKT4vc55xPrPCit3yd1BoWKEHEwAA
+      INSTALL_KATA_RPM: "true"
+      KATA_RPM_VERSION: 3.25.0-5.rhaos4.20.el9
       MUST_GATHER_IMAGE: registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel9:latest
-      MUST_GATHER_ON_FAILURE_ONLY: "true"
+      MUST_GATHER_ON_FAILURE_ONLY: "false"
       RUNTIMECLASS: kata-remote
-      SLEEP_DURATION: 0h
+      SLEEP_DURATION: 6h
       TEST_FILTERS: ~DisconnectedOnly&;~Disruptive&
       TEST_RELEASE_TYPE: Pre-GA
       TEST_SCENARIOS: sig-kata.*Kata Author
-      TEST_TIMEOUT: "90"
-      TRUSTEE_URL: ""
+      TEST_TIMEOUT: "120"
+      TRUSTEE_URL: http://kbs-service-trustee-operator-system.apps.tpb.azure.sandboxedcontainers.com
       WORKLOAD_TO_TEST: peer-pods
     workflow: sandboxed-containers-operator-e2e-aws
   timeout: 24h0m0s
@@ -195,7 +195,7 @@ tests:
   capabilities:
   - intranet
   cron: 0 0 31 2 1
-  restrict_network_access: false
+  restrict_network_access: true
   steps:
     cluster_profile: aws-sandboxed-containers-operator
     env:
@@ -204,18 +204,18 @@ tests:
       CATALOG_SOURCE_NAME: brew-catalog
       ENABLE_MUST_GATHER: "true"
       ENABLEPEERPODS: "true"
-      INITDATA: ""
-      INSTALL_KATA_RPM: "false"
-      KATA_RPM_VERSION: ""
+      INITDATA: H4sICMrPymkAA2luaXRkYXRhLnRvbWwA7Vhbc6pIF33nV1i8ZL7KUdR4TdV54KZiREXwllQq1UILyKWxuxHxVP77NJo5kzlzTOZh5ns6pAyy9+q19+7L6kYQugj71ItKX0s88UC92eK5A8TER3FhqlZqlSrPcU8OoOCZ4wGoUBSFPPPd3NxwTxQFMH6xUbz1XfL8w3PFRjZ6Acye4rBg8yhNyL0gBBtSJhAffBuWKU4JhbCMEogBRbhMcvYcVUCSkApNNhVwSjGsEBA7G3SEDuOmwI9Ziow+KlL7a0zG/Z/GsyGmBTfPl4tLUvvauCSrM0vrabJoqWcrp2uaoiiyLG5NV8w0SXTZxxLHkhvsvcDvd7OqJBqkJypipJtGprlrZWEYiiKxFCIn5x5X49No2c0eV0PP6XdzQ1HvxiejMbH02sQSs4Fnj/XdOtNPeqZbNrPNj8uzzWU2rcm9GfPl7ucRPgvAua7q62K1L5v7vqlt7hRDZSnPRbGhSUomZsz/ICJWliEf4rvTLdjB2mPuOXIYHtb2SeI667rXImMPNWTbM6OqoU3SZNheBM1GLRoq8pY0T52Vn6q90ZYx1IAbTkeHeKLcrgPtIItcGw/BIqNdSLDltp2meacKrbroaN18MW+r69EDULubjur2HX22rNZOc6dl1tv5Wp0fd/uhyinVdOz3h484WSEBrv3p0Yurh1XLjNps2iup6q5H3TzDx0WWCIGt9a3qvrfcSnpvFHTGU8wdHSrVDW2pW/HKyQctiQyNIRYWI6LBvLumD22j2tLrjV1wSIa4Xkferb9qjucd27MbxzriTpsJCMhkC0l7P50N72StjYXV0hgbYzBu7rPa40NQW9sA+aPbiWssoSbOPDxfKIdosa+DEye6uiSK/d3MkhRdbPTF2txRMlUSMkNlE0tOFNGU3PFiMGO4bUeVFbEvGgNBdFVRl6p97tyAMUuSGTw6fgAMq6sfXT2G8PG0bWU9T+2Bn81McSKLLAZnKN1jN0eDfG9syEaeILo+0tqsK+63yWRiDzeLaXXtriYPdltYtcOepYdYC8PG3JrMDdcQOOm0bnZ0sFqn2/HEMat++2jf1fT0JO7uIpp3FkeL6IcukObDk+Avpvlg8BCtRseJ7tRmWevEDWQnq4l1I5nLaCLvGjUPPm7a1ioc7DsPwxy3u2q/P9wA1W+bt6ekQw19hnvJXU/KcGvaMzg2/rnVP6zifWsc1h7rMnrY7PtCMzjIE4cs9E3j1B60gtTR7KM6nFUzBw8EpWm1JW8axvGGi/JafdepCb7emI677QSk3X693tChkO3pAg0dzTm0DqtmZEXVuSOlo+xAccO8HZvtkdXUhtwwqObdHphj9SSru7vZNlB6M+PrV+4sF+pY+ZuEMIHhConleNvx3kT3TXUJsgNYiNBNGvtHpm8CTmPhLIAOjKkPwvKfqiUUzYsWN5yN4ZufsMZPz0w7g439zMUggoWk2fYLe+b/S/VkXC+/FPSXgv5S0F8K+v9QUO7Jj4ALn7nz7YVAO2XH3fwlQaFv54WEfuMduAVpSPn7p288zRPI3/MY7qBN+dfnLzzFICYJwpTw9wxbSC8uvrmejSs+uiq7FBL653P5HL+MyfsohJ1XmYZC03dj6PBf+ADmU0A95mI6Wej6W2osCMPGZeYnAvtXrrLUXl9fb952iEs1FQxd9MfJPAF2wCKW2Cemb+VyrBeKSkrblBYqzZgyhB1S8eOrnu01D2RvCYzxLcOS6DjibDqGvuttECYzuE9ZB5Tuv5bYlgHfw8wMJNfccogINKnjx1cRKMl7fgiv+jEEFMp/9PvHMPOyTV0DKcyIUf4Jqg+pDin27atFM8RkoqsHNhJXIYVVgSzp8CrNyCdUiynEW2DDD1EzlNLrCB1GA0STMHWlfIrR5mpfTuKQ9aE8nbMW1zBTkJLPu3uahqFWrIBrgBkEjknZoLwPtGUHlfeQCB0+D3WBmRSEcOFj6qMtMT2AoY7SmF7tkxkkEDozNtIoUuDhA1gafZ6DCellQNkcs/zoatXFwgchGwM2nldTY6Vg+nnIAmVhYPux+wGGkn/AhJJPiCyaL4slSvzT1drmifNPFuIFpiYejNiJMvx4lC7g72vgY9jHi2AJfPpJx6tHaP8d8tdJyUZ6etbWq3HYdgOvzGzuJxH8bekbV2KXHycpfWGH5ohNSibqbCuxAf2NL/FfLr5KcmlZEbFL/nduQxA7yIMwRBl0vjf149JF/l+K33AqP7jJz4J9/ZGEe+W4dyRFCUWW/I9k/H3p6UxYXLxdvEgUbxFsK6vV25Uq+6vdd6rVVvFSImBIUIpt+H2XA7TYNAFbs3G5uKdEuNz4L/8qKT4vc55xPrPCit3yd1BoWKEHEwAA
+      INSTALL_KATA_RPM: "true"
+      KATA_RPM_VERSION: 3.25.0-5.rhaos4.20.el9
       MUST_GATHER_IMAGE: registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel9:latest
-      MUST_GATHER_ON_FAILURE_ONLY: "true"
+      MUST_GATHER_ON_FAILURE_ONLY: "false"
       RUNTIMECLASS: kata-remote
-      SLEEP_DURATION: 0h
+      SLEEP_DURATION: 6h
       TEST_FILTERS: ~DisconnectedOnly&;~Disruptive&
       TEST_RELEASE_TYPE: Pre-GA
       TEST_SCENARIOS: sig-kata.*Kata Author
-      TEST_TIMEOUT: "90"
-      TRUSTEE_URL: ""
+      TEST_TIMEOUT: "120"
+      TRUSTEE_URL: http://kbs-service-trustee-operator-system.apps.tpb.azure.sandboxedcontainers.com
       WORKLOAD_TO_TEST: coco
     workflow: sandboxed-containers-operator-e2e-aws
   timeout: 24h0m0s


### PR DESCRIPTION
/hold

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enabled stricter network access restrictions for test environments.
  * Updated Kata RPM enablement and versioning across test configurations (version 3.25.0-5).
  * Increased test timeout from 90 to 120 seconds for improved reliability.
  * Configured Trustee service integration for enhanced security testing.
  * Adjusted logging and timing behavior to capture more diagnostic information during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->