### PR TITLE
Set the default rhel-9 repos for 4.22 and 5.0 to 9.8

### DIFF
--- a/core-services/release-controller/_repos/ocp-4.22-rhel9.repo
+++ b/core-services/release-controller/_repos/ocp-4.22-rhel9.repo
@@ -1,29 +1,54 @@
-[rhel-9-baseos]
-name = rhel-9-baseos
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/
+[rhel-9.8-baseos]
+name = rhel-9.8-baseos
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-baseos
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
-[rhel-9-appstream]
-name = rhel-9-appstream
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/
+[rhel-9.8-appstream]
+name = rhel-9.8-appstream
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-appstream
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
+excludepkgs=toolbox*
 
-[rhel-9-fast-datapath]
-name = rhel-9-fast-datapath
+[rhel-9.8-nfv]
+name = rhel-9.8-nfv
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-nfv
+enabled = 1
+gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
+sslverify = false
+gpgcheck = 0
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
+failovermethod = priority
+skip_if_unavailable = true
+
+[rhel-9.8-highavailability]
+name = rhel-9.8-highavailability
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-highavailability
+enabled = 1
+gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
+sslverify = false
+gpgcheck = 0
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
+failovermethod = priority
+skip_if_unavailable = true
+
+[rhel-9.8-fast-datapath]
+name = rhel-9.8-fast-datapath
 baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/fast-datapath/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -34,9 +59,9 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-9-nfv]
-name = rhel-9-nfv
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/x86_64/nfv/os/
+[rhel-98-codeready-builder-rpms]
+name = rhel-98-codeready-builder-rpms
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/codeready-builder/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -46,8 +71,8 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-9-server-ose]
-name = rhel-9-server-ose
+[rhel-9.8-server-ose-4.22]
+name = rhel-9.8-server-ose-4.22
 baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-9-server-ose-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -58,44 +83,55 @@ password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
 skip_if_unavailable = true
 
-[rhel-9-codeready-builder-rpms]
-name = rhel-9-codeready-builder-rpms
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/x86_64/codeready-builder/os/
+# In the el-only variants, we still want the early kernels. Currently
+# those are just part of the plashets, which are OCP-versioned. In
+# https://issues.redhat.com/browse/ART-11248, we've agreed for now that
+# instead of having a separate RHEL-only repo, we'll just reuse a plashet repo
+# and filter out everything *but* the kernel. We just need to make sure to
+# use a plashet of an OCP version we know is based on the RHEL version we're
+# interested in.
+[rhel-9.8-early-kernel]
+name = rhel-9.8-early-kernel
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-9-server-ose-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
+# - Also include the legacy toolbox package until we move to the new containers one
+#   https://docs.google.com/document/d/137krt0IRctfwf2e7k1r7tKYPysWrDlTxqdFhFA9XKbw/edit?tab=t.0#heading=h.slko10np055j
+#   https://issues.redhat.com/browse/OCPBUGS-56600
+includepkgs=kernel,kernel-*,toolbox*,
 
-[rhel-9-baseos-ppc64le]
-name = rhel-9-baseos-ppc64le
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/
+[rhel-9.8-baseos-ppc64le]
+name = rhel-9.8-baseos-ppc64le
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-baseos-ppc64le
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
-[rhel-9-appstream-ppc64le]
-name = rhel-9-appstream-ppc64le
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/
+[rhel-9.8-appstream-ppc64le]
+name = rhel-9.8-appstream-ppc64le
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-appstream-ppc64le
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
-[rhel-9-fast-datapath-ppc64le]
-name = rhel-9-fast-datapath-ppc64le
+[rhel-9.8-fast-datapath-ppc64le]
+name = rhel-9.8-fast-datapath-ppc64le
 baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/ppc64le/fast-datapath/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -106,8 +142,8 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-9-server-ose-ppc64le]
-name = rhel-9-server-ose-ppc64le
+[rhel-9.8-server-ose-4.22-ppc64le]
+name = rhel-9.8-server-ose-4.22-ppc64le
 baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22_ppc64le/rhel-9-server-ose-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -118,9 +154,9 @@ password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
 skip_if_unavailable = true
 
-[rhel-9-codeready-builder-rpms-ppc64le]
-name = rhel-9-codeready-builder-rpms-ppc64le
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/codeready-builder/os/
+[rhel-98-codeready-builder-rpms-ppc64le]
+name = rhel-98-codeready-builder-rpms-ppc64le
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/codeready-builder/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -130,32 +166,32 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-9-baseos-s390x]
-name = rhel-9-baseos-s390x
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/os/
+[rhel-9.8-baseos-s390x]
+name = rhel-9.8-baseos-s390x
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-baseos-s390x
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
-[rhel-9-appstream-s390x]
-name = rhel-9-appstream-s390x
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/
+[rhel-9.8-appstream-s390x]
+name = rhel-9.8-appstream-s390x
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-appstream-s390x
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
-[rhel-9-fast-datapath-s390x]
-name = rhel-9-fast-datapath-s390x
+[rhel-9.8-fast-datapath-s390x]
+name = rhel-9.8-fast-datapath-s390x
 baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/s390x/fast-datapath/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -166,8 +202,8 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-9-server-ose-s390x]
