### PR TITLE
multiarch: use VPN libvirt profile for OCP 5.0 homogeneous s390x jobs

### DIFF
--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-5.0-upgrade-from-nightly-4.22.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-5.0-upgrade-from-nightly-4.22.yaml
@@ -117,10 +117,10 @@ tests:
     workflow: openshift-upgrade-azure
 - as: ocp-ovn-remote-libvirt-multi-z-z
   capabilities:
-  - sshd-bastion
+  - intranet
   cron: 0 8 * * 1-4
   steps:
-    cluster_profile: libvirt-s390x-2
+    cluster_profile: libvirt-s390x-vpn
     dependencies:
       OPENSHIFT_INSTALL_TARGET: release:initial
     env:
@@ -129,7 +129,8 @@ tests:
       ETCD_DISK_SPEED: slow
       NODE_TUNING: "true"
       TEST_TYPE: upgrade
-    workflow: openshift-e2e-libvirt-upi
+      USE_EXTERNAL_DNS: "true"
+    workflow: openshift-e2e-libvirt-vpn
 - as: ocp-ovn-remote-s2s-libvirt-multi-p-p
   cluster: build10
   cron: 0 8 * * 1-4

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-5.0.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-5.0.yaml
@@ -430,10 +430,10 @@ tests:
     workflow: openshift-upgrade-azure
 - as: ocp-e2e-ovn-remote-libvirt-s390x
   capabilities:
-  - sshd-bastion
+  - intranet
   cron: 0 7 * * 6
   steps:
-    cluster_profile: libvirt-s390x-2
+    cluster_profile: libvirt-s390x-vpn
     dependencies:
       OPENSHIFT_INSTALL_TARGET: release:s390x-latest
     env:
@@ -442,26 +442,28 @@ tests:
       ETCD_DISK_SPEED: slow
       NODE_TUNING: "true"
       TEST_TYPE: conformance-parallel
-    workflow: openshift-e2e-libvirt-upi
+      USE_EXTERNAL_DNS: "true"
+    workflow: openshift-e2e-libvirt-vpn
 - as: ocp-e2e-ovn-remote-libvirt-multi-z-z
   capabilities:
-  - sshd-bastion
+  - intranet
   cron: 0 6 * * 6
   steps:
-    cluster_profile: libvirt-s390x-2
+    cluster_profile: libvirt-s390x-vpn
     env:
       ARCH: s390x
       BRANCH: "5.0"
       ETCD_DISK_SPEED: slow
       NODE_TUNING: "true"
       TEST_TYPE: conformance-parallel
-    workflow: openshift-e2e-libvirt-upi
+      USE_EXTERNAL_DNS: "true"
+    workflow: openshift-e2e-libvirt-vpn
 - as: ocp-e2e-ovn-agent-remote-libvirt-multi-z-z
   capabilities:
-  - sshd-bastion
+  - intranet
   cron: 0 8 * * 0
   steps:
-    cluster_profile: libvirt-s390x-2
+    cluster_profile: libvirt-s390x-vpn
     env:
       ARCH: s390x
       BRANCH: "5.0"
@@ -469,8 +471,9 @@ tests:
       INSTALLER_TYPE: agent
       NODE_TUNING: "true"
       TEST_TYPE: conformance-parallel
+      USE_EXTERNAL_DNS: "true"
       VOLUME_CAPACITY: 120G
-    workflow: openshift-e2e-libvirt-upi
+    workflow: openshift-e2e-libvirt-vpn
 - as: ocp-e2e-ovn-remote-libvirt-multi-z-xz
   capabilities:
   - sshd-bastion
@@ -485,46 +488,49 @@ tests:
     workflow: openshift-e2e-libvirt-upi-heterogeneous
 - as: ocp-image-ecosystem-ovn-remote-libvirt-multi-z-z
   capabilities:
-  - sshd-bastion
+  - intranet
   cron: 0 6 * * 0
   steps:
-    cluster_profile: libvirt-s390x-2
+    cluster_profile: libvirt-s390x-vpn
     env:
       ARCH: s390x
       BRANCH: "5.0"
       ETCD_DISK_SPEED: slow
       TEST_TYPE: image-ecosystem
-    workflow: openshift-e2e-libvirt-upi
+      USE_EXTERNAL_DNS: "true"
+    workflow: openshift-e2e-libvirt-vpn
 - as: ocp-jenkins-e2e-ovn-remote-libvirt-multi-z-z
   capabilities:
-  - sshd-bastion
+  - intranet
   cron: 0 7 * * 0
   steps:
-    cluster_profile: libvirt-s390x-2
+    cluster_profile: libvirt-s390x-vpn
     env:
       ARCH: s390x
       BRANCH: "5.0"
       ETCD_DISK_SPEED: slow
       TEST_TYPE: jenkins-e2e-rhel-only
