### PR TITLE
SREP-4403: Add rosa-e2e nightly jobs to testgrid allow-list

### DIFF
--- a/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main.yaml
+++ b/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main.yaml
@@ -41,29 +41,7 @@ tests:
   container:
     from: src
 - as: rosa-ci-daily-status
-  commands: |
-    #!/bin/bash
-    set -euo pipefail
-    SIPPY_API="https://sippy.dptools.openshift.org/api/jobs"
-    RELEASE="rosa-stage"
-    echo "Querying Sippy for ${RELEASE} job results..."
-    response=$(curl -sf "${SIPPY_API}?release=${RELEASE}&limit=100" 2>/dev/null) || {
-      echo "Warning: Failed to fetch data from Sippy API"
-      response="[]"
-    }
-    total=$(echo "${response}" | jq 'length')
-    if [[ "${total}" == "0" ]]; then
-      echo "No jobs found in Sippy for ${RELEASE}"
-      exit 1
-    fi
-    passing=$(echo "${response}" | jq '[.[] | select(.current_pass_percentage >= 80)] | length')
-    failing=$((total - passing))
-    echo "ROSA CI Status: ${passing}/${total} jobs healthy, ${failing} failing"
-    echo "${response}" | jq -r '.[] | "\(.name): \(.current_pass_percentage)%"' | sort
-    if [[ "${failing}" -gt 0 ]]; then
-      echo "Some jobs are below threshold"
-      exit 1
-    fi
+  commands: scripts/ci-status-report.sh
   container:
     from: src
   cron: 0 14 * * *

--- a/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-periodics.yaml
@@ -343,11 +343,11 @@ periodics:
       - failure
       - error
       report_template: '{{if eq .Status.State "success"}} :white_check_mark: ROSA
-        CI Daily Status: all tracked jobs healthy. <{{.Status.URL}}|Full report>
+        CI Daily Status: all tracked jobs healthy. <{{.Status.URL}}|Full report> |
+        <https://sippy.dptools.openshift.org/sippy-ng/release/rosa-stage|Sippy> |
+        <https://prow.ci.openshift.org/?type=periodic&job=*rosa*|All ROSA jobs> {{else}}
+        :x: ROSA CI Daily Status: some jobs failing. <{{.Status.URL}}|Full report>
         | <https://sippy.dptools.openshift.org/sippy-ng/release/rosa-stage|Sippy>
-        | <https://prow.ci.openshift.org/?type=periodic&job=*rosa*|All ROSA jobs>
-        {{else}} :x: ROSA CI Daily Status: some jobs failing. <{{.Status.URL}}|Full
-        report> | <https://sippy.dptools.openshift.org/sippy-ng/release/rosa-stage|Sippy>
         | <https://prow.ci.openshift.org/?type=periodic&job=*rosa*|All ROSA jobs>
         {{end}}'
   spec:

--- a/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-periodics.yaml
@@ -343,9 +343,12 @@ periodics:
       - failure
       - error
       report_template: '{{if eq .Status.State "success"}} :white_check_mark: ROSA
-        CI Daily Status: all jobs healthy. <{{.Status.URL}}|View logs> | <https://sippy.dptools.openshift.org/sippy-ng/release/rosa-stage|Sippy>
-        {{else}} :x: ROSA CI Daily Status: some jobs failing. <{{.Status.URL}}|View
-        logs> | <https://sippy.dptools.openshift.org/sippy-ng/release/rosa-stage|Sippy>
+        CI Daily Status: all tracked jobs healthy. <{{.Status.URL}}|Full report>
+        | <https://sippy.dptools.openshift.org/sippy-ng/release/rosa-stage|Sippy>
+        | <https://prow.ci.openshift.org/?type=periodic&job=*rosa*|All ROSA jobs>
+        {{else}} :x: ROSA CI Daily Status: some jobs failing. <{{.Status.URL}}|Full
+        report> | <https://sippy.dptools.openshift.org/sippy-ng/release/rosa-stage|Sippy>
+        | <https://prow.ci.openshift.org/?type=periodic&job=*rosa*|All ROSA jobs>
         {{end}}'
   spec:
     containers:

