### PR TITLE
chore: add dependabot to trusted_apps for odh-dashboard

### DIFF
--- a/core-services/prow/02_config/opendatahub-io/odh-dashboard/_pluginconfig.yaml
+++ b/core-services/prow/02_config/opendatahub-io/odh-dashboard/_pluginconfig.yaml
@@ -43,3 +43,4 @@ triggers:
   - opendatahub-io/odh-dashboard
   trusted_apps:
   - openshift-merge-bot
+  - dependabot


### PR DESCRIPTION
## Summary

- Add `dependabot` to `trusted_apps` in the Prow trigger config for `opendatahub-io/odh-dashboard`
- This allows Dependabot PRs to trigger CI automatically without requiring `/ok-to-test` from an org member
- Part of the automated dependency update pipeline for odh-dashboard ([RHOAIENG-57872](https://issues.redhat.com/browse/RHOAIENG-57872))

## Details

Currently, Dependabot PRs to odh-dashboard get the `needs-ok-to-test` label and CI does not run until a member comments `/ok-to-test`. This blocks the automated dependency update workflow.

Adding `dependabot` to `trusted_apps` (alongside the existing `openshift-merge-bot`) lets Prow treat Dependabot as a trusted CI trigger, consistent with how many other repos in this release config already handle it.

## Test plan

- [ ] Verify Dependabot PRs to odh-dashboard no longer receive `needs-ok-to-test`
- [ ] Verify CI triggers automatically on Dependabot PRs


Made with [Cursor](https://cursor.com)

[RHOAIENG-57872]: https://redhat.atlassian.net/browse/RHOAIENG-57872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to authorize dependabot for automated dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->