### PR TITLE
refactor(ci): MCE/Hypershift compatibility test trigger

### DIFF
--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.16__periodics-mce.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.16__periodics-mce.yaml
@@ -256,6 +256,7 @@ tests:
     cluster_profile: openshift-org-aws
     dependencies:
       HOSTEDCLUSTER_RELEASE_IMAGE_LATEST: release:416-latest
+      NODEPOOL_RELEASE_IMAGE_LATEST: release:416-latest
     env:
       MCE_VERSION: "2.6"
       TEST_SUITE: openshift/conformance/parallel/minimal

--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.17__periodics-mce.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.17__periodics-mce.yaml
@@ -247,6 +247,7 @@ tests:
     cluster_profile: openshift-org-aws
     dependencies:
       HOSTEDCLUSTER_RELEASE_IMAGE_LATEST: release:417-latest
+      NODEPOOL_RELEASE_IMAGE_LATEST: release:417-latest
     env:
       MCE_VERSION: "2.7"
       TEST_SUITE: openshift/conformance/parallel/minimal

--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.18__periodics-mce.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.18__periodics-mce.yaml
@@ -281,6 +281,7 @@ tests:
     cluster_profile: openshift-org-aws
     dependencies:
       HOSTEDCLUSTER_RELEASE_IMAGE_LATEST: release:418-latest
+      NODEPOOL_RELEASE_IMAGE_LATEST: release:418-latest
     env:
       MCE_VERSION: "2.8"
       TEST_SUITE: openshift/conformance/parallel/minimal

--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.19__periodics-mce.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.19__periodics-mce.yaml
@@ -324,6 +324,7 @@ tests:
     cluster_profile: openshift-org-aws
     dependencies:
       HOSTEDCLUSTER_RELEASE_IMAGE_LATEST: release:419-latest
+      NODEPOOL_RELEASE_IMAGE_LATEST: release:419-latest
     env:
       MCE_VERSION: "2.9"
       TEST_SUITE: openshift/conformance/parallel/minimal

--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.20__periodics-mce.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.20__periodics-mce.yaml
@@ -335,6 +335,7 @@ tests:
     cluster_profile: openshift-org-aws
     dependencies:
       HOSTEDCLUSTER_RELEASE_IMAGE_LATEST: release:420-latest
+      NODEPOOL_RELEASE_IMAGE_LATEST: release:420-latest
     env:
       MCE_VERSION: "2.10"
       TEST_SUITE: openshift/conformance/parallel/minimal

--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.21__periodics-mce.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.21__periodics-mce.yaml
@@ -359,6 +359,7 @@ tests:
     cluster_profile: openshift-org-aws
     dependencies:
       HOSTEDCLUSTER_RELEASE_IMAGE_LATEST: release:421-latest
+      NODEPOOL_RELEASE_IMAGE_LATEST: release:421-latest
     env:
       MCE_VERSION: "2.11"
       TEST_SUITE: openshift/conformance/parallel/minimal

--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.22__periodics-mce.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.22__periodics-mce.yaml
@@ -370,6 +370,7 @@ tests:
     cluster_profile: openshift-org-aws
     dependencies:
       HOSTEDCLUSTER_RELEASE_IMAGE_LATEST: release:422-latest
+      NODEPOOL_RELEASE_IMAGE_LATEST: release:422-latest
     env:
       MCE_VERSION: "2.17"
       TEST_SUITE: openshift/conformance/parallel/minimal

--- a/ci-operator/step-registry/hypershift/mce/multi-version-test/report/hypershift-mce-multi-version-test-report-commands.py
+++ b/ci-operator/step-registry/hypershift/mce/multi-version-test/report/hypershift-mce-multi-version-test-report-commands.py
@@ -1,16 +1,34 @@
 #!/usr/bin/env python
+import json
 import os.path
+import re
+import urllib.request
 
 from dataclasses import dataclass
 from datetime import datetime
-from google.oauth2.credentials import Credentials
+from google.oauth2 import service_account
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 from google.auth.transport.requests import Request
 
-# If modifying these scopes, delete the file token.json.
 SCOPES = ["https://www.googleapis.com/auth/spreadsheets"]
