### PR TITLE
telco5g: Ignore always failing metallb test

### DIFF
--- a/ci-operator/step-registry/telco5g/cnf/tests/telco5g-cnf-tests-commands.sh
+++ b/ci-operator/step-registry/telco5g/cnf/tests/telco5g-cnf-tests-commands.sh
@@ -275,6 +275,9 @@ sriov "Configure rdma namespace"
 # https://issues.redhat.com/browse/RHEL-86883
 sriov "Switchdev create switchdev policies on supported devices"
 
+# always failing
+metallb "MetalLB"
+
 EOF
 
 if [[ "$HYPERSHIFT_ENVIRONMENT" == "true" ]]; then
@@ -313,6 +316,9 @@ sriov "Configure rdma namespace"
 # Known bug
 # https://issues.redhat.com/browse/RHEL-86883
 sriov "Switchdev create switchdev policies on supported devices"
+
+# always failing
+metallb "MetalLB"
 
 EOF
 
@@ -354,6 +360,9 @@ sriov "Configure rdma namespace"
 # https://issues.redhat.com/browse/RHEL-86883
 sriov "Switchdev create switchdev policies on supported devices"
 
+# always failing
+metallb "MetalLB"
+
 EOF
 
 if [[ "$HYPERSHIFT_ENVIRONMENT" == "true" ]]; then
@@ -393,6 +402,9 @@ sriov "Configure rdma namespace"
 # Known bug
 # https://issues.redhat.com/browse/RHEL-86883
 sriov "Switchdev create switchdev policies on supported devices"
+
+# always failing
+metallb "MetalLB"
 
 EOF
 
@@ -611,6 +623,7 @@ else
 fi
 export VALIDATIONS_FEATURES="${VALIDATIONS_FEATURES:-$FEATURES}"
 export TEST_RUN_FEATURES="${TEST_RUN_FEATURES:-$FEATURES}"
+export BLACKLISTED_TESTS="metallb"
 
 export SKIP_TESTS_FILE="${SKIP_TESTS_FILE:-${SHARED_DIR}/telco5g-cnf-tests-skip-list.txt}"
 export SCTPTEST_HAS_NON_CNF_WORKERS="${SCTPTEST_HAS_NON_CNF_WORKERS:-false}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated skip lists across multiple releases to exclude the MetalLB BGP deployment test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->