### PR TITLE
MGMT-23721: add VMaaS periodic E2E jobs to Prow

### DIFF
--- a/ci-operator/config/osac-project/osac-installer/osac-project-osac-installer-main.yaml
+++ b/ci-operator/config/osac-project/osac-installer/osac-project-osac-installer-main.yaml
@@ -102,7 +102,7 @@ tests:
         MASTER_DISK=200000000000
         MASTER_CPU=24
         OPENSHIFT_VERSION=4.20
-      TEST: test_compute_instance_lifecycle
+      TEST: test_compute_instance_creation.py
     workflow: osac-project-ofcir-baremetal
 - as: e2e-metal-vmaas-compute-instance-api-fields
   capabilities:
@@ -120,7 +120,7 @@ tests:
         MASTER_DISK=200000000000
         MASTER_CPU=24
         OPENSHIFT_VERSION=4.20
-      TEST: test_compute_instance_api_fields
+      TEST: test_compute_instance_api_fields.py
     workflow: osac-project-ofcir-baremetal
 - as: e2e-metal-vmaas-compute-instance-cli-fields
   capabilities:
@@ -138,7 +138,7 @@ tests:
         MASTER_DISK=200000000000
         MASTER_CPU=24
         OPENSHIFT_VERSION=4.20
-      TEST: test_compute_instance_cli_fields
+      TEST: test_compute_instance_cli_fields.py
     workflow: osac-project-ofcir-baremetal
 - as: e2e-metal-vmaas-compute-instance-delete-during-provision
   capabilities:
@@ -156,7 +156,7 @@ tests:
         MASTER_DISK=200000000000
         MASTER_CPU=24
         OPENSHIFT_VERSION=4.20
-      TEST: test_compute_instance_delete_during_provision
+      TEST: test_compute_instance_delete_during_provision.py
     workflow: osac-project-ofcir-baremetal
 - as: e2e-metal-vmaas-compute-instance-restart
   capabilities:
@@ -174,7 +174,7 @@ tests:
         MASTER_DISK=200000000000
         MASTER_CPU=24
         OPENSHIFT_VERSION=4.20
-      TEST: test_compute_instance_restart and not negative
+      TEST: test_compute_instance_restart.py
     workflow: osac-project-ofcir-baremetal
 - as: e2e-metal-vmaas-compute-instance-restart-negative
   capabilities:
@@ -192,7 +192,7 @@ tests:
         MASTER_DISK=200000000000
         MASTER_CPU=24
         OPENSHIFT_VERSION=4.20
-      TEST: test_compute_instance_restart_negative
+      TEST: test_compute_instance_restart_negative.py
     workflow: osac-project-ofcir-baremetal
 - as: e2e-metal-vmaas-subnet-lifecycle
   capabilities:
@@ -210,7 +210,7 @@ tests:
         MASTER_DISK=200000000000
         MASTER_CPU=24
         OPENSHIFT_VERSION=4.20
-      TEST: test_subnet_lifecycle
+      TEST: test_subnet_lifecycle.py
     workflow: osac-project-ofcir-baremetal
 - as: e2e-metal-vmaas-virtual-network-lifecycle
   capabilities:
@@ -228,7 +228,7 @@ tests:
         MASTER_DISK=200000000000
         MASTER_CPU=24
         OPENSHIFT_VERSION=4.20
-      TEST: test_virtual_network_lifecycle
+      TEST: test_virtual_network_lifecycle.py
     workflow: osac-project-ofcir-baremetal
 zz_generated_metadata:
   branch: main

--- a/ci-operator/config/osac-project/osac-installer/osac-project-osac-installer-main.yaml
+++ b/ci-operator/config/osac-project/osac-installer/osac-project-osac-installer-main.yaml
@@ -1,4 +1,32 @@
 base_images:
+  assisted-image-service:
+    name: ocm-2.17
+    namespace: edge-infrastructure
+    tag: assisted-image-service
+  assisted-installer:
+    name: ocm-2.17
+    namespace: edge-infrastructure
+    tag: assisted-installer
+  assisted-installer-agent:
+    name: ocm-2.17
+    namespace: edge-infrastructure
+    tag: assisted-installer-agent
+  assisted-installer-controller:
+    name: ocm-2.17
+    namespace: edge-infrastructure
+    tag: assisted-installer-controller
+  assisted-service:
+    name: ocm-2.17
+    namespace: edge-infrastructure
+    tag: assisted-service
+  assisted-test-infra:
+    name: ocm-2.17
+    namespace: edge-infrastructure
+    tag: assisted-test-infra
+  dev-scripts:
+    name: test
+    namespace: ocp-kni
+    tag: dev-scripts
   origin-cli:
     name: "4.20"
     namespace: ocp
@@ -7,6 +35,10 @@ base_images:
     name: latest
     namespace: osac-project
     tag: osac-cli
+  osac-test-infra:
+    name: latest
+    namespace: osac-project
+    tag: osac-test-infra
 build_root:
   image_stream_tag:
     name: release
@@ -40,6 +72,12 @@ promotion:
   to:
   - name: latest
     namespace: osac-project
+releases:
+  latest:
+    candidate:
+      product: ocp
+      stream: nightly
+      version: "4.20"
 resources:
   '*':
     limits:
@@ -48,10 +86,150 @@ resources:
       cpu: 100m
       memory: 200Mi
 tests:
