### PR TITLE
OCPEDGE-2469: Added ocp-edge CI payload monitor periodic job (daily)

### DIFF
--- a/ci-operator/config/openshift-eng/edge-tooling/OWNERS
+++ b/ci-operator/config/openshift-eng/edge-tooling/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+  - edge-enablement-approvers
+reviewers:
+  - edge-enablement-reviewers

--- a/ci-operator/config/openshift-eng/edge-tooling/OWNERS
+++ b/ci-operator/config/openshift-eng/edge-tooling/OWNERS
@@ -2,3 +2,4 @@ approvers:
   - edge-enablement-approvers
 reviewers:
   - edge-enablement-reviewers
+  - microshift-reviewers

--- a/ci-operator/config/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main.yaml
+++ b/ci-operator/config/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main.yaml
@@ -9,7 +9,7 @@ resources:
       cpu: 100m
       memory: 200Mi
 tests:
-- as: edge-payload-monitor
+- as: ocp-ci-monitor
   cron: 0 9 * * *
   steps:
     workflow: openshift-edge-tooling-ci-monitor

--- a/ci-operator/config/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main.yaml
+++ b/ci-operator/config/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main.yaml
@@ -12,7 +12,7 @@ tests:
 - as: edge-payload-monitor
   cron: 0 9 * * *
   steps:
-    workflow: openshift-claude-edge-monitor
+    workflow: openshift-edge-tooling-ci-monitor
 zz_generated_metadata:
   branch: main
   org: openshift-eng

--- a/ci-operator/config/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main.yaml
+++ b/ci-operator/config/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main.yaml
@@ -1,0 +1,19 @@
+build_root:
+  image_stream_tag:
+    name: release
+    namespace: openshift
+    tag: rhel-9-release-golang-1.25-openshift-4.22
+resources:
+  '*':
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: edge-payload-monitor
+  cron: 0 9 * * *
+  steps:
+    workflow: openshift-claude-edge-monitor
+zz_generated_metadata:
+  branch: main
+  org: openshift-eng
+  repo: edge-tooling

--- a/ci-operator/jobs/openshift-eng/edge-tooling/OWNERS
+++ b/ci-operator/jobs/openshift-eng/edge-tooling/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+  - edge-enablement-approvers
+reviewers:
+  - edge-enablement-reviewers

--- a/ci-operator/jobs/openshift-eng/edge-tooling/OWNERS
+++ b/ci-operator/jobs/openshift-eng/edge-tooling/OWNERS
@@ -2,3 +2,4 @@ approvers:
   - edge-enablement-approvers
 reviewers:
   - edge-enablement-reviewers
+  - microshift-reviewers

--- a/ci-operator/jobs/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main-periodics.yaml
@@ -1,0 +1,80 @@
+periodics:
+- agent: kubernetes
+  cluster: build06
+  cron: 0 9 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-eng
+    repo: edge-tooling
+  labels:
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-eng-edge-tooling-main-edge-payload-monitor
+  reporter_config:
+    slack:
+      channel: '#vimauro-test-edge-monitor'
+      job_states_to_report:
+      - success
+      - failure
+      - error
+      report_template: |
+        {{if eq .Status.State "success"}} :large_green_circle: {{else}} :red_circle: {{end}} *Edge Payload Monitor* ended with *{{.Status.State}}*. <https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/{{.Spec.Job}}/{{.Status.BuildID}}/artifacts/edge-payload-monitor/openshift-claude-edge-monitor/artifacts/edge-payload-dashboard.html|View Dashboard>
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=edge-payload-monitor
+      command:
+      - ci-operator
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator

--- a/ci-operator/jobs/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main-periodics.yaml
@@ -12,7 +12,7 @@ periodics:
   labels:
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-eng-edge-tooling-main-edge-payload-monitor
+  name: periodic-ci-openshift-eng-edge-tooling-main-ocp-ci-monitor
   reporter_config:
     slack:
       channel: '#vimauro-test-ci-monitor'
@@ -21,7 +21,7 @@ periodics:
       - failure
       - error
       report_template: |
-        {{if eq .Status.State "success"}} :large_green_circle: {{else}} :red_circle: {{end}} *Edge Payload Monitor* ended with *{{.Status.State}}*. <https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/{{.Spec.Job}}/{{.Status.BuildID}}/artifacts/edge-payload-monitor/openshift-edge-tooling-ci-monitor/artifacts/edge-payload-dashboard.html|View Dashboard>
+        {{if eq .Status.State "success"}} :large_green_circle: {{else}} :red_circle: {{end}} *Edge OCP CI Monitor* ended with *{{.Status.State}}*. <https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/{{.Spec.Job}}/{{.Status.BuildID}}/artifacts/ocp-ci-monitor/openshift-edge-tooling-ci-monitor/artifacts/edge-ci-monitor-summary.html|View Dashboard>
   spec:
     containers:
     - args:
@@ -29,7 +29,7 @@ periodics:
       - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
-      - --target=edge-payload-monitor
+      - --target=ocp-ci-monitor
       command:
       - ci-operator
       env:

--- a/ci-operator/jobs/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main-periodics.yaml
@@ -15,13 +15,13 @@ periodics:
   name: periodic-ci-openshift-eng-edge-tooling-main-edge-payload-monitor
   reporter_config:
     slack:
-      channel: '#vimauro-test-edge-monitor'
+      channel: '#vimauro-test-ci-monitor'
       job_states_to_report:
       - success
       - failure
       - error
       report_template: |
-        {{if eq .Status.State "success"}} :large_green_circle: {{else}} :red_circle: {{end}} *Edge Payload Monitor* ended with *{{.Status.State}}*. <https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/{{.Spec.Job}}/{{.Status.BuildID}}/artifacts/edge-payload-monitor/openshift-claude-edge-monitor/artifacts/edge-payload-dashboard.html|View Dashboard>
+        {{if eq .Status.State "success"}} :large_green_circle: {{else}} :red_circle: {{end}} *Edge Payload Monitor* ended with *{{.Status.State}}*. <https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/{{.Spec.Job}}/{{.Status.BuildID}}/artifacts/edge-payload-monitor/openshift-edge-tooling-ci-monitor/artifacts/edge-payload-dashboard.html|View Dashboard>
   spec:
     containers:
     - args:
@@ -29,22 +29,26 @@ periodics:
       - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
-      - --secret-dir=/secrets/ci-pull-credentials
       - --target=edge-payload-monitor
       command:
       - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
       image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
       imagePullPolicy: Always
       name: ""
+      ports:
+      - containerPort: 8080
+        name: http
       resources:
         requests:
           cpu: 10m
       volumeMounts:
       - mountPath: /etc/boskos
         name: boskos
-        readOnly: true
-      - mountPath: /secrets/ci-pull-credentials
-        name: ci-pull-credentials
         readOnly: true
       - mountPath: /secrets/gcs
         name: gcs-credentials
@@ -66,9 +70,6 @@ periodics:
         - key: credentials
           path: credentials
         secretName: boskos-credentials
-    - name: ci-pull-credentials
-      secret:
-        secretName: ci-pull-credentials
     - name: manifest-tool-local-pusher
       secret:
         secretName: manifest-tool-local-pusher

--- a/ci-operator/step-registry/openshift/claude/edge-monitor/OWNERS
+++ b/ci-operator/step-registry/openshift/claude/edge-monitor/OWNERS
@@ -1,4 +1,0 @@
-approvers:
-- vimauro
-reviewers:
-- vimauro

--- a/ci-operator/step-registry/openshift/claude/edge-monitor/OWNERS
+++ b/ci-operator/step-registry/openshift/claude/edge-monitor/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- vimauro
+reviewers:
+- vimauro

