### PR TITLE
Log rox-ci-image digest in stackrox prow steps

### DIFF
--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master.yaml
@@ -31,7 +31,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: stackrox-ui-test-latest
+    tag: stackrox-ui-test-stable
 releases:
   latest:
     release:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master.yaml
@@ -31,7 +31,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: stackrox-ui-test-stable
+    tag: stackrox-ui-test-latest
 releases:
   latest:
     release:

--- a/ci-operator/step-registry/stackrox/stackrox/begin/stackrox-stackrox-begin-commands.sh
+++ b/ci-operator/step-registry/stackrox/stackrox/begin/stackrox-stackrox-begin-commands.sh
@@ -4,7 +4,7 @@ export OPENSHIFT_CI_STEP_NAME="stackrox-stackrox-begin"
 
 # Log rox-ci-image info for traceability.
 echo "INFO: rox-ci-image:"
-kubectl get imagestreamtag pipeline:root -o jsonpath='{.tag.from.name}{"\n"}{.image.dockerImageMetadata}{"\n"}' || true
+kubectl get imagestreamtag pipeline:root -o jsonpath='{.tag.from.name}{"\n"}Created: {.image.dockerImageMetadata.Created}{"\n"}Labels: {.image.dockerImageMetadata.Config.Labels}{"\n"}' || true
 echo "INFO: /i-am-rox-ci-image:"
 cat /i-am-rox-ci-image || true
 

--- a/ci-operator/step-registry/stackrox/stackrox/begin/stackrox-stackrox-begin-commands.sh
+++ b/ci-operator/step-registry/stackrox/stackrox/begin/stackrox-stackrox-begin-commands.sh
@@ -2,6 +2,41 @@
 
 export OPENSHIFT_CI_STEP_NAME="stackrox-stackrox-begin"
 
+echo "INFO: rox-ci-image:"
+kubectl get imagestreamtag pipeline:root -o jsonpath='{.tag.from.name}{"\n"}{.image.dockerImageMetadata}' || true
+# Query internal registry for image config (labels, env, etc).
+_iid=$(kubectl get pod "$HOSTNAME" -o jsonpath='{.status.containerStatuses[?(@.name=="test")].imageID}') || true
+echo "INFO: rox-ci-image imageID: ${_iid}"
+if [[ "$_iid" =~ ^([^@]+)@(.+)$ ]]; then
+    _registry="${BASH_REMATCH[1]%%/*}"
+    _repo="${BASH_REMATCH[1]#*/}"
+    _digest="${BASH_REMATCH[2]}"
+    echo "INFO: rox-ci-image registry=${_registry} repo=${_repo} digest=${_digest}"
+    _token=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token) || true
+    echo "INFO: rox-ci-image token length: ${#_token}"
+
+    echo "INFO: rox-ci-image: registry v2 catalog test:"
+    curl -sk -H "Authorization: Bearer $_token" "https://${_registry}/v2/" || true
+
+    echo "INFO: rox-ci-image: manifest:"
+    _manifest=$(curl -sk -H "Authorization: Bearer $_token" \
+        -H "Accept: application/vnd.docker.distribution.manifest.v2+json" \
+        "https://${_registry}/v2/${_repo}/manifests/${_digest}") || true
+    echo "$_manifest"
+
+    _config=$(echo "$_manifest" | grep -o '"config":{[^}]*}' | grep -o 'sha256:[a-f0-9]*') || true
+    echo "INFO: rox-ci-image: config digest: ${_config}"
+    if [[ -n "$_config" ]]; then
+        echo "INFO: rox-ci-image: config blob:"
+        curl -sk -H "Authorization: Bearer $_token" \
+            "https://${_registry}/v2/${_repo}/blobs/${_config}" || true
+    fi
+else
+    echo "INFO: rox-ci-image: imageID did not match expected pattern"
+fi
+echo "INFO: /i-am-rox-ci-image:"
+cat /i-am-rox-ci-image || true
+
 if [[ -f .openshift-ci/begin.sh ]]; then
     exec .openshift-ci/begin.sh
 else