-- as: temp
-  commands: echo "Test"
-  container:
-    from: src
+- as: e2e-metal-vmaas-compute-instance-creation
+  capabilities:
+  - intranet
+  run_if_changed: ^(base/|overlays/|scripts/|prerequisites/)
+  steps:
+    cluster_profile: packet-assisted
+    env:
+      ASSISTED_CONFIG: |
+        OLM_OPERATORS=cnv,lvm
+        NUM_MASTERS=1
+        NUM_WORKERS=0
+        MASTER_MEMORY=57344
+        MASTER_DISK_COUNT=2
+        MASTER_DISK=200000000000
+        MASTER_CPU=24
+        OPENSHIFT_VERSION=4.20
+      TEST: test_compute_instance_lifecycle
+    workflow: osac-project-ofcir-baremetal
+- as: e2e-metal-vmaas-compute-instance-api-fields
+  capabilities:
+  - intranet
+  run_if_changed: ^(base/|overlays/|scripts/|prerequisites/)
+  steps:
+    cluster_profile: packet-assisted
+    env:
+      ASSISTED_CONFIG: |
+        OLM_OPERATORS=cnv,lvm
+        NUM_MASTERS=1
+        NUM_WORKERS=0
+        MASTER_MEMORY=57344
+        MASTER_DISK_COUNT=2
+        MASTER_DISK=200000000000
+        MASTER_CPU=24
+        OPENSHIFT_VERSION=4.20
+      TEST: test_compute_instance_api_fields
+    workflow: osac-project-ofcir-baremetal
+- as: e2e-metal-vmaas-compute-instance-cli-fields
+  capabilities:
+  - intranet
+  run_if_changed: ^(base/|overlays/|scripts/|prerequisites/)
+  steps:
+    cluster_profile: packet-assisted
+    env:
+      ASSISTED_CONFIG: |
+        OLM_OPERATORS=cnv,lvm
+        NUM_MASTERS=1
+        NUM_WORKERS=0
+        MASTER_MEMORY=57344
+        MASTER_DISK_COUNT=2
+        MASTER_DISK=200000000000
+        MASTER_CPU=24
+        OPENSHIFT_VERSION=4.20
+      TEST: test_compute_instance_cli_fields
+    workflow: osac-project-ofcir-baremetal
+- as: e2e-metal-vmaas-compute-instance-delete-during-provision
+  capabilities:
+  - intranet
+  run_if_changed: ^(base/|overlays/|scripts/|prerequisites/)
+  steps:
+    cluster_profile: packet-assisted
+    env:
+      ASSISTED_CONFIG: |
+        OLM_OPERATORS=cnv,lvm
+        NUM_MASTERS=1
+        NUM_WORKERS=0
+        MASTER_MEMORY=57344
+        MASTER_DISK_COUNT=2
+        MASTER_DISK=200000000000
+        MASTER_CPU=24
+        OPENSHIFT_VERSION=4.20
+      TEST: test_compute_instance_delete_during_provision
+    workflow: osac-project-ofcir-baremetal
+- as: e2e-metal-vmaas-compute-instance-restart
+  capabilities:
+  - intranet
+  run_if_changed: ^(base/|overlays/|scripts/|prerequisites/)
+  steps:
+    cluster_profile: packet-assisted
+    env:
+      ASSISTED_CONFIG: |
+        OLM_OPERATORS=cnv,lvm
+        NUM_MASTERS=1
+        NUM_WORKERS=0
+        MASTER_MEMORY=57344
+        MASTER_DISK_COUNT=2
+        MASTER_DISK=200000000000
+        MASTER_CPU=24
+        OPENSHIFT_VERSION=4.20
+      TEST: test_compute_instance_restart and not negative
+    workflow: osac-project-ofcir-baremetal
+- as: e2e-metal-vmaas-compute-instance-restart-negative
+  capabilities:
+  - intranet
+  run_if_changed: ^(base/|overlays/|scripts/|prerequisites/)
+  steps:
+    cluster_profile: packet-assisted
+    env:
+      ASSISTED_CONFIG: |
+        OLM_OPERATORS=cnv,lvm
+        NUM_MASTERS=1
+        NUM_WORKERS=0
+        MASTER_MEMORY=57344
+        MASTER_DISK_COUNT=2
+        MASTER_DISK=200000000000
+        MASTER_CPU=24
+        OPENSHIFT_VERSION=4.20
+      TEST: test_compute_instance_restart_negative
+    workflow: osac-project-ofcir-baremetal
+- as: e2e-metal-vmaas-subnet-lifecycle
+  capabilities:
+  - intranet
+  run_if_changed: ^(base/|overlays/|scripts/|prerequisites/)
+  steps:
+    cluster_profile: packet-assisted
+    env:
+      ASSISTED_CONFIG: |
+        OLM_OPERATORS=cnv,lvm
+        NUM_MASTERS=1
+        NUM_WORKERS=0
+        MASTER_MEMORY=57344
+        MASTER_DISK_COUNT=2
+        MASTER_DISK=200000000000
+        MASTER_CPU=24
+        OPENSHIFT_VERSION=4.20
+      TEST: test_subnet_lifecycle
+    workflow: osac-project-ofcir-baremetal
+- as: e2e-metal-vmaas-virtual-network-lifecycle
+  capabilities:
+  - intranet
+  run_if_changed: ^(base/|overlays/|scripts/|prerequisites/)
+  steps:
+    cluster_profile: packet-assisted
+    env:
+      ASSISTED_CONFIG: |
+        OLM_OPERATORS=cnv,lvm
+        NUM_MASTERS=1
+        NUM_WORKERS=0
+        MASTER_MEMORY=57344
+        MASTER_DISK_COUNT=2
+        MASTER_DISK=200000000000
+        MASTER_CPU=24
+        OPENSHIFT_VERSION=4.20
+      TEST: test_virtual_network_lifecycle
+    workflow: osac-project-ofcir-baremetal
 zz_generated_metadata:
   branch: main
   org: osac-project

--- a/ci-operator/config/osac-project/osac-test-infra/osac-project-osac-test-infra-main.yaml
+++ b/ci-operator/config/osac-project/osac-test-infra/osac-project-osac-test-infra-main.yaml
@@ -74,7 +74,7 @@ tests:
         MASTER_DISK=200000000000
         MASTER_CPU=24
         OPENSHIFT_VERSION=4.20
