### PR TITLE
[openshift-psap/fournos] expose the PSAP_FORGE_FOREIGN_TESTING flag for FORGE

### DIFF
--- a/ci-operator/config/openshift-psap/fournos/openshift-psap-fournos-main.yaml
+++ b/ci-operator/config/openshift-psap/fournos/openshift-psap-fournos-main.yaml
@@ -24,11 +24,13 @@ tests:
         export PSAP_FORGE_FOURNOS_DEPLOY_SECRET_PATH=/var/run/psap-forge-fournos-deploy
         export PSAP_FORGE_NOTIFICATIONS_SECRET_PATH=/var/run/psap-forge-notifications
 
+        export PSAP_FORGE_FOREIGN_TESTING=openshift-psap/fournos
+
         TMP_MAIN_BRANCH=fournos-testing
         git -C $HOME fetch --quiet origin $TMP_MAIN_BRANCH
         git -C $HOME reset --hard FETCH_HEAD
 
-        exec ./bin/run_ci foreign_testing ci run
+        exec ./bin/run_ci foreign_testing ci submit
       credentials:
       - mount_path: /var/run/psap-forge-fournos-deploy
         name: psap-forge-fournos-deploy


### PR DESCRIPTION
…

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI testing configuration to enhance test execution workflow.

**Note:** This release contains only internal infrastructure changes with no user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->