### PR TITLE
CCXDEV-16072: remove ReportPortal integration

### DIFF
--- a/ci-operator/config/openshift/insights-operator/openshift-insights-operator-master.yaml
+++ b/ci-operator/config/openshift/insights-operator/openshift-insights-operator-master.yaml
@@ -94,7 +94,7 @@ tests:
     - as: test
       cli: latest
       commands: |
-        pytest.sh -k "not serial and not periodic_only and not slow" --junitxml=$(pwd)/test-report.xml --rp_enabled --rp_name=Insights_operator_e2e_tests_pr_checks
+        pytest.sh -k "not serial and not periodic_only and not slow" --junitxml=$(pwd)/test-report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -120,9 +120,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -136,8 +133,6 @@ tests:
         name: SLACK_BOT_TOKEN
       - default: /secret/slack-webhook-url/slack-webhook-url
         name: SLACK_WEBHOOK_URL
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:
@@ -156,7 +151,7 @@ tests:
     - as: test
       cli: latest
       commands: |
-        pytest.sh -k "serial and not periodic_only and not slow" --junitxml=$(pwd)/test-report.xml --rp_enabled --rp_name=Insights_operator_serial_tests_pr_checks
+        pytest.sh -k "serial and not periodic_only and not slow" --junitxml=$(pwd)/test-report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -182,9 +177,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -198,8 +190,6 @@ tests:
         name: SLACK_BOT_TOKEN
       - default: /secret/slack-webhook-url/slack-webhook-url
         name: SLACK_WEBHOOK_URL
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:
@@ -218,7 +208,7 @@ tests:
     - as: test
       cli: latest
       commands: |
-        pytest.sh -k "not periodic_only and slow" --junitxml=$(pwd)/test-report.xml --rp_enabled --rp_name=Insights_operator_slow_tests_pr_checks
+        pytest.sh -k "not periodic_only and slow" --junitxml=$(pwd)/test-report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -244,9 +234,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -260,8 +247,6 @@ tests:
         name: SLACK_BOT_TOKEN
       - default: /secret/slack-webhook-url/slack-webhook-url
         name: SLACK_WEBHOOK_URL
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:

--- a/ci-operator/config/openshift/insights-operator/openshift-insights-operator-release-4.23.yaml
+++ b/ci-operator/config/openshift/insights-operator/openshift-insights-operator-release-4.23.yaml
@@ -94,7 +94,7 @@ tests:
     - as: test
       cli: latest
       commands: |
-        pytest.sh -k "not serial and not periodic_only and not slow" --junitxml=$(pwd)/test-report.xml --rp_enabled --rp_name=Insights_operator_e2e_tests_pr_checks
+        pytest.sh -k "not serial and not periodic_only and not slow" --junitxml=$(pwd)/test-report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -120,9 +120,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -136,8 +133,6 @@ tests:
         name: SLACK_BOT_TOKEN
       - default: /secret/slack-webhook-url/slack-webhook-url
         name: SLACK_WEBHOOK_URL
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:
@@ -156,7 +151,7 @@ tests:
     - as: test
       cli: latest
       commands: |
-        pytest.sh -k "serial and not periodic_only and not slow" --junitxml=$(pwd)/test-report.xml --rp_enabled --rp_name=Insights_operator_serial_tests_pr_checks
+        pytest.sh -k "serial and not periodic_only and not slow" --junitxml=$(pwd)/test-report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -182,9 +177,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -198,8 +190,6 @@ tests:
         name: SLACK_BOT_TOKEN
       - default: /secret/slack-webhook-url/slack-webhook-url
         name: SLACK_WEBHOOK_URL
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:
@@ -218,7 +208,7 @@ tests:
     - as: test
       cli: latest
       commands: |
