### PR TITLE
HyperShift-KubeVirt: Fix e2e-kubevirt-aws-ovn-reduced job

### DIFF
--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-main.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-main.yaml
@@ -315,14 +315,17 @@ tests:
   as: e2e-kubevirt-aws-ovn-reduced
   pipeline_skip_if_only_changed: (^(\.tekton|\.github|\.claude|docs|examples|enhancements|contrib|\.cursor)/)|(^[A-Z]+\.md$)|((^|/)OWNERS$)|(/overrides\.yaml$)|(^renovate\.json$)|(/\.testcoverage\.yml$)|(^\.gitlint$)|(^\.gitignore$)|(^\.coderabbit\.yaml$)|(^\.dockerignore$)|(^codecov\.yml$)
   steps:
-    cluster_profile: hypershift-aws
+    cluster_profile: openshift-org-aws
     env:
+      COMPUTE_NODE_REPLICAS: "1"
+      COMPUTE_NODE_TYPE: c5n.metal
+      E2E_TEST_REGEX: ^TestCreateCluster$|TestAutoscaling
       ENABLE_HYPERSHIFT_CERT_ROTATION_SCALE: "true"
       ENABLE_HYPERSHIFT_OPERATOR_DEFAULTING_WEBHOOK: "true"
       ETCD_STORAGE_CLASS: gp3-csi
       KUBEVIRT_CSI_INFRA: gp3-csi
-      SKIP_E2E_LOCAL: "true"
-    workflow: hypershift-kubevirt-e2e-nested
+      RUN_EXTERNAL_INFRA_TEST: "false"
+    workflow: hypershift-kubevirt-e2e-aws
 - always_run: false
   as: e2e-kubevirt-aws-ovn
   optional: true

--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.18.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.18.yaml
@@ -100,14 +100,17 @@ tests:
 - as: e2e-kubevirt-aws-ovn-reduced
   skip_if_only_changed: (^(\.tekton|docs|examples|enhancements|contrib)/)|(^[A-Z]+\.md$)|((^|/)OWNERS$)
   steps:
-    cluster_profile: hypershift-aws
+    cluster_profile: openshift-org-aws
     env:
+      COMPUTE_NODE_REPLICAS: "1"
+      COMPUTE_NODE_TYPE: c5n.metal
+      E2E_TEST_REGEX: ^TestCreateCluster$|TestAutoscaling
       ENABLE_HYPERSHIFT_CERT_ROTATION_SCALE: "true"
       ENABLE_HYPERSHIFT_OPERATOR_DEFAULTING_WEBHOOK: "true"
       ETCD_STORAGE_CLASS: gp3-csi
       KUBEVIRT_CSI_INFRA: gp3-csi
-      SKIP_E2E_LOCAL: "true"
-    workflow: hypershift-kubevirt-e2e-nested
+      RUN_EXTERNAL_INFRA_TEST: "false"
+    workflow: hypershift-kubevirt-e2e-aws
 - always_run: false
   as: e2e-kubevirt-aws-ovn
   optional: true

--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.19.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.19.yaml
@@ -207,14 +207,17 @@ tests:
 - as: e2e-kubevirt-aws-ovn-reduced
   skip_if_only_changed: (^(\.tekton|\.github|docs|examples|enhancements|contrib)/)|(^[A-Z]+\.md$)|((^|/)OWNERS$)|(/overrides\.yaml$)|(/\.testcoverage\.yml$)
   steps:
-    cluster_profile: hypershift-aws
+    cluster_profile: openshift-org-aws
     env:
+      COMPUTE_NODE_REPLICAS: "1"
+      COMPUTE_NODE_TYPE: c5n.metal
+      E2E_TEST_REGEX: ^TestCreateCluster$|TestAutoscaling
       ENABLE_HYPERSHIFT_CERT_ROTATION_SCALE: "true"
       ENABLE_HYPERSHIFT_OPERATOR_DEFAULTING_WEBHOOK: "true"
       ETCD_STORAGE_CLASS: gp3-csi
       KUBEVIRT_CSI_INFRA: gp3-csi
-      SKIP_E2E_LOCAL: "true"
-    workflow: hypershift-kubevirt-e2e-nested
+      RUN_EXTERNAL_INFRA_TEST: "false"
+    workflow: hypershift-kubevirt-e2e-aws
 - always_run: false
   as: e2e-kubevirt-aws-ovn
   optional: true

--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.20.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.20.yaml
@@ -212,14 +212,17 @@ tests:
 - as: e2e-kubevirt-aws-ovn-reduced
   skip_if_only_changed: (^(\.tekton|\.github|docs|examples|enhancements|contrib|\.cursor)/)|(^[A-Z]+\.md$)|((^|/)OWNERS$)|(/overrides\.yaml$)|(^renovate\.json$)|(/\.testcoverage\.yml$)|(^\.gitlint$)|(^\.gitignore$)
   steps:
-    cluster_profile: hypershift-aws
+    cluster_profile: openshift-org-aws
     env:
+      COMPUTE_NODE_REPLICAS: "1"
+      COMPUTE_NODE_TYPE: c5n.metal
+      E2E_TEST_REGEX: ^TestCreateCluster$|TestAutoscaling
       ENABLE_HYPERSHIFT_CERT_ROTATION_SCALE: "true"
       ENABLE_HYPERSHIFT_OPERATOR_DEFAULTING_WEBHOOK: "true"
       ETCD_STORAGE_CLASS: gp3-csi
       KUBEVIRT_CSI_INFRA: gp3-csi
-      SKIP_E2E_LOCAL: "true"
-    workflow: hypershift-kubevirt-e2e-nested
+      RUN_EXTERNAL_INFRA_TEST: "false"
+    workflow: hypershift-kubevirt-e2e-aws
 - always_run: false
   as: e2e-kubevirt-aws-ovn
   optional: true

--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.21.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.21.yaml
@@ -235,14 +235,17 @@ tests:
 - as: e2e-kubevirt-aws-ovn-reduced
   skip_if_only_changed: (^(\.tekton|\.github|\.claude|docs|examples|enhancements|contrib|\.cursor)/)|(^[A-Z]+\.md$)|((^|/)OWNERS$)|(/overrides\.yaml$)|(^renovate\.json$)|(/\.testcoverage\.yml$)|(^\.gitlint$)|(^\.gitignore$)
   steps:
-    cluster_profile: hypershift-aws
+    cluster_profile: openshift-org-aws
     env:
+      COMPUTE_NODE_REPLICAS: "1"
+      COMPUTE_NODE_TYPE: c5n.metal
+      E2E_TEST_REGEX: ^TestCreateCluster$|TestAutoscaling
       ENABLE_HYPERSHIFT_CERT_ROTATION_SCALE: "true"
       ENABLE_HYPERSHIFT_OPERATOR_DEFAULTING_WEBHOOK: "true"
       ETCD_STORAGE_CLASS: gp3-csi
       KUBEVIRT_CSI_INFRA: gp3-csi
-      SKIP_E2E_LOCAL: "true"
-    workflow: hypershift-kubevirt-e2e-nested
+      RUN_EXTERNAL_INFRA_TEST: "false"
+    workflow: hypershift-kubevirt-e2e-aws
 - always_run: false
   as: e2e-kubevirt-aws-ovn
   optional: true

--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.22.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.22.yaml
@@ -296,14 +296,17 @@ tests:
   as: e2e-kubevirt-aws-ovn-reduced
   pipeline_skip_if_only_changed: (^(\.tekton|\.github|\.claude|docs|examples|enhancements|contrib|\.cursor)/)|(^[A-Z]+\.md$)|((^|/)OWNERS$)|(/overrides\.yaml$)|(^renovate\.json$)|(/\.testcoverage\.yml$)|(^\.gitlint$)|(^\.gitignore$)|(^\.coderabbit\.yaml$)|(^\.dockerignore$)|(^codecov\.yml$)
   steps:
-    cluster_profile: hypershift-aws
+    cluster_profile: openshift-org-aws
     env:
+      COMPUTE_NODE_REPLICAS: "1"
+      COMPUTE_NODE_TYPE: c5n.metal
+      E2E_TEST_REGEX: ^TestCreateCluster$
       ENABLE_HYPERSHIFT_CERT_ROTATION_SCALE: "true"
       ENABLE_HYPERSHIFT_OPERATOR_DEFAULTING_WEBHOOK: "true"
       ETCD_STORAGE_CLASS: gp3-csi
       KUBEVIRT_CSI_INFRA: gp3-csi
-      SKIP_E2E_LOCAL: "true"
-    workflow: hypershift-kubevirt-e2e-nested
+      RUN_EXTERNAL_INFRA_TEST: "false"
+    workflow: hypershift-kubevirt-e2e-aws
 - always_run: false
   as: e2e-kubevirt-aws-ovn
   optional: true

--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.23.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.23.yaml
@@ -302,14 +302,17 @@ tests:
   as: e2e-kubevirt-aws-ovn-reduced
   pipeline_skip_if_only_changed: (^(\.tekton|\.github|\.claude|docs|examples|enhancements|contrib|\.cursor)/)|(^[A-Z]+\.md$)|((^|/)OWNERS$)|(/overrides\.yaml$)|(^renovate\.json$)|(/\.testcoverage\.yml$)|(^\.gitlint$)|(^\.gitignore$)|(^\.coderabbit\.yaml$)|(^\.dockerignore$)|(^codecov\.yml$)
   steps:
-    cluster_profile: hypershift-aws
+    cluster_profile: openshift-org-aws
     env:
+      COMPUTE_NODE_REPLICAS: "1"
+      COMPUTE_NODE_TYPE: c5n.metal
+      E2E_TEST_REGEX: ^TestCreateCluster$|TestAutoscaling
       ENABLE_HYPERSHIFT_CERT_ROTATION_SCALE: "true"
       ENABLE_HYPERSHIFT_OPERATOR_DEFAULTING_WEBHOOK: "true"
       ETCD_STORAGE_CLASS: gp3-csi
       KUBEVIRT_CSI_INFRA: gp3-csi
-      SKIP_E2E_LOCAL: "true"
-    workflow: hypershift-kubevirt-e2e-nested
+      RUN_EXTERNAL_INFRA_TEST: "false"
+    workflow: hypershift-kubevirt-e2e-aws
 - always_run: false
   as: e2e-kubevirt-aws-ovn
   optional: true

--- a/ci-operator/jobs/openshift/hypershift/openshift-hypershift-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/hypershift/openshift-hypershift-main-presubmits.yaml
@@ -1561,8 +1561,8 @@ presubmits:
     context: ci/prow/e2e-kubevirt-aws-ovn-reduced
     decorate: true
     labels:
-      ci-operator.openshift.io/cloud: hypershift-aws
-      ci-operator.openshift.io/cloud-cluster-profile: hypershift-aws
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-hypershift-main-e2e-kubevirt-aws-ovn-reduced

--- a/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.18-presubmits.yaml
+++ b/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.18-presubmits.yaml
@@ -332,8 +332,8 @@ presubmits:
     context: ci/prow/e2e-kubevirt-aws-ovn-reduced
     decorate: true
     labels:
-      ci-operator.openshift.io/cloud: hypershift-aws
-      ci-operator.openshift.io/cloud-cluster-profile: hypershift-aws
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-hypershift-release-4.18-e2e-kubevirt-aws-ovn-reduced

--- a/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.19-presubmits.yaml
+++ b/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.19-presubmits.yaml
@@ -901,8 +901,8 @@ presubmits:
     context: ci/prow/e2e-kubevirt-aws-ovn-reduced
     decorate: true
     labels:
-      ci-operator.openshift.io/cloud: hypershift-aws
-      ci-operator.openshift.io/cloud-cluster-profile: hypershift-aws
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-hypershift-release-4.19-e2e-kubevirt-aws-ovn-reduced

--- a/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.20-presubmits.yaml
+++ b/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.20-presubmits.yaml
@@ -1063,8 +1063,8 @@ presubmits:
     context: ci/prow/e2e-kubevirt-aws-ovn-reduced
     decorate: true
     labels:
-      ci-operator.openshift.io/cloud: hypershift-aws
-      ci-operator.openshift.io/cloud-cluster-profile: hypershift-aws
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-hypershift-release-4.20-e2e-kubevirt-aws-ovn-reduced

--- a/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.21-presubmits.yaml
+++ b/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.21-presubmits.yaml
@@ -1144,8 +1144,8 @@ presubmits:
     context: ci/prow/e2e-kubevirt-aws-ovn-reduced
     decorate: true
     labels:
-      ci-operator.openshift.io/cloud: hypershift-aws
-      ci-operator.openshift.io/cloud-cluster-profile: hypershift-aws
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-hypershift-release-4.21-e2e-kubevirt-aws-ovn-reduced

--- a/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.22-presubmits.yaml
@@ -1561,8 +1561,8 @@ presubmits:
     context: ci/prow/e2e-kubevirt-aws-ovn-reduced
     decorate: true
     labels:
-      ci-operator.openshift.io/cloud: hypershift-aws
-      ci-operator.openshift.io/cloud-cluster-profile: hypershift-aws
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-hypershift-release-4.22-e2e-kubevirt-aws-ovn-reduced

--- a/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.23-presubmits.yaml
+++ b/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.23-presubmits.yaml
@@ -1561,8 +1561,8 @@ presubmits:
     context: ci/prow/e2e-kubevirt-aws-ovn-reduced
     decorate: true
     labels:
-      ci-operator.openshift.io/cloud: hypershift-aws
-      ci-operator.openshift.io/cloud-cluster-profile: hypershift-aws
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-hypershift-release-4.23-e2e-kubevirt-aws-ovn-reduced

