### PR TITLE
TELCOV10N-1030: NTO - migrating tests to Baremetal nodes

### DIFF
--- a/ci-operator/config/openshift-kni/eco-ci-cd/.config.prowgen
+++ b/ci-operator/config/openshift-kni/eco-ci-cd/.config.prowgen
@@ -25,13 +25,13 @@ slack_reporter:
   - e2e-telcov10n-orion
   - e2e-telcov10n-orion-ptp
   - e2e-telcov10n-orion-oslat
-  - e2e-telcov10n-nto-tests-v1-runc-vm-4-14
-  - e2e-telcov10n-nto-tests-v1-crun-vm-4-16
-  - e2e-telcov10n-nto-tests-v1-vm-4-17
-  - e2e-telcov10n-nto-tests-v1-t0-crun-vm-4-18
-  - e2e-telcov10n-nto-tests-v2-t0-crun-vm-4-18
-  - e2e-telcov10n-nto-tests-v2-t0-crun-vm-4-19
-  - e2e-telcov10n-nto-tests-v2-t0-crun-vm-4-20
-  - e2e-telcov10n-nto-tests-v2-t0-crun-vm-4-21
+  - e2e-telcov10n-nto-tests-v2-t0-crun-bm-4-21
+  - e2e-telcov10n-nto-tests-v2-t0-crun-bm-4-20
+  - e2e-telcov10n-nto-tests-v2-t0-crun-bm-4-19
   - e2e-telcov10n-nto-tests-upgrade-4-19
-  - e2e-telcov10n-nto-tests-v2-t0-vm-4-22-nightly
+  - e2e-telcov10n-nto-tests-v1-t0-crun-bm-4-18
+  - e2e-telcov10n-nto-tests-v2-t0-crun-bm-4-18
+  - e2e-telcov10n-nto-tests-v1-crun-bm-4-17
+  - e2e-telcov10n-nto-tests-v1-crun-bm-4-16
+  - e2e-telcov10n-nto-tests-v1-runc-bm-4-14
+  - e2e-telcov10n-nto-tests-v2-t0-bm-4-22-nightly

--- a/ci-operator/config/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main__compute-nto.yaml
+++ b/ci-operator/config/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main__compute-nto.yaml
@@ -11,144 +11,14 @@ resources:
       cpu: 100m
       memory: 200Mi
 tests:
-- as: e2e-telcov10n-nto-tests-v1-runc-vm-4-14
+- as: e2e-telcov10n-nto-tests-v2-t0-crun-bm-4-21
   capabilities:
   - intranet
-  cron: 59 23 * * 1
-  steps:
-    env:
-      CGROUP_VERSION: v1
-      CLUSTER_NAME: hlxcl51
-      CONTAINER_RUNTIME: runc
-      FEATURES: compute
-      HUGEPAGES_DEFAULT_SIZE: 1G
-      HUGEPAGES_PAGES: '[{"count": 1, "size": "1G"}, {"count": 128, "size": "2M"}]'
-      LABELS: nto
-      RT_KERNEL: "true"
-      VERSION: "4.14"
-    test:
-    - ref: telcov10n-functional-compute-nto-eco-gotests
-    workflow: telcov10n-functional-compute-nto-ocp-setup
-- as: e2e-telcov10n-nto-tests-v1-crun-vm-4-16
-  capabilities:
-  - intranet
-  cron: 59 23 * * 2
-  steps:
-    env:
-      CGROUP_VERSION: v1
-      CLUSTER_NAME: hlxcl51
-      CONTAINER_RUNTIME: crun
-      FEATURES: compute
-      HUGEPAGES_DEFAULT_SIZE: 1G
-      HUGEPAGES_PAGES: '[{"count": 1, "size": "1G"}, {"count": 128, "size": "2M"}]'
-      LABELS: nto
-      RT_KERNEL: "true"
-      VERSION: "4.16"
-    test:
-    - ref: telcov10n-functional-compute-nto-eco-gotests
-    workflow: telcov10n-functional-compute-nto-ocp-setup
-- as: e2e-telcov10n-nto-tests-v1-vm-4-17
-  capabilities:
-  - intranet
-  cron: 59 23 * * 3
-  steps:
-    env:
-      CGROUP_VERSION: v1
-      CLUSTER_NAME: hlxcl51
-      CONTAINER_RUNTIME: crun
-      FEATURES: compute
-      HUGEPAGES_DEFAULT_SIZE: 1G
-      HUGEPAGES_PAGES: '[{"count": 1, "size": "1G"}, {"count": 128, "size": "2M"}]'
-      LABELS: nto
-      RT_KERNEL: "true"
-      VERSION: "4.17"
-    test:
-    - ref: telcov10n-functional-compute-nto-eco-gotests
-    workflow: telcov10n-functional-compute-nto-ocp-setup
-- as: e2e-telcov10n-nto-tests-v1-t0-crun-vm-4-18
-  capabilities:
-  - intranet
-  cron: 59 23 * * 4
-  steps:
-    env:
-      CGROUP_VERSION: v1
-      CLUSTER_NAME: hlxcl51
-      CONTAINER_RUNTIME: crun
-      FEATURES: compute
-      HUGEPAGES_DEFAULT_SIZE: 1G
-      HUGEPAGES_PAGES: '[{"count": 1, "size": "1G"}, {"count": 128, "size": "2M"}]'
-      LABEL_FILTER: tier-0
-      LABELS: nto
-      RT_KERNEL: "true"
-      VERSION: "4.18"
-    test:
-    - ref: telcov10n-functional-compute-nto-eco-gotests
-    workflow: telcov10n-functional-compute-nto-ocp-setup
-- as: e2e-telcov10n-nto-tests-v2-t0-crun-vm-4-18
-  capabilities:
-  - intranet
-  cron: 0 8 * * 5
+  cron: 59 23 * * 0
   steps:
     env:
       CGROUP_VERSION: v2