-        pytest.sh -k "not periodic_only and slow" --junitxml=$(pwd)/test-report.xml --rp_enabled --rp_name=Insights_operator_slow_tests_pr_checks
+        pytest.sh -k "not periodic_only and slow" --junitxml=$(pwd)/test-report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -244,9 +234,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -260,8 +247,6 @@ tests:
         name: SLACK_BOT_TOKEN
       - default: /secret/slack-webhook-url/slack-webhook-url
         name: SLACK_WEBHOOK_URL
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:

--- a/ci-operator/config/openshift/insights-operator/openshift-insights-operator-release-4.23__periodics.yaml
+++ b/ci-operator/config/openshift/insights-operator/openshift-insights-operator-release-4.23__periodics.yaml
@@ -42,7 +42,7 @@ tests:
     - as: test
       cli: latest
       commands: |
-        pytest.sh -k "not techpreview and periodic_only" --junitxml=$(pwd)/test-report.xml --rp_enabled --rp_name=Insights_operator_e2e_tests_periodic
+        pytest.sh -k "not techpreview and periodic_only" --junitxml=$(pwd)/test-report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -62,9 +62,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -74,8 +71,6 @@ tests:
         name: AWS_REGION_PATH
       - default: /secret/aws/aws-secret-access-key/aws-secret-access-key
         name: AWS_SECRET_ACCESS_KEY_PATH
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:
@@ -96,7 +91,6 @@ tests:
     - as: test
       cli: latest
       commands: pytest.sh -m "techpreview and not periodic_only" --junitxml=$(pwd)/test-report.xml
-        --rp_enabled --rp_name=Insights_operator_e2e_tests_techpreview
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -122,9 +116,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -138,8 +129,6 @@ tests:
         name: SLACK_BOT_TOKEN
       - default: /secret/slack-webhook-url/slack-webhook-url
         name: SLACK_WEBHOOK_URL
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       resources:
         requests:
@@ -159,7 +148,7 @@ tests:
     - as: api-insights-tests
       cli: latest
       commands: |
-        pytest.sh -m 'insights_data_gather or data_gather' --junitxml=$(pwd)/junit_report.xml --rp_enabled --rp_name=Insights_operator_e2e_tests_techpreview_4.21
+        pytest.sh -m 'insights_data_gather or data_gather' --junitxml=$(pwd)/junit_report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -179,9 +168,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -191,8 +177,6 @@ tests:
         name: AWS_REGION_PATH
       - default: /secret/aws/aws-secret-access-key/aws-secret-access-key
         name: AWS_SECRET_ACCESS_KEY_PATH
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:
@@ -213,7 +197,7 @@ tests:
     - as: api-insights-tests
       cli: latest
       commands: |
-        pytest.sh -m 'insights_data_gather or data_gather' --junitxml=$(pwd)/junit_report.xml --rp_enabled --rp_name=Insights_operator_e2e_tests_techpreview_4.21
+        pytest.sh -m 'insights_data_gather or data_gather' --junitxml=$(pwd)/junit_report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -233,9 +217,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -245,8 +226,6 @@ tests:
         name: AWS_REGION_PATH
       - default: /secret/aws/aws-secret-access-key/aws-secret-access-key
         name: AWS_SECRET_ACCESS_KEY_PATH
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:
@@ -267,7 +246,7 @@ tests:
     - as: api-insights-tests
       cli: latest
       commands: |
-        pytest.sh -m 'insights_data_gather or data_gather' --junitxml=$(pwd)/junit_report.xml --rp_enabled --rp_name=Insights_operator_e2e_tests_techpreview_4.21
+        pytest.sh -m 'insights_data_gather or data_gather' --junitxml=$(pwd)/junit_report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -287,9 +266,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -299,8 +275,6 @@ tests:
         name: AWS_REGION_PATH
       - default: /secret/aws/aws-secret-access-key/aws-secret-access-key
         name: AWS_SECRET_ACCESS_KEY_PATH
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:
@@ -321,7 +295,7 @@ tests:
     - as: api-insights-tests
       cli: latest
       commands: |
