### PR TITLE
MPIIT: ACS mapping via ExitTrap and migrate ACS 4.22 LP jobs to lp-ocp-compat variants

### DIFF
--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4.21-lp-interop-cr-acs-latest.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4.21-lp-interop-cr-acs-latest.yaml
@@ -42,7 +42,7 @@ tests:
       FIREWATCH_DEFAULT_JIRA_PROJECT: ROX
       MAP_TESTS: "true"
       OCP_VERSION: "4.21"
-      REPORTPORTAL_CMP: ACSLatest-lp-interop
+      REPORTPORTAL_CMP: ACSLatest
       USER_TAGS: |
         scenario acs
     test:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4.22-lp-interop-acs-latest.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4.22-lp-interop-acs-latest.yaml
@@ -42,7 +42,7 @@ tests:
       FIREWATCH_DEFAULT_JIRA_PROJECT: ROX
       MAP_TESTS: "true"
       OCP_VERSION: "4.22"
-      REPORTPORTAL_CMP: ACSLatest-lp-interop
+      REPORTPORTAL_CMP: ACSLatest
       USER_TAGS: |
         scenario acs
     test:
@@ -73,7 +73,7 @@ tests:
       MAP_TESTS: "true"
       OCP_VERSION: "4.22"
       REPORT_TO_DR: "true"
-      REPORTPORTAL_CMP: ACSLatest-lp-interop
+      REPORTPORTAL_CMP: ACSLatest
       USER_TAGS: |
         scenario acs
     test:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4.22-lpMainline-lp-ocp-compat.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4.22-lpMainline-lp-ocp-compat.yaml
@@ -39,7 +39,7 @@ tests:
       BASE_DOMAIN: cspilp.interop.ccitredhat.com
       COMPUTE_NODE_TYPE: m6a.2xlarge
       CONTROL_PLANE_INSTANCE_TYPE: m6a.2xlarge
