### PR TITLE
[HIVE-3096] hive: bump e2e to 4.21 and periodics to 4.22

### DIFF
--- a/ci-operator/config/openshift/hive/openshift-hive-master.yaml
+++ b/ci-operator/config/openshift/hive/openshift-hive-master.yaml
@@ -1,6 +1,6 @@
 base_images:
   openstack-installer:
-    name: "4.20"
+    name: "4.21"
     namespace: ocp
     tag: openstack-installer
   upi-installer:
@@ -12,7 +12,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: rhel-9-release-golang-1.24-openshift-4.20
+    tag: rhel-9-release-golang-1.24-openshift-4.21
 images:
   items:
   - dockerfile_literal: |
@@ -36,12 +36,12 @@ releases:
     candidate:
       product: ocp
       stream: nightly
-      version: "4.20"
+      version: "4.21"
   latest:
     candidate:
       product: ocp
       stream: nightly
-      version: "4.20"
+      version: "4.21"
 resources:
   '*':
     requests:
@@ -100,7 +100,7 @@ tests:
     owner: openshift-ci
     product: ocp
     timeout: 1h0m0s
-    version: "4.20"
+    version: "4.21"
   skip_if_only_changed: ^(?:docs|\.tekton)/|\.md$|^(?:.*/)?(?:\.gitignore|.coderabbit.yaml|OWNERS|PROJECT|LICENSE)$
   steps:
     test:
@@ -145,7 +145,7 @@ tests:
     owner: openshift-ci
     product: ocp
     timeout: 1h0m0s
-    version: "4.20"
+    version: "4.21"
   skip_if_only_changed: ^(?:docs|\.tekton)/|\.md$|^(?:.*/)?(?:\.gitignore|.coderabbit.yaml|OWNERS|PROJECT|LICENSE)$
   steps:
     test:

--- a/ci-operator/config/openshift/hive/openshift-hive-master.yaml
+++ b/ci-operator/config/openshift/hive/openshift-hive-master.yaml
@@ -18,7 +18,7 @@ images:
   - dockerfile_literal: |
       FROM ubi9-minimal
       RUN rm -rf /etc/yum.repos.d/*
-      RUN curl http://base-4-20-rhel9.ocp.svc > /etc/yum.repos.d/base-4-20-rhel9.repo
+      RUN curl http://base-4-21-rhel9.ocp.svc > /etc/yum.repos.d/base-4-21-rhel9.repo
     to: ubi9-minimal-entitled
   - build_args:
     - name: DNF

--- a/ci-operator/config/openshift/hive/openshift-hive-master.yaml
+++ b/ci-operator/config/openshift/hive/openshift-hive-master.yaml
@@ -12,7 +12,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: rhel-9-release-golang-1.24-openshift-4.21
+    tag: rhel-9-release-golang-1.25-openshift-4.21
 images:
   items:
   - dockerfile_literal: |

--- a/ci-operator/config/openshift/hive/openshift-hive-master__periodic.yaml
+++ b/ci-operator/config/openshift/hive/openshift-hive-master__periodic.yaml
@@ -18,7 +18,7 @@ images:
   - dockerfile_literal: |
       FROM ubi9-minimal
       RUN rm -rf /etc/yum.repos.d/*
-      RUN curl http://base-4-21-rhel9.ocp.svc > /etc/yum.repos.d/base-4-21-rhel9.repo
+      RUN curl http://base-4-22-rhel9.ocp.svc > /etc/yum.repos.d/base-4-22-rhel9.repo
     to: ubi9-minimal-entitled
   - build_args:
     - name: DNF

--- a/ci-operator/config/openshift/hive/openshift-hive-master__periodic.yaml
+++ b/ci-operator/config/openshift/hive/openshift-hive-master__periodic.yaml
@@ -1,6 +1,6 @@
 base_images:
   openstack-installer:
-    name: "4.21"
+    name: "4.22"
     namespace: ocp
     tag: openstack-installer
   upi-installer:
@@ -12,7 +12,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: rhel-9-release-golang-1.24-openshift-4.21
+    tag: rhel-9-release-golang-1.24-openshift-4.22
 images:
   items:
   - dockerfile_literal: |
@@ -32,7 +32,7 @@ releases:
     candidate:
       product: ocp
       stream: nightly
-      version: "4.21"
+      version: "4.22"
 resources:
   '*':
     requests:
@@ -53,7 +53,7 @@ tests:
     owner: openshift-ci
     product: ocp
     timeout: 1h0m0s
-    version: "4.21"
+    version: "4.22"
   cron: 5 4 * * 1
   steps:
     test:
@@ -98,7 +98,7 @@ tests:
     owner: openshift-ci
     product: ocp
     timeout: 1h0m0s
-    version: "4.21"
+    version: "4.22"
   cron: 5 4 * * 2
   steps:
     test:

--- a/ci-operator/config/openshift/hive/openshift-hive-master__periodic.yaml
+++ b/ci-operator/config/openshift/hive/openshift-hive-master__periodic.yaml
@@ -12,7 +12,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: rhel-9-release-golang-1.24-openshift-4.22
+    tag: rhel-9-release-golang-1.25-openshift-4.22
 images:
   items:
   - dockerfile_literal: |

--- a/ci-operator/jobs/openshift/hive/openshift-hive-master-periodics.yaml
+++ b/ci-operator/jobs/openshift/hive/openshift-hive-master-periodics.yaml
@@ -388,7 +388,7 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: periodic
     ci.openshift.io/generator: prowgen
-    job-release: "4.21"
+    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-hive-master-periodic-e2e-vsphere-weekly
   reporter_config:

--- a/ci-operator/jobs/openshift/hive/openshift-hive-master-periodics.yaml
+++ b/ci-operator/jobs/openshift/hive/openshift-hive-master-periodics.yaml
@@ -14,7 +14,7 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-azure
     ci-operator.openshift.io/variant: periodic
     ci.openshift.io/generator: prowgen
-    job-release: "4.21"
+    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-hive-master-periodic-e2e-azure-weekly
   reporter_config:
@@ -106,7 +106,7 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: periodic
     ci.openshift.io/generator: prowgen
-    job-release: "4.21"
+    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-hive-master-periodic-e2e-gcp-weekly
   reporter_config:
@@ -198,7 +198,7 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
     ci-operator.openshift.io/variant: periodic
     ci.openshift.io/generator: prowgen
-    job-release: "4.21"
+    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-hive-master-periodic-e2e-openstack-weekly
   reporter_config:
@@ -289,7 +289,7 @@ periodics:
   labels:
     ci-operator.openshift.io/variant: periodic
     ci.openshift.io/generator: prowgen
-    job-release: "4.21"
+    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-hive-master-periodic-e2e-pool-weekly
   reporter_config:
@@ -479,7 +479,7 @@ periodics:
   labels:
     ci-operator.openshift.io/variant: periodic
     ci.openshift.io/generator: prowgen
-    job-release: "4.21"
+    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-hive-master-periodic-e2e-weekly
   reporter_config:

--- a/ci-operator/jobs/openshift/hive/openshift-hive-master-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/hive/openshift-hive-master-postsubmits.yaml
@@ -11,7 +11,7 @@ postsubmits:
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen
-      job-release: "4.20"
+      job-release: "4.21"
     max_concurrency: 1
     name: branch-ci-openshift-hive-master-images
     spec:
@@ -71,7 +71,7 @@ postsubmits:
       skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
-      job-release: "4.20"
+      job-release: "4.21"
     max_concurrency: 1
     name: branch-ci-openshift-hive-master-publish-coverage
     spec:

--- a/ci-operator/jobs/openshift/hive/openshift-hive-master-presubmits.yaml
+++ b/ci-operator/jobs/openshift/hive/openshift-hive-master-presubmits.yaml
@@ -12,7 +12,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
-      job-release: "4.20"
+      job-release: "4.21"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-hive-master-coverage
     rerun_command: /test coverage
@@ -84,7 +84,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
-      job-release: "4.20"
+      job-release: "4.21"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-hive-master-e2e
     rerun_command: /test e2e
@@ -176,7 +176,7 @@ presubmits:
       ci-operator.openshift.io/cloud: azure4
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-azure
       ci.openshift.io/generator: prowgen
-      job-release: "4.20"
+      job-release: "4.21"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-hive-master-e2e-azure
     rerun_command: /test e2e-azure
@@ -260,7 +260,7 @@ presubmits:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
       ci.openshift.io/generator: prowgen
-      job-release: "4.20"
+      job-release: "4.21"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-hive-master-e2e-gcp
     rerun_command: /test e2e-gcp
@@ -344,7 +344,7 @@ presubmits:
       ci-operator.openshift.io/cloud: openstack-vexxhost
       ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
       ci.openshift.io/generator: prowgen
-      job-release: "4.20"
+      job-release: "4.21"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-hive-master-e2e-openstack
     rerun_command: /test e2e-openstack
@@ -426,7 +426,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
-      job-release: "4.20"
+      job-release: "4.21"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-hive-master-e2e-pool
     rerun_command: /test e2e-pool
@@ -517,7 +517,7 @@ presubmits:
       ci-operator.openshift.io/cloud: vsphere
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
       ci.openshift.io/generator: prowgen
-      job-release: "4.20"
+      job-release: "4.21"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-hive-master-e2e-vsphere
     rerun_command: /test e2e-vsphere
@@ -599,7 +599,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
-      job-release: "4.20"
+      job-release: "4.21"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-hive-master-images
     rerun_command: /test images
@@ -657,7 +657,7 @@ presubmits:
     labels:
       ci-operator.openshift.io/variant: periodic
       ci.openshift.io/generator: prowgen
-      job-release: "4.21"
+      job-release: "4.22"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-hive-master-periodic-images
     rerun_command: /test periodic-images
@@ -715,7 +715,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
-      job-release: "4.20"
+      job-release: "4.21"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-hive-master-security
     rerun_command: /test security
@@ -797,7 +797,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
-      job-release: "4.20"
+      job-release: "4.21"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-hive-master-unit
     rerun_command: /test unit
@@ -862,7 +862,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
-      job-release: "4.20"
+      job-release: "4.21"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-hive-master-verify
     rerun_command: /test verify


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI operator configurations and job definitions to support OpenShift versions 4.20, 4.21, and 4.22 across build, test, and release pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->