### PR TITLE
OCPBUGS-83719: split out etcd unit test into individual tests and make them optional

### DIFF
--- a/ci-operator/config/openshift/etcd/openshift-etcd-main.yaml
+++ b/ci-operator/config/openshift/etcd/openshift-etcd-main.yaml
@@ -34,13 +34,28 @@ releases:
 resources:
   '*':
     requests:
-      cpu: 100m
-      memory: 200Mi
+      cpu: "4"
+      memory: 3Gi
 tests:
-- as: unit
-  commands: CGO_ENABLED=1 make test --warn-undefined-variables
+- as: upstream-unit
+  commands: CGO_ENABLED=1 make test-unit --warn-undefined-variables
   container:
     from: bin
+- as: upstream-integration
+  commands: CGO_ENABLED=1 make test-integration --warn-undefined-variables
+  container:
+    from: bin
+  optional: true
+- as: upstream-e2e
+  commands: CGO_ENABLED=1 PASSES="e2e" ./scripts/test.sh
+  container:
+    from: bin
+  optional: true
+- as: upstream-release
+  commands: CGO_ENABLED=1 PASSES="release" ./scripts/test.sh
+  container:
+    from: bin
+  optional: true
 - as: e2e-aws-ovn
   steps:
     cluster_profile: openshift-org-aws

--- a/ci-operator/config/openshift/etcd/openshift-etcd-openshift-4.21.yaml
+++ b/ci-operator/config/openshift/etcd/openshift-etcd-openshift-4.21.yaml
@@ -34,13 +34,28 @@ releases:
 resources:
   '*':
     requests:
-      cpu: 100m
-      memory: 200Mi
+      cpu: "4"
+      memory: 3Gi
 tests:
-- as: unit
-  commands: CGO_ENABLED=1 make test --warn-undefined-variables
+- as: upstream-unit
+  commands: CGO_ENABLED=1 make test-unit --warn-undefined-variables
   container:
     from: bin
+- as: upstream-integration
+  commands: CGO_ENABLED=1 make test-integration --warn-undefined-variables
+  container:
+    from: bin
+  optional: true
+- as: upstream-e2e
+  commands: CGO_ENABLED=1 PASSES="e2e" ./scripts/test.sh
+  container:
+    from: bin
+  optional: true
+- as: upstream-release
+  commands: CGO_ENABLED=1 PASSES="release" ./scripts/test.sh
+  container:
+    from: bin
+  optional: true
 - as: e2e-aws-ovn
   steps:
     cluster_profile: openshift-org-aws

--- a/ci-operator/config/openshift/etcd/openshift-etcd-openshift-4.22.yaml
+++ b/ci-operator/config/openshift/etcd/openshift-etcd-openshift-4.22.yaml
@@ -34,13 +34,28 @@ releases:
 resources:
   '*':
     requests:
-      cpu: 100m
-      memory: 200Mi
+      cpu: "4"
+      memory: 3Gi
 tests:
-- as: unit
-  commands: CGO_ENABLED=1 make test --warn-undefined-variables
+- as: upstream-unit
+  commands: CGO_ENABLED=1 make test-unit --warn-undefined-variables
   container:
     from: bin
+- as: upstream-integration
+  commands: CGO_ENABLED=1 make test-integration --warn-undefined-variables
+  container:
+    from: bin
+  optional: true
+- as: upstream-e2e
+  commands: CGO_ENABLED=1 PASSES="e2e" ./scripts/test.sh
+  container:
+    from: bin
+  optional: true
+- as: upstream-release
+  commands: CGO_ENABLED=1 PASSES="release" ./scripts/test.sh
+  container:
+    from: bin
+  optional: true
 - as: e2e-aws-ovn
   steps:
     cluster_profile: openshift-org-aws

--- a/ci-operator/config/openshift/etcd/openshift-etcd-openshift-4.23.yaml
+++ b/ci-operator/config/openshift/etcd/openshift-etcd-openshift-4.23.yaml
@@ -34,13 +34,28 @@ releases:
 resources:
   '*':
     requests:
