### PR TITLE
prowgen: migrate rehearsal configs to ci-operator config

### DIFF
--- a/ci-operator/config/openshift-knative/eventing-istio/.config.prowgen
+++ b/ci-operator/config/openshift-knative/eventing-istio/.config.prowgen
@@ -1,4 +1,3 @@
-rehearsals: {}
 slack_reporter:
 - channel: '#knative-eventing-ci'
   excluded_variants:

--- a/ci-operator/config/openshift-knative/eventing-kafka-broker/.config.prowgen
+++ b/ci-operator/config/openshift-knative/eventing-kafka-broker/.config.prowgen
@@ -1,4 +1,3 @@
-rehearsals: {}
 slack_reporter:
 - channel: '#knative-eventing-ci'
   excluded_variants:

--- a/ci-operator/config/openshift-knative/eventing/.config.prowgen
+++ b/ci-operator/config/openshift-knative/eventing/.config.prowgen
@@ -1,4 +1,3 @@
-rehearsals: {}
 slack_reporter:
 - channel: '#knative-eventing-ci'
   excluded_variants:

--- a/ci-operator/config/openshift-knative/kn-plugin-event/.config.prowgen
+++ b/ci-operator/config/openshift-knative/kn-plugin-event/.config.prowgen
@@ -1,4 +1,3 @@
-rehearsals: {}
 slack_reporter:
 - channel: '#knative-client'
   excluded_variants:

--- a/ci-operator/config/openshift-knative/serverless-operator/.config.prowgen
+++ b/ci-operator/config/openshift-knative/serverless-operator/.config.prowgen
@@ -1,4 +1,3 @@
-rehearsals: {}
 slack_reporter:
 - channel: '#serverless-ci'
   excluded_variants:

--- a/ci-operator/config/openshift-knative/serving/.config.prowgen
+++ b/ci-operator/config/openshift-knative/serving/.config.prowgen
@@ -1,4 +1,3 @@
-rehearsals: {}
 slack_reporter:
 - channel: '#knative-serving-ci'
   excluded_variants:

--- a/ci-operator/config/openshift-psap/forge/.config.prowgen
+++ b/ci-operator/config/openshift-psap/forge/.config.prowgen
@@ -1,2 +1,0 @@
-rehearsals:
-    disable_all: true

--- a/ci-operator/config/openshift-psap/forge/openshift-psap-forge-main.yaml
+++ b/ci-operator/config/openshift-psap/forge/openshift-psap-forge-main.yaml
@@ -3,6 +3,8 @@ base_images:
     name: ci-tools-build-root
     namespace: ci
     tag: latest
+prowgen:
+  disable_rehearsals: true
 resources:
   '*':
     limits:

--- a/ci-operator/config/openshift-psap/forge/openshift-psap-forge-main__jump.yaml
+++ b/ci-operator/config/openshift-psap/forge/openshift-psap-forge-main__jump.yaml
@@ -3,6 +3,8 @@ base_images:
     name: ci-tools-build-root
     namespace: ci
     tag: latest
+prowgen:
+  disable_rehearsals: true
 resources:
   '*':
     limits:

--- a/ci-operator/config/openshift-psap/fournos/.config.prowgen
+++ b/ci-operator/config/openshift-psap/fournos/.config.prowgen
@@ -1,2 +1,0 @@
-rehearsals:
-    disable_all: true

--- a/ci-operator/config/openshift-psap/fournos/openshift-psap-fournos-main.yaml
+++ b/ci-operator/config/openshift-psap/fournos/openshift-psap-fournos-main.yaml
@@ -3,6 +3,8 @@ base_images:
     name: ci-tools-build-root
     namespace: ci
     tag: latest
+prowgen:
+  disable_rehearsals: true
 resources:
   '*':
     limits:

--- a/ci-operator/config/openshift-psap/topsail/.config.prowgen
+++ b/ci-operator/config/openshift-psap/topsail/.config.prowgen
@@ -1,2 +1,0 @@
-rehearsals:
-    disable_all: true

