### PR TITLE
OCPBUGS-82060: Distribute GCP ARM64 instance types across releases to reduce quota exhaustion

### DIFF
--- a/ci-operator/config/openshift/ci-tools/openshift-ci-tools-main.yaml
+++ b/ci-operator/config/openshift/ci-tools/openshift-ci-tools-main.yaml
@@ -941,7 +941,6 @@ tests:
         field: gsm-e2e-test-sa-key
         group: test-credentials
         mount_path: /tmp/gcp-creds
-        namespace: ""
       - bundle: hive-hive-credentials
         mount_path: /tmp/hive
         namespace: test-credentials
@@ -1197,7 +1196,6 @@ tests:
         field: api-token
         group: snyk-credentials
         mount_path: /snyk-credentials
-        namespace: ""
       env:
       - default: ci-tools
         name: PROJECT_NAME

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.17-upgrade-from-nightly-4.16.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.17-upgrade-from-nightly-4.16.yaml
@@ -101,7 +101,8 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-4
+      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
+      COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance
     workflow: openshift-upgrade-gcp-heterogeneous

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.17-upgrade-from-stable-4.16.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.17-upgrade-from-stable-4.16.yaml
@@ -100,7 +100,8 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-4
+      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
+      COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance
     workflow: openshift-upgrade-gcp-heterogeneous

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.17.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.17.yaml
@@ -653,7 +653,8 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-4
+      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
+      COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SKIPS: deploymentconfigs\| should expose cluster services outside the cluster\|
         FIPS TestFIPS\| Multi-stage image builds should succeed\| Optimized image
@@ -696,7 +697,8 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-4
+      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
+      COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance
     workflow: openshift-upgrade-gcp-heterogeneous

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.18-upgrade-from-nightly-4.17.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.18-upgrade-from-nightly-4.17.yaml
@@ -101,7 +101,8 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-4
+      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
+      COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance
     workflow: openshift-upgrade-gcp-heterogeneous

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.18-upgrade-from-stable-4.17.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.18-upgrade-from-stable-4.17.yaml
@@ -100,7 +100,8 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-4
+      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
+      COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance
     workflow: openshift-upgrade-gcp-heterogeneous

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.18.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.18.yaml
@@ -701,7 +701,8 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-4
+      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
+      COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SKIPS: deploymentconfigs\| should expose cluster services outside the cluster\|
         FIPS TestFIPS\| Multi-stage image builds should succeed\| Optimized image
@@ -744,7 +745,8 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-4
+      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
+      COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance
     workflow: openshift-upgrade-gcp-heterogeneous

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.19-upgrade-from-nightly-4.18.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.19-upgrade-from-nightly-4.18.yaml
@@ -101,7 +101,8 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-4
+      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
+      COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance
     workflow: openshift-upgrade-gcp-heterogeneous

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.19-upgrade-from-stable-4.18.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.19-upgrade-from-stable-4.18.yaml
@@ -100,7 +100,8 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-4
+      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
+      COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance
     workflow: openshift-upgrade-gcp-heterogeneous

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.19.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.19.yaml
@@ -693,7 +693,7 @@ tests:
   steps:
     cluster_profile: openshift-org-gcp
     env:
-      COMPUTE_NODE_TYPE: t2a-standard-4
+      COMPUTE_NODE_TYPE: t2a-standard-1
       OCP_ARCH: arm64
     workflow: openshift-e2e-gcp-ovn
 - as: ocp-e2e-upgrade-gcp-ovn-multi-a-a
@@ -701,7 +701,7 @@ tests:
   steps:
     cluster_profile: openshift-org-gcp
     env:
-      COMPUTE_NODE_TYPE: t2a-standard-4
+      COMPUTE_NODE_TYPE: t2a-standard-1
       OCP_ARCH: arm64
       TEST_TYPE: upgrade-conformance
     workflow: openshift-upgrade-gcp

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.19.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.19.yaml
@@ -695,6 +695,7 @@ tests:
     env:
       COMPUTE_NODE_TYPE: t2a-standard-1
       OCP_ARCH: arm64
+      ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)
     workflow: openshift-e2e-gcp-ovn
 - as: ocp-e2e-upgrade-gcp-ovn-multi-a-a
   cron: 45 0 * * 0
@@ -704,9 +705,10 @@ tests:
       COMPUTE_NODE_TYPE: t2a-standard-1
       OCP_ARCH: arm64
       TEST_TYPE: upgrade-conformance
+      ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)
     workflow: openshift-upgrade-gcp
 - as: ocp-e2e-gcp-ovn-multi-x-ax
-  interval: 168h
+  interval: 174h
   steps:
     cluster_profile: openshift-org-gcp
     env:
@@ -725,12 +727,13 @@ tests:
         alerting rules\| The HAProxy router should\| egressrouter cni resources\|
         pod should start\| pod sysctls\| build volumes should mount given secrets
         and configmaps into the build pod
+      ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)
     test:
     - ref: ipi-install-heterogeneous
     - ref: openshift-e2e-test
     workflow: openshift-e2e-gcp-ovn
 - as: ocp-e2e-gcp-ovn-multi-day-0-a-x
-  interval: 168h
+  interval: 180h
   steps:
     cluster_profile: openshift-org-gcp
     env:
@@ -748,6 +751,7 @@ tests:
         alerting rules\| The HAProxy router should\| egressrouter cni resources\|
         pod should start\| pod sysctls\| build volumes should mount given secrets
         and configmaps into the build pod
+      ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)
     workflow: openshift-e2e-gcp-ovn
 - as: ocp-e2e-upgrade-gcp-ovn-multi-x-ax
   cron: 28 22 * * 6
@@ -759,6 +763,7 @@ tests:
       COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance
+      ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)
     workflow: openshift-upgrade-gcp-heterogeneous
 zz_generated_metadata:
   branch: main

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.19.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.19.yaml
@@ -689,7 +689,7 @@ tests:
     cluster_profile: openshift-org-aws
     workflow: openshift-upgrade-aws
 - as: ocp-e2e-gcp-ovn-multi-a-a
-  cron: 0 11 * * 0
+  interval: 168h
   steps:
     cluster_profile: openshift-org-gcp
     env:
@@ -706,12 +706,13 @@ tests:
       TEST_TYPE: upgrade-conformance
     workflow: openshift-upgrade-gcp
 - as: ocp-e2e-gcp-ovn-multi-x-ax
-  cron: 0 11 * * 0
+  interval: 168h
   steps:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-4
+      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
+      COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SKIPS: deploymentconfigs\| should expose cluster services outside the cluster\|
         FIPS TestFIPS\| Multi-stage image builds should succeed\| Optimized image
@@ -729,7 +730,7 @@ tests:
     - ref: openshift-e2e-test
     workflow: openshift-e2e-gcp-ovn
 - as: ocp-e2e-gcp-ovn-multi-day-0-a-x
-  cron: 0 11 * * 0
+  interval: 168h
   steps:
     cluster_profile: openshift-org-gcp
     env:
@@ -754,7 +755,8 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-4
+      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
+      COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance
     workflow: openshift-upgrade-gcp-heterogeneous

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.19.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.19.yaml
@@ -693,7 +693,7 @@ tests:
   steps:
     cluster_profile: openshift-org-gcp
     env:
-      COMPUTE_NODE_TYPE: t2a-standard-1
+      COMPUTE_NODE_TYPE: t2a-standard-2
       OCP_ARCH: arm64
       ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)
     workflow: openshift-e2e-gcp-ovn
@@ -702,7 +702,7 @@ tests:
   steps:
     cluster_profile: openshift-org-gcp
     env:
-      COMPUTE_NODE_TYPE: t2a-standard-1
+      COMPUTE_NODE_TYPE: t2a-standard-2
       OCP_ARCH: arm64
       TEST_TYPE: upgrade-conformance
       ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.20-upgrade-from-nightly-4.19.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.20-upgrade-from-nightly-4.19.yaml
@@ -101,7 +101,8 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-4
+      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
+      COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance
     workflow: openshift-upgrade-gcp-heterogeneous

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.20-upgrade-from-stable-4.19.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.20-upgrade-from-stable-4.19.yaml
@@ -108,7 +108,8 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-4
+      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
+      COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance
     workflow: openshift-upgrade-gcp-heterogeneous

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.20.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.20.yaml
@@ -773,6 +773,7 @@ tests:
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
       ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
+      ADDITIONAL_WORKERS: "2"
       COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SKIPS: deploymentconfigs\| should expose cluster services outside the cluster\|
@@ -823,6 +824,7 @@ tests:
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
       ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
+      ADDITIONAL_WORKERS: "2"
       COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.20.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.20.yaml
@@ -695,12 +695,13 @@ tests:
     cluster_profile: openshift-org-aws
     workflow: openshift-upgrade-aws
 - as: ocp-e2e-gcp-ovn-multi-a-a
