### PR TITLE
move json parsing from Prow step to Konflux to avoid char escape errors

### DIFF
--- a/ci-operator/step-registry/agent-qe/baremetal/install/ove/disconnected/konflux/extract-iso/agent-qe-baremetal-install-ove-disconnected-konflux-extract-iso-commands.sh
+++ b/ci-operator/step-registry/agent-qe/baremetal/install/ove/disconnected/konflux/extract-iso/agent-qe-baremetal-install-ove-disconnected-konflux-extract-iso-commands.sh
@@ -26,13 +26,8 @@ SSHOPTS=(-o 'ConnectTimeout=5'
 CLUSTER_NAME=$(<"${SHARED_DIR}/cluster_name")
 
 # SNAPSHOT example value passed by Konflux
-# {"application":"ove-ui-4-21","components":[{"name":"ove-ui-iso-4-21","containerImage":"quay.io/redhat-user-workloads/ocp-agent-based-installer-tenant/ove-ui-iso-4-21@sha256:c5c5269aec05dd1b16fedfd762b312f0f7b0858633d1f0850d17969f09e3df33",
-# "source":{"git":{"url":"https://github.com/openshift/agent-installer-utils","revision":"d5e584590355867515ff90bb9ccd2e9019073441"}}}],"artifacts":{}}
+# "quay.io/redhat-user-workloads/ocp-agent-based-installer-tenant/ove-ui-iso-4-21@sha256:c5c5269aec05dd1b16fedfd762b312f0f7b0858633d1f0850d17969f09e3df33"
 
+echo "Konflux snapshot ID: ${SNAPSHOT}"
 
-# Make the code compatible with runs triggered by Konflux and manual testing
-KONFLUX_SNAPSHOT=$(echo ${SNAPSHOT} | jq -r '.components[].containerImage' )
-
-echo "Konflux snapshot ID: ${KONFLUX_SNAPSHOT}"
-
-timeout -s 9 2h ssh "${SSHOPTS[@]}" root@access."${OVE_ISO_STORAGE_HOST}" sh extract_ove_iso.sh "${KONFLUX_SNAPSHOT}" "${CLUSTER_NAME}.agent-ove.x86_64.iso"
+timeout -s 9 2h ssh "${SSHOPTS[@]}" root@access."${OVE_ISO_STORAGE_HOST}" sh extract_ove_iso.sh "${SNAPSHOT}" "${CLUSTER_NAME}.agent-ove.x86_64.iso"


### PR DESCRIPTION
When passing the whole JSON string from Konflux to Prow as an ENV var, the script errors out not being able to correctly parse and escape the payload value containing '{}'

Error on konflux:

STEP-RUN-PROWJOB
  SNAPSHOT: {"application":"ove-ui-4-21","components":[{"name":"ove-ui-iso-4-21","containerImage":"quay.io/redhat-user-workloads/ocp-agent-based-installer-tenant/ove-ui-iso-4-21@sha256:b3c55365f865e06b565e0714e2e043059bcd3de512a6ed58d51b5e78367f6993","source":{"git":{"url":"https://github.com/bfournie/agent-installer-utils","revision":"cccb475367cb64869d17434f87d229142d997d31"}}}],"artifacts":{}}
  Error: 1:36: invalid input text "application\":\"ov..."
  Error: 1:104: invalid input text "\""
  Error: 1:364: invalid input text "\""
  Error: 1:174: invalid input text "\""
  Error: 1:140: invalid input text "\""
  Error: 1:56: invalid input text "\""

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Streamlined snapshot handling in baremetal installation CI workflows for disconnected Konflux environments by simplifying how snapshot identifiers are processed and forwarded to installation scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->