### PR TITLE
Quay: Migrate 3.13 and 3.14 API testing to use Konflux build

### DIFF
--- a/ci-operator/config/quay/quay-tests/quay-quay-tests-master__quay-api.yaml
+++ b/ci-operator/config/quay/quay-tests/quay-quay-tests-master__quay-api.yaml
@@ -30,13 +30,13 @@ tests:
 - as: quay-e2e-tests-quay313-api-testing
   cron: 0 12 * * 6
   steps:
-    cluster_profile: aws-qe
+    cluster_profile: aws-quay-qe
     env:
-      BASE_DOMAIN: qe.devcluster.openshift.com
+      BASE_DOMAIN: quayqe.devcluster.openshift.com
       COMPUTE_NODE_TYPE: m5.2xlarge
-      MULTISTAGE_PARAM_OVERRIDE_QUAY_INDEX_IMAGE: brew.registry.redhat.io/rh-osbs/iib:950387
+      MULTISTAGE_PARAM_OVERRIDE_QUAY_INDEX_IMAGE: quay.io/redhat-user-workloads/quay-eng-tenant/stable-3-13-v4-21@sha256:d72c8d8779cb0dd607e72aab5efab7461fb60067593cce99f9b43fb0129036d9
       QUAY_OPERATOR_CHANNEL: stable-3.13
-      QUAY_OPERATOR_SOURCE: brew-operator-catalog
+      QUAY_OPERATOR_SOURCE: fbc-operator-catalog
       QUAY_VERSION: "3.13"
     test:
     - ref: quay-tests-enable-quay-catalogsource
@@ -46,13 +46,13 @@ tests:
 - as: quay-e2e-tests-quay314-api-testing
   cron: 0 12 * * 3
   steps:
-    cluster_profile: aws-qe
+    cluster_profile: aws-quay-qe
     env:
-      BASE_DOMAIN: qe.devcluster.openshift.com
+      BASE_DOMAIN: quayqe.devcluster.openshift.com
       COMPUTE_NODE_TYPE: m5.2xlarge
-      MULTISTAGE_PARAM_OVERRIDE_QUAY_INDEX_IMAGE: brew.registry.redhat.io/rh-osbs/iib:940263
+      MULTISTAGE_PARAM_OVERRIDE_QUAY_INDEX_IMAGE: quay.io/redhat-user-workloads/quay-eng-tenant/stable-3-14-v4-21@sha256:eedb0e6ffdeccbfd7053cde733627e5af81d4c8ea9c478c9c77f7049a54766a9
       QUAY_OPERATOR_CHANNEL: stable-3.14
-      QUAY_OPERATOR_SOURCE: brew-operator-catalog
+      QUAY_OPERATOR_SOURCE: fbc-operator-catalog
       QUAY_VERSION: "3.14"
     test:
     - ref: quay-tests-enable-quay-catalogsource

--- a/ci-operator/jobs/quay/quay-tests/quay-quay-tests-master-periodics.yaml
+++ b/ci-operator/jobs/quay/quay-tests/quay-quay-tests-master-periodics.yaml
@@ -7167,7 +7167,7 @@ periodics:
     repo: quay-tests
   labels:
     ci-operator.openshift.io/cloud: aws
-    ci-operator.openshift.io/cloud-cluster-profile: aws-qe
+    ci-operator.openshift.io/cloud-cluster-profile: aws-quay-qe
     ci-operator.openshift.io/variant: quay-api
     ci.openshift.io/generator: prowgen
     job-release: "4.21"
@@ -7268,7 +7268,7 @@ periodics:
     repo: quay-tests
   labels:
     ci-operator.openshift.io/cloud: aws
-    ci-operator.openshift.io/cloud-cluster-profile: aws-qe
+    ci-operator.openshift.io/cloud-cluster-profile: aws-quay-qe
     ci-operator.openshift.io/variant: quay-api
     ci.openshift.io/generator: prowgen
     job-release: "4.21"


### PR DESCRIPTION
## Summary

- Switch `quay-e2e-tests-quay313-api-testing` and `quay-e2e-tests-quay314-api-testing` from brew IIB images to Konflux FBC images
- Update `QUAY_OPERATOR_SOURCE` from `brew-operator-catalog` → `fbc-operator-catalog`
- Update `MULTISTAGE_PARAM_OVERRIDE_QUAY_INDEX_IMAGE` to use `quay.io/redhat-user-workloads/quay-eng-tenant` Konflux images
- Update `cluster_profile` from `aws-qe` → `aws-quay-qe` and `BASE_DOMAIN` to `quayqe.devcluster.openshift.com` to match existing Konflux-based API tests (3.15–3.17)

## Test plan

- [x] Verify `quay-e2e-tests-quay313-api-testing` runs successfully with the Konflux FBC image
- [x] Verify `quay-e2e-tests-quay314-api-testing` runs successfully with the Konflux FBC image
- [x] Confirm `fbc-operator-catalog` source is available in the `aws-quay-qe` cluster profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI test infrastructure for API testing: switched test cluster profile and test domain, updated operator catalog source, and refreshed container image references for end-to-end API tests.
  * Adjusted periodic job metadata to reflect the new cluster profile for scheduled test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->