### PR TITLE
prowconfig: add approve, lgtm and tide config for mcp-lifecycle-operator

### DIFF
--- a/core-services/prow/02_config/openshift/mcp-lifecycle-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/mcp-lifecycle-operator/_pluginconfig.yaml
@@ -1,0 +1,19 @@
+approve:
+- commandHelpLink: ""
+  repos:
+  - openshift/mcp-lifecycle-operator
+  require_self_approval: false
+lgtm:
+- repos:
+  - openshift/mcp-lifecycle-operator
+  review_acts_as_lgtm: true
+plugins:
+  openshift/mcp-lifecycle-operator:
+    plugins:
+    - approve
+triggers:
+- repos:
+  - openshift/mcp-lifecycle-operator
+  trusted_apps:
+  - red-hat-konflux
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift/mcp-lifecycle-operator/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/mcp-lifecycle-operator/_prowconfig.yaml
@@ -1,0 +1,15 @@
+tide:
+  queries:
+  - labels:
+    - approved
+    - jira/valid-reference
+    - lgtm
+    missingLabels:
+    - backports/unvalidated-commits
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - jira/invalid-bug
+    - needs-rebase
+    repos:
+    - openshift/mcp-lifecycle-operator


### PR DESCRIPTION
The openshift/mcp-lifecycle-operator repo was missing its public Prow configuration. Without it, the approve plugin does not apply the approved label and Tide does not pick up PRs for automatic merging.

Add _pluginconfig.yaml and _prowconfig.yaml to enable approve, lgtm and tide for openshift/mcp-lifecycle-operator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated code review and pull request merge workflows for the mcp-lifecycle-operator repository to streamline development processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->