### PR TITLE
CNTRLPLANE-2554: Add ExternalOIDCWithUpstreamParity Prow jobs

### DIFF
--- a/ci-operator/config/openshift/cluster-authentication-operator/openshift-cluster-authentication-operator-release-4.23__periodics.yaml
+++ b/ci-operator/config/openshift/cluster-authentication-operator/openshift-cluster-authentication-operator-release-4.23__periodics.yaml
@@ -42,7 +42,7 @@ tests:
     env:
       OPENSHIFT_SKIP_EXTERNAL_TESTS: "True"
       TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
-      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings\]\|\[OCPFeatureGate:ExternalOIDC\]
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWith\|\[OCPFeatureGate:ExternalOIDC\]
         reverting to IntegratedOAuth
       TEST_SUITE: openshift/auth/external-oidc
     workflow: openshift-e2e-aws
@@ -53,7 +53,7 @@ tests:
     env:
       OPENSHIFT_SKIP_EXTERNAL_TESTS: "True"
       TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
-      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings\]\|\[OCPFeatureGate:ExternalOIDC\]
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWith\|\[OCPFeatureGate:ExternalOIDC\]
         reverting to IntegratedOAuth
       TEST_SUITE: openshift/auth/external-oidc
     workflow: openshift-e2e-azure
@@ -64,7 +64,7 @@ tests:
     env:
       OPENSHIFT_SKIP_EXTERNAL_TESTS: "True"
       TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
-      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings\]\|\[OCPFeatureGate:ExternalOIDC\]
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWith\|\[OCPFeatureGate:ExternalOIDC\]
         reverting to IntegratedOAuth
       TEST_SUITE: openshift/auth/external-oidc
     workflow: openshift-e2e-gcp
@@ -75,7 +75,7 @@ tests:
     env:
       OPENSHIFT_SKIP_EXTERNAL_TESTS: "True"
       TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
-      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings\]\|\[OCPFeatureGate:ExternalOIDC\]
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWith\|\[OCPFeatureGate:ExternalOIDC\]
         reverting to IntegratedOAuth
       TEST_SUITE: openshift/auth/external-oidc
     workflow: openshift-e2e-vsphere
@@ -90,7 +90,7 @@ tests:
         IP_STACK=v4
         NETWORK_TYPE=OVNKubernetes
       TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
-      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings\]\|\[OCPFeatureGate:ExternalOIDC\]
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWith\|\[OCPFeatureGate:ExternalOIDC\]
         reverting to IntegratedOAuth
       TEST_SUITE: openshift/auth/external-oidc
     workflow: baremetalds-e2e
@@ -105,7 +105,7 @@ tests:
         IP_STACK=v6
         NETWORK_TYPE=OVNKubernetes
       TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
-      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings\]\|\[OCPFeatureGate:ExternalOIDC\]
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWith\|\[OCPFeatureGate:ExternalOIDC\]
         reverting to IntegratedOAuth
       TEST_SUITE: openshift/auth/external-oidc
     workflow: baremetalds-e2e
@@ -120,7 +120,7 @@ tests:
         IP_STACK=v4v6
         NETWORK_TYPE=OVNKubernetes
       TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
-      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings\]\|\[OCPFeatureGate:ExternalOIDC\]
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWith\|\[OCPFeatureGate:ExternalOIDC\]
         reverting to IntegratedOAuth
       TEST_SUITE: openshift/auth/external-oidc
     workflow: baremetalds-e2e
@@ -130,7 +130,7 @@ tests:
     cluster_profile: openshift-org-aws
     env:
       TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants,legacy-node-invariants,legacy-kube-apiserver-invariants,audit-log-analyzer
-      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings\]\|\[OCPFeatureGate:ExternalOIDC\]
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWith\|\[OCPFeatureGate:ExternalOIDC\]
         reverting to IntegratedOAuth
       TEST_SUITE: openshift/auth/external-oidc
     workflow: openshift-e2e-aws-single-node
@@ -141,7 +141,7 @@ tests:
     env:
       OPENSHIFT_SKIP_EXTERNAL_TESTS: "True"
       TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
-      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings\]\|\[OCPFeatureGate:ExternalOIDC\]
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWith\|\[OCPFeatureGate:ExternalOIDC\]
         external IdP is configured
       TEST_SUITE: openshift/auth/external-oidc
     workflow: openshift-e2e-aws
@@ -152,7 +152,7 @@ tests:
     env:
       OPENSHIFT_SKIP_EXTERNAL_TESTS: "True"
       TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
-      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings\]\|\[OCPFeatureGate:ExternalOIDC\]
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWith\|\[OCPFeatureGate:ExternalOIDC\]
         external IdP is configured
       TEST_SUITE: openshift/auth/external-oidc
     workflow: openshift-e2e-azure
@@ -163,7 +163,7 @@ tests:
     env:
       OPENSHIFT_SKIP_EXTERNAL_TESTS: "True"
       TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
-      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings\]\|\[OCPFeatureGate:ExternalOIDC\]
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWith\|\[OCPFeatureGate:ExternalOIDC\]
         external IdP is configured
       TEST_SUITE: openshift/auth/external-oidc
     workflow: openshift-e2e-gcp
