### PR TITLE
OCPBUGS-53195: rename 'master' to 'main' for router

### DIFF
--- a/ci-operator/config/openshift-priv/router/openshift-priv-router-main.yaml
+++ b/ci-operator/config/openshift-priv/router/openshift-priv-router-main.yaml
@@ -5,6 +5,7 @@ base_images:
     tag: dev-scripts
 build_root:
   from_repository: true
+canonical_go_repository: github.com/openshift/router
 images:
   items:
   - dockerfile_path: images/router/base/Dockerfile.ocp
@@ -14,18 +15,18 @@ images:
     to: haproxy-router
 promotion:
   to:
-  - name: "5.0"
-    namespace: ocp
+  - name: 4.22-priv
+    namespace: ocp-private
 releases:
   initial:
     integration:
-      name: "5.0"
-      namespace: ocp
+      name: 4.22-priv
+      namespace: ocp-private
   latest:
     integration:
       include_built_images: true
-      name: "5.0"
-      namespace: ocp
+      name: 4.22-priv
+      namespace: ocp-private
 resources:
   '*':
     requests:
@@ -234,6 +235,6 @@ tests:
     test:
     - ref: go-verify-deps
 zz_generated_metadata:
-  branch: master
-  org: openshift
+  branch: main
+  org: openshift-priv
   repo: router

--- a/ci-operator/config/openshift/router/openshift-router-main.yaml
+++ b/ci-operator/config/openshift/router/openshift-router-main.yaml
@@ -5,7 +5,6 @@ base_images:
     tag: dev-scripts
 build_root:
   from_repository: true
-canonical_go_repository: github.com/openshift/router
 images:
   items:
   - dockerfile_path: images/router/base/Dockerfile.ocp
@@ -15,18 +14,18 @@ images:
     to: haproxy-router
 promotion:
   to:
-  - name: 4.22-priv
-    namespace: ocp-private
+  - name: "5.0"
+    namespace: ocp
 releases:
   initial:
     integration:
-      name: 4.22-priv
-      namespace: ocp-private
+      name: "5.0"
+      namespace: ocp
   latest:
     integration:
       include_built_images: true
-      name: 4.22-priv
-      namespace: ocp-private
+      name: "5.0"
+      namespace: ocp
 resources:
   '*':
     requests:
@@ -235,6 +234,6 @@ tests:
     test:
     - ref: go-verify-deps
 zz_generated_metadata:
-  branch: master
-  org: openshift-priv
+  branch: main
+  org: openshift
   repo: router

--- a/ci-operator/config/openshift/router/openshift-router-main__okd-scos.yaml
+++ b/ci-operator/config/openshift/router/openshift-router-main__okd-scos.yaml
@@ -45,7 +45,7 @@ tests:
     cluster_profile: openshift-org-aws
     workflow: openshift-e2e-aws
 zz_generated_metadata:
-  branch: master
+  branch: main
   org: openshift
   repo: router
   variant: okd-scos

--- a/ci-operator/jobs/openshift-priv/router/openshift-priv-router-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/router/openshift-priv-router-main-postsubmits.yaml
@@ -15,7 +15,7 @@ postsubmits:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-openshift-priv-router-master-images
+    name: branch-ci-openshift-priv-router-main-images
     path_alias: github.com/openshift/router
     spec:
       containers:

--- a/ci-operator/jobs/openshift-priv/router/openshift-priv-router-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/router/openshift-priv-router-main-postsubmits.yaml
@@ -3,7 +3,7 @@ postsubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
+    - ^main$
     cluster: build08
     decorate: true
     decoration_config:

--- a/ci-operator/jobs/openshift-priv/router/openshift-priv-router-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/router/openshift-priv-router-main-postsubmits.yaml
@@ -3,7 +3,7 @@ postsubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
+    - ^main$
     cluster: build04
     decorate: true
     decoration_config:

--- a/ci-operator/jobs/openshift-priv/router/openshift-priv-router-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/router/openshift-priv-router-main-presubmits.yaml
@@ -3,7 +3,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build04
     context: ci/prow/e2e-agnostic
