### PR TITLE
CNTRLPLANE-3258: Add Slack webhook notifications to jira-agent

### DIFF
--- a/ci-operator/step-registry/hypershift/jira-agent/README.md
+++ b/ci-operator/step-registry/hypershift/jira-agent/README.md
@@ -132,7 +132,7 @@ The workflow uses GitHub App authentication (JWT-based) rather than personal acc
 **Optional:**
 - `hypershift-jira-token`: Jira API token for adding `agent-processed` labels
 - `slack-webhook-url`: Slack incoming webhook URL for posting PR notifications to team-ocp-hypershift
-- `github-to-slack.json`: JSON mapping of GitHub usernames to Slack member IDs, plus a `backup-user` key for fallback (e.g., `{"gh-username": "UXXXXXXXXXX", "backup-user": "UXXXXXXXXXX"}`)
+- `gh-to-slack-ids`: JSON mapping of GitHub usernames to Slack member IDs, plus a `backup-user` key for fallback (e.g., `{"gh-username": "UXXXXXXXXXX", "backup-user": "UXXXXXXXXXX"}`)
 
 These should be configured in Vault with secretsync metadata and synced automatically.
 

--- a/ci-operator/step-registry/hypershift/jira-agent/README.md
+++ b/ci-operator/step-registry/hypershift/jira-agent/README.md
@@ -129,8 +129,10 @@ The workflow requires a single secret in the `test-credentials` namespace:
 
 The workflow uses GitHub App authentication (JWT-based) rather than personal access tokens. This provides better security and allows fine-grained permissions.
 
-**Optional** (currently disabled for testing):
+**Optional:**
 - `hypershift-jira-token`: Jira API token for adding `agent-processed` labels
+- `slack-webhook-url`: Slack incoming webhook URL for posting PR notifications to team-ocp-hypershift
+- `github-to-slack.json`: JSON mapping of GitHub usernames to Slack member IDs, plus a `backup-user` key for fallback (e.g., `{"gh-username": "UXXXXXXXXXX", "backup-user": "UXXXXXXXXXX"}`)
 
 These should be configured in Vault with secretsync metadata and synced automatically.
 
@@ -278,7 +280,6 @@ Then run `make update` to regenerate job configs.
 
 ## Future Enhancements
 
-- Slack notifications for processed issues
 - Metrics push to Prometheus
 - Automatic retries for transient failures
 - Priority-based processing

--- a/ci-operator/step-registry/hypershift/jira-agent/process/hypershift-jira-agent-process-commands.sh
+++ b/ci-operator/step-registry/hypershift/jira-agent/process/hypershift-jira-agent-process-commands.sh
@@ -148,6 +148,36 @@ else
   JIRA_AUTH=""
 fi
 
