### PR TITLE
[openshift-psap/fournos] Use a temporary branch while testing

### DIFF
--- a/ci-operator/config/openshift-psap/fournos/openshift-psap-fournos-main.yaml
+++ b/ci-operator/config/openshift-psap/fournos/openshift-psap-fournos-main.yaml
@@ -24,7 +24,8 @@ tests:
         export PSAP_FORGE_FOURNOS_DEPLOY_SECRET_PATH=/var/run/psap-forge-fournos-deploy
         export PSAP_FORGE_NOTIFICATIONS_SECRET_PATH=/var/run/psap-forge-notifications
 
-        git -C $HOME fetch --quiet origin main
+        TMP_MAIN_BRANCH=fournos-testing
+        git -C $HOME fetch --quiet origin $TMP_MAIN_BRANCH
         git -C $HOME reset --hard FETCH_HEAD
 
         exec ./bin/run_ci foreign_testing ci run


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI configuration to reference an alternative testing branch in the automated test pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->