### PR TITLE
Fix neuron operator version detection in test step

### DIFF
--- a/ci-operator/step-registry/aws-neuron-operator/test/aws-neuron-operator-test-commands.sh
+++ b/ci-operator/step-registry/aws-neuron-operator/test/aws-neuron-operator-test-commands.sh
@@ -145,12 +145,12 @@ echo "=== Cleanup: removing test namespaces ==="
 oc delete namespace neuron-vllm-test --wait=true --timeout=5m 2>/dev/null || true
 
 # Write operator version after tests (operator is deployed during test execution)
-NEURON_CSV=$(oc get csv -A -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null | grep -i neuron | head -1 || echo "")
-if [[ -n "${NEURON_CSV}" ]]; then
-    NEURON_OPERATOR_VERSION=$(oc get csv -A "${NEURON_CSV}" -o jsonpath='{.spec.version}' 2>/dev/null || echo "unknown")
-else
+NEURON_OPERATOR_VERSION=$(oc get csv -A -o json 2>/dev/null \
+    | jq -r '[.items[] | select(.metadata.name | test("neuron";"i"))] | .[0].spec.version // empty' || true)
+if [[ -z "${NEURON_OPERATOR_VERSION}" ]]; then
     NEURON_OPERATOR_VERSION="${ECO_HWACCEL_NEURON_DEVICE_PLUGIN_IMAGE##*:}"
 fi
+NEURON_OPERATOR_VERSION="${NEURON_OPERATOR_VERSION:-unknown}"
 echo "${NEURON_OPERATOR_VERSION}" > "${ARTIFACT_DIR}/operator.version"
 echo "Neuron Operator Version: ${NEURON_OPERATOR_VERSION}"
 


### PR DESCRIPTION
## Summary
- Fix `operator.version` artifact always being "unknown" in CI dashboard
- The previous code used `oc get csv -A <name>` which is invalid — kubectl/oc doesn't support combining `-A` with a specific resource name, so it silently failed
- Replace with a single `jq` command that extracts the version from the full CSV JSON listing

## Test plan
- [x] Verified jq command against simulated CSV JSON matching real cluster output (`aws-neuron-operator.v1.1.2`)
- [x] Verified empty result when no neuron CSV exists (falls back to device plugin image tag)
- [ ] Next CI run should produce correct `operator.version` artifact


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved reliability of version detection in the continuous integration testing pipeline through enhanced JSON query logic and added fallback mechanisms for edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->