-      TEST: test_compute_instance_lifecycle
+      TEST: test_compute_instance_creation.py
     workflow: osac-project-ofcir-baremetal
 - as: e2e-metal-vmaas-compute-instance-api-fields
   capabilities:
@@ -92,7 +92,7 @@ tests:
         MASTER_DISK=200000000000
         MASTER_CPU=24
         OPENSHIFT_VERSION=4.20
-      TEST: test_compute_instance_api_fields
+      TEST: test_compute_instance_api_fields.py
     workflow: osac-project-ofcir-baremetal
 - as: e2e-metal-vmaas-compute-instance-cli-fields
   capabilities:
@@ -110,7 +110,7 @@ tests:
         MASTER_DISK=200000000000
         MASTER_CPU=24
         OPENSHIFT_VERSION=4.20
-      TEST: test_compute_instance_cli_explicit_fields
+      TEST: test_compute_instance_cli_fields.py
     workflow: osac-project-ofcir-baremetal
 - as: e2e-metal-vmaas-compute-instance-delete-during-provision
   capabilities:
@@ -128,7 +128,7 @@ tests:
         MASTER_DISK=200000000000
         MASTER_CPU=24
         OPENSHIFT_VERSION=4.20
-      TEST: test_compute_instance_delete_during_provision
+      TEST: test_compute_instance_delete_during_provision.py
     workflow: osac-project-ofcir-baremetal
 - as: e2e-metal-vmaas-compute-instance-restart
   capabilities:
@@ -146,7 +146,7 @@ tests:
         MASTER_DISK=200000000000
         MASTER_CPU=24
         OPENSHIFT_VERSION=4.20
-      TEST: test_compute_instance_restart and not negative
+      TEST: test_compute_instance_restart.py
     workflow: osac-project-ofcir-baremetal
 - as: e2e-metal-vmaas-compute-instance-restart-negative
   capabilities:
@@ -164,7 +164,7 @@ tests:
         MASTER_DISK=200000000000
         MASTER_CPU=24
         OPENSHIFT_VERSION=4.20
-      TEST: test_compute_instance_restart_past_timestamp_ignored
+      TEST: test_compute_instance_restart_negative.py
     workflow: osac-project-ofcir-baremetal
 - as: e2e-metal-vmaas-subnet-lifecycle
   capabilities:
@@ -182,7 +182,7 @@ tests:
         MASTER_DISK=200000000000
         MASTER_CPU=24
         OPENSHIFT_VERSION=4.20
-      TEST: test_subnet_lifecycle
+      TEST: test_subnet_lifecycle.py
     workflow: osac-project-ofcir-baremetal
 - as: e2e-metal-vmaas-virtual-network-lifecycle
   capabilities:
@@ -200,7 +200,7 @@ tests:
         MASTER_DISK=200000000000
         MASTER_CPU=24
         OPENSHIFT_VERSION=4.20
-      TEST: test_virtual_network_lifecycle
+      TEST: test_virtual_network_lifecycle.py
     workflow: osac-project-ofcir-baremetal
 zz_generated_metadata:
   branch: main

--- a/ci-operator/config/osac-project/osac-test-infra/osac-project-osac-test-infra-main.yaml
+++ b/ci-operator/config/osac-project/osac-test-infra/osac-project-osac-test-infra-main.yaml
@@ -36,6 +36,14 @@ build_root:
     name: release
     namespace: openshift
     tag: rhel-9-release-golang-1.24-openshift-4.21
+images:
+  items:
+  - dockerfile_path: Containerfile
+    to: osac-test-infra
+promotion:
+  to:
+  - name: latest
+    namespace: osac-project
 releases:
   latest:
     candidate:
@@ -50,19 +58,15 @@ resources:
       cpu: 100m
       memory: 200Mi
 tests:
-- as: temp
-  commands: echo "Test"
-  container:
-    from: src
-- as: e2e-metal-osac-test-infra-4-20
+- as: e2e-metal-vmaas-compute-instance-creation
   capabilities:
   - intranet
-  cron: 0 20 * * 0
+  cron: 0 2 * * 1
   steps:
     cluster_profile: packet-assisted
     env:
       ASSISTED_CONFIG: |
-        OLM_OPERATORS=mce,cnv
+        OLM_OPERATORS=cnv,lvm
         NUM_MASTERS=1
         NUM_WORKERS=0
         MASTER_MEMORY=57344
@@ -70,6 +74,133 @@ tests:
         MASTER_DISK=200000000000
         MASTER_CPU=24
         OPENSHIFT_VERSION=4.20
