### PR TITLE
NO-JIRA: upkeep: update to reflect package name change in origin

### DIFF
--- a/ci-operator/config/openshift/origin/openshift-origin-main.yaml
+++ b/ci-operator/config/openshift/origin/openshift-origin-main.yaml
@@ -412,7 +412,7 @@ tests:
   capabilities:
   - intranet
   optional: true
-  pipeline_run_if_changed: (baremetal|metal3|ironic)|^(test/extended/two_node)
+  pipeline_run_if_changed: (baremetal|metal3|ironic)|^(test/extended/edge_topologies)
   steps:
     cluster_profile: equinix-edge-enablement
     workflow: baremetalds-two-node-arbiter
@@ -421,7 +421,7 @@ tests:
   capabilities:
   - intranet
   optional: true
-  pipeline_run_if_changed: (baremetal|metal3|ironic)|^(test/extended/two_node)
+  pipeline_run_if_changed: (baremetal|metal3|ironic)|^(test/extended/edge_topologies)
   steps:
     cluster_profile: equinix-edge-enablement
     workflow: baremetalds-two-node-fencing
@@ -430,7 +430,7 @@ tests:
   capabilities:
   - intranet
   optional: true
-  pipeline_run_if_changed: (baremetal|metal3|ironic)|^(test/extended/two_node)
+  pipeline_run_if_changed: (baremetal|metal3|ironic)|^(test/extended/edge_topologies)
   steps:
     cluster_profile: equinix-edge-enablement
     workflow: baremetalds-two-node-fencing-recovery

--- a/ci-operator/config/openshift/origin/openshift-origin-release-4.23.yaml
+++ b/ci-operator/config/openshift/origin/openshift-origin-release-4.23.yaml
@@ -412,7 +412,7 @@ tests:
   capabilities:
   - intranet
   optional: true
-  pipeline_run_if_changed: (baremetal|metal3|ironic)|^(test/extended/two_node)
+  pipeline_run_if_changed: (baremetal|metal3|ironic)|^(test/extended/edge_topologies)
   steps:
     cluster_profile: equinix-edge-enablement
     workflow: baremetalds-two-node-arbiter
@@ -421,7 +421,7 @@ tests:
   capabilities:
   - intranet
   optional: true
-  pipeline_run_if_changed: (baremetal|metal3|ironic)|^(test/extended/two_node)
+  pipeline_run_if_changed: (baremetal|metal3|ironic)|^(test/extended/edge_topologies)
   steps:
     cluster_profile: equinix-edge-enablement
     workflow: baremetalds-two-node-fencing
@@ -430,7 +430,7 @@ tests:
   capabilities:
   - intranet
   optional: true
-  pipeline_run_if_changed: (baremetal|metal3|ironic)|^(test/extended/two_node)
+  pipeline_run_if_changed: (baremetal|metal3|ironic)|^(test/extended/edge_topologies)
   steps:
     cluster_profile: equinix-edge-enablement
     workflow: baremetalds-two-node-fencing-recovery

--- a/ci-operator/config/openshift/origin/openshift-origin-release-5.0.yaml
+++ b/ci-operator/config/openshift/origin/openshift-origin-release-5.0.yaml
@@ -413,7 +413,7 @@ tests:
   capabilities:
   - intranet
   optional: true
-  pipeline_run_if_changed: (baremetal|metal3|ironic)|^(test/extended/two_node)
+  pipeline_run_if_changed: (baremetal|metal3|ironic)|^(test/extended/edge_topologies)
   steps:
     cluster_profile: equinix-edge-enablement
     workflow: baremetalds-two-node-arbiter
@@ -422,7 +422,7 @@ tests:
   capabilities:
   - intranet
   optional: true
-  pipeline_run_if_changed: (baremetal|metal3|ironic)|^(test/extended/two_node)
+  pipeline_run_if_changed: (baremetal|metal3|ironic)|^(test/extended/edge_topologies)
   steps:
     cluster_profile: equinix-edge-enablement
     workflow: baremetalds-two-node-fencing
@@ -431,7 +431,7 @@ tests:
   capabilities:
   - intranet
   optional: true