-      CLUSTER_NAME: hlxcl51
-      CONTAINER_RUNTIME: crun
-      FEATURES: compute
-      HUGEPAGES_DEFAULT_SIZE: 1G
-      HUGEPAGES_PAGES: '[{"count": 1, "size": "1G"}, {"count": 128, "size": "2M"}]'
-      LABEL_FILTER: tier-0
-      LABELS: nto
-      RT_KERNEL: "true"
-      VERSION: "4.18"
-    test:
-    - ref: telcov10n-functional-compute-nto-eco-gotests
-    workflow: telcov10n-functional-compute-nto-ocp-setup
-- as: e2e-telcov10n-nto-tests-v2-t0-crun-vm-4-19
-  capabilities:
-  - intranet
-  cron: 0 8 * * 6
-  steps:
-    env:
-      CGROUP_VERSION: v2
-      CLUSTER_NAME: hlxcl51
-      CONTAINER_RUNTIME: crun
-      FEATURES: compute
-      HUGEPAGES_DEFAULT_SIZE: 1G
-      HUGEPAGES_PAGES: '[{"count": 1, "size": "1G"}, {"count": 128, "size": "2M"}]'
-      LABEL_FILTER: tier-0
-      LABELS: nto
-      RT_KERNEL: "true"
-      VERSION: "4.19"
-    test:
-    - ref: telcov10n-functional-compute-nto-eco-gotests
-    workflow: telcov10n-functional-compute-nto-ocp-setup
-- as: e2e-telcov10n-nto-tests-v2-t0-crun-vm-4-20
-  capabilities:
-  - intranet
-  cron: 59 23 * * 1
-  steps:
-    env:
-      CGROUP_VERSION: v2
-      CLUSTER_NAME: hlxcl52
-      CONTAINER_RUNTIME: crun
-      FEATURES: compute
-      HUGEPAGES_DEFAULT_SIZE: 1G
-      HUGEPAGES_PAGES: '[{"count": 1, "size": "1G"}, {"count": 128, "size": "2M"}]'
-      LABEL_FILTER: tier-0
-      LABELS: nto
-      RT_KERNEL: "true"
-      VERSION: "4.20"
-    test:
-    - ref: telcov10n-functional-compute-nto-eco-gotests
-    workflow: telcov10n-functional-compute-nto-ocp-setup
-- as: e2e-telcov10n-nto-tests-v2-t0-crun-vm-4-21
-  capabilities:
-  - intranet
-  cron: 59 23 * * 2
-  steps:
-    env:
-      CGROUP_VERSION: v2
-      CLUSTER_NAME: hlxcl52
+      CLUSTER_NAME: hlxcl15
       CONTAINER_RUNTIME: crun
       FEATURES: compute
       HUGEPAGES_DEFAULT_SIZE: 1G
@@ -160,10 +30,48 @@ tests:
     test:
     - ref: telcov10n-functional-compute-nto-eco-gotests
     workflow: telcov10n-functional-compute-nto-ocp-setup
