### PR TITLE
Disable rebasebot bot squashing on cluster infra repositories

### DIFF
--- a/ci-operator/config/openshift-eng/rebasebot/openshift-eng-rebasebot-main.yaml
+++ b/ci-operator/config/openshift-eng/rebasebot/openshift-eng-rebasebot-main.yaml
@@ -48,7 +48,6 @@ tests:
                   --github-cloner-key /secrets/rebasebot/cloud-team-bot-key \
                   --git-username cloud-team-rebase-bot \
                   --git-email cloud-team-rebase-bot@redhat.com \
-                  --bot-emails cloud-team-rebase-bot@redhat.com openshift-bot@redhat.com openshift-ci-robot@redhat.com \
                   --tag-policy=strict
       credentials:
       - mount_path: /secrets/rebasebot
@@ -78,7 +77,6 @@ tests:
                   --github-cloner-key /secrets/rebasebot/cloud-team-bot-key \
                   --git-username cloud-team-rebase-bot \
                   --git-email cloud-team-rebase-bot@redhat.com \
-                  --bot-emails cloud-team-rebase-bot@redhat.com openshift-bot@redhat.com openshift-ci-robot@redhat.com \
                   --tag-policy=strict
       credentials:
       - mount_path: /secrets/rebasebot
@@ -108,7 +106,6 @@ tests:
                   --github-cloner-key /secrets/rebasebot/cloud-team-bot-key \
                   --git-username cloud-team-rebase-bot \
                   --git-email cloud-team-rebase-bot@redhat.com \
-                  --bot-emails cloud-team-rebase-bot@redhat.com openshift-bot@redhat.com openshift-ci-robot@redhat.com \
                   --tag-policy=strict
       credentials:
       - mount_path: /secrets/rebasebot
@@ -138,7 +135,6 @@ tests:
                   --github-cloner-key /secrets/rebasebot/cloud-team-bot-key \
                   --git-username cloud-team-rebase-bot \
                   --git-email cloud-team-rebase-bot@redhat.com \
-                  --bot-emails cloud-team-rebase-bot@redhat.com openshift-bot@redhat.com openshift-ci-robot@redhat.com \
                   --tag-policy=strict
       credentials:
       - mount_path: /secrets/rebasebot
@@ -168,7 +164,6 @@ tests:
                   --github-cloner-key /secrets/rebasebot/cloud-team-bot-key \
                   --git-username cloud-team-rebase-bot \
                   --git-email cloud-team-rebase-bot@redhat.com \
-                  --bot-emails cloud-team-rebase-bot@redhat.com openshift-bot@redhat.com openshift-ci-robot@redhat.com \
                   --tag-policy=strict
       credentials:
       - mount_path: /secrets/rebasebot
@@ -198,7 +193,6 @@ tests:
                   --github-cloner-key /secrets/rebasebot/cloud-team-bot-key \
                   --git-username cloud-team-rebase-bot \
                   --git-email cloud-team-rebase-bot@redhat.com \
-                  --bot-emails cloud-team-rebase-bot@redhat.com openshift-bot@redhat.com openshift-ci-robot@redhat.com \
                   --tag-policy=strict
       credentials:
       - mount_path: /secrets/rebasebot
@@ -228,7 +222,6 @@ tests:
                   --github-cloner-key /secrets/rebasebot/cloud-team-bot-key \
                   --git-username cloud-team-rebase-bot \
                   --git-email cloud-team-rebase-bot@redhat.com \
-                  --bot-emails cloud-team-rebase-bot@redhat.com openshift-bot@redhat.com openshift-ci-robot@redhat.com \
                   --tag-policy=strict
       credentials:
       - mount_path: /secrets/rebasebot
@@ -258,7 +251,6 @@ tests:
                   --github-cloner-key /secrets/rebasebot/cloud-team-bot-key \
                   --git-username cloud-team-rebase-bot \
                   --git-email cloud-team-rebase-bot@redhat.com \
-                  --bot-emails cloud-team-rebase-bot@redhat.com openshift-bot@redhat.com openshift-ci-robot@redhat.com \
                   --tag-policy=strict
       credentials:
       - mount_path: /secrets/rebasebot
@@ -287,7 +279,6 @@ tests:
                   --github-cloner-key /secrets/rebasebot/cloud-team-bot-key \
                   --git-username cloud-team-rebase-bot \
                   --git-email cloud-team-rebase-bot@redhat.com \
-                  --bot-emails cloud-team-rebase-bot@redhat.com openshift-bot@redhat.com openshift-ci-robot@redhat.com \
                   --tag-policy=strict
       credentials:
       - mount_path: /secrets/rebasebot
@@ -315,7 +306,6 @@ tests:
                   --github-cloner-key /secrets/rebasebot/cloud-team-bot-key \
                   --git-username cloud-team-rebase-bot \
                   --git-email cloud-team-rebase-bot@redhat.com \
-                  --bot-emails cloud-team-rebase-bot@redhat.com openshift-bot@redhat.com openshift-ci-robot@redhat.com \
                   --tag-policy=strict
       credentials:
       - mount_path: /secrets/rebasebot
@@ -372,7 +362,6 @@ tests:
                   --github-cloner-key /secrets/rebasebot/cloud-team-bot-key \
                   --git-username cloud-team-rebase-bot \
                   --git-email cloud-team-rebase-bot@redhat.com \
-                  --bot-emails cloud-team-rebase-bot@redhat.com openshift-bot@redhat.com openshift-ci-robot@redhat.com \
                   --tag-policy=strict
       credentials:
       - mount_path: /secrets/rebasebot
@@ -400,7 +389,6 @@ tests:
                   --github-cloner-key /secrets/rebasebot/cloud-team-bot-key \
                   --git-username cloud-team-rebase-bot \
                   --git-email cloud-team-rebase-bot@redhat.com \
-                  --bot-emails cloud-team-rebase-bot@redhat.com openshift-bot@redhat.com openshift-ci-robot@redhat.com \
                   --tag-policy=strict
       credentials:
       - mount_path: /secrets/rebasebot
@@ -428,7 +416,6 @@ tests:
                   --github-cloner-key /secrets/rebasebot/cloud-team-bot-key \
                   --git-username cloud-team-rebase-bot \
                   --git-email cloud-team-rebase-bot@redhat.com \
-                  --bot-emails cloud-team-rebase-bot@redhat.com openshift-bot@redhat.com openshift-ci-robot@redhat.com \
                   --tag-policy=strict
       credentials:
       - mount_path: /secrets/rebasebot
@@ -456,7 +443,6 @@ tests:
                   --github-cloner-key /secrets/rebasebot/cloud-team-bot-key \
                   --git-username cloud-team-rebase-bot \
                   --git-email cloud-team-rebase-bot@redhat.com \
-                  --bot-emails cloud-team-rebase-bot@redhat.com openshift-bot@redhat.com openshift-ci-robot@redhat.com \
                   --tag-policy=strict
       credentials:
       - mount_path: /secrets/rebasebot


### PR DESCRIPTION
This feature is causing issues because it reorders commit history to squash the commits. This can lead into some carry commits being lost.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified rebasebot test configuration by removing explicit bot email arguments across multiple provider variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->