-    workflow: openshift-e2e-libvirt-upi
+      USE_EXTERNAL_DNS: "true"
+    workflow: openshift-e2e-libvirt-vpn
 - as: ocp-e2e-serial-ovn-remote-libvirt-multi-z-z
   capabilities:
-  - sshd-bastion
+  - intranet
   cron: 0 7 * * 1-4
   steps:
-    cluster_profile: libvirt-s390x-2
+    cluster_profile: libvirt-s390x-vpn
     env:
       ARCH: s390x
       BRANCH: "5.0"
       ETCD_DISK_SPEED: slow
       TEST_TYPE: conformance-serial
-    workflow: openshift-e2e-libvirt-upi
+      USE_EXTERNAL_DNS: "true"
+    workflow: openshift-e2e-libvirt-vpn
 - as: ocp-fips-ovn-remote-libvirt-multi-z-z
   capabilities:
-  - sshd-bastion
+  - intranet
   cron: 0 6 * * 1-4
   steps:
-    cluster_profile: libvirt-s390x-2
+    cluster_profile: libvirt-s390x-vpn
     env:
       ARCH: s390x
       BRANCH: "5.0"
@@ -532,7 +538,8 @@ tests:
       FIPS_ENABLED: "true"
       NODE_TUNING: "true"
       TEST_TYPE: conformance-parallel
-    workflow: openshift-e2e-libvirt-upi-fips
+      USE_EXTERNAL_DNS: "true"
+    workflow: openshift-e2e-libvirt-vpn-fips
 - as: ocp-e2e-ovn-remote-s2s-libvirt-ppc64le
   capabilities:
   - power-s2s-dns

--- a/ci-operator/jobs/openshift/multiarch/openshift-multiarch-main-periodics.yaml
+++ b/ci-operator/jobs/openshift/multiarch/openshift-multiarch-main-periodics.yaml
@@ -62100,7 +62100,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
+  cluster: build09
   cron: 0 8 * * 0
   decorate: true
   decoration_config:
@@ -62110,9 +62110,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-2
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-5.0
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -62521,7 +62521,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
+  cluster: build09
   cron: 0 6 * * 6
   decorate: true
   decoration_config:
@@ -62531,9 +62531,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-2
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-5.0
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -62605,7 +62605,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
+  cluster: build09
   cron: 0 7 * * 6
   decorate: true
   decoration_config:
@@ -62615,9 +62615,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-2
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-5.0
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -63191,7 +63191,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
+  cluster: build09
   cron: 0 7 * * 1-4
   decorate: true
   decoration_config:
@@ -63201,9 +63201,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-2
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-5.0
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -64024,7 +64024,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
+  cluster: build09
   cron: 0 6 * * 1-4
   decorate: true
   decoration_config:
@@ -64034,9 +64034,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-2
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-5.0
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -64275,7 +64275,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
+  cluster: build09
   cron: 0 6 * * 0
   decorate: true
   decoration_config:
@@ -64285,9 +64285,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-2
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-5.0
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -64526,7 +64526,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
+  cluster: build09
   cron: 0 7 * * 0
   decorate: true
   decoration_config:
@@ -64536,9 +64536,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-2
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-5.0
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -65025,7 +65025,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
+  cluster: build09
   cron: 0 8 * * 1-4
   decorate: true
   decoration_config:
@@ -65035,9 +65035,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-2
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-5.0-upgrade-from-nightly-4.22
     ci.openshift.io/generator: prowgen
     job-release: "5.0"


### PR DESCRIPTION
## What

Migrate homogeneous IBM Z (`s390x`) libvirt periodics and the related upgrade job for the **OCP 5.0** multiarch variant from the legacy bastion stack to the **VPN** stack.

## Changes

- **`openshift-multiarch-main__nightly-5.0`**: homogeneous Z libvirt tests now use:
  - `cluster_profile: libvirt-s390x-vpn`
  - `capabilities: [intranet]` (replacing `sshd-bastion` where applicable)
  - `USE_EXTERNAL_DNS: "true"`
  - `workflow: openshift-e2e-libvirt-vpn` (and `openshift-e2e-libvirt-vpn-fips` for the FIPS job)
- **`openshift-multiarch-main__nightly-5.0-upgrade-from-nightly-4.22`**: `ocp-ovn-remote-libvirt-multi-z-z` updated to the same VPN profile, capability, DNS env, and workflow.

Heterogeneous libvirt jobs (e.g. `multi-z-xz` on `libvirt-s390x-amd64`) are unchanged.

## Why

Aligns OCP 5.0 with the VPN-based libvirt CI pattern already used on other release streams, so homogeneous Z jobs run on the supported VPN infrastructure instead of the older bastion-based profile.

## Verification

- `make update` (regenerates `ci-operator/jobs/...` and related artifacts).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/testing infrastructure configuration for s390x libvirt environments with revised cluster profiles and network capabilities.
  * Configured external DNS settings for test environments.
  * Reassigned Kubernetes cluster targets for continuous integration job execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->