@@ -94,7 +94,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build07
     context: ci/prow/e2e-aws-fips
@@ -185,7 +185,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build07
     context: ci/prow/e2e-aws-serial-1of2
@@ -277,7 +277,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build07
     context: ci/prow/e2e-aws-serial-2of2
@@ -369,7 +369,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build06
     context: ci/prow/e2e-metal-ipi-ovn-dualstack
@@ -461,7 +461,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build06
     context: ci/prow/e2e-metal-ipi-ovn-ipv6
@@ -553,7 +553,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build06
     context: ci/prow/e2e-metal-ipi-ovn-router
@@ -645,7 +645,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build04
     context: ci/prow/e2e-upgrade
@@ -736,7 +736,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build04
     context: ci/prow/fips-image-scan-haproxy-router
@@ -824,7 +824,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build04
     context: ci/prow/images
@@ -887,7 +887,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build07
     context: ci/prow/perfscale-aws-fips-ingress-perf
@@ -978,7 +978,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build07
     context: ci/prow/perfscale-aws-ingress-perf
@@ -1069,7 +1069,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build04
     context: ci/prow/unit
@@ -1140,7 +1140,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build04
     context: ci/prow/verify
@@ -1211,7 +1211,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build04
     context: ci/prow/verify-deps

--- a/ci-operator/jobs/openshift-priv/router/openshift-priv-router-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/router/openshift-priv-router-main-presubmits.yaml
@@ -4,7 +4,7 @@ presubmits:
     always_run: false
     branches:
     - ^master$
-    - ^master-
+    - ^main-
     cluster: build04
     context: ci/prow/e2e-agnostic
     decorate: true
@@ -18,7 +18,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-router-master-e2e-agnostic
+    name: pull-ci-openshift-priv-router-main-e2e-agnostic
     path_alias: github.com/openshift/router
     rerun_command: /test e2e-agnostic
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|OWNERS_ALIASES|PROJECT|LICENSE)$
@@ -95,7 +95,7 @@ presubmits:
     always_run: false
     branches:
     - ^master$
-    - ^master-
+    - ^main-
     cluster: build07
     context: ci/prow/e2e-aws-fips
     decorate: true
@@ -109,7 +109,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-router-master-e2e-aws-fips
+    name: pull-ci-openshift-priv-router-main-e2e-aws-fips
     path_alias: github.com/openshift/router
     rerun_command: /test e2e-aws-fips
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|OWNERS_ALIASES|PROJECT|LICENSE)$
@@ -186,7 +186,7 @@ presubmits:
     always_run: false
     branches:
     - ^master$
-    - ^master-
+    - ^main-
     cluster: build07
     context: ci/prow/e2e-aws-serial-1of2
     decorate: true
@@ -200,7 +200,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-router-master-e2e-aws-serial-1of2
+    name: pull-ci-openshift-priv-router-main-e2e-aws-serial-1of2
     path_alias: github.com/openshift/router
     rerun_command: /test e2e-aws-serial-1of2
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|OWNERS_ALIASES|PROJECT|LICENSE)$
@@ -278,7 +278,7 @@ presubmits:
     always_run: false
     branches:
     - ^master$
-    - ^master-
+    - ^main-
     cluster: build07
     context: ci/prow/e2e-aws-serial-2of2
     decorate: true
@@ -292,7 +292,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-router-master-e2e-aws-serial-2of2
+    name: pull-ci-openshift-priv-router-main-e2e-aws-serial-2of2
     path_alias: github.com/openshift/router
     rerun_command: /test e2e-aws-serial-2of2
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|OWNERS_ALIASES|PROJECT|LICENSE)$
@@ -370,7 +370,7 @@ presubmits:
     always_run: false
     branches:
     - ^master$
-    - ^master-
+    - ^main-
     cluster: build06
     context: ci/prow/e2e-metal-ipi-ovn-dualstack
     decorate: true
