### PR TITLE
OAPE-453: Add compliance-cve-agent workflow for automated CVE analysis

### DIFF
--- a/ci-operator/config/openshift/secrets-store-csi-driver-operator/openshift-secrets-store-csi-driver-operator-main.yaml
+++ b/ci-operator/config/openshift/secrets-store-csi-driver-operator/openshift-secrets-store-csi-driver-operator-main.yaml
@@ -1,4 +1,8 @@
 base_images:
+  claude-ai-helpers:
+    name: claude-ai-helpers
+    namespace: ci
+    tag: latest
   driver-operand:
     name: "4.22"
     namespace: ocp
@@ -244,6 +248,14 @@ tests:
       SCAN_IMAGE: secrets-store-csi-mustgather
     test:
     - ref: fips-check-image-scan
+- always_run: false
+  as: cve-analysis
+  optional: true
+  steps:
+    env:
+      CVE_AGENT_CVE_ID: CVE-2025-61726
+      CVE_AGENT_TARGET_REPO: openshift/secrets-store-csi-driver-operator
+    workflow: compliance-cve-agent
 zz_generated_metadata:
   branch: main
   org: openshift

--- a/ci-operator/config/openshift/secrets-store-csi-driver-operator/openshift-secrets-store-csi-driver-operator-main.yaml
+++ b/ci-operator/config/openshift/secrets-store-csi-driver-operator/openshift-secrets-store-csi-driver-operator-main.yaml
@@ -256,6 +256,14 @@ tests:
       CVE_AGENT_CVE_ID: CVE-2025-61726
       CVE_AGENT_TARGET_REPO: openshift/secrets-store-csi-driver-operator
     workflow: compliance-cve-agent
+- always_run: false
+  as: cve-analysis-jira
+  optional: true
+  steps:
+    env:
+      CVE_AGENT_JIRA_KEY: CM-812
+      CVE_AGENT_TARGET_REPO: openshift/cert-manager-operator
+    workflow: compliance-cve-agent
 zz_generated_metadata:
   branch: main
   org: openshift

--- a/ci-operator/config/openshift/secrets-store-csi-driver-operator/openshift-secrets-store-csi-driver-operator-main.yaml
+++ b/ci-operator/config/openshift/secrets-store-csi-driver-operator/openshift-secrets-store-csi-driver-operator-main.yaml
@@ -261,7 +261,7 @@ tests:
   optional: true
   steps:
     env:
-      CVE_AGENT_JIRA_KEY: CM-812
+      CVE_AGENT_JIRA_KEY: OCPBUGS-78683
       CVE_AGENT_TARGET_REPO: openshift/cert-manager-operator
     workflow: compliance-cve-agent
 zz_generated_metadata:

--- a/ci-operator/jobs/openshift/secrets-store-csi-driver-operator/openshift-secrets-store-csi-driver-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/secrets-store-csi-driver-operator/openshift-secrets-store-csi-driver-operator-main-presubmits.yaml
@@ -54,6 +54,85 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )ci-index-secrets-store-csi-driver-operator-bundle,?($|\s.*)
   - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build08
+    context: ci/prow/cve-analysis
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-secrets-store-csi-driver-operator-main-cve-analysis
+    optional: true
+    rerun_command: /test cve-analysis
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=cve-analysis
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )cve-analysis,?($|\s.*)
+  - agent: kubernetes
     always_run: true
     branches:
     - ^main$

--- a/ci-operator/jobs/openshift/secrets-store-csi-driver-operator/openshift-secrets-store-csi-driver-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/secrets-store-csi-driver-operator/openshift-secrets-store-csi-driver-operator-main-presubmits.yaml
@@ -133,6 +133,85 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )cve-analysis,?($|\s.*)
   - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build08
+    context: ci/prow/cve-analysis-jira
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-secrets-store-csi-driver-operator-main-cve-analysis-jira
+    optional: true
+    rerun_command: /test cve-analysis-jira
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=cve-analysis-jira
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )cve-analysis-jira,?($|\s.*)
+  - agent: kubernetes
     always_run: true
     branches:
     - ^main$

--- a/ci-operator/step-registry/compliance/cve-agent/OWNERS
+++ b/ci-operator/step-registry/compliance/cve-agent/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- chiragkyal
+reviewers:
+- chiragkyal

