### PR TITLE
remove ocp 5 from release controller for osde2e

### DIFF
--- a/core-services/release-controller/_releases/priv/release-ocp-5.0.json
+++ b/core-services/release-controller/_releases/priv/release-ocp-5.0.json
@@ -549,25 +549,11 @@
                 "name": "periodic-ci-openshift-microshift-release-5.0-periodics-e2e-aws-ovn-ocp-conformance-serial-priv"
             }
         },
-        "openshift-dedicated-aws": {
-            "disabled": true,
-            "optional": true,
-            "prowJob": {
-                "name": "periodic-ci-openshift-osde2e-main-nightly-5.0-osd-aws-priv"
-            }
-        },
         "openshift-dedicated-gcp-conformance": {
             "disabled": true,
             "optional": true,
             "prowJob": {
                 "name": "periodic-ci-openshift-release-main-nightly-5.0-e2e-osd-ccs-gcp-priv"
-            }
-        },
-        "openshift-dedicated-gcp-osde2e": {
-            "disabled": true,
-            "optional": true,
-            "prowJob": {
-                "name": "periodic-ci-openshift-osde2e-main-nightly-5.0-osd-gcp-priv"
             }
         },
         "overall-analysis-all": {
@@ -606,13 +592,6 @@
             "optional": true,
             "prowJob": {
                 "name": "periodic-ci-openshift-release-main-nightly-5.0-e2e-rosa-sts-ovn-priv"
-            }
-        },
-        "rosa-classic-sts-osde2e": {
-            "disabled": true,
-            "optional": true,
-            "prowJob": {
-                "name": "periodic-ci-openshift-osde2e-main-nightly-5.0-rosa-classic-sts-priv"
             }
         },
         "telco5g": {

--- a/core-services/release-controller/_releases/release-ocp-5.0.json
+++ b/core-services/release-controller/_releases/release-ocp-5.0.json
@@ -527,18 +527,6 @@
         "name": "periodic-ci-openshift-microshift-release-5.0-periodics-e2e-aws-ovn-ocp-conformance-serial"
       }
     },
-    "openshift-dedicated-aws": {
-      "optional": true,
-      "prowJob": {
-        "name": "periodic-ci-openshift-osde2e-main-nightly-5.0-osd-aws"
-      }
-    },
-    "openshift-dedicated-gcp-osde2e": {
-      "optional": true,
-      "prowJob": {
-        "name": "periodic-ci-openshift-osde2e-main-nightly-5.0-osd-gcp"
-      }
-    },
     "openshift-dedicated-gcp-conformance": {
       "optional": true,
       "prowJob": {
@@ -562,12 +550,6 @@
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-aws-5.0-nightly-x86-payload-control-plane-6nodes"
-      }
-    },
-    "rosa-classic-sts-osde2e": {
-      "optional": true,
-      "prowJob": {
-        "name": "periodic-ci-openshift-osde2e-main-nightly-5.0-rosa-classic-sts"
       }
     },
     "rosa-classic-sts-conformance": {


### PR DESCRIPTION
remove those versions from release controller as they are not needed for now

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed optional verification jobs for OpenCP Dedicated AWS, OpenCP Dedicated GCP, and ROSA Classic STS from the 5.0 release configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->