### PR TITLE
Onboard openshift-online/platform-engineering-skills to OpenShift CI

### DIFF
--- a/ci-operator/config/openshift-online/platform-engineering-skills/.config.prowgen
+++ b/ci-operator/config/openshift-online/platform-engineering-skills/.config.prowgen
@@ -1,0 +1,2 @@
+private: true
+expose: true

--- a/ci-operator/config/openshift-online/platform-engineering-skills/OWNERS
+++ b/ci-operator/config/openshift-online/platform-engineering-skills/OWNERS
@@ -1,0 +1,15 @@
+# DO NOT EDIT; this file is auto-generated using https://github.com/openshift/ci-tools.
+# Fetched from https://github.com/openshift-online/platform-engineering-skills root OWNERS
+# If the repo had OWNERS_ALIASES then the aliases were expanded
+# Logins who are not members of 'openshift' organization were filtered out
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+- aweiteka
+- gurnben
+- jonmosco
+options: {}
+reviewers:
+- aweiteka
+- gurnben
+- jonmosco

--- a/ci-operator/config/openshift-online/platform-engineering-skills/openshift-online-platform-engineering-skills-main.yaml
+++ b/ci-operator/config/openshift-online/platform-engineering-skills/openshift-online-platform-engineering-skills-main.yaml
@@ -1,0 +1,30 @@
+build_root:
+  project_image:
+    dockerfile_literal: |
+      FROM registry.access.redhat.com/ubi9/ubi:latest
+      RUN dnf module enable -y nodejs:20 && \
+            dnf install -y git npm python3-pip && \
+            npm install -g markdownlint-cli2 markdown-link-check && \
+            pip3 install yamllint
+resources:
+  '*':
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: markdownlint
+  commands: hack/markdownlint.sh
+  container:
+    from: src
+- as: yamllint
+  commands: hack/yamllint.sh
+  container:
+    from: src
+- as: linkcheck
+  commands: hack/linkcheck.sh
+  container:
+    from: src
+zz_generated_metadata:
+  branch: main
+  org: openshift-online
+  repo: platform-engineering-skills

--- a/ci-operator/jobs/openshift-online/platform-engineering-skills/OWNERS
+++ b/ci-operator/jobs/openshift-online/platform-engineering-skills/OWNERS
@@ -1,0 +1,15 @@
+# DO NOT EDIT; this file is auto-generated using https://github.com/openshift/ci-tools.
+# Fetched from https://github.com/openshift-online/platform-engineering-skills root OWNERS
+# If the repo had OWNERS_ALIASES then the aliases were expanded
+# Logins who are not members of 'openshift' organization were filtered out
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+- aweiteka
+- gurnben
+- jonmosco
+options: {}
+reviewers:
+- aweiteka
+- gurnben
+- jonmosco

--- a/ci-operator/jobs/openshift-online/platform-engineering-skills/openshift-online-platform-engineering-skills-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-online/platform-engineering-skills/openshift-online-platform-engineering-skills-main-presubmits.yaml
@@ -1,0 +1,212 @@
+presubmits:
+  openshift-online/platform-engineering-skills:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build01
+    context: ci/prow/linkcheck
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-online-platform-engineering-skills-main-linkcheck
+    rerun_command: /test linkcheck
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --target=linkcheck
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: github-credentials-openshift-ci-robot-private-git-cloner
+        secret:
+          secretName: github-credentials-openshift-ci-robot-private-git-cloner
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )linkcheck,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build01
+    context: ci/prow/markdownlint
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-online-platform-engineering-skills-main-markdownlint
+    rerun_command: /test markdownlint
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --target=markdownlint
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: github-credentials-openshift-ci-robot-private-git-cloner
+        secret:
+          secretName: github-credentials-openshift-ci-robot-private-git-cloner
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )markdownlint,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build01
+    context: ci/prow/yamllint
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-online-platform-engineering-skills-main-yamllint
+    rerun_command: /test yamllint
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --target=yamllint
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: github-credentials-openshift-ci-robot-private-git-cloner
+        secret:
+          secretName: github-credentials-openshift-ci-robot-private-git-cloner
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )yamllint,?($|\s.*)

--- a/core-services/prow/02_config/openshift-online/platform-engineering-skills/OWNERS
+++ b/core-services/prow/02_config/openshift-online/platform-engineering-skills/OWNERS
@@ -1,0 +1,15 @@
+# DO NOT EDIT; this file is auto-generated using https://github.com/openshift/ci-tools.
+# Fetched from https://github.com/openshift-online/platform-engineering-skills root OWNERS
+# If the repo had OWNERS_ALIASES then the aliases were expanded
+# Logins who are not members of 'openshift' organization were filtered out
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+- aweiteka
+- gurnben
+- jonmosco
+options: {}
+reviewers:
+- aweiteka
+- gurnben
+- jonmosco

--- a/core-services/prow/02_config/openshift-online/platform-engineering-skills/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-online/platform-engineering-skills/_pluginconfig.yaml
@@ -1,0 +1,45 @@
+approve:
+- commandHelpLink: https://go.k8s.io/bot-commands
+  lgtm_acts_as_approve: true
+  repos:
+  - openshift-online/platform-engineering-skills
+  require_self_approval: true
+external_plugins:
+  openshift-online/platform-engineering-skills:
+  - endpoint: http://needs-rebase
+    events:
+    - issue_comment
+    - pull_request
+    name: needs-rebase
+plugins:
+  openshift-online/platform-engineering-skills:
+    plugins:
+    - assign
+    - blunderbuss
+    - cat
+    - dog
+    - heart
+    - golint
+    - goose
+    - help
+    - hold
+    - label
+    - lgtm
+    - lifecycle
+    - override
+    - pony
+    - retitle
+    - shrug
+    - sigmention
+    - skip
+    - trigger
+    - verify-owners
+    - owners-label
+    - wip
+    - yuks
+    - approve
+triggers:
+- repos:
+  - openshift-online/platform-engineering-skills
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-online/platform-engineering-skills/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift-online/platform-engineering-skills/_prowconfig.yaml
@@ -1,0 +1,14 @@
+tide:
+  queries:
+  - labels:
+    - approved
+    - lgtm
+    missingLabels:
+    - backports/unvalidated-commits
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - jira/invalid-bug
+    - needs-rebase
+    repos:
+    - openshift-online/platform-engineering-skills


### PR DESCRIPTION
## Summary

- Onboard `openshift-online/platform-engineering-skills` (a GenAI skills markdown repo) to OpenShift CI
- Configure three presubmit validation jobs: `markdownlint`, `yamllint`, and `linkcheck`
- Set owners: `aweiteka`, `gurnben`, `jonmosco`, `tgpski`

## Details

The CI config uses a UBI9 build root with Node.js 20 and Python 3 to install:
- `markdownlint-cli2` — markdown formatting validation
- `markdown-link-check` — broken link detection
- `yamllint` — YAML file validation

The corresponding `hack/` scripts and linter configs have been pushed to the [target repo](https://github.com/openshift-online/platform-engineering-skills).

## Test plan

- [ ] CI presubmit jobs rehearse successfully on this PR
- [ ] Verify Prow jobs trigger correctly on PRs to `platform-engineering-skills`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added repository ownership and approval metadata and configured repo-level plugin and Tide settings.
  * Established CI presubmit job definitions and job orchestration/triggers for the main branch.

* **Tests**
  * Configured automated linting and link-check test jobs to run on pull requests (markdown, YAML, link checks).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->