+- as: e2e-telcov10n-nto-tests-v2-t0-crun-bm-4-20
+  capabilities:
+  - intranet
+  cron: 59 23 * * 1
+  steps:
+    env:
+      CGROUP_VERSION: v2
+      CLUSTER_NAME: hlxcl15
+      CONTAINER_RUNTIME: crun
+      FEATURES: compute
+      HUGEPAGES_DEFAULT_SIZE: 1G
+      HUGEPAGES_PAGES: '[{"count": 1, "size": "1G"}, {"count": 128, "size": "2M"}]'
+      LABEL_FILTER: tier-0
+      LABELS: nto
+      RT_KERNEL: "true"
+      VERSION: "4.20"
+    test:
+    - ref: telcov10n-functional-compute-nto-eco-gotests
+    workflow: telcov10n-functional-compute-nto-ocp-setup
+- as: e2e-telcov10n-nto-tests-v2-t0-crun-bm-4-19
+  capabilities:
+  - intranet
+  cron: 59 23 * * 2
+  steps:
+    env:
+      CGROUP_VERSION: v2
+      CLUSTER_NAME: hlxcl15
+      CONTAINER_RUNTIME: crun
+      FEATURES: compute
+      HUGEPAGES_DEFAULT_SIZE: 1G
+      HUGEPAGES_PAGES: '[{"count": 1, "size": "1G"}, {"count": 128, "size": "2M"}]'
+      LABEL_FILTER: tier-0
+      LABELS: nto
+      RT_KERNEL: "true"
+      VERSION: "4.19"
+    test:
+    - ref: telcov10n-functional-compute-nto-eco-gotests
+    workflow: telcov10n-functional-compute-nto-ocp-setup
 - as: e2e-telcov10n-nto-tests-upgrade-4-19
   capabilities:
   - intranet
-  cron: 0 8 * * 5
+  cron: 59 23 * * 6
   steps:
     env:
       CGROUP_VERSION: v2
@@ -178,6 +86,98 @@ tests:
       RT_KERNEL: "true"
       VERSION: "4.19"
     workflow: telcov10n-functional-compute-nto-ocp-upgrade
+- as: e2e-telcov10n-nto-tests-v1-t0-crun-bm-4-18
+  capabilities:
+  - intranet
+  cron: 59 23 * * 3
+  steps:
+    env:
+      CGROUP_VERSION: v1
+      CLUSTER_NAME: hlxcl15
+      CONTAINER_RUNTIME: crun
+      FEATURES: compute
+      HUGEPAGES_DEFAULT_SIZE: 1G
+      HUGEPAGES_PAGES: '[{"count": 1, "size": "1G"}, {"count": 128, "size": "2M"}]'
+      LABEL_FILTER: tier-0
+      LABELS: nto
+      RT_KERNEL: "true"
+      VERSION: "4.18"
+    test:
+    - ref: telcov10n-functional-compute-nto-eco-gotests
+    workflow: telcov10n-functional-compute-nto-ocp-setup
+- as: e2e-telcov10n-nto-tests-v2-t0-crun-bm-4-18
+  capabilities:
+  - intranet
+  cron: 59 23 * * 4
+  steps:
+    env:
+      CGROUP_VERSION: v2
+      CLUSTER_NAME: hlxcl15
+      CONTAINER_RUNTIME: crun
+      FEATURES: compute
+      HUGEPAGES_DEFAULT_SIZE: 1G
+      HUGEPAGES_PAGES: '[{"count": 1, "size": "1G"}, {"count": 128, "size": "2M"}]'
+      LABEL_FILTER: tier-0
+      LABELS: nto
+      RT_KERNEL: "true"
+      VERSION: "4.18"
+    test:
+    - ref: telcov10n-functional-compute-nto-eco-gotests
+    workflow: telcov10n-functional-compute-nto-ocp-setup
+- as: e2e-telcov10n-nto-tests-v1-crun-bm-4-17
+  capabilities:
+  - intranet
+  cron: 59 11 * * 5
+  steps:
+    env:
+      CGROUP_VERSION: v1
+      CLUSTER_NAME: hlxcl15
+      CONTAINER_RUNTIME: crun
+      FEATURES: compute
+      HUGEPAGES_DEFAULT_SIZE: 1G
+      HUGEPAGES_PAGES: '[{"count": 1, "size": "1G"}, {"count": 128, "size": "2M"}]'
+      LABELS: nto
+      RT_KERNEL: "true"
+      VERSION: "4.17"
+    test:
+    - ref: telcov10n-functional-compute-nto-eco-gotests
+    workflow: telcov10n-functional-compute-nto-ocp-setup
+- as: e2e-telcov10n-nto-tests-v1-crun-bm-4-16
+  capabilities:
+  - intranet
+  cron: 59 23 * * 5
+  steps:
+    env:
+      CGROUP_VERSION: v1
+      CLUSTER_NAME: hlxcl15
+      CONTAINER_RUNTIME: crun
+      FEATURES: compute
+      HUGEPAGES_DEFAULT_SIZE: 1G
+      HUGEPAGES_PAGES: '[{"count": 1, "size": "1G"}, {"count": 128, "size": "2M"}]'
+      LABELS: nto
+      RT_KERNEL: "true"
+      VERSION: "4.16"
+    test:
+    - ref: telcov10n-functional-compute-nto-eco-gotests
+    workflow: telcov10n-functional-compute-nto-ocp-setup
+- as: e2e-telcov10n-nto-tests-v1-runc-bm-4-14
+  capabilities:
+  - intranet
+  cron: 59 11 * * 6
+  steps:
+    env:
+      CGROUP_VERSION: v1
+      CLUSTER_NAME: hlxcl15
+      CONTAINER_RUNTIME: runc
+      FEATURES: compute
+      HUGEPAGES_DEFAULT_SIZE: 1G
+      HUGEPAGES_PAGES: '[{"count": 1, "size": "1G"}, {"count": 128, "size": "2M"}]'
+      LABELS: nto
+      RT_KERNEL: "true"
+      VERSION: "4.14"
+    test:
+    - ref: telcov10n-functional-compute-nto-eco-gotests
+    workflow: telcov10n-functional-compute-nto-ocp-setup
 zz_generated_metadata:
   branch: main
   org: openshift-kni

