### PR TITLE
rhdh: update Slack reporter channel to #rhdh-e2e-alerts

### DIFF
--- a/ci-operator/config/redhat-developer/rhdh/.config.prowgen
+++ b/ci-operator/config/redhat-developer/rhdh/.config.prowgen
@@ -1,5 +1,5 @@
 slack_reporter:
-- channel: '#rhdh-e2e-test-alerts'
+- channel: '#rhdh-e2e-alerts'
   job_states_to_report:
   - success
   - failure
@@ -13,7 +13,7 @@ slack_reporter:
   - ".*-upgrade-nightly$"
   excluded_job_patterns:
   - "^pull-.*"
-- channel: '#rhdh-e2e-test-alerts'
+- channel: '#rhdh-e2e-alerts'
   job_states_to_report:
   - success
   - failure
@@ -27,7 +27,7 @@ slack_reporter:
   - ".*-auth-providers-nightly$"
   excluded_job_patterns:
   - "^pull-.*"
-- channel: '#rhdh-e2e-test-alerts'
+- channel: '#rhdh-e2e-alerts'
   job_states_to_report:
   - error
   report_template: '<!subteam^S07BMJ56R8S>

--- a/ci-operator/jobs/redhat-developer/rhdh/redhat-developer-rhdh-main-periodics.yaml
+++ b/ci-operator/jobs/redhat-developer/rhdh/redhat-developer-rhdh-main-periodics.yaml
@@ -249,7 +249,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-main-e2e-aks-helm-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-test-alerts'
+      channel: '#rhdh-e2e-alerts'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -334,7 +334,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-main-e2e-aks-operator-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-test-alerts'
+      channel: '#rhdh-e2e-alerts'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -419,7 +419,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-main-e2e-eks-helm-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-test-alerts'
+      channel: '#rhdh-e2e-alerts'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -504,7 +504,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-main-e2e-eks-operator-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-test-alerts'
+      channel: '#rhdh-e2e-alerts'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -589,7 +589,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-main-e2e-gke-helm-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-test-alerts'
+      channel: '#rhdh-e2e-alerts'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -674,7 +674,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-main-e2e-gke-operator-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-test-alerts'
+      channel: '#rhdh-e2e-alerts'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -759,7 +759,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-main-e2e-ocp-helm-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-test-alerts'
+      channel: '#rhdh-e2e-alerts'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -851,7 +851,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-main-e2e-ocp-helm-upgrade-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-test-alerts'
+      channel: '#rhdh-e2e-alerts'
       job_states_to_report:
       - success
       - failure
@@ -948,7 +948,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-main-e2e-ocp-operator-auth-providers-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-test-alerts'
+      channel: '#rhdh-e2e-alerts'
       job_states_to_report:
       - success
       - failure
@@ -1045,7 +1045,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-main-e2e-ocp-operator-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-test-alerts'
+      channel: '#rhdh-e2e-alerts'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -1137,7 +1137,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-main-e2e-ocp-v4-19-helm-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-test-alerts'
+      channel: '#rhdh-e2e-alerts'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -1229,7 +1229,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-main-e2e-ocp-v4-20-helm-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-test-alerts'
+      channel: '#rhdh-e2e-alerts'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -1321,7 +1321,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-main-e2e-ocp-v4-21-helm-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-test-alerts'
+      channel: '#rhdh-e2e-alerts'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -1413,7 +1413,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-main-e2e-osd-gcp-helm-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-test-alerts'
+      channel: '#rhdh-e2e-alerts'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -1498,7 +1498,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-main-e2e-osd-gcp-operator-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-test-alerts'
+      channel: '#rhdh-e2e-alerts'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`

--- a/ci-operator/jobs/redhat-developer/rhdh/redhat-developer-rhdh-release-1.8-periodics.yaml
+++ b/ci-operator/jobs/redhat-developer/rhdh/redhat-developer-rhdh-release-1.8-periodics.yaml
@@ -15,7 +15,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.8-e2e-aks-helm-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-test-alerts'
+      channel: '#rhdh-e2e-alerts'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -100,7 +100,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.8-e2e-aks-operator-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-test-alerts'
+      channel: '#rhdh-e2e-alerts'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -185,7 +185,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.8-e2e-eks-helm-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-test-alerts'
+      channel: '#rhdh-e2e-alerts'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -270,7 +270,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.8-e2e-eks-operator-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-test-alerts'
+      channel: '#rhdh-e2e-alerts'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -355,7 +355,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.8-e2e-gke-helm-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-test-alerts'
+      channel: '#rhdh-e2e-alerts'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -440,7 +440,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.8-e2e-gke-operator-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-test-alerts'
+      channel: '#rhdh-e2e-alerts'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -525,7 +525,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.8-e2e-ocp-helm-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-test-alerts'
+      channel: '#rhdh-e2e-alerts'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -617,7 +617,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.8-e2e-ocp-operator-auth-providers-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-test-alerts'
+      channel: '#rhdh-e2e-alerts'
       job_states_to_report:
       - success
       - failure
@@ -714,7 +714,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.8-e2e-ocp-operator-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-test-alerts'
+      channel: '#rhdh-e2e-alerts'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -806,7 +806,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.8-e2e-ocp-v4-16-helm-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-test-alerts'
+      channel: '#rhdh-e2e-alerts'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -898,7 +898,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.8-e2e-ocp-v4-19-helm-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-test-alerts'
+      channel: '#rhdh-e2e-alerts'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -990,7 +990,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.8-e2e-ocp-v4-20-helm-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-test-alerts'
+      channel: '#rhdh-e2e-alerts'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -1082,7 +1082,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.8-e2e-osd-gcp-helm-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-test-alerts'
+      channel: '#rhdh-e2e-alerts'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -1167,7 +1167,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.8-e2e-osd-gcp-operator-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-test-alerts'
+      channel: '#rhdh-e2e-alerts'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`