--- a/ci-operator/step-registry/hypershift/kubevirt/e2e-nested/hypershift-kubevirt-e2e-nested-workflow.yaml
+++ b/ci-operator/step-registry/hypershift/kubevirt/e2e-nested/hypershift-kubevirt-e2e-nested-workflow.yaml
@@ -13,7 +13,7 @@ workflow:
       CNV_SUBSCRIPTION_SOURCE: redhat-operators
       HYPERSHIFT_INSTANCE_TYPE: c5n.metal
       HYPERSHIFT_ZONES: "us-east-1a"
-      RUN_EXTERNAL_INFRA_TEST: "false"
+      RUN_EXTERNAL_INFRA_TEST: "true"
       RUN_HOSTEDCLUSTER_CREATION: "true"
     pre:
       - ref: ipi-install-rbac

--- a/ci-operator/step-registry/hypershift/kubevirt/run-e2e-external/hypershift-kubevirt-run-e2e-external-chain.yaml
+++ b/ci-operator/step-registry/hypershift/kubevirt/run-e2e-external/hypershift-kubevirt-run-e2e-external-chain.yaml
@@ -77,7 +77,6 @@ chain:
                   ${STORAGE_CLASS_FLAG} \
                   --e2e.kubevirt-infra-namespace=${EXTERNAL_INFRA_NS} \
                   --e2e.annotations=hypershift.openshift.io/management-platform=${INFRA_PLATFORM_TYPE}
-
     credentials:
       - mount_path: /etc/ci-pull-credentials
         name: ci-pull-credentials

--- a/ci-operator/step-registry/hypershift/kubevirt/run-e2e-local/hypershift-kubevirt-run-e2e-local-chain.yaml
+++ b/ci-operator/step-registry/hypershift/kubevirt/run-e2e-local/hypershift-kubevirt-run-e2e-local-chain.yaml
@@ -29,7 +29,7 @@ chain:
         hack/ci-test-e2e.sh \
                   --test.v \
                   --test.timeout=0 \
-                  --test.run='^TestCreateCluster$|TestNodePool|TestAutoscaling' \
+                  --test.run="${E2E_TEST_REGEX}" \
                   --e2e.node-pool-replicas=2 \
                   --e2e.kubevirt-node-memory="10Gi" \
                   --e2e.kubevirt-node-cores="4" \
@@ -53,6 +53,8 @@ chain:
         name: KUBECONFIG
       - default: ""
         name: ETCD_STORAGE_CLASS
+      - default: "^TestCreateCluster$|TestNodePool|TestAutoscaling"
+        name: E2E_TEST_REGEX
       - default: "false"
         name: SKIP_E2E_LOCAL
     from: hypershift-tests


### PR DESCRIPTION
## Summary
* Make the test regex in `hypershift-kubevirt-run-e2e-local` configurable via a new E2E_TEST_REGEX env var (defaults to the existing pattern, no behavior change for other jobs)
* Switch e2e-kubevirt-aws-ovn-reduced from running external e2e tests to running local e2e tests with only TestCreateCluster and TestAutoscaling
## Background
The e2e-kubevirt-aws-ovn-reduced job uses the hypershift-kubevirt-e2e-nested workflow, which provisions a nested management cluster on AWS. This topology creates a two-layer setup: an AWS infra cluster hosts a nested OCP management cluster, which in turn hosts KubeVirt-based guest clusters.

The external infra e2e tests (hypershift-kubevirt-run-e2e-external) are incompatible with this nested topology. When guest clusters are created with baseDomainPassthrough: true, the KAS LoadBalancer service creates an AWS ELB that points to the infra cluster's network, but the KAS pods live on the nested management cluster. This makes the API server unreachable, causing all external infra tests to fail with DNS resolution and TLS handshake timeouts.

Local e2e tests work correctly on the nested topology because they interact with the management cluster directly, without relying on external infrastructure routing.

Previously, the job had SKIP_E2E_LOCAL: "true" set and relied on the external chain, which was also disabled by RUN_EXTERNAL_INFRA_TEST: "false" at the workflow level -- meaning the job was effectively running no e2e tests at all.

## Changes
hypershift-kubevirt-run-e2e-local-chain.yaml: Extract the hardcoded --test.run regex into a configurable E2E_TEST_REGEX env var. The default value (^TestCreateCluster$|TestNodePool|TestAutoscaling) preserves the existing behavior for all six workflows that use this chain.

openshift-hypershift-main.yaml (e2e-kubevirt-aws-ovn-reduced job):

SKIP_E2E_LOCAL: "true" -> "false" -- enable local e2e tests
RUN_EXTERNAL_INFRA_TEST: "false" -- explicitly disable external tests (incompatible with nested topology)
E2E_TEST_REGEX: ^TestCreateCluster$|TestAutoscaling -- run only the two tests that are relevant for this reduced job

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow configuration to enhance test coverage in the infrastructure testing pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->