--- a/ci-operator/config/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main__nightly-compute-nto.yaml
+++ b/ci-operator/config/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main__nightly-compute-nto.yaml
@@ -17,15 +17,14 @@ resources:
       cpu: 100m
       memory: 200Mi
 tests:
-- as: e2e-telcov10n-nto-tests-v2-t0-vm-4-22-nightly
+- as: e2e-telcov10n-nto-tests-v2-t0-bm-4-22-nightly
   capabilities:
   - intranet
-  cron: 0 8 * * 6
-  restrict_network_access: false
+  cron: 59 11 * * 0
   steps:
     env:
       CGROUP_VERSION: v2
-      CLUSTER_NAME: hlxcl52
+      CLUSTER_NAME: hlxcl15
       CONTAINER_RUNTIME: crun
       FEATURES: compute
       HUGEPAGES_DEFAULT_SIZE: 1G

--- a/ci-operator/jobs/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main-periodics.yaml
@@ -4876,7 +4876,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build05
-  cron: 0 8 * * 5
+  cron: 59 23 * * 6
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -4962,7 +4962,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build05
-  cron: 59 23 * * 2
+  cron: 59 23 * * 5
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -4975,7 +4975,7 @@ periodics:
     ci-operator.openshift.io/variant: compute-nto
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-kni-eco-ci-cd-main-compute-nto-e2e-telcov10n-nto-tests-v1-crun-vm-4-16
+  name: periodic-ci-openshift-kni-eco-ci-cd-main-compute-nto-e2e-telcov10n-nto-tests-v1-crun-bm-4-16
   reporter_config:
     slack:
       channel: '#eco-ci-cd-notifications'
@@ -4995,7 +4995,7 @@ periodics:
       - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
-      - --target=e2e-telcov10n-nto-tests-v1-crun-vm-4-16
+      - --target=e2e-telcov10n-nto-tests-v1-crun-bm-4-16
       - --variant=compute-nto
       command:
       - ci-operator
@@ -5048,7 +5048,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build05
-  cron: 59 23 * * 1
+  cron: 59 11 * * 5
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -5061,7 +5061,7 @@ periodics:
     ci-operator.openshift.io/variant: compute-nto
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-kni-eco-ci-cd-main-compute-nto-e2e-telcov10n-nto-tests-v1-runc-vm-4-14
+  name: periodic-ci-openshift-kni-eco-ci-cd-main-compute-nto-e2e-telcov10n-nto-tests-v1-crun-bm-4-17
   reporter_config:
     slack:
       channel: '#eco-ci-cd-notifications'
@@ -5081,7 +5081,7 @@ periodics:
       - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
-      - --target=e2e-telcov10n-nto-tests-v1-runc-vm-4-14
+      - --target=e2e-telcov10n-nto-tests-v1-crun-bm-4-17
       - --variant=compute-nto
       command:
       - ci-operator
@@ -5134,7 +5134,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build05
-  cron: 59 23 * * 4
+  cron: 59 11 * * 6
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -5147,7 +5147,7 @@ periodics:
     ci-operator.openshift.io/variant: compute-nto
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-kni-eco-ci-cd-main-compute-nto-e2e-telcov10n-nto-tests-v1-t0-crun-vm-4-18
+  name: periodic-ci-openshift-kni-eco-ci-cd-main-compute-nto-e2e-telcov10n-nto-tests-v1-runc-bm-4-14
   reporter_config:
     slack:
       channel: '#eco-ci-cd-notifications'
