### PR TITLE
CLID-577: Onboard openshift/mirror-gui to Prow CI

### DIFF
--- a/ci-operator/config/openshift/mirror-gui/OWNERS
+++ b/ci-operator/config/openshift/mirror-gui/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+  - yakovbeder
+  - aguidirh
+reviewers:
+  - yakovbeder
+  - aguidirh

--- a/ci-operator/config/openshift/mirror-gui/openshift-mirror-gui-main.yaml
+++ b/ci-operator/config/openshift/mirror-gui/openshift-mirror-gui-main.yaml
@@ -1,0 +1,44 @@
+build_root:
+  from_repository: true
+images:
+  items:
+  - dockerfile_path: Dockerfile
+    to: mirror-gui
+promotion:
+  to:
+  - name: "5.0"
+    namespace: ocp
+releases:
+  initial:
+    integration:
+      name: "5.0"
+      namespace: ocp
+  latest:
+    integration:
+      include_built_images: true
+      name: "5.0"
+      namespace: ocp
+resources:
+  '*':
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+test_binary_build_commands: |
+  ./container-run.sh --build-only
+tests:
+- as: lint
+  commands: npm ci && npm run lint
+  container:
+    from: src
+  skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|LICENSE)$
+- as: unit
+  commands: npm ci && npm run build && npm run test
+  container:
+    from: src
+  skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|LICENSE)$
+zz_generated_metadata:
+  branch: main
+  org: openshift
+  repo: mirror-gui

--- a/ci-operator/config/openshift/mirror-gui/openshift-mirror-gui-main.yaml
+++ b/ci-operator/config/openshift/mirror-gui/openshift-mirror-gui-main.yaml
@@ -25,18 +25,27 @@ resources:
     requests:
       cpu: 100m
       memory: 200Mi
-test_binary_build_commands: |
-  ./container-run.sh --build-only
+test_binary_build_commands: npm ci && npm run build
 tests:
 - as: lint
-  commands: npm ci && npm run lint
+  commands: npm run lint
   container:
-    from: src
+    from: test-bin
   skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|LICENSE)$
 - as: unit
-  commands: npm ci && npm run build && npm run test
+  commands: npm run test
   container:
-    from: src
+    from: test-bin
+  skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|LICENSE)$
+- as: audit-catalog
+  commands: npx vitest run tests/scripts/auditFetchCatalogs.test.ts
+  container:
+    from: test-bin
+  skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|LICENSE)$
+- as: catalog-integrity
+  commands: npx vitest run tests/scripts/catalogDataIntegrity.test.ts
+  container:
+    from: test-bin
   skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|LICENSE)$
 zz_generated_metadata:
   branch: main

--- a/ci-operator/config/openshift/mirror-gui/openshift-mirror-gui-main.yaml
+++ b/ci-operator/config/openshift/mirror-gui/openshift-mirror-gui-main.yaml
@@ -1,5 +1,6 @@
 build_root:
-  from_repository: true
+  project_image:
+    dockerfile_path: .ci-operator/build-root/Dockerfile
 images:
   items:
   - dockerfile_path: Dockerfile

--- a/ci-operator/jobs/openshift/mirror-gui/OWNERS
+++ b/ci-operator/jobs/openshift/mirror-gui/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+  - yakovbeder
+  - aguidirh
+reviewers:
+  - yakovbeder
+  - aguidirh

--- a/ci-operator/jobs/openshift/mirror-gui/openshift-mirror-gui-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/mirror-gui/openshift-mirror-gui-main-postsubmits.yaml
@@ -6,6 +6,8 @@ postsubmits:
     - ^main$
     cluster: build01
     decorate: true
+    decoration_config:
+      skip_cloning: true
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen

--- a/ci-operator/jobs/openshift/mirror-gui/openshift-mirror-gui-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/mirror-gui/openshift-mirror-gui-main-postsubmits.yaml
@@ -1,0 +1,60 @@
+postsubmits:
+  openshift/mirror-gui:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    cluster: build01
+    decorate: true
+    labels:
+      ci-operator.openshift.io/is-promotion: "true"
+      ci.openshift.io/generator: prowgen
+    max_concurrency: 1
+    name: branch-ci-openshift-mirror-gui-main-images
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --image-mirror-push-secret=/etc/push-secret/.dockerconfigjson
+        - --promote
+        - --report-credentials-file=/etc/report/credentials
+        - --target=[images]
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/push-secret
+          name: push-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: push-secret
+        secret:
+          secretName: registry-push-credentials-ci-central
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator

--- a/ci-operator/jobs/openshift/mirror-gui/openshift-mirror-gui-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/mirror-gui/openshift-mirror-gui-main-presubmits.yaml
@@ -1,0 +1,180 @@
+presubmits:
+  openshift/mirror-gui:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build01
+    context: ci/prow/images
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-mirror-gui-main-images
+    rerun_command: /test images
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=[images]
+        - --target=[release:latest]
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )images,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build01
+    context: ci/prow/lint
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-mirror-gui-main-lint
+    rerun_command: /test lint
+    skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|LICENSE)$
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=lint
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )lint,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build01
+    context: ci/prow/unit
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-mirror-gui-main-unit
+    rerun_command: /test unit
+    skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|LICENSE)$
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=unit
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )unit,?($|\s.*)

