### PR TITLE
chore(prow): add opendatahub-io/model-registry-operator

### DIFF
--- a/core-services/prow/02_config/opendatahub-io/model-registry-operator/OWNERS
+++ b/core-services/prow/02_config/opendatahub-io/model-registry-operator/OWNERS
@@ -1,0 +1,32 @@
+# DO NOT EDIT; this file is auto-generated using https://github.com/openshift/ci-tools.
+# Fetched from https://github.com/opendatahub-io/model-registry root OWNERS
+# If the repo had OWNERS_ALIASES then the aliases were expanded
+# Logins who are not members of 'openshift' organization were filtered out
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+- Al-Pragliola
+- adysenrothman
+- dbasunag
+- dkuc
+- fege
+- jonburdo
+- pboyd
+- rareddy
+- tarilabs
+reviewers:
+- Al-Pragliola
+- adysenrothman
+- dbasunag
+- fege
+- jonburdo
+- pboyd
+- rareddy
+- tarilabs
+emeritus_approvers:
+- dhirajsb
+- isinyaaa
+- lampajr
+- nehachopra27
+- rkubis
+- tonyxrmdavidson

--- a/core-services/prow/02_config/opendatahub-io/model-registry-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/opendatahub-io/model-registry-operator/_pluginconfig.yaml
@@ -1,0 +1,72 @@
+approve:
+- commandHelpLink: ""
+  repos:
+  - opendatahub-io/model-registry-operator
+  require_self_approval: false
+external_plugins:
+  opendatahub-io/model-registry-operator:
+  - endpoint: http://refresh
+    events:
+    - issue_comment
+    name: refresh
+  - endpoint: http://cherrypick
+    events:
+    - issue_comment
+    - pull_request
+    name: cherrypick
+  - endpoint: http://needs-rebase
+    events:
+    - issue_comment
+    - pull_request
+    name: needs-rebase
+  - endpoint: http://backport-verifier
+    events:
+    - issue_comment
+    - pull_request
+    name: backport-verifier
+  - endpoint: http://payload-testing-prow-plugin
+    events:
+    - issue_comment
+    name: payload-testing-prow-plugin
+  - endpoint: http://jira-lifecycle-plugin
+    events:
+    - issue_comment
+    - pull_request
+    name: jira-lifecycle-plugin
+lgtm:
+- repos:
+  - opendatahub-io/model-registry-operator
+  review_acts_as_lgtm: true
+plugins:
+  opendatahub-io/model-registry-operator:
+    plugins:
+    - assign
+    - blunderbuss
+    - cat
+    - dog
+    - heart
+    - golint
+    - goose
+    - help
+    - hold
+    - jira
+    - label
+    - lgtm
+    - lifecycle
+    - override
+    - pony
+    - retitle
+    - shrug
+    - sigmention
+    - skip
+    - trigger
+    - verify-owners
+    - owners-label
+    - wip
+    - yuks
+    - approve
+triggers:
+- repos:
+  - opendatahub-io/model-registry-operator
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/opendatahub-io/model-registry-operator/_prowconfig.yaml
+++ b/core-services/prow/02_config/opendatahub-io/model-registry-operator/_prowconfig.yaml
@@ -1,0 +1,16 @@
+tide:
+  merge_method:
+    opendatahub-io/model-registry-operator: squash
+  queries:
+  - labels:
+    - approved
+    - lgtm
+    missingLabels:
+    - backports/unvalidated-commits
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - jira/invalid-bug
+    - needs-rebase
+    repos:
+    - opendatahub-io/model-registry-operator


### PR DESCRIPTION
Add `opendatahub-io/model-registry-operator` to the prow config.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Configured governance and code review policies for the model-registry-operator repository, including approval requirements and reviewer assignments.
* Established CI/CD automation settings with merge workflow validation, automated plugins for pull request processing, and merge conflict handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->