-      cpu: 100m
-      memory: 200Mi
+      cpu: "4"
+      memory: 3Gi
 tests:
-- as: unit
-  commands: CGO_ENABLED=1 make test --warn-undefined-variables
+- as: upstream-unit
+  commands: CGO_ENABLED=1 make test-unit --warn-undefined-variables
   container:
     from: bin
+- as: upstream-integration
+  commands: CGO_ENABLED=1 make test-integration --warn-undefined-variables
+  container:
+    from: bin
+  optional: true
+- as: upstream-e2e
+  commands: CGO_ENABLED=1 PASSES="e2e" ./scripts/test.sh
+  container:
+    from: bin
+  optional: true
+- as: upstream-release
+  commands: CGO_ENABLED=1 PASSES="release" ./scripts/test.sh
+  container:
+    from: bin
+  optional: true
 - as: e2e-aws-ovn
   steps:
     cluster_profile: openshift-org-aws

--- a/ci-operator/config/openshift/etcd/openshift-etcd-openshift-5.0.yaml
+++ b/ci-operator/config/openshift/etcd/openshift-etcd-openshift-5.0.yaml
@@ -35,13 +35,28 @@ releases:
 resources:
   '*':
     requests:
-      cpu: 100m
-      memory: 200Mi
+      cpu: "4"
+      memory: 3Gi
 tests:
-- as: unit
-  commands: CGO_ENABLED=1 make test --warn-undefined-variables
+- as: upstream-unit
+  commands: CGO_ENABLED=1 make test-unit --warn-undefined-variables
   container:
     from: bin
+- as: upstream-integration
+  commands: CGO_ENABLED=1 make test-integration --warn-undefined-variables
+  container:
+    from: bin
+  optional: true
+- as: upstream-e2e
+  commands: CGO_ENABLED=1 PASSES="e2e" ./scripts/test.sh
+  container:
+    from: bin
+  optional: true
+- as: upstream-release
+  commands: CGO_ENABLED=1 PASSES="release" ./scripts/test.sh
+  container:
+    from: bin
+  optional: true
 - as: e2e-aws-ovn
   steps:
     cluster_profile: openshift-org-aws

--- a/ci-operator/config/openshift/etcd/openshift-etcd-openshift-5.1.yaml
+++ b/ci-operator/config/openshift/etcd/openshift-etcd-openshift-5.1.yaml
@@ -34,13 +34,28 @@ releases:
 resources:
   '*':
     requests:
-      cpu: 100m
-      memory: 200Mi
+      cpu: "4"
+      memory: 3Gi
 tests:
-- as: unit
-  commands: CGO_ENABLED=1 make test --warn-undefined-variables
+- as: upstream-unit
+  commands: CGO_ENABLED=1 make test-unit --warn-undefined-variables
   container:
     from: bin
+- as: upstream-integration
+  commands: CGO_ENABLED=1 make test-integration --warn-undefined-variables
+  container:
+    from: bin
+  optional: true
+- as: upstream-e2e
+  commands: CGO_ENABLED=1 PASSES="e2e" ./scripts/test.sh
+  container:
+    from: bin
+  optional: true
+- as: upstream-release
+  commands: CGO_ENABLED=1 PASSES="release" ./scripts/test.sh
+  container:
+    from: bin
+  optional: true
 - as: e2e-aws-ovn
   steps:
     cluster_profile: openshift-org-aws

--- a/ci-operator/jobs/openshift/etcd/openshift-etcd-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/etcd/openshift-etcd-main-presubmits.yaml
@@ -713,21 +713,22 @@ presubmits:
     - ^main$
     - ^main-
     cluster: build01
-    context: ci/prow/unit
+    context: ci/prow/upstream-e2e
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-main-unit
+    name: pull-ci-openshift-etcd-main-upstream-e2e
+    optional: true
     path_alias: go.etcd.io/etcd
