### PR TITLE
Skip PodObservedGenerationTracking E2E Test for PowerVS 4.21

### DIFF
--- a/ci-operator/step-registry/openshift/e2e/libvirt/conf/openshift-e2e-libvirt-conf-commands.sh
+++ b/ci-operator/step-registry/openshift/e2e/libvirt/conf/openshift-e2e-libvirt-conf-commands.sh
@@ -306,6 +306,13 @@ EOF
 "[sig-etcd] etcd should not log excessive took too long messages"
 "[sig-api-machinery] ResourceQuota should verify ResourceQuota with terminating scopes through scope selectors. [Suite:openshift/conformance/parallel] [Suite:k8s]"
 EOF
+       # Skip the PodObservedGenerationTracking test for 4.21 only until https://redhat.atlassian.net/browse/OCPBUGS-83561 is fixed
+       # This test has timeout issues while pulling non-existent image on PowerVS for 4.21 (fixed in 4.22 with K8s 1.35)
+       if [ "${BRANCH}" == "4.21" ]; then
+          cat >> "${SHARED_DIR}/excluded_tests" << EOF
+"[sig-node] Pods Extended (pod generation) [Feature:PodObservedGenerationTracking] [FeatureGate:PodObservedGenerationTracking] [Beta] Pod Generation pod observedGeneration field set in pod conditions"
+EOF
+       fi
     fi
 else
     echo "Executing all tests"


### PR DESCRIPTION
The test `[sig-node] Pods Extended (pod generation) [Feature:PodObservedGenerationTracking] [FeatureGate:PodObservedGenerationTracking] [Beta] Pod Generation pod observedGeneration field set in pod conditions` consistently fails on PowerVS 4.21

Excluding the TestCase until https://redhat.atlassian.net/browse/OCPBUGS-83561 is fixed only for 4.21.

#### The Fix (Already in 4.22)
This issue was fixed in **Kubernetes 1.35** (used by OCP 4.22)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated internal test configuration to exclude specific conformance tests under certain build conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->