### PR TITLE
hive: scale openshift-observability clusterpools to 0 except 4.21 us-east-2 (size/ready 1)

### DIFF
--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-logging-ocp-4-16-0-amd64-aws-us-east-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-logging-ocp-4-16-0-amd64-aws-us-east-1_clusterpool.yaml
@@ -33,7 +33,7 @@ spec:
       region: us-east-1
   pullSecretRef:
     name: pull-secret
-  size: 1
+  size: 0
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-logging-ocp-4-17-0-amd64-aws-us-east-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-logging-ocp-4-17-0-amd64-aws-us-east-1_clusterpool.yaml
@@ -33,7 +33,7 @@ spec:
       region: us-east-1
   pullSecretRef:
     name: pull-secret
-  size: 1
+  size: 0
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-logging-ocp-4-18-amd64-aws-us-east-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-logging-ocp-4-18-amd64-aws-us-east-1_clusterpool.yaml
@@ -33,7 +33,7 @@ spec:
       region: us-east-1
   pullSecretRef:
     name: pull-secret
-  size: 2
+  size: 0
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-logging-ocp-4-19-amd64-aws-us-east-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-logging-ocp-4-19-amd64-aws-us-east-1_clusterpool.yaml
@@ -33,7 +33,7 @@ spec:
       region: us-east-1
   pullSecretRef:
     name: pull-secret
-  size: 2
+  size: 0
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-logging-ocp-4-20-amd64-aws-us-east-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-logging-ocp-4-20-amd64-aws-us-east-1_clusterpool.yaml
@@ -33,7 +33,7 @@ spec:
       region: us-east-1
   pullSecretRef:
     name: pull-secret
-  size: 2
+  size: 0
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-logging-ocp-4-21-amd64-aws-us-east-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-logging-ocp-4-21-amd64-aws-us-east-1_clusterpool.yaml
@@ -33,7 +33,7 @@ spec:
       region: us-east-1
   pullSecretRef:
     name: pull-secret
-  size: 2
+  size: 0
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-13-0-amd64-aws-us-east-2_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-13-0-amd64-aws-us-east-2_clusterpool.yaml
@@ -33,7 +33,7 @@ spec:
       region: us-east-2
   pullSecretRef:
     name: pull-secret
-  size: 1
+  size: 0
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-13-0-fips-amd64-aws-us-east-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-13-0-fips-amd64-aws-us-east-1_clusterpool.yaml
@@ -34,7 +34,7 @@ spec:
       region: us-east-1
   pullSecretRef:
     name: pull-secret
-  size: 1
+  size: 0
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-14-0-amd64-aws-us-east-2_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-14-0-amd64-aws-us-east-2_clusterpool.yaml
@@ -33,7 +33,7 @@ spec:
       region: us-east-2
   pullSecretRef:
     name: pull-secret
-  size: 1
+  size: 0
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-14-0-fips-amd64-aws-us-east-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-14-0-fips-amd64-aws-us-east-1_clusterpool.yaml
@@ -34,7 +34,7 @@ spec:
       region: us-east-1
   pullSecretRef:
     name: pull-secret
-  size: 1
+  size: 0
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-15-0-amd64-aws-us-east-2_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-15-0-amd64-aws-us-east-2_clusterpool.yaml
@@ -33,7 +33,7 @@ spec:
       region: us-east-2
   pullSecretRef:
     name: pull-secret
-  size: 1
+  size: 0
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-15-0-fips-amd64-aws-us-east-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-15-0-fips-amd64-aws-us-east-1_clusterpool.yaml
@@ -34,7 +34,7 @@ spec:
       region: us-east-1
   pullSecretRef:
     name: pull-secret
-  size: 1
+  size: 0
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-16-0-amd64-aws-us-east-2_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-16-0-amd64-aws-us-east-2_clusterpool.yaml
@@ -33,7 +33,7 @@ spec:
       region: us-east-2
   pullSecretRef:
     name: pull-secret