--- a/ci-operator/jobs/openshift/mirror-gui/openshift-mirror-gui-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/mirror-gui/openshift-mirror-gui-main-presubmits.yaml
@@ -8,6 +8,8 @@ presubmits:
     cluster: build01
     context: ci/prow/audit-catalog
     decorate: true
+    decoration_config:
+      skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -70,6 +72,8 @@ presubmits:
     cluster: build01
     context: ci/prow/catalog-integrity
     decorate: true
+    decoration_config:
+      skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -132,6 +136,8 @@ presubmits:
     cluster: build01
     context: ci/prow/images
     decorate: true
+    decoration_config:
+      skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -186,6 +192,8 @@ presubmits:
     cluster: build01
     context: ci/prow/lint
     decorate: true
+    decoration_config:
+      skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -248,6 +256,8 @@ presubmits:
     cluster: build01
     context: ci/prow/unit
     decorate: true
+    decoration_config:
+      skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"

--- a/ci-operator/jobs/openshift/mirror-gui/openshift-mirror-gui-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/mirror-gui/openshift-mirror-gui-main-presubmits.yaml
@@ -1,6 +1,130 @@
 presubmits:
   openshift/mirror-gui:
   - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build01
+    context: ci/prow/audit-catalog
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-mirror-gui-main-audit-catalog
+    rerun_command: /test audit-catalog
+    skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|LICENSE)$
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=audit-catalog
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )audit-catalog,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build01
+    context: ci/prow/catalog-integrity
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-mirror-gui-main-catalog-integrity
+    rerun_command: /test catalog-integrity
+    skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|LICENSE)$
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=catalog-integrity
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )catalog-integrity,?($|\s.*)
+  - agent: kubernetes
     always_run: true
     branches:
     - ^main$

--- a/core-services/prow/02_config/openshift/mirror-gui/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/mirror-gui/_pluginconfig.yaml
@@ -11,4 +11,3 @@ plugins:
   openshift/mirror-gui:
     plugins:
     - approve
-    - lgtm

--- a/core-services/prow/02_config/openshift/mirror-gui/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/mirror-gui/_pluginconfig.yaml
@@ -1,0 +1,13 @@
+approve:
+- commandHelpLink: ""
+  repos:
+  - openshift/mirror-gui
+  require_self_approval: false
+lgtm:
+- repos:
+  - openshift/mirror-gui
+  review_acts_as_lgtm: true
+plugins:
+  openshift/mirror-gui:
+    plugins:
+    - approve

--- a/core-services/prow/02_config/openshift/mirror-gui/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/mirror-gui/_pluginconfig.yaml
@@ -11,3 +11,4 @@ plugins:
   openshift/mirror-gui:
     plugins:
     - approve
+    - lgtm

--- a/core-services/prow/02_config/openshift/mirror-gui/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/mirror-gui/_prowconfig.yaml
@@ -1,0 +1,14 @@
+tide:
+  queries:
+  - labels:
+    - approved
+    - lgtm
+    missingLabels:
+    - backports/unvalidated-commits
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - jira/invalid-bug
+    - needs-rebase
+    repos:
+    - openshift/mirror-gui


### PR DESCRIPTION
# Onboard openshift/mirror-gui to Prow CI

Add CI configuration for the mirror-gui repository with container image builds and test jobs.

## Changes

- Add ci-operator config for openshift/mirror-gui main branch
- Configure container image builds from Dockerfile
- Add test jobs:
  - **lint**: Runs `npm run lint` to check code quality
  - **unit**: Runs `npm run build && npm run test` for unit/integration tests
- Configure image promotion to `ocp/5.0` namespace
- Add Prow plugin configuration (approve/lgtm)
- Add Tide merge automation

## Test Configuration

- Uses `build_root: from_repository: true` for Node.js/TypeScript environment
- Tests skip when only docs/markdown files are changed
- Includes `test_binary_build_commands` for test artifact preparation

## Jobs Generated

**Presubmit (PR) jobs:**
- `ci-operator/jobs/openshift/mirror-gui/openshift-mirror-gui-main-presubmits.yaml`

**Postsubmit (merge) jobs:**
- `ci-operator/jobs/openshift/mirror-gui/openshift-mirror-gui-main-postsubmits.yaml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added CI configuration to build the project image, run a binary build step, apply resource limits, and promote releases (including a "latest" integration).
  * Added presubmit and postsubmit jobs to run image builds and tests (lint, unit, audit-catalog, catalog-integrity) with selective triggering and concurrency controls.
  * Added Prow plugin and Tide rules to require approvals/LGTM and added OWNERS entries for approvers/reviewers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->