--- a/ci-operator/step-registry/openshift/claude/edge-monitor/openshift-claude-edge-monitor-commands.sh
+++ b/ci-operator/step-registry/openshift/claude/edge-monitor/openshift-claude-edge-monitor-commands.sh
@@ -1,0 +1,298 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+echo "=== Edge Enablement Payload Monitor ==="
+echo "Started at $(date -u '+%Y-%m-%d %H:%M UTC')"
+
+# ---------------------------------------------------------------------------
+# Load secrets (xtrace disabled to prevent leaking credentials in logs)
+# ---------------------------------------------------------------------------
+set +x
+
+if [[ -f "${JIRA_API_TOKEN_PATH}" ]]; then
+    export JIRA_TOKEN
+    JIRA_TOKEN=$(cat "${JIRA_API_TOKEN_PATH}")
+    echo "JIRA token loaded."
+fi
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+build_prow_url() {
+    if [[ "${JOB_TYPE:-}" == "presubmit" ]]; then
+        echo "https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/${REPO_OWNER}_${REPO_NAME}/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
+    else
+        echo "https://prow.ci.openshift.org/view/gs/test-platform-results/logs/${JOB_NAME}/${BUILD_ID}"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Install gcloud CLI for Prow artifact access (no root required)
+# ---------------------------------------------------------------------------
+echo "Installing gcloud CLI..."
+curl -sSL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-linux-x86_64.tar.gz | tar -xz -C /tmp
+/tmp/google-cloud-sdk/install.sh --quiet --path-update true
+export PATH="/tmp/google-cloud-sdk/bin:${PATH}"
+
+# ---------------------------------------------------------------------------
+# Configure Claude permissions for headless CI execution
+# ---------------------------------------------------------------------------
+CLAUDE_HOME="/home/claude/.claude"
+mkdir -p "${CLAUDE_HOME}"
+
+if [ ! -f "${CLAUDE_HOME}/.claude.json" ]; then
+    echo "{}" > "${CLAUDE_HOME}/.claude.json"
+fi
+
+cat > "${CLAUDE_HOME}/settings.json" <<'EOF'
+{
+  "permissions": {
+    "allow": [
+      "Read(//tmp/**)",
+      "Write(//tmp/**)",
+      "Bash(python3:*)",
+      "Bash(python:*)",
+      "Bash(pip:*)",
+      "Bash(curl:*)",
+      "Bash(gsutil:*)",
+      "Bash(gcloud:*)",
+      "Bash(gcloud storage:*)",
+      "Bash(cat:*)",
+      "Bash(jq:*)",
+      "Bash(grep:*)",
+      "Bash(ls:*)",
+      "Bash(date:*)",
+      "Bash(wc:*)",
+      "Bash(pip install:*)",
+      "Bash(pip3 install:*)",
+      "Bash(python -m pytest:*)",
+      "Bash(python3 -m pytest:*)",
+      "Bash(python -m payload_monitor:*)",
+      "Bash(python3 -m payload_monitor:*)",
+      "Skill(ci:*)",
+      "Skill(generate-dashboard)"
+    ]
+  }
+}
+EOF
+echo "Claude permissions configured."
+
+# ---------------------------------------------------------------------------
+# Set up workspace
+# ---------------------------------------------------------------------------
+WORKDIR=$(mktemp -d /tmp/edge-monitor-XXXXXX)
+cd "${WORKDIR}"
+
+PROW_JOB_URL=$(build_prow_url)
+
+copy_artifacts() {
+    echo "Copying artifacts to ${ARTIFACT_DIR}..."
+    find "${WORKDIR}" -maxdepth 2 -name "*.html" -exec cp {} "${ARTIFACT_DIR}/" \; 2>/dev/null || true
+    find "${WORKDIR}" -maxdepth 2 -name "*.json" \
+        -not -path "*/.venv/*" -not -path "*/node_modules/*" \
+        -exec cp {} "${ARTIFACT_DIR}/" \; 2>/dev/null || true
+
+    # Archive Claude session for local continuation
+    if [[ -d "${CLAUDE_HOME}/projects" ]]; then
+        echo "Archiving Claude session..."
+        if tar -czf "${ARTIFACT_DIR}/claude-sessions-$(date +%Y%m%d-%H%M%S).tar.gz" \
+            -C "${CLAUDE_HOME}" projects/ 2>/dev/null; then
+            touch "${SHARED_DIR}/claude-session-available"
+        fi
+    fi
+}
+trap copy_artifacts EXIT TERM INT
+
+# ---------------------------------------------------------------------------
+# Clone and set up payload-monitor
+# ---------------------------------------------------------------------------
+echo "Cloning edge-tooling repository..."
+git clone --depth 1 --branch main https://github.com/openshift-eng/edge-tooling.git
+cd edge-tooling/payload-monitor
+
+echo "Setting up Python environment..."
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -q -r requirements.txt
+
+# ===========================================================================
+# Phase 1: Generate dashboard (deterministic, no AI)
+# ===========================================================================
+echo ""
+echo "=== Phase 1: Generating payload dashboard ==="
+
+DASHBOARD_PATH="${WORKDIR}/edge-payload-dashboard.html"
+JSON_PATH="${WORKDIR}/edge-payload-dashboard.json"
+
+MONITOR_ARGS=(
+    --output "${DASHBOARD_PATH}"
+    --json
+    --verbose
+)
+
+if [[ -n "${MONITOR_VERSIONS}" ]]; then
+    MONITOR_ARGS+=(--versions "${MONITOR_VERSIONS}")
+fi
+
+if [[ "${SKIP_PROW}" == "true" ]]; then
+    MONITOR_ARGS+=(--skip-prow)
+fi
+
+if [[ "${WITH_TIMING}" == "true" ]]; then
+    MONITOR_ARGS+=(--with-timing)
+fi
+
+PHASE_MONITOR_START=$(date +%s)
+
+# stdout has blocking markers, stderr has logging
+python -m payload_monitor "${MONITOR_ARGS[@]}" \
+    > "${WORKDIR}/monitor-stdout.txt" \
+    2> >(tee "${ARTIFACT_DIR}/monitor.log" >&2) || {
+    echo "Warning: Payload monitor exited with non-zero status."
+}
+
+PHASE_MONITOR_DURATION=$(( $(date +%s) - PHASE_MONITOR_START ))
+
+# Copy initial dashboard to artifacts immediately
+cp "${DASHBOARD_PATH}" "${ARTIFACT_DIR}/" 2>/dev/null || true
+cp "${JSON_PATH}" "${ARTIFACT_DIR}/" 2>/dev/null || true
+
+BLOCKING_COUNT=$(grep -c "^BLOCKING|" "${WORKDIR}/monitor-stdout.txt" 2>/dev/null || true)
+BLOCKING_LIST=$(grep "^BLOCKING|" "${WORKDIR}/monitor-stdout.txt" 2>/dev/null || true)
+echo "Found ${BLOCKING_COUNT} blocking job failures."
+
+# No blocking failures — exit early
+if [[ "${BLOCKING_COUNT}" -eq 0 ]]; then
+    echo "No blocking failures detected across monitored topologies."
+    exit 0
+fi
+
+# ===========================================================================
+# Phase 2: Claude AI analysis (best-effort)
+# ===========================================================================
+echo ""
+echo "=== Phase 2: Claude AI analysis of ${BLOCKING_COUNT} blocking failures ==="
+
+# Workaround: --continue + -p is broken (anthropics/claude-code#42376).
+export CLAUDE_CODE_ENTRYPOINT=cli
+
+# Install marketplace plugins for CI analysis skills
+echo "Installing marketplace plugins..."
+claude plugin install openshift-eng/edge-tooling 2>/dev/null || echo "Warning: edge-tooling marketplace install failed."
+claude plugin install openshift-eng/ai-helpers 2>/dev/null || echo "Warning: ai-helpers marketplace install failed."
+
+ANALYSIS_JSON="${WORKDIR}/analysis.json"
+ALLOWED_TOOLS="Bash Read Write Edit Grep Glob WebFetch WebSearch Task Skill"
+
+SYSTEM_PROMPT="You are analyzing edge payload monitoring results for OpenShift nightly payloads.
+You have CI analysis skills available — load them using the Skill tool before starting.
+Focus on blocking job failures and identify root causes."
+
+PHASE_ANALYSIS_START=$(date +%s)
+CLAUDE_EXIT=0
+timeout 3600 claude \
+    --model "${CLAUDE_MODEL}" \
+    --allowedTools "${ALLOWED_TOOLS}" \
+    --output-format stream-json \
+    --max-turns 80 \
+    --append-system-prompt "${SYSTEM_PROMPT}" \
+    -p "Analyze the edge payload monitor results. The JSON report is at: ${JSON_PATH}
+
+The following blocking jobs failed:
+${BLOCKING_LIST}
+
+For each blocking failure:
+1. Load relevant CI skills (e.g., /ci:prow-job-analyze-test-failure)
+2. Investigate the Prow job artifacts to find root causes
+3. Check for existing JIRA bugs
+
+After analysis, write a JSON file to ${ANALYSIS_JSON} mapping each prow_url to its analysis summary:
+{\"<prow_url>\": \"<analysis text>\", ...}" \
+    --verbose 2>&1 | tee "${ARTIFACT_DIR}/claude-analysis.log" || CLAUDE_EXIT=$?
+
+PHASE_ANALYSIS_DURATION=$(( $(date +%s) - PHASE_ANALYSIS_START ))
+
+# Handle timeout — nudge Claude to wrap up
+PHASE_NUDGE_START=$(date +%s)
+NUDGE_EXIT=0
+if [[ "${CLAUDE_EXIT}" -eq 124 ]]; then
+    echo ""
+    echo "Claude analysis timed out. Nudging to wrap up..."
+    timeout 600 claude \
+        --model "${CLAUDE_MODEL}" \
+        --continue \
+        --allowedTools "${ALLOWED_TOOLS}" \
+        --output-format stream-json \
+        --max-turns 10 \
+        -p "Time is up. Write the analysis JSON to ${ANALYSIS_JSON} immediately with whatever findings you have." \
+        --verbose 2>&1 | tee -a "${ARTIFACT_DIR}/claude-analysis.log" || NUDGE_EXIT=$?
+fi
+PHASE_NUDGE_DURATION=$(( $(date +%s) - PHASE_NUDGE_START ))
+
+# ===========================================================================
+# Phase 3: Merge analysis into dashboard
+# ===========================================================================
+if [[ -f "${ANALYSIS_JSON}" ]]; then
+    echo ""
+    echo "=== Phase 3: Merging AI analysis into dashboard ==="
+    python -m payload_monitor \
+        --merge-analysis "${ANALYSIS_JSON}" \
+        --output "${DASHBOARD_PATH}" || echo "Warning: Failed to merge analysis."
+    cp "${DASHBOARD_PATH}" "${ARTIFACT_DIR}/" 2>/dev/null || true
+    echo "Dashboard updated with AI analysis."
+else
+    echo "No analysis JSON produced. Dashboard remains without AI enrichment."
+fi
+
+# ===========================================================================
+# JUnit XML for CI tracking
+# ===========================================================================
+TOTAL_DURATION=$(( PHASE_MONITOR_DURATION + PHASE_ANALYSIS_DURATION + PHASE_NUDGE_DURATION ))
+JUNIT_FILE="${ARTIFACT_DIR}/junit_edge-monitor.xml"
+
+PHASE_PREFIX="[sig-edge-enablement]"
+PHASE_CASES="  <testcase name=\"${PHASE_PREFIX} Phase: dashboard generation\" time=\"${PHASE_MONITOR_DURATION}\"/>
+  <testcase name=\"${PHASE_PREFIX} Phase: AI analysis\" time=\"${PHASE_ANALYSIS_DURATION}\"/>"
+PHASE_COUNT=2
+
+FAILURE_COUNT=0
+TIMEOUT_CASES=""
+TIMEOUT_TEST_COUNT=1
+
+if [[ "${CLAUDE_EXIT}" -eq 124 ]]; then
+    FAILURE_COUNT=1
+    TIMEOUT_CASES="  <testcase name=\"${PHASE_PREFIX} Claude should complete in a reasonable time\" time=\"${PHASE_ANALYSIS_DURATION}\">
+    <failure message=\"Claude timed out.\">Claude exceeded the time limit and had to be nudged to wrap up.</failure>
+  </testcase>"
+
+    PHASE_CASES="${PHASE_CASES}
+  <testcase name=\"${PHASE_PREFIX} Phase: recovery nudge\" time=\"${PHASE_NUDGE_DURATION}\"/>"
+    PHASE_COUNT=3
+
+    if [[ "${NUDGE_EXIT}" -ne 0 ]] && [[ ! -f "${ANALYSIS_JSON}" ]]; then
+        FAILURE_COUNT=2
+        TIMEOUT_TEST_COUNT=2
+        TIMEOUT_CASES="${TIMEOUT_CASES}
+  <testcase name=\"${PHASE_PREFIX} Claude should recover after nudge\" time=\"${PHASE_NUDGE_DURATION}\">
+    <failure message=\"Claude failed to recover\">Claude was nudged but did not produce analysis (exit: ${NUDGE_EXIT}).</failure>
+  </testcase>"
+    fi
+else
+    TIMEOUT_CASES="  <testcase name=\"${PHASE_PREFIX} Claude should complete in a reasonable time\" time=\"${PHASE_ANALYSIS_DURATION}\"/>"
+fi
+
+TEST_COUNT=$(( PHASE_COUNT + TIMEOUT_TEST_COUNT ))
+cat > "${JUNIT_FILE}" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="edge-payload-monitor" tests="${TEST_COUNT}" failures="${FAILURE_COUNT}" time="${TOTAL_DURATION}">
+${PHASE_CASES}
+${TIMEOUT_CASES}
+</testsuite>
+EOF
+
+echo ""
+echo "JUnit XML written to ${JUNIT_FILE}"
+echo "=== Edge Payload Monitor complete ==="

--- a/ci-operator/step-registry/openshift/claude/edge-monitor/openshift-claude-edge-monitor-commands.sh
+++ b/ci-operator/step-registry/openshift/claude/edge-monitor/openshift-claude-edge-monitor-commands.sh
@@ -12,6 +12,31 @@ echo "Started at $(date -u '+%Y-%m-%d %H:%M UTC')"
 # ---------------------------------------------------------------------------
 set +x
 
+if [[ -f "${GITHUB_APP_ID_PATH}" ]] && [[ -f "${GITHUB_KEY_PATH}" ]]; then
+    GH_TOKEN_VER="2.0.8"
+    GH_TOKEN_SHA="867d9ebf7dd18e67e2599f0f890f3f41b8673e88c4394a32a05476024c41ea0f"
+    GH_TOKEN_EXE="/tmp/gh-token-${GH_TOKEN_VER}"
+
+    curl -sSL "https://github.com/Link-/gh-token/releases/download/v${GH_TOKEN_VER}/linux-amd64" -o "${GH_TOKEN_EXE}"
+    if ! echo "${GH_TOKEN_SHA}  ${GH_TOKEN_EXE}" | sha256sum -c -; then
+        echo "ERROR: Failed to verify gh-token checksum."
+        exit 1
+    fi
+    chmod +x "${GH_TOKEN_EXE}"
+
+    GITHUB_TOKEN="$("${GH_TOKEN_EXE}" generate --app-id "$(< "${GITHUB_APP_ID_PATH}")" --key "${GITHUB_KEY_PATH}" | jq -r '.token')"
+    rm -f "${GH_TOKEN_EXE}"
+    if [[ -z "${GITHUB_TOKEN}" ]] || [[ "${GITHUB_TOKEN}" == "null" ]]; then
+        echo "ERROR: Failed to generate GitHub token from App credentials."
+        exit 1
+    fi
+    export GITHUB_TOKEN
+    echo "GitHub token generated."
+else
+    echo "ERROR: GitHub App credentials not found. Cannot clone edge-tooling."
+    exit 1
+fi
+
 if [[ -f "${JIRA_API_TOKEN_PATH}" ]]; then
     export JIRA_TOKEN
     JIRA_TOKEN=$(cat "${JIRA_API_TOKEN_PATH}")
@@ -110,7 +135,7 @@ trap copy_artifacts EXIT TERM INT
 # Clone and set up payload-monitor
 # ---------------------------------------------------------------------------
 echo "Cloning edge-tooling repository..."
-git clone --depth 1 --branch main https://github.com/openshift-eng/edge-tooling.git
+gh repo clone openshift-eng/edge-tooling edge-tooling -- --depth 1 --branch main
 cd edge-tooling/payload-monitor
 
 echo "Setting up Python environment..."
@@ -148,17 +173,21 @@ fi
 PHASE_MONITOR_START=$(date +%s)
 
 # stdout has blocking markers, stderr has logging
+MONITOR_EXIT=0
 python -m payload_monitor "${MONITOR_ARGS[@]}" \
     > "${WORKDIR}/monitor-stdout.txt" \
-    2> >(tee "${ARTIFACT_DIR}/monitor.log" >&2) || {
-    echo "Warning: Payload monitor exited with non-zero status."
-}
+    2> >(tee "${ARTIFACT_DIR}/monitor.log" >&2) || MONITOR_EXIT=$?
 
 PHASE_MONITOR_DURATION=$(( $(date +%s) - PHASE_MONITOR_START ))
 
-# Copy initial dashboard to artifacts immediately
+# Copy initial dashboard to artifacts immediately (even on failure)
 cp "${DASHBOARD_PATH}" "${ARTIFACT_DIR}/" 2>/dev/null || true
 cp "${JSON_PATH}" "${ARTIFACT_DIR}/" 2>/dev/null || true
+
+if [[ "${MONITOR_EXIT}" -ne 0 ]]; then
+    echo "ERROR: Payload monitor failed with exit code ${MONITOR_EXIT}."
+    exit "${MONITOR_EXIT}"
+fi
 
 BLOCKING_COUNT=$(grep -c "^BLOCKING|" "${WORKDIR}/monitor-stdout.txt" 2>/dev/null || true)
 BLOCKING_LIST=$(grep "^BLOCKING|" "${WORKDIR}/monitor-stdout.txt" 2>/dev/null || true)

--- a/ci-operator/step-registry/openshift/claude/edge-monitor/openshift-claude-edge-monitor-ref.yaml
+++ b/ci-operator/step-registry/openshift/claude/edge-monitor/openshift-claude-edge-monitor-ref.yaml
@@ -1,0 +1,54 @@
+ref:
+  as: openshift-claude-edge-monitor
+  from_image:
+    namespace: ci
+    name: claude-ai-helpers
+    tag: latest
+  commands: openshift-claude-edge-monitor-commands.sh
+  credentials:
+  - namespace: test-credentials
+    name: hypershift-team-claude-prow
+    mount_path: /var/run/claude-code-service-account
+  - namespace: test-credentials
+    name: claude-payload-agent-jira-token
+    mount_path: /var/run/jira-token
+  env:
+  - name: MONITOR_VERSIONS
+    default: ""
+    documentation: |-
+      Comma-separated OCP versions to monitor (e.g., '4.18,4.19').
+      Empty string monitors all configured versions.
+  - name: SKIP_PROW
+    default: "false"
+    documentation: Skip Prow artifact enrichment for faster runs.
+  - name: WITH_TIMING
+    default: "false"
+    documentation: Include install/upgrade timing insights.
+  - name: CLAUDE_CODE_USE_VERTEX
+    default: "1"
+  - name: CLOUD_ML_REGION
+    default: "us-east5"
+  - name: ANTHROPIC_VERTEX_PROJECT_ID
+    default: "itpc-gcp-hybrid-pe-eng-claude"
+  - name: GOOGLE_APPLICATION_CREDENTIALS
+    default: "/var/run/claude-code-service-account/claude-prow"
+  - name: CLAUDE_MODEL
+    default: "claude-sonnet-4-6"
+  - name: JIRA_API_TOKEN_PATH
+    default: "/var/run/jira-token/token"
+    documentation: |-
+      Path to JIRA API token for searching existing bugs.
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+  timeout: 4h0m0s
+  grace_period: 1m0s
+  documentation: |-
+    Runs the Edge Enablement Payload Monitor to generate an interactive
+    HTML dashboard of nightly payload health across edge topologies
+    (SNO, TNA, TNF). Collects data from Release Controller, Sippy,
+    Component Readiness, and Prow artifacts, then invokes Claude to
+    analyze blocking failures and enrich the dashboard with root-cause
+    analysis. Slack notifications are handled by Prow's reporter_config
+    on the generated periodic job.

--- a/ci-operator/step-registry/openshift/claude/edge-monitor/openshift-claude-edge-monitor-ref.yaml
+++ b/ci-operator/step-registry/openshift/claude/edge-monitor/openshift-claude-edge-monitor-ref.yaml
@@ -10,6 +10,9 @@ ref:
     name: hypershift-team-claude-prow
     mount_path: /var/run/claude-code-service-account
   - namespace: test-credentials
+    name: pr-creds
+    mount_path: /var/run/pr-creds
+  - namespace: test-credentials
     name: claude-payload-agent-jira-token
     mount_path: /var/run/jira-token
   env:
@@ -34,6 +37,14 @@ ref:
     default: "/var/run/claude-code-service-account/claude-prow"
   - name: CLAUDE_MODEL
     default: "claude-sonnet-4-6"
+  - name: GITHUB_APP_ID_PATH
+    default: "/var/run/pr-creds/app_id"
+    documentation: |-
+      Path to GitHub App ID for generating installation tokens.
+  - name: GITHUB_KEY_PATH
+    default: "/var/run/pr-creds/key.pem"
+    documentation: |-
+      Path to GitHub App private key for generating installation tokens.
   - name: JIRA_API_TOKEN_PATH
     default: "/var/run/jira-token/token"
     documentation: |-

--- a/ci-operator/step-registry/openshift/claude/edge-monitor/openshift-claude-edge-monitor-workflow.yaml
+++ b/ci-operator/step-registry/openshift/claude/edge-monitor/openshift-claude-edge-monitor-workflow.yaml
@@ -1,0 +1,13 @@
+workflow:
+  as: openshift-claude-edge-monitor
+  steps:
+    test:
+    - ref: openshift-claude-edge-monitor
+    post:
+    - ref: openshift-claude-post
+  documentation: |-
+    Runs the Edge Enablement Payload Monitor to generate an interactive
+    dashboard of nightly payload health across edge topologies (SNO, TNA,
+    TNF), enriches it with Claude AI analysis of blocking failures, and
+    sends a Slack notification. The post step generates a continue-session
+    HTML page for resuming the Claude session locally.

--- a/ci-operator/step-registry/openshift/edge-tooling/OWNERS
+++ b/ci-operator/step-registry/openshift/edge-tooling/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+  - edge-enablement-approvers
+reviewers:
+  - edge-enablement-reviewers

--- a/ci-operator/step-registry/openshift/edge-tooling/OWNERS
+++ b/ci-operator/step-registry/openshift/edge-tooling/OWNERS
@@ -2,3 +2,4 @@ approvers:
   - edge-enablement-approvers
 reviewers:
   - edge-enablement-reviewers
+  - microshift-reviewers

--- a/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/OWNERS
+++ b/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+  - edge-enablement-approvers
+reviewers:
+  - edge-enablement-reviewers

--- a/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/OWNERS
+++ b/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/OWNERS
@@ -2,3 +2,4 @@ approvers:
   - edge-enablement-approvers
 reviewers:
   - edge-enablement-reviewers
+  - microshift-reviewers

--- a/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-commands.sh
+++ b/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-commands.sh
@@ -125,7 +125,7 @@ echo "Cloning edge-tooling repository..."
 gh repo clone openshift-eng/edge-tooling edge-tooling -- --depth 1 --branch main
 
 # ---------------------------------------------------------------------------
-# Install marketplace plugins for CI analysis skills
+# Register local marketplaces and install plugins
 # ---------------------------------------------------------------------------
 # Workaround: --continue + -p is broken (anthropics/claude-code#42376).
 export CLAUDE_CODE_ENTRYPOINT=cli
@@ -133,9 +133,13 @@ export CLAUDE_CODE_ENTRYPOINT=cli
 echo "Cloning ai-helpers for CI analysis skills..."
 gh repo clone openshift-eng/ai-helpers ai-helpers -- --depth 1 --branch main
 
-echo "Installing plugins from local clones..."
-claude plugin install "${WORKDIR}/edge-tooling"
-claude plugin install "${WORKDIR}/ai-helpers"
+echo "Registering local marketplaces..."
+claude plugin marketplace add "${WORKDIR}/edge-tooling"
+claude plugin marketplace add "${WORKDIR}/ai-helpers"
+
+echo "Installing plugins..."
+claude plugin install edge-ocp-ci
+claude plugin install ci
 
 # ---------------------------------------------------------------------------
 # Build skill arguments from env vars

--- a/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-commands.sh
+++ b/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-commands.sh
@@ -46,8 +46,20 @@ fi
 # ---------------------------------------------------------------------------
 # Install gcloud CLI for Prow artifact access (no root required)
 # ---------------------------------------------------------------------------
-echo "Installing gcloud CLI..."
-curl -sSL --connect-timeout 10 --max-time 300 --fail https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-linux-x86_64.tar.gz | tar -xz -C /tmp
+GCLOUD_VER="565.0.0"
+GCLOUD_SHA="733e3640b5892baecd997474cb1b2cfe80204b6584c64166c3d78bae3f1108c3"
+GCLOUD_TGZ="/tmp/google-cloud-cli.tar.gz"
+
+echo "Installing gcloud CLI ${GCLOUD_VER}..."
+curl -sSL --connect-timeout 10 --max-time 300 --fail \
+    "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${GCLOUD_VER}-linux-x86_64.tar.gz" \
+    -o "${GCLOUD_TGZ}"
+if ! echo "${GCLOUD_SHA}  ${GCLOUD_TGZ}" | sha256sum -c -; then
+    echo "ERROR: Failed to verify gcloud CLI checksum."
+    exit 1
+fi
+tar -xzf "${GCLOUD_TGZ}" -C /tmp
+rm -f "${GCLOUD_TGZ}"
 /tmp/google-cloud-sdk/install.sh --quiet --path-update true
 export PATH="/tmp/google-cloud-sdk/bin:${PATH}"
 
@@ -229,6 +241,11 @@ if [[ "${CLAUDE_EXIT}" -eq 124 ]]; then
     <failure message=\"Claude failed to recover\">Claude was nudged but did not produce analysis (exit: ${NUDGE_EXIT}).</failure>
   </testcase>"
     fi
+elif [[ "${CLAUDE_EXIT}" -ne 0 ]]; then
+    FAILURE_COUNT=1
+    TIMEOUT_CASES="  <testcase name=\"${PHASE_PREFIX} Claude should complete successfully\" time=\"${PHASE_DURATION}\">
+    <failure message=\"Claude exited with code ${CLAUDE_EXIT}\">Claude failed with exit code ${CLAUDE_EXIT}.</failure>
+  </testcase>"
 else
     TIMEOUT_CASES="  <testcase name=\"${PHASE_PREFIX} Claude should complete in a reasonable time\" time=\"${PHASE_DURATION}\"/>"
 fi

--- a/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-commands.sh
+++ b/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-commands.sh
@@ -4,7 +4,7 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
-echo "=== Edge Enablement Payload Monitor ==="
+echo "=== Edge Enablement CI Monitor ==="
 echo "Started at $(date -u '+%Y-%m-%d %H:%M UTC')"
 
 # ---------------------------------------------------------------------------
@@ -87,7 +87,7 @@ cat > "${CLAUDE_HOME}/settings.json" <<'EOF'
       "Bash(python -m payload_monitor:*)",
       "Bash(python3 -m payload_monitor:*)",
       "Skill(ci:*)",
-      "Skill(generate-dashboard)"
+      "Skill(edge-ocp-ci:*)"
     ]
   }
 }