-  interval: 168h
+  interval: 186h
   steps:
     cluster_profile: openshift-org-gcp
     env:
       COMPUTE_NODE_TYPE: t2a-standard-2
       OCP_ARCH: arm64
+      ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)
     workflow: openshift-e2e-gcp-ovn
 - as: ocp-e2e-gcp-ovn-multi-x-x-to-a-x
   interval: 72h
@@ -721,6 +722,7 @@ tests:
         pod should start\| pod sysctls\| build volumes should mount given secrets
         and configmaps into the build pod\| control plane machine set operator should
         not cause an early rollout\| The openshift-image-registry pods
+      ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)
     test:
     - ref: ipi-conf-inframachineset
     - ref: multiarch-migration-machine-type
@@ -748,6 +750,7 @@ tests:
         pod should start\| pod sysctls\| build volumes should mount given secrets
         and configmaps into the build pod\| control plane machine set operator should
         not cause an early rollout\| The openshift-image-registry pods
+      ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)
     test:
     - ref: ipi-conf-inframachineset
     - ref: multiarch-migration-machine-type
@@ -761,9 +764,10 @@ tests:
       COMPUTE_NODE_TYPE: t2a-standard-2
       OCP_ARCH: arm64
       TEST_TYPE: upgrade-conformance
+      ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)
     workflow: openshift-upgrade-gcp
 - as: ocp-e2e-gcp-ovn-multi-x-ax
-  interval: 168h
+  interval: 192h
   steps:
     cluster_profile: openshift-org-gcp
     env:
@@ -784,12 +788,13 @@ tests:
         and configmaps into the build pod\| zstd:chunked Image should successfully
         run date command\| templateinstance readiness test should report ready soon
         after all annotated objects are ready
+      ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)
     test:
     - ref: ipi-install-heterogeneous
     - ref: openshift-e2e-test
     workflow: openshift-e2e-gcp-ovn
 - as: ocp-e2e-gcp-ovn-multi-day-0-a-x
-  interval: 168h
+  interval: 198h
   steps:
     cluster_profile: openshift-org-gcp
     env:
@@ -809,6 +814,7 @@ tests:
         and configmaps into the build pod\| zstd:chunked Image should successfully
         run date command\| templateinstance readiness test should report ready soon
         after all annotated objects are ready
+      ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)
     workflow: openshift-e2e-gcp-ovn
 - as: ocp-e2e-upgrade-gcp-ovn-multi-x-ax
   interval: 72h
@@ -820,6 +826,7 @@ tests:
       COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance
+      ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)
     workflow: openshift-upgrade-gcp-heterogeneous
 zz_generated_metadata:
   branch: main

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.20.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.20.yaml
@@ -695,7 +695,7 @@ tests:
     cluster_profile: openshift-org-aws
     workflow: openshift-upgrade-aws
 - as: ocp-e2e-gcp-ovn-multi-a-a
-  cron: 0 11 * * 0
+  interval: 168h
   steps:
     cluster_profile: openshift-org-gcp
     env:
@@ -708,7 +708,7 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       MIGRATION_CP_MACHINE_TYPE: t2a-standard-4
-      MIGRATION_INFRA_MACHINE_TYPE: t2a-standard-4
+      MIGRATION_INFRA_MACHINE_TYPE: t2a-standard-2
       TEST_SKIPS: deploymentconfigs\| should expose cluster services outside the cluster\|
         FIPS TestFIPS\| Multi-stage image builds should succeed\| Optimized image
         builds should succeed\| build can reference a cluster service\| custom build
@@ -763,12 +763,13 @@ tests:
       TEST_TYPE: upgrade-conformance
     workflow: openshift-upgrade-gcp
 - as: ocp-e2e-gcp-ovn-multi-x-ax
-  cron: 0 11 * * 0
+  interval: 168h
   steps:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-4
+      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
+      COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SKIPS: deploymentconfigs\| should expose cluster services outside the cluster\|
         FIPS TestFIPS\| Multi-stage image builds should succeed\| Optimized image
@@ -788,7 +789,7 @@ tests:
     - ref: openshift-e2e-test
     workflow: openshift-e2e-gcp-ovn
 - as: ocp-e2e-gcp-ovn-multi-day-0-a-x
-  cron: 0 11 * * 0
+  interval: 168h
   steps:
     cluster_profile: openshift-org-gcp
     env:
@@ -815,7 +816,8 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-4
+      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
+      COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance
     workflow: openshift-upgrade-gcp-heterogeneous

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.20.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.20.yaml
@@ -699,7 +699,7 @@ tests:
   steps:
     cluster_profile: openshift-org-gcp
     env:
-      COMPUTE_NODE_TYPE: t2a-standard-4
+      COMPUTE_NODE_TYPE: t2a-standard-2
       OCP_ARCH: arm64
     workflow: openshift-e2e-gcp-ovn
 - as: ocp-e2e-gcp-ovn-multi-x-x-to-a-x
@@ -731,7 +731,7 @@ tests:
   steps:
     cluster_profile: openshift-org-gcp
     env:
-      COMPUTE_NODE_TYPE: t2a-standard-4
+      COMPUTE_NODE_TYPE: t2a-standard-2
       MIGRATION_ARCHITECTURE: x86_64
       MIGRATION_CP_MACHINE_TYPE: n2-standard-4
       MIGRATION_INFRA_MACHINE_TYPE: n2-standard-4
@@ -758,7 +758,7 @@ tests:
   steps:
     cluster_profile: openshift-org-gcp
     env:
-      COMPUTE_NODE_TYPE: t2a-standard-4
+      COMPUTE_NODE_TYPE: t2a-standard-2
       OCP_ARCH: arm64
       TEST_TYPE: upgrade-conformance
     workflow: openshift-upgrade-gcp

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.21-upgrade-from-nightly-4.20.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.21-upgrade-from-nightly-4.20.yaml
@@ -101,7 +101,8 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-4
+      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
+      COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance
     workflow: openshift-upgrade-gcp-heterogeneous

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.21-upgrade-from-stable-4.20.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.21-upgrade-from-stable-4.20.yaml
@@ -108,7 +108,8 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-4
+      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
+      COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance
     workflow: openshift-upgrade-gcp-heterogeneous

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.21.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.21.yaml
@@ -700,12 +700,13 @@ tests:
     cluster_profile: openshift-org-aws
     workflow: openshift-upgrade-aws
 - as: ocp-e2e-gcp-ovn-multi-a-a
-  interval: 168h
+  interval: 204h
   steps:
     cluster_profile: openshift-org-gcp
     env:
       COMPUTE_NODE_TYPE: t2a-standard-2
       OCP_ARCH: arm64
+      ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)
     workflow: openshift-e2e-gcp-ovn
 - as: ocp-e2e-gcp-ovn-multi-x-x-to-a-x
   interval: 72h
@@ -726,6 +727,7 @@ tests:
         pod should start\| pod sysctls\| build volumes should mount given secrets
         and configmaps into the build pod\| control plane machine set operator should
         not cause an early rollout\| The openshift-image-registry pods
+      ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)
     test:
     - ref: ipi-conf-inframachineset
     - ref: multiarch-migration-machine-type
@@ -753,6 +755,7 @@ tests:
         pod should start\| pod sysctls\| build volumes should mount given secrets
         and configmaps into the build pod\| control plane machine set operator should
         not cause an early rollout\| The openshift-image-registry pods
+      ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)
     test:
     - ref: ipi-conf-inframachineset
     - ref: multiarch-migration-machine-type
@@ -766,9 +769,10 @@ tests:
       COMPUTE_NODE_TYPE: t2a-standard-2
       OCP_ARCH: arm64
       TEST_TYPE: upgrade-conformance
+      ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)
     workflow: openshift-upgrade-gcp
 - as: ocp-e2e-gcp-ovn-multi-x-ax
-  interval: 168h
+  interval: 210h
   steps:
     cluster_profile: openshift-org-gcp
     env:
@@ -789,12 +793,13 @@ tests:
         and configmaps into the build pod\| zstd:chunked Image should successfully
         run date command\| templateinstance readiness test should report ready soon
         after all annotated objects are ready
+      ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)
     test:
     - ref: ipi-install-heterogeneous
     - ref: openshift-e2e-test
     workflow: openshift-e2e-gcp-ovn
 - as: ocp-e2e-gcp-ovn-multi-day-0-a-x
-  interval: 168h
+  interval: 216h
   steps:
     cluster_profile: openshift-org-gcp
     env:
@@ -814,6 +819,7 @@ tests:
         and configmaps into the build pod\| zstd:chunked Image should successfully
         run date command\| templateinstance readiness test should report ready soon
         after all annotated objects are ready
+      ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)
     workflow: openshift-e2e-gcp-ovn
 - as: ocp-e2e-upgrade-gcp-ovn-multi-x-ax
   interval: 72h