--- a/ci-operator/config/openshift-psap/topsail/openshift-psap-topsail-main__cont_bench.yaml
+++ b/ci-operator/config/openshift-psap/topsail/openshift-psap-topsail-main__cont_bench.yaml
@@ -3,6 +3,8 @@ base_images:
     name: ci-tools-build-root
     namespace: ci
     tag: latest
+prowgen:
+  disable_rehearsals: true
 resources:
   '*':
     limits:

--- a/ci-operator/config/openshift-psap/topsail/openshift-psap-topsail-main__jump.yaml
+++ b/ci-operator/config/openshift-psap/topsail/openshift-psap-topsail-main__jump.yaml
@@ -3,6 +3,8 @@ base_images:
     name: ci-tools-build-root
     namespace: ci
     tag: latest
+prowgen:
+  disable_rehearsals: true
 resources:
   '*':
     limits:

--- a/ci-operator/config/openshift-psap/topsail/openshift-psap-topsail-main__mac_ai.yaml
+++ b/ci-operator/config/openshift-psap/topsail/openshift-psap-topsail-main__mac_ai.yaml
@@ -3,6 +3,8 @@ base_images:
     name: ci-tools-build-root
     namespace: ci
     tag: latest
+prowgen:
+  disable_rehearsals: true
 resources:
   '*':
     limits:

--- a/ci-operator/config/openshift/backplane-cli/.config.prowgen
+++ b/ci-operator/config/openshift/backplane-cli/.config.prowgen
@@ -1,2 +1,0 @@
-rehearsals:
-    disabled_rehearsals:

--- a/ci-operator/config/openshift/osde2e/.config.prowgen
+++ b/ci-operator/config/openshift/osde2e/.config.prowgen
@@ -1,12 +1,3 @@
-rehearsals:
-  disabled_rehearsals:
-  - aro-ovn-e2e-default
-  - aro-e2e-default
-  - aro-nightly-cleanup
-  - aws-stage-informing-default
-  - aws-prod-cleanup
-  - rosa-stage-e2e-byo-vpc-proxy-install
-  - rosa-stage-e2e-byo-vpc-proxy-postinstall
 slack_reporter:
 - channel: '#hcm-cicd-alerts'
   job_states_to_report:

--- a/ci-operator/config/openshift/osde2e/openshift-osde2e-main.yaml
+++ b/ci-operator/config/openshift/osde2e/openshift-osde2e-main.yaml
@@ -81,6 +81,7 @@ tests:
     clone: true
     from: osde2e
   cron: 0 19 14,28 * *
+  disable_rehearsal: true
   secrets:
   - mount_path: /usr/local/osde2e-common
     name: osde2e-common
@@ -107,6 +108,7 @@ tests:
     clone: true
     from: osde2e
   cron: 0 19 15,29 * *
+  disable_rehearsal: true
   secrets:
   - mount_path: /usr/local/osde2e-common
     name: osde2e-common
@@ -129,6 +131,7 @@ tests:
     clone: true
     from: osde2e
   cron: 0 12 * * 1
+  disable_rehearsal: true
   secrets:
   - mount_path: /usr/local/osde2e-common
     name: osde2e-common

--- a/ci-operator/config/rh-ecosystem-edge/kernel-module-management/.config.prowgen
+++ b/ci-operator/config/rh-ecosystem-edge/kernel-module-management/.config.prowgen
@@ -1,3 +1,0 @@
-rehearsals:
-  disabled_rehearsals:
-    - check-commits-count

--- a/ci-operator/config/rh-ecosystem-edge/kernel-module-management/rh-ecosystem-edge-kernel-module-management-main.yaml
+++ b/ci-operator/config/rh-ecosystem-edge/kernel-module-management/rh-ecosystem-edge-kernel-module-management-main.yaml
@@ -158,6 +158,7 @@ tests:
   container:
     clone: true
     from: go-builder
+  disable_rehearsal: true
 - as: check-api-changes
   steps:
     test:

--- a/ci-operator/config/rh-ecosystem-edge/kernel-module-management/rh-ecosystem-edge-kernel-module-management-release-1.0.yaml
+++ b/ci-operator/config/rh-ecosystem-edge/kernel-module-management/rh-ecosystem-edge-kernel-module-management-release-1.0.yaml
@@ -82,6 +82,7 @@ tests:
   container:
     clone: true
     from: go-builder