-        pytest.sh -m 'insights_data_gather or data_gather' --junitxml=$(pwd)/junit_report.xml --rp_enabled --rp_name=Insights_operator_e2e_tests_techpreview_4.21
+        pytest.sh -m 'insights_data_gather or data_gather' --junitxml=$(pwd)/junit_report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -341,9 +315,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -353,8 +324,6 @@ tests:
         name: AWS_REGION_PATH
       - default: /secret/aws/aws-secret-access-key/aws-secret-access-key
         name: AWS_SECRET_ACCESS_KEY_PATH
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:
@@ -380,7 +349,7 @@ tests:
     - as: api-insights-tests
       cli: latest
       commands: |
-        pytest.sh -m 'insights_data_gather or data_gather' --junitxml=$(pwd)/junit_report.xml --rp_enabled --rp_name=Insights_operator_e2e_tests_techpreview_4.22
+        pytest.sh -m 'insights_data_gather or data_gather' --junitxml=$(pwd)/junit_report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -400,9 +369,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -412,8 +378,6 @@ tests:
         name: AWS_REGION_PATH
       - default: /secret/aws/aws-secret-access-key/aws-secret-access-key
         name: AWS_SECRET_ACCESS_KEY_PATH
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:
@@ -432,7 +396,7 @@ tests:
     - as: api-insights-tests
       cli: latest
       commands: |
-        pytest.sh -m 'insights_data_gather or data_gather' --junitxml=$(pwd)/junit_report.xml --rp_enabled --rp_name=Insights_operator_e2e_tests_techpreview_4.21
+        pytest.sh -m 'insights_data_gather or data_gather' --junitxml=$(pwd)/junit_report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -452,9 +416,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -464,8 +425,6 @@ tests:
         name: AWS_REGION_PATH
       - default: /secret/aws/aws-secret-access-key/aws-secret-access-key
         name: AWS_SECRET_ACCESS_KEY_PATH
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:
@@ -484,7 +443,7 @@ tests:
     - as: api-insights-tests
       cli: latest
       commands: |
-        pytest.sh -m 'insights_runtime_extractor' --junitxml=$(pwd)/junit_report.xml --rp_enabled --rp_name=Insights_operator_tests_insights_runtime_extractor_4.21
+        pytest.sh -m 'insights_runtime_extractor' --junitxml=$(pwd)/junit_report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -504,9 +463,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -516,8 +472,6 @@ tests:
         name: AWS_REGION_PATH
       - default: /secret/aws/aws-secret-access-key/aws-secret-access-key
         name: AWS_SECRET_ACCESS_KEY_PATH
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:
@@ -536,7 +490,7 @@ tests:
     - as: api-insights-tests
       cli: latest
       commands: |
-        pytest.sh -m 'insights_runtime_extractor' --junitxml=$(pwd)/junit_report.xml --rp_enabled --rp_name=Insights_operator_tests_insights_runtime_extractor_4.21
+        pytest.sh -m 'insights_runtime_extractor' --junitxml=$(pwd)/junit_report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -556,9 +510,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -568,8 +519,6 @@ tests:
         name: AWS_REGION_PATH
       - default: /secret/aws/aws-secret-access-key/aws-secret-access-key
         name: AWS_SECRET_ACCESS_KEY_PATH
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:
@@ -588,7 +537,7 @@ tests:
     - as: api-insights-tests
       cli: latest
       commands: |
-        pytest.sh -m 'insights_runtime_extractor' --junitxml=$(pwd)/junit_report.xml --rp_enabled --rp_name=Insights_operator_tests_insights_runtime_extractor_4.21
+        pytest.sh -m 'insights_runtime_extractor' --junitxml=$(pwd)/junit_report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -608,9 +557,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -620,8 +566,6 @@ tests:
         name: AWS_REGION_PATH
       - default: /secret/aws/aws-secret-access-key/aws-secret-access-key
         name: AWS_SECRET_ACCESS_KEY_PATH
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:
@@ -640,7 +584,7 @@ tests:
     - as: api-insights-tests
       cli: latest
       commands: |
