### PR TITLE
hack: fix claude code --continue from -p again

### DIFF
--- a/ci-operator/step-registry/openshift/claude/payload/agent/openshift-claude-payload-agent-commands.sh
+++ b/ci-operator/step-registry/openshift/claude/payload/agent/openshift-claude-payload-agent-commands.sh
@@ -137,8 +137,8 @@ PHASE_WAIT_DURATION=$(( $(date +%s) - PHASE_WAIT_START ))
 
 # Workaround: --continue + -p is broken (anthropics/claude-code#42376).
 # Sessions created by -p get sessionKind tagged and are filtered from --continue lookup.
-# Setting CLAUDE_CODE_ENTRYPOINT=cli prevents the sessionKind tag from being set.
-export CLAUDE_CODE_ENTRYPOINT=cli
+# Setting CLAUDE_CODE_ENTRYPOINT=-sdk-cli prevents the sessionKind tag from being set.
+export CLAUDE_CODE_ENTRYPOINT=sdk-cli
 
 # Run Claude to analyze the payload
 echo "Invoking Claude to analyze payload ${PAYLOAD_TAG}..."


### PR DESCRIPTION
The previous workaround stopped working around v2.1.109.  The *new* workaround is `export CLAUDE_CODE_ENTRYPOINT=sdk-cli`

Let's see how long this one works.


Ref: https://github.com/anthropics/claude-code/issues/43013#issuecomment-4251772540