### PR TITLE
kubevirt: ssp: Update OCP versions and change cluster profile

### DIFF
--- a/ci-operator/config/kubevirt/ssp-operator/kubevirt-ssp-operator-main.yaml
+++ b/ci-operator/config/kubevirt/ssp-operator/kubevirt-ssp-operator-main.yaml
@@ -26,12 +26,12 @@ images:
 releases:
   initial:
     integration:
-      name: "4.19"
+      name: "4.21"
       namespace: ocp
   latest:
     integration:
       include_built_images: true
-      name: "4.19"
+      name: "4.21"
       namespace: ocp
 resources:
   '*':
@@ -44,7 +44,7 @@ tests:
 - as: unittests
   skip_if_only_changed: ^\.github/|^docs/|\.[mM][dD]$|^.gitignore$|^OWNERS$|^PROJECT$|^LICENSE$
   steps:
-    cluster_profile: gcp-virtualization
+    cluster_profile: azure-virtualization
     test:
     - as: unittests
       commands: export GOFLAGS= && make unittest
@@ -63,9 +63,9 @@ tests:
 - as: e2e-functests
   skip_if_only_changed: ^\.github/|^docs/|\.[mM][dD]$|^.gitignore$|^OWNERS$|^PROJECT$|^LICENSE$
   steps:
-    cluster_profile: gcp-virtualization
+    cluster_profile: azure-virtualization
     env:
-      COMPUTE_NODE_TYPE: n2-standard-4
+      BASE_DOMAIN: cnv-devel.azure.devcluster.openshift.com
     test:
     - as: e2e-functests
       cli: latest
@@ -85,13 +85,13 @@ tests:
         requests:
           cpu: 100m
           memory: 200Mi
-    workflow: ipi-gcp
+    workflow: ipi-azure
 - as: e2e-upgrade-functests
   skip_if_only_changed: ^\.github/|^docs/|\.[mM][dD]$|^.gitignore$|^OWNERS$|^PROJECT$|^LICENSE$
   steps:
-    cluster_profile: gcp-virtualization
+    cluster_profile: azure-virtualization
     env:
-      COMPUTE_NODE_TYPE: n2-standard-4
+      BASE_DOMAIN: cnv-devel.azure.devcluster.openshift.com
     test:
     - as: e2e-upgrade-functests
       cli: latest
@@ -111,11 +111,20 @@ tests:
         requests:
           cpu: 100m
           memory: 200Mi
-    workflow: ipi-gcp
+    workflow: ipi-azure
 - as: e2e-single-node-functests
   skip_if_only_changed: ^\.github/|^docs/|\.[mM][dD]$|^.gitignore$|^OWNERS$|^PROJECT$|^LICENSE$
   steps:
-    cluster_profile: gcp-virtualization
+    cluster_profile: azure-virtualization
+    env:
+      BASE_DOMAIN: cnv-devel.azure.devcluster.openshift.com
+    post:
+    - chain: ipi-azure-post
+    pre:
+    - chain: ipi-conf-azure
+    - ref: single-node-conf-azure
+    - ref: single-node-conf-e2e
+    - chain: ipi-install
     test:
     - as: e2e-single-node-functests
       cli: latest
@@ -136,7 +145,6 @@ tests:
         requests:
           cpu: 100m
           memory: 200Mi
-    workflow: ipi-gcp-single-node
 zz_generated_metadata:
   branch: main
   org: kubevirt

--- a/ci-operator/config/kubevirt/ssp-operator/kubevirt-ssp-operator-release-v0.24.yaml
+++ b/ci-operator/config/kubevirt/ssp-operator/kubevirt-ssp-operator-release-v0.24.yaml
@@ -26,12 +26,12 @@ images:
 releases:
   initial:
     integration:
-      name: "4.19"
+      name: "4.20"
       namespace: ocp
   latest:
     integration:
       include_built_images: true
-      name: "4.19"
+      name: "4.20"
       namespace: ocp
 resources:
   '*':
@@ -44,7 +44,7 @@ tests:
 - as: unittests
   skip_if_only_changed: ^\.github/|^docs/|\.[mM][dD]$|^.gitignore$|^OWNERS$|^PROJECT$|^LICENSE$
   steps:
-    cluster_profile: gcp-virtualization
+    cluster_profile: azure-virtualization
     test:
     - as: unittests
       commands: export GOFLAGS= && make unittest
@@ -63,9 +63,9 @@ tests:
 - as: e2e-functests
   skip_if_only_changed: ^\.github/|^docs/|\.[mM][dD]$|^.gitignore$|^OWNERS$|^PROJECT$|^LICENSE$
   steps:
-    cluster_profile: gcp-virtualization
+    cluster_profile: azure-virtualization
     env:
-      COMPUTE_NODE_TYPE: n2-standard-4
+      BASE_DOMAIN: cnv-devel.azure.devcluster.openshift.com
     test:
     - as: e2e-functests
       cli: latest
@@ -85,13 +85,13 @@ tests:
         requests:
           cpu: 100m
           memory: 200Mi
-    workflow: ipi-gcp
+    workflow: ipi-azure
 - as: e2e-upgrade-functests
   skip_if_only_changed: ^\.github/|^docs/|\.[mM][dD]$|^.gitignore$|^OWNERS$|^PROJECT$|^LICENSE$
   steps:
-    cluster_profile: gcp-virtualization
+    cluster_profile: azure-virtualization
     env:
-      COMPUTE_NODE_TYPE: n2-standard-4
+      BASE_DOMAIN: cnv-devel.azure.devcluster.openshift.com
     test:
     - as: e2e-upgrade-functests
       cli: latest
@@ -111,11 +111,20 @@ tests:
         requests:
           cpu: 100m
           memory: 200Mi
-    workflow: ipi-gcp
+    workflow: ipi-azure
 - as: e2e-single-node-functests
   skip_if_only_changed: ^\.github/|^docs/|\.[mM][dD]$|^.gitignore$|^OWNERS$|^PROJECT$|^LICENSE$
   steps:
-    cluster_profile: gcp-virtualization
+    cluster_profile: azure-virtualization
+    env:
+      BASE_DOMAIN: cnv-devel.azure.devcluster.openshift.com
+    post:
+    - chain: ipi-azure-post
+    pre:
+    - chain: ipi-conf-azure
+    - ref: single-node-conf-azure
+    - ref: single-node-conf-e2e
+    - chain: ipi-install
     test:
     - as: e2e-single-node-functests
       cli: latest
@@ -136,7 +145,6 @@ tests:
         requests:
           cpu: 100m
           memory: 200Mi
-    workflow: ipi-gcp-single-node
 zz_generated_metadata:
   branch: release-v0.24
   org: kubevirt

--- a/ci-operator/config/kubevirt/ssp-operator/kubevirt-ssp-operator-release-v0.25.yaml
+++ b/ci-operator/config/kubevirt/ssp-operator/kubevirt-ssp-operator-release-v0.25.yaml
@@ -26,12 +26,12 @@ images:
 releases:
   initial:
     integration:
-      name: "4.19"
+      name: "4.21"
       namespace: ocp
   latest:
     integration:
       include_built_images: true
-      name: "4.19"
+      name: "4.21"
       namespace: ocp
 resources:
   '*':
@@ -44,7 +44,7 @@ tests:
 - as: unittests
   skip_if_only_changed: ^\.github/|^docs/|\.[mM][dD]$|^.gitignore$|^OWNERS$|^PROJECT$|^LICENSE$
   steps:
-    cluster_profile: gcp-virtualization
+    cluster_profile: azure-virtualization
     test:
     - as: unittests
       commands: export GOFLAGS= && make unittest
@@ -63,9 +63,9 @@ tests:
 - as: e2e-functests
   skip_if_only_changed: ^\.github/|^docs/|\.[mM][dD]$|^.gitignore$|^OWNERS$|^PROJECT$|^LICENSE$
   steps:
-    cluster_profile: gcp-virtualization
+    cluster_profile: azure-virtualization
     env:
-      COMPUTE_NODE_TYPE: n2-standard-4
+      BASE_DOMAIN: cnv-devel.azure.devcluster.openshift.com
     test:
     - as: e2e-functests
       cli: latest
@@ -85,13 +85,13 @@ tests:
         requests:
           cpu: 100m
           memory: 200Mi