+      TEST: test_compute_instance_lifecycle
+    workflow: osac-project-ofcir-baremetal
+- as: e2e-metal-vmaas-compute-instance-api-fields
+  capabilities:
+  - intranet
+  cron: 0 6 * * 1
+  steps:
+    cluster_profile: packet-assisted
+    env:
+      ASSISTED_CONFIG: |
+        OLM_OPERATORS=cnv,lvm
+        NUM_MASTERS=1
+        NUM_WORKERS=0
+        MASTER_MEMORY=57344
+        MASTER_DISK_COUNT=2
+        MASTER_DISK=200000000000
+        MASTER_CPU=24
+        OPENSHIFT_VERSION=4.20
+      TEST: test_compute_instance_api_fields
+    workflow: osac-project-ofcir-baremetal
+- as: e2e-metal-vmaas-compute-instance-cli-fields
+  capabilities:
+  - intranet
+  cron: 0 2 * * 2
+  steps:
+    cluster_profile: packet-assisted
+    env:
+      ASSISTED_CONFIG: |
+        OLM_OPERATORS=cnv,lvm
+        NUM_MASTERS=1
+        NUM_WORKERS=0
+        MASTER_MEMORY=57344
+        MASTER_DISK_COUNT=2
+        MASTER_DISK=200000000000
+        MASTER_CPU=24
+        OPENSHIFT_VERSION=4.20
+      TEST: test_compute_instance_cli_explicit_fields
+    workflow: osac-project-ofcir-baremetal
+- as: e2e-metal-vmaas-compute-instance-delete-during-provision
+  capabilities:
+  - intranet
+  cron: 0 6 * * 2
+  steps:
+    cluster_profile: packet-assisted
+    env:
+      ASSISTED_CONFIG: |
+        OLM_OPERATORS=cnv,lvm
+        NUM_MASTERS=1
+        NUM_WORKERS=0
+        MASTER_MEMORY=57344
+        MASTER_DISK_COUNT=2
+        MASTER_DISK=200000000000
+        MASTER_CPU=24
+        OPENSHIFT_VERSION=4.20
+      TEST: test_compute_instance_delete_during_provision
+    workflow: osac-project-ofcir-baremetal
+- as: e2e-metal-vmaas-compute-instance-restart
+  capabilities:
+  - intranet
+  cron: 0 2 * * 3
+  steps:
+    cluster_profile: packet-assisted
+    env:
+      ASSISTED_CONFIG: |
+        OLM_OPERATORS=cnv,lvm
+        NUM_MASTERS=1
+        NUM_WORKERS=0
+        MASTER_MEMORY=57344
+        MASTER_DISK_COUNT=2
+        MASTER_DISK=200000000000
+        MASTER_CPU=24
+        OPENSHIFT_VERSION=4.20
+      TEST: test_compute_instance_restart and not negative
+    workflow: osac-project-ofcir-baremetal
+- as: e2e-metal-vmaas-compute-instance-restart-negative
+  capabilities:
+  - intranet
+  cron: 0 6 * * 3
+  steps:
+    cluster_profile: packet-assisted
+    env:
+      ASSISTED_CONFIG: |
+        OLM_OPERATORS=cnv,lvm
+        NUM_MASTERS=1
+        NUM_WORKERS=0
+        MASTER_MEMORY=57344
+        MASTER_DISK_COUNT=2
+        MASTER_DISK=200000000000
+        MASTER_CPU=24
+        OPENSHIFT_VERSION=4.20
+      TEST: test_compute_instance_restart_past_timestamp_ignored
+    workflow: osac-project-ofcir-baremetal
+- as: e2e-metal-vmaas-subnet-lifecycle
+  capabilities:
+  - intranet
+  cron: 0 2 * * 4
+  steps:
+    cluster_profile: packet-assisted
+    env:
+      ASSISTED_CONFIG: |
+        OLM_OPERATORS=cnv,lvm
+        NUM_MASTERS=1
+        NUM_WORKERS=0
+        MASTER_MEMORY=57344
+        MASTER_DISK_COUNT=2
+        MASTER_DISK=200000000000
+        MASTER_CPU=24
+        OPENSHIFT_VERSION=4.20
+      TEST: test_subnet_lifecycle
+    workflow: osac-project-ofcir-baremetal
+- as: e2e-metal-vmaas-virtual-network-lifecycle
+  capabilities:
+  - intranet
+  cron: 0 6 * * 4
+  steps:
+    cluster_profile: packet-assisted
+    env:
+      ASSISTED_CONFIG: |
+        OLM_OPERATORS=cnv,lvm
+        NUM_MASTERS=1
+        NUM_WORKERS=0
+        MASTER_MEMORY=57344
+        MASTER_DISK_COUNT=2
+        MASTER_DISK=200000000000
+        MASTER_CPU=24
+        OPENSHIFT_VERSION=4.20
+      TEST: test_virtual_network_lifecycle
     workflow: osac-project-ofcir-baremetal
 zz_generated_metadata:
   branch: main

--- a/ci-operator/jobs/osac-project/osac-installer/osac-project-osac-installer-main-postsubmits.yaml
+++ b/ci-operator/jobs/osac-project/osac-installer/osac-project-osac-installer-main-postsubmits.yaml
@@ -11,6 +11,7 @@ postsubmits:
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen
+      job-release: "4.20"
     max_concurrency: 1
     name: branch-ci-osac-project-osac-installer-main-images
     spec:

--- a/ci-operator/jobs/osac-project/osac-installer/osac-project-osac-installer-main-presubmits.yaml
+++ b/ci-operator/jobs/osac-project/osac-installer/osac-project-osac-installer-main-presubmits.yaml
@@ -1,6 +1,686 @@
 presubmits:
   osac-project/osac-installer:
   - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build11
