### PR TITLE
Adding MIWI tests to aro e2e

### DIFF
--- a/ci-operator/config/Azure/ARO-RP/Azure-ARO-RP-master.yaml
+++ b/ci-operator/config/Azure/ARO-RP/Azure-ARO-RP-master.yaml
@@ -38,34 +38,73 @@ resources:
       memory: 200Mi
 tests:
 - always_run: false
-  as: integration-e2e-parallel
+  as: integration-e2e-parallel-miwi
   optional: true
   steps:
     cluster_profile: aro-classic-int
     env:
+      E2E_TYPE: miwi
       LOCATION: uksouth
     workflow: aro-classic-e2e
 - always_run: false
-  as: stage-e2e-parallel
+  as: stage-e2e-parallel-miwi
   optional: true
   steps:
     cluster_profile: aro-classic-stg
     env:
+      E2E_TYPE: miwi
       LOCATION: uksouth
     workflow: aro-classic-e2e
 - always_run: false
-  as: prod-e2e-parallel
+  as: prod-e2e-parallel-miwi
   optional: true
   steps:
     cluster_profile: aro-classic-prod
     env:
+      E2E_TYPE: miwi
       LOCATION: uksouth
     workflow: aro-classic-e2e
 - always_run: false
-  as: e2e-parallel
+  as: e2e-parallel-miwi
   steps:
     cluster_profile: aro-classic-dev
     env:
+      E2E_TYPE: miwi
+      LOCATION: westus3
+    workflow: aro-classic-e2e
+- always_run: false
+  as: integration-e2e-parallel-csp
+  optional: true
+  steps:
+    cluster_profile: aro-classic-int
+    env:
+      E2E_TYPE: csp
+      LOCATION: uksouth
+    workflow: aro-classic-e2e
+- always_run: false
+  as: stage-e2e-parallel-csp
+  optional: true
+  steps:
+    cluster_profile: aro-classic-stg
+    env:
+      E2E_TYPE: csp
+      LOCATION: uksouth
+    workflow: aro-classic-e2e
+- always_run: false
+  as: prod-e2e-parallel-csp
+  optional: true
+  steps:
+    cluster_profile: aro-classic-prod
+    env:
+      E2E_TYPE: csp
+      LOCATION: uksouth
+    workflow: aro-classic-e2e
+- always_run: false
+  as: e2e-parallel-csp
+  steps:
+    cluster_profile: aro-classic-dev
+    env:
+      E2E_TYPE: csp
       LOCATION: westus3
     workflow: aro-classic-e2e
 zz_generated_metadata:

--- a/ci-operator/config/Azure/ARO-RP/Azure-ARO-RP-master__periodic.yaml
+++ b/ci-operator/config/Azure/ARO-RP/Azure-ARO-RP-master__periodic.yaml
@@ -22,27 +22,57 @@ resources:
       memory: 200Mi
 tests:
 - always_run: false
-  as: integration-e2e-parallel
+  as: integration-e2e-parallel-miwi
   cron: 0 0 1 1 *
   steps:
     cluster_profile: aro-classic-int
     env:
+      E2E_TYPE: miwi
       LOCATION: uksouth
     workflow: aro-classic-e2e
 - always_run: false
-  as: stage-e2e-parallel
+  as: stage-e2e-parallel-miwi
   cron: 0 0 1 1 *
   steps:
     cluster_profile: aro-classic-stg
     env:
+      E2E_TYPE: miwi
       LOCATION: uksouth
     workflow: aro-classic-e2e
 - always_run: false
-  as: prod-e2e-parallel
+  as: prod-e2e-parallel-miwi
   cron: 0 0 1 1 *
   steps:
     cluster_profile: aro-classic-prod
     env:
