### PR TITLE
SREP-4474: Fix CLUSTER_SWITCH initialization order in rosa-sts-account-roles-create-commands.sh

### DIFF
--- a/ci-operator/step-registry/rosa/sts/account-roles/create/rosa-sts-account-roles-create-commands.sh
+++ b/ci-operator/step-registry/rosa/sts/account-roles/create/rosa-sts-account-roles-create-commands.sh
@@ -47,6 +47,11 @@ fi
 AWS_ACCOUNT_ID=$(rosa whoami --output json | jq -r '."AWS Account ID"')
 AWS_ACCOUNT_ID_MASK=$(echo "${AWS_ACCOUNT_ID:0:4}***")
 
+CLUSTER_SWITCH="--classic"
+if [[ "$HOSTED_CP" == "true" ]]; then
+   CLUSTER_SWITCH="--hosted-cp"
+fi
+
 # Support to create the account-roles with the higher version
 VERSION_SWITCH=""
 if [[ "$CHANNEL_GROUP" != "stable" ]]; then
@@ -80,11 +85,6 @@ if [[ "$CHANNEL_GROUP" != "stable" ]]; then
   fi
 
   VERSION_SWITCH="--version ${OPENSHIFT_VERSION} --channel-group ${CHANNEL_GROUP}"
-fi
-
-CLUSTER_SWITCH="--classic"
-if [[ "$HOSTED_CP" == "true" ]]; then
-   CLUSTER_SWITCH="--hosted-cp"
 fi
 
 ARN_PATH_SWITCH=""


### PR DESCRIPTION
## What this PR does / why we need it:
CLUSTER_SWITCH was initialized on lines 85-88 but used on line 75
inside the version fallback logic that calls 'rosa list versions'.
Moved the initialization to after line 48 so it is defined before use.

## Which issue(s) this PR fixes:
Fixes [SREP-4474](https://redhat.atlassian.net/browse/SREP-4474)

## Special notes for your reviewer:
This is a pure ordering fix with no logic changes. CLUSTER_SWITCH
initialization block is moved earlier in the script; its content
is unchanged.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SREP-4474]: https://redhat.atlassian.net/browse/SREP-4474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized variable initialization sequence in account role creation script to improve code efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->