-    rerun_command: /test unit
+    rerun_command: /test upstream-e2e
     spec:
       containers:
       - args:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --report-credentials-file=/etc/report/credentials
-        - --target=unit
+        - --target=upstream-e2e
         command:
         - ci-operator
         env:
@@ -768,4 +769,192 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )unit,?($|\s.*)
+    trigger: (?m)^/test( | .* )upstream-e2e,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build01
+    context: ci/prow/upstream-integration
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-etcd-main-upstream-integration
+    optional: true
+    path_alias: go.etcd.io/etcd
+    rerun_command: /test upstream-integration
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=upstream-integration
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )upstream-integration,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build01
+    context: ci/prow/upstream-release
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-etcd-main-upstream-release
+    optional: true
+    path_alias: go.etcd.io/etcd
+    rerun_command: /test upstream-release
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=upstream-release
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )upstream-release,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build01
+    context: ci/prow/upstream-unit
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-etcd-main-upstream-unit
+    path_alias: go.etcd.io/etcd
+    rerun_command: /test upstream-unit
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=upstream-unit
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )upstream-unit,?($|\s.*)

--- a/ci-operator/jobs/openshift/etcd/openshift-etcd-openshift-4.21-presubmits.yaml
+++ b/ci-operator/jobs/openshift/etcd/openshift-etcd-openshift-4.21-presubmits.yaml
@@ -713,21 +713,22 @@ presubmits:
     - ^openshift-4\.21$
     - ^openshift-4\.21-
     cluster: build06
-    context: ci/prow/unit
+    context: ci/prow/upstream-e2e
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-4.21-unit
+    name: pull-ci-openshift-etcd-openshift-4.21-upstream-e2e
+    optional: true
     path_alias: go.etcd.io/etcd
-    rerun_command: /test unit
+    rerun_command: /test upstream-e2e
     spec:
       containers:
       - args:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --report-credentials-file=/etc/report/credentials
-        - --target=unit
+        - --target=upstream-e2e
         command:
         - ci-operator
         env:
@@ -768,4 +769,192 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )unit,?($|\s.*)
+    trigger: (?m)^/test( | .* )upstream-e2e,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^openshift-4\.21$
+    - ^openshift-4\.21-
+    cluster: build06
+    context: ci/prow/upstream-integration
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-etcd-openshift-4.21-upstream-integration
+    optional: true
+    path_alias: go.etcd.io/etcd
+    rerun_command: /test upstream-integration
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=upstream-integration
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )upstream-integration,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^openshift-4\.21$
+    - ^openshift-4\.21-
+    cluster: build06
+    context: ci/prow/upstream-release
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-etcd-openshift-4.21-upstream-release
+    optional: true
+    path_alias: go.etcd.io/etcd
+    rerun_command: /test upstream-release
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=upstream-release
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )upstream-release,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^openshift-4\.21$
+    - ^openshift-4\.21-
+    cluster: build06
+    context: ci/prow/upstream-unit
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-etcd-openshift-4.21-upstream-unit
+    path_alias: go.etcd.io/etcd
+    rerun_command: /test upstream-unit
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=upstream-unit
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )upstream-unit,?($|\s.*)

--- a/ci-operator/jobs/openshift/etcd/openshift-etcd-openshift-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift/etcd/openshift-etcd-openshift-4.22-presubmits.yaml
@@ -713,21 +713,22 @@ presubmits:
     - ^openshift-4\.22$
     - ^openshift-4\.22-
     cluster: build06
-    context: ci/prow/unit
+    context: ci/prow/upstream-e2e
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-4.22-unit
+    name: pull-ci-openshift-etcd-openshift-4.22-upstream-e2e
+    optional: true
     path_alias: go.etcd.io/etcd
-    rerun_command: /test unit
+    rerun_command: /test upstream-e2e
     spec:
       containers:
       - args:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --report-credentials-file=/etc/report/credentials