-      DR__RP__CR_COMP_NAME: lp-ocp-compat--ACSLatest
+      DR__RP__CR_COMP_NAME: lp-ocp-compat--ACS
       FIREWATCH_CONFIG: |
         {
           "failure_rules":
@@ -76,7 +76,7 @@ tests:
       BASE_DOMAIN: cspilp.interop.ccitredhat.com
       COMPUTE_NODE_TYPE: m6a.2xlarge
       CONTROL_PLANE_INSTANCE_TYPE: m6a.2xlarge
-      DR__RP__CR_COMP_NAME: lp-ocp-compat--ACSLatest
+      DR__RP__CR_COMP_NAME: lp-ocp-compat--ACS
       FIPS_ENABLED: "true"
       FIREWATCH_CONFIG: |
         {

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-4.10__ocp-4-22-lpGA-lp-ocp-compat.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-4.10__ocp-4-22-lpGA-lp-ocp-compat.yaml
@@ -39,7 +39,7 @@ tests:
       BASE_DOMAIN: cspilp.interop.ccitredhat.com
       COMPUTE_NODE_TYPE: m6a.2xlarge
       CONTROL_PLANE_INSTANCE_TYPE: m6a.2xlarge
-      DR__RP__CR_COMP_NAME: lp-ocp-compat--ACS--lpMainline
+      DR__RP__CR_COMP_NAME: lp-ocp-compat--ACS
       FIREWATCH_CONFIG: |
         {
           "failure_rules":
@@ -78,7 +78,7 @@ tests:
       BASE_DOMAIN: cspilp.interop.ccitredhat.com
       COMPUTE_NODE_TYPE: m6a.2xlarge
       CONTROL_PLANE_INSTANCE_TYPE: m6a.2xlarge
-      DR__RP__CR_COMP_NAME: lp-ocp-compat--ACS--lpMainline
+      DR__RP__CR_COMP_NAME: lp-ocp-compat--ACS
       FIPS_ENABLED: "true"
       FIREWATCH_CONFIG: |
         {

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-4.9__ocp-4-21-lp-interop-cr.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-4.9__ocp-4-21-lp-interop-cr.yaml
@@ -42,7 +42,7 @@ tests:
       FIREWATCH_DEFAULT_JIRA_PROJECT: ROX
       MAP_TESTS: "true"
       OCP_VERSION: "4.21"
-      REPORTPORTAL_CMP: ACS-lp-interop
+      REPORTPORTAL_CMP: ACS
       TEST_SUITE: ocp-compliance-e2e-tests
       USER_TAGS: |
         scenario acs

--- a/ci-operator/step-registry/stackrox/compliance-e2e/stackrox-compliance-e2e-commands.sh
+++ b/ci-operator/step-registry/stackrox/compliance-e2e/stackrox-compliance-e2e-commands.sh
@@ -3,71 +3,18 @@
 # Enable strict mode options including xtrace (-x) and inherit_errexit
 set -euxo pipefail; shopt -s inherit_errexit
 
-function InstallYq() {
-    : "Installing yq..."
-
-    # Install yq manually
-    mkdir -p /tmp/bin
-    export PATH="/tmp/bin:${PATH}"
-    typeset arch=""
-    arch="$(uname -m | sed 's/aarch64/arm64/;s/x86_64/amd64/')"
-    curl -L "https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_linux_${arch}" \
-        -o /tmp/bin/yq && chmod +x /tmp/bin/yq
-    /tmp/bin/yq --version || export MAP_TESTS=false
-}
-
-# Merge multiple jUnit XML files into one (avoids naming conflict with other Steps). Optionally map suite name for CR.
-# Archives original XMLs so Prow does not see duplicated results.
-function CleanupCollect() {
-    typeset mergedFN="${1:-jUnit.xml}"; (($#)) && shift
-    typeset resultFile=''
-    typeset -a xmlFiles=()
-
-    InstallYq
-
-    if [[ $MAP_TESTS == "false" ]]; then
-        true
-        return
-    fi
-
-    while IFS= read -r -d '' resultFile; do
-        grep -qE '<testsuites?\b' "${resultFile}" && xmlFiles+=("${resultFile}") || true
-    done < <(find "${ARTIFACT_DIR}" -type f -iname "*.xml" ! -name "${mergedFN}" -print0)
-
-    ((${#xmlFiles[@]})) || {
-        : 'Warning: No JUnit XML file found to process'
-        true
-        return
-    }
-
-    # Prepare one jUnit XML: collect -> map suite name and merge into a single document
-    yq eval-all --input-format xml --output-format xml -I2 '
-        (. | [.[] | (.testsuite // .) | ([] + .)[] | select(kind == "map")]) as $suites |
-        $suites | .[] |= (
-            (
-                select(env(MAP_TESTS) == "true") |
-                ."+@name" = env(REPORTPORTAL_CMP)
-            )//. |
-            ([] + (.testcase // [])) as $tc |
-            ."+@tests" = ($tc | length | tostring) |
-            ."+@failures" = ([$tc[] | select(.failure)] | length | tostring) |
-            ."+@errors" = ([$tc[] | select(.error)] | length | tostring)
-        ) |
-        {
-            "+p_xml": "version=\"1.0\" encoding=\"UTF-8\"",
-            "testsuites": {"testsuite": $suites}
-        }
-    ' "${xmlFiles[@]}" 1> "${ARTIFACT_DIR}/${mergedFN}"
-
-    # Archive the original jUnit XMLs so Prow does not see duplicated results.
-    tar zcf "${ARTIFACT_DIR}/jUnit-original.tgz" -C "${ARTIFACT_DIR}/" "${xmlFiles[@]#${ARTIFACT_DIR}/}"
-    rm -f "${xmlFiles[@]}"
-
-    cp "${ARTIFACT_DIR}/${mergedFN}" "${SHARED_DIR}/"
-    true
-}
-
-trap 'CleanupCollect junit--stackrox__compliance-e2e__stackrox-compliance-e2e.xml' EXIT
+# Map results by setting identifier prefix in tests suites names for reporting tools
+# Merge original results into a single file and compress
+# Send modified file to shared dir for Data Router Reporter step
+if [ "${MAP_TESTS}" = "true" ]; then
+    eval "$(
+        curl -fsSL \
+https://raw.githubusercontent.com/RedHatQE/OpenShift-LP-QE--Tools/refs/heads/main/libs/bash/ci-operator/interop/common/ExitTrap--PostProcessPrep.sh
+    )"; trap '
+        LP_IO__ET_PPP__NEW_TS_NAME="${REPORTPORTAL_CMP}--%s" \
+            ExitTrap--PostProcessPrep junit--stackrox__compliance-e2e__stackrox-compliance-e2e.xml
+    ' EXIT
+fi
 
 # Determine job name from test suite or job name safe
 typeset job="${TEST_SUITE:-${JOB_NAME_SAFE#merge-}}"
@@ -88,3 +35,5 @@ trap '' TERM
 
 # Execute dispatch script
 .openshift-ci/dispatch.sh "${job}"
+
+true

--- a/ci-operator/step-registry/stackrox/compliance-e2e/stackrox-compliance-e2e-commands.sh
+++ b/ci-operator/step-registry/stackrox/compliance-e2e/stackrox-compliance-e2e-commands.sh
@@ -3,10 +3,6 @@
 # Enable strict mode options including xtrace (-x) and inherit_errexit
 set -euxo pipefail; shopt -s inherit_errexit
 
-# Env used by CleanupCollect/yq; defaults match step ref so they are always set (for trap and subprocesses).
-export MAP_TESTS="${MAP_TESTS:-false}"
-export MAP_TESTS_SUITE_NAME="${MAP_TESTS_SUITE_NAME:-ACS-lp-interop}"
-
 function InstallYq() {
     : "Installing yq..."
 
@@ -29,6 +25,11 @@ function CleanupCollect() {
 
     InstallYq
 
+    if [[ $MAP_TESTS == "false" ]]; then
+        true
+        return
+    fi
+
     while IFS= read -r -d '' resultFile; do
         grep -qE '<testsuites?\b' "${resultFile}" && xmlFiles+=("${resultFile}") || true
     done < <(find "${ARTIFACT_DIR}" -type f -iname "*.xml" ! -name "${mergedFN}" -print0)
@@ -45,7 +46,7 @@ function CleanupCollect() {
         $suites | .[] |= (
             (
                 select(env(MAP_TESTS) == "true") |
-                ."+@name" = env(MAP_TESTS_SUITE_NAME)
+                ."+@name" = env(REPORTPORTAL_CMP)
             )//. |
             ([] + (.testcase // [])) as $tc |
             ."+@tests" = ($tc | length | tostring) |

--- a/ci-operator/step-registry/stackrox/compliance-e2e/stackrox-compliance-e2e-ref.yaml
+++ b/ci-operator/step-registry/stackrox/compliance-e2e/stackrox-compliance-e2e-ref.yaml
@@ -30,7 +30,7 @@ ref:
   - name: MAP_TESTS
     default: "false"
   - name: REPORTPORTAL_CMP
-    default: "ACS-lp-interop"
+    default: "ACS"
     documentation: |-
       Suite name written into JUnit XML for Component Readiness when MAP_TESTS is true.
   documentation: |-

--- a/ci-operator/step-registry/stackrox/compliance-e2e/stackrox-compliance-e2e-ref.yaml
+++ b/ci-operator/step-registry/stackrox/compliance-e2e/stackrox-compliance-e2e-ref.yaml
@@ -29,7 +29,7 @@ ref:
     default: "false"
   - name: MAP_TESTS
     default: "false"
-  - name: MAP_TESTS_SUITE_NAME
+  - name: REPORTPORTAL_CMP
     default: "ACS-lp-interop"
     documentation: |-
       Suite name written into JUnit XML for Component Readiness when MAP_TESTS is true.

--- a/ci-operator/step-registry/stackrox/qa-e2e/stackrox-qa-e2e-commands.sh
+++ b/ci-operator/step-registry/stackrox/qa-e2e/stackrox-qa-e2e-commands.sh
@@ -8,7 +8,7 @@ function install_yq() {
     # Install yq manually if not found in image
       echo "Installing yq"
       mkdir -p /tmp/bin
-      export PATH=$PATH:/tmp/bin/
+      export PATH="/tmp/bin:${PATH}"
       curl -L "https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_linux_$(uname -m | sed 's/aarch64/arm64/;s/x86_64/amd64/')" \
        -o /tmp/bin/yq && chmod +x /tmp/bin/yq
 
@@ -22,43 +22,59 @@ function install_yq() {
       fi
 }
 
+# Merge multiple jUnit XML files into one (avoids naming conflict with other Steps). Optionally map suite name for CR.
+# Archives original XMLs so Prow does not see duplicated results.
+function CleanupCollect() {
+    typeset mergedFN="${1:-jUnit.xml}"; (($#)) && shift
+    typeset resultFile=''
+    typeset -a xmlFiles=()
 
-function mapTestsForComponentReadiness() {
-    if [[ $MAP_TESTS == "true" ]]; then
-        results_file="${1}"
-        echo "Patching Tests Result File: ${results_file}"
-        if [ -f "${results_file}" ]; then
-            echo "Mapping Test Suite Name To: ACSLatest-lp-interop"
-            /tmp/bin/yq eval --output-format xml -iI0 '.testsuite."+@name" = "ACSLatest-lp-interop"' "$results_file" || echo "Warning: yq failed for ${results_file}, debug manually" >&2
-        fi
+    install_yq
+
+    if [[ $MAP_TESTS == "false" ]]; then
+        true
+        return
     fi
-}
 
+    typeset mergedPath="${ARTIFACT_DIR%/}/${mergedFN}"
+    while IFS= read -r -d '' resultFile; do
+        grep -qE '<testsuites?\b' "${resultFile}" && xmlFiles+=("${resultFile}") || true
+    done < <(find -L "${ARTIFACT_DIR%/}" -type f \( -iname "*.xml" -a -not -path "${mergedPath}" \) -print0)
+    ((${#xmlFiles[@]})) || {
+        : 'Warning: No JUnit XML file found to process'
+        true
+        return
+    }
 
-# Archive results function
-function cleanup-collect() {
-    if [[ $MAP_TESTS == "true" ]]; then
-      install_yq
-      original_results="${ARTIFACT_DIR}/original_results/"
-      mkdir "${original_results}" || true
-      echo "Collecting original results in ${original_results}"
+    # Prepare one jUnit XML: collect -> map suite name and merge into a single document
+    yq eval-all --input-format xml --output-format xml -I2 '
+        (. | [.[] | (.testsuite // .) | ([] + .)[] | select(kind == "map")]) as $suites |
+        $suites | .[] |= (
+            (
+                select(env(MAP_TESTS) == "true") |
+                ."+@name" = env(REPORTPORTAL_CMP)
+            )//. |
+            ([] + (.testcase // [])) as $tc |
+            ."+@tests" = ($tc | length | tostring) |
+            ."+@failures" = ([$tc[] | select(.failure)] | length | tostring) |
+            ."+@errors" = ([$tc[] | select(.error)] | length | tostring)
+        ) |
+        {
+            "+p_xml": "version=\"1.0\" encoding=\"UTF-8\"",
+            "testsuites": {"testsuite": $suites}
+        }
+    ' "${xmlFiles[@]}" 1> "${ARTIFACT_DIR}/${mergedFN}"
 
-      # Keep a copy of all the original Junit files before modifying them
-      cp -r "${ARTIFACT_DIR}"/junit-* "${original_results}" || echo "Warning: couldn't copy original files" >&2
+    # Archive the original jUnit XMLs so Prow does not see duplicated results.
+    tar zcf "${ARTIFACT_DIR}/jUnit-original.tgz" -C "${ARTIFACT_DIR}/" "${xmlFiles[@]#${ARTIFACT_DIR}/}"
+    rm -f "${xmlFiles[@]}"
 
-      # Safely handle filenames with spaces
-      find "${ARTIFACT_DIR}" -type f -iname "*.xml" -print0 | while IFS= read -r -d '' result_file; do
-        # Map tests if needed for related use cases
-        mapTestsForComponentReadiness "${result_file}"
-      done
-
-      # Send modified files to shared dir for Data Router Reporter step
-      cp -r "${ARTIFACT_DIR}"/junit-* "${SHARED_DIR}" || echo "Warning: couldn't copy files to SHARED_DIR" >&2
-    fi
+    cp "${ARTIFACT_DIR}/${mergedFN}" "${SHARED_DIR}/"
+    true
 }
 
 # Post test execution
-trap 'cleanup-collect' SIGINT SIGTERM ERR EXIT
+trap 'CleanupCollect junit--stackrox__qa-e2e__stackrox-qa-e2e.xml' EXIT
 
 job="${TEST_SUITE:-${JOB_NAME_SAFE#merge-}}"
 job="${job#nightly-}"

--- a/ci-operator/step-registry/stackrox/qa-e2e/stackrox-qa-e2e-commands.sh
+++ b/ci-operator/step-registry/stackrox/qa-e2e/stackrox-qa-e2e-commands.sh
@@ -4,77 +4,18 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-function install_yq() {
-    # Install yq manually if not found in image
-      echo "Installing yq"
-      mkdir -p /tmp/bin
-      export PATH="/tmp/bin:${PATH}"
-      curl -L "https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_linux_$(uname -m | sed 's/aarch64/arm64/;s/x86_64/amd64/')" \
-       -o /tmp/bin/yq && chmod +x /tmp/bin/yq
-
-      # Verify installation
-      cmd_yq="$(/tmp/bin/yq --version 2>/dev/null || true)"
-      if [ -n "$cmd_yq" ]; then
-        echo "yq version: $cmd_yq"
-      else
-        # Skip test mapping since yq isn't available
-        export MAP_TESTS="false"
-      fi
-}
-
-# Merge multiple jUnit XML files into one (avoids naming conflict with other Steps). Optionally map suite name for CR.
-# Archives original XMLs so Prow does not see duplicated results.
-function CleanupCollect() {
-    typeset mergedFN="${1:-jUnit.xml}"; (($#)) && shift
-    typeset resultFile=''
-    typeset -a xmlFiles=()
-
-    install_yq
-
-    if [[ $MAP_TESTS == "false" ]]; then
-        true
-        return
-    fi
-
-    typeset mergedPath="${ARTIFACT_DIR%/}/${mergedFN}"
-    while IFS= read -r -d '' resultFile; do
-        grep -qE '<testsuites?\b' "${resultFile}" && xmlFiles+=("${resultFile}") || true
-    done < <(find -L "${ARTIFACT_DIR%/}" -type f \( -iname "*.xml" -a -not -path "${mergedPath}" \) -print0)
-    ((${#xmlFiles[@]})) || {
-        : 'Warning: No JUnit XML file found to process'
-        true
-        return
-    }
-
-    # Prepare one jUnit XML: collect -> map suite name and merge into a single document
-    yq eval-all --input-format xml --output-format xml -I2 '
-        (. | [.[] | (.testsuite // .) | ([] + .)[] | select(kind == "map")]) as $suites |
-        $suites | .[] |= (
-            (
-                select(env(MAP_TESTS) == "true") |
-                ."+@name" = env(REPORTPORTAL_CMP)
-            )//. |
-            ([] + (.testcase // [])) as $tc |
-            ."+@tests" = ($tc | length | tostring) |
-            ."+@failures" = ([$tc[] | select(.failure)] | length | tostring) |
-            ."+@errors" = ([$tc[] | select(.error)] | length | tostring)
-        ) |
-        {
-            "+p_xml": "version=\"1.0\" encoding=\"UTF-8\"",
-            "testsuites": {"testsuite": $suites}
-        }
-    ' "${xmlFiles[@]}" 1> "${ARTIFACT_DIR}/${mergedFN}"
-
-    # Archive the original jUnit XMLs so Prow does not see duplicated results.
-    tar zcf "${ARTIFACT_DIR}/jUnit-original.tgz" -C "${ARTIFACT_DIR}/" "${xmlFiles[@]#${ARTIFACT_DIR}/}"
-    rm -f "${xmlFiles[@]}"
-
-    cp "${ARTIFACT_DIR}/${mergedFN}" "${SHARED_DIR}/"
-    true
-}
-
-# Post test execution
-trap 'CleanupCollect junit--stackrox__qa-e2e__stackrox-qa-e2e.xml' EXIT
+# Map results by setting identifier prefix in tests suites names for reporting tools
+# Merge original results into a single file and compress
+# Send modified file to shared dir for Data Router Reporter step
+if [ "${MAP_TESTS}" = "true" ]; then
+    eval "$(
+        curl -fsSL \
+https://raw.githubusercontent.com/RedHatQE/OpenShift-LP-QE--Tools/refs/heads/main/libs/bash/ci-operator/interop/common/ExitTrap--PostProcessPrep.sh
+    )"; trap '
+        LP_IO__ET_PPP__NEW_TS_NAME="${REPORTPORTAL_CMP}--%s" \
+            ExitTrap--PostProcessPrep junit--stackrox__qa-e2e__stackrox-qa-e2e.xml
+    ' EXIT
+fi
 
 job="${TEST_SUITE:-${JOB_NAME_SAFE#merge-}}"
 job="${job#nightly-}"
@@ -89,3 +30,4 @@ fi
 
 .openshift-ci/dispatch.sh "${job}"
 
+true

--- a/ci-operator/step-registry/stackrox/qa-e2e/stackrox-qa-e2e-ref.yaml
+++ b/ci-operator/step-registry/stackrox/qa-e2e/stackrox-qa-e2e-ref.yaml
@@ -29,6 +29,8 @@ ref:
     default: "false"
   - name: MAP_TESTS
     default: "false"
+  - name: REPORTPORTAL_CMP
+    default: "ACS-lp-interop"
   documentation: |-
     A step that runs a standard stackrox e2e test with mounted credentials, etc.
     Executes .openshift-ci/dispatch.sh in the target repo and passes it the short form test name (JOB_NAME_SAFE), which can be overriden by specifying TEST_SUITE.

--- a/ci-operator/step-registry/stackrox/qa-e2e/stackrox-qa-e2e-ref.yaml
+++ b/ci-operator/step-registry/stackrox/qa-e2e/stackrox-qa-e2e-ref.yaml
@@ -30,7 +30,7 @@ ref:
   - name: MAP_TESTS
     default: "false"
   - name: REPORTPORTAL_CMP
-    default: "ACS-lp-interop"
+    default: "ACS"
   documentation: |-
     A step that runs a standard stackrox e2e test with mounted credentials, etc.
     Executes .openshift-ci/dispatch.sh in the target repo and passes it the short form test name (JOB_NAME_SAFE), which can be overriden by specifying TEST_SUITE.


### PR DESCRIPTION
## Summary

Prepare ACS LP interop jobs for **Component Readiness (CR)** reporting on OCP 4.22 by aligning step-registry post-processing with the shared `ExitTrap--PostProcessPrep` flow and migrating OCP 4.22 periodic configs to the new **lp-ocp-compat** variants.

### Step registry (`stackrox-qa-e2e`, `stackrox-compliance-e2e`)

- Replace bespoke JUnit merge/map logic with **`ExitTrap--PostProcessPrep`** from [RedHatQE/OpenShift-LP-QE--Tools](https://github.com/RedHatQE/OpenShift-LP-QE--Tools) (sourced at runtime via `curl`).
- When `MAP_TESTS=true`, rename test suites using **`DR__RP__CR_COMP_NAME`** (`LP_IO__ET_PPP__NEW_TS_NAME="${DR__RP__CR_COMP_NAME}--%s"`), merge XML artifacts, archive originals, and publish the merged JUnit file to `SHARED_DIR` for the Data Router Reporter step.
- Drop deprecated env vars (`REPORTPORTAL_CMP`, `MAP_TESTS_SUITE_NAME`) from step refs in favor of **`DR__RP__CR_COMP_NAME`** (default `lp-ocp-compat--ACS` in refs; jobs override per stream).
- Work around image-bundled **yq** version conflicts by stubbing `/tmp/bin/yq` so `ExitTrap` installs a current yq when needed.
- Unify both ACS test steps (QA e2e + compliance e2e) on the same mapping/post-process approach.

### CI config / Prow jobs (OCP 4.22 ACS LP interop)

| Branch | Old variant | New variant | CR job | FIPS job |
|--------|-------------|-------------|--------|----------|
| `master` (ACS latest) | `ocp-4.22-lp-interop-acs-latest` | `ocp-4.22-lpMainline-lp-ocp-compat` | `cr--acs--tests-aws` | `acs--tests-aws-fips` |
| `release-4.10` (stable ACS) | `ocp-4-22-lp-interop` | `ocp-4-22-lpGA-lp-ocp-compat` | `cr--acs--tests-aws` | `acs--tests-aws-fips` |

- Remove `REPORTPORTAL_CMP` from job env; set **`DR__RP__CR_COMP_NAME`** (`lp-ocp-compat--ACSLatest` on master, `lp-ocp-compat--ACS--lpMainline` on release-4.10).
- Regenerate periodics in `ci-operator/jobs/stackrox/stackrox/` (legacy `*-lp-interop*` periodics removed for these variants).