### PR TITLE
ci(kserve): pass GOTAGS=distro when building the kserve-controller image

### DIFF
--- a/ci-operator/config/opendatahub-io/kserve/opendatahub-io-kserve-master.yaml
+++ b/ci-operator/config/opendatahub-io/kserve/opendatahub-io-kserve-master.yaml
@@ -21,7 +21,10 @@ build_root:
       ENV BASH_ENV="" ENV="" PROMPT_COMMAND=""
 images:
   items:
-  - dockerfile_path: Dockerfile
+  - build_args:
+    - name: GOTAGS
+      value: distro
+    dockerfile_path: Dockerfile
     from: ubi_minimal
     to: kserve-controller
   - build_args:


### PR DESCRIPTION
The kserve-controller Dockerfile now accepts a `GOTAGS` build arg (wired in opendatahub-io/kserve#1328 and proposed to upstream kserve/kserve). Without passing it, the CI build compiles without any build tags.

All code gated behind `//go:build distro` - including OpenShift Route scheme registration, CA bundle injection, and Route reconciliation - is silently excluded from the binary, causing runtime failures when the controller runs on an OCP cluster. The symptom is `no kind is registered for the type v1.Route in scheme` during ISVC reconciliation.

Passes `GOTAGS=distro` as a `build_arg` for the `kserve-controller` image so the full distro feature set is compiled into the binary used by e2e tests. No other images are affected - the agent and router have no distro-gated code paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration for the kserve-controller image with additional build arguments to support distribution-specific builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->