+# Load Slack webhook URL for notifications
+SLACK_WEBHOOK_FILE="/var/run/claude-code-service-account/slack-webhook-url"
+if [ -f "$SLACK_WEBHOOK_FILE" ]; then
+  SLACK_WEBHOOK_URL=$(cat "$SLACK_WEBHOOK_FILE")
+  echo "Slack webhook URL loaded"
+else
+  echo "Warning: Slack webhook URL not found at $SLACK_WEBHOOK_FILE"
+  echo "Slack notifications will be skipped"
+  SLACK_WEBHOOK_URL=""
+fi
+
+# Load GitHub-to-Slack user ID mapping
+GITHUB_SLACK_MAP_FILE="/var/run/claude-code-service-account/github-to-slack.json"
+if [ -f "$GITHUB_SLACK_MAP_FILE" ]; then
+  GITHUB_SLACK_MAP=$(cat "$GITHUB_SLACK_MAP_FILE")
+  echo "GitHub-to-Slack mapping loaded"
+else
+  echo "Warning: GitHub-to-Slack mapping not found at $GITHUB_SLACK_MAP_FILE"
+  echo "Reviewer pings will use GitHub usernames instead of Slack mentions"
+  GITHUB_SLACK_MAP="{}"
+fi
+
+# Extract Slack fallback user ID from mapping (pinged when no reviewers are assigned)
+SLACK_FALLBACK_USER_ID=$(echo "$GITHUB_SLACK_MAP" | jq -r '.["backup-user"] // empty' 2>/dev/null)
+if [ -n "$SLACK_FALLBACK_USER_ID" ]; then
+  echo "Slack fallback user ID loaded from mapping"
+else
+  echo "Warning: No 'backup-user' key in GitHub-to-Slack mapping"
+fi
+
 # Function to transition a Jira issue to a target status
 transition_issue() {
   local ISSUE_KEY=$1
@@ -186,6 +216,86 @@ set_assignee() {
     -H "Authorization: Basic $JIRA_AUTH" \
     -H "Content-Type: application/json" \
     -d "{\"accountId\":\"$ACCOUNT_ID\"}"
+}
+
+# Function to send Slack notification after PR creation
+send_slack_notification() {
+  local PR_URL=$1
+  local PR_NUM
+
+  if [ -z "$SLACK_WEBHOOK_URL" ]; then
+    echo "   Skipping Slack notification (no webhook URL configured)"
+    return 0
+  fi
+
+  PR_NUM=$(echo "$PR_URL" | grep -o '[0-9]*$' || true)
+  if [ -z "$PR_NUM" ]; then
+    echo "   Warning: Could not extract PR number from URL, skipping Slack notification"
+    return 0
+  fi
+
+  echo "   Polling for PR reviewers (up to 5 minutes)..."
+  local REVIEWERS=""
+  local ATTEMPT=0
+  local MAX_ATTEMPTS=10
+
+  while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
+    REVIEWERS=$(gh pr view "$PR_NUM" --repo openshift/hypershift --json reviewRequests -q '.reviewRequests[].login' 2>/dev/null || echo "")
+    if [ -n "$REVIEWERS" ]; then
+      echo "   Reviewers found: $REVIEWERS"
+      break
+    fi
+    ATTEMPT=$((ATTEMPT + 1))
+    if [ $ATTEMPT -lt $MAX_ATTEMPTS ]; then
+      echo "   No reviewers yet, retrying in 30s (attempt $ATTEMPT/$MAX_ATTEMPTS)..."
+      sleep 30
+    fi
+  done
+
+  # Build reviewer mention string
+  local REVIEWER_MENTIONS=""
+  if [ -n "$REVIEWERS" ]; then
+    while IFS= read -r gh_user; do
+      local slack_id
+      slack_id=$(echo "$GITHUB_SLACK_MAP" | jq -r --arg user "$gh_user" '.[$user] // empty' 2>/dev/null)
+      if [ -n "$slack_id" ]; then
+        REVIEWER_MENTIONS="${REVIEWER_MENTIONS} <@${slack_id}>"
+      else
+        REVIEWER_MENTIONS="${REVIEWER_MENTIONS} ${gh_user}"
+      fi
+    done <<< "$REVIEWERS"
+  else
+    echo "   No reviewers assigned after 5 minutes, using fallback"
+    if [ -n "$SLACK_FALLBACK_USER_ID" ]; then
+      REVIEWER_MENTIONS="<@${SLACK_FALLBACK_USER_ID}>"
+    else
+      REVIEWER_MENTIONS="(none assigned)"
+    fi
+  fi
+  REVIEWER_MENTIONS=$(echo "$REVIEWER_MENTIONS" | sed 's/^ //')
+
+  # Get PR title
+  local PR_TITLE
+  PR_TITLE=$(gh pr view "$PR_NUM" --repo openshift/hypershift --json title -q '.title' 2>/dev/null || echo "PR #${PR_NUM}")
+
+  # Send Slack message
+  local SLACK_PAYLOAD
+  SLACK_PAYLOAD=$(jq -n --arg title "$PR_TITLE" --arg url "$PR_URL" --arg reviewers "$REVIEWER_MENTIONS" \
+    '{text: ":hypershift-bot: *Jira Agent PR ready for review*\n:review: <\($url)|\($title)>\n:eyes: Reviewers: \($reviewers)"}')
+
+  local SLACK_RESPONSE
+  SLACK_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
+    -H 'Content-type: application/json' \
+    --data "$SLACK_PAYLOAD" \
+    "$SLACK_WEBHOOK_URL")
+  local SLACK_HTTP_CODE
+  SLACK_HTTP_CODE=$(echo "$SLACK_RESPONSE" | tail -1)
+
+  if [ "$SLACK_HTTP_CODE" = "200" ]; then
+    echo "   Slack notification sent successfully"
+  else
+    echo "   Warning: Failed to send Slack notification (HTTP $SLACK_HTTP_CODE)"
+  fi
 }
 
 # Query Jira for issues (excluding already processed ones via label)