-        pytest.sh -m 'insights_runtime_extractor' --junitxml=$(pwd)/junit_report.xml --rp_enabled --rp_name=Insights_operator_tests_insights_runtime_extractor_4.21
+        pytest.sh -m 'insights_runtime_extractor' --junitxml=$(pwd)/junit_report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -660,9 +604,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -672,8 +613,6 @@ tests:
         name: AWS_REGION_PATH
       - default: /secret/aws/aws-secret-access-key/aws-secret-access-key
         name: AWS_SECRET_ACCESS_KEY_PATH
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:
@@ -690,7 +629,7 @@ tests:
     - as: api-insights-tests
       cli: latest
       commands: |
-        pytest.sh -m 'insights_runtime_extractor' --junitxml=$(pwd)/junit_report.xml --rp_enabled --rp_name=Insights_operator_e2e_tests_techpreview_4.21
+        pytest.sh -m 'insights_runtime_extractor' --junitxml=$(pwd)/junit_report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -710,9 +649,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -722,8 +658,6 @@ tests:
         name: AWS_REGION_PATH
       - default: /secret/aws/aws-secret-access-key/aws-secret-access-key
         name: AWS_SECRET_ACCESS_KEY_PATH
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:
@@ -751,7 +685,6 @@ tests:
     - as: test
       cli: latest
       commands: pytest.sh -k "not tp_only and not slow and not UI" --junitxml=$(pwd)/test-report.xml
-        --rp_enabled --rp_name=hosted-hypershift-insights-operator-e2e-tests
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -771,9 +704,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -783,8 +713,6 @@ tests:
         name: AWS_REGION_PATH
       - default: /secret/aws/aws-secret-access-key/aws-secret-access-key
         name: AWS_SECRET_ACCESS_KEY_PATH
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:

--- a/ci-operator/config/openshift/insights-operator/openshift-insights-operator-release-5.0.yaml
+++ b/ci-operator/config/openshift/insights-operator/openshift-insights-operator-release-5.0.yaml
@@ -95,7 +95,7 @@ tests:
     - as: test
       cli: latest
       commands: |
-        pytest.sh -k "not serial and not periodic_only and not slow" --junitxml=$(pwd)/test-report.xml --rp_enabled --rp_name=Insights_operator_e2e_tests_pr_checks
+        pytest.sh -k "not serial and not periodic_only and not slow" --junitxml=$(pwd)/test-report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -121,9 +121,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -137,8 +134,6 @@ tests:
         name: SLACK_BOT_TOKEN
       - default: /secret/slack-webhook-url/slack-webhook-url
         name: SLACK_WEBHOOK_URL
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:
@@ -157,7 +152,7 @@ tests:
     - as: test
       cli: latest
       commands: |
-        pytest.sh -k "serial and not periodic_only and not slow" --junitxml=$(pwd)/test-report.xml --rp_enabled --rp_name=Insights_operator_serial_tests_pr_checks
+        pytest.sh -k "serial and not periodic_only and not slow" --junitxml=$(pwd)/test-report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -183,9 +178,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -199,8 +191,6 @@ tests:
         name: SLACK_BOT_TOKEN
       - default: /secret/slack-webhook-url/slack-webhook-url
         name: SLACK_WEBHOOK_URL
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:
@@ -219,7 +209,7 @@ tests:
     - as: test
       cli: latest
       commands: |
-        pytest.sh -k "not periodic_only and slow" --junitxml=$(pwd)/test-report.xml --rp_enabled --rp_name=Insights_operator_slow_tests_pr_checks
+        pytest.sh -k "not periodic_only and slow" --junitxml=$(pwd)/test-report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -245,9 +235,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -261,8 +248,6 @@ tests:
         name: SLACK_BOT_TOKEN
       - default: /secret/slack-webhook-url/slack-webhook-url
         name: SLACK_WEBHOOK_URL
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:

