### PR TITLE
USHIFT-6820: Update build_root image for 5.0

### DIFF
--- a/ci-operator/config/openshift/microshift/openshift-microshift-main.yaml
+++ b/ci-operator/config/openshift/microshift/openshift-microshift-main.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: rhel-9-release-golang-1.25-openshift-4.22
+    tag: rhel-9-release-golang-1.25-openshift-4.23
 images:
   items:
   - dockerfile_literal: |

--- a/ci-operator/config/openshift/microshift/openshift-microshift-release-4.23.yaml
+++ b/ci-operator/config/openshift/microshift/openshift-microshift-release-4.23.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: rhel-9-release-golang-1.25-openshift-4.22
+    tag: rhel-9-release-golang-1.25-openshift-4.23
 images:
   items:
   - dockerfile_literal: |

--- a/ci-operator/config/openshift/microshift/openshift-microshift-release-4.23__periodics.yaml
+++ b/ci-operator/config/openshift/microshift/openshift-microshift-release-4.23__periodics.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: rhel-9-release-golang-1.25-openshift-4.22
+    tag: rhel-9-release-golang-1.25-openshift-4.23
 releases:
   latest:
     candidate:

--- a/ci-operator/config/openshift/microshift/openshift-microshift-release-5.0.yaml
+++ b/ci-operator/config/openshift/microshift/openshift-microshift-release-5.0.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: rhel-9-release-golang-1.25-openshift-4.22
+    tag: rhel-9-release-golang-1.25-openshift-4.23
 images:
   items:
   - dockerfile_literal: |

--- a/ci-operator/config/openshift/microshift/openshift-microshift-release-5.0__periodics.yaml
+++ b/ci-operator/config/openshift/microshift/openshift-microshift-release-5.0__periodics.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: rhel-9-release-golang-1.24-openshift-4.21
+    tag: rhel-9-release-golang-1.25-openshift-4.23
 releases:
   latest:
     candidate:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build root image configurations for microshift main development branch and all release pipelines (versions 4.23 and 5.0) to use updated base image versions. These infrastructure updates affect build and test processes across all microshift release channels. Both standard and periodic build pipelines have been updated accordingly to maintain compatibility and consistency across releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->