### PR TITLE
prowconfig: update must-gather-operator

### DIFF
--- a/core-services/prow/02_config/openshift/must-gather-operator/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/must-gather-operator/_prowconfig.yaml
@@ -1,10 +1,11 @@
 tide:
   queries:
   - includedBranches:
-    - main
-    - master
+    - openshift-4.22
+    - release-4.22
     labels:
     - approved
+    - backport-risk-assessed
     - jira/valid-reference
     - lgtm
     - qe-approved,no-qe
@@ -33,6 +34,7 @@ tide:
     - release-4.21
     labels:
     - approved
+    - backport-risk-assessed
     - jira/valid-reference
     - lgtm
     - verified
@@ -45,9 +47,30 @@ tide:
     - needs-rebase
     repos:
     - openshift/must-gather-operator
+  - includedBranches:
+    - main
+    - master
+    labels:
+    - approved
+    - jira/valid-reference
+    - lgtm
+    - qe-approved,no-qe
+    - verified
+    missingLabels:
+    - backports/unvalidated-commits
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - jira/invalid-bug
+    - keep-main-query-separate
+    - needs-rebase
+    repos:
+    - openshift/must-gather-operator
   - excludedBranches:
     - main
     - master
+    - openshift-4.21
+    - openshift-4.22
     - release-4.12
     - release-4.13
     - release-4.14


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added support for targeting newer 4.22 branches and updated branch targeting rules.
  * Require a backport-risk-assessed label for PRs targeting 4.22 and related release branches.
  * Expanded label validation for older release branches to include backport risk assessment.
  * Separated main-branch approval rules and updated excluded branches list to omit specific release branches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->