### PR TITLE
wmco: Don't run the presubmit images job on konflux updates

### DIFF
--- a/ci-operator/config/openshift/windows-machine-config-operator/openshift-windows-machine-config-operator-master.yaml
+++ b/ci-operator/config/openshift/windows-machine-config-operator/openshift-windows-machine-config-operator-master.yaml
@@ -19,7 +19,7 @@ images:
   items:
   - dockerfile_path: build/Dockerfile.ci
     to: windows-machine-config-operator-test
-  skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
+  skip_if_only_changed: ^(?:docs|\.github|\.tekton)/|\.md$|^(?:\.gitignore|renovate\.json|OWNERS|PROJECT|LICENSE|Containerfile|Containerfile.bundle)$
 operator:
   bundles:
   - as: wmco-bundle

--- a/ci-operator/config/openshift/windows-machine-config-operator/openshift-windows-machine-config-operator-release-4.22.yaml
+++ b/ci-operator/config/openshift/windows-machine-config-operator/openshift-windows-machine-config-operator-release-4.22.yaml
@@ -19,7 +19,7 @@ images:
   items:
   - dockerfile_path: build/Dockerfile.ci
     to: windows-machine-config-operator-test
-  skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
+  skip_if_only_changed: ^(?:docs|\.github|\.tekton)/|\.md$|^(?:\.gitignore|renovate\.json|OWNERS|PROJECT|LICENSE|Containerfile|Containerfile.bundle)$
 operator:
   bundles:
   - as: wmco-bundle

--- a/ci-operator/config/openshift/windows-machine-config-operator/openshift-windows-machine-config-operator-release-4.23.yaml
+++ b/ci-operator/config/openshift/windows-machine-config-operator/openshift-windows-machine-config-operator-release-4.23.yaml
@@ -19,7 +19,7 @@ images:
   items:
   - dockerfile_path: build/Dockerfile.ci
     to: windows-machine-config-operator-test
-  skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
+  skip_if_only_changed: ^(?:docs|\.github|\.tekton)/|\.md$|^(?:\.gitignore|renovate\.json|OWNERS|PROJECT|LICENSE|Containerfile|Containerfile.bundle)$
 operator:
   bundles:
   - as: wmco-bundle

--- a/ci-operator/config/openshift/windows-machine-config-operator/openshift-windows-machine-config-operator-release-5.0.yaml
+++ b/ci-operator/config/openshift/windows-machine-config-operator/openshift-windows-machine-config-operator-release-5.0.yaml
@@ -19,7 +19,7 @@ images:
   items:
   - dockerfile_path: build/Dockerfile.ci
     to: windows-machine-config-operator-test
-  skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
+  skip_if_only_changed: ^(?:docs|\.github|\.tekton)/|\.md$|^(?:\.gitignore|renovate\.json|OWNERS|PROJECT|LICENSE|Containerfile|Containerfile.bundle)$
 operator:
   bundles:
   - as: wmco-bundle

--- a/ci-operator/config/openshift/windows-machine-config-operator/openshift-windows-machine-config-operator-release-5.1.yaml
+++ b/ci-operator/config/openshift/windows-machine-config-operator/openshift-windows-machine-config-operator-release-5.1.yaml
@@ -19,7 +19,7 @@ images:
   items:
   - dockerfile_path: build/Dockerfile.ci
     to: windows-machine-config-operator-test
-  skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
+  skip_if_only_changed: ^(?:docs|\.github|\.tekton)/|\.md$|^(?:\.gitignore|renovate\.json|OWNERS|PROJECT|LICENSE|Containerfile|Containerfile.bundle)$
 operator:
   bundles:
   - as: wmco-bundle

--- a/ci-operator/jobs/openshift/windows-machine-config-operator/openshift-windows-machine-config-operator-master-presubmits.yaml
+++ b/ci-operator/jobs/openshift/windows-machine-config-operator/openshift-windows-machine-config-operator-master-presubmits.yaml
@@ -390,7 +390,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-windows-machine-config-operator-master-images
     rerun_command: /test images
-    skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
+    skip_if_only_changed: ^(?:docs|\.github|\.tekton)/|\.md$|^(?:\.gitignore|renovate\.json|OWNERS|PROJECT|LICENSE|Containerfile|Containerfile.bundle)$
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift/windows-machine-config-operator/openshift-windows-machine-config-operator-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift/windows-machine-config-operator/openshift-windows-machine-config-operator-release-4.22-presubmits.yaml
@@ -390,7 +390,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-windows-machine-config-operator-release-4.22-images
     rerun_command: /test images
-    skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
+    skip_if_only_changed: ^(?:docs|\.github|\.tekton)/|\.md$|^(?:\.gitignore|renovate\.json|OWNERS|PROJECT|LICENSE|Containerfile|Containerfile.bundle)$
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift/windows-machine-config-operator/openshift-windows-machine-config-operator-release-4.23-presubmits.yaml
+++ b/ci-operator/jobs/openshift/windows-machine-config-operator/openshift-windows-machine-config-operator-release-4.23-presubmits.yaml
@@ -390,7 +390,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-windows-machine-config-operator-release-4.23-images
     rerun_command: /test images
-    skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
+    skip_if_only_changed: ^(?:docs|\.github|\.tekton)/|\.md$|^(?:\.gitignore|renovate\.json|OWNERS|PROJECT|LICENSE|Containerfile|Containerfile.bundle)$
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift/windows-machine-config-operator/openshift-windows-machine-config-operator-release-5.0-presubmits.yaml
+++ b/ci-operator/jobs/openshift/windows-machine-config-operator/openshift-windows-machine-config-operator-release-5.0-presubmits.yaml
@@ -390,7 +390,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-windows-machine-config-operator-release-5.0-images
     rerun_command: /test images
-    skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
+    skip_if_only_changed: ^(?:docs|\.github|\.tekton)/|\.md$|^(?:\.gitignore|renovate\.json|OWNERS|PROJECT|LICENSE|Containerfile|Containerfile.bundle)$
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift/windows-machine-config-operator/openshift-windows-machine-config-operator-release-5.1-presubmits.yaml
+++ b/ci-operator/jobs/openshift/windows-machine-config-operator/openshift-windows-machine-config-operator-release-5.1-presubmits.yaml
@@ -390,7 +390,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-windows-machine-config-operator-release-5.1-images
     rerun_command: /test images
-    skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
+    skip_if_only_changed: ^(?:docs|\.github|\.tekton)/|\.md$|^(?:\.gitignore|renovate\.json|OWNERS|PROJECT|LICENSE|Containerfile|Containerfile.bundle)$
     spec:
       containers:
       - args:


### PR DESCRIPTION
This pull request updates the `skip_if_only_changed` patterns for both image build and presubmit job configurations across all Windows Machine Config Operator (WMCO) CI and release branches. The main goal is to ensure that CI jobs are skipped when only non-functional files (like documentation, configuration, or ownership files) are changed, with the exclusion pattern expanded to cover more directories and files.

These changes help reduce unnecessary CI job runs on trivial changes, improving CI efficiency and developer experience.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI build configurations across release branches to skip builds when changes are limited to documentation, GitHub workflows, Tekton pipeline configurations, and container-related files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->