### PR TITLE
hypershift: fix jobs after branching

### DIFF
--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-main.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-main.yaml
@@ -54,62 +54,62 @@ releases:
       relative: 1
       stream: ci
       version: "5.0"
-  initial-421:
+  initial-422:
     candidate:
       product: ocp
       relative: 1
       stream: ci
-      version: "5.0"
+      version: "4.22"
   latest:
     integration:
       include_built_images: true
       name: "5.0"
       namespace: ocp
-  latest-417:
-    candidate:
-      product: ocp
-      stream: ci
-      version: "5.0"
   latest-418:
     candidate:
       product: ocp
       stream: ci
-      version: "5.0"
+      version: "4.18"
   latest-419:
     candidate:
       product: ocp
       stream: ci
-      version: "5.0"
+      version: "4.19"
   latest-420:
     candidate:
       product: ocp
       stream: ci
-      version: "5.0"
+      version: "4.20"
   latest-421:
     candidate:
       product: ocp
       stream: ci
-      version: "5.0"
+      version: "4.21"
+  latest-422:
+    candidate:
+      product: ocp
+      stream: ci
+      version: "4.22"
   n1minor:
     candidate:
       product: ocp
       stream: ci
-      version: "5.0"
+      version: "4.22"
   n2minor:
     candidate:
       product: ocp
       stream: ci
-      version: "5.0"
+      version: "4.21"
   n3minor:
     candidate:
       product: ocp
       stream: ci
-      version: "5.0"
+      version: "4.20"
   n4minor:
     candidate:
       product: ocp
       stream: ci
-      version: "5.0"
+      version: "4.19"
 resources:
   '*':
     limits:
@@ -149,17 +149,17 @@ tests:
     - chain: cucushift-installer-rehearse-azure-aks-deprovision
     workflow: hypershift-azure-aks-e2e
 - always_run: false
-  as: e2e-aks-4-21
+  as: e2e-aks-4-22
   pipeline_run_if_changed: ^(test/e2e|hypershift-operator)
   steps:
     cluster_profile: hypershift-aks
     dependencies:
-      OCP_IMAGE_LATEST: release:latest-421
-      OCP_IMAGE_N1: release:latest-420
-      OCP_IMAGE_N2: release:latest-419
-      OCP_IMAGE_N3: release:latest-418
-      OCP_IMAGE_N4: release:latest-417
-      OCP_IMAGE_PREVIOUS: release:initial-421
+      OCP_IMAGE_LATEST: release:latest-422
+      OCP_IMAGE_N1: release:latest-421
+      OCP_IMAGE_N2: release:latest-420
+      OCP_IMAGE_N3: release:latest-419
+      OCP_IMAGE_N4: release:latest-418
+      OCP_IMAGE_PREVIOUS: release:initial-422
     env:
       AUTH_THROUGH_CERTS: "true"
       ENABLE_HYPERSHIFT_CERT_ROTATION_SCALE: "true"
@@ -282,19 +282,19 @@ tests:
       TEST_CPO_OVERRIDE: "1"
     workflow: hypershift-aws-e2e-nested
 - always_run: false
-  as: e2e-aws-4-21
+  as: e2e-aws-4-22
   capabilities:
   - build-tmpfs
   pipeline_run_if_changed: ^(test/e2e|hypershift-operator)
   steps:
     cluster_profile: hypershift-aws
     dependencies:
-      OCP_IMAGE_LATEST: release:latest-421
-      OCP_IMAGE_N1: release:latest-420
-      OCP_IMAGE_N2: release:latest-419
-      OCP_IMAGE_N3: release:latest-418
-      OCP_IMAGE_N4: release:latest-417
-      OCP_IMAGE_PREVIOUS: release:initial-421
+      OCP_IMAGE_LATEST: release:latest-422
+      OCP_IMAGE_N1: release:latest-421
+      OCP_IMAGE_N2: release:latest-420
+      OCP_IMAGE_N3: release:latest-419
+      OCP_IMAGE_N4: release:latest-418
+      OCP_IMAGE_PREVIOUS: release:initial-422
     env:
       ENABLE_HYPERSHIFT_CERT_ROTATION_SCALE: "true"
       REQUEST_SERVING_COMPONENT_TEST: "true"

--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.22.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.22.yaml
@@ -52,7 +52,7 @@ releases:
       product: ocp
       relative: 1
       stream: ci
-      version: "4.22"
+      version: "4.21"
   latest:
     integration:
       include_built_images: true
@@ -62,47 +62,47 @@ releases:
     candidate:
       product: ocp
       stream: ci
