### PR TITLE
perfscale: upgrade kube-burner-ocp to 1.11.8

### DIFF
--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.21-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.21-nightly-x86.yaml
@@ -41,6 +41,7 @@ tests:
       ES_TYPE: qe
       IGNORE_JOB_ITERATIONS: "true"
       KB_FLAGS: --local-indexing
+      KUBE_BURNER_VERSION: 1.11.8
       ND_CNI_EXTRA_FLAGS: --churn-mode=objects --churn-delay=1m --churn-percent=50
         --churn-cycles=2
       ND_EXTRA_FLAGS: --churn-mode=objects --churn-delay=1m --churn-percent=50 --churn-cycles=2
@@ -67,6 +68,7 @@ tests:
       ENABLE_LAYER_3: "false"
       KB_FLAGS: --set=metricsEndpoints.0.step=2m --set=metricsEndpoints.1.step=2m
         --local-indexing
+      KUBE_BURNER_VERSION: 1.11.8
       NODE_DENSITY_GC: "false"
       OPENSHIFT_INFRA_NODE_INSTANCE_TYPE: r5.4xlarge
       SET_ENV_BY_PLATFORM: custom
@@ -89,6 +91,7 @@ tests:
       BASE_DOMAIN: qe.devcluster.openshift.com
       ENABLE_LAYER_3: "false"
       KB_FLAGS: --local-indexing
+      KUBE_BURNER_VERSION: 1.11.8
       UDN_ITERATION_MULTIPLIER: "3"
       ZONES_COUNT: "3"
     test:

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.22-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.22-nightly-x86.yaml
@@ -41,6 +41,7 @@ tests:
       ES_TYPE: qe
       IGNORE_JOB_ITERATIONS: "true"
       KB_FLAGS: --local-indexing
+      KUBE_BURNER_VERSION: 1.11.8
       ND_CNI_EXTRA_FLAGS: --churn-mode=objects --churn-delay=1m --churn-percent=50
         --churn-cycles=2
       ND_EXTRA_FLAGS: --churn-mode=objects --churn-delay=1m --churn-percent=50 --churn-cycles=2
@@ -92,6 +93,7 @@ tests:
       ENABLE_LAYER_3: "false"
       KB_FLAGS: --set=metricsEndpoints.0.step=2m --set=metricsEndpoints.1.step=2m
         --local-indexing
+      KUBE_BURNER_VERSION: 1.11.8
       NODE_DENSITY_GC: "false"
       OPENSHIFT_INFRA_NODE_INSTANCE_TYPE: r5.4xlarge
       SET_ENV_BY_PLATFORM: custom
@@ -114,6 +116,7 @@ tests:
       BASE_DOMAIN: qe.devcluster.openshift.com
       ENABLE_LAYER_3: "false"
       KB_FLAGS: --local-indexing
+      KUBE_BURNER_VERSION: 1.11.8
       UDN_ITERATION_MULTIPLIER: "3"
       ZONES_COUNT: "3"
     test:

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.23-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.23-nightly-x86.yaml
@@ -41,6 +41,7 @@ tests:
       ES_TYPE: qe
       IGNORE_JOB_ITERATIONS: "true"
       KB_FLAGS: --local-indexing
+      KUBE_BURNER_VERSION: 1.11.8
       ND_CNI_EXTRA_FLAGS: --churn-mode=objects --churn-delay=1m --churn-percent=50
         --churn-cycles=2
       ND_EXTRA_FLAGS: --churn-mode=objects --churn-delay=1m --churn-percent=50 --churn-cycles=2
@@ -92,6 +93,7 @@ tests:
       ENABLE_LAYER_3: "false"
       KB_FLAGS: --set=metricsEndpoints.0.step=2m --set=metricsEndpoints.1.step=2m
         --local-indexing
+      KUBE_BURNER_VERSION: 1.11.8
       NODE_DENSITY_GC: "false"
       OPENSHIFT_INFRA_NODE_INSTANCE_TYPE: r5.4xlarge
       SET_ENV_BY_PLATFORM: custom
@@ -114,6 +116,7 @@ tests:
       BASE_DOMAIN: qe.devcluster.openshift.com
       ENABLE_LAYER_3: "false"
       KB_FLAGS: --local-indexing
+      KUBE_BURNER_VERSION: 1.11.8
       UDN_ITERATION_MULTIPLIER: "3"
       ZONES_COUNT: "3"
     test:

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-5.0-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-5.0-nightly-x86.yaml
@@ -42,6 +42,7 @@ tests:
       ES_TYPE: qe
       IGNORE_JOB_ITERATIONS: "true"
       KB_FLAGS: --local-indexing
+      KUBE_BURNER_VERSION: 1.11.8
       ND_CNI_EXTRA_FLAGS: --churn-mode=objects --churn-delay=1m --churn-percent=50
         --churn-cycles=2
       ND_EXTRA_FLAGS: --churn-mode=objects --churn-delay=1m --churn-percent=50 --churn-cycles=2
@@ -68,6 +69,7 @@ tests:
       ENABLE_LAYER_3: "false"
       KB_FLAGS: --set=metricsEndpoints.0.step=2m --set=metricsEndpoints.1.step=2m
         --local-indexing
+      KUBE_BURNER_VERSION: 1.11.8
       NODE_DENSITY_GC: "false"
       OPENSHIFT_INFRA_NODE_INSTANCE_TYPE: r5.4xlarge
       SET_ENV_BY_PLATFORM: custom
@@ -89,6 +91,7 @@ tests:
       ADDITIONAL_WORKER_NODES: "21"
       BASE_DOMAIN: qe.devcluster.openshift.com
       ENABLE_LAYER_3: "false"
+      KUBE_BURNER_VERSION: 1.11.8
       UDN_ITERATION_MULTIPLIER: "3"
       ZONES_COUNT: "3"
     test:


### PR DESCRIPTION
## Summary
- Upgrade `KUBE_BURNER_VERSION` to `1.11.8` (latest [kube-burner-ocp release](https://github.com/kube-burner/kube-burner-ocp/releases/tag/v1.11.8)) for AWS scale payload jobs:
  - `payload-control-plane-6nodes`
  - `control-plane-24nodes`
  - `control-plane-120nodes`
- Applied across 4.21, 4.22, 4.23, and 5.0 AWS nightly configs

/hold
/pj-rehearse periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-aws-4.22-nightly-x86-payload-control-plane-6nodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test infrastructure environment configurations across OpenShift release pipelines to improve testing consistency and reliability. Changes apply to performance and scale validation testing across multiple OpenShift versions (4.21, 4.22, 4.23, and 5.0), standardizing test environment settings to enable more consistent test execution, improved performance benchmarking metrics, and uniform testing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->