-  pipeline_run_if_changed: (baremetal|metal3|ironic)|^(test/extended/two_node)
+  pipeline_run_if_changed: (baremetal|metal3|ironic)|^(test/extended/edge_topologies)
   steps:
     cluster_profile: equinix-edge-enablement
     workflow: baremetalds-two-node-fencing-recovery

--- a/ci-operator/jobs/openshift/origin/openshift-origin-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/origin/openshift-origin-main-presubmits.yaml
@@ -5699,7 +5699,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     annotations:
-      pipeline_run_if_changed: (baremetal|metal3|ironic)|^(test/extended/two_node)
+      pipeline_run_if_changed: (baremetal|metal3|ironic)|^(test/extended/edge_topologies)
     branches:
     - ^main$
     - ^main-
@@ -5783,7 +5783,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     annotations:
-      pipeline_run_if_changed: (baremetal|metal3|ironic)|^(test/extended/two_node)
+      pipeline_run_if_changed: (baremetal|metal3|ironic)|^(test/extended/edge_topologies)
     branches:
     - ^main$
     - ^main-
@@ -5867,7 +5867,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     annotations:
-      pipeline_run_if_changed: (baremetal|metal3|ironic)|^(test/extended/two_node)
+      pipeline_run_if_changed: (baremetal|metal3|ironic)|^(test/extended/edge_topologies)
     branches:
     - ^main$
     - ^main-

--- a/ci-operator/jobs/openshift/origin/openshift-origin-release-4.23-presubmits.yaml
+++ b/ci-operator/jobs/openshift/origin/openshift-origin-release-4.23-presubmits.yaml
@@ -5699,7 +5699,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     annotations:
-      pipeline_run_if_changed: (baremetal|metal3|ironic)|^(test/extended/two_node)
+      pipeline_run_if_changed: (baremetal|metal3|ironic)|^(test/extended/edge_topologies)
     branches:
     - ^release-4\.23$
     - ^release-4\.23-
@@ -5783,7 +5783,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     annotations:
-      pipeline_run_if_changed: (baremetal|metal3|ironic)|^(test/extended/two_node)
+      pipeline_run_if_changed: (baremetal|metal3|ironic)|^(test/extended/edge_topologies)
     branches:
     - ^release-4\.23$
     - ^release-4\.23-
@@ -5867,7 +5867,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     annotations:
-      pipeline_run_if_changed: (baremetal|metal3|ironic)|^(test/extended/two_node)
+      pipeline_run_if_changed: (baremetal|metal3|ironic)|^(test/extended/edge_topologies)
     branches:
     - ^release-4\.23$
     - ^release-4\.23-

--- a/ci-operator/jobs/openshift/origin/openshift-origin-release-5.0-presubmits.yaml
+++ b/ci-operator/jobs/openshift/origin/openshift-origin-release-5.0-presubmits.yaml
@@ -5699,7 +5699,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     annotations:
-      pipeline_run_if_changed: (baremetal|metal3|ironic)|^(test/extended/two_node)
+      pipeline_run_if_changed: (baremetal|metal3|ironic)|^(test/extended/edge_topologies)
     branches:
     - ^release-5\.0$
     - ^release-5\.0-
@@ -5783,7 +5783,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     annotations:
-      pipeline_run_if_changed: (baremetal|metal3|ironic)|^(test/extended/two_node)
+      pipeline_run_if_changed: (baremetal|metal3|ironic)|^(test/extended/edge_topologies)
     branches:
     - ^release-5\.0$
     - ^release-5\.0-
@@ -5867,7 +5867,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     annotations:
-      pipeline_run_if_changed: (baremetal|metal3|ironic)|^(test/extended/two_node)
+      pipeline_run_if_changed: (baremetal|metal3|ironic)|^(test/extended/edge_topologies)
     branches:
     - ^release-5\.0$
     - ^release-5\.0-


### PR DESCRIPTION
in origin we are updating the package name form two_node to edge_topologies, this updates the trigger regex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline triggers for metal and edge topology tests across multiple release branches (main, 4.23, and 5.0) to detect changes in the correct test directory, ensuring automated testing infrastructure responds appropriately to test code updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->