### PR TITLE
Add ClusterImageSet for amd64

### DIFF
--- a/clusters/hosted-mgmt/hive/pools/ocp-release-4.22.0-ec.5-for-4.22.0-0-to-4.23.0-0_clusterimageset.yaml
+++ b/clusters/hosted-mgmt/hive/pools/ocp-release-4.22.0-ec.5-for-4.22.0-0-to-4.23.0-0_clusterimageset.yaml
@@ -1,0 +1,12 @@
+apiVersion: hive.openshift.io/v1
+kind: ClusterImageSet
+metadata:
+  annotations:
+    version_lower: 4.22.0-0
+    version_stream: 4-dev-preview
+    version_upper: 4.23.0-0
+  creationTimestamp: null
+  name: ocp-release-4.22.0-ec.5-for-4.22.0-0-to-4.23.0-0
+spec:
+  releaseImage: quay.io/openshift-release-dev/ocp-release:4.22.0-ec.5-x86_64
+status: {}


### PR DESCRIPTION
/cc @openshift/test-platform 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for OpenShift Container Platform release 4.22.0-ec.5 (development preview) for cluster provisioning and upgrades within the version range 4.22.0-0 to 4.23.0-0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->