--- a/ci-operator/jobs/redhat-developer/rhdh/redhat-developer-rhdh-release-1.9-periodics.yaml
+++ b/ci-operator/jobs/redhat-developer/rhdh/redhat-developer-rhdh-release-1.9-periodics.yaml
@@ -15,7 +15,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.9-e2e-aks-helm-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-test-alerts'
+      channel: '#rhdh-e2e-alerts'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -100,7 +100,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.9-e2e-aks-operator-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-test-alerts'
+      channel: '#rhdh-e2e-alerts'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -185,7 +185,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.9-e2e-eks-helm-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-test-alerts'
+      channel: '#rhdh-e2e-alerts'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -270,7 +270,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.9-e2e-eks-operator-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-test-alerts'
+      channel: '#rhdh-e2e-alerts'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -355,7 +355,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.9-e2e-gke-helm-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-test-alerts'
+      channel: '#rhdh-e2e-alerts'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -440,7 +440,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.9-e2e-gke-operator-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-test-alerts'
+      channel: '#rhdh-e2e-alerts'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -525,7 +525,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.9-e2e-ocp-helm-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-test-alerts'
+      channel: '#rhdh-e2e-alerts'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -617,7 +617,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.9-e2e-ocp-helm-upgrade-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-test-alerts'
+      channel: '#rhdh-e2e-alerts'
       job_states_to_report:
       - success
       - failure
@@ -714,7 +714,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.9-e2e-ocp-operator-auth-providers-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-test-alerts'
+      channel: '#rhdh-e2e-alerts'
       job_states_to_report:
       - success
       - failure
@@ -811,7 +811,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.9-e2e-ocp-operator-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-test-alerts'
+      channel: '#rhdh-e2e-alerts'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -903,7 +903,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.9-e2e-ocp-v4-16-helm-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-test-alerts'
+      channel: '#rhdh-e2e-alerts'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -995,7 +995,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.9-e2e-ocp-v4-19-helm-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-test-alerts'
+      channel: '#rhdh-e2e-alerts'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -1087,7 +1087,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.9-e2e-ocp-v4-20-helm-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-test-alerts'
+      channel: '#rhdh-e2e-alerts'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -1179,7 +1179,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.9-e2e-ocp-v4-21-helm-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-test-alerts'
+      channel: '#rhdh-e2e-alerts'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -1271,7 +1271,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.9-e2e-osd-gcp-helm-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-test-alerts'
+      channel: '#rhdh-e2e-alerts'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -1356,7 +1356,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.9-e2e-osd-gcp-operator-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-test-alerts'
+      channel: '#rhdh-e2e-alerts'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`


### PR DESCRIPTION
## Summary
- Updates the Prow Slack reporter channel from `#rhdh-e2e-test-alerts` to `#rhdh-e2e-alerts` after the channel was renamed
- This was causing Slack notifications to silently fail for all RHDH nightly periodic jobs (auth-providers, upgrade, helm, operator)
- Regenerated periodic job configs for main, release-1.8, and release-1.9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI pipeline alert routing configuration for periodic job reporters across all release branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->