@@ -5167,7 +5167,7 @@ periodics:
       - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
-      - --target=e2e-telcov10n-nto-tests-v1-t0-crun-vm-4-18
+      - --target=e2e-telcov10n-nto-tests-v1-runc-bm-4-14
       - --variant=compute-nto
       command:
       - ci-operator
@@ -5233,7 +5233,7 @@ periodics:
     ci-operator.openshift.io/variant: compute-nto
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-kni-eco-ci-cd-main-compute-nto-e2e-telcov10n-nto-tests-v1-vm-4-17
+  name: periodic-ci-openshift-kni-eco-ci-cd-main-compute-nto-e2e-telcov10n-nto-tests-v1-t0-crun-bm-4-18
   reporter_config:
     slack:
       channel: '#eco-ci-cd-notifications'
@@ -5253,7 +5253,7 @@ periodics:
       - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
-      - --target=e2e-telcov10n-nto-tests-v1-vm-4-17
+      - --target=e2e-telcov10n-nto-tests-v1-t0-crun-bm-4-18
       - --variant=compute-nto
       command:
       - ci-operator
@@ -5306,7 +5306,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build05
-  cron: 0 8 * * 5
+  cron: 59 23 * * 4
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -5319,7 +5319,7 @@ periodics:
     ci-operator.openshift.io/variant: compute-nto
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-kni-eco-ci-cd-main-compute-nto-e2e-telcov10n-nto-tests-v2-t0-crun-vm-4-18
+  name: periodic-ci-openshift-kni-eco-ci-cd-main-compute-nto-e2e-telcov10n-nto-tests-v2-t0-crun-bm-4-18
   reporter_config:
     slack:
       channel: '#eco-ci-cd-notifications'
@@ -5339,179 +5339,7 @@ periodics:
       - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
-      - --target=e2e-telcov10n-nto-tests-v2-t0-crun-vm-4-18
-      - --variant=compute-nto
-      command:
-      - ci-operator
-      env:
-      - name: HTTP_SERVER_IP
-        valueFrom:
-          fieldRef:
-            fieldPath: status.podIP
-      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-      imagePullPolicy: Always
-      name: ""
-      ports:
-      - containerPort: 8080
-        name: http
-      resources:
-        requests:
-          cpu: 10m
-      volumeMounts:
-      - mountPath: /etc/boskos
-        name: boskos
-        readOnly: true
-      - mountPath: /secrets/gcs
-        name: gcs-credentials
-        readOnly: true
-      - mountPath: /secrets/manifest-tool
-        name: manifest-tool-local-pusher
-        readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
-      - mountPath: /etc/report
-        name: result-aggregator
-        readOnly: true
-    serviceAccountName: ci-operator
-    volumes:
-    - name: boskos
-      secret:
-        items:
-        - key: credentials
-          path: credentials
-        secretName: boskos-credentials
-    - name: manifest-tool-local-pusher
-      secret:
-        secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
-    - name: result-aggregator
-      secret:
-        secretName: result-aggregator
-- agent: kubernetes
-  cluster: build05
-  cron: 0 8 * * 6
-  decorate: true
-  decoration_config:
-    skip_cloning: true
-  extra_refs:
-  - base_ref: main
-    org: openshift-kni
-    repo: eco-ci-cd
-  labels:
-    capability/intranet: intranet
-    ci-operator.openshift.io/variant: compute-nto
-    ci.openshift.io/generator: prowgen
-    pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-kni-eco-ci-cd-main-compute-nto-e2e-telcov10n-nto-tests-v2-t0-crun-vm-4-19
-  reporter_config:
-    slack:
-      channel: '#eco-ci-cd-notifications'
-      job_states_to_report:
-      - failure
-      - error
-      - success
-      - aborted
-      report_template: '{{if eq .Status.State "success"}} :slack-green: Job *{{.Spec.Job}}*
-        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> {{else}} :failed:
-        Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
-        logs> {{end}}'
-  spec:
-    containers:
-    - args:
-      - --gcs-upload-secret=/secrets/gcs/service-account.json
-      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-      - --lease-server-credentials-file=/etc/boskos/credentials
-      - --report-credentials-file=/etc/report/credentials
-      - --target=e2e-telcov10n-nto-tests-v2-t0-crun-vm-4-19
-      - --variant=compute-nto
-      command:
-      - ci-operator
-      env:
-      - name: HTTP_SERVER_IP
-        valueFrom:
-          fieldRef:
-            fieldPath: status.podIP
-      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-      imagePullPolicy: Always
-      name: ""
-      ports:
-      - containerPort: 8080
-        name: http
-      resources:
-        requests:
-          cpu: 10m
-      volumeMounts:
-      - mountPath: /etc/boskos
-        name: boskos
-        readOnly: true
-      - mountPath: /secrets/gcs
-        name: gcs-credentials
-        readOnly: true
-      - mountPath: /secrets/manifest-tool
-        name: manifest-tool-local-pusher
-        readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
-      - mountPath: /etc/report
-        name: result-aggregator
-        readOnly: true
-    serviceAccountName: ci-operator
-    volumes:
-    - name: boskos
-      secret:
-        items:
-        - key: credentials
-          path: credentials
-        secretName: boskos-credentials
-    - name: manifest-tool-local-pusher
-      secret:
-        secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
-    - name: result-aggregator
-      secret:
-        secretName: result-aggregator
-- agent: kubernetes
-  cluster: build05
-  cron: 59 23 * * 1
-  decorate: true
-  decoration_config:
-    skip_cloning: true
-  extra_refs:
-  - base_ref: main
-    org: openshift-kni
-    repo: eco-ci-cd
-  labels:
-    capability/intranet: intranet
-    ci-operator.openshift.io/variant: compute-nto
-    ci.openshift.io/generator: prowgen
-    pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-kni-eco-ci-cd-main-compute-nto-e2e-telcov10n-nto-tests-v2-t0-crun-vm-4-20
-  reporter_config:
-    slack:
-      channel: '#eco-ci-cd-notifications'
-      job_states_to_report:
-      - failure
-      - error
-      - success
-      - aborted
-      report_template: '{{if eq .Status.State "success"}} :slack-green: Job *{{.Spec.Job}}*
-        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> {{else}} :failed:
-        Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
-        logs> {{end}}'
-  spec:
-    containers:
-    - args:
-      - --gcs-upload-secret=/secrets/gcs/service-account.json
-      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-      - --lease-server-credentials-file=/etc/boskos/credentials
-      - --report-credentials-file=/etc/report/credentials
-      - --target=e2e-telcov10n-nto-tests-v2-t0-crun-vm-4-20
+      - --target=e2e-telcov10n-nto-tests-v2-t0-crun-bm-4-18
       - --variant=compute-nto
       command:
       - ci-operator