+    context: ci/prow/e2e-metal-vmaas-compute-instance-api-fields
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      capability/intranet: intranet
+      ci-operator.openshift.io/cloud: packet-edge
+      ci-operator.openshift.io/cloud-cluster-profile: packet-assisted
+      ci.openshift.io/generator: prowgen
+      job-release: "4.20"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-osac-project-osac-installer-main-e2e-metal-vmaas-compute-instance-api-fields
+    rerun_command: /test e2e-metal-vmaas-compute-instance-api-fields
+    run_if_changed: ^(base/|overlays/|scripts/|prerequisites/)
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-metal-vmaas-compute-instance-api-fields
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-metal-vmaas-compute-instance-api-fields,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build11
+    context: ci/prow/e2e-metal-vmaas-compute-instance-cli-fields
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      capability/intranet: intranet
+      ci-operator.openshift.io/cloud: packet-edge
+      ci-operator.openshift.io/cloud-cluster-profile: packet-assisted
+      ci.openshift.io/generator: prowgen
+      job-release: "4.20"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-osac-project-osac-installer-main-e2e-metal-vmaas-compute-instance-cli-fields
+    rerun_command: /test e2e-metal-vmaas-compute-instance-cli-fields
+    run_if_changed: ^(base/|overlays/|scripts/|prerequisites/)
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-metal-vmaas-compute-instance-cli-fields
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-metal-vmaas-compute-instance-cli-fields,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build11
+    context: ci/prow/e2e-metal-vmaas-compute-instance-creation
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      capability/intranet: intranet
+      ci-operator.openshift.io/cloud: packet-edge
+      ci-operator.openshift.io/cloud-cluster-profile: packet-assisted
+      ci.openshift.io/generator: prowgen
+      job-release: "4.20"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-osac-project-osac-installer-main-e2e-metal-vmaas-compute-instance-creation
+    rerun_command: /test e2e-metal-vmaas-compute-instance-creation
+    run_if_changed: ^(base/|overlays/|scripts/|prerequisites/)
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-metal-vmaas-compute-instance-creation
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-metal-vmaas-compute-instance-creation,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build11
+    context: ci/prow/e2e-metal-vmaas-compute-instance-delete-during-provision
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      capability/intranet: intranet
+      ci-operator.openshift.io/cloud: packet-edge
+      ci-operator.openshift.io/cloud-cluster-profile: packet-assisted
+      ci.openshift.io/generator: prowgen
+      job-release: "4.20"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-osac-project-osac-installer-main-e2e-metal-vmaas-compute-instance-delete-during-provision
+    rerun_command: /test e2e-metal-vmaas-compute-instance-delete-during-provision
+    run_if_changed: ^(base/|overlays/|scripts/|prerequisites/)
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-metal-vmaas-compute-instance-delete-during-provision
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-metal-vmaas-compute-instance-delete-during-provision,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build11
+    context: ci/prow/e2e-metal-vmaas-compute-instance-restart
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      capability/intranet: intranet
+      ci-operator.openshift.io/cloud: packet-edge
+      ci-operator.openshift.io/cloud-cluster-profile: packet-assisted
+      ci.openshift.io/generator: prowgen
+      job-release: "4.20"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-osac-project-osac-installer-main-e2e-metal-vmaas-compute-instance-restart
+    rerun_command: /test e2e-metal-vmaas-compute-instance-restart
+    run_if_changed: ^(base/|overlays/|scripts/|prerequisites/)
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-metal-vmaas-compute-instance-restart
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-metal-vmaas-compute-instance-restart,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build11
+    context: ci/prow/e2e-metal-vmaas-compute-instance-restart-negative
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      capability/intranet: intranet
+      ci-operator.openshift.io/cloud: packet-edge
+      ci-operator.openshift.io/cloud-cluster-profile: packet-assisted
+      ci.openshift.io/generator: prowgen
+      job-release: "4.20"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-osac-project-osac-installer-main-e2e-metal-vmaas-compute-instance-restart-negative
+    rerun_command: /test e2e-metal-vmaas-compute-instance-restart-negative
+    run_if_changed: ^(base/|overlays/|scripts/|prerequisites/)
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-metal-vmaas-compute-instance-restart-negative
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-metal-vmaas-compute-instance-restart-negative,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build11
+    context: ci/prow/e2e-metal-vmaas-subnet-lifecycle
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      capability/intranet: intranet
+      ci-operator.openshift.io/cloud: packet-edge
+      ci-operator.openshift.io/cloud-cluster-profile: packet-assisted
+      ci.openshift.io/generator: prowgen
+      job-release: "4.20"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-osac-project-osac-installer-main-e2e-metal-vmaas-subnet-lifecycle
+    rerun_command: /test e2e-metal-vmaas-subnet-lifecycle
+    run_if_changed: ^(base/|overlays/|scripts/|prerequisites/)
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-metal-vmaas-subnet-lifecycle
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-metal-vmaas-subnet-lifecycle,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build11
+    context: ci/prow/e2e-metal-vmaas-virtual-network-lifecycle
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      capability/intranet: intranet
+      ci-operator.openshift.io/cloud: packet-edge
+      ci-operator.openshift.io/cloud-cluster-profile: packet-assisted
+      ci.openshift.io/generator: prowgen
+      job-release: "4.20"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-osac-project-osac-installer-main-e2e-metal-vmaas-virtual-network-lifecycle
+    rerun_command: /test e2e-metal-vmaas-virtual-network-lifecycle
+    run_if_changed: ^(base/|overlays/|scripts/|prerequisites/)
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-metal-vmaas-virtual-network-lifecycle
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-metal-vmaas-virtual-network-lifecycle,?($|\s.*)
+  - agent: kubernetes
     always_run: true
     branches:
     - ^main$
@@ -12,6 +692,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
+      job-release: "4.20"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-osac-project-osac-installer-main-images
     rerun_command: /test images
@@ -55,66 +736,3 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )images,?($|\s.*)
-  - agent: kubernetes
-    always_run: true
-    branches:
-    - ^main$
-    - ^main-
-    cluster: build08
-    context: ci/prow/temp
-    decorate: true
-    decoration_config:
-      skip_cloning: true
-    labels:
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-osac-project-osac-installer-main-temp
-    rerun_command: /test temp
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --report-credentials-file=/etc/report/credentials
-        - --target=temp
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )temp,?($|\s.*)

--- a/ci-operator/jobs/osac-project/osac-test-infra/osac-project-osac-test-infra-main-periodics.yaml
+++ b/ci-operator/jobs/osac-project/osac-test-infra/osac-project-osac-test-infra-main-periodics.yaml
@@ -1,7 +1,7 @@
 periodics:
 - agent: kubernetes
   cluster: build11