+      E2E_TYPE: miwi
+      LOCATION: uksouth
+    workflow: aro-classic-e2e
+- always_run: false
+  as: integration-e2e-parallel-csp
+  cron: 0 0 1 1 *
+  steps:
+    cluster_profile: aro-classic-int
+    env:
+      E2E_TYPE: csp
+      LOCATION: uksouth
+    workflow: aro-classic-e2e
+- always_run: false
+  as: stage-e2e-parallel-csp
+  cron: 0 0 1 1 *
+  steps:
+    cluster_profile: aro-classic-stg
+    env:
+      E2E_TYPE: csp
+      LOCATION: uksouth
+    workflow: aro-classic-e2e
+- always_run: false
+  as: prod-e2e-parallel-csp
+  cron: 0 0 1 1 *
+  steps:
+    cluster_profile: aro-classic-prod
+    env:
+      E2E_TYPE: csp
       LOCATION: uksouth
     workflow: aro-classic-e2e
 zz_generated_metadata:

--- a/ci-operator/jobs/Azure/ARO-RP/Azure-ARO-RP-master-periodics.yaml
+++ b/ci-operator/jobs/Azure/ARO-RP/Azure-ARO-RP-master-periodics.yaml
@@ -15,7 +15,7 @@ periodics:
     ci-operator.openshift.io/variant: periodic
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-Azure-ARO-RP-master-periodic-integration-e2e-parallel
+  name: periodic-ci-Azure-ARO-RP-master-periodic-integration-e2e-parallel-csp
   spec:
     containers:
     - args:
@@ -24,7 +24,89 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=integration-e2e-parallel
+      - --target=integration-e2e-parallel-csp
+      - --variant=periodic
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build06
+  cron: 0 0 1 1 *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: master
+    org: Azure
+    repo: ARO-RP
+  labels:
+    ci-operator.openshift.io/cloud: aro-classic-int
+    ci-operator.openshift.io/cloud-cluster-profile: aro-classic-int
+    ci-operator.openshift.io/variant: periodic
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-Azure-ARO-RP-master-periodic-integration-e2e-parallel-miwi
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=integration-e2e-parallel-miwi
       - --variant=periodic
       command:
       - ci-operator
@@ -97,7 +179,7 @@ periodics:
     ci-operator.openshift.io/variant: periodic
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-Azure-ARO-RP-master-periodic-prod-e2e-parallel
+  name: periodic-ci-Azure-ARO-RP-master-periodic-prod-e2e-parallel-csp
   spec:
     containers:
     - args:
@@ -106,7 +188,89 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=prod-e2e-parallel
+      - --target=prod-e2e-parallel-csp
+      - --variant=periodic
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build06
+  cron: 0 0 1 1 *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: master
+    org: Azure
+    repo: ARO-RP
+  labels:
+    ci-operator.openshift.io/cloud: aro-classic-prod
+    ci-operator.openshift.io/cloud-cluster-profile: aro-classic-prod
+    ci-operator.openshift.io/variant: periodic
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-Azure-ARO-RP-master-periodic-prod-e2e-parallel-miwi
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=prod-e2e-parallel-miwi
       - --variant=periodic
       command:
       - ci-operator
@@ -179,7 +343,7 @@ periodics:
     ci-operator.openshift.io/variant: periodic
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-Azure-ARO-RP-master-periodic-stage-e2e-parallel
+  name: periodic-ci-Azure-ARO-RP-master-periodic-stage-e2e-parallel-csp
   spec:
     containers:
     - args:
@@ -188,7 +352,89 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=stage-e2e-parallel
+      - --target=stage-e2e-parallel-csp
+      - --variant=periodic
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build06
+  cron: 0 0 1 1 *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: master
+    org: Azure
+    repo: ARO-RP
+  labels:
+    ci-operator.openshift.io/cloud: aro-classic-stg
+    ci-operator.openshift.io/cloud-cluster-profile: aro-classic-stg
+    ci-operator.openshift.io/variant: periodic
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-Azure-ARO-RP-master-periodic-stage-e2e-parallel-miwi
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=stage-e2e-parallel-miwi
       - --variant=periodic
       command:
       - ci-operator

--- a/ci-operator/jobs/Azure/ARO-RP/Azure-ARO-RP-master-presubmits.yaml
+++ b/ci-operator/jobs/Azure/ARO-RP/Azure-ARO-RP-master-presubmits.yaml
@@ -6,7 +6,7 @@ presubmits:
     - ^master$
     - ^master-
     cluster: build11
-    context: ci/prow/e2e-parallel
+    context: ci/prow/e2e-parallel-csp
     decorate: true
     decoration_config:
       skip_cloning: true
