### PR TITLE
HYPERFLEET-928 - ci: add tier2 nightly periodic and API chart env vars

### DIFF
--- a/ci-operator/config/openshift-hyperfleet/hyperfleet-e2e/openshift-hyperfleet-hyperfleet-e2e-main__e2e.yaml
+++ b/ci-operator/config/openshift-hyperfleet/hyperfleet-e2e/openshift-hyperfleet-hyperfleet-e2e-main__e2e.yaml
@@ -42,6 +42,15 @@ tests:
       NAMESPACE_PREFIX: e2e
       REGION: us-central1-a
     workflow: openshift-hyperfleet-e2e
+- as: tier2-nightly
+  cron: 30 13 * * *
+  steps:
+    env:
+      CLUSTER_NAME: hyperfleet-dev-prow
+      LABEL_FILTER: tier2
+      NAMESPACE_PREFIX: e2e
+      REGION: us-central1-a
+    workflow: openshift-hyperfleet-e2e
 zz_generated_metadata:
   branch: main
   org: openshift-hyperfleet

--- a/ci-operator/jobs/openshift-hyperfleet/hyperfleet-e2e/openshift-hyperfleet-hyperfleet-e2e-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-hyperfleet/hyperfleet-e2e/openshift-hyperfleet-hyperfleet-e2e-main-periodics.yaml
@@ -167,3 +167,87 @@ periodics:
     - name: result-aggregator
       secret:
         secretName: result-aggregator
+- agent: kubernetes
+  cluster: build06
+  cron: 30 13 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-hyperfleet
+    repo: hyperfleet-e2e
+  labels:
+    ci-operator.openshift.io/variant: e2e
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-hyperfleet-hyperfleet-e2e-main-e2e-tier2-nightly
+  reporter_config:
+    slack:
+      channel: '#hyperfleet-e2e-status'
+      job_states_to_report:
+      - success
+      - failure
+      - error
+      report_template: |-
+        {{if eq .Status.State "success"}}:white_check_mark:{{else}}:x:{{end}} *{{.Spec.Job}}* ended with *{{.Status.State}}*.
+        Build: #{{.Status.BuildID}}
+        Details: <{{.Status.URL}}|View logs> · <https://prow.ci.openshift.org/job-history/gs/test-platform-results/logs/{{.Spec.Job}}|View history>
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --target=tier2-nightly
+      - --variant=e2e
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator

--- a/ci-operator/step-registry/openshift-hyperfleet/e2e/test/openshift-hyperfleet-e2e-test-commands.sh
+++ b/ci-operator/step-registry/openshift-hyperfleet/e2e/test/openshift-hyperfleet-e2e-test-commands.sh
@@ -33,5 +33,10 @@ export IMAGE_REGISTRY="${IMAGE_REGISTRY:-registry.ci.openshift.org}"
 export ADAPTER_IMAGE_REPO="${ADAPTER_IMAGE_REPO:-ci/hyperfleet-adapter}"
 export ADAPTER_IMAGE_TAG="${ADAPTER_IMAGE_TAG:-latest}"
 
+# Export API chart parameters for tier2 tests
+export API_CHART_REPO="${API_CHART_REPO:-https://github.com/openshift-hyperfleet/hyperfleet-api.git}"
+export API_CHART_REF="${API_CHART_REF:-main}"
+export API_CHART_PATH="${API_CHART_PATH:-charts}"
+
 # Run e2e tests via --label-filter
 hyperfleet-e2e test --label-filter=${LABEL_FILTER} --junit-report ${ARTIFACT_DIR}/junit.xml

--- a/ci-operator/step-registry/openshift-hyperfleet/e2e/test/openshift-hyperfleet-e2e-test-ref.yaml
+++ b/ci-operator/step-registry/openshift-hyperfleet/e2e/test/openshift-hyperfleet-e2e-test-ref.yaml
@@ -30,6 +30,15 @@ ref:
   - name: ADAPTER_IMAGE_TAG
     default: "latest"
     documentation: The image tag for the Adapter component.
+  - name: API_CHART_REPO
+    default: "https://github.com/openshift-hyperfleet/hyperfleet-api.git"
+    documentation: The Helm chart repository URL for the API component.
+  - name: API_CHART_REF
+    default: "main"
+    documentation: The git reference (branch/tag/commit) for the API chart repository.
+  - name: API_CHART_PATH
+    default: "charts"
+    documentation: The path to the charts directory within the API chart repository.
   credentials:
   - collection: ""
     namespace: test-credentials


### PR DESCRIPTION
 [HYPERFLEET-928](https://redhat.atlassian.net/browse/HYPERFLEET-928) - ci: add tier2 nightly periodic and API chart env vars

  Add tier2-nightly periodic job running daily at 13:30 UTC with tier2
  label filter for the hyperfleet-e2e suite.

  - Add tier2-nightly cron job to e2e variant periodic config
  - Add generated Prow periodic job with Slack reporting to #hyperfleet-e2e-status
  - Export API_CHART_REPO, API_CHART_REF, API_CHART_PATH env vars in test step for tier2 tests
  - Register new API chart env vars in step-registry ref with defaults and documentation

[HYPERFLEET-928]: https://redhat.atlassian.net/browse/HYPERFLEET-928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a nightly Tier 2 end-to-end test run (new scheduled periodic job at 13:30 UTC).
  * Enabled a Tier 2 target for periodic E2E execution to expand nightly coverage.
  * Introduced configurable environment variables for API chart repository, reference, and path used by E2E tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->