@@ -825,6 +831,7 @@ tests:
       COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance
+      ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)
     workflow: openshift-upgrade-gcp-heterogeneous
 zz_generated_metadata:
   branch: main

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.21.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.21.yaml
@@ -700,7 +700,7 @@ tests:
     cluster_profile: openshift-org-aws
     workflow: openshift-upgrade-aws
 - as: ocp-e2e-gcp-ovn-multi-a-a
-  cron: 0 11 * * 0
+  interval: 168h
   steps:
     cluster_profile: openshift-org-gcp
     env:
@@ -713,7 +713,7 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       MIGRATION_CP_MACHINE_TYPE: t2a-standard-4
-      MIGRATION_INFRA_MACHINE_TYPE: t2a-standard-4
+      MIGRATION_INFRA_MACHINE_TYPE: t2a-standard-2
       TEST_SKIPS: deploymentconfigs\| should expose cluster services outside the cluster\|
         FIPS TestFIPS\| Multi-stage image builds should succeed\| Optimized image
         builds should succeed\| build can reference a cluster service\| custom build
@@ -768,12 +768,13 @@ tests:
       TEST_TYPE: upgrade-conformance
     workflow: openshift-upgrade-gcp
 - as: ocp-e2e-gcp-ovn-multi-x-ax
-  cron: 0 11 * * 0
+  interval: 168h
   steps:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-4
+      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
+      COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SKIPS: deploymentconfigs\| should expose cluster services outside the cluster\|
         FIPS TestFIPS\| Multi-stage image builds should succeed\| Optimized image
@@ -793,7 +794,7 @@ tests:
     - ref: openshift-e2e-test
     workflow: openshift-e2e-gcp-ovn
 - as: ocp-e2e-gcp-ovn-multi-day-0-a-x
-  cron: 0 11 * * 0
+  interval: 168h
   steps:
     cluster_profile: openshift-org-gcp
     env:
@@ -820,7 +821,8 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-4
+      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
+      COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance
     workflow: openshift-upgrade-gcp-heterogeneous

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.21.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.21.yaml
@@ -704,7 +704,7 @@ tests:
   steps:
     cluster_profile: openshift-org-gcp
     env:
-      COMPUTE_NODE_TYPE: t2a-standard-4
+      COMPUTE_NODE_TYPE: t2a-standard-2
       OCP_ARCH: arm64
     workflow: openshift-e2e-gcp-ovn
 - as: ocp-e2e-gcp-ovn-multi-x-x-to-a-x
@@ -713,7 +713,7 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       MIGRATION_CP_MACHINE_TYPE: t2a-standard-4
-      MIGRATION_INFRA_MACHINE_TYPE: t2a-standard-2
+      MIGRATION_INFRA_MACHINE_TYPE: t2a-standard-4
       TEST_SKIPS: deploymentconfigs\| should expose cluster services outside the cluster\|
         FIPS TestFIPS\| Multi-stage image builds should succeed\| Optimized image
         builds should succeed\| build can reference a cluster service\| custom build
@@ -736,7 +736,7 @@ tests:
   steps:
     cluster_profile: openshift-org-gcp
     env:
-      COMPUTE_NODE_TYPE: t2a-standard-4
+      COMPUTE_NODE_TYPE: t2a-standard-2
       MIGRATION_ARCHITECTURE: x86_64
       MIGRATION_CP_MACHINE_TYPE: n2-standard-4
       MIGRATION_INFRA_MACHINE_TYPE: n2-standard-4
@@ -763,7 +763,7 @@ tests:
   steps:
     cluster_profile: openshift-org-gcp
     env:
-      COMPUTE_NODE_TYPE: t2a-standard-4
+      COMPUTE_NODE_TYPE: t2a-standard-2
       OCP_ARCH: arm64
       TEST_TYPE: upgrade-conformance
     workflow: openshift-upgrade-gcp

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.22-upgrade-from-nightly-4.21.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.22-upgrade-from-nightly-4.21.yaml
@@ -101,7 +101,8 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
+      ADDITIONAL_WORKER_DISK_TYPE: hyperdisk-balanced
+      ADDITIONAL_WORKER_VM_TYPE: c4a-standard-4
       COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.22-upgrade-from-nightly-4.21.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.22-upgrade-from-nightly-4.21.yaml
@@ -101,7 +101,8 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-4
+      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
+      COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance
     workflow: openshift-upgrade-gcp-heterogeneous

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.22-upgrade-from-nightly-4.21.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.22-upgrade-from-nightly-4.21.yaml
@@ -101,7 +101,6 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_DISK_TYPE: hyperdisk-balanced
       ADDITIONAL_WORKER_VM_TYPE: c4a-standard-4
       COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.22-upgrade-from-stable-4.21.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.22-upgrade-from-stable-4.21.yaml
@@ -108,7 +108,8 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-4
+      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
+      COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance
     workflow: openshift-upgrade-gcp-heterogeneous

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.22-upgrade-from-stable-4.21.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.22-upgrade-from-stable-4.21.yaml
@@ -108,7 +108,8 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
+      ADDITIONAL_WORKER_DISK_TYPE: hyperdisk-balanced
+      ADDITIONAL_WORKER_VM_TYPE: c4a-standard-4
       COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.22.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.22.yaml
@@ -773,7 +773,7 @@ tests:
     cluster_profile: openshift-org-aws
     workflow: openshift-upgrade-aws
 - as: ocp-e2e-gcp-ovn-multi-a-a
-  cron: 0 11 * * 0
+  interval: 168h
   steps:
     cluster_profile: openshift-org-gcp
     env:
@@ -786,7 +786,7 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       MIGRATION_CP_MACHINE_TYPE: t2a-standard-4
-      MIGRATION_INFRA_MACHINE_TYPE: t2a-standard-4
+      MIGRATION_INFRA_MACHINE_TYPE: t2a-standard-2
       TEST_SKIPS: deploymentconfigs\| should expose cluster services outside the cluster\|
         FIPS TestFIPS\| Multi-stage image builds should succeed\| Optimized image
         builds should succeed\| build can reference a cluster service\| custom build
@@ -841,12 +841,13 @@ tests:
       TEST_TYPE: upgrade-conformance
     workflow: openshift-upgrade-gcp
 - as: ocp-e2e-gcp-ovn-multi-x-ax
-  cron: 0 11 * * 0
+  interval: 168h
   steps:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-4
+      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
+      COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SKIPS: deploymentconfigs\| should expose cluster services outside the cluster\|
         FIPS TestFIPS\| Multi-stage image builds should succeed\| Optimized image
@@ -866,7 +867,7 @@ tests:
     - ref: openshift-e2e-test
     workflow: openshift-e2e-gcp-ovn
 - as: ocp-e2e-gcp-ovn-multi-day-0-a-x
-  cron: 0 11 * * 0
+  interval: 168h
   steps:
     cluster_profile: openshift-org-gcp
     env:
@@ -893,7 +894,8 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-4
+      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
+      COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance
     workflow: openshift-upgrade-gcp-heterogeneous

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.22.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.22.yaml
@@ -777,7 +777,7 @@ tests:
   steps:
     cluster_profile: openshift-org-gcp
     env:
-      COMPUTE_NODE_TYPE: t2a-standard-4
+      COMPUTE_NODE_TYPE: c4a-standard-4
       OCP_ARCH: arm64
     workflow: openshift-e2e-gcp-ovn
 - as: ocp-e2e-gcp-ovn-multi-x-x-to-a-x
@@ -786,7 +786,7 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       MIGRATION_CP_MACHINE_TYPE: t2a-standard-4
-      MIGRATION_INFRA_MACHINE_TYPE: t2a-standard-2
+      MIGRATION_INFRA_MACHINE_TYPE: c4a-standard-4
       TEST_SKIPS: deploymentconfigs\| should expose cluster services outside the cluster\|
         FIPS TestFIPS\| Multi-stage image builds should succeed\| Optimized image
         builds should succeed\| build can reference a cluster service\| custom build
@@ -809,7 +809,7 @@ tests:
   steps:
     cluster_profile: openshift-org-gcp
     env:
-      COMPUTE_NODE_TYPE: t2a-standard-4
+      COMPUTE_NODE_TYPE: c4a-standard-4
       MIGRATION_ARCHITECTURE: x86_64
       MIGRATION_CP_MACHINE_TYPE: n2-standard-4
       MIGRATION_INFRA_MACHINE_TYPE: n2-standard-4
@@ -836,7 +836,7 @@ tests:
   steps:
     cluster_profile: openshift-org-gcp
     env:
-      COMPUTE_NODE_TYPE: t2a-standard-4
+      COMPUTE_NODE_TYPE: c4a-standard-4
       OCP_ARCH: arm64
       TEST_TYPE: upgrade-conformance
     workflow: openshift-upgrade-gcp