@@ -5577,7 +5405,7 @@ periodics:
     ci-operator.openshift.io/variant: compute-nto
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-kni-eco-ci-cd-main-compute-nto-e2e-telcov10n-nto-tests-v2-t0-crun-vm-4-21
+  name: periodic-ci-openshift-kni-eco-ci-cd-main-compute-nto-e2e-telcov10n-nto-tests-v2-t0-crun-bm-4-19
   reporter_config:
     slack:
       channel: '#eco-ci-cd-notifications'
@@ -5597,7 +5425,179 @@ periodics:
       - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
-      - --target=e2e-telcov10n-nto-tests-v2-t0-crun-vm-4-21
+      - --target=e2e-telcov10n-nto-tests-v2-t0-crun-bm-4-19
+      - --variant=compute-nto
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build05
+  cron: 59 23 * * 1
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-kni
+    repo: eco-ci-cd
+  labels:
+    capability/intranet: intranet
+    ci-operator.openshift.io/variant: compute-nto
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-kni-eco-ci-cd-main-compute-nto-e2e-telcov10n-nto-tests-v2-t0-crun-bm-4-20
+  reporter_config:
+    slack:
+      channel: '#eco-ci-cd-notifications'
+      job_states_to_report:
+      - failure
+      - error
+      - success
+      - aborted
+      report_template: '{{if eq .Status.State "success"}} :slack-green: Job *{{.Spec.Job}}*
+        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> {{else}} :failed:
+        Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+        logs> {{end}}'
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --target=e2e-telcov10n-nto-tests-v2-t0-crun-bm-4-20
+      - --variant=compute-nto
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build05
+  cron: 59 23 * * 0
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-kni
+    repo: eco-ci-cd
+  labels:
+    capability/intranet: intranet
+    ci-operator.openshift.io/variant: compute-nto
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-kni-eco-ci-cd-main-compute-nto-e2e-telcov10n-nto-tests-v2-t0-crun-bm-4-21
+  reporter_config:
+    slack:
+      channel: '#eco-ci-cd-notifications'
+      job_states_to_report:
+      - failure
+      - error
+      - success
+      - aborted
+      report_template: '{{if eq .Status.State "success"}} :slack-green: Job *{{.Spec.Job}}*
+        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> {{else}} :failed:
+        Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+        logs> {{end}}'
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --target=e2e-telcov10n-nto-tests-v2-t0-crun-bm-4-21
       - --variant=compute-nto
       command:
       - ci-operator
