### PR TITLE
HYPERFLEET-983: Fix broken Go toolchain in HyperFleet CI build image

### DIFF
--- a/ci-operator/config/openshift-hyperfleet/adapter-pull-secret/openshift-hyperfleet-adapter-pull-secret-main.yaml
+++ b/ci-operator/config/openshift-hyperfleet/adapter-pull-secret/openshift-hyperfleet-adapter-pull-secret-main.yaml
@@ -1,8 +1,8 @@
 build_root:
   image_stream_tag:
-    name: openshift-build
-    namespace: jasee
-    tag: rhel-9-golang-1.25
+    name: builder
+    namespace: ocp
+    tag: rhel-9-golang-1.25-openshift-4.21
 resources:
   '*':
     requests:

--- a/ci-operator/config/openshift-hyperfleet/adapter-pull-secret/openshift-hyperfleet-adapter-pull-secret-main__presubmits.yaml
+++ b/ci-operator/config/openshift-hyperfleet/adapter-pull-secret/openshift-hyperfleet-adapter-pull-secret-main__presubmits.yaml
@@ -5,9 +5,9 @@ base_images:
     tag: latest
 build_root:
   image_stream_tag:
-    name: openshift-build
-    namespace: jasee
-    tag: rhel-9-golang-1.25
+    name: builder
+    namespace: ocp
+    tag: rhel-9-golang-1.25-openshift-4.21
 images:
   items:
   - dockerfile_literal: |

--- a/ci-operator/config/openshift-hyperfleet/hyperfleet-adapter/openshift-hyperfleet-hyperfleet-adapter-main.yaml
+++ b/ci-operator/config/openshift-hyperfleet/hyperfleet-adapter/openshift-hyperfleet-hyperfleet-adapter-main.yaml
@@ -3,15 +3,15 @@ base_images:
     name: ubi
     namespace: ocp
     tag: "9"
-  jasee_openshift-build_rhel-9-golang-1.25:
-    name: openshift-build
-    namespace: jasee
-    tag: rhel-9-golang-1.25
+  ocp_builder_rhel-9-golang-1.25-openshift-4.21:
+    name: builder
+    namespace: ocp
+    tag: rhel-9-golang-1.25-openshift-4.21
 build_root:
   image_stream_tag:
-    name: openshift-build
-    namespace: jasee
-    tag: rhel-9-golang-1.25
+    name: builder
+    namespace: ocp
+    tag: rhel-9-golang-1.25-openshift-4.21
 resources:
   '*':
     requests:

--- a/ci-operator/config/openshift-hyperfleet/hyperfleet-adapter/openshift-hyperfleet-hyperfleet-adapter-main__presubmits.yaml
+++ b/ci-operator/config/openshift-hyperfleet/hyperfleet-adapter/openshift-hyperfleet-hyperfleet-adapter-main__presubmits.yaml
@@ -5,9 +5,9 @@ base_images:
     tag: latest
 build_root:
   image_stream_tag:
-    name: openshift-build
-    namespace: jasee
-    tag: rhel-9-golang-1.25
+    name: builder
+    namespace: ocp
+    tag: rhel-9-golang-1.25-openshift-4.21
 images:
   items:
   - dockerfile_path: test/Dockerfile.integration

--- a/ci-operator/config/openshift-hyperfleet/hyperfleet-adapter/openshift-hyperfleet-hyperfleet-adapter-release-0.2__presubmits.yaml
+++ b/ci-operator/config/openshift-hyperfleet/hyperfleet-adapter/openshift-hyperfleet-hyperfleet-adapter-release-0.2__presubmits.yaml
@@ -5,9 +5,9 @@ base_images:
     tag: latest
 build_root:
   image_stream_tag:
-    name: openshift-build
-    namespace: jasee
-    tag: rhel-9-golang-1.25
+    name: builder
+    namespace: ocp
+    tag: rhel-9-golang-1.25-openshift-4.21
 images:
   items:
   - dockerfile_path: test/Dockerfile.integration

--- a/ci-operator/config/openshift-hyperfleet/hyperfleet-api/openshift-hyperfleet-hyperfleet-api-main.yaml
+++ b/ci-operator/config/openshift-hyperfleet/hyperfleet-api/openshift-hyperfleet-hyperfleet-api-main.yaml
@@ -5,9 +5,9 @@ base_images:
     tag: latest
 build_root:
   image_stream_tag:
-    name: openshift-build
-    namespace: jasee
-    tag: rhel-9-golang-1.25
+    name: builder
+    namespace: ocp
+    tag: rhel-9-golang-1.25-openshift-4.21
 images:
   items:
   - dockerfile_literal: |

--- a/ci-operator/config/openshift-hyperfleet/hyperfleet-api/openshift-hyperfleet-hyperfleet-api-main__presubmits.yaml
+++ b/ci-operator/config/openshift-hyperfleet/hyperfleet-api/openshift-hyperfleet-hyperfleet-api-main__presubmits.yaml
@@ -5,9 +5,9 @@ base_images:
     tag: latest
 build_root:
   image_stream_tag:
-    name: openshift-build
-    namespace: jasee
-    tag: rhel-9-golang-1.25
+    name: builder
+    namespace: ocp
+    tag: rhel-9-golang-1.25-openshift-4.21
 images:
   items:
   - dockerfile_literal: |

--- a/ci-operator/config/openshift-hyperfleet/hyperfleet-api/openshift-hyperfleet-hyperfleet-api-release-0.2__presubmits.yaml
+++ b/ci-operator/config/openshift-hyperfleet/hyperfleet-api/openshift-hyperfleet-hyperfleet-api-release-0.2__presubmits.yaml
@@ -5,9 +5,9 @@ base_images:
     tag: latest
 build_root:
   image_stream_tag:
-    name: openshift-build
-    namespace: jasee
-    tag: rhel-9-golang-1.25
+    name: builder
+    namespace: ocp
+    tag: rhel-9-golang-1.25-openshift-4.21
 images:
   items:
   - dockerfile_literal: |

--- a/ci-operator/config/openshift-hyperfleet/hyperfleet-broker/openshift-hyperfleet-hyperfleet-broker-main.yaml
+++ b/ci-operator/config/openshift-hyperfleet/hyperfleet-broker/openshift-hyperfleet-hyperfleet-broker-main.yaml
@@ -3,15 +3,15 @@ base_images:
     name: ubi
     namespace: ocp
     tag: "9"
-  jasee_openshift-build_rhel-9-golang-1.25:
-    name: openshift-build
-    namespace: jasee
-    tag: rhel-9-golang-1.25
+  ocp_builder_rhel-9-golang-1.25-openshift-4.21:
+    name: builder
+    namespace: ocp
+    tag: rhel-9-golang-1.25-openshift-4.21
 build_root:
   image_stream_tag:
-    name: openshift-build
-    namespace: jasee
-    tag: rhel-9-golang-1.25
+    name: builder
+    namespace: ocp
+    tag: rhel-9-golang-1.25-openshift-4.21
 resources:
   '*':
     requests:

--- a/ci-operator/config/openshift-hyperfleet/hyperfleet-broker/openshift-hyperfleet-hyperfleet-broker-main__presubmits.yaml
+++ b/ci-operator/config/openshift-hyperfleet/hyperfleet-broker/openshift-hyperfleet-hyperfleet-broker-main__presubmits.yaml
@@ -5,9 +5,9 @@ base_images:
     tag: latest
 build_root:
   image_stream_tag:
-    name: openshift-build
-    namespace: jasee
-    tag: rhel-9-golang-1.25
+    name: builder
+    namespace: ocp
+    tag: rhel-9-golang-1.25-openshift-4.21
 images:
   items:
   - dockerfile_literal: |

--- a/ci-operator/config/openshift-hyperfleet/hyperfleet-sentinel/openshift-hyperfleet-hyperfleet-sentinel-main.yaml
+++ b/ci-operator/config/openshift-hyperfleet/hyperfleet-sentinel/openshift-hyperfleet-hyperfleet-sentinel-main.yaml
@@ -5,9 +5,9 @@ base_images:
     tag: latest
 build_root:
   image_stream_tag:
-    name: openshift-build
-    namespace: jasee
-    tag: rhel-9-golang-1.25
+    name: builder
+    namespace: ocp
+    tag: rhel-9-golang-1.25-openshift-4.21
 images:
   items:
   - dockerfile_literal: |

--- a/ci-operator/config/openshift-hyperfleet/hyperfleet-sentinel/openshift-hyperfleet-hyperfleet-sentinel-main__presubmits.yaml
+++ b/ci-operator/config/openshift-hyperfleet/hyperfleet-sentinel/openshift-hyperfleet-hyperfleet-sentinel-main__presubmits.yaml
@@ -5,9 +5,9 @@ base_images:
     tag: latest
 build_root:
   image_stream_tag:
-    name: openshift-build
-    namespace: jasee
-    tag: rhel-9-golang-1.25
+    name: builder
+    namespace: ocp
+    tag: rhel-9-golang-1.25-openshift-4.21
 images:
   items:
   - dockerfile_literal: |

--- a/ci-operator/config/openshift-hyperfleet/hyperfleet-sentinel/openshift-hyperfleet-hyperfleet-sentinel-release-0.2__presubmits.yaml
+++ b/ci-operator/config/openshift-hyperfleet/hyperfleet-sentinel/openshift-hyperfleet-hyperfleet-sentinel-release-0.2__presubmits.yaml
@@ -5,9 +5,9 @@ base_images:
     tag: latest
 build_root:
   image_stream_tag:
-    name: openshift-build
-    namespace: jasee
-    tag: rhel-9-golang-1.25
+    name: builder
+    namespace: ocp
+    tag: rhel-9-golang-1.25-openshift-4.21
 images:
   items:
   - dockerfile_literal: |


### PR DESCRIPTION
## Summary

- Switch `build_root` from `jasee/openshift-build:rhel-9-golang-1.25` (broken since Apr 15) to `ocp/builder:rhel-9-golang-1.25-openshift-4.21` across all 5 HyperFleet repos
- 13 CI config files updated: hyperfleet-api, hyperfleet-adapter, hyperfleet-sentinel, hyperfleet-broker, adapter-pull-secret (main + release-0.2 branches)
- Unblocks 10 PRs currently failing CI across all HyperFleet repos

## Root cause

The Quay.io image `quay.io/jacobsee/openshift-build:rhel-9-golang-1.25` was rebuilt on April 15 with a broken Go 1.25 toolchain causing redeclaration errors in `internal/abi/map_swiss.go`.

## Test plan

- [ ] CI rehearsal jobs pass with the new build image
- [ ] Verify blocked PRs can be retested after merge

JIRA: https://redhat.atlassian.net/browse/HYPERFLEET-983

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration references across OpenShift Hyperfleet projects (adapter-pull-secret, hyperfleet-adapter, hyperfleet-api, hyperfleet-broker, and hyperfleet-sentinel) to use updated build infrastructure tags. No impact on product functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->