@@ -174,7 +174,7 @@ tests:
     env:
       OPENSHIFT_SKIP_EXTERNAL_TESTS: "True"
       TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
-      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings\]\|\[OCPFeatureGate:ExternalOIDC\]
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWith\|\[OCPFeatureGate:ExternalOIDC\]
         external IdP is configured
       TEST_SUITE: openshift/auth/external-oidc
     workflow: openshift-e2e-vsphere
@@ -189,7 +189,7 @@ tests:
         IP_STACK=v4
         NETWORK_TYPE=OVNKubernetes
       TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
-      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings\]\|\[OCPFeatureGate:ExternalOIDC\]
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWith\|\[OCPFeatureGate:ExternalOIDC\]
         external IdP is configured
       TEST_SUITE: openshift/auth/external-oidc
     workflow: baremetalds-e2e
@@ -204,7 +204,7 @@ tests:
         IP_STACK=v6
         NETWORK_TYPE=OVNKubernetes
       TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
-      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings\]\|\[OCPFeatureGate:ExternalOIDC\]
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWith\|\[OCPFeatureGate:ExternalOIDC\]
         external IdP is configured
       TEST_SUITE: openshift/auth/external-oidc
     workflow: baremetalds-e2e
@@ -219,7 +219,7 @@ tests:
         IP_STACK=v4v6
         NETWORK_TYPE=OVNKubernetes
       TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
-      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings\]\|\[OCPFeatureGate:ExternalOIDC\]
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWith\|\[OCPFeatureGate:ExternalOIDC\]
         external IdP is configured
       TEST_SUITE: openshift/auth/external-oidc
     workflow: baremetalds-e2e
@@ -230,7 +230,7 @@ tests:
     env:
       OPENSHIFT_SKIP_EXTERNAL_TESTS: "True"
       TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
-      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDC\]
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDC\]\|\[OCPFeatureGate:ExternalOIDCWithUpstreamParity\]
       TEST_SUITE: openshift/auth/external-oidc
     workflow: openshift-e2e-aws
 - as: e2e-aws-sno-external-oidc-revertoauth
@@ -239,7 +239,7 @@ tests:
     cluster_profile: openshift-org-aws
     env:
       TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants,legacy-node-invariants,legacy-kube-apiserver-invariants,audit-log-analyzer
-      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings\]\|\[OCPFeatureGate:ExternalOIDC\]
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWith\|\[OCPFeatureGate:ExternalOIDC\]
         external IdP is configured
       TEST_SUITE: openshift/auth/external-oidc
     workflow: openshift-e2e-aws-single-node
@@ -250,7 +250,7 @@ tests:
     env:
       OPENSHIFT_SKIP_EXTERNAL_TESTS: "True"
       TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
-      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDC\]
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDC\]\|\[OCPFeatureGate:ExternalOIDCWithUpstreamParity\]
       TEST_SUITE: openshift/auth/external-oidc
     workflow: openshift-e2e-azure
 - as: e2e-gcp-external-oidc-uid-extra
@@ -260,7 +260,7 @@ tests:
     env:
       OPENSHIFT_SKIP_EXTERNAL_TESTS: "True"
       TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
-      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDC\]
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDC\]\|\[OCPFeatureGate:ExternalOIDCWithUpstreamParity\]
       TEST_SUITE: openshift/auth/external-oidc
     workflow: openshift-e2e-gcp
 - as: e2e-vsphere-external-oidc-uid-extra
@@ -270,7 +270,7 @@ tests:
     env:
       OPENSHIFT_SKIP_EXTERNAL_TESTS: "True"
       TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
-      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDC\]
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDC\]\|\[OCPFeatureGate:ExternalOIDCWithUpstreamParity\]
       TEST_SUITE: openshift/auth/external-oidc
     workflow: openshift-e2e-vsphere
 - as: e2e-metal-ovn-ipv4-external-oidc-uid-extra
@@ -284,7 +284,7 @@ tests:
         IP_STACK=v4
         NETWORK_TYPE=OVNKubernetes
       TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
-      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDC\]
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDC\]\|\[OCPFeatureGate:ExternalOIDCWithUpstreamParity\]
       TEST_SUITE: openshift/auth/external-oidc
     workflow: baremetalds-e2e
 - as: e2e-metal-ovn-ipv6-external-oidc-uid-extra
@@ -298,7 +298,7 @@ tests:
         IP_STACK=v6
         NETWORK_TYPE=OVNKubernetes
       TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
-      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDC\]
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDC\]\|\[OCPFeatureGate:ExternalOIDCWithUpstreamParity\]
       TEST_SUITE: openshift/auth/external-oidc
     workflow: baremetalds-e2e
 - as: e2e-metal-ovn-dualstack-external-oidc-uid-extra
@@ -312,7 +312,7 @@ tests:
         IP_STACK=v4v6
         NETWORK_TYPE=OVNKubernetes
       TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
-      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDC\]
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDC\]\|\[OCPFeatureGate:ExternalOIDCWithUpstreamParity\]
       TEST_SUITE: openshift/auth/external-oidc
     workflow: baremetalds-e2e
 - as: e2e-aws-sno-external-oidc-uid-extra
