### PR TITLE
allow the multi-arch-build-controller service account to watch imagestreamtags

### DIFF
--- a/clusters/build-clusters/multiarch_builds/multi-arch-builder-controller/admin_multi-arch-builder-controller_rbac.yaml
+++ b/clusters/build-clusters/multiarch_builds/multi-arch-builder-controller/admin_multi-arch-builder-controller_rbac.yaml
@@ -50,6 +50,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
   - create
   - update
   - delete


### PR DESCRIPTION
/cc @openshift/test-platform 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * System permissions updated to enable real-time monitoring of image resources, improving visibility into image state changes and operations across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->