-  cron: 0 20 * * 0
+  cron: 0 6 * * 1
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -16,7 +16,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.20"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-osac-project-osac-test-infra-main-e2e-metal-osac-test-infra-4-20
+  name: periodic-ci-osac-project-osac-test-infra-main-e2e-metal-vmaas-compute-instance-api-fields
   spec:
     containers:
     - args:
@@ -25,7 +25,581 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=e2e-metal-osac-test-infra-4-20
+      - --target=e2e-metal-vmaas-compute-instance-api-fields
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build11
+  cron: 0 2 * * 2
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: osac-project
+    repo: osac-test-infra
+  labels:
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: packet-edge
+    ci-operator.openshift.io/cloud-cluster-profile: packet-assisted
+    ci.openshift.io/generator: prowgen
+    job-release: "4.20"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-osac-project-osac-test-infra-main-e2e-metal-vmaas-compute-instance-cli-fields
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-metal-vmaas-compute-instance-cli-fields
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build11
+  cron: 0 2 * * 1
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: osac-project
+    repo: osac-test-infra
+  labels:
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: packet-edge
+    ci-operator.openshift.io/cloud-cluster-profile: packet-assisted
+    ci.openshift.io/generator: prowgen
+    job-release: "4.20"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-osac-project-osac-test-infra-main-e2e-metal-vmaas-compute-instance-creation
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-metal-vmaas-compute-instance-creation
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build11
+  cron: 0 6 * * 2
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: osac-project
+    repo: osac-test-infra
+  labels:
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: packet-edge
+    ci-operator.openshift.io/cloud-cluster-profile: packet-assisted
+    ci.openshift.io/generator: prowgen
+    job-release: "4.20"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-osac-project-osac-test-infra-main-e2e-metal-vmaas-compute-instance-delete-during-provision
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-metal-vmaas-compute-instance-delete-during-provision
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build11
+  cron: 0 2 * * 3
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: osac-project
+    repo: osac-test-infra
+  labels:
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: packet-edge
+    ci-operator.openshift.io/cloud-cluster-profile: packet-assisted
+    ci.openshift.io/generator: prowgen
+    job-release: "4.20"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-osac-project-osac-test-infra-main-e2e-metal-vmaas-compute-instance-restart
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-metal-vmaas-compute-instance-restart
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build11
+  cron: 0 6 * * 3
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: osac-project
+    repo: osac-test-infra
+  labels:
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: packet-edge
+    ci-operator.openshift.io/cloud-cluster-profile: packet-assisted
+    ci.openshift.io/generator: prowgen
+    job-release: "4.20"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-osac-project-osac-test-infra-main-e2e-metal-vmaas-compute-instance-restart-negative
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-metal-vmaas-compute-instance-restart-negative
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build11
+  cron: 0 2 * * 4
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: osac-project
+    repo: osac-test-infra
+  labels:
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: packet-edge
+    ci-operator.openshift.io/cloud-cluster-profile: packet-assisted
+    ci.openshift.io/generator: prowgen
+    job-release: "4.20"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-osac-project-osac-test-infra-main-e2e-metal-vmaas-subnet-lifecycle
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-metal-vmaas-subnet-lifecycle
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build11
+  cron: 0 6 * * 4
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: osac-project
+    repo: osac-test-infra
+  labels:
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: packet-edge
+    ci-operator.openshift.io/cloud-cluster-profile: packet-assisted
+    ci.openshift.io/generator: prowgen
+    job-release: "4.20"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-osac-project-osac-test-infra-main-e2e-metal-vmaas-virtual-network-lifecycle
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-metal-vmaas-virtual-network-lifecycle
       command:
       - ci-operator
       env:

--- a/ci-operator/jobs/osac-project/osac-test-infra/osac-project-osac-test-infra-main-postsubmits.yaml
+++ b/ci-operator/jobs/osac-project/osac-test-infra/osac-project-osac-test-infra-main-postsubmits.yaml
@@ -1,26 +1,26 @@
-presubmits:
+postsubmits:
   osac-project/osac-test-infra:
   - agent: kubernetes
     always_run: true
     branches:
     - ^main$
-    - ^main-
-    cluster: build08
-    context: ci/prow/images
+    cluster: build01
     decorate: true
     decoration_config:
       skip_cloning: true
     labels:
+      ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen
       job-release: "4.20"
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-osac-project-osac-test-infra-main-images
-    rerun_command: /test images
+    max_concurrency: 1
+    name: branch-ci-osac-project-osac-test-infra-main-images
     spec:
       containers:
       - args:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --image-mirror-push-secret=/etc/push-secret/.dockerconfigjson
+        - --promote
         - --report-credentials-file=/etc/report/credentials
         - --target=[images]
         command:
@@ -41,6 +41,9 @@ presubmits:
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
+        - mountPath: /etc/push-secret
+          name: push-secret
+          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -52,7 +55,9 @@ presubmits:
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
+      - name: push-secret
+        secret:
+          secretName: registry-push-credentials-ci-central
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )images,?($|\s.*)

--- a/ci-operator/step-registry/osac-project/baremetal/test/osac-project-baremetal-test-commands.sh
+++ b/ci-operator/step-registry/osac-project/baremetal/test/osac-project-baremetal-test-commands.sh
@@ -4,8 +4,34 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
-echo "************ osac-project baremetal test command ************"
+echo "Running OSAC E2E test: ${TEST}"
 
-echo "Running osac-project baremetal test"
+timeout -s 9 60m ssh -F "${SHARED_DIR}/ssh_config" ci_machine bash -s "${TEST}" "${E2E_NAMESPACE}" "${E2E_VM_TEMPLATE}" "${E2E_CLUSTER_TEMPLATE}" "${OSAC_TEST_IMAGE}" <<'REMOTE_EOF'
+set -euo pipefail
 
