### PR TITLE
Revert "add github action 'Tests' to odh-dashboard tide contexts"

### DIFF
--- a/core-services/prow/02_config/_config.yaml
+++ b/core-services/prow/02_config/_config.yaml
@@ -703,8 +703,6 @@ tide:
       opendatahub-io:
         repos:
           odh-dashboard:
-            required-if-present-contexts:
-            - Tests
             skip-unknown-contexts: true
           opendatahub-operator:
             optional-regex-contexts:


### PR DESCRIPTION
reverts https://github.com/openshift/release/pull/73690 as it didn't solve out issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD system configuration for pull request management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->