### PR TITLE
PowerVC: use version 2.0.0

### DIFF
--- a/ci-operator/step-registry/ipi/conf/powervc/ipi-conf-powervc-commands.sh
+++ b/ci-operator/step-registry/ipi/conf/powervc/ipi-conf-powervc-commands.sh
@@ -15,7 +15,7 @@ function install_required_tools() {
 	PATH=${PATH}:/tmp/bin
 	export PATH
 
-	TAG="v1.2.0"
+	TAG="v2.0.0"
 	echo "Installing PowerVC-Tool version ${TAG}"
 	MACHINE=$(uname -m)
 	if [ "${MACHINE}" == "x86_64" ]; then MACHINE="amd64"; fi

--- a/ci-operator/step-registry/ipi/deprovision/deprovision/powervc/deprovision/ipi-deprovision-deprovision-powervc-deprovision-commands.sh
+++ b/ci-operator/step-registry/ipi/deprovision/deprovision/powervc/deprovision/ipi-deprovision-deprovision-powervc-deprovision-commands.sh
@@ -15,7 +15,7 @@ function install_required_tools() {
 	PATH=${PATH}:/tmp/bin
 	export PATH
 
-	TAG="v1.2.0"
+	TAG="v2.0.0"
 	echo "Installing PowerVC-Tool version ${TAG}"
 	MACHINE=$(uname -m)
 	if [ "${MACHINE}" == "x86_64" ]; then MACHINE="amd64"; fi

--- a/ci-operator/step-registry/ipi/install/powervc/install/ipi-install-powervc-install-commands.sh
+++ b/ci-operator/step-registry/ipi/install/powervc/install/ipi-install-powervc-install-commands.sh
@@ -15,7 +15,7 @@ function install_required_tools() {
 	PATH=${PATH}:/tmp/bin
 	export PATH
 
-	TAG="v1.2.0"
+	TAG="v2.0.0"
 	echo "Installing PowerVC-Tool version ${TAG}"
 	MACHINE=$(uname -m)
 	if [ "${MACHINE}" == "x86_64" ]; then MACHINE="amd64"; fi


### PR DESCRIPTION
Use version 2.0.0 of the tools

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PowerVC-Tool from version 1.2.0 to 2.0.0 across provisioning, deprovisioning, and installation configuration steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->