### PR TITLE
imagebuilder: run unit tests with Go 1.25 instead of 1.23

### DIFF
--- a/ci-operator/config/openshift/imagebuilder/openshift-imagebuilder-master.yaml
+++ b/ci-operator/config/openshift/imagebuilder/openshift-imagebuilder-master.yaml
@@ -2,7 +2,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: rhel-9-release-golang-1.23-openshift-4.20
+    tag: rhel-9-release-golang-1.25-openshift-4.22
 resources:
   '*':
     requests:


### PR DESCRIPTION
Run our unit tests with a slightly newer but still not current version of Go.  Version 1.26 is current at the moment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build image configuration to use Go 1.25 and OpenShift 4.22 (previously Go 1.23 and OpenShift 4.20).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->