+  disable_rehearsal: true
 - as: check-api-changes
   steps:
     test:

--- a/ci-operator/config/rh-ecosystem-edge/kernel-module-management/rh-ecosystem-edge-kernel-module-management-release-1.1.yaml
+++ b/ci-operator/config/rh-ecosystem-edge/kernel-module-management/rh-ecosystem-edge-kernel-module-management-release-1.1.yaml
@@ -133,6 +133,7 @@ tests:
   container:
     clone: true
     from: go-builder
+  disable_rehearsal: true
 - as: check-api-changes
   steps:
     test:

--- a/ci-operator/config/rh-ecosystem-edge/kernel-module-management/rh-ecosystem-edge-kernel-module-management-release-2.0.yaml
+++ b/ci-operator/config/rh-ecosystem-edge/kernel-module-management/rh-ecosystem-edge-kernel-module-management-release-2.0.yaml
@@ -138,6 +138,7 @@ tests:
   container:
     clone: true
     from: go-builder
+  disable_rehearsal: true
 - as: check-api-changes
   steps:
     test:

--- a/ci-operator/config/rh-ecosystem-edge/kernel-module-management/rh-ecosystem-edge-kernel-module-management-release-2.1.yaml
+++ b/ci-operator/config/rh-ecosystem-edge/kernel-module-management/rh-ecosystem-edge-kernel-module-management-release-2.1.yaml
@@ -152,6 +152,7 @@ tests:
   container:
     clone: true
     from: go-builder
+  disable_rehearsal: true
 - as: check-api-changes
   steps:
     test:

--- a/ci-operator/config/rh-ecosystem-edge/kernel-module-management/rh-ecosystem-edge-kernel-module-management-release-2.2.yaml
+++ b/ci-operator/config/rh-ecosystem-edge/kernel-module-management/rh-ecosystem-edge-kernel-module-management-release-2.2.yaml
@@ -154,6 +154,7 @@ tests:
   container:
     clone: true
     from: go-builder
+  disable_rehearsal: true
 - as: check-api-changes
   steps:
     test:

--- a/ci-operator/config/rh-ecosystem-edge/kernel-module-management/rh-ecosystem-edge-kernel-module-management-release-2.3.yaml
+++ b/ci-operator/config/rh-ecosystem-edge/kernel-module-management/rh-ecosystem-edge-kernel-module-management-release-2.3.yaml
@@ -152,6 +152,7 @@ tests:
   container:
     clone: true
     from: go-builder
+  disable_rehearsal: true
 - as: check-api-changes
   steps:
     test:

--- a/ci-operator/config/rh-ecosystem-edge/kernel-module-management/rh-ecosystem-edge-kernel-module-management-release-2.4.yaml
+++ b/ci-operator/config/rh-ecosystem-edge/kernel-module-management/rh-ecosystem-edge-kernel-module-management-release-2.4.yaml
@@ -158,6 +158,7 @@ tests:
   container:
     clone: true
     from: go-builder
+  disable_rehearsal: true
 - as: check-api-changes
   steps:
     test:

--- a/ci-operator/config/rh-ecosystem-edge/kernel-module-management/rh-ecosystem-edge-kernel-module-management-release-2.5.yaml
+++ b/ci-operator/config/rh-ecosystem-edge/kernel-module-management/rh-ecosystem-edge-kernel-module-management-release-2.5.yaml
@@ -158,6 +158,7 @@ tests:
   container:
     clone: true
     from: go-builder
+  disable_rehearsal: true
 - as: check-api-changes
   steps:
     test:

--- a/ci-operator/config/rh-ecosystem-edge/kernel-module-management/rh-ecosystem-edge-kernel-module-management-release-2.6.yaml
+++ b/ci-operator/config/rh-ecosystem-edge/kernel-module-management/rh-ecosystem-edge-kernel-module-management-release-2.6.yaml
@@ -158,6 +158,7 @@ tests:
   container:
     clone: true
     from: go-builder
+  disable_rehearsal: true
 - as: check-api-changes
   steps:
     test:

--- a/ci-operator/config/stolostron/submariner-addon/.config.prowgen
+++ b/ci-operator/config/stolostron/submariner-addon/.config.prowgen
@@ -1,3 +1,0 @@
-rehearsals:
-  disabled_rehearsals:
-  - sonarcloud

--- a/ci-operator/config/stolostron/submariner-addon/stolostron-submariner-addon-main.yaml
+++ b/ci-operator/config/stolostron/submariner-addon/stolostron-submariner-addon-main.yaml
@@ -57,6 +57,7 @@ tests:
   container:
     from: test-bin
 - as: sonarcloud
+  disable_rehearsal: true
   steps:
     test:
     - as: test

--- a/ci-operator/config/stolostron/submariner-addon/stolostron-submariner-addon-release-2.11.yaml
+++ b/ci-operator/config/stolostron/submariner-addon/stolostron-submariner-addon-release-2.11.yaml
@@ -58,6 +58,7 @@ tests:
   container:
     from: test-bin
 - as: sonarcloud
+  disable_rehearsal: true
   steps:
     test:
     - as: test

--- a/ci-operator/config/stolostron/submariner-addon/stolostron-submariner-addon-release-2.12.yaml
+++ b/ci-operator/config/stolostron/submariner-addon/stolostron-submariner-addon-release-2.12.yaml
@@ -58,6 +58,7 @@ tests:
   container:
     from: test-bin
 - as: sonarcloud
+  disable_rehearsal: true
   steps:
     test:
     - as: test

--- a/ci-operator/config/stolostron/submariner-addon/stolostron-submariner-addon-release-2.13.yaml
+++ b/ci-operator/config/stolostron/submariner-addon/stolostron-submariner-addon-release-2.13.yaml
@@ -58,6 +58,7 @@ tests:
   container:
     from: test-bin
 - as: sonarcloud
+  disable_rehearsal: true
   steps:
     test:
     - as: test

--- a/ci-operator/config/stolostron/submariner-addon/stolostron-submariner-addon-release-2.14.yaml
+++ b/ci-operator/config/stolostron/submariner-addon/stolostron-submariner-addon-release-2.14.yaml
@@ -57,6 +57,7 @@ tests:
   container:
     from: test-bin
 - as: sonarcloud
+  disable_rehearsal: true
   steps:
     test:
     - as: test

--- a/ci-operator/config/stolostron/submariner-addon/stolostron-submariner-addon-release-2.15.yaml
+++ b/ci-operator/config/stolostron/submariner-addon/stolostron-submariner-addon-release-2.15.yaml
@@ -57,6 +57,7 @@ tests:
   container:
     from: test-bin
 - as: sonarcloud
+  disable_rehearsal: true
   steps:
     test:
     - as: test

--- a/ci-operator/config/stolostron/submariner-addon/stolostron-submariner-addon-release-2.16.yaml
+++ b/ci-operator/config/stolostron/submariner-addon/stolostron-submariner-addon-release-2.16.yaml
@@ -57,6 +57,7 @@ tests:
   container:
     from: test-bin
 - as: sonarcloud
+  disable_rehearsal: true
   steps:
     test:
     - as: test

--- a/ci-operator/config/stolostron/submariner-addon/stolostron-submariner-addon-release-2.17.yaml
+++ b/ci-operator/config/stolostron/submariner-addon/stolostron-submariner-addon-release-2.17.yaml
@@ -58,6 +58,7 @@ tests:
   container:
     from: test-bin
 - as: sonarcloud
+  disable_rehearsal: true
   steps:
     test:
     - as: test


### PR DESCRIPTION
## Summary
- Migrates rehearsal control from `.config.prowgen` to ci-operator config fields (`prowgen.disable_rehearsals` and per-test `disable_rehearsal`)
- Removes `.config.prowgen` files that only contained rehearsal config
- Depends on openshift/ci-tools#5119

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reworked rehearsal configuration: removed several global rehearsal-disable entries and added explicit per-pipeline/ per-job flags to control rehearsals.
  * As a result, some jobs now explicitly opt out of rehearsal runs while others that were globally disabled are no longer forcibly disabled, changing which jobs run during rehearsals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->