### PR TITLE
o/release: bump some stray 4.22 occurences in 5.0 configs

### DIFF
--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
@@ -1462,7 +1462,7 @@ tests:
   steps:
     env:
       T5CI_JOB_TYPE: network-flow-matrix-bm
-      T5CI_VERSION: "4.22"
+      T5CI_VERSION: "5.0"
     observers:
       enable:
       - observers-resource-watch
@@ -1475,7 +1475,7 @@ tests:
   steps:
     env:
       T5CI_JOB_TYPE: network-flow-matrix-single-node-bm
-      T5CI_VERSION: "4.22"
+      T5CI_VERSION: "5.0"
     observers:
       enable:
       - observers-resource-watch
@@ -2131,7 +2131,7 @@ tests:
     cluster_profile: openshift-org-aws
     env:
       FIPS_ENABLED: "true"
-      MAJOR_MINOR: "4.22"
+      MAJOR_MINOR: "5.0"
     test:
     - ref: fips-check-node-scan
     - ref: fips-check-art-fips


### PR DESCRIPTION
I am not sure how these were missed in https://github.com/openshift/release/commit/a7b9af3f67b051335f79a653e328 because other envvars in the same file were apparently migrated just fine.

I have validated that the tooling used (`generated-release-gating-jobs`) will not miss any occurrences in a hypothetical 5.0->5.1 pre-branching which feels like a sufficient assurrance that this omission should not repeat in the future.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI nightly test job configurations to reflect version 5.0 across multiple test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->