### PR TITLE
Drop myself from oVirt reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -67,7 +67,6 @@ aliases:
   - mmartinv
   - bkhizgiy
   - engelmi
-  - sandrobonazzola
   technical-release-team-approvers:
   - stbenjam
   - dgoodwin


### PR DESCRIPTION
I'm not involved anymore in OpenShift activities, removing myself from OWNERS_ALIASES.
Pushed https://github.com/okd-virtualization/release/pull/18 for the remaining occurences of my username in OWNERS files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release team member configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->