@@ -321,7 +321,106 @@ tests:
     cluster_profile: openshift-org-aws
     env:
       TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants,legacy-node-invariants,legacy-kube-apiserver-invariants,audit-log-analyzer
-      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDC\]
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDC\]\|\[OCPFeatureGate:ExternalOIDCWithUpstreamParity\]
+      TEST_SUITE: openshift/auth/external-oidc
+    workflow: openshift-e2e-aws-single-node
+- as: e2e-aws-external-oidc-upstream-parity
+  interval: 24h
+  steps:
+    cluster_profile: openshift-org-aws
+    env:
+      FEATURE_SET: TechPreviewNoUpgrade
+      OPENSHIFT_SKIP_EXTERNAL_TESTS: "True"
+      TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDC\]\|\[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings\]
+      TEST_SUITE: openshift/auth/external-oidc
+    workflow: openshift-e2e-aws
+- as: e2e-azure-external-oidc-upstream-parity
+  interval: 24h
+  steps:
+    cluster_profile: openshift-org-azure
+    env:
+      FEATURE_SET: TechPreviewNoUpgrade
+      OPENSHIFT_SKIP_EXTERNAL_TESTS: "True"
+      TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDC\]\|\[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings\]
+      TEST_SUITE: openshift/auth/external-oidc
+    workflow: openshift-e2e-azure
+- as: e2e-gcp-external-oidc-upstream-parity
+  interval: 24h
+  steps:
+    cluster_profile: openshift-org-gcp
+    env:
+      FEATURE_SET: TechPreviewNoUpgrade
+      OPENSHIFT_SKIP_EXTERNAL_TESTS: "True"
+      TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDC\]\|\[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings\]
+      TEST_SUITE: openshift/auth/external-oidc
+    workflow: openshift-e2e-gcp
+- as: e2e-vsphere-external-oidc-upstream-parity
+  cron: 15 11 * * *
+  steps:
+    cluster_profile: vsphere-elastic
+    env:
+      FEATURE_SET: TechPreviewNoUpgrade
+      OPENSHIFT_SKIP_EXTERNAL_TESTS: "True"
+      TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDC\]\|\[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings\]
+      TEST_SUITE: openshift/auth/external-oidc
+    workflow: openshift-e2e-vsphere
+- as: e2e-metal-ovn-ipv4-external-oidc-upstream-parity
+  capabilities:
+  - intranet
+  interval: 24h
+  steps:
+    cluster_profile: equinix-ocp-metal
+    env:
+      DEVSCRIPTS_CONFIG: |
+        IP_STACK=v4
+        NETWORK_TYPE=OVNKubernetes
+        FEATURE_SET=TechPreviewNoUpgrade
+      TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDC\]\|\[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings\]
+      TEST_SUITE: openshift/auth/external-oidc
+    workflow: baremetalds-e2e
+- as: e2e-metal-ovn-ipv6-external-oidc-upstream-parity
+  capabilities:
+  - intranet
+  interval: 24h
+  steps:
+    cluster_profile: equinix-ocp-metal
+    env:
+      DEVSCRIPTS_CONFIG: |
+        IP_STACK=v6
+        NETWORK_TYPE=OVNKubernetes
+        FEATURE_SET=TechPreviewNoUpgrade
+      TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDC\]\|\[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings\]
+      TEST_SUITE: openshift/auth/external-oidc
+    workflow: baremetalds-e2e
+- as: e2e-metal-ovn-dualstack-external-oidc-upstream-parity
+  capabilities:
+  - intranet
+  interval: 24h
+  steps:
+    cluster_profile: equinix-ocp-metal
+    env:
+      DEVSCRIPTS_CONFIG: |
+        IP_STACK=v4v6
+        NETWORK_TYPE=OVNKubernetes
+        FEATURE_SET=TechPreviewNoUpgrade
+      TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDC\]\|\[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings\]
+      TEST_SUITE: openshift/auth/external-oidc
+    workflow: baremetalds-e2e
+- as: e2e-aws-sno-external-oidc-upstream-parity
+  interval: 24h
+  steps:
+    cluster_profile: openshift-org-aws
+    env:
+      FEATURE_SET: TechPreviewNoUpgrade
+      TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants,legacy-node-invariants,legacy-kube-apiserver-invariants,audit-log-analyzer
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDC\]\|\[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings\]
       TEST_SUITE: openshift/auth/external-oidc
     workflow: openshift-e2e-aws-single-node
 zz_generated_metadata:

--- a/ci-operator/config/openshift/cluster-authentication-operator/openshift-cluster-authentication-operator-release-5.0__periodics.yaml
+++ b/ci-operator/config/openshift/cluster-authentication-operator/openshift-cluster-authentication-operator-release-5.0__periodics.yaml
@@ -42,7 +42,7 @@ tests:
     env:
       OPENSHIFT_SKIP_EXTERNAL_TESTS: "True"
       TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