-SAMPLE_SPREADSHEET_ID = "1j8TjMfyCfEt8OzTgvrAG3tuC6WMweBh5ElzWu6oAvUw"
+SAMPLE_SPREADSHEET_ID = "1g4EFkOrcr6D4WJKo4O8bmOK7txA4ZRTfqFazHtCoM3E"
+# Sheet/tab ID of the template tab that will be copied to create a new tab and
+# filled with the job data
+# The tab id is available in the URL of the template tab after "gid="
+TEMPLATE_TAB_ID = "1597804194"
+TOKEN_PATH = "/secret/ga-gsheet/googlesheet-api-token"
+GCSWEB_BASE = "https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results"
+TEST_STEPS = [
+    "conformance-tests", "csi-conformance-tests",
+    "hypershift-aws-run-e2e-external", "hypershift-aws-run-e2e-nested",
+    "hypershift-aws-run-reqserving-e2e",
+    "hypershift-azure-run-e2e", "hypershift-azure-run-e2e-self-managed",
+    "hypershift-gcp-run-e2e",
+    "hypershift-openstack-e2e-execute",
+    "openstack-test-dpdk", "openstack-test-sriov",
+    "run-e2e", "run-e2e-local", "run-e2e-external", "tests",
+]
 
 @dataclass
 class Job:
@@ -39,27 +57,23 @@ class JobList:
 
 def init():
     global creds
-    if not os.path.exists("/secret/ga-gsheet/token.json"):
-        raise FileNotFoundError("The token.json file does not exist. Please authorize first.")
+    if not os.path.exists(TOKEN_PATH):
+        raise FileNotFoundError("The token file does not exist. Please authorize first.")
 
-    creds = Credentials.from_authorized_user_file("/secret/ga-gsheet/token.json", SCOPES)
-    if not creds or not creds.valid:
-        if creds and creds.expired and creds.refresh_token:
-            creds.refresh(Request())
-        else:
-            raise ValueError("The token.json is invalid or expired. Please reauthorize.")
-
+    creds = service_account.Credentials.from_service_account_file(TOKEN_PATH, scopes=SCOPES)
 
 def create_sheet(sheet_title):
     global creds
+    new_sheet_id = None
     try:
