### PR TITLE
HIVE-3153: Adding otp-e2e tests on periodic jobs for hive

### DIFF
--- a/ci-operator/config/openshift/hive/.config.prowgen
+++ b/ci-operator/config/openshift/hive/.config.prowgen
@@ -20,3 +20,4 @@ slack_reporter:
   job_names:
   - e2e-openstack-weekly
   - e2e-vsphere-weekly
+  - aws-ipi-f7-longduration-hive-sd-rosa

--- a/ci-operator/config/openshift/hive/openshift-hive-master__periodic.yaml
+++ b/ci-operator/config/openshift/hive/openshift-hive-master__periodic.yaml
@@ -3,8 +3,12 @@ base_images:
     name: "4.22"
     namespace: ocp
     tag: openstack-installer
+  tests-private:
+    name: tests-private
+    namespace: ci
+    tag: latest
   upi-installer:
-    name: "4.14"
+    name: "4.22"
     namespace: ocp
     tag: upi-installer
 binary_build_commands: GO_COMPLIANCE_INFO=0 make build
@@ -242,6 +246,31 @@ tests:
         requests:
           cpu: 100m
     workflow: ipi-openstack
+- as: aws-ipi-f7-longduration-hive-sd-rosa
+  cron: 0 6 * * 6
+  steps:
+    cluster_profile: aws-qe
+    env:
+      BASE_DOMAIN: qe.devcluster.openshift.com
+      FILTERS_ADDITIONAL: ~CPaasrunOnly&;HiveSDRosa&;
+      TEST_SCENARIOS: Cluster_Operator
+      TEST_TIMEOUT: "90"
+    test:
+    - as: deploy-hive
+      cli: latest
+      commands: |
+        make deploy
+      dependencies:
+      - env: HIVE_IMAGE
+        name: hive
+      from: src
+      resources:
+        requests:
+          cpu: 100m
+    - chain: cucushift-installer-check-cluster-health
+    - ref: idp-htpasswd
+    - ref: openshift-extended-test-longduration
+    workflow: cucushift-installer-rehearse-aws-ipi
 zz_generated_metadata:
   branch: master
   org: openshift

--- a/ci-operator/jobs/openshift/hive/openshift-hive-master-periodics.yaml
+++ b/ci-operator/jobs/openshift/hive/openshift-hive-master-periodics.yaml
@@ -1,5 +1,98 @@
 periodics:
 - agent: kubernetes
+  cluster: build07
+  cron: 0 6 * * 6
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: master
+    org: openshift
+    repo: hive
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-qe
+    ci-operator.openshift.io/variant: periodic
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-hive-master-periodic-aws-ipi-f7-longduration-hive-sd-rosa
+  reporter_config:
+    slack:
+      channel: '#team-hive-alert'
+      job_states_to_report:
+      - failure
+      - error
+      - aborted
+      - success
+      report_template: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+        logs>
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=aws-ipi-f7-longduration-hive-sd-rosa
+      - --variant=periodic
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
   cluster: build11
   cron: 5 4 * * 4
   decorate: true

--- a/ci-operator/step-registry/cluster-profiles/cluster-profiles-config.yaml
+++ b/ci-operator/step-registry/cluster-profiles/cluster-profiles-config.yaml
@@ -534,6 +534,7 @@ cluster_profiles:
     - cloud-credential-operator
     - csi-operator
     - external-dns-operator
+    - hive
     - hypershift
     - insights-operator
     - installer


### PR DESCRIPTION
/hold

WIP to see if any issues if there is periodic ran from main hive instead of OTP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added CI base images used by workflows.
  * Extended CI cluster-profile allowlist to include the hive repository.
  * Enabled targeted Slack reporting for failures/errors/aborts of the new periodic job.

* **Tests**
  * Added a new weekly periodic job to run a long‑duration AWS installer scenario and execute extended end‑to‑end long‑duration tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->