@@ -846,7 +846,8 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
+      ADDITIONAL_WORKER_DISK_TYPE: hyperdisk-balanced
+      ADDITIONAL_WORKER_VM_TYPE: c4a-standard-4
       COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SKIPS: deploymentconfigs\| should expose cluster services outside the cluster\|
@@ -894,7 +895,8 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
+      ADDITIONAL_WORKER_DISK_TYPE: hyperdisk-balanced
+      ADDITIONAL_WORKER_VM_TYPE: c4a-standard-4
       COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.22.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.22.yaml
@@ -777,7 +777,8 @@ tests:
   steps:
     cluster_profile: openshift-org-gcp
     env:
-      COMPUTE_NODE_TYPE: c4a-standard-4
+      COMPUTE_NODE_TYPE: c4a-standard-2
+      CONTROL_PLANE_NODE_TYPE: c4a-standard-2
       OCP_ARCH: arm64
       ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)
     workflow: openshift-e2e-gcp-ovn
@@ -786,8 +787,8 @@ tests:
   steps:
     cluster_profile: openshift-org-gcp
     env:
-      MIGRATION_CP_MACHINE_TYPE: t2a-standard-4
-      MIGRATION_INFRA_MACHINE_TYPE: c4a-standard-4
+      MIGRATION_CP_MACHINE_TYPE: c4a-standard-2
+      MIGRATION_INFRA_MACHINE_TYPE: c4a-standard-2
       TEST_SKIPS: deploymentconfigs\| should expose cluster services outside the cluster\|
         FIPS TestFIPS\| Multi-stage image builds should succeed\| Optimized image
         builds should succeed\| build can reference a cluster service\| custom build
@@ -811,7 +812,8 @@ tests:
   steps:
     cluster_profile: openshift-org-gcp
     env:
-      COMPUTE_NODE_TYPE: c4a-standard-4
+      COMPUTE_NODE_TYPE: c4a-standard-2
+      CONTROL_PLANE_NODE_TYPE: c4a-standard-2
       MIGRATION_ARCHITECTURE: x86_64
       MIGRATION_CP_MACHINE_TYPE: n2-standard-4
       MIGRATION_INFRA_MACHINE_TYPE: n2-standard-4
@@ -839,7 +841,8 @@ tests:
   steps:
     cluster_profile: openshift-org-gcp
     env:
-      COMPUTE_NODE_TYPE: c4a-standard-4
+      COMPUTE_NODE_TYPE: c4a-standard-2
+      CONTROL_PLANE_NODE_TYPE: c4a-standard-2
       OCP_ARCH: arm64
       TEST_TYPE: upgrade-conformance
       ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)
@@ -851,7 +854,7 @@ tests:
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
       ADDITIONAL_WORKER_DISK_TYPE: hyperdisk-balanced
-      ADDITIONAL_WORKER_VM_TYPE: c4a-standard-4
+      ADDITIONAL_WORKER_VM_TYPE: c4a-standard-2
       COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SKIPS: deploymentconfigs\| should expose cluster services outside the cluster\|
@@ -902,7 +905,7 @@ tests:
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
       ADDITIONAL_WORKER_DISK_TYPE: hyperdisk-balanced
-      ADDITIONAL_WORKER_VM_TYPE: c4a-standard-4
+      ADDITIONAL_WORKER_VM_TYPE: c4a-standard-2
       COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.22.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.22.yaml
@@ -779,9 +779,10 @@ tests:
     env:
       COMPUTE_NODE_TYPE: c4a-standard-4
       OCP_ARCH: arm64
+      ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)
     workflow: openshift-e2e-gcp-ovn
 - as: ocp-e2e-gcp-ovn-multi-x-x-to-a-x
-  interval: 168h
+  interval: 174h
   steps:
     cluster_profile: openshift-org-gcp
     env:
@@ -799,13 +800,14 @@ tests:
         pod should start\| pod sysctls\| build volumes should mount given secrets
         and configmaps into the build pod\| control plane machine set operator should
         not cause an early rollout\| The openshift-image-registry pods
+      ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)
     test:
     - ref: ipi-conf-inframachineset
     - ref: multiarch-migration-machine-type
     - ref: openshift-e2e-test
     workflow: openshift-e2e-gcp-ovn
 - as: ocp-e2e-gcp-ovn-multi-a-a-to-x-a
-  interval: 168h
+  interval: 180h
   steps:
     cluster_profile: openshift-org-gcp
     env:
@@ -826,22 +828,24 @@ tests:
         pod should start\| pod sysctls\| build volumes should mount given secrets
         and configmaps into the build pod\| control plane machine set operator should
         not cause an early rollout\| The openshift-image-registry pods
+      ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)
     test:
     - ref: ipi-conf-inframachineset
     - ref: multiarch-migration-machine-type
     - ref: openshift-e2e-test
     workflow: openshift-e2e-gcp-ovn
 - as: ocp-e2e-upgrade-gcp-ovn-multi-a-a
-  interval: 168h
+  interval: 186h
   steps:
     cluster_profile: openshift-org-gcp
     env:
       COMPUTE_NODE_TYPE: c4a-standard-4
       OCP_ARCH: arm64
       TEST_TYPE: upgrade-conformance
+      ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)
     workflow: openshift-upgrade-gcp
 - as: ocp-e2e-gcp-ovn-multi-x-ax
-  interval: 168h
+  interval: 192h
   steps:
     cluster_profile: openshift-org-gcp
     env:
@@ -863,12 +867,13 @@ tests:
         and configmaps into the build pod\| zstd:chunked Image should successfully
         run date command\| templateinstance readiness test should report ready soon
         after all annotated objects are ready
+      ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)
     test:
     - ref: ipi-install-heterogeneous
     - ref: openshift-e2e-test
     workflow: openshift-e2e-gcp-ovn
 - as: ocp-e2e-gcp-ovn-multi-day-0-a-x
-  interval: 168h
+  interval: 198h
   steps:
     cluster_profile: openshift-org-gcp
     env:
@@ -888,9 +893,10 @@ tests:
         and configmaps into the build pod\| zstd:chunked Image should successfully
         run date command\| templateinstance readiness test should report ready soon
         after all annotated objects are ready
+      ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)
     workflow: openshift-e2e-gcp-ovn
 - as: ocp-e2e-upgrade-gcp-ovn-multi-x-ax
-  interval: 168h
+  interval: 204h
   steps:
     cluster_profile: openshift-org-gcp
     env:
@@ -900,6 +906,7 @@ tests:
       COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance
+      ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)
     workflow: openshift-upgrade-gcp-heterogeneous
 zz_generated_metadata:
   branch: main

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.23-upgrade-from-nightly-4.22.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.23-upgrade-from-nightly-4.22.yaml
@@ -101,7 +101,8 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-4
+      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
+      COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance
     workflow: openshift-upgrade-gcp-heterogeneous

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.23-upgrade-from-nightly-4.22.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.23-upgrade-from-nightly-4.22.yaml
@@ -101,7 +101,8 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
+      ADDITIONAL_WORKER_DISK_TYPE: hyperdisk-balanced
+      ADDITIONAL_WORKER_VM_TYPE: c4a-standard-2
       COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.23-upgrade-from-stable-4.22.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.23-upgrade-from-stable-4.22.yaml
@@ -108,7 +108,8 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-4
+      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
+      COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance
     workflow: openshift-upgrade-gcp-heterogeneous

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.23-upgrade-from-stable-4.22.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.23-upgrade-from-stable-4.22.yaml
@@ -108,7 +108,8 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
+      ADDITIONAL_WORKER_DISK_TYPE: hyperdisk-balanced
+      ADDITIONAL_WORKER_VM_TYPE: c4a-standard-2
       COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.23.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.23.yaml
@@ -735,15 +735,16 @@ tests:
     cluster_profile: openshift-org-aws
     workflow: openshift-upgrade-aws
 - as: ocp-e2e-gcp-ovn-multi-a-a
-  interval: 168h
+  interval: 210h
   steps:
     cluster_profile: openshift-org-gcp
     env:
       COMPUTE_NODE_TYPE: c4a-standard-2
       OCP_ARCH: arm64
+      ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)
     workflow: openshift-e2e-gcp-ovn
 - as: ocp-e2e-gcp-ovn-multi-x-x-to-a-x
-  interval: 168h
+  interval: 216h
   steps:
     cluster_profile: openshift-org-gcp
     env:
@@ -761,6 +762,7 @@ tests:
         pod should start\| pod sysctls\| build volumes should mount given secrets
         and configmaps into the build pod\| control plane machine set operator should
         not cause an early rollout\| The openshift-image-registry pods
+      ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)
     test:
     - ref: ipi-conf-inframachineset
     - ref: multiarch-migration-machine-type
