### PR TITLE
OTA-1956: ci-operator/config/openshift/cluster-update-console-plugin: Promote to CI releases

### DIFF
--- a/ci-operator/config/openshift/cluster-update-console-plugin/openshift-cluster-update-console-plugin-main.yaml
+++ b/ci-operator/config/openshift/cluster-update-console-plugin/openshift-cluster-update-console-plugin-main.yaml
@@ -1,12 +1,19 @@
 build_root:
   from_repository: true
+images:
+  items:
+  - dockerfile_path: Dockerfile
+    to: cluster-update-console-plugin
+promotion:
+  to:
+  - name: "5.0"
+    namespace: ocp
 releases:
   latest:
-    candidate:
-      architecture: amd64
-      product: ocp
-      stream: nightly
-      version: "4.22"
+    integration:
+      include_built_images: true
+      name: "5.0"
+      namespace: ocp
 resources:
   '*':
     limits:

--- a/ci-operator/jobs/openshift/cluster-update-console-plugin/openshift-cluster-update-console-plugin-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-update-console-plugin/openshift-cluster-update-console-plugin-main-postsubmits.yaml
@@ -1,0 +1,60 @@
+postsubmits:
+  openshift/cluster-update-console-plugin:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    cluster: build01
+    decorate: true
+    labels:
+      ci-operator.openshift.io/is-promotion: "true"
+      ci.openshift.io/generator: prowgen
+    max_concurrency: 1
+    name: branch-ci-openshift-cluster-update-console-plugin-main-images
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --image-mirror-push-secret=/etc/push-secret/.dockerconfigjson
+        - --promote
+        - --report-credentials-file=/etc/report/credentials
+        - --target=[images]
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/push-secret
+          name: push-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: push-secret
+        secret:
+          secretName: registry-push-credentials-ci-central
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator

--- a/ci-operator/jobs/openshift/cluster-update-console-plugin/openshift-cluster-update-console-plugin-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-update-console-plugin/openshift-cluster-update-console-plugin-main-presubmits.yaml
@@ -10,7 +10,6 @@ presubmits:
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
-      job-release: "4.22"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-cluster-update-console-plugin-main-frontend
     rerun_command: /test frontend
@@ -63,3 +62,57 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )frontend,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build11
+    context: ci/prow/images
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-update-console-plugin-main-images
+    rerun_command: /test images
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=[images]
+        - --target=[release:latest]
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )images,?($|\s.*)


### PR DESCRIPTION
Bulding on #77093, the goal is to include the plugin in 5.0 OpenShift releases in a similar way to how
[`ci-operator/config/openshift/monitoring-plugin/openshift-monitoring-plugin-main.yaml` already works][0], so just clone that portion of their config.  Docs [here][1] and [here][2].

[0]: https://github.com/openshift/release/blob/66ba1f9d67440cd82a94473470213168c3eb989a/ci-operator/config/openshift/monitoring-plugin/openshift-monitoring-plugin-main.yaml#L19-L34
[1]: https://docs.ci.openshift.org/architecture/ci-operator/#publishing-to-an-integration-stream
[2]: https://docs.ci.openshift.org/architecture/ci-operator/#testing-with-an-ephemeral-openshift-release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched CI to an integration-style latest release that includes built images and promotes a named release as the latest.
  * Added explicit image build inputs and a publish/promotion target so pipeline-built images are produced and published.
  * Adjusted presubmits: removed an outdated release label from the frontend presubmit and added a presubmit that always runs image builds and supports manual reruns.
  * Added a postsubmit promotion job to run image builds and publish artifacts after merges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->