### PR TITLE
OCPBUGS-83598: ovn-kubernetes: use OCP-matching CNV version for BGP virt 4.22 jobs

### DIFF
--- a/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.22__periodics.yaml
+++ b/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.22__periodics.yaml
@@ -78,7 +78,7 @@ tests:
   steps:
     cluster_profile: equinix-ocp-metal
     env:
-      CNV_PRERELEASE_LATEST_CHANNEL: "true"
+      CNV_PRERELEASE_LATEST_CHANNEL: "false"
     workflow: baremetalds-e2e-ovn-bgp-virt-dualstack
 - as: e2e-metal-ipi-ovn-bgp-virt-dualstack-techpreview
   capabilities:
@@ -87,7 +87,7 @@ tests:
   steps:
     cluster_profile: equinix-ocp-metal
     env:
-      CNV_PRERELEASE_LATEST_CHANNEL: "true"
+      CNV_PRERELEASE_LATEST_CHANNEL: "false"
       FEATURE_SET: TechPreviewNoUpgrade
     workflow: baremetalds-e2e-ovn-bgp-virt-dualstack
 - as: e2e-metal-ipi-ovn-bgp-virt-ipv4-techpreview
@@ -97,7 +97,7 @@ tests:
   steps:
     cluster_profile: equinix-ocp-metal
     env:
-      CNV_PRERELEASE_LATEST_CHANNEL: "true"
+      CNV_PRERELEASE_LATEST_CHANNEL: "false"
       FEATURE_SET: TechPreviewNoUpgrade
     workflow: baremetalds-e2e-ovn-bgp-virt-ipv4
 - as: e2e-metal-ipi-ovn-bgp-virt-ipv4
@@ -107,7 +107,7 @@ tests:
   steps:
     cluster_profile: equinix-ocp-metal
     env:
-      CNV_PRERELEASE_LATEST_CHANNEL: "true"
+      CNV_PRERELEASE_LATEST_CHANNEL: "false"
     workflow: baremetalds-e2e-ovn-bgp-virt-ipv4
 zz_generated_metadata:
   branch: release-4.22


### PR DESCRIPTION
## Summary

Bug: https://issues.redhat.com/browse/OCPBUGS-83598

- Change `CNV_PRERELEASE_LATEST_CHANNEL` from `"true"` to `"false"` for the 4 BGP virt periodic jobs on release-4.22
- When set to `"true"`, the kubevirt-install step hardcodes `cnv_version=4.99`, installing a non-existent CNV version
- Setting to `"false"` makes the step derive the version dynamically via `ocp_version()`, correctly resolving to `4.22`

**Affected jobs:**
- `e2e-metal-ipi-ovn-bgp-virt-ipv4-techpreview`
- `e2e-metal-ipi-ovn-bgp-virt-ipv4`
- `e2e-metal-ipi-ovn-bgp-virt-dualstack-techpreview`
- `e2e-metal-ipi-ovn-bgp-virt-dualstack`

## Test plan
- [ ] Verify the affected periodic jobs install CNV 4.22 (nightly-4.22 channel, nightly-catalog:4.22 image)
- [ ] Confirm CNV operator reaches `Succeeded` phase during job execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)