### PR TITLE
image-mirroring: fix artImages regex to include OCP 5.x imagestreams

### DIFF
--- a/core-services/image-mirroring/_config.yaml
+++ b/core-services/image-mirroring/_config.yaml
@@ -1052,14 +1052,14 @@ artImages:
 - namespace: ocp-private
   name: ^builder-priv$
 - namespace: ocp
-  name: ^4.\d+$
+  name: ^\d+\.\d+$
   tag: ^rhel-coreos.*
 - namespace: ocp-private
-  name: ^4.\d+(-priv)?$
+  name: ^\d+\.\d+(-priv)?$
   tag: ^rhel-coreos.*
 - namespace: ocp
-  name: ^4.\d+$
+  name: ^\d+\.\d+$
   tag: ^base$
 - namespace: ocp
-  name: ^4.\d+$
+  name: ^\d+\.\d+$
   tag: ^base-rhel.*$


### PR DESCRIPTION
## Summary

- The `artImages` regexes in `core-services/image-mirroring/_config.yaml` were hardcoded to `^4.\d+$`, only matching 4.x imagestream names
- With OCP 5.0 now tracking main/master, the `ocp/5.0` imagestream is not matched, so `rhel-coreos`, `base`, and `base-rhel` tags are never mirrored to quay.io by the `quay_io_ci_images_distributor`
- This causes presubmits to use stale RHCOS images: ci-operator snapshots the integration stream and constructs `quay-proxy` pull references for each tag, but since the distributor never mirrors 5.0's `rhel-coreos` to quay.io, presubmits pull an outdated image despite the imagestream tag being current
- Fix: broaden the regex from `^4.\d+$` to `^\d+\.\d+$` to match any `X.Y` version pattern, covering 5.0 and future releases

## Test plan

- [ ] Verify `rhel-coreos` tags from `ocp/5.0` are picked up by the distributor after deployment
- [ ] Confirm presubmit jobs for 5.0 components get the current RHCOS image

Made with [Cursor](https://cursor.com)