### PR TITLE
fix: review-agent report shows null tool calls

### DIFF
--- a/ci-operator/step-registry/hypershift/review-agent/report/hypershift-review-agent-report-commands.sh
+++ b/ci-operator/step-registry/hypershift/review-agent/report/hypershift-review-agent-report-commands.sh
@@ -83,8 +83,8 @@ extract_from_stream_json() {
 
   case "$field" in
     text)
-      # Get the final result text
-      grep '"type":"result"' "$json_file" 2>/dev/null | jq -r '.result // empty' 2>/dev/null | head -1 || echo ""
+      # Get all assistant text output (full conversation, separated by newlines)
+      jq -r 'select(.type == "assistant") | .message.content[]? | select(.type == "text") | .text // empty' "$json_file" 2>/dev/null || echo ""
       ;;
     input_tokens)
       grep '"type":"result"' "$json_file" 2>/dev/null | jq -r '.usage.input_tokens // 0' 2>/dev/null | head -1 || echo "0"

--- a/ci-operator/step-registry/hypershift/review-agent/report/hypershift-review-agent-report-commands.sh
+++ b/ci-operator/step-registry/hypershift/review-agent/report/hypershift-review-agent-report-commands.sh
@@ -120,12 +120,12 @@ extract_from_stream_json() {
       grep '"type":"system"' "$json_file" 2>/dev/null | jq -r '.tools // [] | join(",")' 2>/dev/null | head -1 || echo ""
       ;;
     tool_calls)
-      # Extract tool use entries
-      grep '"type":"tool_use"' "$json_file" 2>/dev/null | jq -r '[.name // empty] | join("\n")' 2>/dev/null || echo ""
+      # Extract tool use entries from assistant messages
+      jq -r 'select(.type == "assistant") | .message.content[]? | select(.type == "tool_use") | .name' "$json_file" 2>/dev/null || echo ""
       ;;
     tool_errors)
-      # Extract tool results with is_error=true
-      grep '"is_error":true' "$json_file" 2>/dev/null | jq -r '.content // empty' 2>/dev/null || echo ""
+      # Extract tool error results from user messages
+      jq -r 'select(.type == "user") | .tool_use_result | select(type == "string") | select(startswith("Error:"))' "$json_file" 2>/dev/null || echo ""
       ;;
     model_usage)
       grep '"type":"result"' "$json_file" 2>/dev/null | jq -r '.modelUsage // {} | to_entries[] | "\(.key)|\(.value.inputTokens // .value.input_tokens // 0)|\(.value.outputTokens // .value.output_tokens // 0)|\(.value.cacheReadInputTokens // .value.cache_read_input_tokens // 0)|\(.value.cacheCreationInputTokens // .value.cache_creation_input_tokens // 0)"' 2>/dev/null | head -20 || echo ""
@@ -227,12 +227,11 @@ while IFS= read -r line; do
     TOOL_CALLS_RAW=$(jq -r '.tool_calls[]? // empty' "$SUMMARY_FILE" 2>/dev/null | sed 's/^/  /' || echo "")
     TOOL_ERRORS_RAW=$(jq -r '.tool_errors[]? // empty' "$SUMMARY_FILE" 2>/dev/null || echo "")
   elif [ -f "${OUTPUT_FILE:-}" ] && [ -s "${OUTPUT_FILE:-}" ]; then
-    # Legacy stream-json format
-    TOOL_CALLS_RAW=$(grep '"type":"tool_use"' "$OUTPUT_FILE" 2>/dev/null \
-      | jq -r '"  \(.name)(\(.input | tostring | .[0:120])...)"' 2>/dev/null \
+    # Legacy stream-json format - tool_use is nested inside assistant messages
+    TOOL_CALLS_RAW=$(jq -r 'select(.type == "assistant") | .message.content[]? | select(.type == "tool_use") | "  \(.name)(\(.input | tostring | .[0:120])...)"' "$OUTPUT_FILE" 2>/dev/null \
       || echo "")
-    TOOL_ERRORS_RAW=$(grep '"is_error":true' "$OUTPUT_FILE" 2>/dev/null \
-      | jq -r '.content // "unknown error"' 2>/dev/null \
+    TOOL_ERRORS_RAW=$(jq -r 'select(.type == "user") | .tool_use_result | select(type == "string") | select(startswith("Error:")) | gsub("\n"; "⏎")' "$OUTPUT_FILE" 2>/dev/null \
+      | sed 's/⏎/\n/g' \
       || echo "")
   fi
 


### PR DESCRIPTION
## Summary
- Fix review-agent HTML report rendering tool calls as `null(null...)` and errors as `unknown error`
- The stream-json format nests `tool_use` events inside `"type":"assistant"` messages at `.message.content[]`, but the report script was `grep`-ing for `"type":"tool_use"` at the top level
- Use the correct `jq` selectors matching the pattern used by jira-agent, dependabot-triage, and other working report scripts

**Before:** `null(null...)` × 9 — [example](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_hypershift/8164/pull-ci-openshift-hypershift-main-address-review-comments/2041207376446492672/artifacts/address-review-comments/hypershift-review-agent-report/artifacts/review-agent-report.html)

**After:** `Bash({"command":"..."}...)`, `Read({"file_path":"..."}...)`, etc.

## Test plan
- [x] Validated fix against the actual stream-json output from [PR #8164 CI run](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_hypershift/8164/pull-ci-openshift-hypershift-main-address-review-comments/2041207376446492672/artifacts/address-review-comments/hypershift-review-agent-process/build-log.txt)
- [ ] Trigger `/test address-review-comments` on a HyperShift PR to verify the report renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved review agent diagnostics: more reliable extraction and aggregation of assistant message text, tool usage, and tool error information; preserves multiline error content and normalizes line breaks for consistent reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->