### PR TITLE
updating rhoe 4.22 clusters back to x86_64 and updating name so bot d…

### DIFF
--- a/clusters/hosted-mgmt/hive/pools/ocp-release-4.22.0-ec.5-for-4.22.0-0-to-4.23.0-0__clusterimageset.yaml
+++ b/clusters/hosted-mgmt/hive/pools/ocp-release-4.22.0-ec.5-for-4.22.0-0-to-4.23.0-0__clusterimageset.yaml
@@ -1,0 +1,12 @@
+apiVersion: hive.openshift.io/v1
+kind: ClusterImageSet
+metadata:
+  annotations:
+    version_lower: 4.22.0-0
+    version_stream: 4-dev-preview
+    version_upper: 4.23.0-0
+  creationTimestamp: null
+  name: ocp-release-4.22.0-ec.5-for-4.22.0-0-to-4.23.0-0
+spec:
+  releaseImage: quay.io/openshift-release-dev/ocp-release:4.22.0-ec.5-x86_64
+status: {}

--- a/clusters/hosted-mgmt/hive/pools/rh-openshift-ecosystem/rhoe-ocp-4-22-amd64-aws-us-west-1__clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/rh-openshift-ecosystem/rhoe-ocp-4-22-amd64-aws-us-west-1__clusterpool.yaml
@@ -18,7 +18,7 @@ spec:
   hibernationConfig:
     resumeTimeout: 20m0s
   imageSetRef:
-    name: ocp-release-4.22.0-ec.5-multi-for-4.22.0-0-to-4.23.0-0
+    name: ocp-release-4.22.0-ec.5-for-4.22.0-0-to-4.23.0-0
   installAttemptsLimit: 1
   installConfigSecretTemplateRef:
     name: install-config-4-22-amd64-aws-us-west-1

--- a/clusters/hosted-mgmt/hive/pools/rh-openshift-ecosystem/rhoe-ocp-4-22-amd64-aws-us-west-2__clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/rh-openshift-ecosystem/rhoe-ocp-4-22-amd64-aws-us-west-2__clusterpool.yaml
@@ -18,7 +18,7 @@ spec:
   hibernationConfig:
     resumeTimeout: 20m0s
   imageSetRef:
-    name: ocp-release-4.22.0-ec.5-multi-for-4.22.0-0-to-4.23.0-0
+    name: ocp-release-4.22.0-ec.5-for-4.22.0-0-to-4.23.0-0
   installAttemptsLimit: 1
   installConfigSecretTemplateRef:
     name: install-config-4-22-amd64-aws-us-west-2


### PR DESCRIPTION
…oesn't update changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated cluster pool configurations for OpenShift 4.22 deployments across AWS regions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->