-        copy_response = build("sheets", "v4", credentials=creds).spreadsheets().sheets().copyTo(
+        service = build("sheets", "v4", credentials=creds)
+        copy_response = service.spreadsheets().sheets().copyTo(
             spreadsheetId=SAMPLE_SPREADSHEET_ID,
-            sheetId=772427170,
+            sheetId=TEMPLATE_TAB_ID,
             body={"destinationSpreadsheetId": SAMPLE_SPREADSHEET_ID}
         ).execute()
         new_sheet_id = copy_response["sheetId"]
-        build("sheets", "v4", credentials=creds).spreadsheets().batchUpdate(
+        service.spreadsheets().batchUpdate(
             spreadsheetId=SAMPLE_SPREADSHEET_ID, body={
             "requests": [
                 {
@@ -72,7 +86,57 @@ def create_sheet(sheet_title):
         }
         ).execute()
     except (HttpError, Exception) as e:
+        if new_sheet_id is not None:
+            try:
+                service.spreadsheets().batchUpdate(
+                    spreadsheetId=SAMPLE_SPREADSHEET_ID, body={
+                    "requests": [{"deleteSheet": {"sheetId": new_sheet_id}}]
+                }).execute()
+            except Exception:
+                print(f"Failed to clean up orphaned sheet {new_sheet_id}")
         raise Exception(f"Error occurred while creating sheet: {e}")
+
+def determine_status(job_status, job_url, job_name):
+    """Determine emoji status by checking GCS for test step artifacts.
+
+    - SUCCESS → 🟢
+    - FAILURE + test step finished.json exists → 🟡 (tests ran and failed)
+    - Everything else → 🔴 (install failed, trigger failed, etc.)
+    """
+    if job_status == "SUCCESS":
+        return "\U0001F7E2" # 🟢 all pass
+    if job_status != "FAILURE" or not job_url:
+        return "\U0001F534" # 🔴 install failed, trigger failed, etc.
+
+    # Extract job name and build ID from Prow deck URL
+    # e.g. https://prow.ci.openshift.org/view/gs/test-platform-results/logs/<job-name>/<build-id>
+    url_match = re.search(r'/logs/([^/]+)/(\d+)', job_url)
+    if not url_match:
+        return "\U0001F534"
+    prow_job_name = url_match.group(1)
+    build_id = url_match.group(2)
+
+    # Derive test target from job name
+    # e.g. periodic-ci-openshift-hypershift-release-4.22-periodics-mce-e2e-aws-critical → e2e-aws-critical
+    target_match = re.match(r'periodic-ci-openshift-hypershift-release-[\d.]+-periodics(?:-mce)?-(.+)', prow_job_name)
+    if not target_match:
+        return "\U0001F534" # 🔴 install failed, trigger failed, etc.
+    test_target = target_match.group(1)
+
+    artifacts_base = f"{GCSWEB_BASE}/logs/{prow_job_name}/{build_id}/artifacts/{test_target}"
+    for step in TEST_STEPS:
+        url = f"{artifacts_base}/{step}/finished.json"
+        try:
+            resp = urllib.request.urlopen(url, timeout=10)
+            data = json.loads(resp.read())
+            # There can be passed=true or passed=false in the finished.json file.
+            # The presence of "passed" indicates that the test step finished.
+            if "passed" in data:
+                return "\U0001F7E1" # 🟡 case failed
+        except Exception:
+            continue
+    return "\U0001F534" # 🔴 install failed, trigger failed, etc.
+
 
 def writing_to_sheet(sheet_name, obj):
   global creds
@@ -89,16 +153,16 @@ def writing_to_sheet(sheet_name, obj):
 
 def main():
     init()
-    sheet_title = f"{os.getenv('HOSTEDCLUSTER_PLATFORM')}-{datetime.now().strftime('%Y-%m-%d')}"
+    sheet_title = f"{os.getenv('HOSTEDCLUSTER_PLATFORM')}-{datetime.now().strftime('%Y-%m-%d-%H%M')}"
     create_sheet(sheet_title)
 
-    joblist = JobList(fields=["HUB", "MCE", "HostedCluster", "Platform", "Job", "Job ID", "Status: \U0001F534 install failed \U0001F7E1 case failed \U0001F7E2 all pass \U0001F535 need to check"])
+    joblist = JobList(fields=["HUB", "MCE", "HostedCluster", "Platform", "Job", "Job URL", "Status: \U0001F534 install failed \U0001F7E1 case failed \U0001F7E2 all pass \U0001F535 need to check"])
     job_list_path = os.path.join(os.environ.get("SHARED_DIR"), "job_list")
     with open(job_list_path, 'r') as file:
         for line in file:
             print(line, end=" ")
             job_data = {key.strip(): value.strip() for key, value in (part.split("=") for part in line.strip().split(", "))}
-            status = "\U0001F7E2" if job_data.get("JOB_STATUS") == "SUCCESS" else "\U0001F535"
+            status = determine_status(job_data.get("JOB_STATUS", ""), job_data.get("JOB_URL", ""), job_data.get("JOB", ""))
             joblist.add_row(Job(
                 hub_version=job_data.get("HUB", ""),
                 mce_version=job_data.get("MCE", ""),

--- a/ci-operator/step-registry/hypershift/mce/multi-version-test/report/hypershift-mce-multi-version-test-report-ref.yaml
+++ b/ci-operator/step-registry/hypershift/mce/multi-version-test/report/hypershift-mce-multi-version-test-report-ref.yaml
@@ -16,10 +16,10 @@ ref:
     documentation: HostedCluster's platform. (aws, agent, kubevirt, ibmz, ibmp)
   credentials:
   - namespace: test-credentials
-    name: mce-gsheet
+    name: hypershift-gsheet-api-token
     mount_path: /secret/ga-gsheet
   documentation: |-
     This script reads job data from ${SHARED_DIR}/job_list, 
     creates a Google Sheets tab named after the platform and date, 
     and writes the job details to the sheet using the Google Sheets API.
-    https://docs.google.com/spreadsheets/d/1j8TjMfyCfEt8OzTgvrAG3tuC6WMweBh5ElzWu6oAvUw/edit?gid=0#gid=0
+    https://docs.google.com/spreadsheets/d/1g4EFkOrcr6D4WJKo4O8bmOK7txA4ZRTfqFazHtCoM3E/edit?gid=1257598507#gid=1257598507

--- a/ci-operator/step-registry/hypershift/mce/multi-version-test/trigger-jobs/hypershift-mce-multi-version-test-trigger-jobs-commands.sh
+++ b/ci-operator/step-registry/hypershift/mce/multi-version-test/trigger-jobs/hypershift-mce-multi-version-test-trigger-jobs-commands.sh
@@ -5,36 +5,39 @@ set -o errexit
 set -o pipefail
 set -x
 
-declare -A guest_to_job_aws=(
-    [4.14]="periodic-ci-openshift-hypershift-release-4.14-periodics-mce-e2e-aws-critical"
-    [4.15]="periodic-ci-openshift-hypershift-release-4.15-periodics-mce-e2e-aws-critical"
-    [4.16]="periodic-ci-openshift-hypershift-release-4.16-periodics-mce-e2e-aws-critical"
-    [4.17]="periodic-ci-openshift-hypershift-release-4.17-periodics-mce-e2e-aws-critical"
-    [4.18]="periodic-ci-openshift-hypershift-release-4.18-periodics-mce-e2e-aws-critical"
-    [4.19]="periodic-ci-openshift-hypershift-release-4.19-periodics-mce-e2e-aws-critical"
-)
+export SHARED_DIR=${SHARED_DIR:-/tmp/shared_dir}
+export ARTIFACT_DIR=${ARTIFACT_DIR:-/tmp/artifacts}
+export HOSTEDCLUSTER_PLATFORM=${HOSTEDCLUSTER_PLATFORM:-"aws"}
+export JOB_PARALLEL=${JOB_PARALLEL:-"5"}
+export CHECK_INTERVAL=${CHECK_INTERVAL:-300}
+export CHECK_TIMEOUT=${CHECK_TIMEOUT:-18000}
+
+TOKEN_PATH=${TOKEN_PATH:-/etc/mce-prow-gangway-credentials/token}
+GANGWAY_API=${GANGWAY_API:-"https://gangway-ci.apps.ci.l2s4.p1.openshiftapps.com"}
+
+# Each MCE supports the latest three HostedCluster versions
 declare -A mce_to_guest=(
-    [2.4]="4.14"
-    [2.5]="4.14 4.15"
-    [2.6]="4.14 4.15 4.16"
-    [2.7]="4.14 4.15 4.16 4.17"
-    [2.8]="4.14 4.15 4.16 4.17 4.18"
-    [2.9]="4.15 4.16 4.17 4.18 4.19"
+    [2.8]="4.16 4.17 4.18"
+    [2.9]="4.17 4.18 4.19"
+    [2.10]="4.18 4.19 4.20"
+    [2.11]="4.19 4.20 4.21"
+    [2.17]="4.20 4.21 4.22"
 )
+
+# Each MCE is available on the latest hub version and two versions back
 declare -A hub_to_mce=(
-    [4.14]="2.4 2.5 2.6"
-    [4.15]="2.5 2.6 2.7"
-    [4.16]="2.6 2.7 2.8"
-    [4.17]="2.7 2.8 2.9"
-    [4.18]="2.8 2.9"
-    [4.19]="2.9"
+    [4.18]="2.8 2.9 2.10"
+    [4.19]="2.9 2.10 2.11"
+    [4.20]="2.10 2.11 2.17"
+    [4.21]="2.11 2.17"
+    [4.22]="2.17"
 )
 
 function get_payload_list() {
     declare -A payload_list
-    local versions=("4.14" "4.15" "4.16" "4.17" "4.18" "4.19")
 
-    for version in "${versions[@]}"; do
+    # Get all guest versions and the release image for each guest version
+    for version in $(echo "${mce_to_guest[@]}" | tr ' ' '\n' | sort -uV); do
         image=$(curl -s "https://openshift-release.apps.ci.l2s4.p1.openshiftapps.com/api/v1/releasestream/${version}.0-0.nightly/latest" | jq -r '.pullSpec')
         payload_list["$version"]=$image
     done
@@ -54,13 +57,13 @@ function trigger_prow_job() {
     local _http_post_data="$2"
 
     # Set maximum retry attempts and retry interval (seconds)
-    local max_retries=2
+    local max_retries=30
     local retry_interval=10
 
     set +x
     for ((retry_count=1; retry_count<=max_retries; retry_count++)); do
         response=$(curl -s -X POST -d "${_http_post_data}" \
-            -H "Authorization: Bearer $(cat /etc/mce-prow-gangway-credentials/token)" \
+            -H "Authorization: Bearer $(cat "${TOKEN_PATH}")" \
             "${GANGWAY_API}/v1/executions/${_job_name}" \
             -w "%{http_code}")
 
@@ -80,26 +83,39 @@ function trigger_prow_job() {
     echo "Gangway API is still not available after $max_retries retries. Aborting." && return 0
 }
 
-function check_jobs() {
-    local GANGWAY_API='https://gangway-ci.apps.ci.l2s4.p1.openshiftapps.com'
-
-    local max_retries=2
+function wait_for_jobs() {
+    local job_list_file="$1"
+    local max_retries=30
     local retry_interval=10
+    local start_time
+    start_time=$(date +%s)
 
-    while IFS=, read -r HUB MCE HostedCluster PLATFORM JOB JOB_ID; do
-        JOB_ID=$(echo "$JOB_ID" | awk -F= '{print $2}' || true)
+    cp "$job_list_file" /tmp/job_list_pending
 
-        if [ -z "$JOB_ID" ]; then
-            job_status="TriggerFailed"
-            job_url=""
-        else
+    while true; do
+        true > /tmp/job_list_next_pending
+
+        while IFS= read -r line; do
+            local job_id
+            job_id=$(echo "$line" | awk -F'JOB_ID=' '{print $2}' | tr -d ' ')
+            local prefix
+            prefix=$(echo "$line" | sed 's/, *JOB_ID=.*//')
+
+            if [ -z "$job_id" ]; then
+                echo "${prefix}, JOB_URL=, JOB_STATUS=TriggerFailed" >> "${SHARED_DIR}/job_list"
+                continue
+            fi
+
+            local job_status=""
+            local job_url=""
+            local http_status=""
             set +x
             for ((retry_count=1; retry_count<=max_retries; retry_count++)); do
-                response=$(curl -s -X GET -H "Authorization: Bearer $(cat /etc/mce-prow-gangway-credentials/token)" \
-                    "${GANGWAY_API}/v1/executions/${JOB_ID}" -w "%{http_code}")
+                response=$(curl -s -X GET -H "Authorization: Bearer $(cat "${TOKEN_PATH}")" \
+                    "${GANGWAY_API}/v1/executions/${job_id}" -w "%{http_code}")
 
-                json_body=$(echo "$response" | sed '$d')    # Extract JSON response body
-                http_status=$(echo "$response" | tail -n 1) # Extract HTTP status code
+                json_body=$(echo "$response" | sed '$d')
+                http_status=$(echo "$response" | tail -n 1)
 
                 if [ "$http_status" -eq 200 ]; then
                     job_status=$(jq -r '.job_status' <<< "$json_body")
@@ -114,13 +130,38 @@ function check_jobs() {
                 fi
             done
             set -x
+
             if [ "$http_status" -ne 200 ]; then
-                job_status="QueryNotFound"
-                job_url=""
+                echo "${prefix}, JOB_URL=, JOB_STATUS=QueryNotFound" >> "${SHARED_DIR}/job_list"
+            elif [ "$job_status" == "PENDING" ] || [ "$job_status" == "TRIGGERED" ]; then
+                echo "$line" >> /tmp/job_list_next_pending
+            else
+                echo "${prefix}, JOB_URL=${job_url}, JOB_STATUS=${job_status}" >> "${SHARED_DIR}/job_list"
             fi
+        done < /tmp/job_list_pending
+
+        if [ ! -s /tmp/job_list_next_pending ]; then
+            echo "All jobs have completed."
+            break
         fi
-        echo "$HUB, $MCE, $HostedCluster, $PLATFORM, $JOB, JOB_URL=${job_url}, JOB_STATUS=${job_status}" >> "${SHARED_DIR}/job_list"
-    done < "/tmp/job_list"
+
+        local elapsed=$(( $(date +%s) - start_time ))
+        if [ "$elapsed" -ge "$CHECK_TIMEOUT" ]; then
+            echo "Timeout reached (${CHECK_TIMEOUT}s). Marking remaining jobs as PENDING."
+            while IFS= read -r line; do
+                local prefix
+                prefix=$(echo "$line" | sed 's/, *JOB_ID=.*//')
+                echo "${prefix}, JOB_URL=, JOB_STATUS=PENDING" >> "${SHARED_DIR}/job_list"
+            done < /tmp/job_list_next_pending
+            break
+        fi
+
+        local pending_count
+        pending_count=$(wc -l < /tmp/job_list_next_pending)
+        echo "${pending_count} job(s) still pending. Rechecking in ${CHECK_INTERVAL}s..."
+        sleep "${CHECK_INTERVAL}"
+        mv /tmp/job_list_next_pending /tmp/job_list_pending
+    done
 }
 
 function generate_junit_xml() {
@@ -160,20 +201,22 @@ EOF
 
 eval "$(get_payload_list)"
 
-job_count=1
+true > /tmp/wave_jobs
+job_count=0
 for hub_version in "${!hub_to_mce[@]}"; do
     mce_versions="${hub_to_mce[$hub_version]}"
 
     for mce_version in $mce_versions; do
         guest_versions="${mce_to_guest[$mce_version]}"
-
+        job_name=""
         for guest_version in $guest_versions; do
             case $HOSTEDCLUSTER_PLATFORM in
                 aws)
+                    job_name="periodic-ci-openshift-hypershift-release-${guest_version}-periodics-mce-e2e-aws-critical"
                     post_data=$(jq -n --arg mce_version "$mce_version" \
                         --arg release_image "${payload_list[$hub_version]}" \
                         '{job_execution_type: "1", pod_spec_options: {envs: {MULTISTAGE_PARAM_OVERRIDE_MCE_VERSION: $mce_version, RELEASE_IMAGE_LATEST: $release_image, MULTISTAGE_PARAM_OVERRIDE_TEST_EXTRACT: "true"}}}')
-                    result=$(trigger_prow_job "${guest_to_job_aws[$guest_version]}" "$post_data")
+                    result=$(trigger_prow_job "$job_name" "$post_data")
                     ;;
                 agent)
                     #todo
@@ -183,24 +226,24 @@ for hub_version in "${!hub_to_mce[@]}"; do
                     ;;
             esac
             job_id=$(echo "$result" | grep "JOB_ID###" | cut -d'#' -f4 || true)
-            echo "HUB=${hub_version}, MCE=${mce_version}, HostedCluster=${guest_version}, PLATFORM=${HOSTEDCLUSTER_PLATFORM}, JOB=${guest_to_job_aws[$guest_version]}, JOB_ID=${job_id}" >> "/tmp/job_list"
+            echo "HUB=${hub_version}, MCE=${mce_version}, HostedCluster=${guest_version}, PLATFORM=${HOSTEDCLUSTER_PLATFORM}, JOB=${job_name}, JOB_ID=${job_id}" >> "/tmp/wave_jobs"
 
-            ((job_count++))
+            ((++job_count))
 
-            if ((job_count > JOB_PARALLEL)); then
-                echo "Reached $JOB_PARALLEL jobs, sleeping for ${JOB_DURATION} seconds..."
-                sleep "${JOB_DURATION}"
-                job_count=1
+            if ((job_count >= JOB_PARALLEL)); then
+                echo "Wave of ${job_count} job(s) triggered. Waiting for completion..."
+                wait_for_jobs /tmp/wave_jobs
+                true > /tmp/wave_jobs
+                job_count=0
             fi
         done
     done
 done
 
-if ((job_count > 1)); then
-    echo "Final batch, sleeping for ${JOB_DURATION} seconds..."
-    sleep "${JOB_DURATION}"
+if ((job_count > 0)); then
+    echo "Final wave of ${job_count} job(s) triggered. Waiting for completion..."
+    wait_for_jobs /tmp/wave_jobs
 fi
 
-check_jobs
 generate_junit_xml
 cat "${SHARED_DIR}/job_list" > "$ARTIFACT_DIR/job_list"


### PR DESCRIPTION
Trigger script: replace sleep-based waiting with polling-based
wait_for_jobs() that tracks job completion via Gangway API. Execute
jobs in waves of JOB_PARALLEL, waiting for each wave before triggering
the next. Construct job names dynamically instead of using a static map.
Update hub/MCE/guest version matrices to current releases (4.16-4.22).

Populates the spreadsheet at https://docs.google.com/spreadsheets/d/1g4EFkOrcr6D4WJKo4O8bmOK7txA4ZRTfqFazHtCoM3E/edit?gid=1470614841#gid=1470614841
    
Report script: switch Google Sheets auth from OAuth2 user credentials to
service account. Add determine_status() to detect failure phase by
checking GCS for test step finished.json artifacts (?? pass, ?? test
failed, ?? install failed). Fix orphaned sheet tabs on rename failure.
Add HH:MM to sheet title to avoid name collisions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added runtime-configurable defaults for shared/artifact paths, platform, job parallelism, and job duration.
  * Parameterized authentication and API endpoint to read bearer tokens and use a configurable Gangway endpoint.
  * Replaced static job mappings with computed job-name construction per guest/version and updated job output to reflect computed names.
  * Simplified version-compatibility mappings and made guest-version iteration dynamic for multi-version testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->