### PR TITLE
[SREP-4403] add new jobs for version variant

### DIFF
--- a/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main.yaml
+++ b/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main.yaml
@@ -34,50 +34,12 @@ tests:
   commands: make unit-test
   container:
     from: src
-- as: ocm-fvt-periodic-cs-rosa-hcp-ad-staging-main
-  capabilities:
-  - nested-podman
-  commands: |
-    env -i bash --norc --noprofile << 'EOF' > /tmp/podman.env
-    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
-    export AWS_SHARED_VPC_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
-    source /usr/local/cs-qe-credentials/ocm-tokens
-    env | grep -v '^_='
-    EOF
-
-    podman run \
-    --authfile /usr/local/cs-qe-credentials/.dockerconfigjson \
-    --env-file /tmp/podman.env \
-    -v /usr/local/cs-qe-credentials:/credentials:ro,z \
-    --rm \
-    quay.io/redhat-services-prod/ocmci/ocmci:latest \
-    ocmtest test --service cms --job cs-rosa-hcp-ad-staging-main
-  container:
-    from: nested-podman
-    memory_backed_volume:
-      size: 1Gi
-  cron: 0 8 * * *
-  nested_podman: true
-  secrets:
-  - mount_path: /usr/local/cs-qe-credentials
-    name: cs-qe-credentials
 - as: lint
   commands: |
     unset GOFLAGS
     make lint
   container:
     from: src
-- as: rosa-hcp-e2e-nightly
-  cron: 0 4 * * *
-  steps:
-    cluster_profile: rosa-e2e-01
-    env:
-      CHANNEL_GROUP: stable
-      ENABLE_BILLING_ACCOUNT: "yes"
-      HOSTED_CP: "true"
-      OCM_LOGIN_ENV: staging
-      REPLICAS: "3"
-    workflow: rosa-e2e
 zz_generated_metadata:
   branch: main
   org: openshift-online

--- a/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__periodics.yaml
+++ b/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__periodics.yaml
@@ -1,0 +1,100 @@
+base_images:
+  nested-podman:
+    name: nested-podman
+    namespace: ci
+    tag: latest
+  rosa-aws-cli:
+    name: rosa-aws-cli
+    namespace: ci
+    tag: latest
+build_root:
+  image_stream_tag:
+    name: builder
+    namespace: ocp
+    tag: rhel-9-golang-1.24-openshift-4.22
+images:
+  items:
+  - dockerfile_path: Containerfile
+    to: rosa-e2e
+releases:
+  latest:
+    candidate:
+      product: ocp
+      stream: nightly
+      version: "4.22"
+resources:
+  '*':
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: ocm-fvt-periodic-cs-rosa-hcp-ad-staging-main
+  capabilities:
+  - nested-podman
+  commands: |
+    env -i bash --norc --noprofile << 'EOF' > /tmp/podman.env
+    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
+    export AWS_SHARED_VPC_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
+    source /usr/local/cs-qe-credentials/ocm-tokens
+    env | grep -v '^_='
+    EOF
+
+    podman run \
+    --authfile /usr/local/cs-qe-credentials/.dockerconfigjson \
+    --env-file /tmp/podman.env \
+    -v /usr/local/cs-qe-credentials:/credentials:ro,z \
+    --rm \
+    quay.io/redhat-services-prod/ocmci/ocmci:latest \
+    ocmtest test --service cms --job cs-rosa-hcp-ad-staging-main
+  container:
+    from: nested-podman
+    memory_backed_volume:
+      size: 1Gi
+  cron: 0 8 * * *
+  nested_podman: true
+  secrets:
+  - mount_path: /usr/local/cs-qe-credentials
+    name: cs-qe-credentials
+- as: rosa-hcp-e2e-nightly-4-20
+  cron: 0 4 * * *
+  steps:
+    cluster_profile: rosa-e2e-01
+    env:
+      CHANNEL_GROUP: nightly
+      ENABLE_BILLING_ACCOUNT: "yes"
+      HOSTED_CP: "true"
+      OCM_LOGIN_ENV: staging
+      OPENSHIFT_VERSION: "4.20"
+      REPLICAS: "3"
+    workflow: rosa-e2e
+- as: rosa-hcp-e2e-nightly-4-21
+  cron: 0 4 * * *
+  steps:
+    cluster_profile: rosa-e2e-01
+    env:
+      CHANNEL_GROUP: nightly
+      ENABLE_BILLING_ACCOUNT: "yes"
+      HOSTED_CP: "true"
+      OCM_LOGIN_ENV: staging
+      OPENSHIFT_VERSION: "4.21"
+      REPLICAS: "3"
+    workflow: rosa-e2e
+- as: rosa-hcp-e2e-nightly-4-22
+  cron: 0 4 * * *
+  steps:
+    cluster_profile: rosa-e2e-01
+    env:
+      CHANNEL_GROUP: nightly
+      ENABLE_BILLING_ACCOUNT: "yes"
+      HOSTED_CP: "true"
+      OCM_LOGIN_ENV: staging
+      OPENSHIFT_VERSION: "4.22"
+      REPLICAS: "3"
+    workflow: rosa-e2e
+zz_generated_metadata:
+  branch: main
+  org: openshift-online
+  repo: rosa-e2e
+  variant: periodics

