### PR TITLE
increase rhoe 4.13 pool size to 6

### DIFF
--- a/clusters/hosted-mgmt/hive/pools/rh-openshift-ecosystem/rhoe-ocp-4-13-amd64-aws-us-west-2_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/rh-openshift-ecosystem/rhoe-ocp-4-13-amd64-aws-us-west-2_clusterpool.yaml
@@ -32,7 +32,8 @@ spec:
       region: us-west-2
   pullSecretRef:
     name: pull-secret
-  size: 1
+  size: 6
+  runningCount: 6
   skipMachinePools: true
 status:
   ready: 0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated cluster pool capacity configuration to support increased concurrent resource allocation, raising the pool size to 6 instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->