### PR TITLE
CNF-22981: Allow automatic merge for red-hat-konflux on o-cloud-operator-konflux

### DIFF
--- a/core-services/prow/02_config/_labels.yaml
+++ b/core-services/prow/02_config/_labels.yaml
@@ -1189,11 +1189,58 @@ repos:
         name: no-qe
         target: prs
         addedBy: label
+  openshift-kni/o-cloud-operator-konflux:
+    labels:
+      - color: 0ffa16
+        description: Allows Tide to automatically merge PRs from trusted authors
+        name: allow-automatic-merge
+        target: prs
+        addedBy: label
+  openshift-kni/cnf-features-deploy:
+    labels:
+      - color: 0ffa16
+        description: Allows Tide to automatically merge PRs from trusted authors
+        name: allow-automatic-merge
+        target: prs
+        addedBy: label
+  openshift-kni/cluster-group-upgrades-operator:
+    labels:
+      - color: 0ffa16
+        description: Allows Tide to automatically merge PRs from trusted authors
+        name: allow-automatic-merge
+        target: prs
+        addedBy: label
   openshift-kni/lifecycle-agent:
     labels:
       - color: ed6d6d
         description: Cluster config API changed. It's used by other projects. Review to ensure your change is nonbreaking
         name: cluster-config-api-changed
+        target: prs
+        addedBy: label
+      - color: 0ffa16
+        description: Allows Tide to automatically merge PRs from trusted authors
+        name: allow-automatic-merge
+        target: prs
+        addedBy: label
+  openshift-kni/numaresources-operator:
+    labels:
+      - color: 0ffa16
+        description: Allows Tide to automatically merge PRs from trusted authors
+        name: allow-automatic-merge
+        target: prs
+        addedBy: label
+  openshift-kni/oran-o2ims:
+    labels:
+      - color: 0ffa16
+        description: Allows Tide to automatically merge PRs from trusted authors
+        name: allow-automatic-merge
+        target: prs
+        addedBy: label
+  openshift-kni/telco-reference:
+    labels:
+      - color: 0ffa16
+        description: Allows Tide to automatically merge PRs from trusted authors
+        name: allow-automatic-merge
         target: prs
         addedBy: label
   openshift/monitoring-plugin:

--- a/core-services/prow/02_config/openshift-kni/o-cloud-operator-konflux/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift-kni/o-cloud-operator-konflux/_prowconfig.yaml
@@ -1,3 +1,14 @@
 tide:
   merge_method:
     openshift-kni/o-cloud-operator-konflux: squash
+  queries:
+  - author: red-hat-konflux
+    labels:
+    - allow-automatic-merge
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/hold
+    - do-not-merge/work-in-progress
+    - needs-rebase
+    repos:
+    - openshift-kni/o-cloud-operator-konflux


### PR DESCRIPTION
Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic merge is now enabled for the repository, allowing qualifying pull requests to be merged automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->