-      version: "4.22"
+      version: "4.17"
   latest-418:
     candidate:
       product: ocp
       stream: ci
-      version: "4.22"
+      version: "4.18"
   latest-419:
     candidate:
       product: ocp
       stream: ci
-      version: "4.22"
+      version: "4.19"
   latest-420:
     candidate:
       product: ocp
       stream: ci
-      version: "4.22"
+      version: "4.20"
   latest-421:
     candidate:
       product: ocp
       stream: ci
-      version: "4.22"
+      version: "4.21"
   n1minor:
     candidate:
       product: ocp
       stream: ci
-      version: "4.22"
+      version: "4.21"
   n2minor:
     candidate:
       product: ocp
       stream: ci
-      version: "4.22"
+      version: "4.20"
   n3minor:
     candidate:
       product: ocp
       stream: ci
-      version: "4.22"
+      version: "4.19"
   n4minor:
     candidate:
       product: ocp
       stream: ci
-      version: "4.22"
+      version: "4.18"
 resources:
   '*':
     limits:

--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.23.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.23.yaml
@@ -47,62 +47,62 @@ releases:
       relative: 1
       stream: ci
       version: "4.23"
-  initial-421:
+  initial-422:
     candidate:
       product: ocp
       relative: 1
       stream: ci
-      version: "4.23"
+      version: "4.22"
   latest:
     integration:
       include_built_images: true
       name: "4.23"
       namespace: ocp
-  latest-417:
-    candidate:
-      product: ocp
-      stream: ci
-      version: "4.23"
   latest-418:
     candidate:
       product: ocp
       stream: ci
-      version: "4.23"
+      version: "4.18"
   latest-419:
     candidate:
       product: ocp
       stream: ci
-      version: "4.23"
+      version: "4.19"
   latest-420:
     candidate:
       product: ocp
       stream: ci
-      version: "4.23"
+      version: "4.20"
   latest-421:
     candidate:
       product: ocp
       stream: ci
-      version: "4.23"
+      version: "4.21"
+  latest-422:
+    candidate:
+      product: ocp
+      stream: ci
+      version: "4.22"
   n1minor:
     candidate:
       product: ocp
       stream: ci
-      version: "4.23"
+      version: "4.22"
   n2minor:
     candidate:
       product: ocp
       stream: ci
-      version: "4.23"
+      version: "4.21"
   n3minor:
     candidate:
       product: ocp
       stream: ci
-      version: "4.23"
+      version: "4.20"
   n4minor:
     candidate:
       product: ocp
       stream: ci
-      version: "4.23"
+      version: "4.19"
 resources:
   '*':
     limits:
@@ -142,17 +142,17 @@ tests:
     - chain: cucushift-installer-rehearse-azure-aks-deprovision
     workflow: hypershift-azure-aks-e2e
 - always_run: false
-  as: e2e-aks-4-21
+  as: e2e-aks-4-22
   pipeline_run_if_changed: ^(test/e2e|hypershift-operator)
   steps:
     cluster_profile: hypershift-aks
     dependencies:
-      OCP_IMAGE_LATEST: release:latest-421
-      OCP_IMAGE_N1: release:latest-420
-      OCP_IMAGE_N2: release:latest-419
-      OCP_IMAGE_N3: release:latest-418
-      OCP_IMAGE_N4: release:latest-417
-      OCP_IMAGE_PREVIOUS: release:initial-421
+      OCP_IMAGE_LATEST: release:latest-422
+      OCP_IMAGE_N1: release:latest-421
+      OCP_IMAGE_N2: release:latest-420
+      OCP_IMAGE_N3: release:latest-419
+      OCP_IMAGE_N4: release:latest-418
+      OCP_IMAGE_PREVIOUS: release:initial-422
     env:
       AUTH_THROUGH_CERTS: "true"
       ENABLE_HYPERSHIFT_CERT_ROTATION_SCALE: "true"
@@ -275,19 +275,19 @@ tests:
       TEST_CPO_OVERRIDE: "1"
     workflow: hypershift-aws-e2e-nested
 - always_run: false
-  as: e2e-aws-4-21
+  as: e2e-aws-4-22
   capabilities:
   - build-tmpfs
   pipeline_run_if_changed: ^(test/e2e|hypershift-operator)
   steps:
     cluster_profile: hypershift-aws
     dependencies:
-      OCP_IMAGE_LATEST: release:latest-421
-      OCP_IMAGE_N1: release:latest-420
-      OCP_IMAGE_N2: release:latest-419
-      OCP_IMAGE_N3: release:latest-418
-      OCP_IMAGE_N4: release:latest-417
-      OCP_IMAGE_PREVIOUS: release:initial-421
+      OCP_IMAGE_LATEST: release:latest-422
+      OCP_IMAGE_N1: release:latest-421
+      OCP_IMAGE_N2: release:latest-420
+      OCP_IMAGE_N3: release:latest-419
+      OCP_IMAGE_N4: release:latest-418
+      OCP_IMAGE_PREVIOUS: release:initial-422
     env:
       ENABLE_HYPERSHIFT_CERT_ROTATION_SCALE: "true"
       REQUEST_SERVING_COMPONENT_TEST: "true"

--- a/ci-operator/jobs/openshift/hypershift/openshift-hypershift-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/hypershift/openshift-hypershift-main-presubmits.yaml
@@ -251,15 +251,15 @@ presubmits:
     - ^main$
     - ^main-
     cluster: build01
-    context: ci/prow/e2e-aks-4-21
+    context: ci/prow/e2e-aks-4-22
     decorate: true
     labels:
       ci-operator.openshift.io/cloud: hypershift-aks
       ci-operator.openshift.io/cloud-cluster-profile: hypershift-aks
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-hypershift-main-e2e-aks-4-21
-    rerun_command: /test e2e-aks-4-21
+    name: pull-ci-openshift-hypershift-main-e2e-aks-4-22
+    rerun_command: /test e2e-aks-4-22
     spec:
       containers:
       - args:
@@ -268,7 +268,7 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-aks-4-21
+        - --target=e2e-aks-4-22
         command:
         - ci-operator
         env:
@@ -324,7 +324,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-aks-4-21,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-aks-4-22,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:
@@ -497,7 +497,7 @@ presubmits:
     - ^main$
     - ^main-
     cluster: build01
-    context: ci/prow/e2e-aws-4-21
+    context: ci/prow/e2e-aws-4-22
     decorate: true
     labels:
       capability/build-tmpfs: build-tmpfs
@@ -505,8 +505,8 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: hypershift-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-hypershift-main-e2e-aws-4-21
-    rerun_command: /test e2e-aws-4-21
+    name: pull-ci-openshift-hypershift-main-e2e-aws-4-22
+    rerun_command: /test e2e-aws-4-22
     spec:
       containers:
       - args:
@@ -515,7 +515,7 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-aws-4-21
+        - --target=e2e-aws-4-22
         command:
         - ci-operator
         env:
@@ -571,7 +571,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-aws-4-21,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-aws-4-22,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:

--- a/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.23-presubmits.yaml
+++ b/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.23-presubmits.yaml
@@ -251,15 +251,15 @@ presubmits:
     - ^release-4\.23$
     - ^release-4\.23-
     cluster: build01
-    context: ci/prow/e2e-aks-4-21
+    context: ci/prow/e2e-aks-4-22
     decorate: true
     labels:
       ci-operator.openshift.io/cloud: hypershift-aks
       ci-operator.openshift.io/cloud-cluster-profile: hypershift-aks
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-hypershift-release-4.23-e2e-aks-4-21
-    rerun_command: /test e2e-aks-4-21
+    name: pull-ci-openshift-hypershift-release-4.23-e2e-aks-4-22
+    rerun_command: /test e2e-aks-4-22
     spec:
       containers:
       - args:
@@ -268,7 +268,7 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-aks-4-21
+        - --target=e2e-aks-4-22
         command:
         - ci-operator
         env:
@@ -324,7 +324,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-aks-4-21,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-aks-4-22,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:
@@ -497,7 +497,7 @@ presubmits:
     - ^release-4\.23$
     - ^release-4\.23-
     cluster: build01
-    context: ci/prow/e2e-aws-4-21
+    context: ci/prow/e2e-aws-4-22
     decorate: true
     labels:
       capability/build-tmpfs: build-tmpfs
@@ -505,8 +505,8 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: hypershift-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-hypershift-release-4.23-e2e-aws-4-21
-    rerun_command: /test e2e-aws-4-21
+    name: pull-ci-openshift-hypershift-release-4.23-e2e-aws-4-22
+    rerun_command: /test e2e-aws-4-22
     spec:
       containers:
       - args:
@@ -515,7 +515,7 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-aws-4-21
+        - --target=e2e-aws-4-22
         command:
         - ci-operator
         env:
@@ -571,7 +571,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-aws-4-21,?($|\s.*)
+    trigger: (?m)^/test( | .* )e2e-aws-4-22,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing infrastructure configurations for OpenShift Hypershift release branches 4.22 and 4.23
  * Advanced end-to-end test job configurations from version 4.21 to 4.22
  * Removed version 4.17 support from test matrices
  * Updated test dependencies to align with current release versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->