### PR TITLE
CNTRLPLANE-3198: Test TestAzureScheduler with size tagging on self-managed

### DIFF
--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-main.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-main.yaml
@@ -219,7 +219,7 @@ tests:
       OCP_IMAGE_N1: release:n1minor
       OCP_IMAGE_N2: release:n2minor
     env:
-      CI_TESTS_RUN: ^(TestCreateCluster$|TestAutoscaling|TestNodePool|TestUpgradeControlPlane|TestHAEtcdChaos|TestAzureOAuthLoadBalancer|TestAzurePrivateTopology)$
+      CI_TESTS_RUN: ^TestAzureScheduler$
       ENABLE_HYPERSHIFT_CERT_ROTATION_SCALE: "true"
       HYPERSHIFT_AZURE_LOCATION: centralus
     post:

--- a/ci-operator/step-registry/hypershift/azure/e2e/self-managed/hypershift-azure-e2e-self-managed-workflow.yaml
+++ b/ci-operator/step-registry/hypershift/azure/e2e/self-managed/hypershift-azure-e2e-self-managed-workflow.yaml
@@ -34,4 +34,5 @@ workflow:
       HYPERSHIFT_NODE_COUNT: "3"
       HYPERSHIFT_AZURE_LOCATION: "centralus"
       AZURE_SELF_MANAGED: "true"
+      ENABLE_SIZE_TAGGING: "true"
       HYPERSHIFT_EXTERNAL_DNS_DOMAIN: "aks-e2e.hypershift.azure.devcluster.openshift.com"


### PR DESCRIPTION
## Summary
- Enable `ENABLE_SIZE_TAGGING: "true"` in the `hypershift-azure-e2e-self-managed` workflow
- Set `CI_TESTS_RUN` to `^TestAzureScheduler$` to validate the sizing feature works on self-managed Azure infrastructure
- This is a test-only PR to verify TestAzureScheduler works outside AKS before permanently adding it to the self-managed test suite

## Context
TestAzureScheduler requires the `ClusterSizingConfiguration` CR, which is only created when the HyperShift operator is installed with `--enable-size-tagging`. Currently only AKS workflows set this flag. This PR tests whether enabling it in the self-managed workflow is sufficient for the test to pass.

## Test plan
- [ ] Rehearsal job `pull-ci-openshift-hypershift-main-e2e-azure-self-managed` passes with TestAzureScheduler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/testing configuration for Azure self-managed environments to modify test execution parameters and add environment variable settings.

---

**Note:** This release contains infrastructure updates only. There are no end-user visible changes or new features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->