### PR TITLE
review-agent: fix comment pre-filter to use per-comment reply matching

### DIFF
--- a/ci-operator/step-registry/hypershift/review-agent/process/hypershift-review-agent-process-commands.sh
+++ b/ci-operator/step-registry/hypershift/review-agent/process/hypershift-review-agent-process-commands.sh
@@ -36,6 +36,7 @@ timelines and identifying only threads where:
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 import sys
 from functools import lru_cache
@@ -59,6 +60,14 @@ APPROVED_BOTS = [
     "coderabbitai[bot]",
 ]
 
+# Prow/CI bots whose comments should be ignored entirely
+IGNORED_ACCOUNTS = [
+    "openshift-ci-robot",
+    "openshift-ci",
+    "openshift-merge-robot",
+    "openshift-bot",
+]
+
 # Cache for authorization results to minimize API calls
 _auth_cache: dict[str, bool] = {}
 
@@ -74,11 +83,27 @@ def run_gh(args: list[str]) -> Any:
     return json.loads(result.stdout) if result.stdout.strip() else None
 
 
-def is_bot(login: str) -> bool:
-    """Check if login is a known bot account."""
+def is_our_bot(login: str) -> bool:
+    """Check if login is our bot account (whose comments count as replies)."""
     if not login:
         return False
-    return login in BOT_ACCOUNTS or login.endswith("[bot]")
+    return login in BOT_ACCOUNTS
+
+
+def is_approved_bot(login: str) -> bool:
+    """Check if login is an approved bot whose comments should trigger responses."""
+    if not login:
+        return False
+    return login in APPROVED_BOTS
+
+
+def is_ignored_bot(login: str) -> bool:
+    """Check if login is a bot that should be ignored (prow bots, unknown [bot] accounts)."""
+    if not login:
+        return False
+    if login in BOT_ACCOUNTS or login in APPROVED_BOTS:
+        return False
+    return login in IGNORED_ACCOUNTS or login.endswith("[bot]")
 
 
 def is_openshift_org_member(login: str) -> bool:
@@ -329,41 +354,46 @@ def analyze_review_threads(pr_number: int) -> list[dict]:
         if not comments:
             continue
 
-        # Find last human and last bot comment
-        last_human = None
-        last_bot = None
+        # Classify comments:
+        #   our_bot: our bot's reply (counts as "addressed")
+        #   actionable: human or approved bot comment (needs response)
+        #   ignored: unrecognized bots (skip)
+        last_actionable = None
+        last_our_bot = None
 
         for comment in comments:
             author = comment["author"]["login"] if comment["author"] else "unknown"
-            if is_bot(author):
-                last_bot = comment
-            else:
-                last_human = comment
-
-        # Needs attention if no bot reply, or human commented after bot
-        if last_bot is None:
-            last_author = last_human["author"]["login"] if last_human and last_human["author"] else "unknown"
-            # Check if author is authorized
-            if not is_authorized_author(last_author):
+            if is_our_bot(author):
+                last_our_bot = comment
+            elif is_ignored_bot(author):
                 continue
+            elif is_authorized_author(author):
+                last_actionable = comment
+
+        if last_actionable is None:
+            continue
+
+        last_author = last_actionable["author"]["login"] if last_actionable["author"] else "unknown"
+        author_type = "approved_bot" if is_approved_bot(last_author) else "human"
+
+        # Needs attention if no bot reply, or actionable comment after bot reply
+        if last_our_bot is None:
             needs_attention.append({
                 "type": "review_thread",
                 "id": thread["id"],
-                "last_human_comment": last_human["body"][:200] if last_human else None,
-                "last_human_author": last_author,
+                "last_comment": last_actionable["body"][:200],
+                "last_author": last_author,
+                "author_type": author_type,
                 "reason": "no_bot_reply"
             })
-        elif last_human and last_human["createdAt"] > last_bot["createdAt"]:
-            last_author = last_human["author"]["login"] if last_human["author"] else "unknown"
-            # Check if author is authorized
-            if not is_authorized_author(last_author):
-                continue
+        elif last_actionable["createdAt"] > last_our_bot["createdAt"]:
             needs_attention.append({
                 "type": "review_thread",
                 "id": thread["id"],
-                "last_human_comment": last_human["body"][:200],
-                "last_human_author": last_author,
-                "reason": "human_followup_after_bot"
+                "last_comment": last_actionable["body"][:200],
+                "last_author": last_author,
+                "author_type": author_type,
+                "reason": "followup_after_bot"
             })
 
     return needs_attention
