### PR TITLE
DVO-411: Update DVO operator-sdk to 4.21

### DIFF
--- a/ci-operator/config/app-sre/deployment-validation-operator/app-sre-deployment-validation-operator-master.yaml
+++ b/ci-operator/config/app-sre/deployment-validation-operator/app-sre-deployment-validation-operator-master.yaml
@@ -1,6 +1,6 @@
 base_images:
   cli:
-    name: "4.21"
+    name: "4.20"
     namespace: ocp
     tag: cli
   dvo-tests:
@@ -8,7 +8,7 @@ base_images:
     namespace: ci
     tag: latest
   operator-sdk:
-    name: "4.21"
+    name: "4.20"
     namespace: origin
     tag: operator-sdk
 build_root:

--- a/ci-operator/config/app-sre/deployment-validation-operator/app-sre-deployment-validation-operator-master.yaml
+++ b/ci-operator/config/app-sre/deployment-validation-operator/app-sre-deployment-validation-operator-master.yaml
@@ -1,6 +1,6 @@
 base_images:
   cli:
-    name: "4.19"
+    name: "4.21"
     namespace: ocp
     tag: cli
   dvo-tests:
@@ -8,7 +8,7 @@ base_images:
     namespace: ci
     tag: latest
   operator-sdk:
-    name: "4.19"
+    name: "4.21"
     namespace: origin
     tag: operator-sdk
 build_root:


### PR DESCRIPTION
#### summary

Bump operator-sdk image for the tests of the DVO 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated container build base images for CLI and operator toolkit from OpenShift version 4.19 to 4.20 to align build artifacts with the newer runtime base.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->