-echo "osac-project baremetal test completed"
+TEST="$1"
+E2E_NAMESPACE="$2"
+E2E_VM_TEMPLATE="$3"
+E2E_CLUSTER_TEMPLATE="$4"
+OSAC_TEST_IMAGE="$5"
+
+KUBECONFIG=$(find /root -name kubeconfig -type f -print -quit 2>/dev/null)
+[[ -z "${KUBECONFIG}" ]] && echo "ERROR: No kubeconfig found under /root" && exit 1
+
+PULL_SECRET_PATH="/root/pull-secret"
+
+set +x
+podman run --authfile "${PULL_SECRET_PATH}" --rm --network=host \
+  -v "${KUBECONFIG}:/root/.kube/config:z" \
+  -v "${PULL_SECRET_PATH}:/root/pull-secret:z" \
+  -e KUBECONFIG=/root/.kube/config \
+  -e OSAC_VM_KUBECONFIG=/root/.kube/config \
+  -e OSAC_NAMESPACE="${E2E_NAMESPACE}" \
+  -e OSAC_VM_TEMPLATE="${E2E_VM_TEMPLATE}" \
+  -e OSAC_CLUSTER_TEMPLATE="${E2E_CLUSTER_TEMPLATE}" \
+  -e OSAC_PULL_SECRET_PATH=/root/pull-secret \
+  "${OSAC_TEST_IMAGE}" \
+  make test TEST="${TEST}"
+REMOTE_EOF
+
+echo "Test completed"

--- a/ci-operator/step-registry/osac-project/baremetal/test/osac-project-baremetal-test-commands.sh
+++ b/ci-operator/step-registry/osac-project/baremetal/test/osac-project-baremetal-test-commands.sh
@@ -15,8 +15,8 @@ E2E_VM_TEMPLATE="$3"
 E2E_CLUSTER_TEMPLATE="$4"
 OSAC_TEST_IMAGE="$5"
 
-KUBECONFIG=$(find /root -name kubeconfig -type f -print -quit 2>/dev/null)
-[[ -z "${KUBECONFIG}" ]] && echo "ERROR: No kubeconfig found under /root" && exit 1
+KUBECONFIG=$(find ${KUBECONFIG} -type f -print -quit 2>/dev/null)
+[[ -z "${KUBECONFIG}" ]] && echo "ERROR: No kubeconfig found" && exit 1
 
 PULL_SECRET_PATH="/root/pull-secret"
 

--- a/ci-operator/step-registry/osac-project/baremetal/test/osac-project-baremetal-test-ref.yaml
+++ b/ci-operator/step-registry/osac-project/baremetal/test/osac-project-baremetal-test-ref.yaml
@@ -1,6 +1,9 @@
 ref:
   as: osac-project-baremetal-test
   from: dev-scripts
+  dependencies:
+  - name: osac-test-infra
+    env: OSAC_TEST_IMAGE
   grace_period: 10m
   timeout: 3h0m0s
   commands: osac-project-baremetal-test-commands.sh
@@ -8,3 +11,15 @@ ref:
     requests:
       cpu: 100m
       memory: 200Mi
+  env:
+  - name: TEST
+    documentation: The test name to run (e.g. test_compute_instance_lifecycle)
+  - name: E2E_NAMESPACE
+    default: "osac-e2e-ci"
+    documentation: The namespace to use for the e2e tests
+  - name: E2E_VM_TEMPLATE
+    default: "osac.templates.ocp_virt_vm"
+    documentation: The VM template to use for the e2e tests
+  - name: E2E_CLUSTER_TEMPLATE
+    default: "osac.templates.ocp_4_17_small"
+    documentation: The cluster template to use for CaaS e2e tests

--- a/ci-operator/step-registry/osac-project/baremetal/test/osac-project-baremetal-test-ref.yaml
+++ b/ci-operator/step-registry/osac-project/baremetal/test/osac-project-baremetal-test-ref.yaml
@@ -13,7 +13,7 @@ ref:
       memory: 200Mi
   env:
   - name: TEST
-    documentation: The test name to run (e.g. test_compute_instance_lifecycle)
+    documentation: The test file to run (e.g. test_compute_instance_creation.py)
   - name: E2E_NAMESPACE
     default: "osac-e2e-ci"
     documentation: The namespace to use for the e2e tests

--- a/ci-operator/step-registry/osac-project/installer/osac-project-installer-commands.sh
+++ b/ci-operator/step-registry/osac-project/installer/osac-project-installer-commands.sh
@@ -20,8 +20,6 @@ timeout -s 9 60m ssh -F "${SHARED_DIR}/ssh_config" ci_machine bash - << EOF|& se
 
 CLUSTER_KUBECONFIG=\$(find \${KUBECONFIG} -type f -print -quit)
 
-oc annotate sc lvms-vg1 storageclass.kubernetes.io/is-default-class=true
-
 podman run --authfile /root/pull-secret --rm --network=host \
 -v \${CLUSTER_KUBECONFIG}:/root/.kube/config:z \
 -v /root/pull-secret:/installer/overlays/${E2E_KUSTOMIZE_OVERLAY}/files/quay-pull-secret.json:z \

--- a/ci-operator/step-registry/osac-project/installer/osac-project-installer-commands.sh
+++ b/ci-operator/step-registry/osac-project/installer/osac-project-installer-commands.sh
@@ -18,10 +18,12 @@ timeout -s 9 10m scp -F "${SHARED_DIR}/ssh_config" /tmp/license.zip ci_machine:/
 
 timeout -s 9 60m ssh -F "${SHARED_DIR}/ssh_config" ci_machine bash - << EOF|& sed -e 's/.*auths\{0,1\}".*/*** PULL_SECRET ***/g'
 