@@ -385,7 +385,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-router-master-e2e-metal-ipi-ovn-dualstack
+    name: pull-ci-openshift-priv-router-main-e2e-metal-ipi-ovn-dualstack
     optional: true
     path_alias: github.com/openshift/router
     rerun_command: /test e2e-metal-ipi-ovn-dualstack
@@ -462,7 +462,7 @@ presubmits:
     always_run: false
     branches:
     - ^master$
-    - ^master-
+    - ^main-
     cluster: build06
     context: ci/prow/e2e-metal-ipi-ovn-ipv6
     decorate: true
@@ -477,7 +477,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-router-master-e2e-metal-ipi-ovn-ipv6
+    name: pull-ci-openshift-priv-router-main-e2e-metal-ipi-ovn-ipv6
     optional: true
     path_alias: github.com/openshift/router
     rerun_command: /test e2e-metal-ipi-ovn-ipv6
@@ -554,7 +554,7 @@ presubmits:
     always_run: false
     branches:
     - ^master$
-    - ^master-
+    - ^main-
     cluster: build06
     context: ci/prow/e2e-metal-ipi-ovn-router
     decorate: true
@@ -569,7 +569,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-router-master-e2e-metal-ipi-ovn-router
+    name: pull-ci-openshift-priv-router-main-e2e-metal-ipi-ovn-router
     optional: true
     path_alias: github.com/openshift/router
     rerun_command: /test e2e-metal-ipi-ovn-router
@@ -646,7 +646,7 @@ presubmits:
     always_run: false
     branches:
     - ^master$
-    - ^master-
+    - ^main-
     cluster: build04
     context: ci/prow/e2e-upgrade
     decorate: true
@@ -660,7 +660,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-azure
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-router-master-e2e-upgrade
+    name: pull-ci-openshift-priv-router-main-e2e-upgrade
     path_alias: github.com/openshift/router
     rerun_command: /test e2e-upgrade
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|OWNERS_ALIASES|PROJECT|LICENSE)$
@@ -737,7 +737,7 @@ presubmits:
     always_run: true
     branches:
     - ^master$
-    - ^master-
+    - ^main-
     cluster: build04
     context: ci/prow/fips-image-scan-haproxy-router
     decorate: true
@@ -749,7 +749,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-router-master-fips-image-scan-haproxy-router
+    name: pull-ci-openshift-priv-router-main-fips-image-scan-haproxy-router
     path_alias: github.com/openshift/router
     rerun_command: /test fips-image-scan-haproxy-router
     spec:
@@ -825,7 +825,7 @@ presubmits:
     always_run: true
     branches:
     - ^master$
-    - ^master-
+    - ^main-
     cluster: build04
     context: ci/prow/images
     decorate: true
@@ -837,7 +837,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-router-master-images
+    name: pull-ci-openshift-priv-router-main-images
     path_alias: github.com/openshift/router
     rerun_command: /test images
     spec:
@@ -888,7 +888,7 @@ presubmits:
     always_run: false
     branches:
     - ^master$
-    - ^master-
+    - ^main-
     cluster: build07
     context: ci/prow/perfscale-aws-fips-ingress-perf
     decorate: true
@@ -902,7 +902,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-router-master-perfscale-aws-fips-ingress-perf
+    name: pull-ci-openshift-priv-router-main-perfscale-aws-fips-ingress-perf
     optional: true
     path_alias: github.com/openshift/router
     rerun_command: /test perfscale-aws-fips-ingress-perf
@@ -979,7 +979,7 @@ presubmits:
     always_run: false
     branches:
     - ^master$
-    - ^master-
+    - ^main-
     cluster: build07
     context: ci/prow/perfscale-aws-ingress-perf
     decorate: true
@@ -993,7 +993,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-router-master-perfscale-aws-ingress-perf
+    name: pull-ci-openshift-priv-router-main-perfscale-aws-ingress-perf
     optional: true
     path_alias: github.com/openshift/router
     rerun_command: /test perfscale-aws-ingress-perf
@@ -1070,7 +1070,7 @@ presubmits:
     always_run: true
     branches:
     - ^master$
