### PR TITLE
cleanup the ci-tools-build-root Dockerfile build

### DIFF
--- a/clusters/build-clusters/multiarch_builds/supplemental-ci-images/ci-tools-build-root_mabc.yaml
+++ b/clusters/build-clusters/multiarch_builds/supplemental-ci-images/ci-tools-build-root_mabc.yaml
@@ -33,18 +33,13 @@ spec:
         - destinationDir: .
           sourcePath: /bin/promtool
       dockerfile: |
-        FROM mplatform/manifest-tool:v2.1.3 as builder
         FROM quay.io/centos/centos:stream9
 
-        COPY --from=builder /manifest-tool /usr/bin/manifest-tool
-
-        ENV VERSION=1.25.5 \
+        ENV VERSION=1.25.8 \
             GOCACHE=/go/.cache \
             GOARM=5 \
             GOPATH=/go \
-            GOROOT=/usr/local/go \
-            GOFLAGS='-mod=vendor' \
-            LOGNAME=deadbeef
+            GOROOT=/usr/local/go
         ENV PATH=$PATH:$GOROOT/bin:$GOPATH/bin
 
         RUN mkdir $GOPATH


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified CI build setup by removing an unused builder dependency from the image.
  * Updated the Go toolchain version used in CI.
  * Streamlined environment variable configuration in the CI build image for a leaner build environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->