-      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings\]\|\[OCPFeatureGate:ExternalOIDC\]
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWith\|\[OCPFeatureGate:ExternalOIDC\]
         reverting to IntegratedOAuth
       TEST_SUITE: openshift/auth/external-oidc
     workflow: openshift-e2e-aws
@@ -53,7 +53,7 @@ tests:
     env:
       OPENSHIFT_SKIP_EXTERNAL_TESTS: "True"
       TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
-      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings\]\|\[OCPFeatureGate:ExternalOIDC\]
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWith\|\[OCPFeatureGate:ExternalOIDC\]
         reverting to IntegratedOAuth
       TEST_SUITE: openshift/auth/external-oidc
     workflow: openshift-e2e-azure
@@ -64,7 +64,7 @@ tests:
     env:
       OPENSHIFT_SKIP_EXTERNAL_TESTS: "True"
       TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
-      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings\]\|\[OCPFeatureGate:ExternalOIDC\]
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWith\|\[OCPFeatureGate:ExternalOIDC\]
         reverting to IntegratedOAuth
       TEST_SUITE: openshift/auth/external-oidc
     workflow: openshift-e2e-gcp
@@ -75,7 +75,7 @@ tests:
     env:
       OPENSHIFT_SKIP_EXTERNAL_TESTS: "True"
       TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
-      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings\]\|\[OCPFeatureGate:ExternalOIDC\]
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWith\|\[OCPFeatureGate:ExternalOIDC\]
         reverting to IntegratedOAuth
       TEST_SUITE: openshift/auth/external-oidc
     workflow: openshift-e2e-vsphere
@@ -90,7 +90,7 @@ tests:
         IP_STACK=v4
         NETWORK_TYPE=OVNKubernetes
       TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
-      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings\]\|\[OCPFeatureGate:ExternalOIDC\]
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWith\|\[OCPFeatureGate:ExternalOIDC\]
         reverting to IntegratedOAuth
       TEST_SUITE: openshift/auth/external-oidc
     workflow: baremetalds-e2e
@@ -105,7 +105,7 @@ tests:
         IP_STACK=v6
         NETWORK_TYPE=OVNKubernetes
       TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
-      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings\]\|\[OCPFeatureGate:ExternalOIDC\]
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWith\|\[OCPFeatureGate:ExternalOIDC\]
         reverting to IntegratedOAuth
       TEST_SUITE: openshift/auth/external-oidc
     workflow: baremetalds-e2e
@@ -120,7 +120,7 @@ tests:
         IP_STACK=v4v6
         NETWORK_TYPE=OVNKubernetes
       TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
-      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings\]\|\[OCPFeatureGate:ExternalOIDC\]
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWith\|\[OCPFeatureGate:ExternalOIDC\]
         reverting to IntegratedOAuth
       TEST_SUITE: openshift/auth/external-oidc
     workflow: baremetalds-e2e
@@ -130,7 +130,7 @@ tests:
     cluster_profile: openshift-org-aws
     env:
       TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants,legacy-node-invariants,legacy-kube-apiserver-invariants,audit-log-analyzer
-      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings\]\|\[OCPFeatureGate:ExternalOIDC\]
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWith\|\[OCPFeatureGate:ExternalOIDC\]
         reverting to IntegratedOAuth
       TEST_SUITE: openshift/auth/external-oidc
     workflow: openshift-e2e-aws-single-node
@@ -141,7 +141,7 @@ tests:
     env:
       OPENSHIFT_SKIP_EXTERNAL_TESTS: "True"
       TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
-      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings\]\|\[OCPFeatureGate:ExternalOIDC\]
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWith\|\[OCPFeatureGate:ExternalOIDC\]
         external IdP is configured
       TEST_SUITE: openshift/auth/external-oidc
     workflow: openshift-e2e-aws
@@ -152,7 +152,7 @@ tests:
     env:
       OPENSHIFT_SKIP_EXTERNAL_TESTS: "True"
       TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
-      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings\]\|\[OCPFeatureGate:ExternalOIDC\]
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWith\|\[OCPFeatureGate:ExternalOIDC\]
         external IdP is configured
       TEST_SUITE: openshift/auth/external-oidc
     workflow: openshift-e2e-azure
@@ -163,7 +163,7 @@ tests:
     env:
       OPENSHIFT_SKIP_EXTERNAL_TESTS: "True"
       TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
-      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings\]\|\[OCPFeatureGate:ExternalOIDC\]
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWith\|\[OCPFeatureGate:ExternalOIDC\]
         external IdP is configured
       TEST_SUITE: openshift/auth/external-oidc
     workflow: openshift-e2e-gcp
@@ -174,7 +174,7 @@ tests:
     env:
       OPENSHIFT_SKIP_EXTERNAL_TESTS: "True"
       TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
-      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings\]\|\[OCPFeatureGate:ExternalOIDC\]
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWith\|\[OCPFeatureGate:ExternalOIDC\]
         external IdP is configured
       TEST_SUITE: openshift/auth/external-oidc
     workflow: openshift-e2e-vsphere
@@ -189,7 +189,7 @@ tests:
         IP_STACK=v4
         NETWORK_TYPE=OVNKubernetes
       TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
