### PR TITLE
appliance: per-stream tags for publish (instead of latest)

### DIFF
--- a/ci-operator/config/openshift/appliance/openshift-appliance-release-4.14.yaml
+++ b/ci-operator/config/openshift/appliance/openshift-appliance-release-4.14.yaml
@@ -55,7 +55,7 @@ tests:
       SOURCE_IMAGE_REF: agent-preinstall-image-builder
     env:
       IMAGE_REPO: openshift-appliance
-      IMAGE_TAG: latest
+      IMAGE_TAG: "4.14"
     test:
     - ref: assisted-baremetal-images-publish
 - as: e2e-compact-ipv4-static

--- a/ci-operator/config/openshift/appliance/openshift-appliance-release-4.15.yaml
+++ b/ci-operator/config/openshift/appliance/openshift-appliance-release-4.15.yaml
@@ -55,7 +55,7 @@ tests:
       SOURCE_IMAGE_REF: agent-preinstall-image-builder
     env:
       IMAGE_REPO: openshift-appliance
-      IMAGE_TAG: latest
+      IMAGE_TAG: "4.15"
     test:
     - ref: assisted-baremetal-images-publish
 - as: e2e-compact-ipv4-static

--- a/ci-operator/config/openshift/appliance/openshift-appliance-release-4.16.yaml
+++ b/ci-operator/config/openshift/appliance/openshift-appliance-release-4.16.yaml
@@ -55,7 +55,7 @@ tests:
       SOURCE_IMAGE_REF: agent-preinstall-image-builder
     env:
       IMAGE_REPO: openshift-appliance
-      IMAGE_TAG: latest
+      IMAGE_TAG: "4.16"
     test:
     - ref: assisted-baremetal-images-publish
 - as: e2e-compact-ipv4-static

--- a/ci-operator/config/openshift/appliance/openshift-appliance-release-4.17.yaml
+++ b/ci-operator/config/openshift/appliance/openshift-appliance-release-4.17.yaml
@@ -55,7 +55,7 @@ tests:
       SOURCE_IMAGE_REF: agent-preinstall-image-builder
     env:
       IMAGE_REPO: openshift-appliance
-      IMAGE_TAG: latest
+      IMAGE_TAG: "4.17"
     test:
     - ref: assisted-baremetal-images-publish
 - as: e2e-compact-ipv4-static

--- a/ci-operator/config/openshift/appliance/openshift-appliance-release-4.18.yaml
+++ b/ci-operator/config/openshift/appliance/openshift-appliance-release-4.18.yaml
@@ -55,7 +55,7 @@ tests:
       SOURCE_IMAGE_REF: agent-preinstall-image-builder
     env:
       IMAGE_REPO: openshift-appliance
-      IMAGE_TAG: latest
+      IMAGE_TAG: "4.18"
     test:
     - ref: assisted-baremetal-images-publish
 - as: e2e-compact-ipv4-static

--- a/ci-operator/config/openshift/appliance/openshift-appliance-release-4.19.yaml
+++ b/ci-operator/config/openshift/appliance/openshift-appliance-release-4.19.yaml
@@ -55,7 +55,7 @@ tests:
       SOURCE_IMAGE_REF: agent-preinstall-image-builder
     env:
       IMAGE_REPO: openshift-appliance
-      IMAGE_TAG: latest
+      IMAGE_TAG: "4.19"
     test:
     - ref: assisted-baremetal-images-publish
 - as: e2e-compact-ipv4-static

--- a/ci-operator/config/openshift/appliance/openshift-appliance-release-4.20.yaml
+++ b/ci-operator/config/openshift/appliance/openshift-appliance-release-4.20.yaml
@@ -55,7 +55,7 @@ tests:
       SOURCE_IMAGE_REF: agent-preinstall-image-builder
     env:
       IMAGE_REPO: openshift-appliance
-      IMAGE_TAG: latest
+      IMAGE_TAG: "4.20"
     test:
     - ref: assisted-baremetal-images-publish
 - as: e2e-compact-ipv4-static

--- a/ci-operator/config/openshift/appliance/openshift-appliance-release-4.21.yaml
+++ b/ci-operator/config/openshift/appliance/openshift-appliance-release-4.21.yaml
@@ -56,7 +56,7 @@ tests:
       SOURCE_IMAGE_REF: agent-preinstall-image-builder
     env:
       IMAGE_REPO: openshift-appliance
-      IMAGE_TAG: latest
+      IMAGE_TAG: "4.21"
     test:
     - ref: assisted-baremetal-images-publish
 - always_run: false

--- a/ci-operator/config/openshift/appliance/openshift-appliance-release-4.22.yaml
+++ b/ci-operator/config/openshift/appliance/openshift-appliance-release-4.22.yaml
@@ -56,7 +56,7 @@ tests:
       SOURCE_IMAGE_REF: agent-preinstall-image-builder
     env:
       IMAGE_REPO: openshift-appliance
-      IMAGE_TAG: latest
+      IMAGE_TAG: "4.22"
     test:
     - ref: assisted-baremetal-images-publish
 - always_run: false

--- a/ci-operator/config/openshift/appliance/openshift-appliance-release-5.0.yaml
+++ b/ci-operator/config/openshift/appliance/openshift-appliance-release-5.0.yaml
@@ -57,7 +57,7 @@ tests:
       SOURCE_IMAGE_REF: agent-preinstall-image-builder
     env:
       IMAGE_REPO: openshift-appliance
-      IMAGE_TAG: latest
+      IMAGE_TAG: "5.0"
     test:
     - ref: assisted-baremetal-images-publish
 - always_run: false


### PR DESCRIPTION
Set assisted-baremetal-images-publish IMAGE_TAG to the OCP stream for each ci-operator variant (4.14–4.22) so Quay pushes go to quay.io/edge-infrastructure/openshift-appliance:[stream] instead of a shared :latest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Updated image publishing configuration across OpenShift Appliance releases 4.14 through 4.22 to use release-specific version tags instead of generic naming for improved image version tracking and management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->