### PR TITLE
add trigger trusted-apps autofix periodic flow

### DIFF
--- a/ci-operator/jobs/infra-periodics.yaml
+++ b/ci-operator/jobs/infra-periodics.yaml
@@ -2629,6 +2629,174 @@ periodics:
         secretName: openshift-merge-bot
 - agent: kubernetes
   cluster: app.ci
+  cron: 0 4 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: release
+    workdir: true
+  labels:
+    ci.openshift.io/role: infra
+  name: periodic-openshift-release-trigger-trusted-apps-autofix
+  spec:
+    containers:
+    - args:
+      - -c
+      - |
+        set -o errexit
+        set -o nounset
+        set -o pipefail
+
+        if ! command -v python3 >/dev/null 2>&1; then
+          echo "python3 is required but missing from image" >&2
+          echo "failed" > /shared/fixer.status
+          exit 1
+        fi
+
+        trap 'echo "failed" > /shared/fixer.status' ERR
+        python3 ./hack/validate-trigger-trusted-apps.py --fix
+        python3 ./hack/validate-trigger-trusted-apps.py
+        echo "done" > /shared/fixer.status
+      command:
+      - /bin/bash
+      image: quay.io/openshift/ci-public:ci_python-validation_latest
+      imagePullPolicy: Always
+      name: trigger-trusted-apps-fixer
+      resources:
+        requests:
+          cpu: 500m
+      volumeMounts:
+      - mountPath: /shared
+        name: shared
+    - args:
+      - -c
+      - |
+        set -o errexit
+        set -o nounset
+        set -o pipefail
+
+        for _ in $(seq 1 600); do
+          if [[ -f /shared/fixer.status ]]; then
+            break
+          fi
+          sleep 2
+        done
+
+        if [[ ! -f /shared/fixer.status ]]; then
+          echo "timed out waiting for fixer container status" >&2
+          exit 1
+        fi
+
+        status="$(cat /shared/fixer.status)"
+        if [[ "${status}" != "done" ]]; then
+          echo "fixer container reported status: ${status}" >&2
+          echo "failed" > /shared/prow-config.status
+          exit 1
+        fi
+
+        DETERMINIZE_BIN="/usr/bin/determinize-prow-config"
+        if ! command -v "${DETERMINIZE_BIN}" >/dev/null 2>&1; then
+          DETERMINIZE_BIN="$(command -v determinize-prow-config || true)"
+        fi
+        if [[ -z "${DETERMINIZE_BIN}" ]]; then
+          echo "determinize-prow-config is required but missing from image" >&2
+          echo "failed" > /shared/prow-config.status
+          exit 1
+        fi
+
+        trap 'echo "failed" > /shared/prow-config.status' ERR
+        "${DETERMINIZE_BIN}" \
+        --prow-config-dir ./core-services/prow/02_config \
+        --sharded-prow-config-base-dir ./core-services/prow/02_config \
+        --sharded-plugin-config-base-dir ./core-services/prow/02_config
+        echo "done" > /shared/prow-config.status
+      command:
+      - /bin/bash
+      image: quay.io/openshift/ci-public:ci_auto-config-brancher_latest
+      imagePullPolicy: Always
+      name: trigger-trusted-apps-prow-config
+      resources:
+        requests:
+          cpu: 500m
+      volumeMounts:
+      - mountPath: /shared
+        name: shared
+    - args:
+      - -c
+      - |
+        set -o errexit
+        set -o nounset
+        set -o pipefail
+
+        for _ in $(seq 1 600); do
+          if [[ -f /shared/prow-config.status ]]; then
+            break
+          fi
+          sleep 2
+        done
+
+        if [[ ! -f /shared/prow-config.status ]]; then
+          echo "timed out waiting for prow-config container status" >&2
+          exit 1
+        fi
+
+        status="$(cat /shared/prow-config.status)"
+        if [[ "${status}" != "done" ]]; then
+          echo "prow-config container reported status: ${status}" >&2
+          exit 1
+        fi
+
+        PRCREATOR_BIN="/usr/bin/prcreator"
+        if ! command -v "${PRCREATOR_BIN}" >/dev/null 2>&1; then
+          PRCREATOR_BIN="$(command -v prcreator || true)"
+        fi
+        if [[ -z "${PRCREATOR_BIN}" ]]; then
+          echo "prcreator is required but missing from image" >&2
+          exit 1
+        fi
+
+        if git diff --quiet -- core-services/prow/02_config; then
+          echo "No trigger trusted_apps/prow-config updates needed."
+          exit 0
+        fi
+
+        "${PRCREATOR_BIN}" \
+        -pr-source-mode=branch \
+        -self-approve=true \
+        -github-app-id=$(GITHUB_APP_ID) \
+        -github-app-private-key-path=/etc/github/cert \
+        -organization=openshift -repo=release -branch=main \
+        -git-message="Automated update for trigger trusted apps" \
+        -pr-title="Automated: ensure trigger trusted_apps include openshift-merge-bot"
+      command:
+      - /bin/bash
+      env:
+      - name: GITHUB_APP_ID
+        valueFrom:
+          secretKeyRef:
+            key: appid
+            name: openshift-merge-bot
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_prcreator_latest
+      imagePullPolicy: Always
+      name: trigger-trusted-apps-prcreator
+      resources:
+        requests:
+          cpu: 500m
+      volumeMounts:
+      - mountPath: /etc/github
+        name: github-app-credentials
+        readOnly: true
+      - mountPath: /shared
+        name: shared
+    volumes:
+    - emptyDir: {}
+      name: shared
+    - name: github-app-credentials
+      secret:
+        secretName: openshift-merge-bot
+- agent: kubernetes
+  cluster: app.ci
   cron: 0 10,22 * * *
   decorate: true
   extra_refs:


### PR DESCRIPTION
Introduce a new infra periodic that runs trigger trusted_apps auto-fix, determinizes prow config, and then opens a self-approved PR using openshift-merge-bot app auth.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated daily validation and fixing of trusted apps configuration with automatic pull request creation when changes are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->