### PR TITLE
ovn-kubernetes: replace AWS hypershift presubmit with Azure hypershift KubeVirt

### DIFF
--- a/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-master.yaml
+++ b/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-master.yaml
@@ -340,11 +340,17 @@ tests:
       TEST_SKIPS: CPU Partitioning cluster platform workloads should be annotated
         correctly for Deployments
     workflow: baremetalds-e2e-ovn-bgp-dualstack-local-gw
-- as: e2e-aws-ovn-hypershift
-  skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
+- always_run: false
+  as: e2e-azure-ovn-hypershift-kubevirt
+  optional: true
   steps:
-    cluster_profile: hypershift-aws
-    workflow: hypershift-aws-conformance
+    cluster_profile: openshift-org-azure
+    env:
+      CNV_SUBSCRIPTION_SOURCE: redhat-operators
+      ODF_OPERATOR_CHANNEL: stable-4.20
+      TEST_INCLUDES: sig-kubevirt
+      TEST_SUITE: openshift/conformance/parallel/minimal
+    workflow: hypershift-kubevirt-azure-conformance
 - as: unit
   commands: |
     cd go-controller

--- a/ci-operator/jobs/openshift/ovn-kubernetes/openshift-ovn-kubernetes-master-presubmits.yaml
+++ b/ci-operator/jobs/openshift/ovn-kubernetes/openshift-ovn-kubernetes-master-presubmits.yaml
@@ -714,87 +714,6 @@ presubmits:
     - ^master$
     - ^master-
     cluster: build11
-    context: ci/prow/e2e-aws-ovn-hypershift
-    decorate: true
-    labels:
-      ci-operator.openshift.io/cloud: hypershift-aws
-      ci-operator.openshift.io/cloud-cluster-profile: hypershift-aws
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-ovn-kubernetes-master-e2e-aws-ovn-hypershift
-    rerun_command: /test e2e-aws-ovn-hypershift
-    skip_if_only_changed: ^(docs|\.github|contrib|etc|helm)/|\.md$|^(\.gitignore|OWNERS|LICENSE|CODEOWNERS|\.coderabbit\.yml|crd-docs-config\.yaml|mkdocs\.yml|requirements\.txt)$
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-aws-ovn-hypershift
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-aws-ovn-hypershift,?($|\s.*)
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - ^master$
-    - ^master-
-    cluster: build11
     context: ci/prow/e2e-aws-ovn-local-gateway
     decorate: true
     labels:
@@ -1922,6 +1841,87 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-azure-ovn,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^master$
+    - ^master-
+    cluster: build11
+    context: ci/prow/e2e-azure-ovn-hypershift-kubevirt
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: azure4
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-azure
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-ovn-kubernetes-master-e2e-azure-ovn-hypershift-kubevirt
+    optional: true
+    rerun_command: /test e2e-azure-ovn-hypershift-kubevirt
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-azure-ovn-hypershift-kubevirt
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-azure-ovn-hypershift-kubevirt,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:


### PR DESCRIPTION
## Summary
- Remove the `e2e-aws-ovn-hypershift` presubmit from ovn-kubernetes master config
- Add new `e2e-azure-ovn-hypershift-kubevirt` presubmit using the `hypershift-kubevirt-azure-conformance` workflow
- The new job matches the hypershift periodic configuration: provisions an Azure management cluster with CNV + ODF, creates a KubeVirt-backed hosted cluster, and runs `sig-kubevirt` conformance tests

## Test plan
- [ ] Verify generated Prow jobs are correct
- [ ] Rehearse the new job on a test PR in ovn-kubernetes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Replaced an AWS Hypershift CI presubmit with an Azure Hypershift KubeVirt presubmit.
  * New presubmit is optional, not gated by the previous "only-changed" filter, and uses an updated cluster profile and workflow.
  * CI job now injects CNV_SUBSCRIPTION_SOURCE, TEST_INCLUDES and TEST_SUITE environment variables.
  * Installer now preserves a provided ODF operator channel and otherwise derives the channel from the cluster OCP version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->