### PR TITLE
neuron: mark deprovision steps as best_effort individually

### DIFF
--- a/ci-operator/step-registry/aws-neuron-operator/conditional-e2e-rosa/aws-neuron-operator-conditional-e2e-rosa-workflow.yaml
+++ b/ci-operator/step-registry/aws-neuron-operator/conditional-e2e-rosa/aws-neuron-operator-conditional-e2e-rosa-workflow.yaml
@@ -32,7 +32,14 @@ workflow:
     - ref: aws-neuron-operator-test
     post:
     - ref: aws-neuron-operator-gather
-    - chain: rosa-aws-sts-hcp-deprovision
+    # Inline the rosa-aws-sts-hcp-deprovision chain so we can mark
+    # aws-deprovision-stacks as best_effort independently — its
+    # CloudFormation DELETE_FAILED errors must not fail the overall job.
+    - chain: rosa-cluster-deprovision
+      best_effort: true
+    - chain: rosa-sts-oidc-config-delete
+      best_effort: true
+    - ref: aws-deprovision-stacks
       best_effort: true
   documentation: |-
     This workflow provisions a ROSA HCP cluster with 2x AWS Inferentia (inf2.8xlarge)

--- a/ci-operator/step-registry/aws-neuron-operator/e2e-rosa/aws-neuron-operator-e2e-rosa-workflow.yaml
+++ b/ci-operator/step-registry/aws-neuron-operator/e2e-rosa/aws-neuron-operator-e2e-rosa-workflow.yaml
@@ -32,7 +32,14 @@ workflow:
     - ref: aws-neuron-operator-test
     post:
     - ref: aws-neuron-operator-gather
-    - chain: rosa-aws-sts-hcp-deprovision
+    # Inline the rosa-aws-sts-hcp-deprovision chain so we can mark
+    # aws-deprovision-stacks as best_effort independently — its
+    # CloudFormation DELETE_FAILED errors must not fail the overall job.
+    - chain: rosa-cluster-deprovision
+      best_effort: true
+    - chain: rosa-sts-oidc-config-delete
+      best_effort: true
+    - ref: aws-deprovision-stacks
       best_effort: true
   documentation: |-
     This workflow provisions a ROSA HCP cluster with 2x AWS Inferentia (inf2.8xlarge)


### PR DESCRIPTION
## Summary
- Inline the `rosa-aws-sts-hcp-deprovision` chain in both Neuron workflows and mark each step `best_effort: true` independently
- Fixes CloudFormation `DELETE_FAILED` in `aws-deprovision-stacks` causing the overall job to fail even when all tests pass

## Root cause
`best_effort: true` on a chain does not propagate to individual steps within it. When `aws-deprovision-stacks` (the last step in the chain) hits a CloudFormation `DELETE_FAILED`, ci-operator marks the post phase as failed, which fails the overall job — even though all 14 e2e tests passed.

Example: [job 2044434795143892992](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_neuron-ci/12/pull-ci-rh-ecosystem-edge-neuron-ci-main-4.20-stable-aws-neuron-operator-e2e/2044434795143892992) — all tests passed, job marked FAILURE due to VPC stack cleanup.

## Changes
Both workflows updated:
- `aws-neuron-operator-e2e-rosa` (PR-triggered)
- `aws-neuron-operator-conditional-e2e-rosa` (weekly periodic)

Each deprovision step is now individually marked `best_effort: true`:
- `rosa-cluster-deprovision` (chain)
- `rosa-sts-oidc-config-delete` (chain)
- `aws-deprovision-stacks` (ref)

## Test plan
- [ ] Re-run `pull-ci-rh-ecosystem-edge-neuron-ci-main-4.20-stable-aws-neuron-operator-e2e` and verify VPC cleanup failure no longer fails the job


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved resource cleanup reliability in test workflows by splitting composite deprovision steps into independent operations, ensuring failures in specific cleanup tasks don't prevent other resource cleanup attempts from completing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->