@@ -788,13 +790,14 @@ tests:
         pod should start\| pod sysctls\| build volumes should mount given secrets
         and configmaps into the build pod\| control plane machine set operator should
         not cause an early rollout\| The openshift-image-registry pods
+      ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)
     test:
     - ref: ipi-conf-inframachineset
     - ref: multiarch-migration-machine-type
     - ref: openshift-e2e-test
     workflow: openshift-e2e-gcp-ovn
 - as: ocp-e2e-upgrade-gcp-ovn-multi-a-a
-  interval: 168h
+  interval: 174h
   steps:
     cluster_profile: openshift-org-gcp
     env:
@@ -803,7 +806,7 @@ tests:
       TEST_TYPE: upgrade-conformance
     workflow: openshift-upgrade-gcp
 - as: ocp-e2e-gcp-ovn-multi-x-ax
-  interval: 168h
+  interval: 180h
   steps:
     cluster_profile: openshift-org-gcp
     env:
@@ -825,12 +828,13 @@ tests:
         and configmaps into the build pod\| zstd:chunked Image should successfully
         run date command\| templateinstance readiness test should report ready soon
         after all annotated objects are ready
+      ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)
     test:
     - ref: ipi-install-heterogeneous
     - ref: openshift-e2e-test
     workflow: openshift-e2e-gcp-ovn
 - as: ocp-e2e-gcp-ovn-multi-day-0-a-x
-  interval: 168h
+  interval: 186h
   steps:
     cluster_profile: openshift-org-gcp
     env:
@@ -850,9 +854,10 @@ tests:
         and configmaps into the build pod\| zstd:chunked Image should successfully
         run date command\| templateinstance readiness test should report ready soon
         after all annotated objects are ready
+      ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)
     workflow: openshift-e2e-gcp-ovn
 - as: ocp-e2e-upgrade-gcp-ovn-multi-x-ax
-  interval: 168h
+  interval: 192h
   steps:
     cluster_profile: openshift-org-gcp
     env:
@@ -862,6 +867,7 @@ tests:
       COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance
+      ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)
     workflow: openshift-upgrade-gcp-heterogeneous
 zz_generated_metadata:
   branch: main

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.23.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.23.yaml
@@ -735,7 +735,7 @@ tests:
     cluster_profile: openshift-org-aws
     workflow: openshift-upgrade-aws
 - as: ocp-e2e-gcp-ovn-multi-a-a
-  cron: 0 11 * * 0
+  interval: 168h
   steps:
     cluster_profile: openshift-org-gcp
     env:
@@ -748,7 +748,7 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       MIGRATION_CP_MACHINE_TYPE: t2a-standard-4
-      MIGRATION_INFRA_MACHINE_TYPE: t2a-standard-4
+      MIGRATION_INFRA_MACHINE_TYPE: t2a-standard-2
       TEST_SKIPS: deploymentconfigs\| should expose cluster services outside the cluster\|
         FIPS TestFIPS\| Multi-stage image builds should succeed\| Optimized image
         builds should succeed\| build can reference a cluster service\| custom build
@@ -803,12 +803,13 @@ tests:
       TEST_TYPE: upgrade-conformance
     workflow: openshift-upgrade-gcp
 - as: ocp-e2e-gcp-ovn-multi-x-ax
-  cron: 0 11 * * 0
+  interval: 168h
   steps:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-4
+      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
+      COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SKIPS: deploymentconfigs\| should expose cluster services outside the cluster\|
         FIPS TestFIPS\| Multi-stage image builds should succeed\| Optimized image
@@ -828,7 +829,7 @@ tests:
     - ref: openshift-e2e-test
     workflow: openshift-e2e-gcp-ovn
 - as: ocp-e2e-gcp-ovn-multi-day-0-a-x
-  cron: 0 11 * * 0
+  interval: 168h
   steps:
     cluster_profile: openshift-org-gcp
     env:
@@ -855,7 +856,8 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-4
+      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
+      COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance
     workflow: openshift-upgrade-gcp-heterogeneous

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.23.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.23.yaml
@@ -739,7 +739,7 @@ tests:
   steps:
     cluster_profile: openshift-org-gcp
     env:
-      COMPUTE_NODE_TYPE: t2a-standard-4
+      COMPUTE_NODE_TYPE: c4a-standard-2
       OCP_ARCH: arm64
     workflow: openshift-e2e-gcp-ovn
 - as: ocp-e2e-gcp-ovn-multi-x-x-to-a-x
@@ -748,7 +748,7 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       MIGRATION_CP_MACHINE_TYPE: t2a-standard-4
-      MIGRATION_INFRA_MACHINE_TYPE: t2a-standard-2
+      MIGRATION_INFRA_MACHINE_TYPE: c4a-standard-2
       TEST_SKIPS: deploymentconfigs\| should expose cluster services outside the cluster\|
         FIPS TestFIPS\| Multi-stage image builds should succeed\| Optimized image
         builds should succeed\| build can reference a cluster service\| custom build
@@ -771,7 +771,7 @@ tests:
   steps:
     cluster_profile: openshift-org-gcp
     env:
-      COMPUTE_NODE_TYPE: t2a-standard-4
+      COMPUTE_NODE_TYPE: c4a-standard-2
       MIGRATION_ARCHITECTURE: x86_64
       MIGRATION_CP_MACHINE_TYPE: n2-standard-4
       MIGRATION_INFRA_MACHINE_TYPE: n2-standard-4
@@ -798,7 +798,7 @@ tests:
   steps:
     cluster_profile: openshift-org-gcp
     env:
-      COMPUTE_NODE_TYPE: t2a-standard-4
+      COMPUTE_NODE_TYPE: c4a-standard-2
       OCP_ARCH: arm64
       TEST_TYPE: upgrade-conformance
     workflow: openshift-upgrade-gcp
@@ -808,7 +808,8 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
+      ADDITIONAL_WORKER_DISK_TYPE: hyperdisk-balanced
+      ADDITIONAL_WORKER_VM_TYPE: c4a-standard-2
       COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SKIPS: deploymentconfigs\| should expose cluster services outside the cluster\|
@@ -856,7 +857,8 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
+      ADDITIONAL_WORKER_DISK_TYPE: hyperdisk-balanced
+      ADDITIONAL_WORKER_VM_TYPE: c4a-standard-2
       COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.23.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.23.yaml
@@ -740,6 +740,7 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       COMPUTE_NODE_TYPE: c4a-standard-2
+      CONTROL_PLANE_NODE_TYPE: c4a-standard-2
       OCP_ARCH: arm64
       ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)
     workflow: openshift-e2e-gcp-ovn
@@ -748,7 +749,7 @@ tests:
   steps:
     cluster_profile: openshift-org-gcp
     env:
-      MIGRATION_CP_MACHINE_TYPE: t2a-standard-4
+      MIGRATION_CP_MACHINE_TYPE: c4a-standard-2
       MIGRATION_INFRA_MACHINE_TYPE: c4a-standard-2
       TEST_SKIPS: deploymentconfigs\| should expose cluster services outside the cluster\|
         FIPS TestFIPS\| Multi-stage image builds should succeed\| Optimized image
@@ -774,6 +775,7 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       COMPUTE_NODE_TYPE: c4a-standard-2
+      CONTROL_PLANE_NODE_TYPE: c4a-standard-2
       MIGRATION_ARCHITECTURE: x86_64
       MIGRATION_CP_MACHINE_TYPE: n2-standard-4
       MIGRATION_INFRA_MACHINE_TYPE: n2-standard-4
@@ -802,8 +804,10 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       COMPUTE_NODE_TYPE: c4a-standard-2
+      CONTROL_PLANE_NODE_TYPE: c4a-standard-2
       OCP_ARCH: arm64
       TEST_TYPE: upgrade-conformance
+      ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)
     workflow: openshift-upgrade-gcp
 - as: ocp-e2e-gcp-ovn-multi-x-ax
   interval: 180h

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-5.0-upgrade-from-nightly-4.22.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-5.0-upgrade-from-nightly-4.22.yaml
@@ -101,7 +101,8 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-4
+      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
+      COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance
     workflow: openshift-upgrade-gcp-heterogeneous

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-5.0-upgrade-from-nightly-4.22.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-5.0-upgrade-from-nightly-4.22.yaml
@@ -101,7 +101,7 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
+      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-4
       COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-5.0-upgrade-from-stable-4.22.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-5.0-upgrade-from-stable-4.22.yaml
@@ -108,7 +108,7 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
+      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-4
       COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-5.0-upgrade-from-stable-4.22.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-5.0-upgrade-from-stable-4.22.yaml
@@ -108,7 +108,8 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-4
+      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
+      COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance
     workflow: openshift-upgrade-gcp-heterogeneous

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-5.0.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-5.0.yaml
@@ -713,15 +713,16 @@ tests:
     cluster_profile: openshift-org-aws
     workflow: openshift-upgrade-aws
 - as: ocp-e2e-gcp-ovn-multi-a-a
