### PR TITLE
[jira-lifecycle-plugin] 4.23/5.0 bump fix

### DIFF
--- a/core-services/jira-lifecycle-plugin/config.yaml
+++ b/core-services/jira-lifecycle-plugin/config.yaml
@@ -178,7 +178,7 @@ default:
     - status: ON_QA
     - status: VERIFIED
     dependent_bug_target_versions:
-    - 4.23.0
+    - 5.0.0
     target_version: 4.22.0
     validate_by_default: true
   openshift-4.23:
@@ -309,7 +309,7 @@ default:
     - status: ON_QA
     - status: VERIFIED
     dependent_bug_target_versions:
-    - 4.23.0
+    - 5.0.0
     target_version: 4.22.0
     validate_by_default: true
   release-4.23:


### PR DESCRIPTION
Follow-up fix to https://github.com/openshift/release/pull/77794, updates `openshift-4.22` and `release-4.22` to have `dependent_bug_target_versions` at version `5.0.0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated target version configurations in the Jira lifecycle plugin to reflect new version dependencies across multiple branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->