### PR TITLE
Fix GCP permissions for cri-o workflows by removing hardcoded cluster…

### DIFF
--- a/ci-operator/step-registry/cri-o/common/cri-o-common-workflow.yaml
+++ b/ci-operator/step-registry/cri-o/common/cri-o-common-workflow.yaml
@@ -1,7 +1,6 @@
 workflow:
   as: cri-o-common
   steps:
-    cluster_profile: gcp-3
     test:
       - ref: cri-o-common-test
   documentation: |-

--- a/ci-operator/step-registry/cri-o/e2e/cri-o-e2e-workflow.yaml
+++ b/ci-operator/step-registry/cri-o/e2e/cri-o-e2e-workflow.yaml
@@ -1,7 +1,6 @@
 workflow:
   as: cri-o-e2e
   steps:
-    cluster_profile: gcp-3
     pre:
       - ref: gcp-crio-provision-vpc
       - ref: gcp-crio-provision-buildhost

--- a/ci-operator/step-registry/cri-o/setup-fedora/cri-o-setup-fedora-workflow.yaml
+++ b/ci-operator/step-registry/cri-o/setup-fedora/cri-o-setup-fedora-workflow.yaml
@@ -1,7 +1,6 @@
 workflow:
   as: cri-o-setup-fedora
   steps:
-    cluster_profile: gcp-3
     pre:
       - ref: gcp-crio-provision-vpc
       - ref: gcp-crio-provision-buildhost

--- a/ci-operator/step-registry/cri-o/setup/cri-o-setup-workflow.yaml
+++ b/ci-operator/step-registry/cri-o/setup/cri-o-setup-workflow.yaml
@@ -1,7 +1,6 @@
 workflow:
   as: cri-o-setup
   steps:
-    cluster_profile: gcp-3
     pre:
       - ref: gcp-crio-provision-vpc
       - ref: gcp-crio-provision-buildhost


### PR DESCRIPTION
… profiles

cri-o CI jobs were failing with: "Required 'compute.images.useReadOnly' permission for 'projects/openshift-node-devel/global/images/crio-setup-*'"

Root cause: Commit 8586918ec32 migrated cri-o (and other org) configs to use the openshift-org-gcp cluster profile set. However, the cri-o workflows in step-registry still had cluster_profile: [gcp-3](https://redhat.atlassian.net/browse/gcp-3) hardcoded from commit 3e8085d267a (Nov 2023). The [gcp-3](https://redhat.atlassian.net/browse/gcp-3) profile lacks permissions to access images in the openshift-node-devel GCP project.

Solution: Remove cluster_profile from these 4 cri-o workflows:
- cri-o-e2e-workflow.yaml
- cri-o-common-workflow.yaml
- cri-o-setup-workflow.yaml
- cri-o-setup-fedora-workflow.yaml

This allows them to properly inherit from the config-level openshift-org-gcp cluster profile set, which includes gcp, gcp-arm64, gcp-openshift-gce-devel-ci-2, and [gcp-3](https://redhat.atlassian.net/browse/gcp-3). The scheduler can now select a profile with proper permissions for openshift-node-devel resources.

This follows the established pattern where 96% of workflows inherit cluster profiles from test configs rather than hardcoding them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CRI-O workflow configurations across four workflows by removing explicit cluster profile overrides to enable default cluster selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->