-  interval: 168h
+  interval: 198h
   steps:
     cluster_profile: openshift-org-gcp
     env:
       COMPUTE_NODE_TYPE: t2a-standard-4
       OCP_ARCH: arm64
+      ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)
     workflow: openshift-e2e-gcp-ovn
 - as: ocp-e2e-gcp-ovn-multi-x-x-to-a-x
-  interval: 168h
+  interval: 204h
   steps:
     cluster_profile: openshift-org-gcp
     env:
@@ -739,13 +740,14 @@ tests:
         pod should start\| pod sysctls\| build volumes should mount given secrets
         and configmaps into the build pod\| control plane machine set operator should
         not cause an early rollout\| The openshift-image-registry pods
+      ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)
     test:
     - ref: ipi-conf-inframachineset
     - ref: multiarch-migration-machine-type
     - ref: openshift-e2e-test
     workflow: openshift-e2e-gcp-ovn
 - as: ocp-e2e-gcp-ovn-multi-a-a-to-x-a
-  interval: 168h
+  interval: 210h
   steps:
     cluster_profile: openshift-org-gcp
     env:
@@ -766,19 +768,21 @@ tests:
         pod should start\| pod sysctls\| build volumes should mount given secrets
         and configmaps into the build pod\| control plane machine set operator should
         not cause an early rollout\| The openshift-image-registry pods
+      ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)
     test:
     - ref: ipi-conf-inframachineset
     - ref: multiarch-migration-machine-type
     - ref: openshift-e2e-test
     workflow: openshift-e2e-gcp-ovn
 - as: ocp-e2e-upgrade-gcp-ovn-multi-a-a
-  interval: 168h
+  interval: 216h
   steps:
     cluster_profile: openshift-org-gcp
     env:
       COMPUTE_NODE_TYPE: t2a-standard-4
       OCP_ARCH: arm64
       TEST_TYPE: upgrade-conformance
+      ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)
     workflow: openshift-upgrade-gcp
 - as: ocp-e2e-gcp-ovn-multi-x-ax
   interval: 168h
@@ -802,12 +806,13 @@ tests:
         and configmaps into the build pod\| zstd:chunked Image should successfully
         run date command\| templateinstance readiness test should report ready soon
         after all annotated objects are ready
+      ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)
     test:
     - ref: ipi-install-heterogeneous
     - ref: openshift-e2e-test
     workflow: openshift-e2e-gcp-ovn
 - as: ocp-e2e-gcp-ovn-multi-day-0-a-x
-  interval: 168h
+  interval: 174h
   steps:
     cluster_profile: openshift-org-gcp
     env:
@@ -827,9 +832,10 @@ tests:
         and configmaps into the build pod\| zstd:chunked Image should successfully
         run date command\| templateinstance readiness test should report ready soon
         after all annotated objects are ready
+      ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)
     workflow: openshift-e2e-gcp-ovn
 - as: ocp-e2e-upgrade-gcp-ovn-multi-x-ax
-  interval: 168h
+  interval: 180h
   steps:
     cluster_profile: openshift-org-gcp
     env:
@@ -838,6 +844,7 @@ tests:
       COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance
+      ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)
     workflow: openshift-upgrade-gcp-heterogeneous
 zz_generated_metadata:
   branch: main

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-5.0.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-5.0.yaml
@@ -790,6 +790,7 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
+      ADDITIONAL_WORKER_DISK_TYPE: pd-standard
       ADDITIONAL_WORKER_VM_TYPE: t2a-standard-4
       COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-5.0.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-5.0.yaml
@@ -726,7 +726,7 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       MIGRATION_CP_MACHINE_TYPE: t2a-standard-4
-      MIGRATION_INFRA_MACHINE_TYPE: t2a-standard-2
+      MIGRATION_INFRA_MACHINE_TYPE: t2a-standard-4
       TEST_SKIPS: deploymentconfigs\| should expose cluster services outside the cluster\|
         FIPS TestFIPS\| Multi-stage image builds should succeed\| Optimized image
         builds should succeed\| build can reference a cluster service\| custom build
@@ -786,7 +786,7 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
+      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-4
       COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SKIPS: deploymentconfigs\| should expose cluster services outside the cluster\|
@@ -834,7 +834,7 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
+      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-4
       COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-5.0.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-5.0.yaml
@@ -713,7 +713,7 @@ tests:
     cluster_profile: openshift-org-aws
     workflow: openshift-upgrade-aws
 - as: ocp-e2e-gcp-ovn-multi-a-a
-  cron: 0 11 * * 0
+  interval: 168h
   steps:
     cluster_profile: openshift-org-gcp
     env:
@@ -726,7 +726,7 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       MIGRATION_CP_MACHINE_TYPE: t2a-standard-4
-      MIGRATION_INFRA_MACHINE_TYPE: t2a-standard-4
+      MIGRATION_INFRA_MACHINE_TYPE: t2a-standard-2
       TEST_SKIPS: deploymentconfigs\| should expose cluster services outside the cluster\|
         FIPS TestFIPS\| Multi-stage image builds should succeed\| Optimized image
         builds should succeed\| build can reference a cluster service\| custom build
@@ -781,12 +781,13 @@ tests:
       TEST_TYPE: upgrade-conformance
     workflow: openshift-upgrade-gcp
 - as: ocp-e2e-gcp-ovn-multi-x-ax
-  cron: 0 11 * * 0
+  interval: 168h
   steps:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-4
+      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
+      COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SKIPS: deploymentconfigs\| should expose cluster services outside the cluster\|
         FIPS TestFIPS\| Multi-stage image builds should succeed\| Optimized image
@@ -806,7 +807,7 @@ tests:
     - ref: openshift-e2e-test
     workflow: openshift-e2e-gcp-ovn
 - as: ocp-e2e-gcp-ovn-multi-day-0-a-x
-  cron: 0 11 * * 0
+  interval: 168h
   steps:
     cluster_profile: openshift-org-gcp
     env:
@@ -833,7 +834,8 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-4
+      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
+      COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance
     workflow: openshift-upgrade-gcp-heterogeneous

--- a/ci-operator/jobs/openshift/multiarch/openshift-multiarch-main-periodics.yaml
+++ b/ci-operator/jobs/openshift/multiarch/openshift-multiarch-main-periodics.yaml
@@ -32501,7 +32501,7 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 168h
+  interval: 180h
   labels:
     ci-operator.openshift.io/cloud: gcp
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -32584,7 +32584,7 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 168h
+  interval: 174h
   labels:
     ci-operator.openshift.io/cloud: gcp
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -37586,7 +37586,7 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 168h
+  interval: 186h
   labels:
     ci-operator.openshift.io/cloud: gcp
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -37752,7 +37752,7 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 168h
+  interval: 198h
   labels:
     ci-operator.openshift.io/cloud: gcp
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -37835,7 +37835,7 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 168h
+  interval: 192h
   labels:
     ci-operator.openshift.io/cloud: gcp
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -43088,7 +43088,7 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 168h
+  interval: 204h
   labels:
     ci-operator.openshift.io/cloud: gcp
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -43254,7 +43254,7 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 168h
+  interval: 216h
   labels:
     ci-operator.openshift.io/cloud: gcp
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -43337,7 +43337,7 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 168h
+  interval: 210h
   labels:
     ci-operator.openshift.io/cloud: gcp
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -48590,7 +48590,7 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 168h
+  interval: 180h
   labels:
     ci-operator.openshift.io/cloud: gcp
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -48673,7 +48673,7 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 168h
+  interval: 198h
   labels:
     ci-operator.openshift.io/cloud: gcp
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -48756,7 +48756,7 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 168h
+  interval: 192h
   labels:
     ci-operator.openshift.io/cloud: gcp
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -48839,7 +48839,7 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 168h
+  interval: 174h
   labels:
     ci-operator.openshift.io/cloud: gcp
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -51182,7 +51182,7 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 168h
+  interval: 186h
   labels:
     ci-operator.openshift.io/cloud: gcp
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -51265,7 +51265,7 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 168h
+  interval: 204h
   labels:
     ci-operator.openshift.io/cloud: gcp
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -54346,7 +54346,7 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 168h
+  interval: 210h
   labels:
     ci-operator.openshift.io/cloud: gcp
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -54512,7 +54512,7 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 168h
+  interval: 186h
   labels:
     ci-operator.openshift.io/cloud: gcp
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -54595,7 +54595,7 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 168h
+  interval: 180h
   labels:
     ci-operator.openshift.io/cloud: gcp
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -54678,7 +54678,7 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 168h
+  interval: 216h
   labels:
     ci-operator.openshift.io/cloud: gcp
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -56853,7 +56853,7 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 168h
+  interval: 174h
   labels:
     ci-operator.openshift.io/cloud: gcp
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -56936,7 +56936,7 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 168h
+  interval: 192h
   labels:
     ci-operator.openshift.io/cloud: gcp
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -61527,7 +61527,7 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 168h
+  interval: 198h
   labels:
     ci-operator.openshift.io/cloud: gcp
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -61610,7 +61610,7 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 168h
+  interval: 210h
   labels:
     ci-operator.openshift.io/cloud: gcp
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -61693,7 +61693,7 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 168h
+  interval: 174h
   labels:
     ci-operator.openshift.io/cloud: gcp
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -61859,7 +61859,7 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 168h
+  interval: 204h
   labels:
     ci-operator.openshift.io/cloud: gcp
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -63866,7 +63866,7 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 168h
+  interval: 216h
   labels:
     ci-operator.openshift.io/cloud: gcp
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -63949,7 +63949,7 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 168h
+  interval: 180h
   labels:
     ci-operator.openshift.io/cloud: gcp
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp

--- a/ci-operator/jobs/openshift/multiarch/openshift-multiarch-main-periodics.yaml
+++ b/ci-operator/jobs/openshift/multiarch/openshift-multiarch-main-periodics.yaml
@@ -32411,7 +32411,6 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
-  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -32419,6 +32418,7 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
+  interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -32494,7 +32494,6 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
-  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -32502,6 +32501,7 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
+  interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -32577,7 +32577,6 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
-  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -32585,6 +32584,7 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
+  interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -37579,7 +37579,6 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
-  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -37587,6 +37586,7 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
+  interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -37745,7 +37745,6 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
-  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -37753,6 +37752,7 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
+  interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -37828,7 +37828,6 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
-  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -37836,6 +37835,7 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
+  interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -43081,7 +43081,6 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
-  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -43089,6 +43088,7 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
+  interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -43247,7 +43247,6 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
-  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -43255,6 +43254,7 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
+  interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -43330,7 +43330,6 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
-  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -43338,6 +43337,7 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
+  interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -48500,7 +48500,6 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
-  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -48508,6 +48507,7 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
+  interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -48666,7 +48666,6 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
-  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -48674,6 +48673,7 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
+  interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -48749,7 +48749,6 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
-  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -48757,6 +48756,7 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
+  interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -54339,7 +54339,6 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
-  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -54347,6 +54346,7 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
+  interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -54505,7 +54505,6 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
-  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -54513,6 +54512,7 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
+  interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -54588,7 +54588,6 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
-  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -54596,6 +54595,7 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
+  interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -61520,7 +61520,6 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
-  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -61528,6 +61527,7 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
+  interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -61686,7 +61686,6 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
-  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -61694,6 +61693,7 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
+  interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -61769,7 +61769,6 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
-  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -61777,6 +61776,7 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
+  interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp

--- a/ci-operator/step-registry/ipi/conf/gcp/zones/ipi-conf-gcp-zones-commands.sh
+++ b/ci-operator/step-registry/ipi/conf/gcp/zones/ipi-conf-gcp-zones-commands.sh
@@ -15,6 +15,7 @@ echo "$(date -u --rfc-3339=seconds) - INFO: COMPUTE_ZONES '${COMPUTE_ZONES}'"
 echo "$(date -u --rfc-3339=seconds) - INFO: COMPUTE_NODE_TYPE '${COMPUTE_NODE_TYPE}'"
 echo "$(date -u --rfc-3339=seconds) - INFO: CONTROL_PLANE_ZONES '${CONTROL_PLANE_ZONES}'"
 echo "$(date -u --rfc-3339=seconds) - INFO: CONTROL_PLANE_NODE_TYPE '${CONTROL_PLANE_NODE_TYPE}'"
