### PR TITLE
[jira-lifecycle-plugin] 4.23/5.0 bump

### DIFF
--- a/core-services/jira-lifecycle-plugin/config.yaml
+++ b/core-services/jira-lifecycle-plugin/config.yaml
@@ -53,7 +53,7 @@ default:
       status: MODIFIED
     state_after_validation:
       status: POST
-    target_version: 4.22.0
+    target_version: 5.0.0
     valid_states:
     - status: NEW
     - status: ASSIGNED
@@ -72,7 +72,7 @@ default:
       status: MODIFIED
     state_after_validation:
       status: POST
-    target_version: 4.22.0
+    target_version: 5.0.0
     valid_states:
     - status: NEW
     - status: ASSIGNED
@@ -187,8 +187,17 @@ default:
     - status: ON_QA
     - status: VERIFIED
     dependent_bug_target_versions:
-    - 4.24.0
+    - 5.0.0
     target_version: 4.23.0
+    validate_by_default: true
+  openshift-5.0:
+    dependent_bug_states:
+    - status: MODIFIED
+    - status: ON_QA
+    - status: VERIFIED
+    dependent_bug_target_versions:
+    - 5.1.0
+    target_version: 5.0.0
     validate_by_default: true
   release-4.6:
     dependent_bug_target_versions:
@@ -300,8 +309,17 @@ default:
     - status: ON_QA
     - status: VERIFIED
     dependent_bug_target_versions:
-    - 4.24.0
+    - 5.0.0
     target_version: 4.23.0
+    validate_by_default: true
+  release-5.0:
+    dependent_bug_states:
+    - status: MODIFIED
+    - status: ON_QA
+    - status: VERIFIED
+    dependent_bug_target_versions:
+    - 5.1.0
+    target_version: 5.0.0
     validate_by_default: true
 orgs:
   openshift-eng:


### PR DESCRIPTION
This PR:
1. Moves the `main` and `master` configurations up to version `5.0.0`
2. Updates `openshift-4.23` and `release-4.23` to have `dependent_bug_target_versions` at version `5.0.0`
3. Adds `openshift-5.0` and `release-5.0` with  `dependent_bug_target_versions` at version `5.1.0`

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated development target versions from 4.22.0 to 5.0.0 for main and master branches
  * Updated dependent bug target versions from 4.24.0 to 5.0.0 across existing release branch configurations
  * Added new 5.0 release configuration with automatic validation enabled and comprehensive dependent bug tracking for modified, quality assurance, and verified bug states

<!-- end of auto-generated comment: release notes by coderabbit.ai -->