### PR TITLE
TELCOV10N-923 - add cnf gotests step

### DIFF
--- a/ci-operator/config/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main__cnf-ran-sno-day2-worker-4.20.yaml
+++ b/ci-operator/config/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main__cnf-ran-sno-day2-worker-4.20.yaml
@@ -24,8 +24,11 @@ tests:
   steps:
     env:
       CLUSTER_NAME: kni-qe-106
+      CNF_GOTESTS_FEATURES: reboot
       DISABLE_INSIGHTS: "true"
       DISCONNECTED: "true"
+      DOWNSTREAM_TEST_REPO: https://gitlab.cee.redhat.com/cnf/cnf-gotests/
+      HUB_CLUSTER: kni-qe-106
       HUB_OPERATORS: |
         [
           {"name":"local-storage-operator","catalog":"redhat-operators","nsname":"openshift-local-storage","channel":"stable","og_name":"local-operator-group","subscription_name":"local-storage-operator","deploy_default_config":false,"ns_annotations":{"workload.openshift.io/allowed":"management"}},
@@ -35,6 +38,7 @@ tests:
           {"name":"topology-aware-lifecycle-manager","catalog":"topology-aware-lifecycle-manager-fbc","og_name":"global-operators","nsname":"openshift-operators","fbc_iib_repo":"latest","channel":"stable","deploy_default_config":false,"ocp_operator_mirror_fbc_image_base":"quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-fbc-4-20"},
           {"name":"cluster-logging","catalog":"redhat-operators","nsname":"openshift-logging","channel":"stable-6.2","default_channel":"stable-6.5","og_name":"cluster-logging","subscription_name":"cluster-logging","og_spec":{"targetNamespaces":[]}}
         ]
