### PR TITLE
NO-JIRA: upkeep: add always run gather on edge clusters

### DIFF
--- a/ci-operator/step-registry/baremetalds/sno/baremetalds-sno-workflow.yaml
+++ b/ci-operator/step-registry/baremetalds/sno/baremetalds-sno-workflow.yaml
@@ -1,7 +1,6 @@
 workflow:
   as: baremetalds-sno
   steps:
-    allow_skip_on_success: true
     allow_best_effort_post_steps: true
     cluster_profile: equinix-edge-enablement
     pre:

--- a/ci-operator/step-registry/baremetalds/two-node/arbiter/baremetalds-two-node-arbiter-workflow.yaml
+++ b/ci-operator/step-registry/baremetalds/two-node/arbiter/baremetalds-two-node-arbiter-workflow.yaml
@@ -1,7 +1,6 @@
 workflow:
   as: baremetalds-two-node-arbiter
   steps:
-    allow_skip_on_success: true
     allow_best_effort_post_steps: true
     cluster_profile: equinix-edge-enablement
     pre:

--- a/ci-operator/step-registry/baremetalds/two-node/arbiter/e2e-openshift-test-private-tests/baremetalds-two-node-arbiter-e2e-openshift-test-private-tests-workflow.yaml
+++ b/ci-operator/step-registry/baremetalds/two-node/arbiter/e2e-openshift-test-private-tests/baremetalds-two-node-arbiter-e2e-openshift-test-private-tests-workflow.yaml
@@ -1,6 +1,7 @@
 workflow:
   as: baremetalds-two-node-arbiter-e2e-openshift-test-private-tests
   steps:
+    allow_best_effort_post_steps: true
     cluster_profile: equinix-edge-enablement
     pre:
       - chain: baremetalds-ofcir-pre

--- a/ci-operator/step-registry/baremetalds/two-node/arbiter/techpreview/baremetalds-two-node-arbiter-techpreview-workflow.yaml
+++ b/ci-operator/step-registry/baremetalds/two-node/arbiter/techpreview/baremetalds-two-node-arbiter-techpreview-workflow.yaml
@@ -1,7 +1,6 @@
 workflow:
   as: baremetalds-two-node-arbiter-techpreview
   steps:
-    allow_skip_on_success: true
     allow_best_effort_post_steps: true
     cluster_profile: equinix-edge-enablement
     pre:

--- a/ci-operator/step-registry/baremetalds/two-node/arbiter/upgrade/baremetalds-two-node-arbiter-upgrade-workflow.yaml
+++ b/ci-operator/step-registry/baremetalds/two-node/arbiter/upgrade/baremetalds-two-node-arbiter-upgrade-workflow.yaml
@@ -1,6 +1,7 @@
 workflow:
   as: baremetalds-two-node-arbiter-upgrade
   steps:
+    allow_best_effort_post_steps: true
     pre:
       - chain: baremetalds-ofcir-pre
     test:

--- a/ci-operator/step-registry/baremetalds/two-node/arbiter/upgrade/day-2-workers/baremetalds-two-node-arbiter-upgrade-day-2-workers-workflow.yaml
+++ b/ci-operator/step-registry/baremetalds/two-node/arbiter/upgrade/day-2-workers/baremetalds-two-node-arbiter-upgrade-day-2-workers-workflow.yaml
@@ -1,6 +1,7 @@
 workflow:
   as: baremetalds-two-node-arbiter-upgrade-day-2-workers
   steps:
+    allow_best_effort_post_steps: true
     pre:
       - chain: baremetalds-ofcir-pre
       - ref: baremetalds-two-node-arbiter-add-workers

--- a/ci-operator/step-registry/baremetalds/two-node/arbiter/workload-partitioning/baremetalds-two-node-arbiter-workload-partitioning-workflow.yaml
+++ b/ci-operator/step-registry/baremetalds/two-node/arbiter/workload-partitioning/baremetalds-two-node-arbiter-workload-partitioning-workflow.yaml
@@ -1,7 +1,6 @@
 workflow:
   as: baremetalds-two-node-arbiter-workload-partitioning
   steps:
-    allow_skip_on_success: true
     allow_best_effort_post_steps: true
     cluster_profile: equinix-edge-enablement
     pre:

--- a/ci-operator/step-registry/openshift/e2e/aws/single-node/openshift-e2e-aws-single-node-workflow.yaml
+++ b/ci-operator/step-registry/openshift/e2e/aws/single-node/openshift-e2e-aws-single-node-workflow.yaml
@@ -1,6 +1,7 @@
 workflow:
   as: openshift-e2e-aws-single-node
   steps:
+    allow_best_effort_post_steps: true
     pre:
     - chain: ipi-conf-aws
     - ref: single-node-conf-aws

--- a/ci-operator/step-registry/openshift/e2e/aws/single-node/recert/openshift-e2e-aws-single-node-recert-workflow.yaml
+++ b/ci-operator/step-registry/openshift/e2e/aws/single-node/recert/openshift-e2e-aws-single-node-recert-workflow.yaml
@@ -1,6 +1,7 @@
 workflow:
   as: openshift-e2e-aws-single-node-recert
   steps:
+    allow_best_effort_post_steps: true
     pre:
     - ref: ipi-conf
     - ref: aws-provision-vpc-shared

--- a/ci-operator/step-registry/openshift/e2e/aws/single-node/workers/openshift-e2e-aws-single-node-workers-workflow.yaml
+++ b/ci-operator/step-registry/openshift/e2e/aws/single-node/workers/openshift-e2e-aws-single-node-workers-workflow.yaml
@@ -1,6 +1,7 @@
 workflow:
   as: openshift-e2e-aws-single-node-workers
   steps:
+    allow_best_effort_post_steps: true
     pre:
     - chain: ipi-conf-aws
     - ref: single-node-conf-aws


### PR DESCRIPTION
added always run flag for gather steps on tna/sno clusters added allow best effort to avoid failing the run when the post step fails

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configurations for bare metal deployment and OpenShift e2e test scenarios to modify step execution behavior, including enabling best-effort post-step execution in multiple workflows and disabling skip-on-success logic in others.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->