### PR TITLE
Change close command to 'close not-planned' for rotten

### DIFF
--- a/ci-operator/jobs/infra-periodics.yaml
+++ b/ci-operator/jobs/infra-periodics.yaml
@@ -377,7 +377,7 @@ periodics:
         Mark the issue as fresh by commenting `/remove-lifecycle rotten`.
         Exclude this issue from closing again by commenting `/lifecycle frozen`.
 
-        /close
+        /close not-planned
       - --template
       - --ceiling=10
       - --confirm


### PR DESCRIPTION
Closing as completed is misleading on inactive issues.

Utilizes https://github.com/kubernetes-sigs/prow/commit/b03af6db0cb446e0c83795553901d6f9cd6637ae

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automatic issue closure workflow to mark stale issues as "not-planned" when they are closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->