### PR TITLE
OTA-1954: bump cpou job for 4.20-4.22

### DIFF
--- a/ci-operator/config/openshift/verification-tests/openshift-verification-tests-main__ota-multi-stable-4.22-cpou-upgrade-from-stable-4.20.yaml
+++ b/ci-operator/config/openshift/verification-tests/openshift-verification-tests-main__ota-multi-stable-4.22-cpou-upgrade-from-stable-4.20.yaml
@@ -1,0 +1,72 @@
+base_images:
+  ansible:
+    name: "4.20"
+    namespace: ocp
+    tag: ansible
+  cli:
+    name: "4.20"
+    namespace: ocp
+    tag: cli
+  dev-scripts:
+    name: test
+    namespace: ocp-kni
+    tag: dev-scripts
+  openstack-installer:
+    name: "4.20"
+    namespace: ocp
+    tag: openstack-installer
+  tools:
+    name: "4.20"
+    namespace: ocp
+    tag: tools
+  upi-installer:
+    name: "4.20"
+    namespace: ocp
+    tag: upi-installer
+releases:
+  intermediate:
+    release:
+      architecture: multi
+      channel: candidate
+      version: "4.21"
+  latest:
+    release:
+      architecture: multi
+      channel: stable
+      version: "4.20"
+  target:
+    release:
+      architecture: multi
+      channel: candidate
+      version: "4.22"
+resources:
+  '*':
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: azure-ipi-arm-f28
+  cron: 17 21 21 * *
+  steps:
+    allow_skip_on_success: true
+    cluster_profile: azure-qe
+    env:
+      BASE_DOMAIN: qe.azure.devcluster.openshift.com
+      COMPUTE_NODE_TYPE: Standard_D4ps_v5
+      ENABLE_OTA_TEST: OCP-48683
+      OCP_ARCH: arm64
+    test:
+    - ref: cucushift-upgrade-setedge-2hops
+    - ref: cucushift-upgrade-drop-last-hop
+    - ref: cucushift-upgrade-setchannel
+    - ref: cucushift-upgrade-cpou-pause-worker-mcp
+    - ref: cucushift-chainupgrade-toversion
+    - ref: cucushift-upgrade-toversion
+    - ref: cucushift-upgrade-cpou-unpause-worker-mcp
+    - ref: cucushift-upgrade-healthcheck
+    workflow: cucushift-installer-rehearse-azure-ipi
+zz_generated_metadata:
+  branch: main
+  org: openshift
+  repo: verification-tests
+  variant: ota-multi-stable-4.22-cpou-upgrade-from-stable-4.20

--- a/ci-operator/jobs/openshift/verification-tests/openshift-verification-tests-main-periodics.yaml
+++ b/ci-operator/jobs/openshift/verification-tests/openshift-verification-tests-main-periodics.yaml
@@ -79039,6 +79039,88 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
+  cluster: build08
+  cron: 17 21 21 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: verification-tests
+  labels:
+    ci-operator.openshift.io/cloud: azure4
+    ci-operator.openshift.io/cloud-cluster-profile: azure-qe
+    ci-operator.openshift.io/variant: ota-multi-stable-4.22-cpou-upgrade-from-stable-4.20
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-verification-tests-main-ota-multi-stable-4.22-cpou-upgrade-from-stable-4.20-azure-ipi-arm-f28
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=azure-ipi-arm-f28
+      - --variant=ota-multi-stable-4.22-cpou-upgrade-from-stable-4.20
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
   cluster: build01
   cron: 52 11 2 * *
   decorate: true

--- a/ci-operator/step-registry/cucushift/upgrade/cpou/pause-worker-mcp/cucushift-upgrade-cpou-pause-worker-mcp-commands.sh
+++ b/ci-operator/step-registry/cucushift/upgrade/cpou/pause-worker-mcp/cucushift-upgrade-cpou-pause-worker-mcp-commands.sh
@@ -40,6 +40,17 @@ then
     source "${SHARED_DIR}/proxy-conf.sh"
 fi
 
+# Mimic https://github.com/openshift/installer/blob/98d5859f6cb6d2660cf9ffbed8885d9c9907ec56/pkg/asset/ignition/bootstrap/cvoignore.go#L142-L158
+# which is available from 4.21+
+installed_version=$(oc get clusterversion version -o jsonpath='{.status.history[-1].version}')
+echo "The installed version is $installed_version"
+if [[ $installed_version == "4.20."* ]]; then
+    echo "Overriding the cluster-scoped 'openshift' ClusterImagePolicy"
+    oc patch clusterversion version --type json -p '[{"op": "add", "path": "/spec/overrides", "value": [{"group": "config.openshift.io", "kind": "ClusterImagePolicy", "name": "openshift", "namespace": "", "unmanaged": true}]}]'
+    echo "Showing the ClusterVersion spec"
+    oc get clusterversion version -o jsonpath='{.spec}{"\n"}'
+fi
+
 # check all actual mcp, if any of them unknown then break the job.
 echo "Checking if there are unexpected mcps..."
 expected_mcp=("master" "worker")

--- a/cluster-profile-set-details.json
+++ b/cluster-profile-set-details.json
@@ -1,0 +1,19 @@
+{
+  "openshift-org-aws": [
+    "aws",
+    "aws-2",
+    "aws-3",
+    "aws-4",
+    "aws-5"
+  ],
+  "openshift-org-azure": [
+    "azure-2",
+    "azure4"
+  ],
+  "openshift-org-gcp": [
+    "gcp",
+    "gcp-arm64",
+    "gcp-openshift-gce-devel-ci-2",
+    "gcp-3"
+  ]
+}


### PR DESCRIPTION
Follow up https://github.com/openshift/release/pull/77224#issuecomment-4216795887

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated testing for OTA upgrade paths from OpenShift stable 4.20 → 4.21 → 4.22 to validate multi-architecture upgrades.
  * Added scheduled periodic execution targeting ARM Azure installs to broaden platform coverage and reliability.
  * Introduced shared cluster profile mappings to simplify cluster selection and resource requests for verification tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->