### PR TITLE
hypershift: repin mgmt cluster release image to 4.22.0-ec.5

### DIFF
--- a/ci-operator/step-registry/hypershift/setup-nested-management-cluster/hypershift-setup-nested-management-cluster-chain.yaml
+++ b/ci-operator/step-registry/hypershift/setup-nested-management-cluster/hypershift-setup-nested-management-cluster-chain.yaml
@@ -61,7 +61,7 @@ chain:
 
       DOMAIN=${HYPERSHIFT_BASE_DOMAIN:-$DEFAULT_BASE_DOMAIN}
       DEFAULT_RELEASE_STREAM=4-stable
-      HYPERSHIFT_HC_RELEASE_IMAGE=${HYPERSHIFT_HC_RELEASE_IMAGE:-quay.io/openshift-release-dev/ocp-release:4.22.0-ec.3-multi}
+      HYPERSHIFT_HC_RELEASE_IMAGE=${HYPERSHIFT_HC_RELEASE_IMAGE:-quay.io/openshift-release-dev/ocp-release:4.22.0-ec.5-multi}
 
       CLUSTER_NAME="$(echo -n $PROW_JOB_ID|sha256sum|cut -c-10)-mgmt"
 


### PR DESCRIPTION
## Summary
- Update the default nested management cluster release image from `4.22.0-ec.3-multi` to `4.22.0-ec.5-multi` in the `hypershift-setup-nested-management-cluster` chain
- This image is used as the base OCP version for ephemeral management clusters created during HyperShift e2e CI jobs

## Test plan
- [ ] Verify HyperShift e2e presubmit jobs (e.g. `e2e-v2-aws`) pass with the updated release image
- [ ] Confirm management cluster comes up successfully with `4.22.0-ec.5-multi`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated the default release image version for nested management cluster setup to the latest available build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->