### PR TITLE
Fix release-4.22 configs promoting to wrong release version

### DIFF
--- a/ci-operator/config/kubev2v/migration-planner/kubev2v-migration-planner-release-4.22.yaml
+++ b/ci-operator/config/kubev2v/migration-planner/kubev2v-migration-planner-release-4.22.yaml
@@ -5,17 +5,17 @@ build_root:
     tag: rhel-8-release-golang-1.25-openshift-4.23
 promotion:
   to:
-  - name: "5.0"
+  - name: "4.22"
     namespace: ocp
 releases:
   initial:
     integration:
-      name: "5.0"
+      name: "4.22"
       namespace: ocp
   latest:
     integration:
       include_built_images: true
-      name: "5.0"
+      name: "4.22"
       namespace: ocp
 resources:
   '*':

--- a/ci-operator/config/openshift-online/access-transparency-service/openshift-online-access-transparency-service-release-4.22.yaml
+++ b/ci-operator/config/openshift-online/access-transparency-service/openshift-online-access-transparency-service-release-4.22.yaml
@@ -6,17 +6,17 @@ build_root:
     tag: rhel-9-golang-1.23-openshift-4.19
 promotion:
   to:
-  - name: "5.0"
+  - name: "4.22"
     namespace: ocp
 releases:
   initial:
     integration:
-      name: "5.0"
+      name: "4.22"
       namespace: ocp
   latest:
     integration:
       include_built_images: true
-      name: "5.0"
+      name: "4.22"
       namespace: ocp
 resources:
   '*':

--- a/ci-operator/config/openshift/bpfman-operator/openshift-bpfman-operator-release-4.22.yaml
+++ b/ci-operator/config/openshift/bpfman-operator/openshift-bpfman-operator-release-4.22.yaml
@@ -1,10 +1,10 @@
 base_images:
   bpfman:
-    name: "5.0"
+    name: "4.22"
     namespace: ocp
     tag: bpfman
   kube-rbac-proxy:
-    name: "5.0"
+    name: "4.22"
     namespace: ocp
     tag: kube-rbac-proxy
 build_root:
@@ -33,17 +33,17 @@ operator:
     with: pipeline:kube-rbac-proxy
 promotion:
   to:
-  - name: "5.0"
+  - name: "4.22"
     namespace: ocp
 releases:
   initial:
     integration:
-      name: "5.0"
+      name: "4.22"
       namespace: ocp
   latest:
     integration:
       include_built_images: true
-      name: "5.0"
+      name: "4.22"
       namespace: ocp
 resources:
   '*':

--- a/ci-operator/config/openshift/bpfman/openshift-bpfman-release-4.22.yaml
+++ b/ci-operator/config/openshift/bpfman/openshift-bpfman-release-4.22.yaml
@@ -6,17 +6,17 @@ images:
     to: bpfman
 promotion:
   to:
-  - name: "5.0"
+  - name: "4.22"
     namespace: ocp
 releases:
   initial:
     integration:
-      name: "5.0"
+      name: "4.22"
       namespace: ocp
   latest:
     integration:
       include_built_images: true
-      name: "5.0"
+      name: "4.22"
       namespace: ocp
 resources:
   '*':

--- a/ci-operator/config/openstack-lightspeed/operator/openstack-lightspeed-operator-release-4.22.yaml
+++ b/ci-operator/config/openstack-lightspeed/operator/openstack-lightspeed-operator-release-4.22.yaml
@@ -1,6 +1,6 @@
 base_images:
   base:
-    name: "5.0"
+    name: "4.22"
     namespace: ocp
     tag: base
 build_root:
@@ -10,17 +10,17 @@ build_root:
     tag: rhel-9-release-golang-1.22-openshift-4.19
 promotion:
   to:
-  - name: "5.0"
+  - name: "4.22"
     namespace: ocp
 releases:
   initial:
     integration:
-      name: "5.0"
+      name: "4.22"
       namespace: ocp
   latest:
     integration:
       include_built_images: true
-      name: "5.0"
+      name: "4.22"
       namespace: ocp
 resources:
   '*':


### PR DESCRIPTION
Five release-4.22 CI configs were incorrectly referencing ocp/5.0 instead of ocp/4.22 in their promotion, releases, and base_images stanzas, causing persistent fast-forward job failures with "invalid branch promoting to current release" errors.

Affected repos:
- kubev2v/migration-planner
- openshift/bpfman
- openshift/bpfman-operator
- openshift-online/access-transparency-service
- openstack-lightspeed/operator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI operator release configuration for version 4.22 across multiple projects, adjusting promotion targets and release integration identifiers to align with the current release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->