### PR TITLE
CAPK: Switch default e2e to reduced nested workflow

### DIFF
--- a/ci-operator/config/openshift/cluster-api-provider-kubevirt/openshift-cluster-api-provider-kubevirt-main.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-kubevirt/openshift-cluster-api-provider-kubevirt-main.yaml
@@ -87,6 +87,18 @@ tests:
 - as: e2e-hypershift-kubevirt
   skip_if_only_changed: ^\.tekton/|^docs/\^\.github|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
   steps:
+    cluster_profile: hypershift-aws
+    env:
+      CNV_SUBSCRIPTION_SOURCE: redhat-operators
+      ETCD_STORAGE_CLASS: gp3-csi
+      KUBEVIRT_CSI_INFRA: gp3-csi
+      SKIP_E2E_LOCAL: "true"
+    workflow: hypershift-kubevirt-e2e-nested
+- always_run: false
+  as: e2e-hypershift-kubevirt-full
+  optional: true
+  skip_if_only_changed: ^\.tekton/|^docs/\^\.github|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
+  steps:
     cluster_profile: aws-virtualization
     env:
       BASE_DOMAIN: cnv-ci.syseng.devcluster.openshift.com

--- a/ci-operator/jobs/openshift/cluster-api-provider-kubevirt/openshift-cluster-api-provider-kubevirt-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-kubevirt/openshift-cluster-api-provider-kubevirt-main-presubmits.yaml
@@ -11,8 +11,8 @@ presubmits:
     decoration_config:
       skip_cloning: true
     labels:
-      ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws-virtualization
+      ci-operator.openshift.io/cloud: hypershift-aws
+      ci-operator.openshift.io/cloud-cluster-profile: hypershift-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-cluster-api-provider-kubevirt-main-e2e-hypershift-kubevirt
@@ -83,6 +83,90 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-hypershift-kubevirt,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build07
+    context: ci/prow/e2e-hypershift-kubevirt-full
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: aws-virtualization
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-api-provider-kubevirt-main-e2e-hypershift-kubevirt-full
+    optional: true
+    rerun_command: /test e2e-hypershift-kubevirt-full
+    skip_if_only_changed: ^\.tekton/|^docs/\^\.github|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-hypershift-kubevirt-full
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-hypershift-kubevirt-full,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:


### PR DESCRIPTION
## Summary

- Switch the default `e2e-hypershift-kubevirt` presubmit for `cluster-api-provider-kubevirt` from the full `hypershift-kubevirt-e2e-aws-capk` workflow to the lighter `hypershift-kubevirt-e2e-nested` workflow with `SKIP_E2E_LOCAL=true`
- This matches the approach used by the hypershift repo's `e2e-kubevirt-aws-ovn-reduced` test
- Keep the full test available as an optional job (`e2e-hypershift-kubevirt-full`) triggerable via `/test e2e-hypershift-kubevirt-full`

## Motivation

The full e2e test has been consistently failing on [PR #415](https://github.com/openshift/cluster-api-provider-kubevirt/pull/415) (and was overridden on [PR #389](https://github.com/openshift/cluster-api-provider-kubevirt/pull/389)) due to DNS resolution failures and infrastructure timeouts when provisioning bare-metal IPI clusters with ODF. The reduced test uses a nested management cluster which is faster to provision and more reliable.

## Changes

| | Before | After |
|---|---|---|
| **Default test** (`e2e-hypershift-kubevirt`) | Full IPI bare-metal + ODF + custom CAPK + local e2e | Nested mgmt cluster + external infra tests only |
| **Full test** (`e2e-hypershift-kubevirt-full`) | N/A | Optional, `/test e2e-hypershift-kubevirt-full` |
| **Cluster profile** | `aws-virtualization` | `hypershift-aws` (default), `aws-virtualization` (full) |

## Test plan

- [ ] CI rehearsal passes for the new reduced test
- [ ] Verify `/test e2e-hypershift-kubevirt-full` can still be triggered manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new E2E test configuration for extended hypershift-kubevirt testing scenarios
  * Updated and expanded presubmit job configurations to enhance test coverage and execution paths

<!-- end of auto-generated comment: release notes by coderabbit.ai -->