### PR TITLE
request resources for vector unit test job

### DIFF
--- a/ci-operator/config/ViaQ/vector/ViaQ-vector-v0.47.0-rh.yaml
+++ b/ci-operator/config/ViaQ/vector/ViaQ-vector-v0.47.0-rh.yaml
@@ -62,9 +62,28 @@ resources:
       memory: 200Mi
 tests:
 - as: unit
-  commands: make test
-  container:
-    from: logging-vector-test-unit
+  cluster_claim:
+    architecture: amd64
+    cloud: aws
+    labels:
+      region: us-east-1
+    owner: obs-logging
+    product: ocp
+    timeout: 1h0m0s
+    version: "4.20"
+  steps:
+    test:
+    - as: test
+      commands: make test
+      from: pipeline:logging-vector-test-unit
+      resources:
+        limits:
+          memory: 20Gi
+        requests:
+          cpu: 100m
+          memory: 8Gi
+      timeout: 45m0s
+    workflow: generic-claim
 - as: cargo-deny-check-bans
   commands: cargo deny --no-default-features --features ocp-logging check bans
   container:

--- a/ci-operator/jobs/ViaQ/vector/ViaQ-vector-v0.47.0-rh-presubmits.yaml
+++ b/ci-operator/jobs/ViaQ/vector/ViaQ-vector-v0.47.0-rh-presubmits.yaml
@@ -502,8 +502,11 @@ presubmits:
       containers:
       - args:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --hive-kubeconfig=/secrets/hive-hive-credentials/kubeconfig
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
         - --target=unit
         command:
         - ci-operator
@@ -522,8 +525,17 @@ presubmits:
           requests:
             cpu: 10m
         volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
         - mountPath: /secrets/gcs
           name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/hive-hive-credentials
+          name: hive-hive-credentials
           readOnly: true
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
@@ -536,6 +548,18 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: hive-hive-credentials
+        secret:
+          secretName: hive-hive-credentials
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher


### PR DESCRIPTION
cc @vparfonov 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Unit test execution moved to cluster-claimed runners with explicit per-step CPU/memory requests and memory limits, and a per-step timeout; targets AWS (us-east-1) with claim metadata.
* **Chores**
  * Presubmit job updated to provide additional credentials via read-only secret mounts and corresponding runtime flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->