### PR TITLE
[DON'T MERGE, JUST TESTING] stackrox: roxie in CI

### DIFF
--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-roxie-in-ci.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-roxie-in-ci.yaml
@@ -1,0 +1,24 @@
+build_root:
+  image_stream_tag:
+    name: apollo-ci
+    namespace: stackrox
+    tag: stackrox-ui-test-latest
+resources:
+  '*':
+    requests:
+      cpu: 2000m
+      memory: 4000Mi
+test_binary_build_commands: .openshift-ci/dispatch.sh test-binary-build-commands
+tests:
+- as: gke-qa-e2e-tests
+  optional: true
+  skip_if_only_changed: ^ui/
+  steps:
+    env:
+      COLLECTION_METHOD: core_bpf
+      USE_ROXIE_DEPLOY: "true"
+    workflow: stackrox-stackrox-e2e-job
+zz_generated_metadata:
+  branch: roxie-in-ci
+  org: stackrox
+  repo: stackrox

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-roxie-in-ci.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-roxie-in-ci.yaml
@@ -1,3 +1,4 @@
+base_images:
 build_root:
   image_stream_tag:
     name: apollo-ci

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-roxie-in-ci.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-roxie-in-ci.yaml
@@ -17,7 +17,6 @@ tests:
   steps:
     env:
       COLLECTION_METHOD: core_bpf
-      USE_ROXIE_DEPLOY: "true"
     workflow: stackrox-stackrox-e2e-job
 zz_generated_metadata:
   branch: roxie-in-ci

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-roxie-in-ci__ocp-4-21.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-roxie-in-ci__ocp-4-21.yaml
@@ -1,0 +1,35 @@
+base_images:
+  cli:
+    name: "4.21"
+    namespace: ocp
+    tag: cli
+  ocp-4:
+    name: automation-flavors
+    namespace: stackrox
+    tag: openshift-4-stable
+build_root:
+  image_stream_tag:
+    name: apollo-ci
+    namespace: stackrox
+    tag: stackrox-ui-test-latest
+resources:
+  '*':
+    requests:
+      cpu: 2000m
+      memory: 4000Mi
+test_binary_build_commands: .openshift-ci/dispatch.sh test-binary-build-commands
+tests:
+- as: qa-e2e-tests
+  optional: true
+  run_if_changed: ^((generated|image|operator|pkg|make|deploy|scripts)/.*|Makefile|status\.sh|[A-Z_]+_VERSION)
+  steps:
+    env:
+      COLLECTION_METHOD: core_bpf
+      OCP_VERSION: ocp/candidate-4.21
+      TEST_SUITE: ocp-qa-e2e-tests
+    workflow: stackrox-automation-flavors-ocp-4-e2e
+zz_generated_metadata:
+  branch: roxie-in-ci
+  org: stackrox
+  repo: stackrox
+  variant: ocp-4-21

--- a/ci-operator/jobs/stackrox/stackrox/stackrox-stackrox-roxie-in-ci-presubmits.yaml
+++ b/ci-operator/jobs/stackrox/stackrox/stackrox-stackrox-roxie-in-ci-presubmits.yaml
@@ -1,0 +1,77 @@
+presubmits:
+  stackrox/stackrox:
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^roxie-in-ci$
+    - ^roxie-in-ci-
+    cluster: build01
+    context: ci/prow/gke-qa-e2e-tests
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-stackrox-stackrox-roxie-in-ci-gke-qa-e2e-tests
+    optional: true
+    rerun_command: /test gke-qa-e2e-tests
+    skip_if_only_changed: ^ui/
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --target=gke-qa-e2e-tests
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )gke-qa-e2e-tests,?($|\s.*)

--- a/ci-operator/jobs/stackrox/stackrox/stackrox-stackrox-roxie-in-ci-presubmits.yaml
+++ b/ci-operator/jobs/stackrox/stackrox/stackrox-stackrox-roxie-in-ci-presubmits.yaml
@@ -75,3 +75,80 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )gke-qa-e2e-tests,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^roxie-in-ci$
+    - ^roxie-in-ci-
+    cluster: build01
+    context: ci/prow/ocp-4-21-qa-e2e-tests
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/variant: ocp-4-21
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-stackrox-stackrox-roxie-in-ci-ocp-4-21-qa-e2e-tests
+    optional: true
+    rerun_command: /test ocp-4-21-qa-e2e-tests
+    run_if_changed: ^((generated|image|operator|pkg|make|deploy|scripts)/.*|Makefile|status\.sh|[A-Z_]+_VERSION)
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --target=qa-e2e-tests
+        - --variant=ocp-4-21
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )ocp-4-21-qa-e2e-tests,?($|\s.*)

--- a/ci-operator/step-registry/stackrox/stackrox/e2e-test/stackrox-stackrox-e2e-test-ref.yaml
+++ b/ci-operator/step-registry/stackrox/stackrox/e2e-test/stackrox-stackrox-e2e-test-ref.yaml
@@ -27,6 +27,8 @@ ref:
   # TODO: We should remove this option after scanner v2 is removed
   - name: ROX_SCANNER_V4
     default: "false"
+  - name: USE_ROXIE_DEPLOY
+    default: "false"
   documentation: |-
     A step that runs a standard stackrox/stackrox e2e test with mounted
     credentials, etc. Executes .openshift-ci/dispatch.sh in the target repo and

--- a/ci-operator/step-registry/stackrox/stackrox/e2e-test/stackrox-stackrox-e2e-test-ref.yaml
+++ b/ci-operator/step-registry/stackrox/stackrox/e2e-test/stackrox-stackrox-e2e-test-ref.yaml
@@ -27,8 +27,6 @@ ref:
   # TODO: We should remove this option after scanner v2 is removed
   - name: ROX_SCANNER_V4
     default: "false"
-  - name: USE_ROXIE_DEPLOY
-    default: "false"
   documentation: |-
     A step that runs a standard stackrox/stackrox e2e test with mounted
     credentials, etc. Executes .openshift-ci/dispatch.sh in the target repo and


### PR DESCRIPTION
/hold


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional GKE end-to-end test target and presubmit job to allow running E2E tests on pull requests.
  * Introduced a configurable flag to enable Roxie deployment during tests (USE_ROXIE_DEPLOY).

* **Chores**
  * Added CI pipeline configurations and job wiring to support the new test target, OCP variant testing, and presubmit behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->