--- a/ci-operator/config/openshift/insights-operator/openshift-insights-operator-release-5.0__periodics.yaml
+++ b/ci-operator/config/openshift/insights-operator/openshift-insights-operator-release-5.0__periodics.yaml
@@ -42,7 +42,7 @@ tests:
     - as: test
       cli: latest
       commands: |
-        pytest.sh -k "not tp_only and not slow" --junitxml=$(pwd)/test-report.xml --rp_enabled --rp_name=Insights_operator_e2e_tests_periodic
+        pytest.sh -k "not tp_only and not slow" --junitxml=$(pwd)/test-report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -62,9 +62,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -74,8 +71,6 @@ tests:
         name: AWS_REGION_PATH
       - default: /secret/aws/aws-secret-access-key/aws-secret-access-key
         name: AWS_SECRET_ACCESS_KEY_PATH
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:
@@ -96,7 +91,7 @@ tests:
     - as: api-insights-tests
       cli: latest
       commands: |
-        pytest.sh -m 'insights_data_gather or data_gather' --junitxml=$(pwd)/junit_report.xml --rp_enabled --rp_name=Insights_operator_e2e_tests_techpreview_4.21
+        pytest.sh -m 'insights_data_gather or data_gather' --junitxml=$(pwd)/junit_report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -116,9 +111,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -128,8 +120,6 @@ tests:
         name: AWS_REGION_PATH
       - default: /secret/aws/aws-secret-access-key/aws-secret-access-key
         name: AWS_SECRET_ACCESS_KEY_PATH
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:
@@ -150,7 +140,7 @@ tests:
     - as: api-insights-tests
       cli: latest
       commands: |
-        pytest.sh -m 'insights_data_gather or data_gather' --junitxml=$(pwd)/junit_report.xml --rp_enabled --rp_name=Insights_operator_e2e_tests_techpreview_4.21
+        pytest.sh -m 'insights_data_gather or data_gather' --junitxml=$(pwd)/junit_report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -170,9 +160,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -182,8 +169,6 @@ tests:
         name: AWS_REGION_PATH
       - default: /secret/aws/aws-secret-access-key/aws-secret-access-key
         name: AWS_SECRET_ACCESS_KEY_PATH
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:
@@ -204,7 +189,7 @@ tests:
     - as: api-insights-tests
       cli: latest
       commands: |
-        pytest.sh -m 'insights_data_gather or data_gather' --junitxml=$(pwd)/junit_report.xml --rp_enabled --rp_name=Insights_operator_e2e_tests_techpreview_4.21
+        pytest.sh -m 'insights_data_gather or data_gather' --junitxml=$(pwd)/junit_report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -224,9 +209,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -236,8 +218,6 @@ tests:
         name: AWS_REGION_PATH
       - default: /secret/aws/aws-secret-access-key/aws-secret-access-key
         name: AWS_SECRET_ACCESS_KEY_PATH
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:
@@ -258,7 +238,7 @@ tests:
     - as: api-insights-tests
       cli: latest
       commands: |
-        pytest.sh -m 'insights_data_gather or data_gather' --junitxml=$(pwd)/junit_report.xml --rp_enabled --rp_name=Insights_operator_e2e_tests_techpreview_4.21
+        pytest.sh -m 'insights_data_gather or data_gather' --junitxml=$(pwd)/junit_report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -278,9 +258,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -290,8 +267,6 @@ tests:
         name: AWS_REGION_PATH
       - default: /secret/aws/aws-secret-access-key/aws-secret-access-key
         name: AWS_SECRET_ACCESS_KEY_PATH
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:
@@ -317,7 +292,7 @@ tests:
     - as: api-insights-tests
       cli: latest
       commands: |
-        pytest.sh -m 'insights_data_gather or data_gather' --junitxml=$(pwd)/junit_report.xml --rp_enabled --rp_name=Insights_operator_e2e_tests_techpreview_4.22
+        pytest.sh -m 'insights_data_gather or data_gather' --junitxml=$(pwd)/junit_report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -337,9 +312,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -349,8 +321,6 @@ tests:
         name: AWS_REGION_PATH
       - default: /secret/aws/aws-secret-access-key/aws-secret-access-key
         name: AWS_SECRET_ACCESS_KEY_PATH
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:
@@ -369,7 +339,7 @@ tests:
     - as: api-insights-tests
       cli: latest
       commands: |
