### PR TITLE
switching rhoe 4.22 to single x86_64 imagestream

### DIFF
--- a/clusters/hosted-mgmt/hive/pools/rh-openshift-ecosystem/rhoe-ocp-4-22-amd64-aws-us-west-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/rh-openshift-ecosystem/rhoe-ocp-4-22-amd64-aws-us-west-1_clusterpool.yaml
@@ -18,7 +18,7 @@ spec:
   hibernationConfig:
     resumeTimeout: 20m0s
   imageSetRef:
-    name: ocp-release-4.22.0-ec.5-multi-for-4.22.0-0-to-4.23.0-0
+    name: ocp-release-4.22.0-ec.5-for-4.22.0-0-to-4.23.0-0
   installAttemptsLimit: 1
   installConfigSecretTemplateRef:
     name: install-config-4-22-amd64-aws-us-west-1

--- a/clusters/hosted-mgmt/hive/pools/rh-openshift-ecosystem/rhoe-ocp-4-22-amd64-aws-us-west-2_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/rh-openshift-ecosystem/rhoe-ocp-4-22-amd64-aws-us-west-2_clusterpool.yaml
@@ -18,7 +18,7 @@ spec:
   hibernationConfig:
     resumeTimeout: 20m0s
   imageSetRef:
-    name: ocp-release-4.22.0-ec.5-multi-for-4.22.0-0-to-4.23.0-0
+    name: ocp-release-4.22.0-ec.5-for-4.22.0-0-to-4.23.0-0
   installAttemptsLimit: 1
   installConfigSecretTemplateRef:
     name: install-config-4-22-amd64-aws-us-west-2


### PR DESCRIPTION
- Relates: #77739 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenShift cluster pool image set references across multiple AWS regions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->