-        - --target=unit
+        - --target=upstream-e2e
         command:
         - ci-operator
         env:
@@ -768,4 +769,192 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )unit,?($|\s.*)
+    trigger: (?m)^/test( | .* )upstream-e2e,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^openshift-4\.22$
+    - ^openshift-4\.22-
+    cluster: build06
+    context: ci/prow/upstream-integration
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-etcd-openshift-4.22-upstream-integration
+    optional: true
+    path_alias: go.etcd.io/etcd
+    rerun_command: /test upstream-integration
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=upstream-integration
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )upstream-integration,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^openshift-4\.22$
+    - ^openshift-4\.22-
+    cluster: build06
+    context: ci/prow/upstream-release
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-etcd-openshift-4.22-upstream-release
+    optional: true
+    path_alias: go.etcd.io/etcd
+    rerun_command: /test upstream-release
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=upstream-release
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )upstream-release,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^openshift-4\.22$
+    - ^openshift-4\.22-
+    cluster: build06
+    context: ci/prow/upstream-unit
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-etcd-openshift-4.22-upstream-unit
+    path_alias: go.etcd.io/etcd
+    rerun_command: /test upstream-unit
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=upstream-unit
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )upstream-unit,?($|\s.*)

--- a/ci-operator/jobs/openshift/etcd/openshift-etcd-openshift-4.23-presubmits.yaml
+++ b/ci-operator/jobs/openshift/etcd/openshift-etcd-openshift-4.23-presubmits.yaml
@@ -713,21 +713,22 @@ presubmits:
     - ^openshift-4\.23$
     - ^openshift-4\.23-
     cluster: build06
-    context: ci/prow/unit
+    context: ci/prow/upstream-e2e
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-4.23-unit
+    name: pull-ci-openshift-etcd-openshift-4.23-upstream-e2e
+    optional: true
     path_alias: go.etcd.io/etcd
-    rerun_command: /test unit
+    rerun_command: /test upstream-e2e
     spec:
       containers:
       - args:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --report-credentials-file=/etc/report/credentials
-        - --target=unit
+        - --target=upstream-e2e
         command:
         - ci-operator
         env:
@@ -768,4 +769,192 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )unit,?($|\s.*)
+    trigger: (?m)^/test( | .* )upstream-e2e,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^openshift-4\.23$
+    - ^openshift-4\.23-
+    cluster: build06
+    context: ci/prow/upstream-integration
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-etcd-openshift-4.23-upstream-integration
+    optional: true
+    path_alias: go.etcd.io/etcd
+    rerun_command: /test upstream-integration
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=upstream-integration
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )upstream-integration,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^openshift-4\.23$
+    - ^openshift-4\.23-
+    cluster: build06
+    context: ci/prow/upstream-release
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-etcd-openshift-4.23-upstream-release
+    optional: true
+    path_alias: go.etcd.io/etcd
+    rerun_command: /test upstream-release
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=upstream-release
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )upstream-release,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^openshift-4\.23$
+    - ^openshift-4\.23-
+    cluster: build06
+    context: ci/prow/upstream-unit
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-etcd-openshift-4.23-upstream-unit
+    path_alias: go.etcd.io/etcd
+    rerun_command: /test upstream-unit
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=upstream-unit
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )upstream-unit,?($|\s.*)

--- a/ci-operator/jobs/openshift/etcd/openshift-etcd-openshift-5.0-presubmits.yaml
+++ b/ci-operator/jobs/openshift/etcd/openshift-etcd-openshift-5.0-presubmits.yaml
@@ -712,21 +712,22 @@ presubmits:
     - ^openshift-5\.0$
     - ^openshift-5\.0-
     cluster: build06
-    context: ci/prow/unit
+    context: ci/prow/upstream-e2e
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-5.0-unit
+    name: pull-ci-openshift-etcd-openshift-5.0-upstream-e2e
+    optional: true
     path_alias: go.etcd.io/etcd