-        pytest.sh -m 'insights_data_gather or data_gather' --junitxml=$(pwd)/junit_report.xml --rp_enabled --rp_name=Insights_operator_e2e_tests_techpreview_4.21
+        pytest.sh -m 'insights_data_gather or data_gather' --junitxml=$(pwd)/junit_report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -389,9 +359,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -401,8 +368,6 @@ tests:
         name: AWS_REGION_PATH
       - default: /secret/aws/aws-secret-access-key/aws-secret-access-key
         name: AWS_SECRET_ACCESS_KEY_PATH
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:
@@ -421,7 +386,7 @@ tests:
     - as: api-insights-tests
       cli: latest
       commands: |
-        pytest.sh -m 'insights_runtime_extractor' --junitxml=$(pwd)/junit_report.xml --rp_enabled --rp_name=Insights_operator_tests_insights_runtime_extractor_4.21
+        pytest.sh -m 'insights_runtime_extractor' --junitxml=$(pwd)/junit_report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -441,9 +406,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -453,8 +415,6 @@ tests:
         name: AWS_REGION_PATH
       - default: /secret/aws/aws-secret-access-key/aws-secret-access-key
         name: AWS_SECRET_ACCESS_KEY_PATH
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:
@@ -473,7 +433,7 @@ tests:
     - as: api-insights-tests
       cli: latest
       commands: |
-        pytest.sh -m 'insights_runtime_extractor' --junitxml=$(pwd)/junit_report.xml --rp_enabled --rp_name=Insights_operator_tests_insights_runtime_extractor_4.21
+        pytest.sh -m 'insights_runtime_extractor' --junitxml=$(pwd)/junit_report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -493,9 +453,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -505,8 +462,6 @@ tests:
         name: AWS_REGION_PATH
       - default: /secret/aws/aws-secret-access-key/aws-secret-access-key
         name: AWS_SECRET_ACCESS_KEY_PATH
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:
@@ -525,7 +480,7 @@ tests:
     - as: api-insights-tests
       cli: latest
       commands: |
-        pytest.sh -m 'insights_runtime_extractor' --junitxml=$(pwd)/junit_report.xml --rp_enabled --rp_name=Insights_operator_tests_insights_runtime_extractor_4.21
+        pytest.sh -m 'insights_runtime_extractor' --junitxml=$(pwd)/junit_report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -545,9 +500,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -557,8 +509,6 @@ tests:
         name: AWS_REGION_PATH
       - default: /secret/aws/aws-secret-access-key/aws-secret-access-key
         name: AWS_SECRET_ACCESS_KEY_PATH
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:
@@ -577,7 +527,7 @@ tests:
     - as: api-insights-tests
       cli: latest
       commands: |
-        pytest.sh -m 'insights_runtime_extractor' --junitxml=$(pwd)/junit_report.xml --rp_enabled --rp_name=Insights_operator_tests_insights_runtime_extractor_4.21
+        pytest.sh -m 'insights_runtime_extractor' --junitxml=$(pwd)/junit_report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -597,9 +547,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -609,8 +556,6 @@ tests:
         name: AWS_REGION_PATH
       - default: /secret/aws/aws-secret-access-key/aws-secret-access-key
         name: AWS_SECRET_ACCESS_KEY_PATH
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:
@@ -627,7 +572,7 @@ tests:
     - as: api-insights-tests
       cli: latest
       commands: |