+echo "$(date -u --rfc-3339=seconds) - INFO: ADDITIONAL_WORKER_VM_TYPE '${ADDITIONAL_WORKER_VM_TYPE}'"
 
 function get_zones_from_region() {
   # shellcheck disable=SC2178
@@ -177,6 +178,26 @@ if [[ -z "${CONTROL_PLANE_ZONES}" ]]; then
   fi
   echo "$(date -u --rfc-3339=seconds) - INFO: As a temporary workaround of https://redhat.atlassian.net/browse/OCPBUGS-78431, ensure the zones of compute & controlPlane machines are the same"
   array_intersection_or_fallback CANDIDATE_ZONES_ARRAY ZONES_ARRAY2
+fi
+
+# For heterogeneous clusters, also constrain zones based on additional worker machine type
+if [[ -n "${ADDITIONAL_WORKER_VM_TYPE}" ]]; then
+  echo "$(date -u --rfc-3339=seconds) - INFO: ADDITIONAL_WORKER_VM_TYPE specified, getting zones supporting '${ADDITIONAL_WORKER_VM_TYPE}'"
+  ZONES_ARRAY3=()
+  get_zones_by_machine_type "${ADDITIONAL_WORKER_VM_TYPE}" ZONES_ARRAY3
+
+  if [[ ${#ZONES_ARRAY3[@]} -eq 0 ]]; then
+    echo "$(date -u --rfc-3339=seconds) - ERROR: No zones found supporting additional worker machine type '${ADDITIONAL_WORKER_VM_TYPE}' in region ${GCP_REGION}"
+    exit 1
+  fi
+
+  echo "$(date -u --rfc-3339=seconds) - INFO: For heterogeneous clusters, restrict zones to those supporting all machine types"
+  array_intersection_or_fallback CANDIDATE_ZONES_ARRAY ZONES_ARRAY3
+
+  if [[ ${#CANDIDATE_ZONES_ARRAY[@]} -eq 0 ]]; then
+    echo "$(date -u --rfc-3339=seconds) - ERROR: No common zones support all machine types (compute: ${MACHINE_TYPE1}, control-plane: ${MACHINE_TYPE2}, additional: ${ADDITIONAL_WORKER_VM_TYPE})"
+    exit 1
+  fi
 fi
 
 if [[ ${#CANDIDATE_ZONES_ARRAY[@]} -gt 0 ]]; then

--- a/ci-operator/step-registry/ipi/conf/gcp/zones/ipi-conf-gcp-zones-commands.sh
+++ b/ci-operator/step-registry/ipi/conf/gcp/zones/ipi-conf-gcp-zones-commands.sh
@@ -181,7 +181,22 @@ if [[ -z "${CONTROL_PLANE_ZONES}" ]]; then
 fi
 
 # For heterogeneous clusters, also constrain zones based on additional worker machine type
-if [[ -n "${ADDITIONAL_WORKER_VM_TYPE}" ]]; then
+# Only apply this logic for OCP 4.17+ to avoid changing behavior of older releases
+is_version_gte_4_17() {
+  if command -v oc &> /dev/null && command -v openshift-install &> /dev/null; then
+    local release_image ocp_version
+    release_image="$(openshift-install version | sed -n 's/^release image\s\+\(.*\)$/\1/p' | tr -d '\n')"
+    ocp_version="$(oc adm release info "$release_image" -o json | jq -r '.metadata.version' | tr -d '\n')"
+    echo "$(date -u --rfc-3339=seconds) - INFO: Detected OCP version: ${ocp_version}"
+    printf '%s\n%s' "4.17" "$ocp_version" | sort -C -V
+  else
+    # If we can't detect version, assume it's new enough
+    echo "$(date -u --rfc-3339=seconds) - WARNING: Cannot detect OCP version, assuming >= 4.17"
+    return 0
+  fi
+}
+
+if [[ -n "${ADDITIONAL_WORKER_VM_TYPE}" ]] && is_version_gte_4_17; then
   echo "$(date -u --rfc-3339=seconds) - INFO: ADDITIONAL_WORKER_VM_TYPE specified, getting zones supporting '${ADDITIONAL_WORKER_VM_TYPE}'"
   ZONES_ARRAY3=()
   get_zones_by_machine_type "${ADDITIONAL_WORKER_VM_TYPE}" ZONES_ARRAY3
@@ -198,6 +213,8 @@ if [[ -n "${ADDITIONAL_WORKER_VM_TYPE}" ]]; then
     echo "$(date -u --rfc-3339=seconds) - ERROR: No common zones support all machine types (compute: ${MACHINE_TYPE1}, control-plane: ${MACHINE_TYPE2}, additional: ${ADDITIONAL_WORKER_VM_TYPE})"
     exit 1
   fi
+elif [[ -n "${ADDITIONAL_WORKER_VM_TYPE}" ]]; then
+  echo "$(date -u --rfc-3339=seconds) - INFO: ADDITIONAL_WORKER_VM_TYPE specified but OCP version < 4.17, skipping zone intersection logic"
 fi
 
 if [[ ${#CANDIDATE_ZONES_ARRAY[@]} -gt 0 ]]; then

--- a/ci-operator/step-registry/ipi/conf/gcp/zones/ipi-conf-gcp-zones-ref.yaml
+++ b/ci-operator/step-registry/ipi/conf/gcp/zones/ipi-conf-gcp-zones-ref.yaml
@@ -32,5 +32,9 @@ ref:
     default: ""
     documentation: |-
       Set zones for control-plane nodes according to the node type.
+  - name: ADDITIONAL_WORKER_VM_TYPE
+    default: ""
+    documentation: |-
+      For heterogeneous clusters, restrict zones to those supporting the additional worker machine type (e.g. ARM instances).
   documentation: |-
     The IPI configure step updates install-config.yaml with the controlPlane & compute zones settings according to the specified zone(s), or machine type(s).

--- a/ci-operator/step-registry/ipi/install/heterogeneous/ipi-install-heterogeneous-commands.sh
+++ b/ci-operator/step-registry/ipi/install/heterogeneous/ipi-install-heterogeneous-commands.sh
@@ -192,8 +192,14 @@ fi
 EXPECTED_NODES=$(( $(get_ready_nodes_count) + ADDITIONAL_WORKERS ))
 
 #there will be two kind of machinesets when cluster-api is enabled, using full name to get the correct machinesets
+# Count worker machinesets and randomly select one to distribute load across zones
+WORKER_MACHINESET_COUNT=$(oc -n openshift-machine-api get machinesets.machine.openshift.io -o yaml | \
+  yq-v4 '[.items[] | select(.spec.template.metadata.labels["machine.openshift.io/cluster-api-machine-role"] == "worker")] | length')
+RANDOM_INDEX=$(( RANDOM % WORKER_MACHINESET_COUNT ))
+echo "Found ${WORKER_MACHINESET_COUNT} worker machinesets, randomly selected index ${RANDOM_INDEX} to avoid zone capacity issues"
+
 MACHINE_SET=$(oc -n openshift-machine-api get -o yaml machinesets.machine.openshift.io | yq-v4 "$(cat <<EOF
-  [.items[] | select(.spec.template.metadata.labels["machine.openshift.io/cluster-api-machine-role"] == "worker")][0]
+  [.items[] | select(.spec.template.metadata.labels["machine.openshift.io/cluster-api-machine-role"] == "worker")][${RANDOM_INDEX}]
   | .metadata.name += "-additional"
   | .spec.replicas = ${ADDITIONAL_WORKERS}
   | .spec.selector.matchLabels."machine.openshift.io/cluster-api-machineset" = .metadata.name
@@ -373,6 +379,12 @@ EOF
   MACHINE_SET=$(yq-v4 ".spec.template.spec.providerSpec.value.machineType = \"${ADDITIONAL_WORKER_VM_TYPE}\"
                      | .spec.template.spec.providerSpec.value.disks[0].image = \"projects/$workers_addi_rhcos_image_project/global/images/$workers_addi_rhcos_image_name\"
               " <<< "${MACHINE_SET}")
+
+  # Set disk type if ADDITIONAL_WORKER_DISK_TYPE is specified
+  if [[ -n "${ADDITIONAL_WORKER_DISK_TYPE}" ]]; then
+    echo "Setting disk type to ${ADDITIONAL_WORKER_DISK_TYPE} for additional workers..."
+    MACHINE_SET=$(yq-v4 ".spec.template.spec.providerSpec.value.disks[0].type = \"${ADDITIONAL_WORKER_DISK_TYPE}\"" <<< "${MACHINE_SET}")
+  fi
 ;;
 *ibmcloud*)
   FULL_CLUSTER_NAME=$(yq-v4 '.metadata.labels."machine.openshift.io/cluster-api-cluster"' <<< $MACHINE_SET)

--- a/ci-operator/step-registry/ipi/install/heterogeneous/ipi-install-heterogeneous-commands.sh
+++ b/ci-operator/step-registry/ipi/install/heterogeneous/ipi-install-heterogeneous-commands.sh
@@ -195,6 +195,10 @@ EXPECTED_NODES=$(( $(get_ready_nodes_count) + ADDITIONAL_WORKERS ))
 # Count worker machinesets and randomly select one to distribute load across zones
 WORKER_MACHINESET_COUNT=$(oc -n openshift-machine-api get machinesets.machine.openshift.io -o yaml | \
   yq-v4 '[.items[] | select(.spec.template.metadata.labels["machine.openshift.io/cluster-api-machine-role"] == "worker")] | length')
+if (( WORKER_MACHINESET_COUNT == 0 )); then
+  echo >&2 "Error: No worker machinesets found in cluster"
+  exit 1
+fi
 RANDOM_INDEX=$(( RANDOM % WORKER_MACHINESET_COUNT ))
 echo "Found ${WORKER_MACHINESET_COUNT} worker machinesets, randomly selected index ${RANDOM_INDEX} to avoid zone capacity issues"
 

--- a/ci-operator/step-registry/ipi/install/heterogeneous/ipi-install-heterogeneous-ref.yaml
+++ b/ci-operator/step-registry/ipi/install/heterogeneous/ipi-install-heterogeneous-ref.yaml
@@ -20,6 +20,9 @@ ref:
   - name: ADDITIONAL_WORKER_VM_TYPE
     default: "m6g.xlarge"
     documentation: "VM Instance type for Heterogeneous worker, default set to arm64 instance type"
+  - name: ADDITIONAL_WORKER_DISK_TYPE
+    default: ""
+    documentation: "Disk type for additional heterogeneous workers. If empty, the disk type from the base machineset will be used."
   - name: CLOUD_TYPE
     default: "aws"
     documentation: |-


### PR DESCRIPTION
This change further addresses GCP ARM instance capacity exhaustion by
    distributing different instance types across releases 4.21, 4.22, 4.23,
    and 5.0, eliminating quota competition between releases.
    
    Problem:
    - GCP multi-arch jobs failing with "verify all machines should be in Running state"
    - Machines stuck in PROVISIONING for ~32s, then "Instance not found on provider"
    - Previous mitigation (a8311b93361) implemented zone randomization and scheduling
      distribution, but all 4 releases still competed for the same T2A quota
    - Multiple releases requesting t2a-standard-4 or t2a-standard-2 simultaneously
      exhausted available quota in us-central1 region
    
    1. Release 4.21: T2A standard-2 (smallest T2A, best availability)
       - COMPUTE_NODE_TYPE: t2a-standard-2
       - ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
       - MIGRATION_INFRA_MACHINE_TYPE: t2a-standard-4
       - Disk: pd-standard (default, compatible with T2A)
    
    2. Release 4.22: C4A standard-4 (newer Axion generation)
       - COMPUTE_NODE_TYPE: c4a-standard-4
       - ADDITIONAL_WORKER_VM_TYPE: c4a-standard-4
       - ADDITIONAL_WORKER_DISK_TYPE: pd-balanced (required for C4A)
       - MIGRATION_INFRA_MACHINE_TYPE: c4a-standard-4
    
    3. Release 4.23: C4A standard-2 (smallest Axion)
       - COMPUTE_NODE_TYPE: c4a-standard-2
       - ADDITIONAL_WORKER_VM_TYPE: c4a-standard-2
       - ADDITIONAL_WORKER_DISK_TYPE: pd-balanced (required for C4A)
       - MIGRATION_INFRA_MACHINE_TYPE: c4a-standard-2

    4. Release 5.0: T2A standard-4 (larger T2A)
       - COMPUTE_NODE_TYPE: t2a-standard-4
       - ADDITIONAL_WORKER_VM_TYPE: t2a-standard-4
       - MIGRATION_INFRA_MACHINE_TYPE: t2a-standard-4
       - Disk: pd-standard (default, compatible with T2A)
    
    Benefits:
    - Eliminates quota competition between releases (4 separate quota buckets)
    - Reduces "Instance not found on provider" errors
    - Combines with existing zone randomization (from a8311b93361) for maximum distribution
    - Combines with interval scheduling (168h) to prevent simultaneous execution
    - Smaller instances (standard-2) generally have better availability than larger
    - Risk isolation: C4A issues won't affect T2A releases and vice versa
    - Tests both T2A and C4A across multiple OpenShift releases
    - Maintains backward compatibility (T2A with pd-standard for 4.21/5.0)
    - Future-ready: C4A adoption validates Axion processors for newer releases

Notes:
    This commit includes the cherry-pick of work originally authored by @jianlinliu [here](https://github.com/openshift/release/pull/77483)
    The rest of the code changes were generated by claude from direction and review by @barbacbd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reduced GCP VM sizes for multi-arch and heterogeneous test jobs to lower resource usage.
  * Introduced and standardized COMPUTE_NODE_REPLICAS="2" across heterogeneous upgrade workflows.
  * Switched several nightly test schedules from cron to a 168h interval for consistency.
  * Added configurable additional-worker disk type support for heterogeneous installs.
  * Improved additional-worker machineset selection and zone compatibility checks for heterogeneous installs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->