--- a/ci-operator/step-registry/rosa/sts/account-roles/create/rosa-sts-account-roles-create-commands.sh
+++ b/ci-operator/step-registry/rosa/sts/account-roles/create/rosa-sts-account-roles-create-commands.sh
@@ -82,7 +82,7 @@ if [[ "$CHANNEL_GROUP" != "stable" ]]; then
   # version that has existing account-role policies in the AWS account.
   if ! rosa list account-roles --output json 2>/dev/null | jq -e --arg v "${OPENSHIFT_VERSION}" '.[] | select(.Version // "" | startswith($v))' > /dev/null 2>&1; then
     echo "Version ${OPENSHIFT_VERSION} may not have published policies, checking account roles for available versions..."
-    available_version=$(rosa list account-roles --output json 2>/dev/null | jq -r '[.[].Version // empty] | map(split(".") | .[0:2] | join(".")) | unique | sort | last // empty' 2>/dev/null || true)
+    available_version=$(rosa list account-roles --output json 2>/dev/null | jq -r '.[].Version // empty' 2>/dev/null | cut -d'.' -f1,2 | sort -Vu | tail -1 || true)
     if [[ -n "${available_version}" && "${available_version}" != "${OPENSHIFT_VERSION}" ]]; then
       echo "Falling back from ${OPENSHIFT_VERSION} to ${available_version} (latest with published policies)"
       OPENSHIFT_VERSION="${available_version}"

--- a/ci-operator/step-registry/rosa/sts/account-roles/create/rosa-sts-account-roles-create-commands.sh
+++ b/ci-operator/step-registry/rosa/sts/account-roles/create/rosa-sts-account-roles-create-commands.sh
@@ -79,14 +79,15 @@ if [[ "$CHANNEL_GROUP" != "stable" ]]; then
   fi
 
   # Verify the version has published policies. If not, fall back to the latest
-  # available version. This handles cases where nightly builds for unreleased
-  # versions (e.g., 4.23, 5.0) don't have IAM policies published yet.
+  # version that has existing account-role policies in the AWS account.
   if ! rosa list account-roles --output json 2>/dev/null | jq -e --arg v "${OPENSHIFT_VERSION}" '.[] | select(.Version // "" | startswith($v))' > /dev/null 2>&1; then
-    echo "Version ${OPENSHIFT_VERSION} may not have published policies, checking available versions..."
-    available_version=$(rosa list versions --channel-group ${CHANNEL_GROUP} ${CLUSTER_SWITCH} -o json 2>/dev/null | jq -r '.[].raw_id' | cut -d'.' -f1,2 | sort -Vu | tail -1)
-    if [[ -n "${available_version}" ]]; then
-      echo "Falling back from ${OPENSHIFT_VERSION} to ${available_version}"
+    echo "Version ${OPENSHIFT_VERSION} may not have published policies, checking account roles for available versions..."
+    available_version=$(rosa list account-roles --output json 2>/dev/null | jq -r '[.[].Version // empty] | map(split(".") | .[0:2] | join(".")) | unique | sort | last // empty' 2>/dev/null || true)
+    if [[ -n "${available_version}" && "${available_version}" != "${OPENSHIFT_VERSION}" ]]; then
+      echo "Falling back from ${OPENSHIFT_VERSION} to ${available_version} (latest with published policies)"
       OPENSHIFT_VERSION="${available_version}"
+    else
+      echo "WARNING: No fallback version found in account roles, continuing with ${OPENSHIFT_VERSION}"
     fi
   fi
 

--- a/core-services/testgrid-config-generator/_allow-list.yaml
+++ b/core-services/testgrid-config-generator/_allow-list.yaml
@@ -38,10 +38,10 @@ periodic-ci-openshift-osde2e-main-osd-aws-upgrade-latest-default-y-minus-1-to-la
 periodic-ci-openshift-osde2e-main-osd-aws-upgrade-latest-default-z-minus-1-to-latest-default-z: osde2e
 periodic-ci-openshift-osde2e-main-osd-aws-upgrade-latest-default-y-to-latest-y-plus-1: osde2e
 periodic-ci-openshift-osde2e-main-osd-aws-upgrade-latest-default-y-plus-1-to-latest-y: osde2e