--- a/ci-operator/step-registry/stackrox/stackrox/begin/stackrox-stackrox-begin-commands.sh
+++ b/ci-operator/step-registry/stackrox/stackrox/begin/stackrox-stackrox-begin-commands.sh
@@ -2,38 +2,9 @@
 
 export OPENSHIFT_CI_STEP_NAME="stackrox-stackrox-begin"
 
+# Log rox-ci-image info for traceability.
 echo "INFO: rox-ci-image:"
-kubectl get imagestreamtag pipeline:root -o jsonpath='{.tag.from.name}{"\n"}{.image.dockerImageMetadata}' || true
-# Query internal registry for image config (labels, env, etc).
-_iid=$(kubectl get pod "$HOSTNAME" -o jsonpath='{.status.containerStatuses[?(@.name=="test")].imageID}') || true
-echo "INFO: rox-ci-image imageID: ${_iid}"
-if [[ "$_iid" =~ ^([^@]+)@(.+)$ ]]; then
-    _registry="${BASH_REMATCH[1]%%/*}"
-    _repo="${BASH_REMATCH[1]#*/}"
-    _digest="${BASH_REMATCH[2]}"
-    echo "INFO: rox-ci-image registry=${_registry} repo=${_repo} digest=${_digest}"
-    _token=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token) || true
-    echo "INFO: rox-ci-image token length: ${#_token}"
-
-    echo "INFO: rox-ci-image: registry v2 catalog test:"
-    curl -sk -H "Authorization: Bearer $_token" "https://${_registry}/v2/" || true
-
-    echo "INFO: rox-ci-image: manifest:"
-    _manifest=$(curl -sk -H "Authorization: Bearer $_token" \
-        -H "Accept: application/vnd.docker.distribution.manifest.v2+json" \
-        "https://${_registry}/v2/${_repo}/manifests/${_digest}") || true
-    echo "$_manifest"
-
-    _config=$(echo "$_manifest" | grep -o '"config":{[^}]*}' | grep -o 'sha256:[a-f0-9]*') || true
-    echo "INFO: rox-ci-image: config digest: ${_config}"
-    if [[ -n "$_config" ]]; then
-        echo "INFO: rox-ci-image: config blob:"
-        curl -sk -H "Authorization: Bearer $_token" \
-            "https://${_registry}/v2/${_repo}/blobs/${_config}" || true
-    fi
-else
-    echo "INFO: rox-ci-image: imageID did not match expected pattern"
-fi
+kubectl get imagestreamtag pipeline:root -o jsonpath='{.tag.from.name}{"\n"}{.image.dockerImageMetadata}{"\n"}' || true
 echo "INFO: /i-am-rox-ci-image:"
 cat /i-am-rox-ci-image || true
 


### PR DESCRIPTION
## Summary
- Log the rox-ci-image image information in the "begin" stackrox step
- Uses `kubectl get pod` to query the container's metadata
> Needed for traceability when using floating tags like `stable` or `latest`

New output including /i-am-rox-ci-image content:
```
INFO: rox-ci-image:
quay-proxy.ci.openshift.org/openshift/ci:stackrox_apollo-ci_stackrox-ui-test-latest
Created: 2026-04-17T14:55:23Z
Labels: {"io.buildah.version":"1.33.14","org.label-schema.build-date":"20260413","org.label-schema.license":"GPLv2","org.label-schema.name":"CentOS Stream 9 Base Image","org.label-schema.schema-version":"1.0","org.label-schema.vendor":"CentOS"}
INFO: /i-am-rox-ci-image:
rox-ci-image-version=0.5.10
rox-ci-image-revision=954c9c4356c2594e94bc28cf3217e44aa2bb21d9
aws=aws-cli/2.7.17 Python/3.9.11 Linux/6.17.0-1010-azure exe/x86_64.centos.9 prompt/off
bats=Bats 1.10.0
...
INFO: Fri Apr 17 20:28:26 UTC 2026: Start of CI handling
```
https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_release/77727/rehearse-77727-pull-ci-stackrox-stackrox-master-gke-qa-e2e-tests/2045232982628765696/artifacts/gke-qa-e2e-tests/stackrox-stackrox-begin/build-log.txt

🤖 Assisted with [Claude Code](https://claude.com/claude-code)