### PR TITLE
NO-ISSUE: ci(quay): increase chainsaw timeout

### DIFF
--- a/ci-operator/step-registry/quay/test-chainsaw/quay-test-chainsaw-ref.yaml
+++ b/ci-operator/step-registry/quay/test-chainsaw/quay-test-chainsaw-ref.yaml
@@ -6,7 +6,7 @@ ref:
     requests:
       cpu: 100m
       memory: 200Mi
-  timeout: 1h
+  timeout: 2h
   documentation: |-
     Runs Chainsaw e2e tests for the quay-operator from the source repo.
     Executes reconcile and HPA test suites against an OpenShift cluster


### PR DESCRIPTION
https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/quay_quay-operator/1240/pull-ci-quay-quay-operator-master-ocp-latest-e2e/2044055965044576256

timing out mid ca-rotation run

Signed-off-by: Brady Pratt <bpratt@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test infrastructure configuration to improve execution reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->