-name = rhel-9-server-ose-s390x
+[rhel-9.8-server-ose-4.22-s390x]
+name = rhel-9.8-server-ose-4.22-s390x
 baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22_s390x/rhel-9-server-ose-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -178,9 +214,9 @@ password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
 skip_if_unavailable = true
 
-[rhel-9-codeready-builder-rpms-s390x]
-name = rhel-9-codeready-builder-rpms-s390x
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/s390x/codeready-builder/os/
+[rhel-98-codeready-builder-rpms-s390x]
+name = rhel-98-codeready-builder-rpms-s390x
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/codeready-builder/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -190,32 +226,32 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-9-baseos-aarch64]
-name = rhel-9-baseos-aarch64
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/
+[rhel-9.8-baseos-aarch64]
+name = rhel-9.8-baseos-aarch64
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-baseos-aarch64
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
-[rhel-9-appstream-aarch64]
-name = rhel-9-appstream-aarch64
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/
+[rhel-9.8-appstream-aarch64]
+name = rhel-9.8-appstream-aarch64
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-appstream-aarch64
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
-[rhel-9-fast-datapath-aarch64]
-name = rhel-9-fast-datapath-aarch64
+[rhel-9.8-fast-datapath-aarch64]
+name = rhel-9.8-fast-datapath-aarch64
 baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/aarch64/fast-datapath/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -226,8 +262,8 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-9-server-ose-aarch64]
-name = rhel-9-server-ose-aarch64
+[rhel-9.8-server-ose-4.22-aarch64]
+name = rhel-9.8-server-ose-4.22-aarch64
 baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22_aarch64/rhel-9-server-ose-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -238,9 +274,9 @@ password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
 skip_if_unavailable = true
 
-[rhel-9-codeready-builder-rpms-aarch64]
-name = rhel-9-codeready-builder-rpms-aarch64
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/aarch64/codeready-builder/os/
+[rhel-98-codeready-builder-rpms-aarch64]
+name = rhel-98-codeready-builder-rpms-aarch64
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/codeready-builder/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false

--- a/core-services/release-controller/_repos/ocp-5.0-rhel9.repo
+++ b/core-services/release-controller/_repos/ocp-5.0-rhel9.repo
@@ -1,29 +1,54 @@
-[rhel-9-baseos]
-name = rhel-9-baseos
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/
+[rhel-9.8-baseos]
+name = rhel-9.8-baseos
+baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0/rhel-98-baseos
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
-[rhel-9-appstream]
-name = rhel-9-appstream
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/
+[rhel-9.8-appstream]
+name = rhel-9.8-appstream
+baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0/rhel-98-appstream
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
+excludepkgs = toolbox*
 
-[rhel-9-fast-datapath]
-name = rhel-9-fast-datapath
+[rhel-9.8-nfv]
+name = rhel-9.8-nfv
+baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0/rhel-98-nfv
+enabled = 1
+gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
+sslverify = false
+gpgcheck = 0
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
+failovermethod = priority
+skip_if_unavailable = true
+
+[rhel-9.8-highavailability]
+name = rhel-9.8-highavailability
+baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0/rhel-98-highavailability
+enabled = 1
+gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
+sslverify = false
+gpgcheck = 0
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
+failovermethod = priority
+skip_if_unavailable = true
+
+[rhel-9.8-fast-datapath]
+name = rhel-9.8-fast-datapath
 baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/fast-datapath/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -34,9 +59,9 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-9-nfv]
-name = rhel-9-nfv
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/x86_64/nfv/os/
+[rhel-98-codeready-builder-rpms]
+name = rhel-98-codeready-builder-rpms
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/codeready-builder/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -46,8 +71,8 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-9-server-ose]
-name = rhel-9-server-ose
+[rhel-9.8-server-ose-5.0]
+name = rhel-9.8-server-ose-5.0
 baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0/rhel-9-server-ose-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -58,44 +83,56 @@ password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
 skip_if_unavailable = true
 
-[rhel-9-codeready-builder-rpms]
-name = rhel-9-codeready-builder-rpms
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/x86_64/codeready-builder/os/
+# In the el-only variants, we still want the early kernels. Currently
+# those are just part of the plashets, which are OCP-versioned. In
+# https://issues.redhat.com/browse/ART-11248, we've agreed for now that
+# instead of having a separate RHEL-only repo, we'll just reuse a plashet repo
+# and filter out everything *but* the kernel. We just need to make sure to
+# use a plashet of an OCP version we know is based on the RHEL version we're
+# interested in.
+[rhel-9.8-early-kernel]
+name = rhel-9.8-early-kernel
+baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0/rhel-9-server-ose-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
+# - Also include the legacy toolbox package until we move to the new containers one
+# https://docs.google.com/document/d/137krt0IRctfwf2e7k1r7tKYPysWrDlTxqdFhFA9XKbw/edit?tab=t.0#heading=h.slko10np055j
+# https://issues.redhat.com/browse/OCPBUGS-56600
+includepkgs = kernel,kernel-*,toolbox*,
 
