### PR TITLE
OLM: calcluate commit ranges to ensure proper commitchecker bounding

### DIFF
--- a/ci-operator/config/openshift/operator-framework-operator-controller/openshift-operator-framework-operator-controller-main.yaml
+++ b/ci-operator/config/openshift/operator-framework-operator-controller/openshift-operator-framework-operator-controller-main.yaml
@@ -54,7 +54,9 @@ tests:
   container:
     from: src
 - as: verify-commits
-  commands: commitchecker --start ${PULL_BASE_SHA:-main}
+  commands: |
+    commitchecker --start "$(git merge-base ${PULL_BASE_SHA:-main} ${PULL_PULL_SHA:-HEAD})" \
+                  --end "${PULL_PULL_SHA:-HEAD}"
   container:
     from: commitchecker
 - as: check-sync-pr-valid

--- a/ci-operator/config/openshift/operator-framework-operator-controller/openshift-operator-framework-operator-controller-release-4.22.yaml
+++ b/ci-operator/config/openshift/operator-framework-operator-controller/openshift-operator-framework-operator-controller-release-4.22.yaml
@@ -54,7 +54,9 @@ tests:
   container:
     from: src
 - as: verify-commits
-  commands: commitchecker --start ${PULL_BASE_SHA:-main}
+  commands: |
+    commitchecker --start "$(git merge-base ${PULL_BASE_SHA:-main} ${PULL_PULL_SHA:-HEAD})" \
+                  --end "${PULL_PULL_SHA:-HEAD}"
   container:
     from: commitchecker
 - as: check-sync-pr-valid

--- a/ci-operator/config/openshift/operator-framework-operator-controller/openshift-operator-framework-operator-controller-release-4.23.yaml
+++ b/ci-operator/config/openshift/operator-framework-operator-controller/openshift-operator-framework-operator-controller-release-4.23.yaml
@@ -54,7 +54,9 @@ tests:
   container:
     from: src
 - as: verify-commits
-  commands: commitchecker --start ${PULL_BASE_SHA:-main}
+  commands: |
+    commitchecker --start "$(git merge-base ${PULL_BASE_SHA:-main} ${PULL_PULL_SHA:-HEAD})" \
+                  --end "${PULL_PULL_SHA:-HEAD}"
   container:
     from: commitchecker
 - as: check-sync-pr-valid

--- a/ci-operator/config/openshift/operator-framework-operator-controller/openshift-operator-framework-operator-controller-release-5.0.yaml
+++ b/ci-operator/config/openshift/operator-framework-operator-controller/openshift-operator-framework-operator-controller-release-5.0.yaml
@@ -55,7 +55,9 @@ tests:
   container:
     from: src
 - as: verify-commits
-  commands: commitchecker --start ${PULL_BASE_SHA:-main}
+  commands: |
+    commitchecker --start "$(git merge-base ${PULL_BASE_SHA:-main} ${PULL_PULL_SHA:-HEAD})" \
+                  --end "${PULL_PULL_SHA:-HEAD}"
   container:
     from: commitchecker
 - as: check-sync-pr-valid


### PR DESCRIPTION
We have had a problem with the default commit calculations of commitchecker, when a commit was merged to our downstream main branch after a sync PR was created from an ancestor commit.   This PR duplicates the solution [here](https://github.com/openshift/release/pull/67720) to address the issue.

The problem could yield cases where the range calculation would be erroneously calculated due to the diverged ancestry.  
When this presented with a false positive (no errors) case that allowed a non-compliant PR to merge, a subsequent merge PR would fail due to our branching strategy where our downstream branch is really our upstream branch with carry|drop|pr conventions re-applied as necessary.  A non-compliant merged PR would fail future checks as we attempted to determine what to do with it, requiring manual intervention/correction. 

Given stale branch:
```
  main:   A --- B --- C --- D  (PULL_BASE_SHA)
           \
  PR:      E --- F --- G       (PULL_PULL_SHA)
```

  After CI merge:
```
           A --- B --- C --- D
           \                  \
            E --- F --- G --- M  (HEAD = merge commit)
```

  OLD computation for the merge commit range:
  - evaluates merge-base(M, D) = D (since D is parent of M)
  - git log --ancestry-path D..M
  - E, F, G are not descendants of D → excluded
  - Result: 0 commits evaluated = false positive

  NEW computation (#67720):
  - merge-base(D, G) = A (common ancestor)
  - git log --ancestry-path A..G
  - E, F, G are descendants of A → included
  - Result: 3 commits validated = correct evaluation

This change should make https://github.com/openshift/build-machinery-go/pull/114 unnecessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI commit validation improved to explicitly compute the common merge-base and bound the checked commit range up to the pull request head.
  * Applied consistently across multiple release CI configurations to make PR commit checks more accurate and deterministic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->