-      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings\]\|\[OCPFeatureGate:ExternalOIDC\]
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWith\|\[OCPFeatureGate:ExternalOIDC\]
         external IdP is configured
       TEST_SUITE: openshift/auth/external-oidc
     workflow: baremetalds-e2e
@@ -204,7 +204,7 @@ tests:
         IP_STACK=v6
         NETWORK_TYPE=OVNKubernetes
       TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
-      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings\]\|\[OCPFeatureGate:ExternalOIDC\]
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWith\|\[OCPFeatureGate:ExternalOIDC\]
         external IdP is configured
       TEST_SUITE: openshift/auth/external-oidc
     workflow: baremetalds-e2e
@@ -219,7 +219,7 @@ tests:
         IP_STACK=v4v6
         NETWORK_TYPE=OVNKubernetes
       TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
-      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings\]\|\[OCPFeatureGate:ExternalOIDC\]
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWith\|\[OCPFeatureGate:ExternalOIDC\]
         external IdP is configured
       TEST_SUITE: openshift/auth/external-oidc
     workflow: baremetalds-e2e
@@ -230,7 +230,7 @@ tests:
     env:
       OPENSHIFT_SKIP_EXTERNAL_TESTS: "True"
       TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
-      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDC\]
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDC\]\|\[OCPFeatureGate:ExternalOIDCWithUpstreamParity\]
       TEST_SUITE: openshift/auth/external-oidc
     workflow: openshift-e2e-aws
 - as: e2e-aws-sno-external-oidc-revertoauth
@@ -239,7 +239,7 @@ tests:
     cluster_profile: openshift-org-aws
     env:
       TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants,legacy-node-invariants,legacy-kube-apiserver-invariants,audit-log-analyzer
-      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings\]\|\[OCPFeatureGate:ExternalOIDC\]
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDCWith\|\[OCPFeatureGate:ExternalOIDC\]
         external IdP is configured
       TEST_SUITE: openshift/auth/external-oidc
     workflow: openshift-e2e-aws-single-node
@@ -250,7 +250,7 @@ tests:
     env:
       OPENSHIFT_SKIP_EXTERNAL_TESTS: "True"
       TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
-      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDC\]
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDC\]\|\[OCPFeatureGate:ExternalOIDCWithUpstreamParity\]
       TEST_SUITE: openshift/auth/external-oidc
     workflow: openshift-e2e-azure
 - as: e2e-gcp-external-oidc-uid-extra
@@ -260,7 +260,7 @@ tests:
     env:
       OPENSHIFT_SKIP_EXTERNAL_TESTS: "True"
       TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
-      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDC\]
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDC\]\|\[OCPFeatureGate:ExternalOIDCWithUpstreamParity\]
       TEST_SUITE: openshift/auth/external-oidc
     workflow: openshift-e2e-gcp
 - as: e2e-vsphere-external-oidc-uid-extra
@@ -270,7 +270,7 @@ tests:
     env:
       OPENSHIFT_SKIP_EXTERNAL_TESTS: "True"
       TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
-      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDC\]
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDC\]\|\[OCPFeatureGate:ExternalOIDCWithUpstreamParity\]
       TEST_SUITE: openshift/auth/external-oidc
     workflow: openshift-e2e-vsphere
 - as: e2e-metal-ovn-ipv4-external-oidc-uid-extra
@@ -284,7 +284,7 @@ tests:
         IP_STACK=v4
         NETWORK_TYPE=OVNKubernetes
       TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
-      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDC\]
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDC\]\|\[OCPFeatureGate:ExternalOIDCWithUpstreamParity\]
       TEST_SUITE: openshift/auth/external-oidc
     workflow: baremetalds-e2e
 - as: e2e-metal-ovn-ipv6-external-oidc-uid-extra
@@ -298,7 +298,7 @@ tests:
         IP_STACK=v6
         NETWORK_TYPE=OVNKubernetes
       TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
-      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDC\]
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDC\]\|\[OCPFeatureGate:ExternalOIDCWithUpstreamParity\]
       TEST_SUITE: openshift/auth/external-oidc
     workflow: baremetalds-e2e
 - as: e2e-metal-ovn-dualstack-external-oidc-uid-extra
@@ -312,7 +312,7 @@ tests:
         IP_STACK=v4v6
         NETWORK_TYPE=OVNKubernetes
       TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
-      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDC\]
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDC\]\|\[OCPFeatureGate:ExternalOIDCWithUpstreamParity\]
       TEST_SUITE: openshift/auth/external-oidc
     workflow: baremetalds-e2e
 - as: e2e-aws-sno-external-oidc-uid-extra
@@ -321,7 +321,106 @@ tests:
     cluster_profile: openshift-org-aws
     env:
       TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants,legacy-node-invariants,legacy-kube-apiserver-invariants,audit-log-analyzer