--- a/ci-operator/step-registry/compliance/cve-agent/README.md
+++ b/ci-operator/step-registry/compliance/cve-agent/README.md
@@ -1,0 +1,83 @@
+# CVE Analysis Agent Workflow
+
+Automated CVE vulnerability analysis for Go-based OpenShift components using Claude Code and the `compliance:analyze-cve` plugin from [openshift-eng/ai-helpers](https://github.com/openshift-eng/ai-helpers).
+
+## Overview
+
+This workflow runs the full CVE analysis pipeline non-interactively:
+
+1. **Setup**: Verifies Claude CLI, Go toolchain, and installs analysis tools (govulncheck, callgraph, digraph)
+2. **Process**: Clones the target repository, loads all compliance skills, runs Claude with the analyze-cve pipeline
+3. **Report**: Generates an HTML report with token usage, cost, and analysis output
+
+## Data Flow
+
+```mermaid
+flowchart TD
+    Trigger([Presubmit / Gangway Trigger]) --> Setup
+
+    subgraph Setup[PRE: Setup]
+        VerifyClaude[Verify Claude CLI]
+        VerifyGo[Verify Go toolchain]
+        InstallTools[Install govulncheck, callgraph, digraph]
+    end
+
+    Setup --> Process
+
+    subgraph Process[TEST: Analyze CVE]
+        CloneRepos[Clone ai-helpers + target repo]
+        LoadSkills[Load command + 4 skills as system prompt]
+        RunClaude[Run Claude non-interactively]
+        SaveArtifacts[Save stream-json + analysis artifacts]
+    end
+
+    Process --> Report
+
+    subgraph Report[POST: Generate Report]
+        ParseJSON[Parse stream-json telemetry]
+        BuildHTML[Generate HTML report]
+        Upload[Upload to ARTIFACT_DIR]
+    end
+```
+
+## Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `CVE_AGENT_CVE_ID` | Yes | - | CVE identifier (e.g., `CVE-2024-45338`) |
+| `CVE_AGENT_TARGET_REPO` | Yes | - | GitHub repo (e.g., `openshift/secrets-store-csi-driver-operator`) |
+| `CVE_AGENT_TARGET_BRANCH` | No | `main` | Branch to analyze |
+| `CVE_AGENT_ALGO` | No | `vta` | Call graph algorithm (`vta`, `rta`, `cha`, `static`) |
+| `CLAUDE_MODEL` | No | `claude-opus-4-6` | Claude model |
+
+## Secrets
+
+All steps mount `test-credentials/hypershift-team-claude-prow` at `/var/run/claude-code-service-account/`.
+
+Required keys:
+- `claude-prow` -- GCP service account JSON for Vertex AI authentication
+
+## Usage
+
+### As an optional presubmit (triggered via `/test cve-analysis`)
+
+```yaml
+- always_run: false
+  as: cve-analysis
+  optional: true
+  skip_if_only_changed: .*
+  steps:
+    env:
+      CVE_AGENT_CVE_ID: "CVE-2024-45338"
+      CVE_AGENT_TARGET_REPO: "openshift/secrets-store-csi-driver-operator"
+    workflow: compliance-cve-agent
+```
+
+## Report
+
+The HTML report is saved as `cve-agent-report.html` in the CI artifacts directory and includes:
+- Analysis status and metadata (CVE, repo, algorithm, model)
+- Token usage and cost breakdown
+- Full analysis output text
+- Tool call and error summaries
+- Generated analysis report (if produced)

--- a/ci-operator/step-registry/compliance/cve-agent/compliance-cve-agent-workflow.metadata.json
+++ b/ci-operator/step-registry/compliance/cve-agent/compliance-cve-agent-workflow.metadata.json
@@ -1,0 +1,11 @@
+{
+	"path": "compliance/cve-agent/compliance-cve-agent-workflow.yaml",
+	"owners": {
+		"approvers": [
+			"chiragkyal"
+		],
+		"reviewers": [
+			"chiragkyal"
+		]
+	}
+}

--- a/ci-operator/step-registry/compliance/cve-agent/compliance-cve-agent-workflow.yaml
+++ b/ci-operator/step-registry/compliance/cve-agent/compliance-cve-agent-workflow.yaml
@@ -1,0 +1,19 @@
+workflow:
+  as: compliance-cve-agent
+  steps:
+    pre:
+      - ref: compliance-cve-agent-setup
+    test:
+      - ref: compliance-cve-agent-process
+    post:
+      - ref: compliance-cve-agent-report
+  documentation: |-
+    CVE Analysis Agent workflow for automated vulnerability assessment of Go projects.
+
+    This workflow:
+    1. Setup: Verifies Claude Code CLI, Go toolchain, and analysis tools (govulncheck, callgraph, digraph)
+    2. Process: For a given CVE ID, runs the /compliance:analyze-cve skill pipeline
+    3. Report: Generates HTML report with token usage, cost, and analysis output
+
+    The workflow uses the compliance plugin skills from openshift-eng/ai-helpers in non-interactive mode.
+    CVE ID is passed via CVE_AGENT_CVE_ID env var or Gangway override.

--- a/ci-operator/step-registry/compliance/cve-agent/process/OWNERS
+++ b/ci-operator/step-registry/compliance/cve-agent/process/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- chiragkyal
+reviewers:
+- chiragkyal

--- a/ci-operator/step-registry/compliance/cve-agent/process/compliance-cve-agent-process-commands.sh
+++ b/ci-operator/step-registry/compliance/cve-agent/process/compliance-cve-agent-process-commands.sh
@@ -49,6 +49,13 @@ if [ ! -f "${COMPLIANCE_PLUGIN_DIR}/commands/analyze-cve.md" ]; then
 fi
 echo "Compliance plugin found"
 
+# Install required analysis tools in the same container context as Claude
+echo "Installing analysis tools..."
+GOFLAGS="" go install golang.org/x/vuln/cmd/govulncheck@latest 2>&1 || { echo "ERROR: Failed to install govulncheck"; exit 1; }
+GOFLAGS="" go install golang.org/x/tools/cmd/callgraph@latest 2>&1 || { echo "ERROR: Failed to install callgraph"; exit 1; }
+GOFLAGS="" go install golang.org/x/tools/cmd/digraph@latest 2>&1 || { echo "ERROR: Failed to install digraph"; exit 1; }
+echo "Tools installed: $(which govulncheck) $(which callgraph) $(which digraph)"
+
 # Clone target repository
 echo "Cloning target repository: ${TARGET_REPO}..."
 git clone "https://github.com/${TARGET_REPO}.git" /tmp/target-repo
@@ -74,6 +81,7 @@ IMPORTANT CI CONTEXT:
 - Always generate the full analysis report regardless of risk level.
 - Skip Phase 5 (Interactive Fix Application) -- only generate the report and remediation plan.
 - Save all artifacts to: ${SHARED_DIR}/cve-artifacts-${CVE_ID}/
+- The tools govulncheck, callgraph, and digraph are ALREADY INSTALLED and should be available in PATH. Use GOFLAGS='' before any go commands to avoid -mod=vendor issues.
 
 === COMMAND: analyze-cve ===
 ${COMMAND_CONTENT}
@@ -102,7 +110,7 @@ ANALYSIS_START=$(date +%s)
 set +e
 claude -p "${CVE_ID} --algo=${ALGO}" \
   --system-prompt "$SYSTEM_PROMPT" \
-  --allowedTools "Bash Read Write Edit Grep Glob WebFetch" \
+  --allowedTools "Bash Read Write Edit Grep Glob WebFetch WebSearch" \
   --max-turns 200 \
   --model "${CLAUDE_MODEL:-claude-opus-4-6}" \
   --verbose \
@@ -149,7 +157,7 @@ grep '"type":"result"' "/tmp/claude-${CVE_ID}-analysis.json" \
       cache_read_input_tokens: (.usage.cache_read_input_tokens // 0),
       cache_creation_input_tokens: (.usage.cache_creation_input_tokens // 0),
       model_usage: (.modelUsage // {}),
-      model: ((.modelUsage // {} | keys | first) // "unknown")
+      model: ((.modelUsage // {} | to_entries | sort_by(.value.output_tokens // 0) | last | .key) // "unknown")
     }' > "${SHARED_DIR}/claude-${CVE_ID}-tokens.json" 2>/dev/null \
   || echo '{"total_cost_usd":0,"duration_ms":0,"num_turns":0,"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"model_usage":{},"model":"unknown"}' \
     > "${SHARED_DIR}/claude-${CVE_ID}-tokens.json"

--- a/ci-operator/step-registry/compliance/cve-agent/process/compliance-cve-agent-process-commands.sh
+++ b/ci-operator/step-registry/compliance/cve-agent/process/compliance-cve-agent-process-commands.sh
@@ -1,0 +1,199 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "=== CVE Analysis Agent Process ==="
+
+# Apply Gangway API overrides
+if [[ -n "${MULTISTAGE_PARAM_OVERRIDE_CVE_AGENT_CVE_ID:-}" ]]; then
+  echo "Applying Gangway override: CVE_AGENT_CVE_ID=${MULTISTAGE_PARAM_OVERRIDE_CVE_AGENT_CVE_ID}"
+  export CVE_AGENT_CVE_ID="${MULTISTAGE_PARAM_OVERRIDE_CVE_AGENT_CVE_ID}"
+fi
+
+# Validate required parameters
+CVE_ID="${CVE_AGENT_CVE_ID:-}"
+TARGET_REPO="${CVE_AGENT_TARGET_REPO:-}"
+TARGET_BRANCH="${CVE_AGENT_TARGET_BRANCH:-main}"
+ALGO="${CVE_AGENT_ALGO:-vta}"
+
+if [ -z "$CVE_ID" ]; then
+  echo "ERROR: CVE_AGENT_CVE_ID is required"
+  echo "Set it via env var or Gangway override: MULTISTAGE_PARAM_OVERRIDE_CVE_AGENT_CVE_ID"
+  exit 1
+fi
+
+if [ -z "$TARGET_REPO" ]; then
+  echo "ERROR: CVE_AGENT_TARGET_REPO is required (e.g., openshift/secrets-store-csi-driver-operator)"
+  exit 1
+fi
+
+echo "Configuration:"
+echo "  CVE ID:        $CVE_ID"
+echo "  Target repo:   $TARGET_REPO"
+echo "  Target branch: $TARGET_BRANCH"
+echo "  Algorithm:     $ALGO"
+echo "  Claude model:  ${CLAUDE_MODEL:-claude-opus-4-6}"
+
+# State file for sharing results with report step
+STATE_FILE="${SHARED_DIR}/processed-cves.txt"
+
+# Clone ai-helpers repository (contains compliance plugin + skills)
+echo ""
+echo "Cloning ai-helpers repository..."
+git clone https://github.com/openshift-eng/ai-helpers /tmp/ai-helpers
+
+# Verify compliance plugin exists
+COMPLIANCE_PLUGIN_DIR="/tmp/ai-helpers/plugins/compliance"
+if [ ! -f "${COMPLIANCE_PLUGIN_DIR}/commands/analyze-cve.md" ]; then
+  echo "ERROR: compliance plugin not found at ${COMPLIANCE_PLUGIN_DIR}"
+  exit 1
+fi
+echo "Compliance plugin found"
+
+# Clone target repository
+echo "Cloning target repository: ${TARGET_REPO}..."
+git clone "https://github.com/${TARGET_REPO}.git" /tmp/target-repo
+cd /tmp/target-repo
+git checkout "$TARGET_BRANCH"
+echo "Target repo cloned and checked out to ${TARGET_BRANCH}"
+
+# Load skill content files for system prompt context
+echo ""
+echo "Loading skill files..."
+COMMAND_CONTENT=$(cat "${COMPLIANCE_PLUGIN_DIR}/commands/analyze-cve.md")
+SKILL_CVE_INTEL=$(cat "${COMPLIANCE_PLUGIN_DIR}/skills/cve-intelligence-gathering/SKILL.md")
+SKILL_IMPACT=$(cat "${COMPLIANCE_PLUGIN_DIR}/skills/codebase-impact-analysis/SKILL.md")
+SKILL_CALLGRAPH=$(cat "${COMPLIANCE_PLUGIN_DIR}/skills/call-graph-analysis/SKILL.md")
+SKILL_REMEDIATION=$(cat "${COMPLIANCE_PLUGIN_DIR}/skills/remediation-planning/SKILL.md")
+
+# Build system prompt with all skills concatenated
+SYSTEM_PROMPT="You are a CVE analysis agent running in CI. Execute the analyze-cve command fully and autonomously.
+
+IMPORTANT CI CONTEXT:
+- You are running non-interactively in a CI pipeline. Do NOT ask for user input.
+- If you cannot find CVE details online, exit with an error. Do NOT proceed without CVE details.
+- Always generate the full analysis report regardless of risk level.
+- Skip Phase 5 (Interactive Fix Application) -- only generate the report and remediation plan.
+- Save all artifacts to: ${SHARED_DIR}/cve-artifacts-${CVE_ID}/
+
+=== COMMAND: analyze-cve ===
+${COMMAND_CONTENT}
+
+=== SKILL: CVE Intelligence Gathering ===
+${SKILL_CVE_INTEL}
+
+=== SKILL: Codebase Impact Analysis ===
+${SKILL_IMPACT}
+
+=== SKILL: Call Graph Analysis ===
+${SKILL_CALLGRAPH}
+
+=== SKILL: Remediation Planning ===
+${SKILL_REMEDIATION}"
+
+TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+echo ""
+echo "=========================================="
+echo "Analyzing: ${CVE_ID} against ${TARGET_REPO}"
+echo "=========================================="
+
+ANALYSIS_START=$(date +%s)
+
+set +e
+claude -p "${CVE_ID} --algo=${ALGO}" \
+  --system-prompt "$SYSTEM_PROMPT" \
+  --allowedTools "Bash Read Write Edit Grep Glob WebFetch" \
+  --max-turns 200 \
+  --model "${CLAUDE_MODEL:-claude-opus-4-6}" \
+  --verbose \
+  --output-format stream-json \
+  2> "/tmp/claude-${CVE_ID}-analysis.log" \
+  | tee "/tmp/claude-${CVE_ID}-analysis.json"
+EXIT_CODE=$?
+set -e
+
+ANALYSIS_END=$(date +%s)
+ANALYSIS_DURATION=$((ANALYSIS_END - ANALYSIS_START))
+echo "Analysis duration: ${ANALYSIS_DURATION}s"
+
+# Copy raw stream-json to SHARED_DIR for the report step
+cp "/tmp/claude-${CVE_ID}-analysis.json" "${SHARED_DIR}/claude-${CVE_ID}-analysis.json" 2>/dev/null || true
+cp "/tmp/claude-${CVE_ID}-analysis.log" "${SHARED_DIR}/claude-${CVE_ID}-analysis.log" 2>/dev/null || true
+
+# Extract text output for report
+jq -j 'select(.type == "assistant") | .message.content[]? | select(.type == "text") | .text // empty' \
+  "/tmp/claude-${CVE_ID}-analysis.json" \
+  > "${SHARED_DIR}/claude-${CVE_ID}-analysis-text.txt" 2>/dev/null || true
+
+# Extract tool call summary
+jq -r 'select(.type == "assistant") | .message.content[]? | select(.type == "tool_use") | "\(.name): \(.input | keys | join(", "))"' \
+  "/tmp/claude-${CVE_ID}-analysis.json" 2>/dev/null \
+  | sort | uniq -c | sort -rn \
+  > "${SHARED_DIR}/claude-${CVE_ID}-analysis-tools.txt" 2>/dev/null || true
+
+# Extract errors
+jq -r 'select(.type == "user") | .tool_use_result | select(type == "string") | select(startswith("Error:")) | gsub("\n"; "⏎")' \
+  "/tmp/claude-${CVE_ID}-analysis.json" 2>/dev/null \
+  | sort | uniq -c | sort -rn | sed 's/⏎/\n/g' \
+  > "${SHARED_DIR}/claude-${CVE_ID}-analysis-errors.txt" 2>/dev/null || true
+
+# Extract token usage
+grep '"type":"result"' "/tmp/claude-${CVE_ID}-analysis.json" \
+  | head -1 \
+  | jq '{
+      total_cost_usd: (.total_cost_usd // 0),
+      duration_ms: (.duration_ms // 0),
+      num_turns: (.num_turns // 0),
+      input_tokens: (.usage.input_tokens // 0),
+      output_tokens: (.usage.output_tokens // 0),
+      cache_read_input_tokens: (.usage.cache_read_input_tokens // 0),
+      cache_creation_input_tokens: (.usage.cache_creation_input_tokens // 0),
+      model_usage: (.modelUsage // {}),
+      model: ((.modelUsage // {} | keys | first) // "unknown")
+    }' > "${SHARED_DIR}/claude-${CVE_ID}-tokens.json" 2>/dev/null \
+  || echo '{"total_cost_usd":0,"duration_ms":0,"num_turns":0,"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"model_usage":{},"model":"unknown"}' \
+    > "${SHARED_DIR}/claude-${CVE_ID}-tokens.json"
+
+echo "Token usage: $(cat "${SHARED_DIR}/claude-${CVE_ID}-tokens.json")"
+
+# Print human-readable analysis output
+echo ""
+echo "=========================================="
+echo "Analysis Output for ${CVE_ID}"
+echo "=========================================="
+cat "${SHARED_DIR}/claude-${CVE_ID}-analysis-text.txt" 2>/dev/null || echo "(no text output captured)"
+echo ""
+echo "=========================================="
+
+# Save analysis duration
+echo "$ANALYSIS_DURATION" > "${SHARED_DIR}/claude-${CVE_ID}-duration.txt"
+
+# Copy analysis artifacts if generated (check both possible output locations)
+for ARTIFACT_SRC in "${SHARED_DIR}/cve-artifacts-${CVE_ID}" ".work/compliance/analyze-cve/${CVE_ID}"; do
+  if [ -d "$ARTIFACT_SRC" ]; then
+    echo "Found artifacts at ${ARTIFACT_SRC}"
+    if [ "$ARTIFACT_SRC" != "${SHARED_DIR}/cve-artifacts-${CVE_ID}" ]; then
+      cp -r "$ARTIFACT_SRC" "${SHARED_DIR}/cve-artifacts-${CVE_ID}" 2>/dev/null || true
+    fi
+    break
+  fi
+done
+
+# Save metadata for report step
+echo "${CVE_ID}" > "${SHARED_DIR}/cve-id.txt"
+echo "${TARGET_REPO}" > "${SHARED_DIR}/target-repo.txt"
+echo "${ALGO}" > "${SHARED_DIR}/algo.txt"
+
+# Record result
+if [ $EXIT_CODE -eq 0 ]; then
+  echo "✅ CVE analysis completed for ${CVE_ID}"
+  echo "${CVE_ID} ${TIMESTAMP} ${TARGET_REPO} SUCCESS" >> "$STATE_FILE"
+else
+  echo "❌ CVE analysis failed for ${CVE_ID} (exit code: ${EXIT_CODE})"
+  echo "Error output (last 20 lines):"
+  tail -20 "/tmp/claude-${CVE_ID}-analysis.log" 2>/dev/null || true
+  echo "${CVE_ID} ${TIMESTAMP} ${TARGET_REPO} FAILED" >> "$STATE_FILE"
+fi
+
+echo ""
+echo "=== Processing Complete ==="

--- a/ci-operator/step-registry/compliance/cve-agent/process/compliance-cve-agent-process-commands.sh
+++ b/ci-operator/step-registry/compliance/cve-agent/process/compliance-cve-agent-process-commands.sh
@@ -217,6 +217,34 @@ fi
 cp "/tmp/claude-${CVE_ID}-analysis.json" "${ARTIFACT_DIR}/analysis-stream.json" 2>/dev/null || true
 cp "/tmp/claude-${CVE_ID}-analysis.log" "${ARTIFACT_DIR}/analysis.log" 2>/dev/null || true
 
+# Generate human-readable transcript from stream-json
+echo "Generating analysis transcript..."
+jq -r '
+if .type == "assistant" then
+  (.message.content[]? |
+    if .type == "text" then
+      "\n\(.text)"
+    elif .type == "tool_use" then
+      "\n>>> \(.name)" +
+      (if .input.command then " $ \(.input.command | .[0:200])"
+       elif .input.file_path then " \(.input.file_path)"
+       elif .input.pattern then " /\(.input.pattern | .[0:100])/"
+       elif .input.url then " \(.input.url | .[0:150])"
+       elif .input.search_term then " \"\(.input.search_term | .[0:100])\""
+       elif .input.description then " (\(.input.description))"
+       else "" end)
+    else empty end)
+elif .type == "user" then
+  (.message.content[]? |
+    if .type == "tool_result" then
+      "    " + (.content | tostring | split("\n") | if length > 10 then (.[0:10] | join("\n    ")) + "\n    ... (\(length) lines total)" else join("\n    ") end)
+    else empty end)
+elif .type == "result" then
+  "\n\n════════════════════════════════════════════════════\n ANALYSIS COMPLETE\n Duration: \((.duration_ms // 0) / 1000 | floor)s | Cost: $\(.total_cost_usd // 0) | Turns: \(.num_turns // 0)\n════════════════════════════════════════════════════\n\n\(.result // "")"
+else empty end
+' "/tmp/claude-${CVE_ID}-analysis.json" > "${ARTIFACT_DIR}/analysis-transcript.txt" 2>/dev/null || true
+echo "Transcript: $(wc -l < "${ARTIFACT_DIR}/analysis-transcript.txt" 2>/dev/null || echo '0') lines"
+
 # Copy report.md to SHARED_DIR (small, needed by report step for HTML)
 if [ -f "${ARTIFACT_DIR}/report.md" ]; then
   cp "${ARTIFACT_DIR}/report.md" "${SHARED_DIR}/cve-report-${CVE_ID}.md" 2>/dev/null || true

--- a/ci-operator/step-registry/compliance/cve-agent/process/compliance-cve-agent-process-commands.sh
+++ b/ci-operator/step-registry/compliance/cve-agent/process/compliance-cve-agent-process-commands.sh
@@ -80,7 +80,8 @@ IMPORTANT CI CONTEXT:
 - If you cannot find CVE details online, exit with an error. Do NOT proceed without CVE details.
 - Always generate the full analysis report regardless of risk level.
 - Skip Phase 5 (Interactive Fix Application) -- only generate the report and remediation plan.
-- Save all artifacts to: ${ARTIFACT_DIR}/
+- Save ALL artifacts (report.md, evidence.json, callgraph.txt, callgraph.dot, govulncheck-output.txt, etc.) to: ${ARTIFACT_DIR}/
+- Do NOT use .work/ for artifact output. The ONLY artifact directory is ${ARTIFACT_DIR}/ — files saved elsewhere will be lost after the CI job completes.
 - The tools govulncheck, callgraph, and digraph are ALREADY INSTALLED and available in PATH. Do NOT reinstall them. Use GOFLAGS='' before any go commands to avoid -mod=vendor issues.
 - Your working directory is /tmp/target-repo which contains the target Go project with go.mod. Always run govulncheck and other go tools from this directory.
 
@@ -197,15 +198,32 @@ cat "${SHARED_DIR}/claude-${CVE_ID}-analysis-text.txt" 2>/dev/null || echo "(no 
 echo ""
 echo "=========================================="
 
+# Fallback: copy any artifacts Claude saved to .work/ into ARTIFACT_DIR
+# (Skills default to .work/ paths; the system prompt overrides this but Claude may still use it)
+WORK_DIR=".work/compliance/analyze-cve/${CVE_ID}"
+if [ -d "$WORK_DIR" ]; then
+  echo "Fallback: found artifacts in ${WORK_DIR}, copying to ARTIFACT_DIR..."
+  for f in "$WORK_DIR"/*; do
+    [ -f "$f" ] || continue
+    BASENAME=$(basename "$f")
+    if [ ! -f "${ARTIFACT_DIR}/${BASENAME}" ]; then
+      cp "$f" "${ARTIFACT_DIR}/${BASENAME}" 2>/dev/null || true
+      echo "  Copied (fallback): ${BASENAME} ($(stat -c%s "$f" 2>/dev/null || echo '?') bytes)"
+    fi
+  done
+fi
+
+# Copy stream-json and log to ARTIFACT_DIR
+cp "/tmp/claude-${CVE_ID}-analysis.json" "${ARTIFACT_DIR}/analysis-stream.json" 2>/dev/null || true
+cp "/tmp/claude-${CVE_ID}-analysis.log" "${ARTIFACT_DIR}/analysis.log" 2>/dev/null || true
+
 # Copy report.md to SHARED_DIR (small, needed by report step for HTML)
 if [ -f "${ARTIFACT_DIR}/report.md" ]; then
   cp "${ARTIFACT_DIR}/report.md" "${SHARED_DIR}/cve-report-${CVE_ID}.md" 2>/dev/null || true
   echo "Copied report.md to SHARED_DIR ($(stat -c%s "${ARTIFACT_DIR}/report.md" 2>/dev/null || echo '?') bytes)"
+else
+  echo "WARNING: report.md not found in ARTIFACT_DIR"
 fi
-
-# Copy stream-json and log to ARTIFACT_DIR (Claude artifacts are already there)
-cp "/tmp/claude-${CVE_ID}-analysis.json" "${ARTIFACT_DIR}/analysis-stream.json" 2>/dev/null || true
-cp "/tmp/claude-${CVE_ID}-analysis.log" "${ARTIFACT_DIR}/analysis.log" 2>/dev/null || true
 
 echo ""
 echo "ARTIFACT_DIR contents:"

--- a/ci-operator/step-registry/compliance/cve-agent/process/compliance-cve-agent-process-commands.sh
+++ b/ci-operator/step-registry/compliance/cve-agent/process/compliance-cve-agent-process-commands.sh
@@ -81,7 +81,8 @@ IMPORTANT CI CONTEXT:
 - Always generate the full analysis report regardless of risk level.
 - Skip Phase 5 (Interactive Fix Application) -- only generate the report and remediation plan.
 - Save all artifacts to: ${SHARED_DIR}/cve-artifacts-${CVE_ID}/
-- The tools govulncheck, callgraph, and digraph are ALREADY INSTALLED and should be available in PATH. Use GOFLAGS='' before any go commands to avoid -mod=vendor issues.
+- The tools govulncheck, callgraph, and digraph are ALREADY INSTALLED and available in PATH. Do NOT reinstall them. Use GOFLAGS='' before any go commands to avoid -mod=vendor issues.
+- Your working directory is /tmp/target-repo which contains the target Go project with go.mod. Always run govulncheck and other go tools from this directory.
 
 === COMMAND: analyze-cve ===
 ${COMMAND_CONTENT}
@@ -157,7 +158,7 @@ grep '"type":"result"' "/tmp/claude-${CVE_ID}-analysis.json" \
       cache_read_input_tokens: (.usage.cache_read_input_tokens // 0),
       cache_creation_input_tokens: (.usage.cache_creation_input_tokens // 0),
       model_usage: (.modelUsage // {}),
-      model: ((.modelUsage // {} | to_entries | sort_by(.value.output_tokens // 0) | last | .key) // "unknown")
+      model: ((.modelUsage // {} | to_entries | max_by(.value.costUSD // 0) | .key) // "unknown")
     }' > "${SHARED_DIR}/claude-${CVE_ID}-tokens.json" 2>/dev/null \
   || echo '{"total_cost_usd":0,"duration_ms":0,"num_turns":0,"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"model_usage":{},"model":"unknown"}' \
     > "${SHARED_DIR}/claude-${CVE_ID}-tokens.json"
@@ -176,16 +177,25 @@ echo "=========================================="
 # Save analysis duration
 echo "$ANALYSIS_DURATION" > "${SHARED_DIR}/claude-${CVE_ID}-duration.txt"
 
-# Copy analysis artifacts if generated (check both possible output locations)
+# Copy analysis artifacts to SHARED_DIR as flat files (subdirectories don't persist across CI steps)
+ARTIFACT_FOUND=false
 for ARTIFACT_SRC in "${SHARED_DIR}/cve-artifacts-${CVE_ID}" ".work/compliance/analyze-cve/${CVE_ID}"; do
   if [ -d "$ARTIFACT_SRC" ]; then
-    echo "Found artifacts at ${ARTIFACT_SRC}"
-    if [ "$ARTIFACT_SRC" != "${SHARED_DIR}/cve-artifacts-${CVE_ID}" ]; then
-      cp -r "$ARTIFACT_SRC" "${SHARED_DIR}/cve-artifacts-${CVE_ID}" 2>/dev/null || true
-    fi
+    echo "Found artifacts at ${ARTIFACT_SRC}:"
+    ls -la "$ARTIFACT_SRC" 2>/dev/null || true
+    for f in "$ARTIFACT_SRC"/*; do
+      [ -f "$f" ] || continue
+      BASENAME=$(basename "$f")
+      cp "$f" "${SHARED_DIR}/cve-artifact-${CVE_ID}-${BASENAME}" 2>/dev/null || true
+      echo "  Copied: ${BASENAME} -> ${SHARED_DIR}/cve-artifact-${CVE_ID}-${BASENAME}"
+    done
+    ARTIFACT_FOUND=true
     break
   fi
 done
+if [ "$ARTIFACT_FOUND" = false ]; then
+  echo "WARNING: No artifact directory found in expected locations"
+fi
 
 # Save metadata for report step
 echo "${CVE_ID}" > "${SHARED_DIR}/cve-id.txt"

--- a/ci-operator/step-registry/compliance/cve-agent/process/compliance-cve-agent-process-commands.sh
+++ b/ci-operator/step-registry/compliance/cve-agent/process/compliance-cve-agent-process-commands.sh
@@ -177,27 +177,7 @@ echo "=========================================="
 # Save analysis duration
 echo "$ANALYSIS_DURATION" > "${SHARED_DIR}/claude-${CVE_ID}-duration.txt"
 
-# Copy analysis artifacts to SHARED_DIR as flat files (subdirectories don't persist across CI steps)
-ARTIFACT_FOUND=false
-for ARTIFACT_SRC in "${SHARED_DIR}/cve-artifacts-${CVE_ID}" ".work/compliance/analyze-cve/${CVE_ID}"; do
-  if [ -d "$ARTIFACT_SRC" ]; then
-    echo "Found artifacts at ${ARTIFACT_SRC}:"
-    ls -la "$ARTIFACT_SRC" 2>/dev/null || true
-    for f in "$ARTIFACT_SRC"/*; do
-      [ -f "$f" ] || continue
-      BASENAME=$(basename "$f")
-      cp "$f" "${SHARED_DIR}/cve-artifact-${CVE_ID}-${BASENAME}" 2>/dev/null || true
-      echo "  Copied: ${BASENAME} -> ${SHARED_DIR}/cve-artifact-${CVE_ID}-${BASENAME}"
-    done
-    ARTIFACT_FOUND=true
-    break
-  fi
-done
-if [ "$ARTIFACT_FOUND" = false ]; then
-  echo "WARNING: No artifact directory found in expected locations"
-fi
-
-# Save metadata for report step
+# Save metadata for report step FIRST (before large artifact copies that may fill SHARED_DIR)
 echo "${CVE_ID}" > "${SHARED_DIR}/cve-id.txt"
 echo "${TARGET_REPO}" > "${SHARED_DIR}/target-repo.txt"
 echo "${ALGO}" > "${SHARED_DIR}/algo.txt"
@@ -211,6 +191,33 @@ else
   echo "Error output (last 20 lines):"
   tail -20 "/tmp/claude-${CVE_ID}-analysis.log" 2>/dev/null || true
   echo "${CVE_ID} ${TIMESTAMP} ${TARGET_REPO} FAILED" >> "$STATE_FILE"
+fi
+
+# Copy analysis artifacts to SHARED_DIR as flat files (subdirectories don't persist across CI steps)
+# Skip files > 5MB to avoid filling up SHARED_DIR volume (callgraph.txt can be 60MB+)
+MAX_ARTIFACT_SIZE=$((5 * 1024 * 1024))
+ARTIFACT_FOUND=false
+for ARTIFACT_SRC in "${SHARED_DIR}/cve-artifacts-${CVE_ID}" ".work/compliance/analyze-cve/${CVE_ID}"; do
+  if [ -d "$ARTIFACT_SRC" ]; then
+    echo "Found artifacts at ${ARTIFACT_SRC}:"
+    ls -la "$ARTIFACT_SRC" 2>/dev/null || true
+    for f in "$ARTIFACT_SRC"/*; do
+      [ -f "$f" ] || continue
+      BASENAME=$(basename "$f")
+      FILE_SIZE=$(stat -c%s "$f" 2>/dev/null || echo "0")
+      if [ "$FILE_SIZE" -gt "$MAX_ARTIFACT_SIZE" ]; then
+        echo "  Skipped (${FILE_SIZE} bytes > 5MB limit): ${BASENAME}"
+        continue
+      fi
+      cp "$f" "${SHARED_DIR}/cve-artifact-${CVE_ID}-${BASENAME}" 2>/dev/null || true
+      echo "  Copied: ${BASENAME} (${FILE_SIZE} bytes)"
+    done
+    ARTIFACT_FOUND=true
+    break
+  fi
+done
+if [ "$ARTIFACT_FOUND" = false ]; then
+  echo "WARNING: No artifact directory found in expected locations"
 fi
 
 echo ""

--- a/ci-operator/step-registry/compliance/cve-agent/process/compliance-cve-agent-process-commands.sh
+++ b/ci-operator/step-registry/compliance/cve-agent/process/compliance-cve-agent-process-commands.sh
@@ -215,7 +215,7 @@ fi
 
 # Copy stream-json and log to ARTIFACT_DIR
 cp "/tmp/claude-${CVE_ID}-analysis.json" "${ARTIFACT_DIR}/analysis-stream.json" 2>/dev/null || true
-cp "/tmp/claude-${CVE_ID}-analysis.log" "${ARTIFACT_DIR}/analysis.log" 2>/dev/null || true
+cp "/tmp/claude-${CVE_ID}-analysis.log" "${ARTIFACT_DIR}/claude-stderr.log" 2>/dev/null || true
 
 # Generate human-readable transcript from stream-json
 echo "Generating analysis transcript..."

--- a/ci-operator/step-registry/compliance/cve-agent/process/compliance-cve-agent-process-commands.sh
+++ b/ci-operator/step-registry/compliance/cve-agent/process/compliance-cve-agent-process-commands.sh
@@ -237,7 +237,7 @@ if .type == "assistant" then
 elif .type == "user" then
   (.message.content[]? |
     if .type == "tool_result" then
-      "    " + (.content | tostring | split("\n") | if length > 10 then (.[0:10] | join("\n    ")) + "\n    ... (\(length) lines total)" else join("\n    ") end)
+      "    " + (.content | tostring | split("\n") | join("\n    "))
     else empty end)
 elif .type == "result" then
   "\n\n════════════════════════════════════════════════════\n ANALYSIS COMPLETE\n Duration: \((.duration_ms // 0) / 1000 | floor)s | Cost: $\(.total_cost_usd // 0) | Turns: \(.num_turns // 0)\n════════════════════════════════════════════════════\n\n\(.result // "")"

--- a/ci-operator/step-registry/compliance/cve-agent/process/compliance-cve-agent-process-commands.sh
+++ b/ci-operator/step-registry/compliance/cve-agent/process/compliance-cve-agent-process-commands.sh
@@ -194,7 +194,7 @@ else
 fi
 
 # Copy analysis artifacts to SHARED_DIR as flat files (subdirectories don't persist across CI steps)
-# Skip files > 5MB to avoid filling up SHARED_DIR volume (callgraph.txt can be 60MB+)
+# Truncate files > 5MB to avoid filling up SHARED_DIR volume (callgraph.txt can be 60MB+)
 MAX_ARTIFACT_SIZE=$((5 * 1024 * 1024))
 ARTIFACT_FOUND=false
 for ARTIFACT_SRC in "${SHARED_DIR}/cve-artifacts-${CVE_ID}" ".work/compliance/analyze-cve/${CVE_ID}"; do
@@ -204,13 +204,15 @@ for ARTIFACT_SRC in "${SHARED_DIR}/cve-artifacts-${CVE_ID}" ".work/compliance/an
     for f in "$ARTIFACT_SRC"/*; do
       [ -f "$f" ] || continue
       BASENAME=$(basename "$f")
+      DEST="${SHARED_DIR}/cve-artifact-${CVE_ID}-${BASENAME}"
       FILE_SIZE=$(stat -c%s "$f" 2>/dev/null || echo "0")
       if [ "$FILE_SIZE" -gt "$MAX_ARTIFACT_SIZE" ]; then
-        echo "  Skipped (${FILE_SIZE} bytes > 5MB limit): ${BASENAME}"
-        continue
+        head -c "$MAX_ARTIFACT_SIZE" "$f" > "$DEST" 2>/dev/null || true
+        echo "  Truncated: ${BASENAME} (${FILE_SIZE} -> 5MB)"
+      else
+        cp "$f" "$DEST" 2>/dev/null || true
+        echo "  Copied: ${BASENAME} (${FILE_SIZE} bytes)"
       fi
-      cp "$f" "${SHARED_DIR}/cve-artifact-${CVE_ID}-${BASENAME}" 2>/dev/null || true
-      echo "  Copied: ${BASENAME} (${FILE_SIZE} bytes)"
     done
     ARTIFACT_FOUND=true
     break

--- a/ci-operator/step-registry/compliance/cve-agent/process/compliance-cve-agent-process-commands.sh
+++ b/ci-operator/step-registry/compliance/cve-agent/process/compliance-cve-agent-process-commands.sh
@@ -8,16 +8,118 @@ if [[ -n "${MULTISTAGE_PARAM_OVERRIDE_CVE_AGENT_CVE_ID:-}" ]]; then
   echo "Applying Gangway override: CVE_AGENT_CVE_ID=${MULTISTAGE_PARAM_OVERRIDE_CVE_AGENT_CVE_ID}"
   export CVE_AGENT_CVE_ID="${MULTISTAGE_PARAM_OVERRIDE_CVE_AGENT_CVE_ID}"
 fi
+if [[ -n "${MULTISTAGE_PARAM_OVERRIDE_CVE_AGENT_JIRA_KEY:-}" ]]; then
+  echo "Applying Gangway override: CVE_AGENT_JIRA_KEY=${MULTISTAGE_PARAM_OVERRIDE_CVE_AGENT_JIRA_KEY}"
+  export CVE_AGENT_JIRA_KEY="${MULTISTAGE_PARAM_OVERRIDE_CVE_AGENT_JIRA_KEY}"
+fi
 
-# Validate required parameters
+# Read parameters
 CVE_ID="${CVE_AGENT_CVE_ID:-}"
+JIRA_KEY="${CVE_AGENT_JIRA_KEY:-}"
+JIRA_URL="${CVE_AGENT_JIRA_URL:-https://redhat.atlassian.net}"
 TARGET_REPO="${CVE_AGENT_TARGET_REPO:-}"
 TARGET_BRANCH="${CVE_AGENT_TARGET_BRANCH:-main}"
 ALGO="${CVE_AGENT_ALGO:-vta}"
 
+# Jira context (populated if JIRA_KEY is set)
+JIRA_SUMMARY=""
+JIRA_DESCRIPTION_TEXT=""
+JIRA_CONTEXT_PROMPT=""
+
+# --- Jira integration: fetch issue and extract CVE ID ---
+if [ -n "$JIRA_KEY" ]; then
+  echo ""
+  echo "=== Jira Integration ==="
+  echo "Fetching Jira issue: ${JIRA_KEY}"
+
+  # Load Jira API credentials (Basic Auth: email:api-token)
+  JIRA_TOKEN_FILE="/var/run/claude-code-service-account/jira-pat"
+  JIRA_EMAIL_FILE="/var/run/claude-code-service-account/jira-email"
+
+  if [ ! -f "$JIRA_TOKEN_FILE" ] || [ ! -f "$JIRA_EMAIL_FILE" ]; then
+    echo "ERROR: Jira credentials not found (need both jira-pat and jira-email)"
+    echo "Available files in credential mount:"
+    ls -la /var/run/claude-code-service-account/ 2>/dev/null || echo "  (mount not found)"
+    exit 1
+  fi
+
+  JIRA_TOKEN=$(cat "$JIRA_TOKEN_FILE")
+  JIRA_EMAIL=$(cat "$JIRA_EMAIL_FILE")
+  JIRA_AUTH=$(echo -n "${JIRA_EMAIL}:${JIRA_TOKEN}" | base64 | tr -d '\n')
+  echo "Jira credentials loaded"
+
+  # Fetch issue via REST API
+  JIRA_RESPONSE=$(curl -s -w "\n%{http_code}" \
+    "${JIRA_URL}/rest/api/3/issue/${JIRA_KEY}?fields=summary,description" \
+    -H "Authorization: Basic ${JIRA_AUTH}" \
+    -H "Accept: application/json")
+  JIRA_HTTP_CODE=$(echo "$JIRA_RESPONSE" | tail -1)
+  JIRA_BODY=$(echo "$JIRA_RESPONSE" | sed '$d')
+
+  if [ "$JIRA_HTTP_CODE" != "200" ]; then
+    echo "ERROR: Failed to fetch Jira issue ${JIRA_KEY} (HTTP ${JIRA_HTTP_CODE})"
+    echo "Response: ${JIRA_BODY}"
+    exit 1
+  fi
+
+  echo "Jira issue fetched successfully"
+
+  # Save raw response to ARTIFACT_DIR
+  echo "$JIRA_BODY" > "/tmp/jira-issue-${JIRA_KEY}.json"
+
+  # Extract summary
+  JIRA_SUMMARY=$(echo "$JIRA_BODY" | jq -r '.fields.summary // ""')
+  echo "  Summary: ${JIRA_SUMMARY}"
+
+  # Extract description text from Atlassian Document Format (ADF)
+  # ADF is a nested JSON structure; recursively extract all text nodes
+  JIRA_DESCRIPTION_TEXT=$(echo "$JIRA_BODY" | jq -r '
+    [.fields.description? // {} | .. | .text? // empty] | join(" ")
+  ' 2>/dev/null || echo "")
+  if [ -n "$JIRA_DESCRIPTION_TEXT" ]; then
+    echo "  Description: $(echo "$JIRA_DESCRIPTION_TEXT" | head -c 200)..."
+  else
+    echo "  Description: (empty)"
+  fi
+
+  # Extract CVE ID(s) from summary + description
+  ALL_TEXT="${JIRA_SUMMARY} ${JIRA_DESCRIPTION_TEXT}"
+  EXTRACTED_CVES=$(echo "$ALL_TEXT" | grep -oE 'CVE-[0-9]{4}-[0-9]{4,}' | sort -u || true)
+
+  if [ -n "$EXTRACTED_CVES" ]; then
+    echo "  CVE(s) found in Jira issue:"
+    echo "$EXTRACTED_CVES" | sed 's/^/    - /'
+  fi
+
+  # If CVE_ID was not explicitly provided, use the first extracted CVE
+  if [ -z "$CVE_ID" ]; then
+    if [ -z "$EXTRACTED_CVES" ]; then
+      echo "ERROR: No CVE ID found in Jira issue ${JIRA_KEY} and CVE_AGENT_CVE_ID is not set"
+      echo "The issue summary and description must contain a CVE identifier (e.g., CVE-2024-45338)"
+      exit 1
+    fi
+    CVE_ID=$(echo "$EXTRACTED_CVES" | head -1)
+    echo "  Using extracted CVE ID: ${CVE_ID}"
+  else
+    echo "  CVE_AGENT_CVE_ID is set explicitly: ${CVE_ID} (takes precedence)"
+  fi
+
+  # Build Jira context for Claude's system prompt
+  JIRA_CONTEXT_PROMPT="
+=== JIRA CONTEXT ===
+Issue: ${JIRA_KEY}
+URL: ${JIRA_URL}/browse/${JIRA_KEY}
+Summary: ${JIRA_SUMMARY}
+Description:
+${JIRA_DESCRIPTION_TEXT}
+"
+  echo "=== Jira Integration Complete ==="
+fi
+
+# Validate required parameters
 if [ -z "$CVE_ID" ]; then
-  echo "ERROR: CVE_AGENT_CVE_ID is required"
-  echo "Set it via env var or Gangway override: MULTISTAGE_PARAM_OVERRIDE_CVE_AGENT_CVE_ID"
+  echo "ERROR: No CVE ID available."
+  echo "Provide either CVE_AGENT_CVE_ID or CVE_AGENT_JIRA_KEY (with a CVE in the issue)."
   exit 1
 fi
 
@@ -26,8 +128,10 @@ if [ -z "$TARGET_REPO" ]; then
   exit 1
 fi
 
+echo ""
 echo "Configuration:"
 echo "  CVE ID:        $CVE_ID"
+echo "  Jira key:      ${JIRA_KEY:-none}"
 echo "  Target repo:   $TARGET_REPO"
 echo "  Target branch: $TARGET_BRANCH"
 echo "  Algorithm:     $ALGO"
@@ -98,7 +202,8 @@ ${SKILL_IMPACT}
 ${SKILL_CALLGRAPH}
 
 === SKILL: Remediation Planning ===
-${SKILL_REMEDIATION}"
+${SKILL_REMEDIATION}
+${JIRA_CONTEXT_PROMPT}"
 
 TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
@@ -135,6 +240,12 @@ echo "${CVE_ID}" > "${SHARED_DIR}/cve-id.txt"
 echo "${TARGET_REPO}" > "${SHARED_DIR}/target-repo.txt"
 echo "${ALGO}" > "${SHARED_DIR}/algo.txt"
 echo "$ANALYSIS_DURATION" > "${SHARED_DIR}/claude-${CVE_ID}-duration.txt"
+
+# Save Jira metadata if a Jira issue was used
+if [ -n "$JIRA_KEY" ]; then
+  echo "${JIRA_KEY}" > "${SHARED_DIR}/jira-key.txt"
+  cp "/tmp/jira-issue-${JIRA_KEY}.json" "${ARTIFACT_DIR}/jira-issue.json" 2>/dev/null || true
+fi
 
 # Record result
 if [ $EXIT_CODE -eq 0 ]; then

--- a/ci-operator/step-registry/compliance/cve-agent/process/compliance-cve-agent-process-commands.sh
+++ b/ci-operator/step-registry/compliance/cve-agent/process/compliance-cve-agent-process-commands.sh
@@ -125,28 +125,28 @@ ANALYSIS_END=$(date +%s)
 ANALYSIS_DURATION=$((ANALYSIS_END - ANALYSIS_START))
 echo "Analysis duration: ${ANALYSIS_DURATION}s"
 
-# Copy raw stream-json to SHARED_DIR for the report step
-cp "/tmp/claude-${CVE_ID}-analysis.json" "${SHARED_DIR}/claude-${CVE_ID}-analysis.json" 2>/dev/null || true
-cp "/tmp/claude-${CVE_ID}-analysis.log" "${SHARED_DIR}/claude-${CVE_ID}-analysis.log" 2>/dev/null || true
+# --- SHARED_DIR is backed by a K8s Secret with a 3MB hard limit ---
+# Only write small metadata files to SHARED_DIR for the report step.
+# All large files (stream-json, callgraph, etc.) go to ARTIFACT_DIR.
 
-# Extract text output for report
-jq -j 'select(.type == "assistant") | .message.content[]? | select(.type == "text") | .text // empty' \
-  "/tmp/claude-${CVE_ID}-analysis.json" \
-  > "${SHARED_DIR}/claude-${CVE_ID}-analysis-text.txt" 2>/dev/null || true
+# Save metadata for report step
+echo "${CVE_ID}" > "${SHARED_DIR}/cve-id.txt"
+echo "${TARGET_REPO}" > "${SHARED_DIR}/target-repo.txt"
+echo "${ALGO}" > "${SHARED_DIR}/algo.txt"
+echo "$ANALYSIS_DURATION" > "${SHARED_DIR}/claude-${CVE_ID}-duration.txt"
 
-# Extract tool call summary
-jq -r 'select(.type == "assistant") | .message.content[]? | select(.type == "tool_use") | "\(.name): \(.input | keys | join(", "))"' \
-  "/tmp/claude-${CVE_ID}-analysis.json" 2>/dev/null \
-  | sort | uniq -c | sort -rn \
-  > "${SHARED_DIR}/claude-${CVE_ID}-analysis-tools.txt" 2>/dev/null || true
+# Record result
+if [ $EXIT_CODE -eq 0 ]; then
+  echo "✅ CVE analysis completed for ${CVE_ID}"
+  echo "${CVE_ID} ${TIMESTAMP} ${TARGET_REPO} SUCCESS" >> "$STATE_FILE"
+else
+  echo "❌ CVE analysis failed for ${CVE_ID} (exit code: ${EXIT_CODE})"
+  echo "Error output (last 20 lines):"
+  tail -20 "/tmp/claude-${CVE_ID}-analysis.log" 2>/dev/null || true
+  echo "${CVE_ID} ${TIMESTAMP} ${TARGET_REPO} FAILED" >> "$STATE_FILE"
+fi
 
-# Extract errors
-jq -r 'select(.type == "user") | .tool_use_result | select(type == "string") | select(startswith("Error:")) | gsub("\n"; "⏎")' \
-  "/tmp/claude-${CVE_ID}-analysis.json" 2>/dev/null \
-  | sort | uniq -c | sort -rn | sed 's/⏎/\n/g' \
-  > "${SHARED_DIR}/claude-${CVE_ID}-analysis-errors.txt" 2>/dev/null || true
-
-# Extract token usage
+# Extract token usage (small JSON, safe for SHARED_DIR)
 grep '"type":"result"' "/tmp/claude-${CVE_ID}-analysis.json" \
   | head -1 \
   | jq '{
@@ -165,6 +165,29 @@ grep '"type":"result"' "/tmp/claude-${CVE_ID}-analysis.json" \
 
 echo "Token usage: $(cat "${SHARED_DIR}/claude-${CVE_ID}-tokens.json")"
 
+# Extract small text summaries for the report step (safe for SHARED_DIR)
+# Truncate analysis text to 1MB max to stay within 3MB K8s Secret limit
+jq -j 'select(.type == "assistant") | .message.content[]? | select(.type == "text") | .text // empty' \
+  "/tmp/claude-${CVE_ID}-analysis.json" \
+  > "/tmp/claude-${CVE_ID}-analysis-text-full.txt" 2>/dev/null || true
+TEXT_SIZE=$(stat -c%s "/tmp/claude-${CVE_ID}-analysis-text-full.txt" 2>/dev/null || echo "0")
+if [ "$TEXT_SIZE" -gt 1048576 ]; then
+  head -c 1048576 "/tmp/claude-${CVE_ID}-analysis-text-full.txt" > "${SHARED_DIR}/claude-${CVE_ID}-analysis-text.txt"
+  echo "Analysis text truncated: ${TEXT_SIZE} -> 1MB"
+else
+  cp "/tmp/claude-${CVE_ID}-analysis-text-full.txt" "${SHARED_DIR}/claude-${CVE_ID}-analysis-text.txt"
+fi
+
+jq -r 'select(.type == "assistant") | .message.content[]? | select(.type == "tool_use") | "\(.name): \(.input | keys | join(", "))"' \
+  "/tmp/claude-${CVE_ID}-analysis.json" 2>/dev/null \
+  | sort | uniq -c | sort -rn \
+  > "${SHARED_DIR}/claude-${CVE_ID}-analysis-tools.txt" 2>/dev/null || true
+
+jq -r 'select(.type == "user") | .tool_use_result | select(type == "string") | select(startswith("Error:")) | gsub("\n"; "⏎")' \
+  "/tmp/claude-${CVE_ID}-analysis.json" 2>/dev/null \
+  | sort | uniq -c | sort -rn | sed 's/⏎/\n/g' \
+  > "${SHARED_DIR}/claude-${CVE_ID}-analysis-errors.txt" 2>/dev/null || true
+
 # Print human-readable analysis output
 echo ""
 echo "=========================================="
@@ -174,45 +197,28 @@ cat "${SHARED_DIR}/claude-${CVE_ID}-analysis-text.txt" 2>/dev/null || echo "(no 
 echo ""
 echo "=========================================="
 
-# Save analysis duration
-echo "$ANALYSIS_DURATION" > "${SHARED_DIR}/claude-${CVE_ID}-duration.txt"
+# Copy report.md to SHARED_DIR (small, needed by report step for HTML)
+for ARTIFACT_SRC in "${SHARED_DIR}/cve-artifacts-${CVE_ID}" ".work/compliance/analyze-cve/${CVE_ID}"; do
+  if [ -d "$ARTIFACT_SRC" ] && [ -f "${ARTIFACT_SRC}/report.md" ]; then
+    cp "${ARTIFACT_SRC}/report.md" "${SHARED_DIR}/cve-report-${CVE_ID}.md" 2>/dev/null || true
+    echo "Copied report.md to SHARED_DIR ($(stat -c%s "${ARTIFACT_SRC}/report.md" 2>/dev/null || echo '?') bytes)"
+    break
+  fi
+done
 
-# Save metadata for report step FIRST (before large artifact copies that may fill SHARED_DIR)
-echo "${CVE_ID}" > "${SHARED_DIR}/cve-id.txt"
-echo "${TARGET_REPO}" > "${SHARED_DIR}/target-repo.txt"
-echo "${ALGO}" > "${SHARED_DIR}/algo.txt"
-
-# Record result
-if [ $EXIT_CODE -eq 0 ]; then
-  echo "✅ CVE analysis completed for ${CVE_ID}"
-  echo "${CVE_ID} ${TIMESTAMP} ${TARGET_REPO} SUCCESS" >> "$STATE_FILE"
-else
-  echo "❌ CVE analysis failed for ${CVE_ID} (exit code: ${EXIT_CODE})"
-  echo "Error output (last 20 lines):"
-  tail -20 "/tmp/claude-${CVE_ID}-analysis.log" 2>/dev/null || true
-  echo "${CVE_ID} ${TIMESTAMP} ${TARGET_REPO} FAILED" >> "$STATE_FILE"
-fi
-
-# Copy analysis artifacts to SHARED_DIR as flat files (subdirectories don't persist across CI steps)
-# Truncate files > 5MB to avoid filling up SHARED_DIR volume (callgraph.txt can be 60MB+)
-MAX_ARTIFACT_SIZE=$((5 * 1024 * 1024))
+# Copy ALL artifacts (including large ones) to this step's ARTIFACT_DIR (no size limit)
+cp "/tmp/claude-${CVE_ID}-analysis.json" "${ARTIFACT_DIR}/analysis-stream.json" 2>/dev/null || true
+cp "/tmp/claude-${CVE_ID}-analysis.log" "${ARTIFACT_DIR}/analysis.log" 2>/dev/null || true
 ARTIFACT_FOUND=false
 for ARTIFACT_SRC in "${SHARED_DIR}/cve-artifacts-${CVE_ID}" ".work/compliance/analyze-cve/${CVE_ID}"; do
   if [ -d "$ARTIFACT_SRC" ]; then
-    echo "Found artifacts at ${ARTIFACT_SRC}:"
+    echo "Copying artifacts from ${ARTIFACT_SRC} to ARTIFACT_DIR:"
     ls -la "$ARTIFACT_SRC" 2>/dev/null || true
     for f in "$ARTIFACT_SRC"/*; do
       [ -f "$f" ] || continue
       BASENAME=$(basename "$f")
-      DEST="${SHARED_DIR}/cve-artifact-${CVE_ID}-${BASENAME}"
-      FILE_SIZE=$(stat -c%s "$f" 2>/dev/null || echo "0")
-      if [ "$FILE_SIZE" -gt "$MAX_ARTIFACT_SIZE" ]; then
-        head -c "$MAX_ARTIFACT_SIZE" "$f" > "$DEST" 2>/dev/null || true
-        echo "  Truncated: ${BASENAME} (${FILE_SIZE} -> 5MB)"
-      else
-        cp "$f" "$DEST" 2>/dev/null || true
-        echo "  Copied: ${BASENAME} (${FILE_SIZE} bytes)"
-      fi
+      cp "$f" "${ARTIFACT_DIR}/${BASENAME}" 2>/dev/null || true
+      echo "  -> ${BASENAME} ($(stat -c%s "$f" 2>/dev/null || echo '?') bytes)"
     done
     ARTIFACT_FOUND=true
     break
@@ -221,6 +227,12 @@ done
 if [ "$ARTIFACT_FOUND" = false ]; then
   echo "WARNING: No artifact directory found in expected locations"
 fi
+
+# Debug: show SHARED_DIR total size to verify it stays under 3MB K8s Secret limit
+echo ""
+echo "SHARED_DIR usage:"
+du -sh "${SHARED_DIR}" 2>/dev/null || true
+ls -la "${SHARED_DIR}/" 2>/dev/null || true
 
 echo ""
 echo "=== Processing Complete ==="

--- a/ci-operator/step-registry/compliance/cve-agent/process/compliance-cve-agent-process-commands.sh
+++ b/ci-operator/step-registry/compliance/cve-agent/process/compliance-cve-agent-process-commands.sh
@@ -38,21 +38,25 @@ if [ -n "$JIRA_KEY" ]; then
 
   if [ ! -f "$JIRA_TOKEN_FILE" ] || [ ! -f "$JIRA_EMAIL_FILE" ]; then
     echo "ERROR: Jira credentials not found (need both jira-pat and jira-email)"
-    echo "Available files in credential mount:"
-    ls -la /var/run/claude-code-service-account/ 2>/dev/null || echo "  (mount not found)"
     exit 1
   fi
 
-  JIRA_TOKEN=$(cat "$JIRA_TOKEN_FILE")
-  JIRA_EMAIL=$(cat "$JIRA_EMAIL_FILE")
-  JIRA_AUTH=$(echo -n "${JIRA_EMAIL}:${JIRA_TOKEN}" | base64 | tr -d '\n')
   echo "Jira credentials loaded"
 
   # Fetch issue via REST API
+  # Use a temp netrc file to avoid leaking credentials in process args (/proc/PID/cmdline)
+  JIRA_NETRC=$(mktemp)
+  chmod 600 "$JIRA_NETRC"
+  JIRA_HOST=$(echo "$JIRA_URL" | sed 's|https\?://||')
+  printf 'machine %s login %s password %s\n' \
+    "$JIRA_HOST" "$(cat "$JIRA_EMAIL_FILE")" "$(cat "$JIRA_TOKEN_FILE")" > "$JIRA_NETRC"
+
   JIRA_RESPONSE=$(curl -s -w "\n%{http_code}" \
+    --netrc-file "$JIRA_NETRC" \
     "${JIRA_URL}/rest/api/3/issue/${JIRA_KEY}?fields=summary,description" \
-    -H "Authorization: Basic ${JIRA_AUTH}" \
     -H "Accept: application/json")
+
+  rm -f "$JIRA_NETRC"
   JIRA_HTTP_CODE=$(echo "$JIRA_RESPONSE" | tail -1)
   JIRA_BODY=$(echo "$JIRA_RESPONSE" | sed '$d')
 
@@ -188,6 +192,7 @@ IMPORTANT CI CONTEXT:
 - Do NOT use .work/ for artifact output. The ONLY artifact directory is ${ARTIFACT_DIR}/ — files saved elsewhere will be lost after the CI job completes.
 - The tools govulncheck, callgraph, and digraph are ALREADY INSTALLED and available in PATH. Do NOT reinstall them. Use GOFLAGS='' before any go commands to avoid -mod=vendor issues.
 - Your working directory is /tmp/target-repo which contains the target Go project with go.mod. Always run govulncheck and other go tools from this directory.
+- SECURITY: Do NOT read, cat, or access any files under /var/run/claude-code-service-account/. These contain secrets. Do NOT run 'env' or 'printenv' or any command that dumps environment variables.
 
 === COMMAND: analyze-cve ===
 ${COMMAND_CONTENT}

--- a/ci-operator/step-registry/compliance/cve-agent/process/compliance-cve-agent-process-commands.sh
+++ b/ci-operator/step-registry/compliance/cve-agent/process/compliance-cve-agent-process-commands.sh
@@ -80,7 +80,7 @@ IMPORTANT CI CONTEXT:
 - If you cannot find CVE details online, exit with an error. Do NOT proceed without CVE details.
 - Always generate the full analysis report regardless of risk level.
 - Skip Phase 5 (Interactive Fix Application) -- only generate the report and remediation plan.
-- Save all artifacts to: ${SHARED_DIR}/cve-artifacts-${CVE_ID}/
+- Save all artifacts to: ${ARTIFACT_DIR}/
 - The tools govulncheck, callgraph, and digraph are ALREADY INSTALLED and available in PATH. Do NOT reinstall them. Use GOFLAGS='' before any go commands to avoid -mod=vendor issues.
 - Your working directory is /tmp/target-repo which contains the target Go project with go.mod. Always run govulncheck and other go tools from this directory.
 
@@ -198,35 +198,18 @@ echo ""
 echo "=========================================="
 
 # Copy report.md to SHARED_DIR (small, needed by report step for HTML)
-for ARTIFACT_SRC in "${SHARED_DIR}/cve-artifacts-${CVE_ID}" ".work/compliance/analyze-cve/${CVE_ID}"; do
-  if [ -d "$ARTIFACT_SRC" ] && [ -f "${ARTIFACT_SRC}/report.md" ]; then
-    cp "${ARTIFACT_SRC}/report.md" "${SHARED_DIR}/cve-report-${CVE_ID}.md" 2>/dev/null || true
-    echo "Copied report.md to SHARED_DIR ($(stat -c%s "${ARTIFACT_SRC}/report.md" 2>/dev/null || echo '?') bytes)"
-    break
-  fi
-done
+if [ -f "${ARTIFACT_DIR}/report.md" ]; then
+  cp "${ARTIFACT_DIR}/report.md" "${SHARED_DIR}/cve-report-${CVE_ID}.md" 2>/dev/null || true
+  echo "Copied report.md to SHARED_DIR ($(stat -c%s "${ARTIFACT_DIR}/report.md" 2>/dev/null || echo '?') bytes)"
+fi
 
-# Copy ALL artifacts (including large ones) to this step's ARTIFACT_DIR (no size limit)
+# Copy stream-json and log to ARTIFACT_DIR (Claude artifacts are already there)
 cp "/tmp/claude-${CVE_ID}-analysis.json" "${ARTIFACT_DIR}/analysis-stream.json" 2>/dev/null || true
 cp "/tmp/claude-${CVE_ID}-analysis.log" "${ARTIFACT_DIR}/analysis.log" 2>/dev/null || true
-ARTIFACT_FOUND=false
-for ARTIFACT_SRC in "${SHARED_DIR}/cve-artifacts-${CVE_ID}" ".work/compliance/analyze-cve/${CVE_ID}"; do
-  if [ -d "$ARTIFACT_SRC" ]; then
-    echo "Copying artifacts from ${ARTIFACT_SRC} to ARTIFACT_DIR:"
-    ls -la "$ARTIFACT_SRC" 2>/dev/null || true
-    for f in "$ARTIFACT_SRC"/*; do
-      [ -f "$f" ] || continue
-      BASENAME=$(basename "$f")
-      cp "$f" "${ARTIFACT_DIR}/${BASENAME}" 2>/dev/null || true
-      echo "  -> ${BASENAME} ($(stat -c%s "$f" 2>/dev/null || echo '?') bytes)"
-    done
-    ARTIFACT_FOUND=true
-    break
-  fi
-done
-if [ "$ARTIFACT_FOUND" = false ]; then
-  echo "WARNING: No artifact directory found in expected locations"
-fi
+
+echo ""
+echo "ARTIFACT_DIR contents:"
+ls -la "${ARTIFACT_DIR}/" 2>/dev/null || true
 
 # Debug: show SHARED_DIR total size to verify it stays under 3MB K8s Secret limit
 echo ""

--- a/ci-operator/step-registry/compliance/cve-agent/process/compliance-cve-agent-process-commands.sh
+++ b/ci-operator/step-registry/compliance/cve-agent/process/compliance-cve-agent-process-commands.sh
@@ -36,27 +36,56 @@ if [ -n "$JIRA_KEY" ]; then
   JIRA_TOKEN_FILE="/var/run/claude-code-service-account/jira-pat"
   JIRA_EMAIL_FILE="/var/run/claude-code-service-account/jira-email"
 
+  # Validate credential files (safe diagnostics -- no values printed)
+  echo "  Credential mount contents:"
+  ls -la /var/run/claude-code-service-account/ 2>/dev/null | grep -E 'jira' || echo "    (no jira files found)"
+  echo "  jira-pat:   exists=$([ -f "$JIRA_TOKEN_FILE" ] && echo yes || echo NO)  size=$(stat -c%s "$JIRA_TOKEN_FILE" 2>/dev/null || echo 0) bytes  readable=$([ -r "$JIRA_TOKEN_FILE" ] && echo yes || echo NO)"
+  echo "  jira-email: exists=$([ -f "$JIRA_EMAIL_FILE" ] && echo yes || echo NO)  size=$(stat -c%s "$JIRA_EMAIL_FILE" 2>/dev/null || echo 0) bytes  readable=$([ -r "$JIRA_EMAIL_FILE" ] && echo yes || echo NO)"
+
   if [ ! -f "$JIRA_TOKEN_FILE" ] || [ ! -f "$JIRA_EMAIL_FILE" ]; then
     echo "ERROR: Jira credentials not found (need both jira-pat and jira-email)"
+    exit 1
+  fi
+  if [ ! -s "$JIRA_TOKEN_FILE" ] || [ ! -s "$JIRA_EMAIL_FILE" ]; then
+    echo "ERROR: Jira credential files exist but are empty"
     exit 1
   fi
 
   echo "Jira credentials loaded"
 
   # Fetch issue via REST API
-  # Use a temp netrc file to avoid leaking credentials in process args (/proc/PID/cmdline)
-  JIRA_NETRC=$(mktemp)
-  chmod 600 "$JIRA_NETRC"
-  JIRA_HOST=$(echo "$JIRA_URL" | sed 's|https\?://||')
-  printf 'machine %s login %s password %s\n' \
-    "$JIRA_HOST" "$(cat "$JIRA_EMAIL_FILE")" "$(cat "$JIRA_TOKEN_FILE")" > "$JIRA_NETRC"
+  # Use a curl config file to pass the auth header securely (avoids /proc/PID/cmdline exposure)
+  JIRA_CURL_CFG=$(mktemp)
+  chmod 600 "$JIRA_CURL_CFG"
+  JIRA_EMAIL_VAL=$(cat "$JIRA_EMAIL_FILE" | tr -d '\n')
+  JIRA_TOKEN_VAL=$(cat "$JIRA_TOKEN_FILE" | tr -d '\n')
+  printf 'header = "Authorization: Basic %s"\n' \
+    "$(printf '%s:%s' "$JIRA_EMAIL_VAL" "$JIRA_TOKEN_VAL" | base64 | tr -d '\n')" > "$JIRA_CURL_CFG"
+  unset JIRA_EMAIL_VAL JIRA_TOKEN_VAL
+
+  # Debug: test auth against a known endpoint first
+  echo "  Testing Jira auth (GET /rest/api/3/myself)..."
+  JIRA_AUTH_TEST=$(curl -s -w "\n%{http_code}" \
+    -K "$JIRA_CURL_CFG" \
+    "${JIRA_URL}/rest/api/3/myself" \
+    -H "Accept: application/json")
+  JIRA_AUTH_TEST_CODE=$(echo "$JIRA_AUTH_TEST" | tail -1)
+  if [ "$JIRA_AUTH_TEST_CODE" = "200" ]; then
+    JIRA_AUTH_USER=$(echo "$JIRA_AUTH_TEST" | sed '$d' | jq -r '.displayName // .emailAddress // "unknown"' 2>/dev/null || echo "unknown")
+    echo "  Auth OK: logged in as '${JIRA_AUTH_USER}'"
+  else
+    echo "  Auth FAILED (HTTP ${JIRA_AUTH_TEST_CODE})"
+    echo "  Response: $(echo "$JIRA_AUTH_TEST" | sed '$d')"
+    rm -f "$JIRA_CURL_CFG"
+    exit 1
+  fi
 
   JIRA_RESPONSE=$(curl -s -w "\n%{http_code}" \
-    --netrc-file "$JIRA_NETRC" \
+    -K "$JIRA_CURL_CFG" \
     "${JIRA_URL}/rest/api/3/issue/${JIRA_KEY}?fields=summary,description" \
     -H "Accept: application/json")
 
-  rm -f "$JIRA_NETRC"
+  rm -f "$JIRA_CURL_CFG"
   JIRA_HTTP_CODE=$(echo "$JIRA_RESPONSE" | tail -1)
   JIRA_BODY=$(echo "$JIRA_RESPONSE" | sed '$d')
 

--- a/ci-operator/step-registry/compliance/cve-agent/process/compliance-cve-agent-process-ref.metadata.json
+++ b/ci-operator/step-registry/compliance/cve-agent/process/compliance-cve-agent-process-ref.metadata.json
@@ -1,0 +1,11 @@
+{
+	"path": "compliance/cve-agent/process/compliance-cve-agent-process-ref.yaml",
+	"owners": {
+		"approvers": [
+			"chiragkyal"
+		],
+		"reviewers": [
+			"chiragkyal"
+		]
+	}
+}

--- a/ci-operator/step-registry/compliance/cve-agent/process/compliance-cve-agent-process-ref.yaml
+++ b/ci-operator/step-registry/compliance/cve-agent/process/compliance-cve-agent-process-ref.yaml
@@ -23,7 +23,8 @@ ref:
     default: ""
     documentation: |-
       The CVE identifier to analyze (e.g., CVE-2024-45338).
-      Required. The job exits if not provided.
+      Required unless CVE_AGENT_JIRA_KEY is set (CVE ID will be
+      extracted from the Jira issue).
   - name: MULTISTAGE_PARAM_OVERRIDE_CVE_AGENT_CVE_ID
     default: ""
     documentation: |-
@@ -34,6 +35,29 @@ ref:
           "MULTISTAGE_PARAM_OVERRIDE_CVE_AGENT_CVE_ID": "CVE-2024-45338"
         }
       }
+  - name: CVE_AGENT_JIRA_KEY
+    default: ""
+    documentation: |-
+      Optional Jira issue key (e.g., OCPBUGS-12345). When set, the
+      process step fetches the issue from Jira, extracts CVE ID(s)
+      from the summary/description, and runs analysis with enriched
+      Jira context. If CVE_AGENT_CVE_ID is also set, it takes
+      precedence but Jira context is still fetched.
+  - name: MULTISTAGE_PARAM_OVERRIDE_CVE_AGENT_JIRA_KEY
+    default: ""
+    documentation: |-
+      Gangway API override for CVE_AGENT_JIRA_KEY. When triggering
+      this job via the Gangway API, pass it as:
+      "pod_spec_options": {
+        "envs": {
+          "MULTISTAGE_PARAM_OVERRIDE_CVE_AGENT_JIRA_KEY": "OCPBUGS-12345"
+        }
+      }
+  - name: CVE_AGENT_JIRA_URL
+    default: "https://redhat.atlassian.net"
+    documentation: |-
+      Jira instance base URL for fetching issue details.
+      Defaults to Red Hat Atlassian Cloud.
   - name: CVE_AGENT_TARGET_REPO
     default: ""
     documentation: |-
@@ -64,9 +88,10 @@ ref:
     Process step for the CVE analysis agent.
     This step:
     1. Clones ai-helpers (compliance plugin + skills) and the target repository
-    2. Loads the analyze-cve command and all skill files as system context
-    3. Runs Claude non-interactively with the analyze-cve skill pipeline
-    4. Captures stream-json output for token/cost telemetry
-    5. Saves analysis artifacts (report, call graph, evidence) to SHARED_DIR
-    CVE ID is passed via CVE_AGENT_CVE_ID env var or Gangway override.
+    2. Optionally fetches a Jira issue to extract CVE ID and context
+    3. Loads the analyze-cve command and all skill files as system context
+    4. Runs Claude non-interactively with the analyze-cve skill pipeline
+    5. Captures stream-json output for token/cost telemetry
+    6. Saves analysis artifacts (report, call graph, evidence) to ARTIFACT_DIR
+    Input: CVE_AGENT_CVE_ID (direct) or CVE_AGENT_JIRA_KEY (extracts CVE from Jira).
     Uses Vertex AI for Claude authentication via GCP service account.

--- a/ci-operator/step-registry/compliance/cve-agent/process/compliance-cve-agent-process-ref.yaml
+++ b/ci-operator/step-registry/compliance/cve-agent/process/compliance-cve-agent-process-ref.yaml
@@ -1,0 +1,72 @@
+ref:
+  as: compliance-cve-agent-process
+  from: claude-ai-helpers
+  commands: compliance-cve-agent-process-commands.sh
+  env:
+  - name: CLAUDE_CODE_USE_VERTEX
+    default: "1"
+    documentation: |-
+      Enable Vertex AI for Claude Code.
+  - name: CLOUD_ML_REGION
+    default: "us-east5"
+    documentation: |-
+      Google Cloud region for Vertex AI.
+  - name: ANTHROPIC_VERTEX_PROJECT_ID
+    default: "itpc-gcp-hybrid-pe-eng-claude"
+    documentation: |-
+      Google Cloud project ID for Vertex AI authentication.
+  - name: GOOGLE_APPLICATION_CREDENTIALS
+    default: "/var/run/claude-code-service-account/claude-prow"
+    documentation: |-
+      Path to the Google Cloud service account JSON key file for Vertex AI authentication.
+  - name: CVE_AGENT_CVE_ID
+    default: ""
+    documentation: |-
+      The CVE identifier to analyze (e.g., CVE-2024-45338).
+      Required. The job exits if not provided.
+  - name: MULTISTAGE_PARAM_OVERRIDE_CVE_AGENT_CVE_ID
+    default: ""
+    documentation: |-
+      Gangway API override for CVE_AGENT_CVE_ID. When triggering
+      this job via the Gangway API, pass it as:
+      "pod_spec_options": {
+        "envs": {
+          "MULTISTAGE_PARAM_OVERRIDE_CVE_AGENT_CVE_ID": "CVE-2024-45338"
+        }
+      }
+  - name: CVE_AGENT_TARGET_REPO
+    default: ""
+    documentation: |-
+      GitHub repository to analyze (e.g., "openshift/secrets-store-csi-driver-operator").
+      Required. The job exits if not provided.
+  - name: CVE_AGENT_TARGET_BRANCH
+    default: "main"
+    documentation: |-
+      Branch of the target repository to analyze. Defaults to "main".
+  - name: CVE_AGENT_ALGO
+    default: "vta"
+    documentation: |-
+      Call graph construction algorithm. Options: vta, rta, cha, static.
+      Defaults to "vta" (most precise, fewest false positives).
+  - name: CLAUDE_MODEL
+    default: "claude-opus-4-6"
+    documentation: |-
+      Claude model to use for CVE analysis.
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+  credentials:
+  - namespace: test-credentials
+    name: hypershift-team-claude-prow
+    mount_path: /var/run/claude-code-service-account
+  documentation: |-
+    Process step for the CVE analysis agent.
+    This step:
+    1. Clones ai-helpers (compliance plugin + skills) and the target repository
+    2. Loads the analyze-cve command and all skill files as system context
+    3. Runs Claude non-interactively with the analyze-cve skill pipeline
+    4. Captures stream-json output for token/cost telemetry
+    5. Saves analysis artifacts (report, call graph, evidence) to SHARED_DIR
+    CVE ID is passed via CVE_AGENT_CVE_ID env var or Gangway override.
+    Uses Vertex AI for Claude authentication via GCP service account.

--- a/ci-operator/step-registry/compliance/cve-agent/report/OWNERS
+++ b/ci-operator/step-registry/compliance/cve-agent/report/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- chiragkyal
+reviewers:
+- chiragkyal

--- a/ci-operator/step-registry/compliance/cve-agent/report/compliance-cve-agent-report-commands.sh
+++ b/ci-operator/step-registry/compliance/cve-agent/report/compliance-cve-agent-report-commands.sh
@@ -1,0 +1,216 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "=== CVE Analysis Agent Report Generation ==="
+
+STATE_FILE="${SHARED_DIR}/processed-cves.txt"
+REPORT_FILE="${ARTIFACT_DIR}/cve-agent-report.html"
+
+if [ ! -f "$STATE_FILE" ]; then
+  echo "No processed CVEs state file found. Nothing to report."
+  exit 0
+fi
+
+# Read metadata
+CVE_ID=$(cat "${SHARED_DIR}/cve-id.txt" 2>/dev/null || echo "unknown")
+TARGET_REPO=$(cat "${SHARED_DIR}/target-repo.txt" 2>/dev/null || echo "unknown")
+ALGO=$(cat "${SHARED_DIR}/algo.txt" 2>/dev/null || echo "vta")
+STATUS=$(awk '{print $4}' "$STATE_FILE" | head -1)
+TIMESTAMP=$(awk '{print $2}' "$STATE_FILE" | head -1)
+RUN_TIMESTAMP=$(date -u +"%Y-%m-%d %H:%M:%S UTC")
+
+read_extracted() {
+  local file=$1
+  if [ -f "$file" ] && [ -s "$file" ]; then
+    cat "$file"
+  else
+    echo "(no output captured)"
+  fi
+}
+
+read_token_field() {
+  local file=$1
+  local field=$2
+  if [ -f "$file" ] && [ -s "$file" ]; then
+    jq -r ".${field} // 0" "$file" 2>/dev/null || echo "0"
+  else
+    echo "0"
+  fi
+}
+
+format_number() {
+  local num=$1
+  printf "%s" "$num" | sed -e ':a' -e 's/\([0-9]\)\([0-9]\{3\}\)\(\b\)/\1,\2\3/' -e 'ta'
+}
+
+format_cost() {
+  local cost_usd=${1:-0}
+  printf '$%.4f' "$cost_usd"
+}
+
+format_duration() {
+  local secs=$1
+  if [ "$secs" -eq 0 ] 2>/dev/null; then
+    echo "-"
+    return
+  fi
+  local hours=$((secs / 3600))
+  local mins=$(( (secs % 3600) / 60 ))
+  local s=$((secs % 60))
+  if [ "$hours" -gt 0 ]; then
+    printf "%dh %dm %ds" "$hours" "$mins" "$s"
+  elif [ "$mins" -gt 0 ]; then
+    printf "%dm %ds" "$mins" "$s"
+  else
+    printf "%ds" "$s"
+  fi
+}
+
+html_escape() {
+  sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g; s/"/\&quot;/g'
+}
+
+# Read token data
+TOKEN_FILE="${SHARED_DIR}/claude-${CVE_ID}-tokens.json"
+DURATION_FILE="${SHARED_DIR}/claude-${CVE_ID}-duration.txt"
+
+INPUT_TOKENS=$(read_token_field "$TOKEN_FILE" "input_tokens")
+OUTPUT_TOKENS=$(read_token_field "$TOKEN_FILE" "output_tokens")
+CACHE_READ=$(read_token_field "$TOKEN_FILE" "cache_read_input_tokens")
+CACHE_CREATE=$(read_token_field "$TOKEN_FILE" "cache_creation_input_tokens")
+NUM_TURNS=$(read_token_field "$TOKEN_FILE" "num_turns")
+TOTAL_COST_RAW=$(read_token_field "$TOKEN_FILE" "total_cost_usd")
+TOTAL_COST=$(format_cost "$TOTAL_COST_RAW")
+MODEL=$(read_token_field "$TOKEN_FILE" "model")
+DURATION=$(cat "$DURATION_FILE" 2>/dev/null | tr -d '[:space:]' || echo "0")
+DURATION_FMT=$(format_duration "$DURATION")
+
+# Read analysis output
+ANALYSIS_TEXT=$(read_extracted "${SHARED_DIR}/claude-${CVE_ID}-analysis-text.txt" | html_escape)
+ANALYSIS_TOOLS=$(read_extracted "${SHARED_DIR}/claude-${CVE_ID}-analysis-tools.txt" | html_escape)
+ANALYSIS_ERRORS=$(read_extracted "${SHARED_DIR}/claude-${CVE_ID}-analysis-errors.txt" | html_escape)
+
+# Check for analysis report artifact
+REPORT_ARTIFACT=""
+ARTIFACT_DIR_SRC="${SHARED_DIR}/cve-artifacts-${CVE_ID}"
+if [ -d "$ARTIFACT_DIR_SRC" ]; then
+  if [ -f "${ARTIFACT_DIR_SRC}/report.md" ]; then
+    REPORT_ARTIFACT=$(cat "${ARTIFACT_DIR_SRC}/report.md" | html_escape)
+  fi
+  cp -r "$ARTIFACT_DIR_SRC"/* "${ARTIFACT_DIR}/" 2>/dev/null || true
+fi
+
+# Status styling
+if [ "$STATUS" = "SUCCESS" ]; then
+  STATUS_CLASS="success"
+  STATUS_LABEL="Success"
+else
+  STATUS_CLASS="failed"
+  STATUS_LABEL="Failed"
+fi
+
+echo "Generating HTML report for ${CVE_ID} (${STATUS})..."
+
+cat > "$REPORT_FILE" <<EOF
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>CVE Analysis Report - ${CVE_ID}</title>
+<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; margin: 2em; background: #f5f5f5; color: #333; }
+  h1 { border-bottom: 2px solid #333; padding-bottom: 0.3em; }
+  .summary-stats { display: flex; gap: 2em; margin: 1em 0; flex-wrap: wrap; }
+  .stat { background: #fff; padding: 1em 1.5em; border-radius: 6px; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+  .stat .value { font-size: 2em; font-weight: bold; }
+  .stat .label { color: #666; }
+  table { border-collapse: collapse; width: 100%; background: #fff; border-radius: 6px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.1); margin: 1em 0; }
+  th, td { padding: 0.75em 1em; text-align: left; border-bottom: 1px solid #eee; }
+  th { background: #f8f8f8; font-weight: 600; }
+  a { color: #0366d6; text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  .status { padding: 0.2em 0.6em; border-radius: 3px; font-size: 0.85em; font-weight: 600; }
+  .status.success { background: #dcffe4; color: #22863a; }
+  .status.failed { background: #ffdce0; color: #cb2431; }
+  .card { background: #fff; border-radius: 6px; padding: 1.5em; margin: 1.5em 0; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+  .card h2 { margin-top: 0; }
+  .card h3 { color: #555; margin-top: 1.5em; }
+  .output pre { background: #f6f8fa; padding: 1em; border-radius: 4px; overflow-x: auto; white-space: pre-wrap; word-wrap: break-word; font-size: 0.85em; max-height: 600px; overflow-y: auto; }
+  details { margin: 0.5em 0 1em 0; }
+  details summary { cursor: pointer; color: #666; font-size: 0.9em; }
+  details pre { background: #f6f8fa; padding: 1em; border-radius: 4px; font-size: 0.8em; overflow-x: auto; }
+  .timestamp { color: #666; font-size: 0.9em; }
+  .token-table { width: auto; min-width: 500px; }
+  .token-table td, .token-table th { text-align: right; }
+  .token-table td:first-child, .token-table th:first-child { text-align: left; }
+  .model-info { color: #666; font-size: 0.85em; margin-top: 0.3em; }
+  .error-pre { background: #fff5f5; border-left: 3px solid #cb2431; }
+  .meta-table td:first-child { font-weight: 600; min-width: 120px; }
+</style>
+</head>
+<body>
+<h1>CVE Analysis Report</h1>
+<p class="timestamp">Generated: ${RUN_TIMESTAMP}</p>
+
+<div class="summary-stats">
+  <div class="stat"><div class="value">${CVE_ID}</div><div class="label">CVE</div></div>
+  <div class="stat"><div class="value"><span class="status ${STATUS_CLASS}">${STATUS_LABEL}</span></div><div class="label">Status</div></div>
+  <div class="stat"><div class="value">${DURATION_FMT}</div><div class="label">Duration</div></div>
+  <div class="stat"><div class="value">${TOTAL_COST}</div><div class="label">Cost</div></div>
+  <div class="stat"><div class="value">${NUM_TURNS}</div><div class="label">Turns</div></div>
+</div>
+
+<div class="card">
+  <h2>Analysis Metadata</h2>
+  <table class="meta-table">
+    <tr><td>CVE ID</td><td>${CVE_ID}</td></tr>
+    <tr><td>Repository</td><td><a href="https://github.com/${TARGET_REPO}">${TARGET_REPO}</a></td></tr>
+    <tr><td>Algorithm</td><td>${ALGO}</td></tr>
+    <tr><td>Model</td><td>${MODEL}</td></tr>
+    <tr><td>Timestamp</td><td>${TIMESTAMP}</td></tr>
+  </table>
+</div>
+
+<div class="card">
+  <h2>Token Usage &amp; Cost</h2>
+  <table class="token-table">
+    <thead><tr><th>Metric</th><th>Value</th></tr></thead>
+    <tbody>
+      <tr><td>Input Tokens</td><td>$(format_number "$INPUT_TOKENS")</td></tr>
+      <tr><td>Output Tokens</td><td>$(format_number "$OUTPUT_TOKENS")</td></tr>
+      <tr><td>Cache Read</td><td>$(format_number "$CACHE_READ")</td></tr>
+      <tr><td>Cache Create</td><td>$(format_number "$CACHE_CREATE")</td></tr>
+      <tr><td>Turns</td><td>${NUM_TURNS}</td></tr>
+      <tr><td><strong>Total Cost</strong></td><td><strong>${TOTAL_COST}</strong></td></tr>
+    </tbody>
+  </table>
+  <p class="model-info">Model: ${MODEL}</p>
+</div>
+
+<div class="card">
+  <h2>Analysis Output</h2>
+  <div class="output"><pre>${ANALYSIS_TEXT}</pre></div>
+  <details><summary>Tool calls</summary><pre>${ANALYSIS_TOOLS}</pre></details>
+  <details><summary>Tool errors</summary><pre class="error-pre">${ANALYSIS_ERRORS}</pre></details>
+</div>
+
+EOF
+
+# Append generated report if available
+if [ -n "$REPORT_ARTIFACT" ]; then
+  cat >> "$REPORT_FILE" <<EOF
+<div class="card">
+  <h2>Generated Analysis Report</h2>
+  <div class="output"><pre>${REPORT_ARTIFACT}</pre></div>
+</div>
+
+EOF
+fi
+
+cat >> "$REPORT_FILE" <<EOF
+</body>
+</html>
+EOF
+
+echo "Report written to ${REPORT_FILE}"
+echo "=== Report generation complete ==="

--- a/ci-operator/step-registry/compliance/cve-agent/report/compliance-cve-agent-report-commands.sh
+++ b/ci-operator/step-registry/compliance/cve-agent/report/compliance-cve-agent-report-commands.sh
@@ -90,14 +90,25 @@ ANALYSIS_TEXT=$(read_extracted "${SHARED_DIR}/claude-${CVE_ID}-analysis-text.txt
 ANALYSIS_TOOLS=$(read_extracted "${SHARED_DIR}/claude-${CVE_ID}-analysis-tools.txt" | html_escape)
 ANALYSIS_ERRORS=$(read_extracted "${SHARED_DIR}/claude-${CVE_ID}-analysis-errors.txt" | html_escape)
 
+# Debug: list SHARED_DIR contents for troubleshooting
+echo "SHARED_DIR contents:"
+ls -la "${SHARED_DIR}/" 2>/dev/null || echo "(empty)"
+echo ""
+
 # Check for analysis report artifact
 REPORT_ARTIFACT=""
 ARTIFACT_DIR_SRC="${SHARED_DIR}/cve-artifacts-${CVE_ID}"
 if [ -d "$ARTIFACT_DIR_SRC" ]; then
+  echo "Found artifact directory: ${ARTIFACT_DIR_SRC}"
+  ls -la "$ARTIFACT_DIR_SRC" 2>/dev/null || true
   if [ -f "${ARTIFACT_DIR_SRC}/report.md" ]; then
     REPORT_ARTIFACT=$(cat "${ARTIFACT_DIR_SRC}/report.md" | html_escape)
   fi
   cp -r "$ARTIFACT_DIR_SRC"/* "${ARTIFACT_DIR}/" 2>/dev/null || true
+else
+  echo "No artifact directory found at ${ARTIFACT_DIR_SRC}"
+  echo "Searching SHARED_DIR for any report files..."
+  find "${SHARED_DIR}" -name "*.md" -o -name "*.json" -o -name "*.txt" 2>/dev/null || true
 fi
 
 # Status styling

--- a/ci-operator/step-registry/compliance/cve-agent/report/compliance-cve-agent-report-commands.sh
+++ b/ci-operator/step-registry/compliance/cve-agent/report/compliance-cve-agent-report-commands.sh
@@ -6,8 +6,13 @@ echo "=== CVE Analysis Agent Report Generation ==="
 STATE_FILE="${SHARED_DIR}/processed-cves.txt"
 REPORT_FILE="${ARTIFACT_DIR}/cve-agent-report.html"
 
+# Debug: always list SHARED_DIR contents (before checking state file)
+echo "SHARED_DIR contents:"
+ls -la "${SHARED_DIR}/" 2>/dev/null || echo "(empty)"
+echo ""
+
 if [ ! -f "$STATE_FILE" ]; then
-  echo "No processed CVEs state file found. Nothing to report."
+  echo "No processed CVEs state file found at ${STATE_FILE}. Nothing to report."
   exit 0
 fi
 
@@ -89,11 +94,6 @@ DURATION_FMT=$(format_duration "$DURATION")
 ANALYSIS_TEXT=$(read_extracted "${SHARED_DIR}/claude-${CVE_ID}-analysis-text.txt" | html_escape)
 ANALYSIS_TOOLS=$(read_extracted "${SHARED_DIR}/claude-${CVE_ID}-analysis-tools.txt" | html_escape)
 ANALYSIS_ERRORS=$(read_extracted "${SHARED_DIR}/claude-${CVE_ID}-analysis-errors.txt" | html_escape)
-
-# Debug: list SHARED_DIR contents for troubleshooting
-echo "SHARED_DIR contents:"
-ls -la "${SHARED_DIR}/" 2>/dev/null || echo "(empty)"
-echo ""
 
 # Collect analysis artifacts (stored as flat files with cve-artifact-<CVE_ID>- prefix)
 REPORT_ARTIFACT=""

--- a/ci-operator/step-registry/compliance/cve-agent/report/compliance-cve-agent-report-commands.sh
+++ b/ci-operator/step-registry/compliance/cve-agent/report/compliance-cve-agent-report-commands.sh
@@ -95,21 +95,28 @@ echo "SHARED_DIR contents:"
 ls -la "${SHARED_DIR}/" 2>/dev/null || echo "(empty)"
 echo ""
 
-# Check for analysis report artifact
+# Collect analysis artifacts (stored as flat files with cve-artifact-<CVE_ID>- prefix)
 REPORT_ARTIFACT=""
-ARTIFACT_DIR_SRC="${SHARED_DIR}/cve-artifacts-${CVE_ID}"
-if [ -d "$ARTIFACT_DIR_SRC" ]; then
-  echo "Found artifact directory: ${ARTIFACT_DIR_SRC}"
-  ls -la "$ARTIFACT_DIR_SRC" 2>/dev/null || true
-  if [ -f "${ARTIFACT_DIR_SRC}/report.md" ]; then
-    REPORT_ARTIFACT=$(cat "${ARTIFACT_DIR_SRC}/report.md" | html_escape)
+ARTIFACT_PREFIX="cve-artifact-${CVE_ID}-"
+ARTIFACT_COUNT=0
+echo "Looking for artifacts with prefix: ${ARTIFACT_PREFIX}"
+for f in "${SHARED_DIR}/${ARTIFACT_PREFIX}"*; do
+  [ -f "$f" ] || continue
+  BASENAME=$(basename "$f")
+  ORIGINAL_NAME="${BASENAME#${ARTIFACT_PREFIX}}"
+  cp "$f" "${ARTIFACT_DIR}/${ORIGINAL_NAME}" 2>/dev/null || true
+  echo "  Copied to ARTIFACT_DIR: ${ORIGINAL_NAME}"
+  ARTIFACT_COUNT=$((ARTIFACT_COUNT + 1))
+  if [ "$ORIGINAL_NAME" = "report.md" ]; then
+    REPORT_ARTIFACT=$(cat "$f" | html_escape)
   fi
-  cp -r "$ARTIFACT_DIR_SRC"/* "${ARTIFACT_DIR}/" 2>/dev/null || true
-else
-  echo "No artifact directory found at ${ARTIFACT_DIR_SRC}"
-  echo "Searching SHARED_DIR for any report files..."
-  find "${SHARED_DIR}" -name "*.md" -o -name "*.json" -o -name "*.txt" 2>/dev/null || true
-fi
+done
+echo "Total artifacts copied: ${ARTIFACT_COUNT}"
+
+# Also copy the raw stream-json and log to ARTIFACT_DIR for accessibility
+for f in "${SHARED_DIR}/claude-${CVE_ID}-analysis.json" "${SHARED_DIR}/claude-${CVE_ID}-analysis.log"; do
+  [ -f "$f" ] && cp "$f" "${ARTIFACT_DIR}/" 2>/dev/null || true
+done
 
 # Status styling
 if [ "$STATUS" = "SUCCESS" ]; then

--- a/ci-operator/step-registry/compliance/cve-agent/report/compliance-cve-agent-report-commands.sh
+++ b/ci-operator/step-registry/compliance/cve-agent/report/compliance-cve-agent-report-commands.sh
@@ -95,28 +95,15 @@ ANALYSIS_TEXT=$(read_extracted "${SHARED_DIR}/claude-${CVE_ID}-analysis-text.txt
 ANALYSIS_TOOLS=$(read_extracted "${SHARED_DIR}/claude-${CVE_ID}-analysis-tools.txt" | html_escape)
 ANALYSIS_ERRORS=$(read_extracted "${SHARED_DIR}/claude-${CVE_ID}-analysis-errors.txt" | html_escape)
 
-# Collect analysis artifacts (stored as flat files with cve-artifact-<CVE_ID>- prefix)
+# Read the generated report.md (small file, passed via SHARED_DIR)
 REPORT_ARTIFACT=""
-ARTIFACT_PREFIX="cve-artifact-${CVE_ID}-"
-ARTIFACT_COUNT=0
-echo "Looking for artifacts with prefix: ${ARTIFACT_PREFIX}"
-for f in "${SHARED_DIR}/${ARTIFACT_PREFIX}"*; do
-  [ -f "$f" ] || continue
-  BASENAME=$(basename "$f")
-  ORIGINAL_NAME="${BASENAME#${ARTIFACT_PREFIX}}"
-  cp "$f" "${ARTIFACT_DIR}/${ORIGINAL_NAME}" 2>/dev/null || true
-  echo "  Copied to ARTIFACT_DIR: ${ORIGINAL_NAME}"
-  ARTIFACT_COUNT=$((ARTIFACT_COUNT + 1))
-  if [ "$ORIGINAL_NAME" = "report.md" ]; then
-    REPORT_ARTIFACT=$(cat "$f" | html_escape)
-  fi
-done
-echo "Total artifacts copied: ${ARTIFACT_COUNT}"
-
-# Also copy the raw stream-json and log to ARTIFACT_DIR for accessibility
-for f in "${SHARED_DIR}/claude-${CVE_ID}-analysis.json" "${SHARED_DIR}/claude-${CVE_ID}-analysis.log"; do
-  [ -f "$f" ] && cp "$f" "${ARTIFACT_DIR}/" 2>/dev/null || true
-done
+REPORT_MD="${SHARED_DIR}/cve-report-${CVE_ID}.md"
+if [ -f "$REPORT_MD" ] && [ -s "$REPORT_MD" ]; then
+  REPORT_ARTIFACT=$(cat "$REPORT_MD" | html_escape)
+  echo "Found report.md in SHARED_DIR ($(wc -c < "$REPORT_MD") bytes)"
+else
+  echo "No report.md found in SHARED_DIR (large artifacts are in the process step's artifacts)"
+fi
 
 # Status styling
 if [ "$STATUS" = "SUCCESS" ]; then

--- a/ci-operator/step-registry/compliance/cve-agent/report/compliance-cve-agent-report-ref.metadata.json
+++ b/ci-operator/step-registry/compliance/cve-agent/report/compliance-cve-agent-report-ref.metadata.json
@@ -1,0 +1,11 @@
+{
+	"path": "compliance/cve-agent/report/compliance-cve-agent-report-ref.yaml",
+	"owners": {
+		"approvers": [
+			"chiragkyal"
+		],
+		"reviewers": [
+			"chiragkyal"
+		]
+	}
+}

--- a/ci-operator/step-registry/compliance/cve-agent/report/compliance-cve-agent-report-ref.yaml
+++ b/ci-operator/step-registry/compliance/cve-agent/report/compliance-cve-agent-report-ref.yaml
@@ -1,0 +1,13 @@
+ref:
+  as: compliance-cve-agent-report
+  from: claude-ai-helpers
+  commands: compliance-cve-agent-report-commands.sh
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+  documentation: |-
+    Generates an HTML report from the CVE analysis agent output.
+    Parses stream-json output and analysis artifacts to produce
+    a readable report with token usage, cost, and analysis findings
+    in ${ARTIFACT_DIR}.

--- a/ci-operator/step-registry/compliance/cve-agent/setup/OWNERS
+++ b/ci-operator/step-registry/compliance/cve-agent/setup/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- chiragkyal
+reviewers:
+- chiragkyal

--- a/ci-operator/step-registry/compliance/cve-agent/setup/compliance-cve-agent-setup-commands.sh
+++ b/ci-operator/step-registry/compliance/cve-agent/setup/compliance-cve-agent-setup-commands.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "=== CVE Analysis Agent Setup ==="
+
+# Verify Claude Code CLI
+echo "Verifying Claude Code CLI..."
+claude --version || { echo "ERROR: Claude Code CLI not found"; exit 1; }
+
+# Verify Go toolchain
+echo "Verifying Go toolchain..."
+go version || { echo "ERROR: Go not found"; exit 1; }
+
+# Install required analysis tools
+echo "Installing analysis tools..."
+go install golang.org/x/vuln/cmd/govulncheck@latest 2>&1 || { echo "ERROR: Failed to install govulncheck"; exit 1; }
+go install golang.org/x/tools/cmd/callgraph@latest 2>&1 || { echo "ERROR: Failed to install callgraph"; exit 1; }
+go install golang.org/x/tools/cmd/digraph@latest 2>&1 || { echo "ERROR: Failed to install digraph"; exit 1; }
+
+# Verify installations
+echo "Verifying tool installations..."
+which govulncheck || { echo "ERROR: govulncheck not in PATH"; exit 1; }
+which callgraph || { echo "ERROR: callgraph not in PATH"; exit 1; }
+which digraph || { echo "ERROR: digraph not in PATH"; exit 1; }
+
+echo "Setup complete - all tools verified"

--- a/ci-operator/step-registry/compliance/cve-agent/setup/compliance-cve-agent-setup-commands.sh
+++ b/ci-operator/step-registry/compliance/cve-agent/setup/compliance-cve-agent-setup-commands.sh
@@ -12,10 +12,11 @@ echo "Verifying Go toolchain..."
 go version || { echo "ERROR: Go not found"; exit 1; }
 
 # Install required analysis tools
+# Unset GOFLAGS to avoid -mod=vendor blocking remote module fetches
 echo "Installing analysis tools..."
-go install golang.org/x/vuln/cmd/govulncheck@latest 2>&1 || { echo "ERROR: Failed to install govulncheck"; exit 1; }
-go install golang.org/x/tools/cmd/callgraph@latest 2>&1 || { echo "ERROR: Failed to install callgraph"; exit 1; }
-go install golang.org/x/tools/cmd/digraph@latest 2>&1 || { echo "ERROR: Failed to install digraph"; exit 1; }
+GOFLAGS="" go install golang.org/x/vuln/cmd/govulncheck@latest 2>&1 || { echo "ERROR: Failed to install govulncheck"; exit 1; }
+GOFLAGS="" go install golang.org/x/tools/cmd/callgraph@latest 2>&1 || { echo "ERROR: Failed to install callgraph"; exit 1; }
+GOFLAGS="" go install golang.org/x/tools/cmd/digraph@latest 2>&1 || { echo "ERROR: Failed to install digraph"; exit 1; }
 
 # Verify installations
 echo "Verifying tool installations..."

--- a/ci-operator/step-registry/compliance/cve-agent/setup/compliance-cve-agent-setup-commands.sh
+++ b/ci-operator/step-registry/compliance/cve-agent/setup/compliance-cve-agent-setup-commands.sh
@@ -11,17 +11,4 @@ claude --version || { echo "ERROR: Claude Code CLI not found"; exit 1; }
 echo "Verifying Go toolchain..."
 go version || { echo "ERROR: Go not found"; exit 1; }
 
-# Install required analysis tools
-# Unset GOFLAGS to avoid -mod=vendor blocking remote module fetches
-echo "Installing analysis tools..."
-GOFLAGS="" go install golang.org/x/vuln/cmd/govulncheck@latest 2>&1 || { echo "ERROR: Failed to install govulncheck"; exit 1; }
-GOFLAGS="" go install golang.org/x/tools/cmd/callgraph@latest 2>&1 || { echo "ERROR: Failed to install callgraph"; exit 1; }
-GOFLAGS="" go install golang.org/x/tools/cmd/digraph@latest 2>&1 || { echo "ERROR: Failed to install digraph"; exit 1; }
-
-# Verify installations
-echo "Verifying tool installations..."
-which govulncheck || { echo "ERROR: govulncheck not in PATH"; exit 1; }
-which callgraph || { echo "ERROR: callgraph not in PATH"; exit 1; }
-which digraph || { echo "ERROR: digraph not in PATH"; exit 1; }
-
-echo "Setup complete - all tools verified"
+echo "Setup complete"

--- a/ci-operator/step-registry/compliance/cve-agent/setup/compliance-cve-agent-setup-ref.metadata.json
+++ b/ci-operator/step-registry/compliance/cve-agent/setup/compliance-cve-agent-setup-ref.metadata.json
@@ -1,0 +1,11 @@
+{
+	"path": "compliance/cve-agent/setup/compliance-cve-agent-setup-ref.yaml",
+	"owners": {
+		"approvers": [
+			"chiragkyal"
+		],
+		"reviewers": [
+			"chiragkyal"
+		]
+	}
+}

--- a/ci-operator/step-registry/compliance/cve-agent/setup/compliance-cve-agent-setup-ref.yaml
+++ b/ci-operator/step-registry/compliance/cve-agent/setup/compliance-cve-agent-setup-ref.yaml
@@ -1,0 +1,36 @@
+ref:
+  as: compliance-cve-agent-setup
+  from: claude-ai-helpers
+  commands: compliance-cve-agent-setup-commands.sh
+  env:
+  - name: CLAUDE_CODE_USE_VERTEX
+    default: "1"
+    documentation: |-
+      Enable Vertex AI for Claude Code.
+  - name: CLOUD_ML_REGION
+    default: "us-east5"
+    documentation: |-
+      Google Cloud region for Vertex AI.
+  - name: ANTHROPIC_VERTEX_PROJECT_ID
+    default: "itpc-gcp-hybrid-pe-eng-claude"
+    documentation: |-
+      Google Cloud project ID for Vertex AI authentication.
+  - name: GOOGLE_APPLICATION_CREDENTIALS
+    default: "/var/run/claude-code-service-account/claude-prow"
+    documentation: |-
+      Path to the Google Cloud service account JSON key file for Vertex AI authentication.
+  resources:
+    requests:
+      cpu: 100m
+      memory: 200Mi
+  credentials:
+  - namespace: test-credentials
+    name: hypershift-team-claude-prow
+    mount_path: /var/run/claude-code-service-account
+  documentation: |-
+    Setup step for the CVE analysis agent.
+    This step:
+    - Verifies Claude Code CLI is available
+    - Verifies Go toolchain is present
+    - Installs required analysis tools (govulncheck, callgraph, digraph)
+    - Uses Vertex AI for Claude authentication via GCP service account


### PR DESCRIPTION
## Summary

- Adds a reusable `compliance-cve-agent` step-registry workflow (setup/process/report) that runs the `/compliance:analyze-cve` plugin from [openshift-eng/ai-helpers](https://github.com/openshift-eng/ai-helpers) as a non-interactive Prow job
- Uses Claude Code (Opus) with Vertex AI to analyze Go codebases for CVE impact via govulncheck, call graph reachability, source code analysis, and dependency matching
- Generates an HTML report with token usage, cost breakdown, and analysis findings as CI artifacts
- Adds an optional presubmit (`cve-analysis`) to `secrets-store-csi-driver-operator` for initial testing against CVE-2025-61726

## Workflow Architecture

```
Pre:  compliance-cve-agent-setup   → verify CLI, Go, install govulncheck/callgraph/digraph
Test: compliance-cve-agent-process → clone repos, load skills, run Claude, capture telemetry
Post: compliance-cve-agent-report  → generate HTML report from stream-json artifacts
```

## Test Plan

- [ ] Trigger with `/test cve-analysis` on a secrets-store-csi-driver-operator PR
- [ ] Verify setup step installs all tools successfully
- [ ] Verify process step runs CVE analysis and produces output
- [ ] Verify report step generates HTML with token/cost data
- [ ] Verify artifacts are accessible via gcsweb


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Optional presubmit (/test cve-analysis) for main branches to run a non-interactive CVE analysis workflow.
  - New CI steps that perform automated CVE analysis, capture telemetry (tokens/cost/duration), collect artifacts, and produce an HTML CVE report.

* **Documentation**
  - Added a user-facing README explaining workflow usage, required inputs/environment variables, and presubmit example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->