### PR TITLE
OTA-1962: ci-operator/config/openshift/cluster-version-operator: Build cluster-update-lightspeed-skills

### DIFF
--- a/ci-operator/config/openshift/cluster-version-operator/openshift-cluster-version-operator-main.yaml
+++ b/ci-operator/config/openshift/cluster-version-operator/openshift-cluster-version-operator-main.yaml
@@ -25,6 +25,9 @@ images:
   items:
   - dockerfile_path: Dockerfile.rhel
     to: cluster-version-operator
+  - context_dir: lightspeed
+    dockerfile_path: Containerfile.skills
+    to: cluster-update-lightspeed-skills
 promotion:
   to:
   - name: "5.0"


### PR DESCRIPTION
Catching up with openshift/cluster-version-operator@97f8588285 (openshift/cluster-version-operator#1376).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new image build configuration for the cluster update component, introducing an additional build variant.
  * Publishes the new image variant while keeping existing promotion targets, releases, resources, and tests unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->