-CLUSTER_KUBECONFIG=\$(find \${KUBECONFIG} -type f -print -quit)
+export KUBECONFIG=\$(find \${KUBECONFIG} -type f -print -quit)
+
+oc annotate sc lvms-vg1 storageclass.kubernetes.io/is-default-class=true --overwrite
 
 podman run --authfile /root/pull-secret --rm --network=host \
--v \${CLUSTER_KUBECONFIG}:/root/.kube/config:z \
+-v \${KUBECONFIG}:/root/.kube/config:z \
 -v /root/pull-secret:/installer/overlays/${E2E_KUSTOMIZE_OVERLAY}/files/quay-pull-secret.json:z \
 -v /tmp/license.zip:/installer/overlays/${E2E_KUSTOMIZE_OVERLAY}/files/license.zip:z \
 -e INSTALLER_NAMESPACE=${E2E_NAMESPACE} \

--- a/ci-operator/step-registry/osac-project/installer/osac-project-installer-commands.sh
+++ b/ci-operator/step-registry/osac-project/installer/osac-project-installer-commands.sh
@@ -22,6 +22,19 @@ export KUBECONFIG=\$(find \${KUBECONFIG} -type f -print -quit)
 
 oc annotate sc lvms-vg1 storageclass.kubernetes.io/is-default-class=true --overwrite
 
+echo "Waiting for OpenShift Virtualization to be ready..."
+oc wait --for=condition=Available hyperconverged/kubevirt-hyperconverged -n openshift-cnv --timeout=900s
+
+cat <<NADEOF | oc apply -f -
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: default
+  namespace: openshift-ovn-kubernetes
+spec:
+  config: '{"cniVersion": "0.4.0", "name": "ovn-kubernetes", "type": "ovn-k8s-cni-overlay"}'
+NADEOF
+
 podman run --authfile /root/pull-secret --rm --network=host \
 -v \${KUBECONFIG}:/root/.kube/config:z \
 -v /root/pull-secret:/installer/overlays/${E2E_KUSTOMIZE_OVERLAY}/files/quay-pull-secret.json:z \
@@ -29,7 +42,6 @@ podman run --authfile /root/pull-secret --rm --network=host \
 -e INSTALLER_NAMESPACE=${E2E_NAMESPACE} \
 -e INSTALLER_KUSTOMIZE_OVERLAY=${E2E_KUSTOMIZE_OVERLAY} \
 -e INSTALLER_VM_TEMPLATE=${E2E_VM_TEMPLATE} \
--e VIRT_SERVICE=true \
 ${OSAC_INSTALLER_IMAGE} sh /installer/scripts/setup.sh
 
 EOF

--- a/ci-operator/step-registry/osac-project/installer/osac-project-installer-commands.sh
+++ b/ci-operator/step-registry/osac-project/installer/osac-project-installer-commands.sh
@@ -16,7 +16,7 @@ base64 -d /var/run/osac-installer-aap/license > /tmp/license.zip
 
 timeout -s 9 10m scp -F "${SHARED_DIR}/ssh_config" /tmp/license.zip ci_machine:/tmp/license.zip
 
-timeout -s 9 60m ssh -F "${SHARED_DIR}/ssh_config" ci_machine bash - << EOF|& sed -e 's/.*auths\{0,1\}".*/*** PULL_SECRET ***/g'
+timeout -s 9 120m ssh -F "${SHARED_DIR}/ssh_config" ci_machine bash - << EOF|& sed -e 's/.*auths\{0,1\}".*/*** PULL_SECRET ***/g'
 
 export KUBECONFIG=\$(find \${KUBECONFIG} -type f -print -quit)
 
@@ -29,6 +29,7 @@ podman run --authfile /root/pull-secret --rm --network=host \
 -e INSTALLER_NAMESPACE=${E2E_NAMESPACE} \
 -e INSTALLER_KUSTOMIZE_OVERLAY=${E2E_KUSTOMIZE_OVERLAY} \
 -e INSTALLER_VM_TEMPLATE=${E2E_VM_TEMPLATE} \
+-e VIRT_SERVICE=true \
 ${OSAC_INSTALLER_IMAGE} sh /installer/scripts/setup.sh
 
 EOF

--- a/ci-operator/step-registry/osac-project/installer/osac-project-installer-ref.yaml
+++ b/ci-operator/step-registry/osac-project/installer/osac-project-installer-ref.yaml
@@ -20,7 +20,7 @@ ref:
     default: "osac-e2e-ci"
     documentation: The namespace to use for the e2e tests
   - name: E2E_KUSTOMIZE_OVERLAY
-    default: "ci"
+    default: "vmaas-ci"
     documentation: The kustomize overlay to use for the e2e tests
   - name: E2E_VM_TEMPLATE
     default: "osac.templates.ocp_virt_vm"


### PR DESCRIPTION
https://redhat.atlassian.net/browse/MGMT-23721

Add 8 periodic VMaaS E2E jobs to Prow, one per test:
- compute instance lifecycle
- API fields
- CLI fields
- delete during provision
- restart
- restart negative
- virtual network lifecycle
- subnet lifecycle

Schedule: spread across Mon-Thu at 02:00/06:00 UTC.
Uses the existing `osac-project-ofcir-baremetal` workflow with `OLM_OPERATORS=cnv`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched presubmit targets to validate image builds, updated triggers/rerun commands, and reinserted the images presubmit.
  * Added top-level image build & publish for osac-test-infra and a new postsubmit to promote images.
  * Changed default installer overlay to "vmaas-ci".
* **New Features**
  * Added multiple periodic and presubmit e2e Metal vMAAS test jobs (compute, API/CLI fields, creation, delete-during-provision, restart incl. negative, subnet, virtual-network) with per-job schedules and gating.
  * Reworked E2E runner to execute tests via a containerized remote flow and expose configurable TEST/E2E env vars.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->