-    workflow: ipi-gcp
+    workflow: ipi-azure
 - as: e2e-upgrade-functests
   skip_if_only_changed: ^\.github/|^docs/|\.[mM][dD]$|^.gitignore$|^OWNERS$|^PROJECT$|^LICENSE$
   steps:
-    cluster_profile: gcp-virtualization
+    cluster_profile: azure-virtualization
     env:
-      COMPUTE_NODE_TYPE: n2-standard-4
+      BASE_DOMAIN: cnv-devel.azure.devcluster.openshift.com
     test:
     - as: e2e-upgrade-functests
       cli: latest
@@ -111,11 +111,20 @@ tests:
         requests:
           cpu: 100m
           memory: 200Mi
-    workflow: ipi-gcp
+    workflow: ipi-azure
 - as: e2e-single-node-functests
   skip_if_only_changed: ^\.github/|^docs/|\.[mM][dD]$|^.gitignore$|^OWNERS$|^PROJECT$|^LICENSE$
   steps:
-    cluster_profile: gcp-virtualization
+    cluster_profile: azure-virtualization
+    env:
+      BASE_DOMAIN: cnv-devel.azure.devcluster.openshift.com
+    post:
+    - chain: ipi-azure-post
+    pre:
+    - chain: ipi-conf-azure
+    - ref: single-node-conf-azure
+    - ref: single-node-conf-e2e
+    - chain: ipi-install
     test:
     - as: e2e-single-node-functests
       cli: latest
@@ -136,7 +145,6 @@ tests:
         requests:
           cpu: 100m
           memory: 200Mi
-    workflow: ipi-gcp-single-node
 zz_generated_metadata:
   branch: release-v0.25
   org: kubevirt

--- a/ci-operator/jobs/kubevirt/ssp-operator/kubevirt-ssp-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/kubevirt/ssp-operator/kubevirt-ssp-operator-main-presubmits.yaml
@@ -11,8 +11,8 @@ presubmits:
     decoration_config:
       skip_cloning: true
     labels:
-      ci-operator.openshift.io/cloud: gcp
-      ci-operator.openshift.io/cloud-cluster-profile: gcp-virtualization
+      ci-operator.openshift.io/cloud: azure4
+      ci-operator.openshift.io/cloud-cluster-profile: azure-virtualization
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-kubevirt-ssp-operator-main-e2e-functests
@@ -94,8 +94,8 @@ presubmits:
     decoration_config:
       skip_cloning: true
     labels:
-      ci-operator.openshift.io/cloud: gcp
-      ci-operator.openshift.io/cloud-cluster-profile: gcp-virtualization
+      ci-operator.openshift.io/cloud: azure4
+      ci-operator.openshift.io/cloud-cluster-profile: azure-virtualization
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-kubevirt-ssp-operator-main-e2e-single-node-functests
@@ -177,8 +177,8 @@ presubmits:
     decoration_config:
       skip_cloning: true
     labels:
-      ci-operator.openshift.io/cloud: gcp
-      ci-operator.openshift.io/cloud-cluster-profile: gcp-virtualization
+      ci-operator.openshift.io/cloud: azure4
+      ci-operator.openshift.io/cloud-cluster-profile: azure-virtualization
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-kubevirt-ssp-operator-main-e2e-upgrade-functests
@@ -315,8 +315,8 @@ presubmits:
     decoration_config:
       skip_cloning: true
     labels:
-      ci-operator.openshift.io/cloud: gcp
-      ci-operator.openshift.io/cloud-cluster-profile: gcp-virtualization
+      ci-operator.openshift.io/cloud: azure4
+      ci-operator.openshift.io/cloud-cluster-profile: azure-virtualization
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-kubevirt-ssp-operator-main-unittests

--- a/ci-operator/jobs/kubevirt/ssp-operator/kubevirt-ssp-operator-release-v0.24-presubmits.yaml
+++ b/ci-operator/jobs/kubevirt/ssp-operator/kubevirt-ssp-operator-release-v0.24-presubmits.yaml
@@ -11,8 +11,8 @@ presubmits:
     decoration_config:
       skip_cloning: true
     labels:
-      ci-operator.openshift.io/cloud: gcp
-      ci-operator.openshift.io/cloud-cluster-profile: gcp-virtualization
+      ci-operator.openshift.io/cloud: azure4
+      ci-operator.openshift.io/cloud-cluster-profile: azure-virtualization
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-kubevirt-ssp-operator-release-v0.24-e2e-functests
@@ -94,8 +94,8 @@ presubmits:
     decoration_config:
       skip_cloning: true
     labels:
-      ci-operator.openshift.io/cloud: gcp
-      ci-operator.openshift.io/cloud-cluster-profile: gcp-virtualization
+      ci-operator.openshift.io/cloud: azure4
+      ci-operator.openshift.io/cloud-cluster-profile: azure-virtualization
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-kubevirt-ssp-operator-release-v0.24-e2e-single-node-functests
@@ -177,8 +177,8 @@ presubmits:
     decoration_config:
       skip_cloning: true
     labels:
-      ci-operator.openshift.io/cloud: gcp
-      ci-operator.openshift.io/cloud-cluster-profile: gcp-virtualization
+      ci-operator.openshift.io/cloud: azure4
+      ci-operator.openshift.io/cloud-cluster-profile: azure-virtualization
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-kubevirt-ssp-operator-release-v0.24-e2e-upgrade-functests
@@ -315,8 +315,8 @@ presubmits:
     decoration_config:
       skip_cloning: true
     labels:
-      ci-operator.openshift.io/cloud: gcp
-      ci-operator.openshift.io/cloud-cluster-profile: gcp-virtualization
+      ci-operator.openshift.io/cloud: azure4
+      ci-operator.openshift.io/cloud-cluster-profile: azure-virtualization
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-kubevirt-ssp-operator-release-v0.24-unittests

--- a/ci-operator/jobs/kubevirt/ssp-operator/kubevirt-ssp-operator-release-v0.25-presubmits.yaml
+++ b/ci-operator/jobs/kubevirt/ssp-operator/kubevirt-ssp-operator-release-v0.25-presubmits.yaml
@@ -11,8 +11,8 @@ presubmits:
     decoration_config:
       skip_cloning: true
     labels:
-      ci-operator.openshift.io/cloud: gcp
-      ci-operator.openshift.io/cloud-cluster-profile: gcp-virtualization
+      ci-operator.openshift.io/cloud: azure4
+      ci-operator.openshift.io/cloud-cluster-profile: azure-virtualization
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-kubevirt-ssp-operator-release-v0.25-e2e-functests
@@ -94,8 +94,8 @@ presubmits:
     decoration_config:
       skip_cloning: true
     labels:
-      ci-operator.openshift.io/cloud: gcp
-      ci-operator.openshift.io/cloud-cluster-profile: gcp-virtualization
+      ci-operator.openshift.io/cloud: azure4
+      ci-operator.openshift.io/cloud-cluster-profile: azure-virtualization
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-kubevirt-ssp-operator-release-v0.25-e2e-single-node-functests
@@ -177,8 +177,8 @@ presubmits:
     decoration_config:
       skip_cloning: true
     labels:
-      ci-operator.openshift.io/cloud: gcp
-      ci-operator.openshift.io/cloud-cluster-profile: gcp-virtualization
+      ci-operator.openshift.io/cloud: azure4
+      ci-operator.openshift.io/cloud-cluster-profile: azure-virtualization
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-kubevirt-ssp-operator-release-v0.25-e2e-upgrade-functests
@@ -315,8 +315,8 @@ presubmits:
     decoration_config:
       skip_cloning: true
     labels:
-      ci-operator.openshift.io/cloud: gcp
-      ci-operator.openshift.io/cloud-cluster-profile: gcp-virtualization
+      ci-operator.openshift.io/cloud: azure4
+      ci-operator.openshift.io/cloud-cluster-profile: azure-virtualization
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-kubevirt-ssp-operator-release-v0.25-unittests


### PR DESCRIPTION
Updated test configurations to use more recent OpenShift versions.
The gcp-virtualization cluster profile does not work lately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated OpenShift integration targets: main -> 4.21; release branches -> 4.20 and 4.21.
  * Switched CI test execution from GCP to Azure and updated related install workflows for E2E and single-node jobs.
  * Replaced per-step compute node env with a BASE_DOMAIN setting for E2E jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->