-      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDC\]
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDC\]\|\[OCPFeatureGate:ExternalOIDCWithUpstreamParity\]
+      TEST_SUITE: openshift/auth/external-oidc
+    workflow: openshift-e2e-aws-single-node
+- as: e2e-aws-external-oidc-upstream-parity
+  interval: 24h
+  steps:
+    cluster_profile: openshift-org-aws
+    env:
+      FEATURE_SET: TechPreviewNoUpgrade
+      OPENSHIFT_SKIP_EXTERNAL_TESTS: "True"
+      TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDC\]\|\[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings\]
+      TEST_SUITE: openshift/auth/external-oidc
+    workflow: openshift-e2e-aws
+- as: e2e-azure-external-oidc-upstream-parity
+  interval: 24h
+  steps:
+    cluster_profile: openshift-org-azure
+    env:
+      FEATURE_SET: TechPreviewNoUpgrade
+      OPENSHIFT_SKIP_EXTERNAL_TESTS: "True"
+      TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDC\]\|\[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings\]
+      TEST_SUITE: openshift/auth/external-oidc
+    workflow: openshift-e2e-azure
+- as: e2e-gcp-external-oidc-upstream-parity
+  interval: 24h
+  steps:
+    cluster_profile: openshift-org-gcp
+    env:
+      FEATURE_SET: TechPreviewNoUpgrade
+      OPENSHIFT_SKIP_EXTERNAL_TESTS: "True"
+      TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDC\]\|\[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings\]
+      TEST_SUITE: openshift/auth/external-oidc
+    workflow: openshift-e2e-gcp
+- as: e2e-vsphere-external-oidc-upstream-parity
+  cron: 30 21 * * 3
+  steps:
+    cluster_profile: vsphere-elastic
+    env:
+      FEATURE_SET: TechPreviewNoUpgrade
+      OPENSHIFT_SKIP_EXTERNAL_TESTS: "True"
+      TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDC\]\|\[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings\]
+      TEST_SUITE: openshift/auth/external-oidc
+    workflow: openshift-e2e-vsphere
+- as: e2e-metal-ovn-ipv4-external-oidc-upstream-parity
+  capabilities:
+  - intranet
+  interval: 24h
+  steps:
+    cluster_profile: equinix-ocp-metal
+    env:
+      DEVSCRIPTS_CONFIG: |
+        IP_STACK=v4
+        NETWORK_TYPE=OVNKubernetes
+        FEATURE_SET=TechPreviewNoUpgrade
+      TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDC\]\|\[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings\]
+      TEST_SUITE: openshift/auth/external-oidc
+    workflow: baremetalds-e2e
+- as: e2e-metal-ovn-ipv6-external-oidc-upstream-parity
+  capabilities:
+  - intranet
+  interval: 24h
+  steps:
+    cluster_profile: equinix-ocp-metal
+    env:
+      DEVSCRIPTS_CONFIG: |
+        IP_STACK=v6
+        NETWORK_TYPE=OVNKubernetes
+        FEATURE_SET=TechPreviewNoUpgrade
+      TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDC\]\|\[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings\]
+      TEST_SUITE: openshift/auth/external-oidc
+    workflow: baremetalds-e2e
+- as: e2e-metal-ovn-dualstack-external-oidc-upstream-parity
+  capabilities:
+  - intranet
+  interval: 24h
+  steps:
+    cluster_profile: equinix-ocp-metal
+    env:
+      DEVSCRIPTS_CONFIG: |
+        IP_STACK=v4v6
+        NETWORK_TYPE=OVNKubernetes
+        FEATURE_SET=TechPreviewNoUpgrade
+      TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDC\]\|\[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings\]
+      TEST_SUITE: openshift/auth/external-oidc
+    workflow: baremetalds-e2e
+- as: e2e-aws-sno-external-oidc-upstream-parity
+  interval: 24h
+  steps:
+    cluster_profile: openshift-org-aws
+    env:
+      FEATURE_SET: TechPreviewNoUpgrade
+      TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants,legacy-node-invariants,legacy-kube-apiserver-invariants,audit-log-analyzer
+      TEST_SKIPS: \[OCPFeatureGate:ExternalOIDC\]\|\[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings\]
       TEST_SUITE: openshift/auth/external-oidc
     workflow: openshift-e2e-aws-single-node
 zz_generated_metadata:

--- a/ci-operator/jobs/openshift/cluster-authentication-operator/openshift-cluster-authentication-operator-release-4.23-periodics.yaml
+++ b/ci-operator/jobs/openshift/cluster-authentication-operator/openshift-cluster-authentication-operator-release-4.23-periodics.yaml
@@ -249,6 +249,87 @@ periodics:
   - base_ref: release-4.23
     org: openshift
     repo: cluster-authentication-operator
+  interval: 24h
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "4.23"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-cluster-authentication-operator-release-4.23-periodics-e2e-aws-external-oidc-upstream-parity
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-aws-external-oidc-upstream-parity
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build09
+  decorate: true
+  extra_refs:
+  - base_ref: release-4.23
+    org: openshift
+    repo: cluster-authentication-operator
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: aws
@@ -486,7 +567,88 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build11
+  cluster: build09
+  decorate: true
+  extra_refs:
+  - base_ref: release-4.23
+    org: openshift
+    repo: cluster-authentication-operator
+  interval: 24h
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "4.23"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-cluster-authentication-operator-release-4.23-periodics-e2e-aws-sno-external-oidc-upstream-parity
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-aws-sno-external-oidc-upstream-parity
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build10
   decorate: true
   extra_refs:
   - base_ref: release-4.23