-    - ^master-
+    - ^main-
     cluster: build04
     context: ci/prow/unit
     decorate: true
@@ -1082,7 +1082,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-router-master-unit
+    name: pull-ci-openshift-priv-router-main-unit
     path_alias: github.com/openshift/router
     rerun_command: /test unit
     spec:
@@ -1141,7 +1141,7 @@ presubmits:
     always_run: true
     branches:
     - ^master$
-    - ^master-
+    - ^main-
     cluster: build04
     context: ci/prow/verify
     decorate: true
@@ -1153,7 +1153,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-router-master-verify
+    name: pull-ci-openshift-priv-router-main-verify
     path_alias: github.com/openshift/router
     rerun_command: /test verify
     spec:
@@ -1212,7 +1212,7 @@ presubmits:
     always_run: true
     branches:
     - ^master$
-    - ^master-
+    - ^main-
     cluster: build04
     context: ci/prow/verify-deps
     decorate: true
@@ -1224,7 +1224,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-priv-router-master-verify-deps
+    name: pull-ci-openshift-priv-router-main-verify-deps
     path_alias: github.com/openshift/router
     rerun_command: /test verify-deps
     spec:

--- a/ci-operator/jobs/openshift-priv/router/openshift-priv-router-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/router/openshift-priv-router-main-presubmits.yaml
@@ -3,7 +3,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build13
     context: ci/prow/e2e-agnostic
@@ -98,7 +98,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build07
     context: ci/prow/e2e-aws-fips
@@ -193,7 +193,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build07
     context: ci/prow/e2e-aws-serial-1of2
@@ -289,7 +289,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build07
     context: ci/prow/e2e-aws-serial-2of2
@@ -385,7 +385,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build09
     context: ci/prow/e2e-metal-ipi-ovn-dualstack
@@ -481,7 +481,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build09
     context: ci/prow/e2e-metal-ipi-ovn-ipv6
@@ -577,7 +577,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build09
     context: ci/prow/e2e-metal-ipi-ovn-router
@@ -673,7 +673,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build04
     context: ci/prow/e2e-upgrade
@@ -768,7 +768,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build04
     context: ci/prow/fips-image-scan-haproxy-router
@@ -860,7 +860,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build04
     context: ci/prow/images
@@ -927,7 +927,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build07
     context: ci/prow/perfscale-aws-fips-ingress-perf
@@ -1022,7 +1022,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build07
     context: ci/prow/perfscale-aws-ingress-perf
@@ -1117,7 +1117,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build04
     context: ci/prow/unit
@@ -1192,7 +1192,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build04
     context: ci/prow/verify
@@ -1267,7 +1267,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build04
     context: ci/prow/verify-deps

--- a/ci-operator/jobs/openshift/router/openshift-router-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/router/openshift-router-main-postsubmits.yaml
@@ -10,7 +10,7 @@ postsubmits:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-openshift-router-master-images
+    name: branch-ci-openshift-router-main-images
     spec:
       containers:
       - args:
@@ -71,7 +71,7 @@ postsubmits:
       ci-operator.openshift.io/variant: okd-scos
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-openshift-router-master-okd-scos-images
+    name: branch-ci-openshift-router-main-okd-scos-images
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift/router/openshift-router-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/router/openshift-router-main-postsubmits.yaml
@@ -3,7 +3,7 @@ postsubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
+    - ^main$
     cluster: build05
     decorate: true
     labels:
@@ -61,7 +61,7 @@ postsubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
+    - ^main$
     cluster: build05
     decorate: true
     decoration_config:

--- a/ci-operator/jobs/openshift/router/openshift-router-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/router/openshift-router-main-postsubmits.yaml
@@ -3,7 +3,7 @@ postsubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
+    - ^main$
     cluster: build13
     decorate: true
     decoration_config:
@@ -66,7 +66,7 @@ postsubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
+    - ^main$
     cluster: build13
     decorate: true
     decoration_config:

--- a/ci-operator/jobs/openshift/router/openshift-router-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/router/openshift-router-main-presubmits.yaml
@@ -4,7 +4,7 @@ presubmits:
     always_run: false
     branches:
     - ^master$
-    - ^master-
+    - ^main-
     cluster: build08
     context: ci/prow/e2e-agnostic
     decorate: true
@@ -13,7 +13,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-router-master-e2e-agnostic
+    name: pull-ci-openshift-router-main-e2e-agnostic
     rerun_command: /test e2e-agnostic
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|OWNERS_ALIASES|PROJECT|LICENSE)$
     spec:
@@ -85,7 +85,7 @@ presubmits:
     always_run: false
     branches:
     - ^master$
-    - ^master-
+    - ^main-
     cluster: build11
     context: ci/prow/e2e-aws-fips
     decorate: true
@@ -94,7 +94,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-router-master-e2e-aws-fips
+    name: pull-ci-openshift-router-main-e2e-aws-fips
     rerun_command: /test e2e-aws-fips
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|OWNERS_ALIASES|PROJECT|LICENSE)$
     spec:
@@ -166,7 +166,7 @@ presubmits:
     always_run: false
     branches:
     - ^master$
-    - ^master-
+    - ^main-
     cluster: build11
     context: ci/prow/e2e-aws-serial-1of2
     decorate: true
@@ -175,7 +175,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-router-master-e2e-aws-serial-1of2
+    name: pull-ci-openshift-router-main-e2e-aws-serial-1of2
     rerun_command: /test e2e-aws-serial-1of2
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|OWNERS_ALIASES|PROJECT|LICENSE)$
     spec:
@@ -248,7 +248,7 @@ presubmits:
     always_run: false
     branches:
     - ^master$
-    - ^master-
+    - ^main-
     cluster: build11
     context: ci/prow/e2e-aws-serial-2of2
     decorate: true
@@ -257,7 +257,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-router-master-e2e-aws-serial-2of2
+    name: pull-ci-openshift-router-main-e2e-aws-serial-2of2
     rerun_command: /test e2e-aws-serial-2of2
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|OWNERS_ALIASES|PROJECT|LICENSE)$
     spec:
@@ -330,7 +330,7 @@ presubmits:
     always_run: false
     branches:
     - ^master$
-    - ^master-
+    - ^main-
     cluster: build09
     context: ci/prow/e2e-metal-ipi-ovn-dualstack
     decorate: true
@@ -340,7 +340,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-router-master-e2e-metal-ipi-ovn-dualstack
+    name: pull-ci-openshift-router-main-e2e-metal-ipi-ovn-dualstack
     optional: true
     rerun_command: /test e2e-metal-ipi-ovn-dualstack
     spec:
@@ -412,7 +412,7 @@ presubmits:
     always_run: false
     branches:
     - ^master$
-    - ^master-
+    - ^main-
     cluster: build09
     context: ci/prow/e2e-metal-ipi-ovn-ipv6
     decorate: true
@@ -422,7 +422,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-router-master-e2e-metal-ipi-ovn-ipv6
+    name: pull-ci-openshift-router-main-e2e-metal-ipi-ovn-ipv6
     optional: true
     rerun_command: /test e2e-metal-ipi-ovn-ipv6
     spec:
@@ -494,7 +494,7 @@ presubmits:
     always_run: false
     branches:
     - ^master$
-    - ^master-
+    - ^main-
     cluster: build09
     context: ci/prow/e2e-metal-ipi-ovn-router
     decorate: true
@@ -504,7 +504,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-router-master-e2e-metal-ipi-ovn-router
+    name: pull-ci-openshift-router-main-e2e-metal-ipi-ovn-router
     optional: true
     rerun_command: /test e2e-metal-ipi-ovn-router
     spec:
@@ -576,7 +576,7 @@ presubmits:
     always_run: false
     branches:
     - ^master$
-    - ^master-
+    - ^main-
     cluster: build09
     context: ci/prow/e2e-upgrade
     decorate: true