@@ -6802,7 +6802,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build05
-  cron: 0 8 * * 6
+  cron: 59 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -6816,7 +6816,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-kni-eco-ci-cd-main-nightly-compute-nto-e2e-telcov10n-nto-tests-v2-t0-vm-4-22-nightly
+  name: periodic-ci-openshift-kni-eco-ci-cd-main-nightly-compute-nto-e2e-telcov10n-nto-tests-v2-t0-bm-4-22-nightly
   reporter_config:
     slack:
       channel: '#eco-ci-cd-notifications'
@@ -6837,7 +6837,7 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=e2e-telcov10n-nto-tests-v2-t0-vm-4-22-nightly
+      - --target=e2e-telcov10n-nto-tests-v2-t0-bm-4-22-nightly
       - --variant=nightly-compute-nto
       command:
       - ci-operator

--- a/ci-operator/step-registry/telcov10n/functional/compute-nto/cleanup-old-clusters/telcov10n-functional-compute-nto-cleanup-old-clusters-ref.yaml
+++ b/ci-operator/step-registry/telcov10n/functional/compute-nto/cleanup-old-clusters/telcov10n-functional-compute-nto-cleanup-old-clusters-ref.yaml
@@ -23,6 +23,7 @@ ref:
   - namespace: test-credentials
     name: telcov10n-ansible-group-hypervisors
     mount_path: /var/group_variables/common/hypervisors
+
   - namespace: test-credentials
     name: telcov10n-ansible-group-hlxcl51-masters
     mount_path: /var/group_variables/hlxcl51/masters
@@ -83,6 +84,7 @@ ref:
   - namespace: test-credentials
     name: telcov10n-ansible-hypervisors-ocp-hlxcl52
     mount_path: /var/host_variables/hlxcl52/hypervisor
+
   - namespace: test-credentials
     name: telcov10n-ansible-group-hlxcl15-masters
     mount_path: /var/group_variables/hlxcl15/masters

--- a/ci-operator/step-registry/telcov10n/functional/compute-nto/ocp-deploy-upgrade/telcov10n-functional-compute-nto-ocp-deploy-upgrade-ref.yaml
+++ b/ci-operator/step-registry/telcov10n/functional/compute-nto/ocp-deploy-upgrade/telcov10n-functional-compute-nto-ocp-deploy-upgrade-ref.yaml
@@ -53,6 +53,7 @@ ref:
   - namespace: test-credentials
     name: telcov10n-ansible-group-hypervisors
     mount_path: /var/group_variables/common/hypervisors
+
   - namespace: test-credentials
     name: telcov10n-ansible-group-hlxcl51-sno-masters
     mount_path: /var/group_variables/hlxcl51-sno/masters

--- a/ci-operator/step-registry/telcov10n/functional/compute-nto/ocp-deploy/telcov10n-functional-compute-nto-ocp-deploy-ref.yaml
+++ b/ci-operator/step-registry/telcov10n/functional/compute-nto/ocp-deploy/telcov10n-functional-compute-nto-ocp-deploy-ref.yaml
@@ -33,36 +33,34 @@ ref:
   - namespace: test-credentials
     name: telcov10n-ansible-group-hypervisors
     mount_path: /var/group_variables/common/hypervisors
+
   - namespace: test-credentials
-    name: telcov10n-ansible-group-hlxcl51-masters
-    mount_path: /var/group_variables/hlxcl51/masters
+    name: telcov10n-ansible-group-hlxcl51-sno-masters
+    mount_path: /var/group_variables/hlxcl51-sno/masters
   - namespace: test-credentials
-    name: telcov10n-ansible-group-hlxcl51-workers
-    mount_path: /var/group_variables/hlxcl51/workers
+    name: telcov10n-ansible-group-hlxcl51-sno-nodes
+    mount_path: /var/group_variables/hlxcl51-sno/nodes
   - namespace: test-credentials
-    name: telcov10n-ansible-group-hlxcl51-nodes
-    mount_path: /var/group_variables/hlxcl51/nodes
+    name: telcov10n-ansible-hlxcl51-sno-bastion
+    mount_path: /var/host_variables/hlxcl51-sno/bastion
   - namespace: test-credentials
-    name: telcov10n-ansible-hlxcl51-bastion
-    mount_path: /var/host_variables/hlxcl51/bastion
+    name: telcov10n-ansible-hlxcl51-sno-master0
+    mount_path: /var/host_variables/hlxcl51-sno/master0
   - namespace: test-credentials