@@ -672,6 +834,87 @@ periodics:
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
       - --target=e2e-azure-external-oidc-uid-extra
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build10
+  decorate: true
+  extra_refs:
+  - base_ref: release-4.23
+    org: openshift
+    repo: cluster-authentication-operator
+  interval: 24h
+  labels:
+    ci-operator.openshift.io/cloud: azure4
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-azure
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "4.23"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-cluster-authentication-operator-release-4.23-periodics-e2e-azure-external-oidc-upstream-parity
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-azure-external-oidc-upstream-parity
       - --variant=periodics
       command:
       - ci-operator
@@ -915,6 +1158,87 @@ periodics:
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
       - --target=e2e-gcp-external-oidc-uid-extra
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build08
+  decorate: true
+  extra_refs:
+  - base_ref: release-4.23
+    org: openshift
+    repo: cluster-authentication-operator
+  interval: 24h
+  labels:
+    ci-operator.openshift.io/cloud: gcp
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "4.23"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-cluster-authentication-operator-release-4.23-periodics-e2e-gcp-external-oidc-upstream-parity
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-gcp-external-oidc-upstream-parity
       - --variant=periodics
       command:
       - ci-operator
@@ -1224,6 +1548,88 @@ periodics:
   - base_ref: release-4.23
     org: openshift
     repo: cluster-authentication-operator
+  interval: 24h
+  labels:
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: equinix-ocp-metal
+    ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "4.23"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-cluster-authentication-operator-release-4.23-periodics-e2e-metal-ovn-dualstack-external-oidc-upstream-parity
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-metal-ovn-dualstack-external-oidc-upstream-parity
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build11
+  decorate: true
+  extra_refs:
+  - base_ref: release-4.23
+    org: openshift
+    repo: cluster-authentication-operator
   interval: 168h
   labels:
     capability/intranet: intranet
@@ -1407,6 +1813,88 @@ periodics:
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
       - --target=e2e-metal-ovn-ipv4-external-oidc-uid-extra
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build11
+  decorate: true
+  extra_refs:
+  - base_ref: release-4.23
+    org: openshift
+    repo: cluster-authentication-operator
+  interval: 24h
+  labels:
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: equinix-ocp-metal
+    ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "4.23"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-cluster-authentication-operator-release-4.23-periodics-e2e-metal-ovn-ipv4-external-oidc-upstream-parity
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-metal-ovn-ipv4-external-oidc-upstream-parity
       - --variant=periodics
       command:
       - ci-operator
@@ -1710,6 +2198,88 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
+  cluster: build11
+  decorate: true
+  extra_refs:
+  - base_ref: release-4.23
+    org: openshift
+    repo: cluster-authentication-operator
+  interval: 24h
+  labels:
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: equinix-ocp-metal
+    ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "4.23"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-cluster-authentication-operator-release-4.23-periodics-e2e-metal-ovn-ipv6-external-oidc-upstream-parity
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-metal-ovn-ipv6-external-oidc-upstream-parity
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
   cluster: vsphere02
   cron: 27 16 * * *
   decorate: true
@@ -1896,6 +2466,87 @@ periodics:
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
       - --target=e2e-vsphere-external-oidc-uid-extra
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: vsphere02
+  cron: 15 11 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: release-4.23
+    org: openshift
+    repo: cluster-authentication-operator
+  labels:
+    ci-operator.openshift.io/cloud: vsphere
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "4.23"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-cluster-authentication-operator-release-4.23-periodics-e2e-vsphere-external-oidc-upstream-parity
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-vsphere-external-oidc-upstream-parity
       - --variant=periodics
       command:
       - ci-operator

--- a/ci-operator/jobs/openshift/cluster-authentication-operator/openshift-cluster-authentication-operator-release-5.0-periodics.yaml
+++ b/ci-operator/jobs/openshift/cluster-authentication-operator/openshift-cluster-authentication-operator-release-5.0-periodics.yaml
@@ -249,6 +249,87 @@ periodics:
   - base_ref: release-5.0
     org: openshift
     repo: cluster-authentication-operator
+  interval: 24h
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "5.0"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-cluster-authentication-operator-release-5.0-periodics-e2e-aws-external-oidc-upstream-parity
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-aws-external-oidc-upstream-parity
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build07
+  decorate: true
+  extra_refs:
+  - base_ref: release-5.0
+    org: openshift
+    repo: cluster-authentication-operator
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: aws
@@ -486,7 +567,88 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build10
+  cluster: build07
+  decorate: true
+  extra_refs:
+  - base_ref: release-5.0
+    org: openshift
+    repo: cluster-authentication-operator
+  interval: 24h
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "5.0"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-cluster-authentication-operator-release-5.0-periodics-e2e-aws-sno-external-oidc-upstream-parity
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-aws-sno-external-oidc-upstream-parity
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build06
   decorate: true
   extra_refs:
   - base_ref: release-5.0