-[rhel-9-baseos-ppc64le]
-name = rhel-9-baseos-ppc64le
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/
+
+[rhel-9.8-baseos-ppc64le]
+name = rhel-9.8-baseos-ppc64le
+baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0/rhel-98-baseos-ppc64le
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
-[rhel-9-appstream-ppc64le]
-name = rhel-9-appstream-ppc64le
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/
+[rhel-9.8-appstream-ppc64le]
+name = rhel-9.8-appstream-ppc64le
+baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0/rhel-98-appstream-ppc64le
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
-[rhel-9-fast-datapath-ppc64le]
-name = rhel-9-fast-datapath-ppc64le
+[rhel-9.8-fast-datapath-ppc64le]
+name = rhel-9.8-fast-datapath-ppc64le
 baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/ppc64le/fast-datapath/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -106,8 +143,8 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-9-server-ose-ppc64le]
-name = rhel-9-server-ose-ppc64le
+[rhel-9.8-server-ose-5.0-ppc64le]
+name = rhel-9.8-server-ose-5.0-ppc64le
 baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0_ppc64le/rhel-9-server-ose-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -118,9 +155,9 @@ password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
 skip_if_unavailable = true
 
-[rhel-9-codeready-builder-rpms-ppc64le]
-name = rhel-9-codeready-builder-rpms-ppc64le
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/codeready-builder/os/
+[rhel-98-codeready-builder-rpms-ppc64le]
+name = rhel-98-codeready-builder-rpms-ppc64le
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/codeready-builder/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -130,32 +167,32 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-9-baseos-s390x]
-name = rhel-9-baseos-s390x
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/os/
+[rhel-9.8-baseos-s390x]
+name = rhel-9.8-baseos-s390x
+baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0/rhel-98-baseos-s390x
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
-[rhel-9-appstream-s390x]
-name = rhel-9-appstream-s390x
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/
+[rhel-9.8-appstream-s390x]
+name = rhel-9.8-appstream-s390x
+baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0/rhel-98-appstream-s390x
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
-[rhel-9-fast-datapath-s390x]
-name = rhel-9-fast-datapath-s390x
+[rhel-9.8-fast-datapath-s390x]
+name = rhel-9.8-fast-datapath-s390x
 baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/s390x/fast-datapath/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -166,8 +203,8 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-9-server-ose-s390x]
-name = rhel-9-server-ose-s390x
+[rhel-9.8-server-ose-5.0-s390x]
+name = rhel-9.8-server-ose-5.0-s390x
 baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0_s390x/rhel-9-server-ose-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -178,9 +215,9 @@ password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
 skip_if_unavailable = true
 
-[rhel-9-codeready-builder-rpms-s390x]
-name = rhel-9-codeready-builder-rpms-s390x
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/s390x/codeready-builder/os/
+[rhel-98-codeready-builder-rpms-s390x]
+name = rhel-98-codeready-builder-rpms-s390x
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/codeready-builder/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -190,32 +227,32 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-9-baseos-aarch64]
-name = rhel-9-baseos-aarch64
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/
+[rhel-9.8-baseos-aarch64]
+name = rhel-9.8-baseos-aarch64
+baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0/rhel-98-baseos-aarch64
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
-[rhel-9-appstream-aarch64]
-name = rhel-9-appstream-aarch64
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/
+[rhel-9.8-appstream-aarch64]
+name = rhel-9.8-appstream-aarch64
+baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0/rhel-98-appstream-aarch64
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
-[rhel-9-fast-datapath-aarch64]
-name = rhel-9-fast-datapath-aarch64
+[rhel-9.8-fast-datapath-aarch64]
+name = rhel-9.8-fast-datapath-aarch64
 baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/aarch64/fast-datapath/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -226,8 +263,8 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-9-server-ose-aarch64]
-name = rhel-9-server-ose-aarch64
+[rhel-9.8-server-ose-5.0-aarch64]
+name = rhel-9.8-server-ose-5.0-aarch64
 baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0_aarch64/rhel-9-server-ose-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -238,9 +275,9 @@ password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
 skip_if_unavailable = true
 
-[rhel-9-codeready-builder-rpms-aarch64]
-name = rhel-9-codeready-builder-rpms-aarch64
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/aarch64/codeready-builder/os/
+[rhel-98-codeready-builder-rpms-aarch64]
+name = rhel-98-codeready-builder-rpms-aarch64
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/codeready-builder/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -249,4 +286,3 @@ gpgcheck = 0
 sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
-


### PR DESCRIPTION
The base images that ART produces for CI builds now include 9.8 content so using repos prior to 9.8 creates dependency issues.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration for RHEL 9.8 support across OpenShift 4.22 and 5.0 deployments.
  * Refreshed package source URLs and authentication methods to align with OpenShift mirror infrastructure.
  * Added new repository channels for high availability and kernel package management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->