-    rerun_command: /test unit
+    rerun_command: /test upstream-e2e
     spec:
       containers:
       - args:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --report-credentials-file=/etc/report/credentials
-        - --target=unit
+        - --target=upstream-e2e
         command:
         - ci-operator
         env:
@@ -767,4 +768,192 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )unit,?($|\s.*)
+    trigger: (?m)^/test( | .* )upstream-e2e,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^openshift-5\.0$
+    - ^openshift-5\.0-
+    cluster: build06
+    context: ci/prow/upstream-integration
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-etcd-openshift-5.0-upstream-integration
+    optional: true
+    path_alias: go.etcd.io/etcd
+    rerun_command: /test upstream-integration
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=upstream-integration
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )upstream-integration,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^openshift-5\.0$
+    - ^openshift-5\.0-
+    cluster: build06
+    context: ci/prow/upstream-release
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-etcd-openshift-5.0-upstream-release
+    optional: true
+    path_alias: go.etcd.io/etcd
+    rerun_command: /test upstream-release
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=upstream-release
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )upstream-release,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^openshift-5\.0$
+    - ^openshift-5\.0-
+    cluster: build06
+    context: ci/prow/upstream-unit
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-etcd-openshift-5.0-upstream-unit
+    path_alias: go.etcd.io/etcd
+    rerun_command: /test upstream-unit
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=upstream-unit
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )upstream-unit,?($|\s.*)

--- a/ci-operator/jobs/openshift/etcd/openshift-etcd-openshift-5.1-presubmits.yaml
+++ b/ci-operator/jobs/openshift/etcd/openshift-etcd-openshift-5.1-presubmits.yaml
@@ -713,21 +713,22 @@ presubmits:
     - ^openshift-5\.1$
     - ^openshift-5\.1-
     cluster: build06
-    context: ci/prow/unit
+    context: ci/prow/upstream-e2e
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-5.1-unit
+    name: pull-ci-openshift-etcd-openshift-5.1-upstream-e2e
+    optional: true
     path_alias: go.etcd.io/etcd
-    rerun_command: /test unit
+    rerun_command: /test upstream-e2e
     spec:
       containers:
       - args:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --report-credentials-file=/etc/report/credentials
-        - --target=unit
+        - --target=upstream-e2e
         command:
         - ci-operator
         env:
@@ -768,4 +769,192 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )unit,?($|\s.*)
+    trigger: (?m)^/test( | .* )upstream-e2e,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^openshift-5\.1$
+    - ^openshift-5\.1-
+    cluster: build06
+    context: ci/prow/upstream-integration
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-etcd-openshift-5.1-upstream-integration
+    optional: true
+    path_alias: go.etcd.io/etcd
+    rerun_command: /test upstream-integration
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=upstream-integration
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )upstream-integration,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^openshift-5\.1$
+    - ^openshift-5\.1-
+    cluster: build06
+    context: ci/prow/upstream-release
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-etcd-openshift-5.1-upstream-release
+    optional: true
+    path_alias: go.etcd.io/etcd
+    rerun_command: /test upstream-release
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=upstream-release
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )upstream-release,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^openshift-5\.1$
+    - ^openshift-5\.1-
+    cluster: build06
+    context: ci/prow/upstream-unit
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-etcd-openshift-5.1-upstream-unit
+    path_alias: go.etcd.io/etcd
+    rerun_command: /test upstream-unit
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=upstream-unit
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )upstream-unit,?($|\s.*)


### PR DESCRIPTION
The upstream etcd integration and e2e tests are notoriously flakey, this keeps the basic unit tests as required, but splits out the other tests into optional jobs

Co-Authored by Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased CI pod CPU and memory requests across etcd OpenShift CI configs to improve build/test performance and reliability.
* **Tests**
  * Replaced single unit job with an expanded upstream test suite (unit, integration, e2e, release). New integration/e2e/release stages are optional and added corresponding presubmit jobs to run in CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->