### PR TITLE
Increase memory request for Vector v0.47.0 unit tests

### DIFF
--- a/ci-operator/config/ViaQ/vector/ViaQ-vector-v0.47.0-rh.yaml
+++ b/ci-operator/config/ViaQ/vector/ViaQ-vector-v0.47.0-rh.yaml
@@ -62,12 +62,28 @@ resources:
       memory: 200Mi
 tests:
 - as: unit
-  commands: make test
-  container:
-    from: logging-vector-test-unit
-  resources:
-    requests:
-      memory: 4Gi
+  cluster_claim:
+    architecture: amd64
+    cloud: aws
+    labels:
+      region: us-east-1
+    owner: obs-logging
+    product: ocp
+    timeout: 1h0m0s
+    version: "4.20"
+  steps:
+    test:
+    - as: test
+      commands: CARGO_BUILD_JOBS=4 make test
+      from: pipeline:logging-vector-test-unit
+      resources:
+        limits:
+          memory: 20Gi
+        requests:
+          cpu: 100m
+          memory: 8Gi
+      timeout: 1h45m0s
+    workflow: generic-claim
 - as: cargo-deny-check-bans
   commands: cargo deny --no-default-features --features ocp-logging check bans
   container:

--- a/ci-operator/config/ViaQ/vector/ViaQ-vector-v0.47.0-rh.yaml
+++ b/ci-operator/config/ViaQ/vector/ViaQ-vector-v0.47.0-rh.yaml
@@ -65,6 +65,9 @@ tests:
   commands: make test
   container:
     from: logging-vector-test-unit
+  resources:
+    requests:
+      memory: 4Gi
 - as: cargo-deny-check-bans
   commands: cargo deny --no-default-features --features ocp-logging check bans
   container:

--- a/ci-operator/jobs/ViaQ/vector/ViaQ-vector-v0.47.0-rh-presubmits.yaml
+++ b/ci-operator/jobs/ViaQ/vector/ViaQ-vector-v0.47.0-rh-presubmits.yaml
@@ -502,8 +502,11 @@ presubmits:
       containers:
       - args:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --hive-kubeconfig=/secrets/hive-hive-credentials/kubeconfig
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
         - --target=unit
         command:
         - ci-operator
@@ -522,8 +525,17 @@ presubmits:
           requests:
             cpu: 10m
         volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
         - mountPath: /secrets/gcs
           name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/hive-hive-credentials
+          name: hive-hive-credentials
           readOnly: true
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
@@ -536,6 +548,18 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: hive-hive-credentials
+        secret:
+          secretName: hive-hive-credentials
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher


### PR DESCRIPTION
The unit test (make test) for Vector v0.47.0-rh was getting OOMKilled in CI. Local runs show the test consuming ~4-5GB of memory. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated test execution to run on provisioned cluster workers with explicit resource requests/limits and longer timeouts to improve stability.
  * Added cluster selection metadata for targeted runs (region, architecture, platform).
  * Introduced additional CI credentials and read-only secret mounts for improved orchestration and access to external services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->