+      MIRROR_REGISTRY: disconnected.registry.local:5000
       SPOKE_CLUSTER: '[''kni-qe-107'']'
       SPOKE_OPERATORS: |
         [
@@ -54,6 +58,8 @@ tests:
     - ref: telcov10n-functional-cnf-ran-mirror-spoke-operators
     - ref: telcov10n-functional-cnf-ran-deploy-spoke-sno
     - ref: telcov10n-functional-cnf-ran-deploy-spoke-sno-day2-worker
+    test:
+    - ref: telcov10n-functional-cnf-ran-cnf-gotests-sno-worker
 zz_generated_metadata:
   branch: main
   org: openshift-kni

--- a/ci-operator/step-registry/telcov10n/functional/cnf-ran/cnf-gotests-sno-worker/OWNERS
+++ b/ci-operator/step-registry/telcov10n/functional/cnf-ran/cnf-gotests-sno-worker/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+- shaior
+- kononovn
+- eifrach
+- rdiscala

--- a/ci-operator/step-registry/telcov10n/functional/cnf-ran/cnf-gotests-sno-worker/telcov10n-functional-cnf-ran-cnf-gotests-sno-worker-commands.sh
+++ b/ci-operator/step-registry/telcov10n/functional/cnf-ran/cnf-gotests-sno-worker/telcov10n-functional-cnf-ran-cnf-gotests-sno-worker-commands.sh
@@ -1,0 +1,303 @@
+#!/bin/bash
+set -e
+set -o pipefail
+
+echo "Checking if the job should be skipped..."
+if [ -f "${SHARED_DIR}/skip.txt" ]; then
+  echo "Detected skip.txt file — skipping the job"
+  exit 0
+fi
+
+ECO_CI_CD_INVENTORY_PATH="/eco-ci-cd/inventories/cnf"
+
+process_inventory() {
+    local directory="$1"
+    local dest_file="$2"
+
+    if [ -z "$directory" ]; then
+        echo "Usage: process_inventory <directory> <dest_file>"
+        return 1
+    fi
+
+    if [ ! -d "$directory" ]; then
+        echo "Error: '$directory' is not a valid directory"
+        return 1
+    fi
+
+    find "$directory" -type f | while IFS= read -r filename; do
+        if [[ $filename == *"secretsync-vault-source-path"* ]]; then
+          continue
+        fi
+        local content
+        content=$(cat "$filename")
+        local varname
+        varname=$(basename "${filename}")
+        if [[ "$content" == *$'\n'* ]]; then
+          echo "${varname}: |"
+          echo "$content" | sed 's/^/  /'
+        else
+          echo "${varname}: '${content//\'/\'\'}'"
+        fi
+    done > "${dest_file}"
+
+    echo "Processing complete. Check \"${dest_file}\""
+}
+
+SPOKE_CLUSTER=$(echo "${SPOKE_CLUSTER}" | tr -d "[]'\" ")
+if [[ "${SPOKE_CLUSTER}" == *,* ]]; then
+  echo "Error: SPOKE_CLUSTER must resolve to exactly one cluster name, got: '${SPOKE_CLUSTER}'"
+  exit 1
+fi
+if [[ -z "${SPOKE_CLUSTER}" ]]; then
+  echo "Error: SPOKE_CLUSTER is empty after normalization"
+  exit 1
+fi
+if [[ ! "${SPOKE_CLUSTER}" =~ ^[a-z0-9]([a-z0-9-]*[a-z0-9])?$ ]]; then
+  echo "Error: SPOKE_CLUSTER contains invalid characters: '${SPOKE_CLUSTER}'"
+  exit 1
+fi
+
+HUB_CLUSTER=$(echo "${HUB_CLUSTER}" | tr -d "[]'\" ")
+if [[ "${HUB_CLUSTER}" == *,* ]]; then
+  echo "Error: HUB_CLUSTER must resolve to exactly one cluster name, got: '${HUB_CLUSTER}'"
+  exit 1
+fi
+if [[ -z "${HUB_CLUSTER}" ]]; then
+  echo "Error: HUB_CLUSTER is empty after normalization"
+  exit 1
+fi
+if [[ ! "${HUB_CLUSTER}" =~ ^[a-z0-9]([a-z0-9-]*[a-z0-9])?$ ]]; then
+  echo "Error: HUB_CLUSTER contains invalid characters: '${HUB_CLUSTER}'"
+  exit 1
+fi
+
+echo "SPOKE_CLUSTER=${SPOKE_CLUSTER}"
+echo "HUB_CLUSTER=${HUB_CLUSTER}"
+if [[ -z "${CNF_GOTESTS_FEATURES}" ]]; then
+  echo "Error: CNF_GOTESTS_FEATURES must be set and non-empty"
+  exit 1
+fi
+echo "CNF_GOTESTS_FEATURES=${CNF_GOTESTS_FEATURES}"
+echo "DOWNSTREAM_TEST_REPO=${DOWNSTREAM_TEST_REPO}"
+
+echo "Create group_vars directory"
+mkdir -p "${ECO_CI_CD_INVENTORY_PATH}/group_vars"
+
+echo "Process all common group variables"
+while read -r dir; do
+    echo "Process group inventory file: ${dir}"
+    process_inventory "$dir" "${ECO_CI_CD_INVENTORY_PATH}/group_vars/$(basename "${dir}")"
+done < <(find /var/group_variables/common/ -mindepth 1 -maxdepth 1 -type d ! -name '..*' 2>/dev/null)
+
+echo "Process spoke cluster group variables"
+while read -r dir; do
+    echo "Process group inventory file: ${dir}"
+    process_inventory "$dir" "${ECO_CI_CD_INVENTORY_PATH}/group_vars/$(basename "${dir}")"
+done < <(find "/var/group_variables/${SPOKE_CLUSTER}/" -mindepth 1 -maxdepth 1 -type d ! -name '..*' 2>/dev/null)
+
+echo "Create host_vars directory"
+mkdir -p "${ECO_CI_CD_INVENTORY_PATH}/host_vars"
+
+echo "Process bastion host variables (from hub ${HUB_CLUSTER})"
+while read -r dir; do
+    echo "Process host inventory file: ${dir}"
+    process_inventory "$dir" "${ECO_CI_CD_INVENTORY_PATH}/host_vars/$(basename "${dir}")"
+done < <(find "/var/host_variables/${HUB_CLUSTER}/" -mindepth 1 -maxdepth 1 -type d ! -name '..*' 2>/dev/null)
+
+echo "Process spoke cluster host variables"
+while read -r dir; do
+    echo "Process host inventory file: ${dir}"
+    process_inventory "$dir" "${ECO_CI_CD_INVENTORY_PATH}/host_vars/$(basename "${dir}")"
+done < <(find "/var/host_variables/${SPOKE_CLUSTER}/" -mindepth 1 -maxdepth 1 -type d ! -name '..*' 2>/dev/null)
+
+WORKDIR=$(mktemp -d)
+HUB_CLUSTERCONFIGS_PATH="/home/telcov10n/project/generated/${HUB_CLUSTER}"
+HUB_KUBECONFIG_PATH="${HUB_CLUSTERCONFIGS_PATH}/auth/kubeconfig"
+
+echo "Set bastion ssh configuration"
+cat /var/group_variables/common/all/ansible_ssh_private_key > "${WORKDIR}/temp_ssh_key"
+
+chmod 600 "${WORKDIR}/temp_ssh_key"
+BASTION_IP=$(grep -oP '(?<=ansible_host: ).*' "${ECO_CI_CD_INVENTORY_PATH}/host_vars/bastion" | sed "s/'//g")
+BASTION_USER=$(grep -oP '(?<=ansible_user: ).*' "${ECO_CI_CD_INVENTORY_PATH}/group_vars/all" | sed "s/'//g")
+
+SSH_OPTS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null)
+SSH_OPTS_KEEPALIVE=(-o ServerAliveInterval=60 -o ServerAliveCountMax=3 "${SSH_OPTS[@]}")
+
+echo "Create remote working directory"
+REMOTE_WORKDIR=$(ssh "${SSH_OPTS[@]}" "${BASTION_USER}@${BASTION_IP}" -i "${WORKDIR}/temp_ssh_key" "mktemp -d")
+
+SPOKE_KUBECONFIG="${REMOTE_WORKDIR}/${SPOKE_CLUSTER}-kubeconfig"
+DOWNSTREAM_TEST_DIR="${REMOTE_WORKDIR}/cnf-gotests"
+DOWNSTREAM_REPORT_PATH="${REMOTE_WORKDIR}/downstream_report"
+
+cleanup() {
+  ssh "${SSH_OPTS[@]}" "${BASTION_USER}@${BASTION_IP}" -i "${WORKDIR}/temp_ssh_key" \
+    "rm -rf '${REMOTE_WORKDIR}'" 2>/dev/null || true
+  rm -rf "${WORKDIR}"
+}
+trap cleanup EXIT
+
+echo "Extract spoke kubeconfig from hub via bastion"
+ssh "${SSH_OPTS[@]}" "${BASTION_USER}@${BASTION_IP}" -i "${WORKDIR}/temp_ssh_key" \
+  "oc --kubeconfig='${HUB_KUBECONFIG_PATH}' \
+    get secret ${SPOKE_CLUSTER}-admin-kubeconfig \
+    -n ${SPOKE_CLUSTER} \
+    -o jsonpath='{.data.kubeconfig}' | base64 -d > '${SPOKE_KUBECONFIG}'"
+
+echo "Wait for spoke worker node to be Ready"
+ssh "${SSH_OPTS_KEEPALIVE[@]}" "${BASTION_USER}@${BASTION_IP}" -i "${WORKDIR}/temp_ssh_key" \
+  "oc --kubeconfig='${SPOKE_KUBECONFIG}' \
+    wait --for=condition=Ready node \
+    --selector=node-role.kubernetes.io/worker,\!node-role.kubernetes.io/master \
+    --timeout=30m"
+
+echo "Label spoke worker nodes with workercnf role"
+ssh "${SSH_OPTS[@]}" "${BASTION_USER}@${BASTION_IP}" -i "${WORKDIR}/temp_ssh_key" \
+  "oc --kubeconfig='${SPOKE_KUBECONFIG}' \
+    label node --overwrite \
+    --selector=node-role.kubernetes.io/worker,\!node-role.kubernetes.io/master \
+    node-role.kubernetes.io/workercnf="
+
+echo "Resolve OCP tools image for CNF_TEST_IMAGE (available on disconnected registry)"
+CNF_TEST_IMAGE=$(ssh "${SSH_OPTS[@]}" "${BASTION_USER}@${BASTION_IP}" -i "${WORKDIR}/temp_ssh_key" \
+  "oc --kubeconfig='${SPOKE_KUBECONFIG}' adm release info --image-for=tools")
+echo "CNF_TEST_IMAGE=${CNF_TEST_IMAGE}"
+
+cd /eco-ci-cd
+
+echo "Run ansible playbook to generate downstream test script"
+ansible-playbook ./playbooks/cnf/deploy-run-downstream-tests-script.yaml \
+  -i ./inventories/cnf/run-tests.yaml \
+  --extra-vars "kubeconfig=${SPOKE_KUBECONFIG} \
+    downstream_test_repo=${DOWNSTREAM_TEST_REPO} \
+    downstream_test_dir=${REMOTE_WORKDIR}/ \
+    downstream_test_report_path=${DOWNSTREAM_REPORT_PATH} \
+    metallb_vlans= \
+    switch_interfaces= \
+    switch_user= \
+    switch_pass= \
+    switch_address= \
+    switch_lag_names= \
+    cnf_interfaces= \
+    tests_mlb_addr_list= \
+    frr_image_link= \
+    network_test_container_link=" \
+  -vv
+
+echo "Mirror workload images to disconnected registry"
+ssh "${SSH_OPTS[@]}" "${BASTION_USER}@${BASTION_IP}" -i "${WORKDIR}/temp_ssh_key" bash -s -- \
+  "${MIRROR_REGISTRY}" <<'MIRROR_SCRIPT'
+set -e
+set -o pipefail
+
+MIRROR_REGISTRY="$1"
+AUTHFILE="${HOME}/auth/auth.compact.json"
+ACCEPT_POLICY='{"default":[{"type":"insecureAcceptAnything"}]}'
+
+if [[ -z "${MIRROR_REGISTRY}" ]]; then
+  echo "MIRROR_REGISTRY not set, skipping image mirror"
+  exit 0
+fi
+
+for image in container-perf-tools/oslat:latest container-perf-tools/stress-ng:latest; do
+  echo "Mirroring quay.io/${image} → ${MIRROR_REGISTRY}/${image}"
+  skopeo copy \
+    --policy <(echo "${ACCEPT_POLICY}") \
+    --authfile "${AUTHFILE}" \
+    --dest-tls-verify=false \
+    "docker://quay.io/${image}" \
+    "docker://${MIRROR_REGISTRY}/${image}"
+done
+
+echo "Image mirroring complete"
+MIRROR_SCRIPT
+
+echo "Fix ginkgo, patch generated script, install nc, and run tests via SSH"
+cnf_gotests_rc=0
+ssh "${SSH_OPTS_KEEPALIVE[@]}" "${BASTION_USER}@${BASTION_IP}" -i "${WORKDIR}/temp_ssh_key" bash -s -- \
+  "${DOWNSTREAM_TEST_DIR}" "${CNF_GOTESTS_FEATURES}" "${CNF_TEST_IMAGE}" "${MIRROR_REGISTRY}" "${DOWNSTREAM_REPORT_PATH}" <<'REMOTE_SCRIPT' || cnf_gotests_rc=$?
+set -e
+set -o pipefail
+
+DOWNSTREAM_TEST_DIR="$1"
+CNF_GOTESTS_FEATURES="$2"
+CNF_TEST_IMAGE="$3"
+MIRROR_REGISTRY="$4"
+DOWNSTREAM_REPORT_PATH="$5"
+GENERATED_SCRIPT="${DOWNSTREAM_TEST_DIR}/downstream-tests-run.sh"
+
+mkdir -p "${DOWNSTREAM_REPORT_PATH}"
+
+if [[ ! -f "${GENERATED_SCRIPT}" ]]; then
+  echo "ERROR: ${GENERATED_SCRIPT} not found"
+  exit 1
+fi
+
+if ! command -v nc &>/dev/null; then
+  echo "Installing nmap-ncat (provides nc for node reachability checks)..."
+  sudo dnf install -y nmap-ncat
+fi
+
+echo "Re-install ginkgo CLI from project vendor to match library version..."
+export PATH="/usr/local/go/bin:$PATH"
+cd "${DOWNSTREAM_TEST_DIR}"
+go install -mod=vendor github.com/onsi/ginkgo/v2/ginkgo
+echo "Ginkgo version fix complete"
+
+echo "Patching generated script with feature selection and disconnected image overrides..."
+PATCH_EXPORTS="export FEATURES=${CNF_GOTESTS_FEATURES}"
+PATCH_EXPORTS="${PATCH_EXPORTS}\nexport CNF_TEST_IMAGE=${CNF_TEST_IMAGE}"
+if [[ -n "${MIRROR_REGISTRY}" ]]; then
+  PATCH_EXPORTS="${PATCH_EXPORTS}\nexport OSLAT_TEST_IMAGE=${MIRROR_REGISTRY}/container-perf-tools/oslat:latest"
+  PATCH_EXPORTS="${PATCH_EXPORTS}\nexport STRESSNG_TEST_IMAGE=${MIRROR_REGISTRY}/container-perf-tools/stress-ng:latest"
+fi
+
+sed -i "s|^make test-all|${PATCH_EXPORTS}\nmake test-features|" "${GENERATED_SCRIPT}"
+
+echo "Running cnf-gotests..."
+./downstream-tests-run.sh || exit $?
+REMOTE_SCRIPT
+
+echo "Create artifact directory for reports"
+mkdir -p "${ARTIFACT_DIR}/junit_downstream/"
+
+echo "Gather reports from bastion"
+scp_stderr=$(mktemp)
+scp_rc=0
+scp -r "${SSH_OPTS[@]}" -i "${WORKDIR}/temp_ssh_key" \
+  "${BASTION_USER}@${BASTION_IP}:${DOWNSTREAM_REPORT_PATH}/*.xml" \
+  "${ARTIFACT_DIR}/junit_downstream/" 2>"${scp_stderr}" || scp_rc=$?
+if [[ ${scp_rc} -ne 0 ]]; then
+  scp_err_msg=$(cat "${scp_stderr}")
+  if [[ "${scp_err_msg}" == *"No such file"* || "${scp_err_msg}" == *"not found"* ]]; then
+    echo "No report files found on bastion (non-fatal): ${scp_err_msg}"
+  else
+    echo "ERROR: scp failed (exit code ${scp_rc}) copying reports from ${BASTION_USER}@${BASTION_IP}:${DOWNSTREAM_REPORT_PATH}/*.xml"
+    echo "stderr: ${scp_err_msg}"
+    rm -f "${scp_stderr}"
+    exit 1
+  fi
+fi
+rm -f "${scp_stderr}"
+
+echo "Copy reports to SHARED_DIR with prefixes"
+for f in "${ARTIFACT_DIR}"/junit_downstream/*_polarion.xml; do
+  if [[ -f "$f" ]]; then
+    filename=$(basename "$f")
+    echo "Copying polarion report: $filename -> polarion_${filename}"
+    cp "$f" "${SHARED_DIR}/polarion_${filename}"
+  fi
+done
+
+for f in "${ARTIFACT_DIR}"/junit_downstream/*.xml; do
+  if [[ -f "$f" ]]; then
+    filename=$(basename "$f")
+    if [[ "$filename" == *_suite_test.xml ]] && [[ "$filename" != *_polarion.xml ]]; then
+      echo "Copying junit report: $filename -> junit_${filename}"
+      cp "$f" "${SHARED_DIR}/junit_${filename}"
+    fi
+  fi
+done
+
+exit "${cnf_gotests_rc}"

--- a/ci-operator/step-registry/telcov10n/functional/cnf-ran/cnf-gotests-sno-worker/telcov10n-functional-cnf-ran-cnf-gotests-sno-worker-ref.metadata.json
+++ b/ci-operator/step-registry/telcov10n/functional/cnf-ran/cnf-gotests-sno-worker/telcov10n-functional-cnf-ran-cnf-gotests-sno-worker-ref.metadata.json
@@ -1,0 +1,11 @@
+{
+	"path": "telcov10n/functional/cnf-ran/cnf-gotests-sno-worker/telcov10n-functional-cnf-ran-cnf-gotests-sno-worker-ref.yaml",
+	"owners": {
+		"approvers": [
+			"shaior",
+			"kononovn",
+			"eifrach",
+			"rdiscala"
+		]
+	}
+}

--- a/ci-operator/step-registry/telcov10n/functional/cnf-ran/cnf-gotests-sno-worker/telcov10n-functional-cnf-ran-cnf-gotests-sno-worker-ref.yaml
+++ b/ci-operator/step-registry/telcov10n/functional/cnf-ran/cnf-gotests-sno-worker/telcov10n-functional-cnf-ran-cnf-gotests-sno-worker-ref.yaml
@@ -1,0 +1,58 @@
+ref:
+  as: telcov10n-functional-cnf-ran-cnf-gotests-sno-worker
+  from_image:
+    namespace: telcov10n-ci
+    name: eco-ci-cd
+    tag: eco-ci-cd
+  commands: telcov10n-functional-cnf-ran-cnf-gotests-sno-worker-commands.sh
+  documentation: |-
+    Run cnf-gotests downstream tests on SNO spoke cluster with day-2 worker node
+  grace_period: 10s
+  timeout: 24h0m0s
+  resources:
+    requests:
+      cpu: 100m
+      memory: 200Mi
+
+  env:
+  - name: SPOKE_CLUSTER
+    default: "kni-qe-107"
+    documentation: Spoke SNO cluster name with added worker node
+  - name: HUB_CLUSTER
+    default: "kni-qe-106"
+    documentation: Hub cluster name
+  - name: CNF_GOTESTS_FEATURES
+    default: "reboot"
+    documentation: Space-separated list of cnf-gotests features to run
+  - name: MIRROR_REGISTRY
+    default: ""
+    documentation: Disconnected mirror registry hostname (e.g. disconnected.registry.local:5000). When set, workload images are mirrored here before tests run.
+  - name: DOWNSTREAM_TEST_REPO
+    default: "https://gitlab.cee.redhat.com/cnf/cnf-gotests/"
+    documentation: Git URL of the cnf-gotests downstream test repository
+
+  credentials:
+  - namespace: test-credentials
+    name: telcov10n-ansible-group-all
+    mount_path: /var/group_variables/common/all
+  - namespace: test-credentials
+    name: telcov10n-ansible-group-bastions
+    mount_path: /var/group_variables/common/bastions
+  - namespace: test-credentials
+    name: telcov10n-ansible-group-hypervisors
+    mount_path: /var/group_variables/common/hypervisors
+  - namespace: test-credentials
+    name: telcov10n-ansible-group-kni-qe-106-nodes
+    mount_path: /var/group_variables/kni-qe-106/nodes
+  - namespace: test-credentials
+    name: telcov10n-ansible-group-kni-qe-106-masters
+    mount_path: /var/group_variables/kni-qe-106/masters
+  - namespace: test-credentials
+    name: telcov10n-ansible-kni-qe-106-bastion
+    mount_path: /var/host_variables/kni-qe-106/bastion
+  - namespace: test-credentials
+    name: telcov10n-ansible-kni-qe-106-master0
+    mount_path: /var/host_variables/kni-qe-106/master0
+  - namespace: test-credentials
+    name: telcov10n-ansible-hypervisors-hv16
+    mount_path: /var/host_variables/fthub-01/hypervisor

--- a/ci-operator/step-registry/telcov10n/functional/cnf-ran/deploy-spoke-sno-day2-worker/telcov10n-functional-cnf-ran-deploy-spoke-sno-day2-worker-commands.sh
+++ b/ci-operator/step-registry/telcov10n/functional/cnf-ran/deploy-spoke-sno-day2-worker/telcov10n-functional-cnf-ran-deploy-spoke-sno-day2-worker-commands.sh
@@ -84,7 +84,7 @@ KUBECONFIG_PATH="/home/telcov10n/project/generated/${CLUSTER_NAME}/auth/kubeconf
 SPOKE_CLUSTER_NAME=$(echo "${SPOKE_CLUSTER}" | tr -d "[]' ")
 
 echo "Running day 2 worker expansion for SNO spoke cluster: ${SPOKE_CLUSTER_NAME}"
-ansible-playbook ./playbooks/deploy-ocp-sno-day2-worker.yml \
+ansible-playbook ./playbooks/ran/deploy-ocp-sno-day2-worker.yml \
     -i ./inventories/ocp-deployment/build-inventory.py \
     --extra-vars "kubeconfig=${KUBECONFIG_PATH} \
         spoke_cluster_name=${SPOKE_CLUSTER_NAME} \

--- a/ci-operator/step-registry/telcov10n/functional/cnf-ran/hub-deploy/telcov10n-functional-cnf-ran-hub-deploy-ref.yaml
+++ b/ci-operator/step-registry/telcov10n/functional/cnf-ran/hub-deploy/telcov10n-functional-cnf-ran-hub-deploy-ref.yaml
@@ -19,7 +19,7 @@ ref:
       documentation: BM Cluster name
     - name: DISABLE_INSIGHTS
       default: "false"
-      documentation: Set to "true" to disable the Insights operator via an extra manifest
+      documentation: Set to "true" to remove cloud.openshift.com from pull secret, disabling Insights and Telemetry
   credentials:
     - namespace: test-credentials
       name: telcov10n-ansible-group-all


### PR DESCRIPTION
Add telcov10n-functional-cnf-ran-cnf-tests-sno-worker step to the cnf-ran-sno-day2-worker-4.20 job. The step runs CNF conformance tests on the spoke cluster's day-2 worker node after ZTP provisioning.

The step:
- Builds Ansible inventory from its own credential mounts
- Extracts the spoke kubeconfig from the hub cluster
- Waits for the worker node to reach Ready state (30m timeout)
- Labels worker nodes with workercnf role
- Runs cnf-features-deploy tests via Ansible and remote SSH execution
- Collects JUnit and Polarion XML reports as CI artifacts

  Also adds CNF_TESTS_FEATURES and HUB_CLUSTER env vars to the test configuration for explicit control of test scope and hub identity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced test pipeline with new testing scenarios and environment variable configuration for improved test coverage and reliability in CI/CD operations.

* **Chores**
  * Updated continuous integration infrastructure configuration to support expanded testing capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->