### PR TITLE
Mark OCP 4.11 and OKD/SCOS 4.15-4.18 as end-of-life

### DIFF
--- a/core-services/release-controller/_releases/priv/release-ocp-4.11-arm64.json
+++ b/core-services/release-controller/_releases/priv/release-ocp-4.11-arm64.json
@@ -1,6 +1,7 @@
 {
     "alternateImageRepository": "quay.io/openshift-release-dev/dev-release-priv",
     "alternateImageRepositorySecretName": "release-controller-quay-mirror-secret",
+    "endOfLife": true,
     "expires": "168h",
     "maxUnreadyReleases": 1,
     "message": "<!-- GENERATED FROM PUBLIC ANNOTATION CONFIG - DO NOT EDIT. -->This release contains official image builds of all arm64 code in release-4.11 (main) branches, and is updated after those builds are synced to quay.io.",

--- a/core-services/release-controller/_releases/priv/release-ocp-4.11-multi.json
+++ b/core-services/release-controller/_releases/priv/release-ocp-4.11-multi.json
@@ -2,6 +2,7 @@
     "alternateImageRepository": "quay.io/openshift-release-dev/dev-release-priv",
     "alternateImageRepositorySecretName": "release-controller-quay-mirror-secret",
     "as": "Stable",
+    "endOfLife": true,
     "expires": "168h",
     "maxUnreadyReleases": 1,
     "message": "<!-- GENERATED FROM PUBLIC ANNOTATION CONFIG - DO NOT EDIT. -->This release contains official image builds of all multi-arch code in release-4.11 (main) branches, and is updated after those builds are synced to quay.io.<br><b>Important:</b> Multi-arch release payloads are for exploratory purposes only. No current or future support for any heterogeneous topology is expressed or implied.",

--- a/core-services/release-controller/_releases/priv/release-ocp-4.11-ppc64le.json
+++ b/core-services/release-controller/_releases/priv/release-ocp-4.11-ppc64le.json
@@ -1,6 +1,7 @@
 {
     "alternateImageRepository": "quay.io/openshift-release-dev/dev-release-priv",
     "alternateImageRepositorySecretName": "release-controller-quay-mirror-secret",
+    "endOfLife": true,
     "expires": "168h",
     "message": "<!-- GENERATED FROM PUBLIC ANNOTATION CONFIG - DO NOT EDIT. -->This release contains official image builds of all ppc64le code in release-4.11 (main) branches, and is updated after those builds are synced to quay.io.",
     "mirrorPrefix": "4.11-art-latest-ppc64le-priv",

--- a/core-services/release-controller/_releases/priv/release-ocp-4.11-s390x.json
+++ b/core-services/release-controller/_releases/priv/release-ocp-4.11-s390x.json
@@ -1,6 +1,7 @@
 {
     "alternateImageRepository": "quay.io/openshift-release-dev/dev-release-priv",
     "alternateImageRepositorySecretName": "release-controller-quay-mirror-secret",
+    "endOfLife": true,
     "expires": "168h",
     "message": "<!-- GENERATED FROM PUBLIC ANNOTATION CONFIG - DO NOT EDIT. -->This release contains official image builds of all s390x code in release-4.11 (main) branches, and is updated after those builds are synced to quay.io.",
     "mirrorPrefix": "4.11-art-latest-s390x-priv",

--- a/core-services/release-controller/_releases/priv/release-ocp-4.11.json
+++ b/core-services/release-controller/_releases/priv/release-ocp-4.11.json
@@ -1,6 +1,7 @@
 {
     "alternateImageRepository": "quay.io/openshift-release-dev/dev-release-priv",
     "alternateImageRepositorySecretName": "release-controller-quay-mirror-secret",
+    "endOfLife": true,
     "expires": "126h",
     "maxUnreadyReleases": 1,
     "message": "<!-- GENERATED FROM PUBLIC ANNOTATION CONFIG - DO NOT EDIT. -->This release contains official image builds of all code in release-4.11 (main) branches, and is updated after those builds are synced to quay.io.",

--- a/core-services/release-controller/_releases/release-ocp-4.11-arm64.json
+++ b/core-services/release-controller/_releases/release-ocp-4.11-arm64.json
@@ -1,5 +1,6 @@
 {
   "name":"4.11.0-0.nightly-arm64",
+  "endOfLife": true,
   "to": "release-arm64",
   "message": "This release contains official image builds of all arm64 code in release-4.11 (main) branches, and is updated after those builds are synced to quay.io.",
   "mirrorPrefix": "4.11-art-latest-arm64",

--- a/core-services/release-controller/_releases/release-ocp-4.11-ci.json
+++ b/core-services/release-controller/_releases/release-ocp-4.11-ci.json
@@ -1,5 +1,6 @@
 {
   "name":"4.11.0-0.ci",
+  "endOfLife": true,
   "to": "release",
   "message": "This release contains CI image builds of all code in release-4.11 (main) branches, and is updated each time someone merges.",
   "mirrorPrefix": "4.11",

--- a/core-services/release-controller/_releases/release-ocp-4.11-multi.json
+++ b/core-services/release-controller/_releases/release-ocp-4.11-multi.json
@@ -1,5 +1,6 @@
 {
   "name":"4.11.0-0.nightly-multi",
+  "endOfLife": true,
   "as": "Stable",
   "message": "This release contains official image builds of all multi-arch code in release-4.11 (main) branches, and is updated after those builds are synced to quay.io.<br><b>Important:</b> Multi-arch release payloads are for exploratory purposes only. No current or future support for any heterogeneous topology is expressed or implied.",
   "mirrorPrefix": "4.11-art-latest-multi",

--- a/core-services/release-controller/_releases/release-ocp-4.11-ppc64le.json
+++ b/core-services/release-controller/_releases/release-ocp-4.11-ppc64le.json
@@ -1,5 +1,6 @@
 {
   "name":"4.11.0-0.nightly-ppc64le",
+  "endOfLife": true,
   "to": "release-ppc64le",
   "message": "This release contains official image builds of all ppc64le code in release-4.11 (main) branches, and is updated after those builds are synced to quay.io.",
   "mirrorPrefix": "4.11-art-latest-ppc64le",

--- a/core-services/release-controller/_releases/release-ocp-4.11-s390x.json
+++ b/core-services/release-controller/_releases/release-ocp-4.11-s390x.json
@@ -1,5 +1,6 @@
 {
   "name":"4.11.0-0.nightly-s390x",
+  "endOfLife": true,
   "to": "release-s390x",
   "message": "This release contains official image builds of all s390x code in release-4.11 (main) branches, and is updated after those builds are synced to quay.io.",
   "mirrorPrefix": "4.11-art-latest-s390x",

--- a/core-services/release-controller/_releases/release-ocp-4.11.json
+++ b/core-services/release-controller/_releases/release-ocp-4.11.json
@@ -1,5 +1,6 @@
 {
   "name":"4.11.0-0.nightly",
+  "endOfLife": true,
   "to": "release",
   "message": "This release contains official image builds of all code in release-4.11 (main) branches, and is updated after those builds are synced to quay.io.",
   "mirrorPrefix": "4.11-art-latest",

--- a/core-services/release-controller/_releases/release-okd-4.15.json
+++ b/core-services/release-controller/_releases/release-okd-4.15.json
@@ -1,5 +1,6 @@
 {
   "name": "4.15.0-0.okd",
+  "endOfLife": true,
   "to": "release",
   "mirrorPrefix": "4.15",
   "expires": "72h",

--- a/core-services/release-controller/_releases/release-okd-scos-4.15.json
+++ b/core-services/release-controller/_releases/release-okd-scos-4.15.json
@@ -1,5 +1,6 @@
 {
   "name": "4.15.0-0.okd-scos",
+  "endOfLife": true,
   "to": "release-scos",
   "mirrorPrefix": "4.15-okd-scos",
   "expires": "72h",

--- a/core-services/release-controller/_releases/release-okd-scos-4.16.json
+++ b/core-services/release-controller/_releases/release-okd-scos-4.16.json
@@ -1,5 +1,6 @@
 {
   "name": "4.16.0-0.okd-scos",
+  "endOfLife": true,
   "to": "release-scos",
   "mirrorPrefix": "4.16-okd-scos",
   "expires": "72h",

--- a/core-services/release-controller/_releases/release-okd-scos-4.17.json
+++ b/core-services/release-controller/_releases/release-okd-scos-4.17.json
@@ -1,5 +1,6 @@
 {
   "name": "4.17.0-0.okd-scos",
+  "endOfLife": true,
   "to": "release-scos",
   "mirrorPrefix": "4.17-okd-scos",
   "expires": "72h",

--- a/core-services/release-controller/_releases/release-okd-scos-4.18.json
+++ b/core-services/release-controller/_releases/release-okd-scos-4.18.json
@@ -1,5 +1,6 @@
 {
   "name": "4.18.0-0.okd-scos",
+  "endOfLife": true,
   "to": "release-scos",
   "mirrorPrefix": "4.18-okd-scos",
   "expires": "72h",


### PR DESCRIPTION
## Summary
- Mark all OCP 4.11 release controllers as end-of-life (amd64, arm64, ci, multi, ppc64le, s390x — public and private)
- Mark OKD 4.15 and OKD SCOS 4.15, 4.16, 4.17, 4.18 release controllers as end-of-life

## Test plan
- [x] `make release-controllers` ran successfully with no additional generated changes
- [ ] Verify release controller pages reflect EOL status after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Marked OpenShift Container Platform 4.11 releases (all architectures) as end-of-life
  * Marked Origin Kubernetes Distribution 4.15 and OKD Single-Core Operating System variants (4.15–4.18) as end-of-life

<!-- end of auto-generated comment: release notes by coderabbit.ai -->