@@ -672,6 +834,87 @@ periodics:
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
       - --target=e2e-azure-external-oidc-uid-extra
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build06
+  decorate: true
+  extra_refs:
+  - base_ref: release-5.0
+    org: openshift
+    repo: cluster-authentication-operator
+  interval: 24h
+  labels:
+    ci-operator.openshift.io/cloud: azure4
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-azure
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "5.0"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-cluster-authentication-operator-release-5.0-periodics-e2e-azure-external-oidc-upstream-parity
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-azure-external-oidc-upstream-parity
       - --variant=periodics
       command:
       - ci-operator
@@ -915,6 +1158,87 @@ periodics:
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
       - --target=e2e-gcp-external-oidc-uid-extra
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build04
+  decorate: true
+  extra_refs:
+  - base_ref: release-5.0
+    org: openshift
+    repo: cluster-authentication-operator
+  interval: 24h
+  labels:
+    ci-operator.openshift.io/cloud: gcp
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "5.0"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-cluster-authentication-operator-release-5.0-periodics-e2e-gcp-external-oidc-upstream-parity
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-gcp-external-oidc-upstream-parity
       - --variant=periodics
       command:
       - ci-operator
@@ -1224,6 +1548,88 @@ periodics:
   - base_ref: release-5.0
     org: openshift
     repo: cluster-authentication-operator
+  interval: 24h
+  labels:
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: equinix-ocp-metal
+    ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "5.0"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-cluster-authentication-operator-release-5.0-periodics-e2e-metal-ovn-dualstack-external-oidc-upstream-parity
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-metal-ovn-dualstack-external-oidc-upstream-parity
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build10
+  decorate: true
+  extra_refs:
+  - base_ref: release-5.0
+    org: openshift
+    repo: cluster-authentication-operator
   interval: 168h
   labels:
     capability/intranet: intranet
@@ -1407,6 +1813,88 @@ periodics:
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
       - --target=e2e-metal-ovn-ipv4-external-oidc-uid-extra
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build10
+  decorate: true
+  extra_refs:
+  - base_ref: release-5.0
+    org: openshift
+    repo: cluster-authentication-operator
+  interval: 24h
+  labels:
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: equinix-ocp-metal
+    ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "5.0"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-cluster-authentication-operator-release-5.0-periodics-e2e-metal-ovn-ipv4-external-oidc-upstream-parity
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-metal-ovn-ipv4-external-oidc-upstream-parity
       - --variant=periodics
       command:
       - ci-operator
@@ -1710,6 +2198,88 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
+  cluster: build10
+  decorate: true
+  extra_refs:
+  - base_ref: release-5.0
+    org: openshift
+    repo: cluster-authentication-operator
+  interval: 24h
+  labels:
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: equinix-ocp-metal
+    ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "5.0"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-cluster-authentication-operator-release-5.0-periodics-e2e-metal-ovn-ipv6-external-oidc-upstream-parity
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-metal-ovn-ipv6-external-oidc-upstream-parity
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
   cluster: vsphere02
   cron: 47 16 * * 3
   decorate: true
@@ -1896,6 +2466,87 @@ periodics:
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
       - --target=e2e-vsphere-external-oidc-uid-extra
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: vsphere02
+  cron: 30 21 * * 3
+  decorate: true
+  extra_refs:
+  - base_ref: release-5.0
+    org: openshift
+    repo: cluster-authentication-operator
+  labels:
+    ci-operator.openshift.io/cloud: vsphere
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "5.0"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-cluster-authentication-operator-release-5.0-periodics-e2e-vsphere-external-oidc-upstream-parity
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-vsphere-external-oidc-upstream-parity
       - --variant=periodics
       command:
       - ci-operator


### PR DESCRIPTION
This PR adds periodic Prow jobs to test the `ExternalOIDCWithUpstreamParity` feature gate across all supported platforms, enabling automated regression testing as required for feature promotion from TechPreview to GA.

**This replaces #77059** because the original author has left the company.

## Changes
### Periodic Jobs Added

Creates daily/weekly periodic test jobs for the following platforms and releases:

**Platforms (all 8 required for promotion):**
- AWS
- Azure
- GCP
- VSphere
- Baremetal IPv4
- Baremetal IPv6
- Baremetal Dualstack
- Single Node OpenShift (SNO)

**Releases:**
- **4.22**: Daily jobs (cron schedules)

### Job Configuration

Each job is configured with:
```yaml
FEATURE_SET: TechPreviewNoUpgrade          # Enable TechPreview features
TEST_FOCUS: \[OCPFeatureGate:ExternalOIDCWithUpstreamParity\]  # Run only these tests
TEST_SUITE: openshift/auth/external-oidc   # Test suite containing the new tests
TEST_ARGS: --disable-monitor=legacy-cvo-invariants,legacy-test-framework-invariants


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Removed a set of periodic external-OIDC test jobs for release 4.22.
  * Added and expanded upstream-parity periodic external-OIDC tests across multiple clouds for releases 4.23 and 5.0.
  * Adjusted test-skip/feature-gate configurations for external-OIDC tests across releases 4.22, 4.23, and 5.0.

* **Chores**
  * During test initialization, the test runner now extracts and uses a specific test binary from a container image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->