### PR TITLE
Exclude Konflux branches from branch protection for bpfman repos

### DIFF
--- a/core-services/prow/02_config/openshift/bpfman-catalog/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/bpfman-catalog/_prowconfig.yaml
@@ -3,6 +3,9 @@ branch-protection:
     openshift:
       repos:
         bpfman-catalog:
+          exclude:
+          - ^konflux-
+          - ^konflux/
           protect: true
           required_status_checks: {}
 tide:

--- a/core-services/prow/02_config/openshift/bpfman-operator/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/bpfman-operator/_prowconfig.yaml
@@ -3,6 +3,9 @@ branch-protection:
     openshift:
       repos:
         bpfman-operator:
+          exclude:
+          - ^konflux-
+          - ^konflux/
           protect: true
           required_status_checks: {}
 tide:

--- a/core-services/prow/02_config/openshift/bpfman/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/bpfman/_prowconfig.yaml
@@ -1,3 +1,13 @@
+branch-protection:
+  orgs:
+    openshift:
+      repos:
+        bpfman:
+          exclude:
+          - ^konflux-
+          - ^konflux/
+          protect: true
+          required_status_checks: {}
 tide:
   queries:
   - includedBranches:


### PR DESCRIPTION
Konflux automation creates branches prefixed with `konflux/` and `konflux-` for nudge PRs and dependency updates. When Prow's branchprotector marks these branches as protected, Renovate's `pruneStaleBranches` cannot delete them. This becomes a problem when the target release branch changes: the automation reuses the old branch (rooted on a previous release) rather than creating a fresh one, resulting in nudge PRs that carry hundreds of unrelated commits from the diverged history.

This was observed on openshift/bpfman-operator where nudge PRs targeting `release-0.6` appeared with 533 commits because the branches had originally been created against `release-0.5.8`. The branches could not be deleted or force-pushed due to the protection rules, and resolving the merge conflicts discarded the actual nudge updates, making the PRs undeliverable.

- https://github.com/openshift/bpfman-operator/pull/1717 — original nudge PR with 533 unrelated commits
- https://github.com/openshift/bpfman-operator/pull/1723 — bpfman-agent-zstream nudge, same issue
- https://github.com/openshift/bpfman-operator/pull/1724 — bpfman-daemon-zstream nudge, same issue
- https://github.com/openshift/bpfman-operator/pull/1725 — bpfman-operator-zstream nudge, conflict resolution discarded the actual update

This change adds `exclude` patterns for `^konflux-` and `^konflux/` to the branch protection configuration for openshift/bpfman, openshift/bpfman-operator, and openshift/bpfman-catalog. All other branches remain protected. This follows the approach already taken by oadp-operator, openshift-velero-plugin, hypershift-oadp-plugin, and oadp-must-gather.

Slack discussion: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1776172390760359

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated branch protection configuration for three repositories to exclude specific branch patterns from protection rules, while maintaining protection for all other branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->