--- a/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-periodics.yaml
@@ -11,10 +11,11 @@ periodics:
     repo: rosa-e2e
   labels:
     capability/nested-podman: nested-podman
+    ci-operator.openshift.io/variant: periodics
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-online-rosa-e2e-main-ocm-fvt-periodic-cs-rosa-hcp-ad-staging-main
+  name: periodic-ci-openshift-online-rosa-e2e-main-periodics-ocm-fvt-periodic-cs-rosa-hcp-ad-staging-main
   spec:
     containers:
     - args:
@@ -23,6 +24,7 @@ periodics:
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/cs-qe-credentials
       - --target=ocm-fvt-periodic-cs-rosa-hcp-ad-staging-main
+      - --variant=periodics
       command:
       - ci-operator
       env:
@@ -82,10 +84,11 @@ periodics:
   labels:
     ci-operator.openshift.io/cloud: aws
     ci-operator.openshift.io/cloud-cluster-profile: rosa-e2e-01
+    ci-operator.openshift.io/variant: periodics
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-online-rosa-e2e-main-rosa-hcp-e2e-nightly
+  name: periodic-ci-openshift-online-rosa-e2e-main-periodics-rosa-hcp-e2e-nightly-4-20
   spec:
     containers:
     - args:
@@ -94,7 +97,174 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=rosa-hcp-e2e-nightly
+      - --target=rosa-hcp-e2e-nightly-4-20
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build09
+  cron: 0 4 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-online
+    repo: rosa-e2e
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: rosa-e2e-01
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-online-rosa-e2e-main-periodics-rosa-hcp-e2e-nightly-4-21
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=rosa-hcp-e2e-nightly-4-21
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build09
+  cron: 0 4 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-online
+    repo: rosa-e2e
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: rosa-e2e-01
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-online-rosa-e2e-main-periodics-rosa-hcp-e2e-nightly-4-22
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=rosa-hcp-e2e-nightly-4-22
+      - --variant=periodics
       command:
       - ci-operator
       env:

--- a/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-presubmits.yaml
@@ -126,6 +126,64 @@ presubmits:
     - ^main$
     - ^main-
     cluster: build03
+    context: ci/prow/periodics-images
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/variant: periodics
+      ci.openshift.io/generator: prowgen
+      job-release: "4.22"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-online-rosa-e2e-main-periodics-images
+    rerun_command: /test periodics-images
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=[images]
+        - --variant=periodics
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )periodics-images,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build03
     context: ci/prow/unit
     decorate: true
     decoration_config:


### PR DESCRIPTION
Created new file for periodic jobs 
Move the existing ocm fvt and rosa-e2e ci job to the new location
Adding rosa-e2e jobs for different cluster versions

Co-authored by Claude Code Sonnet 4.5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added periodic CI tests for ROSA HCP E2E on OpenShift 4.20, 4.21, and 4.22.
  * Added a presubmit job to validate periodic image configurations.
* **Refactor**
  * Reorganized CI into dedicated periodic configs and updated job names/targets with a periodics variant and expanded job runtime setup.
* **Chores**
  * Removed two legacy scheduled ROSA E2E test jobs.
* **Other**
  * Updated ROSA workflow channel from "stable" to "nightly".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->