-periodic-ci-openshift-online-rosa-e2e-main-periodics-rosa-hcp-e2e-nightly-4-20: rosa-e2e
-periodic-ci-openshift-online-rosa-e2e-main-periodics-rosa-hcp-e2e-nightly-4-21: rosa-e2e
-periodic-ci-openshift-online-rosa-e2e-main-periodics-rosa-hcp-e2e-nightly-4-22: rosa-e2e
-periodic-ci-openshift-online-rosa-e2e-main-rosa-ci-daily-status: rosa-e2e
+periodic-ci-openshift-online-rosa-e2e-main-periodics-rosa-hcp-e2e-nightly-4-20: informing
+periodic-ci-openshift-online-rosa-e2e-main-periodics-rosa-hcp-e2e-nightly-4-21: informing
+periodic-ci-openshift-online-rosa-e2e-main-periodics-rosa-hcp-e2e-nightly-4-22: informing
+periodic-ci-openshift-online-rosa-e2e-main-rosa-ci-daily-status: informing
 periodic-ci-redhat-chaos-krkn-hub-main-krkn-hub-tests: generic-informing
 periodic-ci-openshift-operator-framework-olm-master-periodics-e2e-gcp-console-olm: olm
 periodic-ci-openshift-operator-framework-olm-master-periodics-e2e-gcp-olm: olm

--- a/core-services/testgrid-config-generator/_allow-list.yaml
+++ b/core-services/testgrid-config-generator/_allow-list.yaml
@@ -38,6 +38,10 @@ periodic-ci-openshift-osde2e-main-osd-aws-upgrade-latest-default-y-minus-1-to-la
 periodic-ci-openshift-osde2e-main-osd-aws-upgrade-latest-default-z-minus-1-to-latest-default-z: osde2e
 periodic-ci-openshift-osde2e-main-osd-aws-upgrade-latest-default-y-to-latest-y-plus-1: osde2e
 periodic-ci-openshift-osde2e-main-osd-aws-upgrade-latest-default-y-plus-1-to-latest-y: osde2e
+periodic-ci-openshift-online-rosa-e2e-main-periodics-rosa-hcp-e2e-nightly-4-20: rosa-e2e
+periodic-ci-openshift-online-rosa-e2e-main-periodics-rosa-hcp-e2e-nightly-4-21: rosa-e2e
+periodic-ci-openshift-online-rosa-e2e-main-periodics-rosa-hcp-e2e-nightly-4-22: rosa-e2e
+periodic-ci-openshift-online-rosa-e2e-main-rosa-ci-daily-status: rosa-e2e
 periodic-ci-redhat-chaos-krkn-hub-main-krkn-hub-tests: generic-informing
 periodic-ci-openshift-operator-framework-olm-master-periodics-e2e-gcp-console-olm: olm
 periodic-ci-openshift-operator-framework-olm-master-periodics-e2e-gcp-olm: olm


### PR DESCRIPTION
Add rosa-e2e nightly and daily-status jobs so they get indexed into BigQuery via testgrid, enabling Sippy to ingest test results for the rosa-stage dashboard.

Jira: TRT-2588, [SREP-4403](https://redhat.atlassian.net/browse/SREP-4403)

[SREP-4403]: https://redhat.atlassian.net/browse/SREP-4403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added new test-job mappings to the test-grid allow-list to improve categorization and visibility of additional periodic jobs.
  * Switched the scheduled CI health check to use an external status-reporting script, standardizing reporting and error handling.
  * Improved version-fallback logic used during account-role retrieval to reduce spurious failures and emit a warning when no fallback is available.
* **Documentation / Notifications**
  * Updated the periodic Slack report template: clarified success/failure messaging and added links to a full report and an "All ROSA jobs" view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->