### PR TITLE
Output version and md5sum of downloaded rpm

### DIFF
--- a/ci-operator/step-registry/sandboxed-containers-operator/get-kata-rpm/sandboxed-containers-operator-get-kata-rpm-commands.sh
+++ b/ci-operator/step-registry/sandboxed-containers-operator/get-kata-rpm/sandboxed-containers-operator-get-kata-rpm-commands.sh
@@ -44,7 +44,7 @@ if [ $err -ne 0 ]; then
     exit 2
 fi
 
-ls -lh kata-containers.rpm
+echo "upload RPM to workers: $(ls -lh kata-containers.rpm)"
 
 # checks for a bad URL
 if grep -q 'title.*404 Not Found' kata-containers.rpm && \
@@ -55,8 +55,11 @@ if grep -q 'title.*404 Not Found' kata-containers.rpm && \
 fi
 
 kata_rpm_md5sum=$(md5sum kata-containers.rpm | cut -d' ' -f1)
+# output the rpm version
+echo "upload RPM version: $(rpm -q ./kata-containers.rpm)"
+echo "upload RPM md5sum: ${kata_rpm_md5sum}"
 
-echo "Upload to workers and check against the rpm md5sum"
+echo "Uploading RPM to workers and checking against the rpm md5sum"
 failed_nodes=""
 nodes=$(oc get node -l node-role.kubernetes.io/worker= -o name)
 if [[ -z "${nodes}" ]]; then


### PR DESCRIPTION
After files is downloaded and checked for bad URL, output its:
    ls -lh
    rpm -q
    md5sum

For tracking tests, its important to track the rpm version

This will output the rpm version that is put on the nodes into the artifacts
If the RPM isn't supposed to be uploaded, the log will have
`INSTALL_KATA_RPM=***** Do not install the Kata RPM`

dig will have to be updated to track this fully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD logging output with improved message formatting and additional information display in the Kata RPM build step.
  * Added visibility into RPM version details and checksum values during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->