### PR TITLE
Specifying an ODF channel for it's setup

### DIFF
--- a/ci-operator/config/medik8s/storage-based-remediation/medik8s-storage-based-remediation-main__4.20-sbr-rename.yaml
+++ b/ci-operator/config/medik8s/storage-based-remediation/medik8s-storage-based-remediation-main__4.20-sbr-rename.yaml
@@ -71,7 +71,7 @@ tests:
         unset KUBERNETES_SERVICE_HOST KUBERNETES_SERVICE_PORT
 
         make setup-odf-storage
-        make run-setup-odf-storage-retry
+        ODF_SUBSCRIPTION_CHANNEL="stable-4.20" make run-setup-odf-storage-retry
       from: src
       resources:
         requests:

--- a/ci-operator/config/medik8s/storage-based-remediation/medik8s-storage-based-remediation-main__4.20.yaml
+++ b/ci-operator/config/medik8s/storage-based-remediation/medik8s-storage-based-remediation-main__4.20.yaml
@@ -71,7 +71,7 @@ tests:
         unset KUBERNETES_SERVICE_HOST KUBERNETES_SERVICE_PORT
 
         make setup-odf-storage
-        make run-setup-odf-storage-retry
+        ODF_SUBSCRIPTION_CHANNEL="stable-4.20" make run-setup-odf-storage-retry
       from: src
       resources:
         requests:


### PR DESCRIPTION
Adding a specific channel to odf setup instead of falling back to default one, since we plan to remove the default and make this mandatory .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

[RHWA-761](https://redhat.atlassian.net/browse/RHWA-761)

## Summary by CodeRabbit

* **Chores**
  * Updated test configuration to explicitly specify the storage subscription channel version (stable-4.20) for consistent test environment setup across multiple configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[RHWA-761]: https://redhat.atlassian.net/browse/RHWA-761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