### PR TITLE
Show Kata rpm version

### DIFF
--- a/ci-operator/config/openshift/sandboxed-containers-operator/openshift-sandboxed-containers-operator-devel__downstream-candidate420.yaml
+++ b/ci-operator/config/openshift/sandboxed-containers-operator/openshift-sandboxed-containers-operator-devel__downstream-candidate420.yaml
@@ -23,7 +23,7 @@ tests:
   capabilities:
   - intranet
   cron: 0 0 31 2 1
-  restrict_network_access: false
+  restrict_network_access: true
   steps:
     cluster_profile: azure-qe
     env:
@@ -49,7 +49,7 @@ tests:
   capabilities:
   - intranet
   cron: 0 0 31 2 1
-  restrict_network_access: false
+  restrict_network_access: true
   steps:
     cluster_profile: azure-qe
     env:
@@ -78,7 +78,7 @@ tests:
   capabilities:
   - intranet
   cron: 0 0 31 2 1
-  restrict_network_access: false
+  restrict_network_access: true
   steps:
     cluster_profile: azure-qe
     env:
@@ -107,7 +107,7 @@ tests:
   capabilities:
   - intranet
   cron: 0 0 31 2 1
-  restrict_network_access: false
+  restrict_network_access: true
   steps:
     cluster_profile: azure-qe
     env:
@@ -137,7 +137,7 @@ tests:
   capabilities:
   - intranet
   cron: 0 0 31 2 1
-  restrict_network_access: false
+  restrict_network_access: true
   steps:
     cluster_profile: azure-qe
     env:
@@ -167,7 +167,7 @@ tests:
   capabilities:
   - intranet
   cron: 0 0 31 2 1
-  restrict_network_access: false
+  restrict_network_access: true
   steps:
     cluster_profile: aws-sandboxed-containers-operator
     env:
@@ -195,7 +195,7 @@ tests:
   capabilities:
   - intranet
   cron: 0 0 31 2 1
-  restrict_network_access: false
+  restrict_network_access: true
   steps:
     cluster_profile: aws-sandboxed-containers-operator
     env:

--- a/ci-operator/step-registry/sandboxed-containers-operator/get-kata-rpm/sandboxed-containers-operator-get-kata-rpm-commands.sh
+++ b/ci-operator/step-registry/sandboxed-containers-operator/get-kata-rpm/sandboxed-containers-operator-get-kata-rpm-commands.sh
@@ -55,6 +55,9 @@ if grep -q 'title.*404 Not Found' kata-containers.rpm && \
 fi
 
 kata_rpm_md5sum=$(md5sum kata-containers.rpm | cut -d' ' -f1)
+# output the rpm version
+echo "RPM version: $(rpm -q ./kata-containers.rpm)"
+echo "md5sum: ${kata_rpm_md5sum}"
 
 echo "Upload to workers and check against the rpm md5sum"
 failed_nodes=""


### PR DESCRIPTION
For tracking tests, its important to track the rpm version

This will output the rpm version that is put on the nodes into the artifacts
If the RPM isn't supposed to be uploaded, the log will have
`INSTALL_KATA_RPM=***** Do not install the Kata RPM`

dig will have to be updated to track this fully