### PR TITLE
cnf ran: added two-sno lane for ocp4.18

### DIFF
--- a/ci-operator/config/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main__cnf-ran-two-sno-4.18.yaml
+++ b/ci-operator/config/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main__cnf-ran-two-sno-4.18.yaml
@@ -1,0 +1,63 @@
+build_root:
+  image_stream_tag:
+    name: eco-ci-cd
+    namespace: telcov10n-ci
+    tag: eco-ci-cd
+releases:
+  latest:
+    candidate:
+      product: ocp
+      stream: nightly
+      version: "4.18"
+resources:
+  '*':
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: cnf-ran-ztp-tests
+  capabilities:
+  - intranet
+  cron: 0 23 31 2 *
+  steps:
+    env:
+      CLUSTER_NAME: fthub-01
+      HUB_OPERATORS: |
+        [
+          {"name":"local-storage-operator","catalog":"redhat-operators","nsname":"openshift-local-storage","channel":"stable","og_name":"local-operator-group","subscription_name":"local-storage-operator","deploy_default_config":false,"ns_annotations":{"workload.openshift.io/allowed":"management"}},
+          {"name":"openshift-gitops-operator","catalog":"redhat-operators","nsname":"openshift-gitops-operator","channel":"latest","og_name":"openshift-gitops-operator","subscription_name":"openshift-gitops-operator","deploy_default_config":false,"og_spec":{"targetNamespaces":[]}},
+          {"name":"advanced-cluster-management","catalog":"redhat-operators","nsname":"open-cluster-management","channel":"release-2.13","default_channel":"release-2.16","og_name":"open-cluster-management","subscription_name":"acm-operator-subscription","deploy_default_config":false,"og_spec":{"targetNamespaces":["open-cluster-management"]}},
+          {"name":"multicluster-engine","catalog":"redhat-operators","nsname":"multicluster-engine","channel":"stable-2.8","default_channel":"stable-2.11","og_name":"multicluster-engine","subscription_name":"multicluster-engine","deploy_default_config":true,"og_spec":{}},
+          {"name":"topology-aware-lifecycle-manager","catalog":"topology-aware-lifecycle-manager-fbc","og_name":"global-operators","nsname":"openshift-operators","fbc_iib_repo":"latest","channel":"stable","deploy_default_config":false,"ocp_operator_mirror_fbc_image_base":"quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-fbc-4-18"}
+        ]
+      RAN_METRICS_LIST: spoke_general_ocp,hub_general_ocp,sriov,sriov_fec,ptp,acm,talm,gitops,local_storage,logging
+      REPORTER_TEMPLATE_NAME: Telco 5G RAN Regression 4_18 - Telco 5G RAN Regression
+        - <build> - 4.18
+      REPORTPORTAL_FILES: .reportportal_url_Two_Sno
+      REPORTS_PORTAL_ATTRIBUTES_ENV: ci-lane:telco-ft-ran-two-sno;spoke_ocp_version:4.18
+      SPOKE_CLUSTER: '[''worker-0'',''worker-1'']'
+      SPOKE_OPERATORS: |
+        [
+          {"name":"sriov-fec","catalog":"certified-operators","nsname":"vran-acceleration-operators","channel":"stable"},
+          {"name":"ptp-operator","catalog":"redhat-operators-ptp-art","fbc_iib_repo":"ose-ptp-rhel9-operator","nsname":"openshift-ptp","channel":"stable","ns_labels":{"workload.openshift.io/allowed":"management","name":"openshift-ptp"}},
+          {"name":"sriov-network-operator","catalog":"redhat-operators-sriov-art","fbc_iib_repo":"ose-sriov-network-rhel9-operator","nsname":"openshift-sriov-network-operator","channel":"stable","og_name":"sriov-network-operators","subscription_name":"sriov-network-operator-subscription"},
+          {"name":"cluster-logging","catalog":"redhat-operators","nsname":"openshift-logging","channel":"stable-6.1","default_channel":"stable-6.3","og_name":"cluster-logging","subscription_name":"cluster-logging","og_spec":{"targetNamespaces":[]}},
+          {"name":"local-storage-operator","fbc_iib_repo":"ose-local-storage-rhel9-operator","catalog":"redhat-operators-storage-art","nsname":"openshift-local-storage","channel":"stable","og_name":"local-operator-group","subscription_name":"local-storage-operator","deploy_default_config":false,"ns_labels":{"workload.openshift.io/allowed":"management"}}
+        ]
+      VERSION: "4.18"
+      ZTP_GIT_BRANCH: two_sno
+    pre:
+    - ref: telcov10n-functional-cnf-ran-hub-deploy
+    - ref: telcov10n-functional-cnf-ran-hub-config
+    - ref: telcov10n-functional-cnf-ran-mirror-spoke-operators
+    - ref: telcov10n-functional-cnf-ran-deploy-spoke-sno
+    - ref: telcov10n-functional-cnf-ran-eco-gotests-two-sno
+    - ref: telcov10n-functional-cnf-ran-report-compact
+    - ref: telcov10n-functional-cnf-ran-send-slack-notification
+zz_generated_metadata:
+  branch: main
+  org: openshift-kni
+  repo: eco-ci-cd
+  variant: cnf-ran-two-sno-4.18

--- a/ci-operator/jobs/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main-periodics.yaml
@@ -3834,6 +3834,88 @@ periodics:
     repo: eco-ci-cd
   labels:
     capability/intranet: intranet
+    ci-operator.openshift.io/variant: cnf-ran-two-sno-4.18
+    ci.openshift.io/generator: prowgen
+    job-release: "4.18"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-kni-eco-ci-cd-main-cnf-ran-two-sno-4.18-cnf-ran-ztp-tests
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=cnf-ran-ztp-tests
+      - --variant=cnf-ran-two-sno-4.18
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build05
+  cron: 0 23 31 2 *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-kni
+    repo: eco-ci-cd
+  labels:
+    capability/intranet: intranet
     ci-operator.openshift.io/variant: cnf-ran-two-sno-4.20
     ci.openshift.io/generator: prowgen
     job-release: "4.20"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added OpenShift Container Platform 4.18 support with a new eco-ci-cd configuration for the CNF RAN two-node variant, including default resource requests/limits for jobs and preconfigured test parameters.
  * Added a scheduled ZTP test pipeline for the 4.18 variant on the designated build cluster (cron-based periodic job).
  * Removed the existing periodic testing configuration for the 4.20 CNF RAN variant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->