-        pytest.sh -m 'insights_runtime_extractor' --junitxml=$(pwd)/junit_report.xml --rp_enabled --rp_name=Insights_operator_e2e_tests_techpreview_4.21
+        pytest.sh -m 'insights_runtime_extractor' --junitxml=$(pwd)/junit_report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -647,9 +592,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -659,8 +601,6 @@ tests:
         name: AWS_REGION_PATH
       - default: /secret/aws/aws-secret-access-key/aws-secret-access-key
         name: AWS_SECRET_ACCESS_KEY_PATH
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:
@@ -679,7 +619,7 @@ tests:
     - as: test
       cli: latest
       commands: |
-        pytest.sh -k "slow and not tp_only" --junitxml=$(pwd)/test-report.xml --rp_enabled --rp_name=Insights_operator_e2e_tests_slow_tests
+        pytest.sh -k "slow and not tp_only" --junitxml=$(pwd)/test-report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -696,9 +636,6 @@ tests:
       - mount_path: /secret/aws/aws-secret-access-key
         name: aws-secret-access-key
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -708,8 +645,6 @@ tests:
         name: AWS_REGION_PATH
       - default: /secret/aws/aws-secret-access-key/aws-secret-access-key
         name: AWS_SECRET_ACCESS_KEY_PATH
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:
@@ -737,7 +672,6 @@ tests:
     - as: test
       cli: latest
       commands: pytest.sh -k "not tp_only and not slow and not UI" --junitxml=$(pwd)/test-report.xml
-        --rp_enabled --rp_name=hosted-hypershift-insights-operator-e2e-tests
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -757,9 +691,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -769,8 +700,6 @@ tests:
         name: AWS_REGION_PATH
       - default: /secret/aws/aws-secret-access-key/aws-secret-access-key
         name: AWS_SECRET_ACCESS_KEY_PATH
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:

--- a/ci-operator/config/openshift/insights-operator/openshift-insights-operator-release-5.1.yaml
+++ b/ci-operator/config/openshift/insights-operator/openshift-insights-operator-release-5.1.yaml
@@ -94,7 +94,7 @@ tests:
     - as: test
       cli: latest
       commands: |
-        pytest.sh -k "not serial and not periodic_only and not slow" --junitxml=$(pwd)/test-report.xml --rp_enabled --rp_name=Insights_operator_e2e_tests_pr_checks
+        pytest.sh -k "not serial and not periodic_only and not slow" --junitxml=$(pwd)/test-report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -120,9 +120,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -136,8 +133,6 @@ tests:
         name: SLACK_BOT_TOKEN
       - default: /secret/slack-webhook-url/slack-webhook-url
         name: SLACK_WEBHOOK_URL
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:
@@ -156,7 +151,7 @@ tests:
     - as: test
       cli: latest
       commands: |
-        pytest.sh -k "serial and not periodic_only and not slow" --junitxml=$(pwd)/test-report.xml --rp_enabled --rp_name=Insights_operator_serial_tests_pr_checks
+        pytest.sh -k "serial and not periodic_only and not slow" --junitxml=$(pwd)/test-report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -182,9 +177,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -198,8 +190,6 @@ tests:
         name: SLACK_BOT_TOKEN
       - default: /secret/slack-webhook-url/slack-webhook-url
         name: SLACK_WEBHOOK_URL
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:
@@ -218,7 +208,7 @@ tests:
     - as: test
       cli: latest
       commands: |
-        pytest.sh -k "not periodic_only and slow" --junitxml=$(pwd)/test-report.xml --rp_enabled --rp_name=Insights_operator_slow_tests_pr_checks
+        pytest.sh -k "not periodic_only and slow" --junitxml=$(pwd)/test-report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -244,9 +234,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -260,8 +247,6 @@ tests:
         name: SLACK_BOT_TOKEN
       - default: /secret/slack-webhook-url/slack-webhook-url
         name: SLACK_WEBHOOK_URL
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:


### PR DESCRIPTION
ReportPortal is no longer used and maintained. The upload of data has been failing for a long time and the errors are logged into test results, which makes it hard to read and find real errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated testing infrastructure configuration across multiple release branches to streamline CI/CD pipeline operations and simplify test workflow dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->