### PR TITLE
fix: change skip_if_only_changed for terraform-provider-rhcs

### DIFF
--- a/ci-operator/config/terraform-redhat/terraform-provider-rhcs/terraform-redhat-terraform-provider-rhcs-main__e2e-presubmits.yaml
+++ b/ci-operator/config/terraform-redhat/terraform-provider-rhcs/terraform-redhat-terraform-provider-rhcs-main__e2e-presubmits.yaml
@@ -19,7 +19,7 @@ resources:
       memory: 200Mi
 tests:
 - as: rosa-sts-advanced-critical-high-presubmit
-  skip_if_only_changed: ^(LICENSE|OWNERS|README\.md|\.gitignore|\.goreleaser\.yaml)$|^docs/|^subsystem/|^examples/
+  skip_if_only_changed: ^(LICENSE|OWNERS|README\.md|\.gitignore|\.goreleaser\.yaml|\.golang-ci\.yml|renovate\.json|\.ci-operator\.yaml)$|^(?:docs|\.github|\.tekton|subsystem|examples)
   steps:
     cluster_profile: oex-aws-qe
     env:
@@ -35,7 +35,7 @@ tests:
     - ref: rhcs-e2e-tests
     workflow: rhcs-aws-sts
 - as: rosa-sts-private-critical-high-presubmit
-  skip_if_only_changed: ^(LICENSE|OWNERS|README\.md|\.gitignore|\.goreleaser\.yaml)$|^docs/|^subsystem/|^examples/
+  skip_if_only_changed: ^(LICENSE|OWNERS|README\.md|\.gitignore|\.goreleaser\.yaml|\.golang-ci\.yml|renovate\.json|\.ci-operator\.yaml)$|^(?:docs|\.github|\.tekton|subsystem|examples)
   steps:
     cluster_profile: oex-aws-qe
     env:
@@ -190,7 +190,7 @@ tests:
     workflow: rhcs-aws-sts
 - always_run: false
   as: rosa-hcp-advanced-critical-high-presubmit
-  skip_if_only_changed: ^(LICENSE|OWNERS|README\.md|\.gitignore|\.goreleaser\.yaml)$|^docs/|^subsystem/|^examples/
+  skip_if_only_changed: ^(LICENSE|OWNERS|README\.md|\.gitignore|\.goreleaser\.yaml|\.golang-ci\.yml|renovate\.json|\.ci-operator\.yaml)$|^(?:docs|\.github|\.tekton|subsystem|examples)
   steps:
     cluster_profile: oex-aws-qe
     env:
@@ -206,7 +206,7 @@ tests:
     workflow: rhcs-aws-sts
 - always_run: false
   as: rosa-hcp-private-critical-high-presubmit
-  skip_if_only_changed: ^(LICENSE|OWNERS|README\.md|\.gitignore|\.goreleaser\.yaml)$|^docs/|^subsystem/|^examples/
+  skip_if_only_changed: ^(LICENSE|OWNERS|README\.md|\.gitignore|\.goreleaser\.yaml|\.golang-ci\.yml|renovate\.json|\.ci-operator\.yaml)$|^(?:docs|\.github|\.tekton|subsystem|examples)
   steps:
     cluster_profile: oex-aws-qe
     env:

--- a/ci-operator/jobs/terraform-redhat/terraform-provider-rhcs/terraform-redhat-terraform-provider-rhcs-main-presubmits.yaml
+++ b/ci-operator/jobs/terraform-redhat/terraform-provider-rhcs/terraform-redhat-terraform-provider-rhcs-main-presubmits.yaml
@@ -292,7 +292,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-terraform-redhat-terraform-provider-rhcs-main-e2e-presubmits-rosa-hcp-advanced-critical-high-presubmit
     rerun_command: /test e2e-presubmits-rosa-hcp-advanced-critical-high-presubmit
-    skip_if_only_changed: ^(LICENSE|OWNERS|README\.md|\.gitignore|\.goreleaser\.yaml)$|^docs/|^subsystem/|^examples/
+    skip_if_only_changed: ^(LICENSE|OWNERS|README\.md|\.gitignore|\.goreleaser\.yaml|\.golang-ci\.yml|renovate\.json|\.ci-operator\.yaml)$|^(?:docs|\.github|\.tekton|subsystem|examples)
     spec:
       containers:
       - args:
@@ -873,7 +873,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-terraform-redhat-terraform-provider-rhcs-main-e2e-presubmits-rosa-hcp-private-critical-high-presubmit
     rerun_command: /test e2e-presubmits-rosa-hcp-private-critical-high-presubmit
-    skip_if_only_changed: ^(LICENSE|OWNERS|README\.md|\.gitignore|\.goreleaser\.yaml)$|^docs/|^subsystem/|^examples/
+    skip_if_only_changed: ^(LICENSE|OWNERS|README\.md|\.gitignore|\.goreleaser\.yaml|\.golang-ci\.yml|renovate\.json|\.ci-operator\.yaml)$|^(?:docs|\.github|\.tekton|subsystem|examples)
     spec:
       containers:
       - args:
@@ -1205,7 +1205,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-terraform-redhat-terraform-provider-rhcs-main-e2e-presubmits-rosa-sts-advanced-critical-high-presubmit
     rerun_command: /test e2e-presubmits-rosa-sts-advanced-critical-high-presubmit
-    skip_if_only_changed: ^(LICENSE|OWNERS|README\.md|\.gitignore|\.goreleaser\.yaml)$|^docs/|^subsystem/|^examples/
+    skip_if_only_changed: ^(LICENSE|OWNERS|README\.md|\.gitignore|\.goreleaser\.yaml|\.golang-ci\.yml|renovate\.json|\.ci-operator\.yaml)$|^(?:docs|\.github|\.tekton|subsystem|examples)
     spec:
       containers:
       - args:
@@ -1454,7 +1454,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-terraform-redhat-terraform-provider-rhcs-main-e2e-presubmits-rosa-sts-private-critical-high-presubmit
     rerun_command: /test e2e-presubmits-rosa-sts-private-critical-high-presubmit
-    skip_if_only_changed: ^(LICENSE|OWNERS|README\.md|\.gitignore|\.goreleaser\.yaml)$|^docs/|^subsystem/|^examples/
+    skip_if_only_changed: ^(LICENSE|OWNERS|README\.md|\.gitignore|\.goreleaser\.yaml|\.golang-ci\.yml|renovate\.json|\.ci-operator\.yaml)$|^(?:docs|\.github|\.tekton|subsystem|examples)
     spec:
       containers:
       - args:


### PR DESCRIPTION
This PR changes configuration for skipping jobs in terraform-provider-rhcs. 

The new regex includes .tekton, .github, renovate.json, golang-ci.yml and .ci-operator.yaml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced E2E presubmit test workflows to expand skip conditions for configuration-only changes. Tests will now be bypassed when modifications are limited to CI configuration files, infrastructure directories, and documentation. This optimization reduces unnecessary test execution, improves pipeline efficiency, and allows testing resources to focus on actual code changes while providing faster feedback for non-code updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->