### PR TITLE
Add condition to use single-tenant setup for agent-specific jobs

### DIFF
--- a/ci-operator/step-registry/ipi/conf/vsphere/check/vcm/ipi-conf-vsphere-check-vcm-commands.sh
+++ b/ci-operator/step-registry/ipi/conf/vsphere/check/vcm/ipi-conf-vsphere-check-vcm-commands.sh
@@ -59,7 +59,8 @@ LEASES=()
 
 DEFAULT_NETWORK_TYPE=${DEFAULT_NETWORK_TYPE:-"multi-tenant"}
 for job_safe_name in ${SINGLE_TENANT_LEASE_JOB_SAFE_NAMES}; do
-  if [ "${job_safe_name}" == "${JOB_NAME_SAFE}" ]; then
+  job_safe_name=$(echo "${job_safe_name}" | tr -d '[:space:]\r')
+  if [[ "${JOB_NAME_SAFE}" == "${job_safe_name}"* ]]; then
     log "job ${JOB_NAME_SAFE} requires a single-tenant lease. will request a single-tenant network if there is no override in the job yaml."
     DEFAULT_NETWORK_TYPE="single-tenant"
     break


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable network selection for vSphere provisioning: job names with extra whitespace or carriage returns are now handled correctly.
  * Single-tenant routing improved by using prefix matching of job names, reducing misclassification and ensuring deployments use the intended single-tenant network when applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->