### PR TITLE
feat: update OCP to 4.22 for common templates ci

### DIFF
--- a/ci-operator/config/kubevirt/common-templates/kubevirt-common-templates-master.yaml
+++ b/ci-operator/config/kubevirt/common-templates/kubevirt-common-templates-master.yaml
@@ -1,6 +1,6 @@
 base_images:
   base:
-    name: "4.19"
+    name: "4.22"
     namespace: ocp
     tag: base
 build_root:
@@ -9,12 +9,12 @@ build_root:
 releases:
   initial:
     integration:
-      name: "4.19"
+      name: "4.22"
       namespace: ocp
   latest:
     integration:
       include_built_images: true
-      name: "4.19"
+      name: "4.22"
       namespace: ocp
 resources:
   '*':


### PR DESCRIPTION
feat: update OCP to 4.22 for common templates ci

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated base image versions to align with current platform infrastructure requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->