@@ -585,7 +585,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-azure
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-router-master-e2e-upgrade
+    name: pull-ci-openshift-router-main-e2e-upgrade
     rerun_command: /test e2e-upgrade
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|OWNERS_ALIASES|PROJECT|LICENSE)$
     spec:
@@ -657,14 +657,14 @@ presubmits:
     always_run: true
     branches:
     - ^master$
-    - ^master-
+    - ^main-
     cluster: build09
     context: ci/prow/fips-image-scan-haproxy-router
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-router-master-fips-image-scan-haproxy-router
+    name: pull-ci-openshift-router-main-fips-image-scan-haproxy-router
     rerun_command: /test fips-image-scan-haproxy-router
     spec:
       containers:
@@ -735,14 +735,14 @@ presubmits:
     always_run: true
     branches:
     - ^master$
-    - ^master-
+    - ^main-
     cluster: build09
     context: ci/prow/images
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-router-master-images
+    name: pull-ci-openshift-router-main-images
     rerun_command: /test images
     spec:
       containers:
@@ -789,7 +789,7 @@ presubmits:
     always_run: false
     branches:
     - ^master$
-    - ^master-
+    - ^main-
     cluster: build11
     context: ci/prow/okd-scos-e2e-aws-ovn
     decorate: true
@@ -801,7 +801,7 @@ presubmits:
       ci-operator.openshift.io/variant: okd-scos
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-router-master-okd-scos-e2e-aws-ovn
+    name: pull-ci-openshift-router-main-okd-scos-e2e-aws-ovn
     optional: true
     rerun_command: /test okd-scos-e2e-aws-ovn
     spec:
@@ -874,7 +874,7 @@ presubmits:
     always_run: true
     branches:
     - ^master$
-    - ^master-
+    - ^main-
     cluster: build09
     context: ci/prow/okd-scos-images
     decorate: true
@@ -884,7 +884,7 @@ presubmits:
       ci-operator.openshift.io/variant: okd-scos
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-router-master-okd-scos-images
+    name: pull-ci-openshift-router-main-okd-scos-images
     rerun_command: /test okd-scos-images
     spec:
       containers:
@@ -932,7 +932,7 @@ presubmits:
     always_run: false
     branches:
     - ^master$
-    - ^master-
+    - ^main-
     cluster: build11
     context: ci/prow/perfscale-aws-fips-ingress-perf
     decorate: true
@@ -941,7 +941,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-router-master-perfscale-aws-fips-ingress-perf
+    name: pull-ci-openshift-router-main-perfscale-aws-fips-ingress-perf
     optional: true
     rerun_command: /test perfscale-aws-fips-ingress-perf
     spec:
@@ -1013,7 +1013,7 @@ presubmits:
     always_run: false
     branches:
     - ^master$
-    - ^master-
+    - ^main-
     cluster: build11
     context: ci/prow/perfscale-aws-ingress-perf
     decorate: true
@@ -1022,7 +1022,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-router-master-perfscale-aws-ingress-perf
+    name: pull-ci-openshift-router-main-perfscale-aws-ingress-perf
     optional: true
     rerun_command: /test perfscale-aws-ingress-perf
     spec:
@@ -1094,14 +1094,14 @@ presubmits:
     always_run: true
     branches:
     - ^master$
-    - ^master-
+    - ^main-
     cluster: build09
     context: ci/prow/unit
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-router-master-unit
+    name: pull-ci-openshift-router-main-unit
     rerun_command: /test unit
     spec:
       containers:
@@ -1155,14 +1155,14 @@ presubmits:
     always_run: true
     branches:
     - ^master$
-    - ^master-
+    - ^main-
     cluster: build09
     context: ci/prow/verify
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-router-master-verify
+    name: pull-ci-openshift-router-main-verify
     rerun_command: /test verify
     spec:
       containers:
@@ -1216,14 +1216,14 @@ presubmits:
     always_run: true
     branches:
     - ^master$