@@ -102,8 +102,8 @@ cd "${WORKDIR}"
 
 copy_artifacts() {
     echo "Copying artifacts to ${ARTIFACT_DIR}..."
-    find "${WORKDIR}" -maxdepth 2 -name "*.html" -exec cp {} "${ARTIFACT_DIR}/" \; 2>/dev/null || true
-    find "${WORKDIR}" -maxdepth 2 -name "*.json" \
+    find "${WORKDIR}" -maxdepth 3 -name "*.html" -exec cp {} "${ARTIFACT_DIR}/" \; 2>/dev/null || true
+    find "${WORKDIR}" -maxdepth 3 -name "*.json" \
         -not -path "*/.venv/*" -not -path "*/node_modules/*" \
         -exec cp {} "${ARTIFACT_DIR}/" \; 2>/dev/null || true
 
@@ -119,155 +119,81 @@ copy_artifacts() {
 trap copy_artifacts EXIT TERM INT
 
 # ---------------------------------------------------------------------------
-# Clone and set up payload-monitor
+# Clone edge-tooling (needed for payload-monitor tool and plugin skills)
 # ---------------------------------------------------------------------------
 echo "Cloning edge-tooling repository..."
 gh repo clone openshift-eng/edge-tooling edge-tooling -- --depth 1 --branch main
-cd edge-tooling/payload-monitor
 
-echo "Setting up Python environment..."
-python3 -m venv .venv
-source .venv/bin/activate
-pip install -q -r requirements.txt
-
-# ===========================================================================
-# Phase 1: Generate dashboard (deterministic, no AI)
-# ===========================================================================
-echo ""
-echo "=== Phase 1: Generating payload dashboard ==="
-
-DASHBOARD_PATH="${WORKDIR}/edge-payload-dashboard.html"
-JSON_PATH="${WORKDIR}/edge-payload-dashboard.json"
-
-MONITOR_ARGS=(
-    --output "${DASHBOARD_PATH}"
-    --json
-    --verbose
-)
-
-if [[ -n "${MONITOR_VERSIONS}" ]]; then
-    MONITOR_ARGS+=(--versions "${MONITOR_VERSIONS}")
-fi
-
-if [[ "${SKIP_PROW}" == "true" ]]; then
-    MONITOR_ARGS+=(--skip-prow)
-fi
-
-if [[ "${WITH_TIMING}" == "true" ]]; then
-    MONITOR_ARGS+=(--with-timing)
-fi
-
-PHASE_MONITOR_START=$(date +%s)
-
-# stdout has blocking markers, stderr has logging
-MONITOR_EXIT=0
-python -m payload_monitor "${MONITOR_ARGS[@]}" \
-    > "${WORKDIR}/monitor-stdout.txt" \
-    2> >(tee "${ARTIFACT_DIR}/monitor.log" >&2) || MONITOR_EXIT=$?
-
-PHASE_MONITOR_DURATION=$(( $(date +%s) - PHASE_MONITOR_START ))
-
-# Copy initial dashboard to artifacts immediately (even on failure)
-cp "${DASHBOARD_PATH}" "${ARTIFACT_DIR}/" 2>/dev/null || true
-cp "${JSON_PATH}" "${ARTIFACT_DIR}/" 2>/dev/null || true
-
-if [[ "${MONITOR_EXIT}" -ne 0 ]]; then
-    echo "ERROR: Payload monitor failed with exit code ${MONITOR_EXIT}."
-    exit "${MONITOR_EXIT}"
-fi
-
-BLOCKING_COUNT=$(grep -c "^BLOCKING|" "${WORKDIR}/monitor-stdout.txt" 2>/dev/null || true)
-BLOCKING_LIST=$(grep "^BLOCKING|" "${WORKDIR}/monitor-stdout.txt" 2>/dev/null || true)
-echo "Found ${BLOCKING_COUNT} blocking job failures."
-
-# No blocking failures — exit early
-if [[ "${BLOCKING_COUNT}" -eq 0 ]]; then
-    echo "No blocking failures detected across monitored topologies."
-    exit 0
-fi
-
-# ===========================================================================
-# Phase 2: Claude AI analysis (best-effort)
-# ===========================================================================
-echo ""
-echo "=== Phase 2: Claude AI analysis of ${BLOCKING_COUNT} blocking failures ==="
-
+# ---------------------------------------------------------------------------
+# Install marketplace plugins for CI analysis skills
+# ---------------------------------------------------------------------------
 # Workaround: --continue + -p is broken (anthropics/claude-code#42376).
 export CLAUDE_CODE_ENTRYPOINT=cli
 
-# Install marketplace plugins for CI analysis skills
 echo "Installing marketplace plugins..."
-claude plugin install openshift-eng/edge-tooling 2>/dev/null || echo "Warning: edge-tooling marketplace install failed."
-claude plugin install openshift-eng/ai-helpers 2>/dev/null || echo "Warning: ai-helpers marketplace install failed."
+claude plugin install openshift-eng/edge-tooling
+claude plugin install openshift-eng/ai-helpers
 
-ANALYSIS_JSON="${WORKDIR}/analysis.json"
+# ---------------------------------------------------------------------------
+# Build skill arguments from env vars
+# ---------------------------------------------------------------------------
+SKILL_ARGS=""
+if [[ -n "${MONITOR_VERSIONS}" ]]; then
+    SKILL_ARGS+="--versions ${MONITOR_VERSIONS} "
+fi
+if [[ "${SKIP_PROW}" == "true" ]]; then
+    SKILL_ARGS+="--skip-prow "
+fi
+if [[ "${WITH_TIMING}" == "true" ]]; then
+    SKILL_ARGS+="--with-timing "
+fi
+
+# ===========================================================================
+# Invoke Claude with the generate-dashboard skill
+# ===========================================================================
+echo ""
+echo "=== Invoking Claude with edge-ocp-ci:generate-dashboard ==="
+
 ALLOWED_TOOLS="Agent Bash Read Write Edit Grep Glob WebFetch WebSearch Task Skill"
 
-PHASE_ANALYSIS_START=$(date +%s)
+PHASE_START=$(date +%s)
 CLAUDE_EXIT=0
 timeout 3600 claude \
     --model "${CLAUDE_MODEL}" \
     --allowedTools "${ALLOWED_TOOLS}" \
     --output-format stream-json \
     --max-turns 80 \
-    -p "Load the /edge-ocp-ci:generate-dashboard skill.
-
-Phase 1 (Steps 1-3) is already complete. The payload monitor has run and produced:
-- HTML dashboard: ${DASHBOARD_PATH}
-- JSON report: ${JSON_PATH}
-- Python tool directory: $(pwd) (venv already activated)
-
-The following blocking jobs were detected:
-${BLOCKING_LIST}
-
-Start from Step 4 of the skill. Analyze each blocking failure, write the analysis
-JSON to ${ANALYSIS_JSON}, then merge it into the dashboard (Steps 4-6)." \
+    -p "/edge-ocp-ci:generate-dashboard ${SKILL_ARGS}" \
     --verbose 2>&1 | tee "${ARTIFACT_DIR}/claude-analysis.log" || CLAUDE_EXIT=$?
 
-PHASE_ANALYSIS_DURATION=$(( $(date +%s) - PHASE_ANALYSIS_START ))
+PHASE_DURATION=$(( $(date +%s) - PHASE_START ))
 
 # Handle timeout — nudge Claude to wrap up
 PHASE_NUDGE_START=$(date +%s)
 NUDGE_EXIT=0
 if [[ "${CLAUDE_EXIT}" -eq 124 ]]; then
     echo ""
-    echo "Claude analysis timed out. Nudging to wrap up..."
+    echo "Claude timed out. Nudging to wrap up..."
     timeout 600 claude \
         --model "${CLAUDE_MODEL}" \
         --continue \
         --allowedTools "${ALLOWED_TOOLS}" \
         --output-format stream-json \
         --max-turns 10 \
-        -p "Time is up. Write the analysis JSON to ${ANALYSIS_JSON} immediately with whatever findings you have." \
+        -p "Time is up. Write whatever analysis you have to the JSON file now (Step 5), then merge into the dashboard (Step 6)." \
         --verbose 2>&1 | tee -a "${ARTIFACT_DIR}/claude-analysis.log" || NUDGE_EXIT=$?
 fi
 PHASE_NUDGE_DURATION=$(( $(date +%s) - PHASE_NUDGE_START ))
 
 # ===========================================================================
-# Phase 3: Merge analysis into dashboard
-# ===========================================================================
-if [[ -f "${ANALYSIS_JSON}" ]]; then
-    echo ""
-    echo "=== Phase 3: Merging AI analysis into dashboard ==="
-    python -m payload_monitor \
-        --merge-analysis "${ANALYSIS_JSON}" \
-        --output "${DASHBOARD_PATH}" || echo "Warning: Failed to merge analysis."
-    cp "${DASHBOARD_PATH}" "${ARTIFACT_DIR}/" 2>/dev/null || true
-    echo "Dashboard updated with AI analysis."
-else
-    echo "No analysis JSON produced. Dashboard remains without AI enrichment."
-fi
-
-# ===========================================================================
 # JUnit XML for CI tracking
 # ===========================================================================
-TOTAL_DURATION=$(( PHASE_MONITOR_DURATION + PHASE_ANALYSIS_DURATION + PHASE_NUDGE_DURATION ))
+TOTAL_DURATION=$(( PHASE_DURATION + PHASE_NUDGE_DURATION ))
 JUNIT_FILE="${ARTIFACT_DIR}/junit_ci-monitor.xml"
 
 PHASE_PREFIX="[sig-edge-enablement]"
-PHASE_CASES="  <testcase name=\"${PHASE_PREFIX} Phase: dashboard generation\" time=\"${PHASE_MONITOR_DURATION}\"/>
-  <testcase name=\"${PHASE_PREFIX} Phase: AI analysis\" time=\"${PHASE_ANALYSIS_DURATION}\"/>"
-PHASE_COUNT=2
+PHASE_CASES="  <testcase name=\"${PHASE_PREFIX} CI monitor\" time=\"${PHASE_DURATION}\"/>"
+PHASE_COUNT=1
 
 FAILURE_COUNT=0
 TIMEOUT_CASES=""
@@ -275,15 +201,15 @@ TIMEOUT_TEST_COUNT=1
 
 if [[ "${CLAUDE_EXIT}" -eq 124 ]]; then
     FAILURE_COUNT=1
-    TIMEOUT_CASES="  <testcase name=\"${PHASE_PREFIX} Claude should complete in a reasonable time\" time=\"${PHASE_ANALYSIS_DURATION}\">
+    TIMEOUT_CASES="  <testcase name=\"${PHASE_PREFIX} Claude should complete in a reasonable time\" time=\"${PHASE_DURATION}\">
     <failure message=\"Claude timed out.\">Claude exceeded the time limit and had to be nudged to wrap up.</failure>
   </testcase>"
 
     PHASE_CASES="${PHASE_CASES}
-  <testcase name=\"${PHASE_PREFIX} Phase: recovery nudge\" time=\"${PHASE_NUDGE_DURATION}\"/>"
-    PHASE_COUNT=3
+  <testcase name=\"${PHASE_PREFIX} Recovery nudge\" time=\"${PHASE_NUDGE_DURATION}\"/>"
+    PHASE_COUNT=2
 
-    if [[ "${NUDGE_EXIT}" -ne 0 ]] && [[ ! -f "${ANALYSIS_JSON}" ]]; then
+    if [[ "${NUDGE_EXIT}" -ne 0 ]]; then
         FAILURE_COUNT=2
         TIMEOUT_TEST_COUNT=2
         TIMEOUT_CASES="${TIMEOUT_CASES}
@@ -292,13 +218,13 @@ if [[ "${CLAUDE_EXIT}" -eq 124 ]]; then
   </testcase>"
     fi
 else
-    TIMEOUT_CASES="  <testcase name=\"${PHASE_PREFIX} Claude should complete in a reasonable time\" time=\"${PHASE_ANALYSIS_DURATION}\"/>"
+    TIMEOUT_CASES="  <testcase name=\"${PHASE_PREFIX} Claude should complete in a reasonable time\" time=\"${PHASE_DURATION}\"/>"
 fi
 
 TEST_COUNT=$(( PHASE_COUNT + TIMEOUT_TEST_COUNT ))
 cat > "${JUNIT_FILE}" <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="edge-payload-monitor" tests="${TEST_COUNT}" failures="${FAILURE_COUNT}" time="${TOTAL_DURATION}">
+<testsuite name="edge-ci-monitor" tests="${TEST_COUNT}" failures="${FAILURE_COUNT}" time="${TOTAL_DURATION}">
 ${PHASE_CASES}
 ${TIMEOUT_CASES}
 </testsuite>
@@ -306,4 +232,4 @@ EOF
 
 echo ""
 echo "JUnit XML written to ${JUNIT_FILE}"
-echo "=== Edge Payload Monitor complete ==="
+echo "=== Edge CI Monitor complete ==="

--- a/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-commands.sh
+++ b/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-commands.sh
@@ -43,6 +43,12 @@ if [[ -f "${JIRA_API_TOKEN_PATH}" ]]; then
     echo "JIRA token loaded."
 fi
 
+if [[ -f "${JIRA_USERNAME_PATH}" ]]; then
+    export JIRA_USERNAME
+    JIRA_USERNAME=$(cat "${JIRA_USERNAME_PATH}")
+    echo "JIRA username loaded."
+fi
+
 # ---------------------------------------------------------------------------
 # Install gcloud CLI for Prow artifact access (no root required)
 # ---------------------------------------------------------------------------

--- a/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-commands.sh
+++ b/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-commands.sh
@@ -182,7 +182,7 @@ ALLOWED_TOOLS="Agent Bash Read Write Edit Grep Glob WebFetch WebSearch Task Skil
 
 PHASE_START=$(date +%s)
 CLAUDE_EXIT=0
-timeout 3600 claude \
+timeout 7200 claude \
     --model "${CLAUDE_MODEL}" \
     --allowedTools "${ALLOWED_TOOLS}" \
     --output-format stream-json \

--- a/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-commands.sh
+++ b/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-commands.sh
@@ -17,7 +17,7 @@ if [[ -f "${GITHUB_APP_ID_PATH}" ]] && [[ -f "${GITHUB_KEY_PATH}" ]]; then
     GH_TOKEN_SHA="867d9ebf7dd18e67e2599f0f890f3f41b8673e88c4394a32a05476024c41ea0f"
     GH_TOKEN_EXE="/tmp/gh-token-${GH_TOKEN_VER}"
 
-    curl -sSL "https://github.com/Link-/gh-token/releases/download/v${GH_TOKEN_VER}/linux-amd64" -o "${GH_TOKEN_EXE}"
+    curl -sSL --connect-timeout 10 --max-time 30 --fail "https://github.com/Link-/gh-token/releases/download/v${GH_TOKEN_VER}/linux-amd64" -o "${GH_TOKEN_EXE}"
     if ! echo "${GH_TOKEN_SHA}  ${GH_TOKEN_EXE}" | sha256sum -c -; then
         echo "ERROR: Failed to verify gh-token checksum."
         exit 1
@@ -44,21 +44,10 @@ if [[ -f "${JIRA_API_TOKEN_PATH}" ]]; then
 fi
 
 # ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-build_prow_url() {
-    if [[ "${JOB_TYPE:-}" == "presubmit" ]]; then
-        echo "https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/${REPO_OWNER}_${REPO_NAME}/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
-    else
-        echo "https://prow.ci.openshift.org/view/gs/test-platform-results/logs/${JOB_NAME}/${BUILD_ID}"
-    fi
-}
-
-# ---------------------------------------------------------------------------
 # Install gcloud CLI for Prow artifact access (no root required)
 # ---------------------------------------------------------------------------
 echo "Installing gcloud CLI..."
-curl -sSL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-linux-x86_64.tar.gz | tar -xz -C /tmp
+curl -sSL --connect-timeout 10 --max-time 300 --fail https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-linux-x86_64.tar.gz | tar -xz -C /tmp
 /tmp/google-cloud-sdk/install.sh --quiet --path-update true
 export PATH="/tmp/google-cloud-sdk/bin:${PATH}"
 
@@ -108,10 +97,8 @@ echo "Claude permissions configured."
 # ---------------------------------------------------------------------------
 # Set up workspace
 # ---------------------------------------------------------------------------
-WORKDIR=$(mktemp -d /tmp/edge-monitor-XXXXXX)
+WORKDIR=$(mktemp -d /tmp/ci-monitor-XXXXXX)
 cd "${WORKDIR}"
-
-PROW_JOB_URL=$(build_prow_url)
 
 copy_artifacts() {
     echo "Copying artifacts to ${ARTIFACT_DIR}..."
@@ -214,11 +201,7 @@ claude plugin install openshift-eng/edge-tooling 2>/dev/null || echo "Warning: e
 claude plugin install openshift-eng/ai-helpers 2>/dev/null || echo "Warning: ai-helpers marketplace install failed."
 
 ANALYSIS_JSON="${WORKDIR}/analysis.json"
-ALLOWED_TOOLS="Bash Read Write Edit Grep Glob WebFetch WebSearch Task Skill"
-
-SYSTEM_PROMPT="You are analyzing edge payload monitoring results for OpenShift nightly payloads.
-You have CI analysis skills available — load them using the Skill tool before starting.
-Focus on blocking job failures and identify root causes."
+ALLOWED_TOOLS="Agent Bash Read Write Edit Grep Glob WebFetch WebSearch Task Skill"
 
 PHASE_ANALYSIS_START=$(date +%s)
 CLAUDE_EXIT=0
@@ -227,19 +210,18 @@ timeout 3600 claude \
     --allowedTools "${ALLOWED_TOOLS}" \
     --output-format stream-json \
     --max-turns 80 \
-    --append-system-prompt "${SYSTEM_PROMPT}" \
-    -p "Analyze the edge payload monitor results. The JSON report is at: ${JSON_PATH}
+    -p "Load the /edge-ocp-ci:generate-dashboard skill.
 
-The following blocking jobs failed:
+Phase 1 (Steps 1-3) is already complete. The payload monitor has run and produced:
+- HTML dashboard: ${DASHBOARD_PATH}
+- JSON report: ${JSON_PATH}
+- Python tool directory: $(pwd) (venv already activated)
+
+The following blocking jobs were detected:
 ${BLOCKING_LIST}
 
-For each blocking failure:
-1. Load relevant CI skills (e.g., /ci:prow-job-analyze-test-failure)
-2. Investigate the Prow job artifacts to find root causes
-3. Check for existing JIRA bugs
-
-After analysis, write a JSON file to ${ANALYSIS_JSON} mapping each prow_url to its analysis summary:
-{\"<prow_url>\": \"<analysis text>\", ...}" \
+Start from Step 4 of the skill. Analyze each blocking failure, write the analysis
+JSON to ${ANALYSIS_JSON}, then merge it into the dashboard (Steps 4-6)." \
     --verbose 2>&1 | tee "${ARTIFACT_DIR}/claude-analysis.log" || CLAUDE_EXIT=$?
 
 PHASE_ANALYSIS_DURATION=$(( $(date +%s) - PHASE_ANALYSIS_START ))
@@ -280,7 +262,7 @@ fi
 # JUnit XML for CI tracking
 # ===========================================================================
 TOTAL_DURATION=$(( PHASE_MONITOR_DURATION + PHASE_ANALYSIS_DURATION + PHASE_NUDGE_DURATION ))
-JUNIT_FILE="${ARTIFACT_DIR}/junit_edge-monitor.xml"
+JUNIT_FILE="${ARTIFACT_DIR}/junit_ci-monitor.xml"
 
 PHASE_PREFIX="[sig-edge-enablement]"
 PHASE_CASES="  <testcase name=\"${PHASE_PREFIX} Phase: dashboard generation\" time=\"${PHASE_MONITOR_DURATION}\"/>

--- a/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-commands.sh
+++ b/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-commands.sh
@@ -130,9 +130,12 @@ gh repo clone openshift-eng/edge-tooling edge-tooling -- --depth 1 --branch main
 # Workaround: --continue + -p is broken (anthropics/claude-code#42376).
 export CLAUDE_CODE_ENTRYPOINT=cli
 
-echo "Installing marketplace plugins..."
-claude plugin install openshift-eng/edge-tooling
-claude plugin install openshift-eng/ai-helpers
+echo "Cloning ai-helpers for CI analysis skills..."
+gh repo clone openshift-eng/ai-helpers ai-helpers -- --depth 1 --branch main
+
+echo "Installing plugins from local clones..."
+claude plugin install "${WORKDIR}/edge-tooling"
+claude plugin install "${WORKDIR}/ai-helpers"
 
 # ---------------------------------------------------------------------------
 # Build skill arguments from env vars

--- a/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-commands.sh
+++ b/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-commands.sh
@@ -102,10 +102,15 @@ cd "${WORKDIR}"
 
 copy_artifacts() {
     echo "Copying artifacts to ${ARTIFACT_DIR}..."
-    find "${WORKDIR}" -maxdepth 3 -name "*.html" -exec cp {} "${ARTIFACT_DIR}/" \; 2>/dev/null || true
-    find "${WORKDIR}" -maxdepth 3 -name "*.json" \
-        -not -path "*/.venv/*" -not -path "*/node_modules/*" \
-        -exec cp {} "${ARTIFACT_DIR}/" \; 2>/dev/null || true
+    local report_dir="${WORKDIR}/edge-tooling/payload-monitor/reports"
+    if [[ -d "${report_dir}" ]]; then
+        local latest_html
+        latest_html=$(ls -t "${report_dir}"/*.html 2>/dev/null | head -1)
+        if [[ -n "${latest_html}" ]]; then
+            cp "${latest_html}" "${ARTIFACT_DIR}/edge-ci-monitor-summary.html"
+        fi
+        cp "${report_dir}"/*.json "${ARTIFACT_DIR}/" 2>/dev/null || true
+    fi
 
     # Archive Claude session for local continuation
     if [[ -d "${CLAUDE_HOME}/projects" ]]; then

--- a/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-ref.metadata.json
@@ -5,7 +5,8 @@
 			"edge-enablement-approvers"
 		],
 		"reviewers": [
-			"edge-enablement-reviewers"
+			"edge-enablement-reviewers",
+			"microshift-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-ref.metadata.json
@@ -1,0 +1,11 @@
+{
+	"path": "openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-ref.yaml",
+	"owners": {
+		"approvers": [
+			"edge-enablement-approvers"
+		],
+		"reviewers": [
+			"edge-enablement-reviewers"
+		]
+	}
+}

--- a/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-ref.yaml
+++ b/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-ref.yaml
@@ -49,6 +49,10 @@ ref:
     default: "/var/run/jira-token/token"
     documentation: |-
       Path to JIRA API token for searching existing bugs.
+  - name: JIRA_USERNAME_PATH
+    default: "/var/run/jira-token/username"
+    documentation: |-
+      Path to the Atlassian account email/username for JIRA Basic Auth.
   resources:
     requests:
       cpu: 500m

--- a/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-ref.yaml
+++ b/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-ref.yaml
@@ -1,10 +1,10 @@
 ref:
-  as: openshift-claude-edge-monitor
+  as: openshift-edge-tooling-ci-monitor
   from_image:
     namespace: ci
     name: claude-ai-helpers
     tag: latest
-  commands: openshift-claude-edge-monitor-commands.sh
+  commands: openshift-edge-tooling-ci-monitor-commands.sh
   credentials:
   - namespace: test-credentials
     name: hypershift-team-claude-prow

--- a/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-ref.yaml
+++ b/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-ref.yaml
@@ -25,7 +25,7 @@ ref:
     default: "false"
     documentation: Skip Prow artifact enrichment for faster runs.
   - name: WITH_TIMING
-    default: "false"
+    default: "true"
     documentation: Include install/upgrade timing insights.
   - name: CLAUDE_CODE_USE_VERTEX
     default: "1"

--- a/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-workflow.metadata.json
+++ b/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-workflow.metadata.json
@@ -5,7 +5,8 @@
 			"edge-enablement-approvers"
 		],
 		"reviewers": [
-			"edge-enablement-reviewers"
+			"edge-enablement-reviewers",
+			"microshift-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-workflow.metadata.json
+++ b/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-workflow.metadata.json
@@ -1,0 +1,11 @@
+{
+	"path": "openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-workflow.yaml",
+	"owners": {
+		"approvers": [
+			"edge-enablement-approvers"
+		],
+		"reviewers": [
+			"edge-enablement-reviewers"
+		]
+	}
+}

--- a/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-workflow.yaml
+++ b/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-workflow.yaml
@@ -1,8 +1,8 @@
 workflow:
-  as: openshift-claude-edge-monitor
+  as: openshift-edge-tooling-ci-monitor
   steps:
     test:
-    - ref: openshift-claude-edge-monitor
+    - ref: openshift-edge-tooling-ci-monitor
     post:
     - ref: openshift-claude-post
   documentation: |-


### PR DESCRIPTION
## Summary

  Adds a daily periodic job that monitors nightly OpenShift payload health across
  edge topologies (SNO, TNA, TNF) using the [edge-tooling payload-monitor](https://github.com/openshift-eng/edge-tooling/tree/main/payload-monitor).

  The dashboard is uploaded to the Prow artifacts tab and a Slack notification with
  a direct link is sent via Prow's reporter_config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Daily edge payload monitor producing an interactive dashboard (runs daily at 09:00 UTC).
  * AI-powered analysis that highlights and enriches blocking failures.
  * Slack notifications linking to dashboard results.

* **Chores**
  * Added CI/job and step/workflow configurations to run the monitor.
  * Set resource defaults for monitor jobs and added ownership metadata for reviewers/approvers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->