### PR TITLE
Ignore rhbk/sso-test in check-gh-automation jobs

### DIFF
--- a/ci-operator/jobs/infra-periodics.yaml
+++ b/ci-operator/jobs/infra-periodics.yaml
@@ -2389,6 +2389,7 @@ periodics:
       - --ignore=jws-qe/interop-ocp-ci
       - --ignore=openshift-logging/extended-logging-tests-interop
       - --ignore=Azure/ARO-HCP
+      - --ignore=rhbk/sso-test
       command:
       - ./hack/check-gh-automation.sh
       env:
@@ -2457,6 +2458,7 @@ periodics:
       - --ignore=jws-qe/interop-ocp-ci
       - --ignore=red-hat-storage/rook
       - --ignore=Azure/ARO-HCP
+      - --ignore=rhbk/sso-test
       command:
       - ./hack/check-gh-automation.sh
       env:

--- a/ci-operator/jobs/openshift/release/openshift-release-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/release/openshift-release-main-presubmits.yaml
@@ -73,6 +73,7 @@ presubmits:
         - --ignore=ran-telco5g/kpi-results
         - --ignore=openshift-logging/extended-logging-tests-interop
         - --ignore=Azure/ARO-HCP
+        - --ignore=rhbk/sso-test
         command:
         - ./hack/check-gh-automation.sh
         env:
@@ -135,6 +136,7 @@ presubmits:
         - --ignore=rh-openjdk/jdkContainerOcpTests
         - --ignore=jws-qe/interop-ocp-ci
         - --ignore=Azure/ARO-HCP
+        - --ignore=rhbk/sso-test
         command:
         - ./hack/check-gh-automation.sh
         env:


### PR DESCRIPTION
The openshift-ci GitHub App is not installed in the rhbk org, causing periodic-check-gh-automation-tide to fail. Add rhbk/sso-test to the ignore list for all check-gh-automation periodic and presubmit jobs until the app is properly installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub automation check configurations to exclude a specific repository from automated validation scans across multiple job workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->