@@ -15,8 +15,8 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aro-classic-dev
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-Azure-ARO-RP-master-e2e-parallel
-    rerun_command: /test e2e-parallel
+    name: pull-ci-Azure-ARO-RP-master-e2e-parallel-csp
+    rerun_command: /test e2e-parallel-csp
     spec:
       containers:
       - args:
@@ -25,7 +25,7 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-parallel
+        - --target=e2e-parallel-csp
         command:
         - ci-operator
         env:
@@ -81,7 +81,89 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )(e2e-parallel|remaining-required),?($|\s.*)
+    trigger: (?m)^/test( | .* )(e2e-parallel-csp|remaining-required),?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^master$
+    - ^master-
+    cluster: build11
+    context: ci/prow/e2e-parallel-miwi
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: aro-classic-dev
+      ci-operator.openshift.io/cloud-cluster-profile: aro-classic-dev
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-Azure-ARO-RP-master-e2e-parallel-miwi
+    rerun_command: /test e2e-parallel-miwi
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-parallel-miwi
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )(e2e-parallel-miwi|remaining-required),?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:
@@ -143,7 +225,7 @@ presubmits:
     - ^master$
     - ^master-
     cluster: build11
-    context: ci/prow/integration-e2e-parallel
+    context: ci/prow/integration-e2e-parallel-csp
     decorate: true
     decoration_config:
       skip_cloning: true
@@ -152,9 +234,9 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aro-classic-int
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-Azure-ARO-RP-master-integration-e2e-parallel
+    name: pull-ci-Azure-ARO-RP-master-integration-e2e-parallel-csp
     optional: true
-    rerun_command: /test integration-e2e-parallel
+    rerun_command: /test integration-e2e-parallel-csp
     spec:
       containers:
       - args:
@@ -163,7 +245,7 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=integration-e2e-parallel
+        - --target=integration-e2e-parallel-csp
         command:
         - ci-operator
         env:
@@ -219,14 +301,97 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )integration-e2e-parallel,?($|\s.*)
+    trigger: (?m)^/test( | .* )integration-e2e-parallel-csp,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:
     - ^master$
     - ^master-
     cluster: build11
-    context: ci/prow/prod-e2e-parallel
+    context: ci/prow/integration-e2e-parallel-miwi
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: aro-classic-int
+      ci-operator.openshift.io/cloud-cluster-profile: aro-classic-int
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-Azure-ARO-RP-master-integration-e2e-parallel-miwi
+    optional: true
+    rerun_command: /test integration-e2e-parallel-miwi
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=integration-e2e-parallel-miwi
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )integration-e2e-parallel-miwi,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^master$
+    - ^master-
+    cluster: build11
+    context: ci/prow/prod-e2e-parallel-csp
     decorate: true
     decoration_config:
       skip_cloning: true
@@ -235,9 +400,9 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aro-classic-prod
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-Azure-ARO-RP-master-prod-e2e-parallel
+    name: pull-ci-Azure-ARO-RP-master-prod-e2e-parallel-csp
     optional: true
-    rerun_command: /test prod-e2e-parallel
+    rerun_command: /test prod-e2e-parallel-csp
     spec:
       containers:
       - args:
@@ -246,7 +411,7 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=prod-e2e-parallel
+        - --target=prod-e2e-parallel-csp
         command:
         - ci-operator
         env:
@@ -302,14 +467,97 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )prod-e2e-parallel,?($|\s.*)
+    trigger: (?m)^/test( | .* )prod-e2e-parallel-csp,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:
     - ^master$
     - ^master-
     cluster: build11
-    context: ci/prow/stage-e2e-parallel
+    context: ci/prow/prod-e2e-parallel-miwi
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: aro-classic-prod
+      ci-operator.openshift.io/cloud-cluster-profile: aro-classic-prod
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-Azure-ARO-RP-master-prod-e2e-parallel-miwi
+    optional: true
+    rerun_command: /test prod-e2e-parallel-miwi
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=prod-e2e-parallel-miwi
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )prod-e2e-parallel-miwi,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^master$
+    - ^master-
+    cluster: build11
+    context: ci/prow/stage-e2e-parallel-csp
     decorate: true
     decoration_config:
       skip_cloning: true
