### PR TITLE
CNV-83205: enable RebootPolicy feature gate in interop deploy-cnv

### DIFF
--- a/ci-operator/step-registry/interop-tests/deploy-cnv/interop-tests-deploy-cnv-commands.sh
+++ b/ci-operator/step-registry/interop-tests/deploy-cnv/interop-tests-deploy-cnv-commands.sh
@@ -261,13 +261,23 @@ EOF
 oc wait hyperconverged -n "${CNV_INSTALL_NAMESPACE}" "${CNV_HYPERCONVERGED_NAME}" --for=condition=Available --timeout=15m
 
 # Enable KubeVirt RebootPolicy feature gate (interop e2e exercises reboot policy specs).
-oc annotate hyperconverged kubevirt-hyperconverged \
+oc annotate hyperconverged "${CNV_HYPERCONVERGED_NAME}" \
   --namespace="${CNV_INSTALL_NAMESPACE}" \
   --overwrite \
   kubevirt.kubevirt.io/jsonpatch='[
     {"op": "add", "path": "/spec/configuration/developerConfiguration/featureGates/-", "value": "RebootPolicy"}
   ]'
 
-oc wait hyperconverged -n openshift-cnv kubevirt-hyperconverged --for=condition=Available --timeout=15m
+# Wait until HCO reconciles the annotation (Available alone can return before spec is fully applied).
+for _ in {1..90}; do
+  gen=$(oc get hyperconverged -n "${CNV_INSTALL_NAMESPACE}" "${CNV_HYPERCONVERGED_NAME}" -o jsonpath='{.metadata.generation}' 2>/dev/null || true)
+  obs=$(oc get hyperconverged -n "${CNV_INSTALL_NAMESPACE}" "${CNV_HYPERCONVERGED_NAME}" -o jsonpath='{.status.observedGeneration}' 2>/dev/null || true)
+  if [[ -n "${gen}" && -n "${obs}" && "${obs}" -ge "${gen}" ]]; then
+    break
+  fi
+  sleep 10
+done
+
+oc wait hyperconverged -n "${CNV_INSTALL_NAMESPACE}" "${CNV_HYPERCONVERGED_NAME}" --for=condition=Available --timeout=15m
 
 echo "CNV is deployed successfully"

--- a/ci-operator/step-registry/interop-tests/deploy-cnv/interop-tests-deploy-cnv-commands.sh
+++ b/ci-operator/step-registry/interop-tests/deploy-cnv/interop-tests-deploy-cnv-commands.sh
@@ -260,4 +260,14 @@ EOF
 
 oc wait hyperconverged -n "${CNV_INSTALL_NAMESPACE}" "${CNV_HYPERCONVERGED_NAME}" --for=condition=Available --timeout=15m
 
+# Enable KubeVirt RebootPolicy feature gate (interop e2e exercises reboot policy specs).
+oc annotate hyperconverged kubevirt-hyperconverged \
+  --namespace="${CNV_INSTALL_NAMESPACE}" \
+  --overwrite \
+  kubevirt.kubevirt.io/jsonpatch='[
+    {"op": "add", "path": "/spec/configuration/developerConfiguration/featureGates/-", "value": "RebootPolicy"}
+  ]'
+
+oc wait hyperconverged -n openshift-cnv kubevirt-hyperconverged --for=condition=Available --timeout=15m
+
 echo "CNV is deployed successfully"


### PR DESCRIPTION
## [CNV-83205](https://redhat.atlassian.net/browse/CNV-83205)

Interop periodic `interop-tests-cnv-tests-e2e-deploy` was failing with:
`RebootPolicy is specified but the RebootPolicy feature gate is not enabled`.

## Change

After HyperConverged is first Available, annotate it with the same `kubevirt.kubevirt.io/jsonpatch` used in cnv-qe-automation (append `RebootPolicy` to KubeVirt `developerConfiguration.featureGates`), then wait for Available again.

## File

- `ci-operator/step-registry/interop-tests/deploy-cnv/interop-tests-deploy-cnv-commands.sh`

[CNV-83205]: https://redhat.atlassian.net/browse/CNV-83205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * KubeVirt `RebootPolicy` feature gate is now enabled during interop test deployments.

* **Test Updates**
  * Added validation step to confirm the system reaches `Available` state after deployment configuration changes, ensuring stability before proceeding with tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->