@@ -570,6 +680,11 @@ ${REPORT_SECTION}"
             gh pr edit "$PR_NUM" --repo openshift/hypershift --body "$UPDATED_BODY" 2>/dev/null || echo "Warning: Failed to update PR #${PR_NUM} description"
           fi
         fi
+      fi
+
+      # Send Slack notification to team channel
+      if [ -n "$PR_URL" ]; then
+        send_slack_notification "$PR_URL"
       fi
     else
       echo "No code changes detected for $ISSUE_KEY, skipping review and PR creation"

--- a/ci-operator/step-registry/hypershift/jira-agent/process/hypershift-jira-agent-process-commands.sh
+++ b/ci-operator/step-registry/hypershift/jira-agent/process/hypershift-jira-agent-process-commands.sh
@@ -163,7 +163,7 @@ fi
 $_SLACK_WAS_TRACING && set -x
 
 # Load GitHub-to-Slack user ID mapping
-GITHUB_SLACK_MAP_FILE="/var/run/claude-code-service-account/github-to-slack.json"
+GITHUB_SLACK_MAP_FILE="/var/run/claude-code-service-account/gh-to-slack-ids"
 if [ -f "$GITHUB_SLACK_MAP_FILE" ]; then
   if GITHUB_SLACK_MAP=$(jq -c . < "$GITHUB_SLACK_MAP_FILE" 2>/dev/null); then
     echo "GitHub-to-Slack mapping loaded"