@@ -318,9 +566,9 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aro-classic-stg
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-Azure-ARO-RP-master-stage-e2e-parallel
+    name: pull-ci-Azure-ARO-RP-master-stage-e2e-parallel-csp
     optional: true
-    rerun_command: /test stage-e2e-parallel
+    rerun_command: /test stage-e2e-parallel-csp
     spec:
       containers:
       - args:
@@ -329,7 +577,7 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=stage-e2e-parallel
+        - --target=stage-e2e-parallel-csp
         command:
         - ci-operator
         env:
@@ -385,4 +633,87 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )stage-e2e-parallel,?($|\s.*)
+    trigger: (?m)^/test( | .* )stage-e2e-parallel-csp,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^master$
+    - ^master-
+    cluster: build11
+    context: ci/prow/stage-e2e-parallel-miwi
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: aro-classic-stg
+      ci-operator.openshift.io/cloud-cluster-profile: aro-classic-stg
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-Azure-ARO-RP-master-stage-e2e-parallel-miwi
+    optional: true
+    rerun_command: /test stage-e2e-parallel-miwi
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=stage-e2e-parallel-miwi
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )stage-e2e-parallel-miwi,?($|\s.*)

--- a/ci-operator/step-registry/aro-classic/test/persistent/aro-classic-test-persistent-commands.sh
+++ b/ci-operator/step-registry/aro-classic/test/persistent/aro-classic-test-persistent-commands.sh
@@ -19,13 +19,15 @@ export LOCATION; LOCATION="${LOCATION:=${LEASED_RESOURCE}}"
 if [[ -n "${MULTISTAGE_PARAM_OVERRIDE_LOCATION:-}" ]]; then
   LOCATION="${MULTISTAGE_PARAM_OVERRIDE_LOCATION}"
 fi
+
 export E2E_TYPE; E2E_TYPE="${E2E_TYPE:=csp}"
+if [[ "${E2E_TYPE}" == "miwi" ]]; then
+  export USE_WI="true"
+  export PLATFORM_WORKLOAD_IDENTITY_ROLE_SETS; PLATFORM_WORKLOAD_IDENTITY_ROLE_SETS=$(az rest --method GET --uri "/subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.redhatopenshift/locations/${LOCATION}/platformworkloadidentityrolesets?api-version=2025-07-25" --query "value[*].properties")
+else
+  export USE_WI="false"
+fi
 export RESOURCEGROUP; RESOURCEGROUP="${NAMESPACE}-prow-${LOCATION}-${UNIQUE_HASH}-${E2E_TYPE}"
 export CLUSTER; CLUSTER="${RESOURCEGROUP}"
-
-
-echo "Location: ${LOCATION}"
-echo "Resource Group: ${RESOURCEGROUP}"
-echo "Cluster Name: ${CLUSTER}"
 
 e2e.test -test.v --ginkgo.v --ginkgo.timeout 180m --ginkgo.flake-attempts=2 --ginkgo.no-color --ginkgo.label-filter=!smoke

--- a/ci-operator/step-registry/aro-classic/test/persistent/aro-classic-test-persistent-ref.yaml
+++ b/ci-operator/step-registry/aro-classic/test/persistent/aro-classic-test-persistent-ref.yaml
@@ -16,5 +16,10 @@ ref:
     - name: MULTISTAGE_PARAM_OVERRIDE_LOCATION
       default: ""
       documentation: Overrides LOCATION via Gangway API.
+        That way we can have tests that choose different locations.
+    - name: E2E_TYPE
+      default: "csp"
+      documentation: |-
+        Type of end-to-end test to run.  For example, "csp" or "miwi".
   documentation: |-
     Run the Azure/ARO-RP/e2e binary.


### PR DESCRIPTION
Adding MIWI tests to aro e2e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Extended CI/CD testing infrastructure to support two end-to-end test variants: CSP (Classic Service Principal) and MIWI (Managed Identity Workload Identity).
  * Updated presubmit and periodic job definitions with separate test configurations for each variant.
  * Added conditional workload identity configuration logic based on test type selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->