-  size: 1
+  size: 0
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-16-0-fips-amd64-aws-us-east-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-16-0-fips-amd64-aws-us-east-1_clusterpool.yaml
@@ -34,7 +34,7 @@ spec:
       region: us-east-1
   pullSecretRef:
     name: pull-secret
-  size: 1
+  size: 0
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-17-0-amd64-aws-us-east-2_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-17-0-amd64-aws-us-east-2_clusterpool.yaml
@@ -33,7 +33,7 @@ spec:
       region: us-east-2
   pullSecretRef:
     name: pull-secret
-  size: 1
+  size: 0
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-17-0-fips-amd64-aws-us-east-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-17-0-fips-amd64-aws-us-east-1_clusterpool.yaml
@@ -34,7 +34,7 @@ spec:
       region: us-east-1
   pullSecretRef:
     name: pull-secret
-  size: 1
+  size: 0
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-18-0-amd64-aws-us-east-2_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-18-0-amd64-aws-us-east-2_clusterpool.yaml
@@ -33,7 +33,7 @@ spec:
       region: us-east-2
   pullSecretRef:
     name: pull-secret
-  size: 1
+  size: 0
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-18-0-fips-amd64-aws-us-east-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-18-0-fips-amd64-aws-us-east-1_clusterpool.yaml
@@ -34,7 +34,7 @@ spec:
       region: us-east-1
   pullSecretRef:
     name: pull-secret
-  size: 1
+  size: 0
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-19-0-amd64-aws-us-east-2_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-19-0-amd64-aws-us-east-2_clusterpool.yaml
@@ -33,7 +33,7 @@ spec:
       region: us-east-2
   pullSecretRef:
     name: pull-secret
-  size: 1
+  size: 0
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-19-0-fips-amd64-aws-us-east-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-19-0-fips-amd64-aws-us-east-1_clusterpool.yaml
@@ -34,7 +34,7 @@ spec:
       region: us-east-1
   pullSecretRef:
     name: pull-secret
-  size: 1
+  size: 0
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-20-0-amd64-aws-us-east-2_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-20-0-amd64-aws-us-east-2_clusterpool.yaml
@@ -33,7 +33,7 @@ spec:
       region: us-east-2
   pullSecretRef:
     name: pull-secret
-  size: 1
+  size: 0
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-20-0-fips-amd64-aws-us-east-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-20-0-fips-amd64-aws-us-east-1_clusterpool.yaml
@@ -34,7 +34,7 @@ spec:
       region: us-east-1
   pullSecretRef:
     name: pull-secret
-  size: 1
+  size: 0
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-21-0-amd64-aws-us-east-2_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-21-0-amd64-aws-us-east-2_clusterpool.yaml
@@ -36,6 +36,6 @@ spec:
   size: 1
   skipMachinePools: true
 status:
-  ready: 0
-  size: 0
+  ready: 1
+  size: 1
   standby: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-21-0-fips-amd64-aws-us-east-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-21-0-fips-amd64-aws-us-east-1_clusterpool.yaml
@@ -34,7 +34,7 @@ spec:
       region: us-east-1
   pullSecretRef:
     name: pull-secret
-  size: 3
+  size: 0
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-22-0-amd64-aws-us-east-2_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-22-0-amd64-aws-us-east-2_clusterpool.yaml
@@ -33,7 +33,7 @@ spec:
       region: us-east-2
   pullSecretRef:
     name: pull-secret
-  size: 1
+  size: 0
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-22-0-fips-amd64-aws-us-east-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-22-0-fips-amd64-aws-us-east-1_clusterpool.yaml
@@ -34,7 +34,7 @@ spec:
       region: us-east-1
   pullSecretRef:
     name: pull-secret
-  size: 3
+  size: 0
   skipMachinePools: true
 status:
   ready: 0


### PR DESCRIPTION
/cc @bear-redhat 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted cluster pool sizing configurations for observability infrastructure across multiple OpenShift versions to align with deployment requirements.
  * Updated pool availability status for specific cluster configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->