@@ -240,7 +240,7 @@ send_slack_notification() {
   local REVIEWERS=""
   local PR_TITLE=""
   local ATTEMPT=0
-  local MAX_ATTEMPTS=4
+  local MAX_ATTEMPTS=5
 
   while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
     local PR_DATA
@@ -295,6 +295,8 @@ send_slack_notification() {
   set +e
   local SLACK_RESPONSE
   SLACK_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
+    --connect-timeout 10 \
+    --max-time 20 \
     -H 'Content-type: application/json' \
     --data "$SLACK_PAYLOAD" \
     "$SLACK_WEBHOOK_URL")

--- a/ci-operator/step-registry/hypershift/jira-agent/process/hypershift-jira-agent-process-commands.sh
+++ b/ci-operator/step-registry/hypershift/jira-agent/process/hypershift-jira-agent-process-commands.sh
@@ -148,8 +148,10 @@ else
   JIRA_AUTH=""
 fi
 
-# Load Slack webhook URL for notifications
+# Load Slack webhook URL for notifications (tracing disabled to protect credential)
 SLACK_WEBHOOK_FILE="/var/run/claude-code-service-account/slack-webhook-url"
+[[ $- == *x* ]] && _SLACK_WAS_TRACING=true || _SLACK_WAS_TRACING=false
+set +x
 if [ -f "$SLACK_WEBHOOK_FILE" ]; then
   SLACK_WEBHOOK_URL=$(cat "$SLACK_WEBHOOK_FILE")
   echo "Slack webhook URL loaded"
@@ -158,6 +160,7 @@ else
   echo "Slack notifications will be skipped"
   SLACK_WEBHOOK_URL=""
 fi
+$_SLACK_WAS_TRACING && set -x
 
 # Load GitHub-to-Slack user ID mapping
 GITHUB_SLACK_MAP_FILE="/var/run/claude-code-service-account/github-to-slack.json"
@@ -221,26 +224,24 @@ set_assignee() {
 # Function to send Slack notification after PR creation
 send_slack_notification() {
   local PR_URL=$1
-  local PR_NUM
+  local PR_NUM=$2
 
   if [ -z "$SLACK_WEBHOOK_URL" ]; then
     echo "   Skipping Slack notification (no webhook URL configured)"
     return 0
   fi
 
-  PR_NUM=$(echo "$PR_URL" | grep -o '[0-9]*$' || true)
-  if [ -z "$PR_NUM" ]; then
-    echo "   Warning: Could not extract PR number from URL, skipping Slack notification"
-    return 0
-  fi
-
-  echo "   Polling for PR reviewers (up to 5 minutes)..."
+  echo "   Polling for PR reviewers (up to 2 minutes)..."
   local REVIEWERS=""
+  local PR_TITLE=""
   local ATTEMPT=0
-  local MAX_ATTEMPTS=10
+  local MAX_ATTEMPTS=4
 
   while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
-    REVIEWERS=$(gh pr view "$PR_NUM" --repo openshift/hypershift --json reviewRequests -q '.reviewRequests[].login' 2>/dev/null || echo "")
+    local PR_DATA
+    PR_DATA=$(gh pr view "$PR_NUM" --repo openshift/hypershift --json reviewRequests,title 2>/dev/null || echo "{}")
+    PR_TITLE=$(echo "$PR_DATA" | jq -r '.title // empty' 2>/dev/null)
+    REVIEWERS=$(echo "$PR_DATA" | jq -r '.reviewRequests[]?.login // empty' 2>/dev/null)
     if [ -n "$REVIEWERS" ]; then
       echo "   Reviewers found: $REVIEWERS"
       break
@@ -251,6 +252,11 @@ send_slack_notification() {
       sleep 30
     fi
   done
+
+  # Fallback PR title if not fetched
+  if [ -z "$PR_TITLE" ]; then
+    PR_TITLE="PR #${PR_NUM}"
+  fi
 
   # Build reviewer mention string
   local REVIEWER_MENTIONS=""
@@ -265,7 +271,7 @@ send_slack_notification() {
       fi
     done <<< "$REVIEWERS"
   else
-    echo "   No reviewers assigned after 5 minutes, using fallback"
+    echo "   No reviewers assigned after 2 minutes, using fallback"
     if [ -n "$SLACK_FALLBACK_USER_ID" ]; then
       REVIEWER_MENTIONS="<@${SLACK_FALLBACK_USER_ID}>"
     else
@@ -274,20 +280,19 @@ send_slack_notification() {
   fi
   REVIEWER_MENTIONS=$(echo "$REVIEWER_MENTIONS" | sed 's/^ //')
 
-  # Get PR title
-  local PR_TITLE
-  PR_TITLE=$(gh pr view "$PR_NUM" --repo openshift/hypershift --json title -q '.title' 2>/dev/null || echo "PR #${PR_NUM}")
-
-  # Send Slack message
+  # Send Slack message (tracing disabled to protect webhook URL)
   local SLACK_PAYLOAD
   SLACK_PAYLOAD=$(jq -n --arg title "$PR_TITLE" --arg url "$PR_URL" --arg reviewers "$REVIEWER_MENTIONS" \
     '{text: ":hypershift-bot: *Jira Agent PR ready for review*\n:review: <\($url)|\($title)>\n:eyes: Reviewers: \($reviewers)"}')
 
+  [[ $- == *x* ]] && local _was_tracing=true || local _was_tracing=false
+  set +x
   local SLACK_RESPONSE
   SLACK_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
     -H 'Content-type: application/json' \
     --data "$SLACK_PAYLOAD" \
     "$SLACK_WEBHOOK_URL")
+  $_was_tracing && set -x
   local SLACK_HTTP_CODE
   SLACK_HTTP_CODE=$(echo "$SLACK_RESPONSE" | tail -1)
 
@@ -683,8 +688,8 @@ ${REPORT_SECTION}"
       fi
 
       # Send Slack notification to team channel
-      if [ -n "$PR_URL" ]; then
-        send_slack_notification "$PR_URL"
+      if [ -n "$PR_URL" ] && [ -n "$PR_NUM" ]; then
+        send_slack_notification "$PR_URL" "$PR_NUM"
       fi
     else
       echo "No code changes detected for $ISSUE_KEY, skipping review and PR creation"

--- a/ci-operator/step-registry/hypershift/jira-agent/process/hypershift-jira-agent-process-commands.sh
+++ b/ci-operator/step-registry/hypershift/jira-agent/process/hypershift-jira-agent-process-commands.sh
@@ -165,8 +165,13 @@ $_SLACK_WAS_TRACING && set -x
 # Load GitHub-to-Slack user ID mapping
 GITHUB_SLACK_MAP_FILE="/var/run/claude-code-service-account/github-to-slack.json"
 if [ -f "$GITHUB_SLACK_MAP_FILE" ]; then
-  GITHUB_SLACK_MAP=$(cat "$GITHUB_SLACK_MAP_FILE")
-  echo "GitHub-to-Slack mapping loaded"
+  if GITHUB_SLACK_MAP=$(jq -c . < "$GITHUB_SLACK_MAP_FILE" 2>/dev/null); then
+    echo "GitHub-to-Slack mapping loaded"
+  else
+    echo "Warning: GitHub-to-Slack mapping is invalid JSON"
+    echo "Reviewer pings will use GitHub usernames instead of Slack mentions"
+    GITHUB_SLACK_MAP="{}"
+  fi
 else
   echo "Warning: GitHub-to-Slack mapping not found at $GITHUB_SLACK_MAP_FILE"
   echo "Reviewer pings will use GitHub usernames instead of Slack mentions"
@@ -174,7 +179,7 @@ else
 fi
 
 # Extract Slack fallback user ID from mapping (pinged when no reviewers are assigned)
-SLACK_FALLBACK_USER_ID=$(echo "$GITHUB_SLACK_MAP" | jq -r '.["backup-user"] // empty' 2>/dev/null)
+SLACK_FALLBACK_USER_ID=$(jq -r '.["backup-user"] // empty' <<<"$GITHUB_SLACK_MAP")
 if [ -n "$SLACK_FALLBACK_USER_ID" ]; then
   echo "Slack fallback user ID loaded from mapping"
 else
@@ -287,12 +292,21 @@ send_slack_notification() {
 
   [[ $- == *x* ]] && local _was_tracing=true || local _was_tracing=false
   set +x
+  set +e
   local SLACK_RESPONSE
   SLACK_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
     -H 'Content-type: application/json' \
     --data "$SLACK_PAYLOAD" \
     "$SLACK_WEBHOOK_URL")
+  local CURL_EXIT_CODE=$?
+  set -e
   $_was_tracing && set -x
+
+  if [ $CURL_EXIT_CODE -ne 0 ]; then
+    echo "   Warning: Failed to send Slack notification (curl exit $CURL_EXIT_CODE)"
+    return 0
+  fi
+
   local SLACK_HTTP_CODE
   SLACK_HTTP_CODE=$(echo "$SLACK_RESPONSE" | tail -1)
 


### PR DESCRIPTION
## Summary

- After successful PR creation, the jira-agent now sends a Slack notification to the team-ocp-hypershift channel
- Polls for reviewer assignment for up to 2 minutes, maps GitHub usernames to Slack member IDs via Vault-stored JSON mapping
- Falls back to a designated backup user if no reviewers are assigned
- Gracefully skips if webhook URL is not configured — no existing behavior changes

## New Vault Secrets

Two new keys in `hypershift-team-claude-prow`:
- `slack-webhook-url` — Slack incoming webhook URL
- `gh-to-slack-ids` — GitHub username to Slack member ID mapping (includes `backup-user` fallback key)

## Test plan

- [x] Verify Slack webhook URL and mapping JSON are correctly loaded from Vault mount
- [x] Verify notification is sent after successful PR creation with correct format
- [x] Verify reviewer polling works and maps GitHub usernames to Slack pings
- [ ] Verify fallback user is pinged when no reviewers are assigned
- [ ] Verify graceful degradation when webhook URL is not configured
- [ ] Verify no credential leakage in CI logs (webhook URL protected by `set +x`)

/cc @bryan-cox

Jira: https://redhat.atlassian.net/browse/CNTRLPLANE-3258