### PR TITLE
limits parallel rustc processes to 4

### DIFF
--- a/ci-operator/config/ViaQ/vector/ViaQ-vector-v0.54.0-rh.yaml
+++ b/ci-operator/config/ViaQ/vector/ViaQ-vector-v0.54.0-rh.yaml
@@ -58,7 +58,7 @@ resources:
       memory: 200Mi
 tests:
 - as: unit
-  commands: make test
+  commands: CARGO_BUILD_JOBS=4 make test
   container:
     from: logging-vector-test-unit
 - as: cargo-deny-check-bans


### PR DESCRIPTION
This PR limits parallel rustc processes to 4, reducing peak memory during compilation.
Now unit test runs with `CARGO_BUILD_JOBS=4`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated unit test build configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->