### PR TITLE
Fix test: e2e-aws-ovn-upgrade-paused

### DIFF
--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22-upgrade-from-stable-4.20.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22-upgrade-from-stable-4.20.yaml
@@ -30,6 +30,7 @@ tests:
   steps:
     cluster_profile: openshift-org-aws
     env:
+      TEST_ARGS: --disable-monitor=etcd-log-analyzer,node-lifecycle,on-prem-haproxy,on-prem-keepalived,initial-and-final-operator-log-scraper,apiserver-incluster-availability,kubelet-log-collector,audit-log-analyzer,metrics-endpoints-down,alert-summary-serializer,cpu-metric-collector,pod-network-avalibility,service-type-load-balancer-availability,ingress-availability,pathological-event-analyzer,legacy-test-framework-invariants,operator-state-analyzer,legacy-cvo-invariants,apiserver-external-availability,azure-metrics-collector,etcd-disk-metrics-intervals,termination-message-policy,legacy-test-framework-invariants-alerts,legacy-networking-invariants,oc-adm-upgrade-status
       TEST_UPGRADE_OPTIONS: ""
     observers:
       enable:

--- a/ci-operator/step-registry/openshift/e2e/test/openshift-e2e-test-commands.sh
+++ b/ci-operator/step-registry/openshift/e2e/test/openshift-e2e-test-commands.sh
@@ -288,7 +288,7 @@ function upgrade_paused() {
     oc patch mcp/worker --type merge --patch '{"spec":{"paused":true}}'
 
     echo "Starting control-plane upgrade to ${OPENSHIFT_UPGRADE0_RELEASE_IMAGE_OVERRIDE}"
-    openshift-tests run-upgrade "${TEST_UPGRADE_SUITE}" \
+    openshift-tests run-upgrade "${TEST_UPGRADE_SUITE}" "${TEST_ARGS:-}" \
         --to-image "${OPENSHIFT_UPGRADE0_RELEASE_IMAGE_OVERRIDE}" \
         --options "${TEST_UPGRADE_OPTIONS-}" \
         --provider "${TEST_PROVIDER}" \

--- a/ci-operator/step-registry/openshift/e2e/test/openshift-e2e-test-commands.sh
+++ b/ci-operator/step-registry/openshift/e2e/test/openshift-e2e-test-commands.sh
@@ -288,12 +288,16 @@ function upgrade_paused() {
     # Mimic https://github.com/openshift/installer/blob/98d5859f6cb6d2660cf9ffbed8885d9c9907ec56/pkg/asset/ignition/bootstrap/cvoignore.go#L142-L158
     # which is available from 4.21+
     installed_version=$(oc get clusterversion version -o jsonpath='{.status.history[-1].version}')
+    # remove --disable-monitor=oc-adm-upgrade-status when https://redhat.atlassian.net/browse/OTA-1977 is fixed
+    # TODO: define it from the job like TEST_ARGS
+    TEST_ARGS_2="--disable-monitor=oc-adm-upgrade-status"
     echo "The installed version is $installed_version"
     if [[ $installed_version == "4.20."* ]]; then
         echo "Overriding the cluster-scoped 'openshift' ClusterImagePolicy"
         oc patch clusterversion version --type json -p '[{"op": "add", "path": "/spec/overrides", "value": [{"group": "config.openshift.io", "kind": "ClusterImagePolicy", "name": "openshift", "namespace": "", "unmanaged": true}]}]'
         echo "Showing the ClusterVersion spec"
         oc get clusterversion version -o jsonpath='{.spec}{"\n"}'
+        TEST_ARGS_2="--disable-monitor=oc-adm-upgrade-status,legacy-cvo-invariants"
     fi
 
     oc patch mcp/worker --type merge --patch '{"spec":{"paused":true}}'
@@ -308,10 +312,9 @@ function upgrade_paused() {
     wait "$!"
     echo "Upgraded control-plane to ${OPENSHIFT_UPGRADE0_RELEASE_IMAGE_OVERRIDE}"
 
-    # remove --disable-monitor=oc-adm-upgrade-status when https://redhat.atlassian.net/browse/OTA-1977 is fixed
     echo "Starting control-plane upgrade to ${OPENSHIFT_UPGRADE1_RELEASE_IMAGE_OVERRIDE}"
     openshift-tests run-upgrade "${TEST_UPGRADE_SUITE}" \
-        --to-image "${OPENSHIFT_UPGRADE1_RELEASE_IMAGE_OVERRIDE}" --disable-monitor=oc-adm-upgrade-status \
+        --to-image "${OPENSHIFT_UPGRADE1_RELEASE_IMAGE_OVERRIDE}" "${TEST_ARGS_2:-}" \
         --options "${TEST_UPGRADE_OPTIONS-}" \
         --provider "${TEST_PROVIDER}" \
         -o "${ARTIFACT_DIR}/e2e.log" \

--- a/ci-operator/step-registry/openshift/e2e/test/openshift-e2e-test-commands.sh
+++ b/ci-operator/step-registry/openshift/e2e/test/openshift-e2e-test-commands.sh
@@ -285,6 +285,17 @@ function upgrade_paused() {
     OPENSHIFT_UPGRADE0_RELEASE_IMAGE_OVERRIDE="$(echo $TARGET_RELEASES | cut -f1 -d,)"
     OPENSHIFT_UPGRADE1_RELEASE_IMAGE_OVERRIDE="$(echo $TARGET_RELEASES | cut -f2 -d,)"
 
+    # Mimic https://github.com/openshift/installer/blob/98d5859f6cb6d2660cf9ffbed8885d9c9907ec56/pkg/asset/ignition/bootstrap/cvoignore.go#L142-L158
+    # which is available from 4.21+
+    installed_version=$(oc get clusterversion version -o jsonpath='{.status.history[-1].version}')
+    echo "The installed version is $installed_version"
+    if [[ $installed_version == "4.20."* ]]; then
+        echo "Overriding the cluster-scoped 'openshift' ClusterImagePolicy"
+        oc patch clusterversion version --type json -p '[{"op": "add", "path": "/spec/overrides", "value": [{"group": "config.openshift.io", "kind": "ClusterImagePolicy", "name": "openshift", "namespace": "", "unmanaged": true}]}]'
+        echo "Showing the ClusterVersion spec"
+        oc get clusterversion version -o jsonpath='{.spec}{"\n"}'
+    fi
+
     oc patch mcp/worker --type merge --patch '{"spec":{"paused":true}}'
 
     echo "Starting control-plane upgrade to ${OPENSHIFT_UPGRADE0_RELEASE_IMAGE_OVERRIDE}"

--- a/ci-operator/step-registry/openshift/e2e/test/openshift-e2e-test-commands.sh
+++ b/ci-operator/step-registry/openshift/e2e/test/openshift-e2e-test-commands.sh
@@ -297,9 +297,10 @@ function upgrade_paused() {
     wait "$!"
     echo "Upgraded control-plane to ${OPENSHIFT_UPGRADE0_RELEASE_IMAGE_OVERRIDE}"
 
+    # remove --disable-monitor=oc-adm-upgrade-status when https://redhat.atlassian.net/browse/OTA-1977 is fixed
     echo "Starting control-plane upgrade to ${OPENSHIFT_UPGRADE1_RELEASE_IMAGE_OVERRIDE}"
     openshift-tests run-upgrade "${TEST_UPGRADE_SUITE}" \
-        --to-image "${OPENSHIFT_UPGRADE1_RELEASE_IMAGE_OVERRIDE}" \
+        --to-image "${OPENSHIFT_UPGRADE1_RELEASE_IMAGE_OVERRIDE}" --disable-monitor=oc-adm-upgrade-status \
         --options "${TEST_UPGRADE_OPTIONS-}" \
         --provider "${TEST_PROVIDER}" \
         -o "${ARTIFACT_DIR}/e2e.log" \


### PR DESCRIPTION
The binary of the target release 4.y is used in each upgrade in the
`e2e-aws-ovn-upgrade-paused` e2e test. This limitation of the test
configuration may cause unexpected failure of the job, e.g.,

- The fix of a bug is shipped in 4.y but not backported to 4.y-1.
- The exception for the bug is removed on 4.y. We could wait longer to
  do so but it is unintuitive in my opinion.

Then, the 4.y test with upgrade from 4.y-2 might fail because the fix is not
available in 4.y-1.

Ideally, we should use the 4.y-1 binary for the first one. Before that is
implemented, we use this as a workaround to fix the test nightly-4.22-upgrade-from-stable-4.20.

Many monitors have been disabled in the first upgrade to avoid failures.
It should not impact the product quality because there are tests in release
4.y-1 that do only one upgrade from 4.y-2 to 4.y-1.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a configurable TEST_ARGS variable to supply additional disable flags for selected monitors/analyzers during paused upgrade test runs.
  * Updated paused-upgrade test invocation to propagate this configured argument to the initial control-plane upgrade step.
  * No other test sequencing, observer enablement, workflow control, or upgrade steps were modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->