-    - ^master-
+    - ^main-
     cluster: build09
     context: ci/prow/verify-deps
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-router-master-verify-deps
+    name: pull-ci-openshift-router-main-verify-deps
     rerun_command: /test verify-deps
     spec:
       containers:

--- a/ci-operator/jobs/openshift/router/openshift-router-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/router/openshift-router-main-presubmits.yaml
@@ -3,7 +3,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build08
     context: ci/prow/e2e-agnostic
@@ -84,7 +84,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build11
     context: ci/prow/e2e-aws-fips
@@ -165,7 +165,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build11
     context: ci/prow/e2e-aws-serial-1of2
@@ -247,7 +247,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build11
     context: ci/prow/e2e-aws-serial-2of2
@@ -329,7 +329,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build09
     context: ci/prow/e2e-metal-ipi-ovn-dualstack
@@ -411,7 +411,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build09
     context: ci/prow/e2e-metal-ipi-ovn-ipv6
@@ -493,7 +493,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build09
     context: ci/prow/e2e-metal-ipi-ovn-router
@@ -575,7 +575,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build09
     context: ci/prow/e2e-upgrade
@@ -656,7 +656,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build09
     context: ci/prow/fips-image-scan-haproxy-router
@@ -734,7 +734,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build09
     context: ci/prow/images
@@ -788,7 +788,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build11
     context: ci/prow/okd-scos-e2e-aws-ovn
@@ -873,7 +873,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build09
     context: ci/prow/okd-scos-images
@@ -931,7 +931,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build11
     context: ci/prow/perfscale-aws-fips-ingress-perf
@@ -1012,7 +1012,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build11
     context: ci/prow/perfscale-aws-ingress-perf
@@ -1093,7 +1093,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build09
     context: ci/prow/unit
@@ -1154,7 +1154,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build09
     context: ci/prow/verify
@@ -1215,7 +1215,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build09
     context: ci/prow/verify-deps

--- a/ci-operator/jobs/openshift/router/openshift-router-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/router/openshift-router-main-presubmits.yaml
@@ -3,7 +3,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build13
     context: ci/prow/e2e-agnostic
@@ -89,7 +89,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build11
     context: ci/prow/e2e-aws-fips
@@ -175,7 +175,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build11
     context: ci/prow/e2e-aws-serial-1of2
@@ -262,7 +262,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build11
     context: ci/prow/e2e-aws-serial-2of2
@@ -349,7 +349,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build12
     context: ci/prow/e2e-metal-ipi-ovn-dualstack
@@ -436,7 +436,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build12
     context: ci/prow/e2e-metal-ipi-ovn-ipv6
@@ -523,7 +523,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build12
     context: ci/prow/e2e-metal-ipi-ovn-router
@@ -610,7 +610,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build11
     context: ci/prow/e2e-upgrade
@@ -696,7 +696,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build11
     context: ci/prow/fips-image-scan-haproxy-router
@@ -779,7 +779,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build11
     context: ci/prow/images
@@ -838,7 +838,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build11
     context: ci/prow/okd-scos-e2e-aws-ovn
@@ -925,7 +925,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build11
     context: ci/prow/okd-scos-images
@@ -985,7 +985,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build11
     context: ci/prow/perfscale-aws-fips-ingress-perf
@@ -1071,7 +1071,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build11
     context: ci/prow/perfscale-aws-ingress-perf
@@ -1157,7 +1157,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build11
     context: ci/prow/unit
@@ -1223,7 +1223,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build11
     context: ci/prow/verify
@@ -1289,7 +1289,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
+    - ^main$
     - ^main-
     cluster: build11
     context: ci/prow/verify-deps


### PR DESCRIPTION
This PR reverts the revert PR https://github.com/openshift/release/pull/63746 to permanently switch the router repository branches from 'master' to 'main' across the CI operator configuration.

Jira issue: https://issues.redhat.com/browse/OCPBUGS-53195

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configuration files for OpenShift router repositories to align branch references and standardize job identifiers across build, test, presubmit, and postsubmit pipeline definitions. These infrastructure changes ensure consistent configuration across repository configurations without affecting router functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->