### PR TITLE
aws-account-operator: Add OPERATOR_IMAGE dependency for integration tests

### DIFF
--- a/ci-operator/config/openshift/aws-account-operator/openshift-aws-account-operator-master.yaml
+++ b/ci-operator/config/openshift/aws-account-operator/openshift-aws-account-operator-master.yaml
@@ -3,7 +3,7 @@ build_root:
 images:
   items:
   - dockerfile_path: build/Dockerfile
-    to: unused
+    to: aws-account-operator
 resources:
   '*':
     limits:
@@ -68,6 +68,9 @@ tests:
       - mount_path: /tmp/secret/aao-aws-creds
         name: aao-aws-creds
         namespace: test-credentials
+      dependencies:
+      - env: OPERATOR_IMAGE
+        name: aws-account-operator
       from: src
       resources:
         limits:


### PR DESCRIPTION
## Summary

Rename aws-account-operator built image from "unused" to "aws-account-operator" and expose it as `OPERATOR_IMAGE` env var in integration tests.

## Problem

AWS Account Operator integration tests currently rebuild the operator image in-cluster using OpenShift Build API (`ImageStream`/`BuildConfig`). However, Build API is not available in all PROW cluster pools, causing tests to fail with:

error: no matches for kind "ImageStream" in version "image.openshift.io/v1"
error: no matches for kind "BuildConfig" in version "build.openshift.io/v1"

## Solution

1. Rename the built image from "unused" to "aws-account-operator" (more meaningful name)
2. Expose this image as the `OPERATOR_IMAGE` environment variable in the test container

This allows integration tests to use the pre-built image instead of rebuilding in-cluster.

## Changes

- Rename `images.items[0].to` from "unused" to "aws-account-operator"
- Add `dependencies` section to `integration-test` step mapping the image to `OPERATOR_IMAGE` env var

## Pattern

This follows the same pattern used by other operators (e.g., `analytics-operator`, `addon-operator`) that need access to their pre-built images during integration tests.

## Testing

- Integration tests will use `$OPERATOR_IMAGE` when set (PROW)
- Fall back to in-cluster build when not set (local/staging development)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configuration to ensure operator container images are properly built and made accessible during integration testing workflows. This configuration enhancement strengthens build reliability and test consistency, improving the overall stability and operational efficiency of the continuous integration and deployment process through proper image dependency management and explicit declaration of build targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[SREP-3397](https://redhat.atlassian.net/browse/SREP-3397)

[SREP-3397]: https://redhat.atlassian.net/browse/SREP-3397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