-    name: telcov10n-ansible-hlxcl51-master0
-    mount_path: /var/host_variables/hlxcl51/master0
+    name: telcov10n-ansible-group-hlxcl52-sno-masters
+    mount_path: /var/group_variables/hlxcl52-sno/masters
   - namespace: test-credentials
-    name: telcov10n-ansible-hlxcl51-master1
-    mount_path: /var/host_variables/hlxcl51/master1
+    name: telcov10n-ansible-group-hlxcl52-sno-nodes
+    mount_path: /var/group_variables/hlxcl52-sno/nodes
   - namespace: test-credentials
-    name: telcov10n-ansible-hlxcl51-master2
-    mount_path: /var/host_variables/hlxcl51/master2
+    name: telcov10n-ansible-hlxcl52-sno-bastion
+    mount_path: /var/host_variables/hlxcl52-sno/bastion
   - namespace: test-credentials
-    name: telcov10n-ansible-hlxcl51-worker0
-    mount_path: /var/host_variables/hlxcl51/worker0
-  - namespace: test-credentials
-    name: telcov10n-ansible-hlxcl51-worker1
-    mount_path: /var/host_variables/hlxcl51/worker1
+    name: telcov10n-ansible-hlxcl52-sno-master0
+    mount_path: /var/host_variables/hlxcl52-sno/master0
   - namespace: test-credentials
     name: telcov10n-ansible-hypervisors-ocp-hlxcl51
-    mount_path: /var/host_variables/hlxcl51/hypervisor
+    mount_path: /var/host_variables/hlxcl51-sno/hypervisor
   - namespace: test-credentials
     name: telcov10n-ansible-group-hlxcl52-masters
     mount_path: /var/group_variables/hlxcl52/masters
@@ -93,6 +91,7 @@ ref:
   - namespace: test-credentials
     name: telcov10n-ansible-hypervisors-ocp-hlxcl52
     mount_path: /var/host_variables/hlxcl52/hypervisor
+
   - namespace: test-credentials
     name: telcov10n-ansible-group-hlxcl15-masters
     mount_path: /var/group_variables/hlxcl15/masters

--- a/ci-operator/step-registry/telcov10n/functional/compute-nto/process-inventory/telcov10n-functional-compute-nto-process-inventory-ref.yaml
+++ b/ci-operator/step-registry/telcov10n/functional/compute-nto/process-inventory/telcov10n-functional-compute-nto-process-inventory-ref.yaml
@@ -98,3 +98,34 @@ ref:
   - namespace: test-credentials
     name: telcov10n-ansible-hypervisors-ocp-hlxcl52
     mount_path: /var/host_variables/hlxcl52/hypervisor
+    
+  - namespace: test-credentials
+    name: telcov10n-ansible-group-hlxcl15-masters
+    mount_path: /var/group_variables/hlxcl15/masters
+  - namespace: test-credentials
+    name: telcov10n-ansible-group-hlxcl15-workers
+    mount_path: /var/group_variables/hlxcl15/workers
+  - namespace: test-credentials
+    name: telcov10n-ansible-group-hlxcl15-nodes
+    mount_path: /var/group_variables/hlxcl15/nodes
+  - namespace: test-credentials
+    name: telcov10n-ansible-hlxcl15-bastion
+    mount_path: /var/host_variables/hlxcl15/bastion
+  - namespace: test-credentials
+    name: telcov10n-ansible-hlxcl15-master0
+    mount_path: /var/host_variables/hlxcl15/master0
+  - namespace: test-credentials
+    name: telcov10n-ansible-hlxcl15-master1
+    mount_path: /var/host_variables/hlxcl15/master1
+  - namespace: test-credentials
+    name: telcov10n-ansible-hlxcl15-master2
+    mount_path: /var/host_variables/hlxcl15/master2
+  - namespace: test-credentials
+    name: telcov10n-ansible-hlxcl15-worker0
+    mount_path: /var/host_variables/hlxcl15/worker0
+  - namespace: test-credentials
+    name: telcov10n-ansible-hlxcl15-worker1
+    mount_path: /var/host_variables/hlxcl15/worker1
+  - namespace: test-credentials
+    name: telcov10n-ansible-hypervisors-ocp-edge91
+    mount_path: /var/host_variables/hlxcl15/hypervisor


### PR DESCRIPTION
- changing time and cluster name
- changing secrets for new cluster only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Migrated many compute NTO tests from VM targets to bare‑metal targets, renamed test identifiers, adjusted schedules, updated cluster/runtime selections, and replaced a setup test with an upgrade workflow.
* **Chores**
  * Updated CI notifications to track the new bare‑metal job set.
  * Removed deprecated credentials for two old clusters and consolidated credential mounts to the active cluster and edge host.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->