### PR TITLE
hypershift/gcp/gke: fix project ID collision between e2e-gke and e2e-v2-gke

### DIFF
--- a/ci-operator/step-registry/hypershift/gcp/gke/deprovision/hypershift-gcp-gke-deprovision-commands.sh
+++ b/ci-operator/step-registry/hypershift/gcp/gke/deprovision/hypershift-gcp-gke-deprovision-commands.sh
@@ -18,8 +18,8 @@ else
     # If the provision step is aborted (SIGTERM), the Secret update may not complete,
     # leaving SHARED_DIR empty for post steps. Reconstruct from env vars.
     RESOURCE_NAME_PREFIX="${NAMESPACE}-${UNIQUE_HASH}"
-    INFRA_ID="${RESOURCE_NAME_PREFIX}"
-    CP_PROJECT_ID="${INFRA_ID:0:14}-control-plane"
+    PROJECT_HASH="ci$(echo -n "${BUILD_ID}" | sha256sum | cut -c1-8)"
+    CP_PROJECT_ID="${PROJECT_HASH}-control-plane"
     CP_CLUSTER_NAME="${RESOURCE_NAME_PREFIX}-gke"
     GCP_REGION="${GKE_REGION}"
     echo "WARNING: SHARED_DIR files missing - reconstructed resource names from env vars"
@@ -41,8 +41,8 @@ fi
 if [[ -f "${SHARED_DIR}/hosted-cluster-project-id" ]]; then
     HC_PROJECT_ID="$(<"${SHARED_DIR}/hosted-cluster-project-id")"
 else
-    INFRA_ID="${INFRA_ID:-${NAMESPACE}-${UNIQUE_HASH}}"
-    HC_PROJECT_ID="${INFRA_ID:0:14}-hosted-cluster"
+    PROJECT_HASH="${PROJECT_HASH:-ci$(echo -n "${BUILD_ID}" | sha256sum | cut -c1-8)}"
+    HC_PROJECT_ID="${PROJECT_HASH}-hosted-cluster"
     echo "WARNING: Reconstructed HC_PROJECT_ID=${HC_PROJECT_ID}"
 fi
 

--- a/ci-operator/step-registry/hypershift/gcp/gke/provision/hypershift-gcp-gke-provision-commands.sh
+++ b/ci-operator/step-registry/hypershift/gcp/gke/provision/hypershift-gcp-gke-provision-commands.sh
@@ -20,9 +20,13 @@ CLUSTER_NAME="${RESOURCE_NAME_PREFIX}-gke"
 INFRA_ID="${RESOURCE_NAME_PREFIX}"
 
 # Dynamic project IDs (created per-test)
-# Truncate to meet GCP's 30 character limit for project IDs
-CP_PROJECT_ID="${INFRA_ID:0:14}-control-plane"
-HC_PROJECT_ID="${INFRA_ID:0:14}-hosted-cluster"
+# Use BUILD_ID (unique per Prow job) to avoid project ID collisions between
+# concurrent tests sharing the same NAMESPACE and UNIQUE_HASH (e.g. e2e-gke and e2e-v2-gke).
+# Prefix with "ci" to satisfy GCP's requirement that project IDs start with a letter.
+# Result: "ci" + 8 hex chars + suffix = 24-25 chars, under the 30-char GCP limit.
+PROJECT_HASH="ci$(echo -n "${BUILD_ID}" | sha256sum | cut -c1-8)"
+CP_PROJECT_ID="${PROJECT_HASH}-control-plane"
+HC_PROJECT_ID="${PROJECT_HASH}-hosted-cluster"
 
 # Write deprovision-critical values to SHARED_DIR before creating any resources,
 # so the deprovision step can clean up if the step fails or the job is interrupted.


### PR DESCRIPTION
## Summary

- Both `e2e-gke` and `e2e-v2-gke` tests are defined in the same ci-operator config and share the same `NAMESPACE` and `UNIQUE_HASH`
- The GKE provision script was constructing GCP project IDs from `${NAMESPACE}-${UNIQUE_HASH}` truncated to 14 chars, producing identical project names for both concurrent tests
- Fix uses `BUILD_ID` (unique per Prow job execution) to derive project IDs via SHA256 hash, eliminating the collision

## Test plan

- [ ] Verify `bash -n` passes on both modified scripts (no syntax errors)
- [ ] Open a PR touching GCP-related files in openshift/hypershift to trigger both `e2e-gke` and `e2e-v2-gke` simultaneously and confirm both provision steps succeed without project ID conflicts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure Updates**
  * Improved GCP project identification for hypershift control-plane and hosted-cluster resources. Project naming now uses build-based deterministic identifiers instead of truncated infrastructure IDs, enhancing consistency in provisioning and deprovisioning workflows while maintaining GCP requirements compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->