### PR TITLE
Fix OKD SCOS upgrade periodic jobs (drop openshift_installer)

### DIFF
--- a/ci-operator/jobs/openshift/release/openshift-release-infra-periodics.yaml
+++ b/ci-operator/jobs/openshift/release/openshift-release-infra-periodics.yaml
@@ -2730,21 +2730,23 @@ periodics:
                 memory: 200Mi
           tests:
           - as: e2e-$(CLUSTER_TYPE)
-            commands: TEST_SUITE=openshift/conformance/parallel run-tests
-            openshift_installer:
+            steps:
               cluster_profile: "$(CLUSTER_TYPE)"
+              workflow: openshift-e2e-$(CLUSTER_TYPE)
           - as: e2e-$(CLUSTER_TYPE)-serial
-            commands: TEST_SUITE=openshift/conformance/serial run-tests
-            openshift_installer:
+            steps:
               cluster_profile: "$(CLUSTER_TYPE)"
+              workflow: openshift-e2e-$(CLUSTER_TYPE)-serial
           - as: e2e-$(CLUSTER_TYPE)-upgrade
             steps:
               cluster_profile: "$(CLUSTER_TYPE)"
               workflow: openshift-upgrade-$(CLUSTER_TYPE)
           - as: launch-$(CLUSTER_TYPE)
-            commands: sleep 9000 & wait
-            openshift_installer:
+            steps:
               cluster_profile: "$(CLUSTER_TYPE)"
+              test:
+              - ref: clusterbot-wait
+              workflow: openshift-e2e-$(CLUSTER_TYPE)
       image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
       imagePullPolicy: Always
       name: ""
@@ -2933,22 +2935,23 @@ periodics:
                 memory: 200Mi
           tests:
           - as: e2e-$(CLUSTER_TYPE)
-            commands: TEST_SUITE=openshift/conformance/parallel run-tests
-            openshift_installer:
+            steps:
               cluster_profile: "$(CLUSTER_TYPE)"
+              workflow: openshift-e2e-$(CLUSTER_TYPE)
           - as: e2e-$(CLUSTER_TYPE)-serial
-            commands: TEST_SUITE=openshift/conformance/serial run-tests
-            openshift_installer:
+            steps:
               cluster_profile: "$(CLUSTER_TYPE)"
+              workflow: openshift-e2e-$(CLUSTER_TYPE)-serial
           - as: e2e-$(CLUSTER_TYPE)-upgrade
-            commands: TEST_SUITE=all run-upgrade-tests
-            openshift_installer:
+            steps:
               cluster_profile: "$(CLUSTER_TYPE)"
-              upgrade: true
+              workflow: openshift-upgrade-$(CLUSTER_TYPE)
           - as: launch-$(CLUSTER_TYPE)
-            commands: sleep 9000 & wait
-            openshift_installer:
+            steps:
               cluster_profile: "$(CLUSTER_TYPE)"
+              test:
+              - ref: clusterbot-wait
+              workflow: openshift-e2e-$(CLUSTER_TYPE)
       image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
       imagePullPolicy: Always
       name: ""
@@ -3032,22 +3035,23 @@ periodics:
                 memory: 200Mi
           tests:
           - as: e2e-$(CLUSTER_TYPE)
-            commands: TEST_SUITE=openshift/conformance/parallel run-tests
-            openshift_installer:
+            steps:
               cluster_profile: "$(CLUSTER_TYPE)"
+              workflow: openshift-e2e-$(CLUSTER_TYPE)
           - as: e2e-$(CLUSTER_TYPE)-serial
-            commands: TEST_SUITE=openshift/conformance/serial run-tests
-            openshift_installer:
+            steps:
               cluster_profile: "$(CLUSTER_TYPE)"
+              workflow: openshift-e2e-$(CLUSTER_TYPE)-serial
           - as: e2e-$(CLUSTER_TYPE)-upgrade
-            commands: TEST_SUITE=all run-upgrade-tests
-            openshift_installer:
+            steps:
               cluster_profile: "$(CLUSTER_TYPE)"
-              upgrade: true
+              workflow: openshift-upgrade-$(CLUSTER_TYPE)
           - as: launch-$(CLUSTER_TYPE)
-            commands: sleep 9000 & wait
-            openshift_installer:
+            steps:
               cluster_profile: "$(CLUSTER_TYPE)"
+              test:
+              - ref: clusterbot-wait
+              workflow: openshift-e2e-$(CLUSTER_TYPE)
       image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
       imagePullPolicy: Always
       name: ""


### PR DESCRIPTION
Fixes remaining jobs that were missed in #77943:
- release-openshift-okd-scos-installer-e2e-aws-upgrade-from-scos-next
- release-openshift-okd-scos-installer-e2e-gcp-upgrade-from-scos-stable
- release-openshift-okd-scos-installer-e2e-gcp-upgrade-from-scos-next Convert from deprecated openshift_installer to steps/workflow format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Consolidated and streamlined internal CI/CD infrastructure configurations for periodic job testing, unifying the execution model across conformance parallel testing, serial testing, upgrade testing, and cluster launch procedures. This refactoring improves consistency and maintainability of testing workflows while preserving all existing functionality and test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->