### PR TITLE
CNTRLPLANE-3279: Add hypershift-specific stale PR management periodic jobs

### DIFF
--- a/ci-operator/jobs/infra-periodics.yaml
+++ b/ci-operator/jobs/infra-periodics.yaml
@@ -643,6 +643,151 @@ periodics:
         secretName: github-credentials-openshift-bot
 - agent: kubernetes
   cluster: app.ci
+  cron: 30 1,9 * * *
+  decorate: true
+  labels:
+    ci.openshift.io/role: infra
+  name: periodic-hypershift-pr-stale
+  spec:
+    containers:
+    - args:
+      - |-
+        --query=repo:openshift/hypershift
+        is:pr
+        is:open
+        comments:<2500
+        -label:lifecycle/frozen
+        -label:lifecycle/stale
+        -label:lifecycle/rotten
+        -label:tide/merge-blocker
+        -label:do-not-merge/hold
+      - --updated=720h
+      - --token=/etc/oauth/oauth
+      - |-
+        --comment=Stale PRs are closed after 21d of inactivity.
+
+        If this PR is still relevant, comment to refresh it or remove the stale label.
+        Mark the PR as fresh by commenting `/remove-lifecycle stale`.
+
+        If this PR is safe to close now please do so with `/close`.
+
+        /lifecycle stale
+      - --template
+      - --ceiling=30
+      - --confirm
+      command:
+      - /ko-app/commenter
+      image: quay.io/openshift/ci:ci_commenter_latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 500m
+      volumeMounts:
+      - mountPath: /etc/oauth
+        name: token
+    volumes:
+    - name: token
+      secret:
+        secretName: github-credentials-openshift-bot
+- agent: kubernetes
+  cluster: app.ci
+  cron: 0 2,10 * * *
+  decorate: true
+  labels:
+    ci.openshift.io/role: infra
+  name: periodic-hypershift-pr-rotten
+  spec:
+    containers:
+    - args:
+      - |-
+        --query=repo:openshift/hypershift
+        is:pr
+        is:open
+        comments:<2500
+        -label:tide/merge-blocker
+        -label:lifecycle/frozen
+        label:lifecycle/stale
+        -label:lifecycle/rotten
+        -label:do-not-merge/hold
+      - --updated=336h
+      - --token=/etc/oauth/oauth
+      - |-
+        --comment=Stale PRs rot after 14d of inactivity.
+
+        Mark the PR as fresh by commenting `/remove-lifecycle rotten`.
+        Rotten PRs close after an additional 7d of inactivity.
+
+        If this PR is safe to close now please do so with `/close`.
+
+        /lifecycle rotten
+        /remove-lifecycle stale
+      - --template
+      - --ceiling=30
+      - --confirm
+      command:
+      - /ko-app/commenter
+      image: quay.io/openshift/ci:ci_commenter_latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 500m
+      volumeMounts:
+      - mountPath: /etc/oauth
+        name: token
+    volumes:
+    - name: token
+      secret:
+        secretName: github-credentials-openshift-bot
+- agent: kubernetes
+  cluster: app.ci
+  cron: 30 2,10 * * *
+  decorate: true
+  labels:
+    ci.openshift.io/role: infra
+  name: periodic-hypershift-pr-close
+  spec:
+    containers:
+    - args:
+      - |-
+        --query=repo:openshift/hypershift
+        is:pr
+        is:open
+        comments:<2500
+        -label:lifecycle/frozen
+        -label:tide/merge-blocker
+        label:lifecycle/rotten
+        -label:do-not-merge/hold
+      - --updated=168h
+      - --token=/etc/oauth/oauth
+      - |-
+        --comment=Rotten PRs close after 7d of inactivity.
+
+        Reopen the PR by commenting `/reopen`.
+        Mark the PR as fresh by commenting `/remove-lifecycle rotten`.
+
+        /close
+      - --template
+      - --ceiling=30
+      - --confirm
+      command:
+      - /ko-app/commenter
+      image: quay.io/openshift/ci:ci_commenter_latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 500m
+      volumeMounts:
+      - mountPath: /etc/oauth
+        name: token
+    volumes:
+    - name: token
+      secret:
+        secretName: github-credentials-openshift-bot
+- agent: kubernetes
+  cluster: app.ci
   cron: 0 0 * * 3
   decorate: true
   decoration_config:


### PR DESCRIPTION
## Summary

- Adds three periodic commenter jobs (`periodic-hypershift-pr-stale`, `periodic-hypershift-pr-rotten`, `periodic-hypershift-pr-close`) to automatically manage stale PRs in `openshift/hypershift`
- The existing org-wide lifecycle jobs take **150 days** to close a PR and only process 10 items per run across all of `openshift/` — this adds repo-specific jobs with a **51-day** timeline and a ceiling of 30
- Follows the same pattern already established by the `periodic-enhancements-*` jobs

## Problem

As of today, `openshift/hypershift` has **224 open PRs**, of which **92 (41%)** haven't been updated in 30+ days. Only 10 of those have any `lifecycle/*` label — the org-wide jobs are too slow and too broadly scoped to keep up.

## Design

| Setting | Org-wide (current) | Enhancements | **This PR (HyperShift)** |
|---|---|---|---|
| Stale after | 90 days | 28 days | **30 days** |
| Rotten after | +30 days | +7 days | **+14 days** |
| Close after | +30 days | +7 days | **+7 days** |
| **Total to close** | **150 days** | **42 days** | **51 days** |
| Ceiling per run | 10 | 10 | **30** |
| Scope | `org:openshift` | `repo:openshift/enhancements` | `repo:openshift/hypershift is:pr` |

Key choices:
- **`is:pr` filter** — only targets pull requests, not issues
- **Excludes `do-not-merge/hold`** — 62% of current stale PRs carry this label and are intentionally parked
- **Higher ceiling (30)** — repo-scoped means far fewer items to process per run
- **51-day total timeline** — gives authors a full month before any escalation, but doesn't let PRs linger for 5 months

## Test plan

- [ ] Verify the YAML is valid and the jobs appear in Prow's job list after merge
- [ ] Monitor `openshift/hypershift` for `lifecycle/stale` labels appearing on inactive PRs within 1-2 days
- [ ] Confirm PRs with `do-not-merge/hold` are excluded from labeling
- [ ] Verify the close stage works by checking a rotten PR after 7 days

/cc @openshift/hypershift-team

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated PR lifecycle management for HyperShift repository with periodic jobs for marking stale and rotten pull requests, and automatically closing inactive ones.

* **Bug Fixes**
  * Fixed label filtering in PR lifecycle automation to correctly identify stale pull requests for transition to rotten status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->