@@ -404,7 +434,7 @@ def analyze_review_bodies(pr_number: int) -> list[dict]:
     reviews = result["data"]["repository"]["pullRequest"]["reviews"]["nodes"]
     needs_attention = []
 
-    # Get issue comments to check if bot has replied to any review
+    # Get bot issue comment bodies to check for review ID references
     try:
         issue_comments = run_gh([
             "api", f"repos/openshift/hypershift/issues/{pr_number}/comments",
@@ -413,18 +443,15 @@ def analyze_review_bodies(pr_number: int) -> list[dict]:
     except subprocess.CalledProcessError:
         issue_comments = []
 
-    # Find last bot comment time from issue comments
-    bot_comment_times = []
-    if issue_comments:
-        for c in issue_comments:
-            if c["user"]["login"] in BOT_ACCOUNTS:
-                bot_comment_times.append(c["created_at"])
-    last_bot_time = max(bot_comment_times) if bot_comment_times else None
+    bot_bodies = [
+        c["body"] for c in (issue_comments or [])
+        if c["user"]["login"] in BOT_ACCOUNTS
+    ]
 
     for review in reviews:
-        # Skip reviews without bodies or from bots
+        # Skip reviews without bodies, from our bot, or from ignored bots
         author = review["author"]["login"] if review["author"] else None
-        if not author or is_bot(author):
+        if not author or is_our_bot(author) or is_ignored_bot(author):
             continue
 
         body = review.get("body", "").strip()
@@ -435,25 +462,33 @@ def analyze_review_bodies(pr_number: int) -> list[dict]:
         if not is_authorized_author(author):
             continue
 
-        submitted_at = review["submittedAt"]
+        review_id = review["id"]
 
-        # Needs attention if no bot reply, or review was submitted after last bot comment
-        if last_bot_time is None or submitted_at > last_bot_time:
+        # Check if any bot comment references this specific review
+        replied = any(str(review_id) in b for b in bot_bodies)
+
+        if not replied:
             needs_attention.append({
                 "type": "review_body",
-                "id": review["id"],
+                "id": review_id,
                 "author": author,
+                "author_type": "approved_bot" if is_approved_bot(author) else "human",
                 "state": review["state"],
-                "body": body[:500],  # Include more context for review bodies
-                "submitted_at": submitted_at,
-                "reason": "no_bot_reply" if last_bot_time is None else "review_after_bot_reply"
+                "body": body[:500],
+                "submitted_at": review["submittedAt"],
+                "reason": "no_bot_reply"
             })
 
     return needs_attention
 
 
 def analyze_issue_comments(pr_number: int) -> list[dict]:
-    """Analyze issue comments (general PR comments) and return those needing attention."""
+    """Analyze issue comments (general PR comments) and return those needing attention.
+
+    Since issue comments are flat (no threading), we rely on our bot
+    including the comment URL when replying. A comment is considered
+    addressed only if our bot's reply contains its URL or comment ID anchor.
+    """
     try:
         comments = run_gh([
             "api", f"repos/openshift/hypershift/issues/{pr_number}/comments",
@@ -465,34 +500,50 @@ def analyze_issue_comments(pr_number: int) -> list[dict]:
     if not comments:
         return []
 
-    # Separate human and bot comments
-    human_comments = [c for c in comments if not is_bot(c["user"]["login"])]
-    bot_comments = [c for c in comments if c["user"]["login"] in BOT_ACCOUNTS]
+    # Actionable comments: humans and approved bots (not our bot, not ignored bots)
+    actionable_comments = [
+        c for c in comments
+        if not is_our_bot(c["user"]["login"]) and not is_ignored_bot(c["user"]["login"])
+    ]
+    # Our bot's comments (used for reply matching)
+    bot_comments = [c for c in comments if is_our_bot(c["user"]["login"])]
 
-    if not human_comments:
+    if not actionable_comments:
         return []
 
-    # Find the last bot comment timestamp
-    last_bot_time = None
-    if bot_comments:
-        last_bot_time = max(c["created_at"] for c in bot_comments)
+    # Collect all our bot comment bodies for reference matching
+    bot_bodies = [c["body"] for c in bot_comments]
 
     needs_attention = []
 
-    # Find human comments after last bot reply
-    for comment in human_comments:
-        if last_bot_time is None or comment["created_at"] > last_bot_time:
-            author = comment["user"]["login"]
-            # Check if author is authorized
-            if not is_authorized_author(author):
-                continue
+    for comment in actionable_comments:
+        author = comment["user"]["login"]
+        # Check if author is authorized
+        if not is_authorized_author(author):
+            continue
+
+        # Check if any bot comment references this specific comment
+        comment_id = str(comment["id"])
+        comment_url = comment.get("html_url", "")
+        # Match by full URL or by the #issuecomment-{id} anchor with word boundary
+        # to prevent #issuecomment-123 from matching #issuecomment-1234
+        anchor_pattern = re.compile(rf"#issuecomment-{re.escape(comment_id)}(?!\d)")
+
+        replied = any(
+            anchor_pattern.search(body) or (comment_url and comment_url in body)
+            for body in bot_bodies
+        )
+
+        if not replied:
             needs_attention.append({
                 "type": "issue_comment",
                 "id": comment["id"],
+                "html_url": comment_url,
                 "author": author,
+                "author_type": "approved_bot" if is_approved_bot(author) else "human",
                 "body": comment["body"][:200],
                 "created_at": comment["created_at"],
-                "reason": "no_bot_reply" if last_bot_time is None else "human_followup_after_bot"
+                "reason": "no_bot_reply"
             })
 
     return needs_attention
@@ -792,6 +843,9 @@ RESPONSE RULES:
 1. For each piece of feedback, choose ONE response mechanism only - never respond to the same feedback via both inline reply AND general PR comment
 2. Only make code changes when explicitly requested (look for imperative language like 'change', 'fix', 'update', 'remove')
 3. For questions or clarifications, reply with an explanation only - do not change code unless asked
+4. COMMENT LINKAGE: When replying to a flat comment (type: issue_comment or review_body), you MUST include a reference so the system knows which comment you addressed:
+   - For issue_comment: include the html_url from the JSON in your reply. Format: start with 'Re: <html_url>' on its own line
+   - For review_body: include the review id from the JSON in your reply. Format: start with 'Re: review <id>' on its own line
 
 ${SUBAGENT_PROMPT}"
 
@@ -811,9 +865,53 @@ ${SUBAGENT_PROMPT}"
   set -e
   echo "Claude processing complete. Full output saved to /tmp/claude-pr-${PR_NUMBER}-output.json"
 
-  # Copy Claude output to SHARED_DIR for the report step
   if [ -f "/tmp/claude-pr-${PR_NUMBER}-output.json" ]; then
-    cp "/tmp/claude-pr-${PR_NUMBER}-output.json" "${SHARED_DIR}/claude-pr-${PR_NUMBER}-output.json"
+    # Full output to ARTIFACT_DIR (GCS-backed, no size limit)
+    cp "/tmp/claude-pr-${PR_NUMBER}-output.json" "${ARTIFACT_DIR}/claude-pr-${PR_NUMBER}-output.json"
+    # Compact summary to SHARED_DIR for the report step.
+    # SHARED_DIR is backed by a Kubernetes secret (1MB limit), so we
+    # extract only the fields the report needs into a small JSON file.
+    python3 -c "
+import json, sys
+f = sys.argv[1]
+result_line = system_line = None
+tool_calls = []
+tool_errors = []
+for line in open(f):
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        obj = json.loads(line)
+    except json.JSONDecodeError:
+        continue
+    t = obj.get('type', '')
+    if t == 'result':
+        result_line = obj
+    elif t == 'system':
+        system_line = obj
+    elif t == 'tool_use':
+        tool_calls.append(obj.get('name', 'unknown'))
+    if obj.get('is_error'):
+        tool_errors.append(str(obj.get('content', ''))[:200])
+summary = {}
+if result_line:
+    summary['result'] = (result_line.get('result') or '')[:5000]
+    summary['usage'] = result_line.get('usage', {})
+    summary['duration_ms'] = result_line.get('duration_ms', 0)
+    summary['duration_api_ms'] = result_line.get('duration_api_ms', 0)
+    summary['num_turns'] = result_line.get('num_turns', 0)
+    summary['session_id'] = result_line.get('session_id', '')
+    summary['total_cost_usd'] = result_line.get('total_cost_usd', 0)
+    summary['modelUsage'] = result_line.get('modelUsage', {})
+if system_line:
+    summary['model'] = system_line.get('model', 'unknown')
+    summary['tools'] = system_line.get('tools', [])
+summary['tool_calls'] = tool_calls
+summary['tool_errors'] = tool_errors
+print(json.dumps(summary))
+" "/tmp/claude-pr-${PR_NUMBER}-output.json" \
+      > "${SHARED_DIR}/claude-pr-${PR_NUMBER}-summary.json" 2>/dev/null || true
   fi
 
   if [ $EXIT_CODE -eq 0 ]; then

--- a/ci-operator/step-registry/hypershift/review-agent/report/hypershift-review-agent-report-commands.sh
+++ b/ci-operator/step-registry/hypershift/review-agent/report/hypershift-review-agent-report-commands.sh
@@ -157,24 +157,41 @@ while IFS= read -r line; do
     STATUS_LABEL="Failed"
   fi
 
-  # Try to find the Claude output JSON
-  OUTPUT_FILE="${SHARED_DIR}/claude-pr-${PR_NUMBER}-output.json"
-  if [ ! -f "$OUTPUT_FILE" ]; then
-    OUTPUT_FILE="/tmp/claude-pr-${PR_NUMBER}-output.json"
+  # Read from compact summary JSON (written by process step)
+  SUMMARY_FILE="${SHARED_DIR}/claude-pr-${PR_NUMBER}-summary.json"
+  if [ ! -f "$SUMMARY_FILE" ]; then
+    # Fallback to legacy stream-json format
+    SUMMARY_FILE="${SHARED_DIR}/claude-pr-${PR_NUMBER}-output.json"
   fi
 
-  # Extract data from stream-json output
-  RESULT_TEXT=$(extract_from_stream_json "$OUTPUT_FILE" "text" | html_escape)
-  PR_INPUT=$(extract_from_stream_json "$OUTPUT_FILE" "input_tokens")
-  PR_OUTPUT=$(extract_from_stream_json "$OUTPUT_FILE" "output_tokens")
-  PR_CACHE_READ=$(extract_from_stream_json "$OUTPUT_FILE" "cache_read")
-  PR_CACHE_CREATE=$(extract_from_stream_json "$OUTPUT_FILE" "cache_create")
-  DURATION_MS=$(extract_from_stream_json "$OUTPUT_FILE" "duration_ms")
-  DURATION_API_MS=$(extract_from_stream_json "$OUTPUT_FILE" "duration_api_ms")
-  NUM_TURNS=$(extract_from_stream_json "$OUTPUT_FILE" "num_turns")
-  MODEL=$(extract_from_stream_json "$OUTPUT_FILE" "model")
-  SESSION_ID=$(extract_from_stream_json "$OUTPUT_FILE" "session_id")
-  TOOLS_AVAILABLE=$(extract_from_stream_json "$OUTPUT_FILE" "tools_available")
+  if [ -f "$SUMMARY_FILE" ] && grep -q '"result"' "$SUMMARY_FILE" 2>/dev/null && ! grep -q '"type":"result"' "$SUMMARY_FILE" 2>/dev/null; then
+    # New compact summary format
+    RESULT_TEXT=$(jq -r '.result // empty' "$SUMMARY_FILE" 2>/dev/null | html_escape)
+    PR_INPUT=$(jq -r '.usage.input_tokens // 0' "$SUMMARY_FILE" 2>/dev/null)
+    PR_OUTPUT=$(jq -r '.usage.output_tokens // 0' "$SUMMARY_FILE" 2>/dev/null)
+    PR_CACHE_READ=$(jq -r '.usage.cache_read_input_tokens // 0' "$SUMMARY_FILE" 2>/dev/null)
+    PR_CACHE_CREATE=$(jq -r '.usage.cache_creation_input_tokens // (.usage.cache_creation.ephemeral_5m_input_tokens // 0)' "$SUMMARY_FILE" 2>/dev/null)
+    DURATION_MS=$(jq -r '.duration_ms // 0' "$SUMMARY_FILE" 2>/dev/null)
+    DURATION_API_MS=$(jq -r '.duration_api_ms // 0' "$SUMMARY_FILE" 2>/dev/null)
+    NUM_TURNS=$(jq -r '.num_turns // 0' "$SUMMARY_FILE" 2>/dev/null)
+    MODEL=$(jq -r '.model // "unknown"' "$SUMMARY_FILE" 2>/dev/null)
+    SESSION_ID=$(jq -r '.session_id // "unknown"' "$SUMMARY_FILE" 2>/dev/null)
+    TOOLS_AVAILABLE=$(jq -r '.tools // [] | join(",")' "$SUMMARY_FILE" 2>/dev/null)
+  else
+    # Legacy stream-json format
+    OUTPUT_FILE="$SUMMARY_FILE"
+    RESULT_TEXT=$(extract_from_stream_json "$OUTPUT_FILE" "text" | html_escape)
+    PR_INPUT=$(extract_from_stream_json "$OUTPUT_FILE" "input_tokens")
+    PR_OUTPUT=$(extract_from_stream_json "$OUTPUT_FILE" "output_tokens")
+    PR_CACHE_READ=$(extract_from_stream_json "$OUTPUT_FILE" "cache_read")
+    PR_CACHE_CREATE=$(extract_from_stream_json "$OUTPUT_FILE" "cache_create")
+    DURATION_MS=$(extract_from_stream_json "$OUTPUT_FILE" "duration_ms")
+    DURATION_API_MS=$(extract_from_stream_json "$OUTPUT_FILE" "duration_api_ms")
+    NUM_TURNS=$(extract_from_stream_json "$OUTPUT_FILE" "num_turns")
+    MODEL=$(extract_from_stream_json "$OUTPUT_FILE" "model")
+    SESSION_ID=$(extract_from_stream_json "$OUTPUT_FILE" "session_id")
+    TOOLS_AVAILABLE=$(extract_from_stream_json "$OUTPUT_FILE" "tools_available")
+  fi
 
   : "${PR_INPUT:=0}"
   : "${PR_OUTPUT:=0}"
@@ -185,7 +202,13 @@ while IFS= read -r line; do
 
   DURATION_SECS=$((DURATION_MS / 1000))
   DURATION_API_SECS=$((DURATION_API_MS / 1000))
-  PR_COST_RAW=$(extract_from_stream_json "$OUTPUT_FILE" "cost_usd")
+
+  # Cost - try summary format first, then legacy
+  if [ -f "$SUMMARY_FILE" ] && ! grep -q '"type":"result"' "$SUMMARY_FILE" 2>/dev/null; then
+    PR_COST_RAW=$(jq -r '.total_cost_usd // 0' "$SUMMARY_FILE" 2>/dev/null)
+  else
+    PR_COST_RAW=$(extract_from_stream_json "${OUTPUT_FILE:-$SUMMARY_FILE}" "cost_usd")
+  fi
   : "${PR_COST_RAW:=0}"
   PR_COST=$(format_cost "$PR_COST_RAW")
 
@@ -196,16 +219,18 @@ while IFS= read -r line; do
   GRAND_TOTAL_CACHE_CREATE=$((GRAND_TOTAL_CACHE_CREATE + PR_CACHE_CREATE))
   GRAND_TOTAL_COST_USD=$(sum_costs "$GRAND_TOTAL_COST_USD" "$PR_COST_RAW")
 
-  # Extract tool calls from stream-json
+  # Extract tool calls and errors
   TOOL_CALLS_RAW=""
   TOOL_ERRORS_RAW=""
-  if [ -f "$OUTPUT_FILE" ] && [ -s "$OUTPUT_FILE" ]; then
-    # Tool calls: extract tool_use messages with name and input
+  if [ -f "$SUMMARY_FILE" ] && ! grep -q '"type":"result"' "$SUMMARY_FILE" 2>/dev/null; then
+    # New compact summary format - tool_calls is a list of names, tool_errors is a list of strings
+    TOOL_CALLS_RAW=$(jq -r '.tool_calls[]? // empty' "$SUMMARY_FILE" 2>/dev/null | sed 's/^/  /' || echo "")
+    TOOL_ERRORS_RAW=$(jq -r '.tool_errors[]? // empty' "$SUMMARY_FILE" 2>/dev/null || echo "")
+  elif [ -f "${OUTPUT_FILE:-}" ] && [ -s "${OUTPUT_FILE:-}" ]; then
+    # Legacy stream-json format
     TOOL_CALLS_RAW=$(grep '"type":"tool_use"' "$OUTPUT_FILE" 2>/dev/null \
       | jq -r '"  \(.name)(\(.input | tostring | .[0:120])...)"' 2>/dev/null \
       || echo "")
-
-    # Tool errors: extract tool_result messages where is_error is true
     TOOL_ERRORS_RAW=$(grep '"is_error":true' "$OUTPUT_FILE" 2>/dev/null \
       | jq -r '.content // "unknown error"' 2>/dev/null \
       || echo "")
@@ -254,7 +279,11 @@ while IFS= read -r line; do
   # Token usage table
   # Build per-model breakdown rows
   MODEL_BREAKDOWN_ROWS=""
-  MODEL_BREAKDOWN_RAW=$(extract_from_stream_json "$OUTPUT_FILE" "model_usage")
+  if [ -f "$SUMMARY_FILE" ] && ! grep -q '"type":"result"' "$SUMMARY_FILE" 2>/dev/null; then
+    MODEL_BREAKDOWN_RAW=$(jq -r '.modelUsage // {} | to_entries[] | "\(.key)|\(.value.inputTokens // .value.input_tokens // 0)|\(.value.outputTokens // .value.output_tokens // 0)|\(.value.cacheReadInputTokens // .value.cache_read_input_tokens // 0)|\(.value.cacheCreationInputTokens // .value.cache_creation_input_tokens // 0)"' "$SUMMARY_FILE" 2>/dev/null | head -20 || echo "")
+  else
+    MODEL_BREAKDOWN_RAW=$(extract_from_stream_json "${OUTPUT_FILE:-$SUMMARY_FILE}" "model_usage")
+  fi
   if [ -n "$MODEL_BREAKDOWN_RAW" ]; then
     MODEL_BREAKDOWN_ROWS="<tr><td colspan=\"7\" style=\"background:#f0f0f0; font-size:0.85em; color:#666; padding:0.3em 1em;\"><em>Per-model breakdown</em></td></tr>"
     while IFS='|' read -r M_NAME M_INPUT M_OUTPUT M_CACHE_READ M_CACHE_CREATE; do


### PR DESCRIPTION
## Summary

Fixes the review agent's comment pre-filter which incorrectly skipped legitimate review feedback.

**The problem**: The `comment_analyzer.py` used a global `last_bot_time` timestamp cutoff to determine which comments were already addressed. Any bot comment posted after a human comment — even a completely unrelated one — would suppress that human comment from being flagged.

**How it was discovered**: On [PR #8211](https://github.com/openshift/hypershift/pull/8211), a reviewer [left feedback](https://github.com/openshift/hypershift/pull/8211#issuecomment-4238360555) ("verify is failing"), then [triggered the job](https://github.com/openshift/hypershift/pull/8211#issuecomment-4238887154) (`/test address-review-comments`). The [job ran successfully](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_hypershift/8211/pull-ci-openshift-hypershift-main-address-review-comments/2043766125514199040/) but concluded there were no comments needing attention — because an unrelated bot comment (a test failure analysis) happened to be posted between the reviewer's comment and the `/test` trigger.

**The fix**:
- **Issue comments**: Since these are flat (no threading), the bot must now include the comment URL (`Re: <url>`) when replying. The pre-filter checks if any bot reply references a specific comment's URL or `#issuecomment-{id}` anchor.
- **Review bodies**: Same approach — checks if any bot reply references the review ID.
- **Review threads**: Unchanged (already per-thread via GraphQL).

**Bot classification** is now three-way instead of a single `is_bot()`:

| Category | Examples | Behavior |
|---|---|---|
| **Our bot** (`BOT_ACCOUNTS`) | `hypershift-jira-solve-ci[bot]` | Comments count as "already replied" |
| **Approved bot** (`APPROVED_BOTS`) | `coderabbitai[bot]` | Comments trigger responses, labeled `author_type: "approved_bot"` |
| **Ignored** (`IGNORED_ACCOUNTS` + `[bot]` suffix) | `openshift-ci-robot`, `openshift-ci` | Skipped entirely |

This also fixes a pre-existing issue where `coderabbitai[bot]` comments were silently dropped by the old `is_bot()` catch-all `[bot]` suffix check, even though `APPROVED_BOTS` was defined.

## Test plan
- [x] Extracted `comment_analyzer.py` and ran locally against PR #8211
- [x] Verified the "verify is failing" comment is now correctly flagged
- [x] Verified prow bot comments (`openshift-ci-robot`) are filtered out
- [x] Verified `coderabbitai[bot]` comments are flagged with `author_type: "approved_bot"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bot classification so CI/unrecognized bots are ignored; only humans and approved bots are treated as actionable. Analysis now records author type, last actionable comment/author, and comment URLs for clearer traceability. Reply detection is more reliable and unaddressed reporting simplified.

* **New Features**
  * Bot replies must include explicit links to the referenced comment or review ID for automated matching and auditability.

* **Chores**
  * Full processing stream is preserved and a filtered, size-reduced report is written for shared artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->