### PR TITLE
Disable all informing jobs on 4.20 release controllers

### DIFF
--- a/core-services/release-controller/_releases/release-ocp-4.20-multi.json
+++ b/core-services/release-controller/_releases/release-ocp-4.20-multi.json
@@ -24,7 +24,8 @@
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-multiarch-main-nightly-4.20-ocp-e2e-aws-ovn-multi-x-ax"
-      }
+      },
+      "disabled": true
     },
     "hypershift-e2e-aws": {
       "prowJob": {
@@ -32,7 +33,8 @@
       },
       "optional": true,
       "upgrade": true,
-      "upgradeFrom": "Previous"
+      "upgradeFrom": "Previous",
+      "disabled": true
     },
     "hypershift-e2e-aks-multi-x-ax": {
       "maxRetries": 1,
@@ -48,7 +50,8 @@
         "name": "periodic-ci-openshift-multiarch-main-nightly-4.20-ocp-e2e-upgrade-aws-ovn-multi-x-x"
       },
       "upgrade": true,
-      "upgradeFrom": "Previous"
+      "upgradeFrom": "Previous",
+      "disabled": true
     },
     "e2e-aws-ovn-nightly-upgrade-multi-x-ax": {
       "optional": true,
@@ -56,7 +59,8 @@
         "name": "periodic-ci-openshift-multiarch-main-nightly-4.20-ocp-e2e-aws-ovn-upgrade-multi-x-ax"
       },
       "upgrade": true,
-      "upgradeFrom": "Previous"
+      "upgradeFrom": "Previous",
+      "disabled": true
     },
     "e2e-aws-ovn-minor-upgrade-multi-a-a": {
       "optional": true,
@@ -69,7 +73,8 @@
           "stream": "nightly-multi",
           "version": "4.19"
         }
-      }
+      },
+      "disabled": true
     },
     "e2e-aws-ovn-minor-upgrade-multi-x-ax": {
       "optional": true,
@@ -82,7 +87,8 @@
           "stream": "nightly-multi",
           "version": "4.19"
         }
-      }
+      },
+      "disabled": true
     },
     "e2e-nightly-upgrade-azure-ovn-multi-x-ax": {
       "optional": true,
@@ -90,7 +96,8 @@
         "name": "periodic-ci-openshift-multiarch-main-nightly-4.20-ocp-e2e-upgrade-azure-ovn-multi-x-ax"
       },
       "upgrade": true,
-      "upgradeFrom": "Previous"
+      "upgradeFrom": "Previous",
+      "disabled": true
     },
     "e2e-minor-upgrade-azure-ovn-multi-x-ax": {
       "optional": true,
@@ -103,19 +110,22 @@
           "stream": "nightly-multi",
           "version": "4.19"
         }
-      }
+      },
+      "disabled": true
     },
     "e2e-azure-ovn-multi-x-ax": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-multiarch-main-nightly-4.20-ocp-e2e-azure-ovn-multi-x-ax"
-      }
+      },
+      "disabled": true
     },
     "e2e-gcp-ovn-multi-x-ax": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-multiarch-main-nightly-4.20-ocp-e2e-gcp-ovn-multi-x-ax"
-      }
+      },
+      "disabled": true
     },
     "e2e-nightly-upgrade-gcp-ovn-multi-x-ax": {
       "optional": true,
@@ -123,7 +133,8 @@
         "name": "periodic-ci-openshift-multiarch-main-nightly-4.20-ocp-e2e-upgrade-gcp-ovn-multi-x-ax"
       },
       "upgrade": true,
-      "upgradeFrom": "Previous"
+      "upgradeFrom": "Previous",
+      "disabled": true
     },
     "e2e-minor-upgrade-gcp-ovn-multi-x-ax": {
       "optional": true,
@@ -136,13 +147,15 @@
           "stream": "nightly-multi",
           "version": "4.19"
         }
-      }
+      },
+      "disabled": true
     },
     "e2e-serial-aws-ovn-multi-x-ax": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-multiarch-main-nightly-4.20-ocp-e2e-serial-aws-ovn-multi-x-ax"
-      }
+      },
+      "disabled": true
     },
     "e2e-aws-ovn-multi-a-a": {
       "maxRetries": 1,
@@ -156,31 +169,36 @@
         "name": "periodic-ci-openshift-multiarch-main-nightly-4.20-ocp-e2e-upgrade-aws-ovn-multi-a-a"
       },
       "upgrade": true,
-      "upgradeFrom": "Previous"
+      "upgradeFrom": "Previous",
+      "disabled": true
     },
     "e2e-ovn-serial-aws-multi-a-a-1of2": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-multiarch-main-nightly-4.20-ocp-e2e-ovn-serial-aws-multi-a-a-1of2"
-      }
+      },
+      "disabled": true
     },
     "e2e-ovn-serial-aws-multi-a-a-2of2": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-multiarch-main-nightly-4.20-ocp-e2e-ovn-serial-aws-multi-a-a-2of2"
-      }
+      },
+      "disabled": true
     },
     "e2e-aws-ovn-sno-multi-a-a": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-multiarch-main-nightly-4.20-ocp-e2e-aws-ovn-sno-multi-a-a"
-      }
+      },
+      "disabled": true
     },
     "e2e-azure-ovn-multi-a-a": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-multiarch-main-nightly-4.20-ocp-e2e-azure-ovn-multi-a-a"
-      }
+      },
+      "disabled": true
     },
     "e2e-nightly-upgrade-azure-ovn-multi-a-a": {
       "optional": true,
@@ -188,7 +206,8 @@
         "name": "periodic-ci-openshift-multiarch-main-nightly-4.20-ocp-e2e-upgrade-azure-ovn-multi-a-a"
       },
       "upgrade": true,
-      "upgradeFrom": "Previous"
+      "upgradeFrom": "Previous",
+      "disabled": true
     },
     "e2e-minor-upgrade-azure-ovn-multi-a-a": {
       "optional": true,
@@ -201,13 +220,15 @@
           "stream": "nightly-multi",
           "version": "4.19"
         }
-      }
+      },
+      "disabled": true
     },
     "e2e-gcp-ovn-multi-a-a": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-multiarch-main-nightly-4.20-ocp-e2e-gcp-ovn-multi-a-a"
-      }
+      },
+      "disabled": true
     },
     "e2e-minor-upgrade-gcp-ovn-multi-a-a": {
       "optional": true,
@@ -220,7 +241,8 @@
           "stream": "nightly-multi",
           "version": "4.19"
         }
-      }
+      },
+      "disabled": true
     }
   }
 }

--- a/core-services/release-controller/_releases/release-ocp-4.20.json
+++ b/core-services/release-controller/_releases/release-ocp-4.20.json
@@ -72,13 +72,15 @@
       "maxRetries": 1,
       "prowJob": {
         "name": "periodic-ci-openshift-hypershift-release-4.20-periodics-e2e-azure-aks-ovn-conformance"
-      }
+      },
+      "disabled": true
     },
     "hypershift-kubevirt-ovn-conformance-4.20": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-hypershift-release-4.20-periodics-e2e-azure-kubevirt-ovn"
-      }
+      },
+      "disabled": true
     },
     "aws-ovn-single-node-upgrade-4.20-micro": {
       "maxRetries": 1,
@@ -91,31 +93,36 @@
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-nightly-4.20-console-aws"
-      }
+      },
+      "disabled": true
     },
     "aws-control-plane-machine-set-operator": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.20-periodics-e2e-aws"
-      }
+      },
+      "disabled": true
     },
     "aws-csi": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-nightly-4.20-e2e-aws-csi"
-      }
+      },
+      "disabled": true
     },
     "aws-ovn": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-ci-4.20-e2e-aws-ovn"
-      }
+      },
+      "disabled": true
     },
     "aws-ovn-fips": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-nightly-4.20-e2e-aws-ovn-fips"
-      }
+      },
+      "disabled": true
     },
     "aws-ovn-serial-1of2": {
       "maxRetries": 1,
@@ -133,19 +140,22 @@
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-nightly-4.20-e2e-aws-ovn-single-node"
-      }
+      },
+      "disabled": true
     },
     "aws-ovn-single-node-serial": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-nightly-4.20-e2e-aws-ovn-single-node-serial"
-      }
+      },
+      "disabled": true
     },
     "aws-ovn-single-node-csi": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-nightly-4.20-e2e-aws-ovn-single-node-csi"
-      }
+      },
+      "disabled": true
     },
     "aws-ovn-single-node-upgrade-minor": {
       "optional": true,
@@ -158,63 +168,73 @@
           "stream": "nightly",
           "version": "4.19"
         }
-      }
+      },
+      "disabled": true
     },
     "aws-ovn-upgrade-out-of-change": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-ci-4.20-e2e-aws-ovn-upgrade-out-of-change"
       },
-      "upgrade": true
+      "upgrade": true,
+      "disabled": true
     },
     "aws-ovn-cgroupsv2": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-nightly-4.20-e2e-aws-ovn-cgroupsv2"
-      }
+      },
+      "disabled": true
     },
     "aws-upi": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-nightly-4.20-e2e-aws-ovn-upi"
-      }
+      },
+      "disabled": true
     },
     "azure-control-plane-machine-set-operator": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.20-periodics-e2e-azure"
-      }
+      },
+      "disabled": true
     },
     "azure-csi": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-nightly-4.20-e2e-azure-csi"
-      }
+      },
+      "disabled": true
     },
     "azure-ovn": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-ci-4.20-e2e-azure-ovn"
-      }
+      },
+      "disabled": true
     },
     "azure-ovn-serial": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-ci-4.20-e2e-azure-ovn-serial"
-      }
+      },
+      "disabled": true
     },
     "azure-ovn-upgrade-out-of-change": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-ci-4.20-e2e-azure-ovn-upgrade-out-of-change"
       },
-      "upgrade": true
+      "upgrade": true,
+      "disabled": true
     },
     "cnv": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-cnv-nightly-4.20-deploy-azure-kubevirt-ovn"
-      }
+      },
+      "disabled": true
     },
     "driver-toolkit": {
       "maxRetries": 1,
@@ -226,25 +246,29 @@
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.20-periodics-e2e-gcp"
-      }
+      },
+      "disabled": true
     },
     "gcp-ovn": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-ci-4.20-e2e-gcp-ovn"
-      }
+      },
+      "disabled": true
     },
     "gcp-ovn-csi": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-nightly-4.20-e2e-gcp-ovn-csi"
-      }
+      },
+      "disabled": true
     },
     "gcp-ovn-rt": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-nightly-4.20-e2e-gcp-ovn-rt"
-      }
+      },
+      "disabled": true
     },
     "gcp-ovn-upgrade-4.20-minor": {
       "optional": true,
@@ -257,27 +281,31 @@
           "stream": "nightly",
           "version": "4.19"
         }
-      }
+      },
+      "disabled": true
     },
     "gcp-ovn-serial": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-nightly-4.20-e2e-gcp-ovn-serial"
-      }
+      },
+      "disabled": true
     },
     "gcp-ovn-upgrade-micro": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-ci-4.20-e2e-gcp-ovn-upgrade"
       },
-      "upgrade": true
+      "upgrade": true,
+      "disabled": true
     },
     "install-analysis-all": {
       "maxRetries": 1,
       "multiJobAnalysis": true,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-nightly-4.20-install-analysis-all"
-      }
+      },
+      "disabled": true
     },
     "upgrade-analysis-all": {
       "optional": true,
@@ -285,13 +313,15 @@
       "multiJobAnalysis": true,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-nightly-4.20-upgrade-analysis-all"
-      }
+      },
+      "disabled": true
     },
     "metal-ipi-ovn-dualstack": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-nightly-4.20-e2e-metal-ipi-ovn-dualstack"
-      }
+      },
+      "disabled": true
     },
     "metal-ipi-ovn-ipv6": {
       "maxRetries": 1,
@@ -303,13 +333,15 @@
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-nightly-4.20-e2e-metal-ipi-ovn-serial-virtualmedia-1of2"
-      }
+      },
+      "disabled": true
     },
     "metal-ipi-ovn-serial-virtualmedia-2of2": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-nightly-4.20-e2e-metal-ipi-ovn-serial-virtualmedia-2of2"
-      }
+      },
+      "disabled": true
     },
     "metal-ipi-ovn-bm": {
       "maxRetries": 1,
@@ -322,7 +354,8 @@
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-nightly-4.20-e2e-metal-ipi-ovn-upgrade"
       },
-      "upgrade": true
+      "upgrade": true,
+      "disabled": true
     },
     "metal-ipi-ovn-upgrade-minor": {
       "optional": true,
@@ -335,32 +368,37 @@
           "stream": "nightly",
           "version": "4.19"
         }
-      }
+      },
+      "disabled": true
     },
     "metal-ipi-ovn-serial": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-nightly-4.20-e2e-metal-ipi-ovn-serial-ipv4"
-      }
+      },
+      "disabled": true
     },
     "metal-ipi-serial-ipv6": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-nightly-4.20-e2e-metal-ipi-serial-ovn-ipv6"
-      }
+      },
+      "disabled": true
     },
     "metal-ipi-serial-ovn-dualstack": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-nightly-4.20-e2e-metal-ipi-serial-ovn-dualstack"
-      }
+      },
+      "disabled": true
     },
     "metal-ipi-upgrade-ovn-ipv6": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-nightly-4.20-e2e-metal-ipi-upgrade-ovn-ipv6"
       },
-      "upgrade": true
+      "upgrade": true,
+      "disabled": true
     },
     "metal-ipi-upgrade-ovn-ipv6-minor": {
       "optional": true,
@@ -373,7 +411,8 @@
           "stream": "nightly",
           "version": "4.19"
         }
-      }
+      },
+      "disabled": true
     },
     "microshift-ovn-conformance-parallel": {
       "maxRetries": 1,
@@ -391,70 +430,81 @@
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-osde2e-main-nightly-4.20-osd-aws"
-      }
+      },
+      "disabled": true
     },
     "openshift-dedicated-gcp-osde2e": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-osde2e-main-nightly-4.20-osd-gcp"
-      }
+      },
+      "disabled": true
     },
     "openshift-dedicated-gcp-conformance": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-nightly-4.20-e2e-osd-ccs-gcp"
-      }
+      },
+      "disabled": true
     },
     "overall-analysis-all": {
       "maxRetries": 1,
       "multiJobAnalysis": true,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-nightly-4.20-overall-analysis-all"
-      }
+      },
+      "disabled": true
     },
     "ovn-proxy": {
       "maxRetries": 1,
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-nightly-4.20-e2e-aws-ovn-proxy"
-      }
+      },
+      "disabled": true
     },
     "ovn-single-node-live-iso": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-nightly-4.20-e2e-metal-ovn-single-node-live-iso"
-      }
+      },
+      "disabled": true
     },
     "rosa-classic-sts-osde2e": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-osde2e-main-nightly-4.20-rosa-classic-sts"
-      }
+      },
+      "disabled": true
     },
     "rosa-classic-sts-conformance": {
       "optional": true,
       "maxRetries": 1,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-nightly-4.20-e2e-rosa-sts-ovn"
-      }
+      },
+      "disabled": true
     },
     "rosa-hcp-conformance": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-nightly-4.20-e2e-rosa-hcp-ovn"
-      }
+      },
+      "disabled": true
     },
     "telcov10n-metal-single-node-spoke": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-kni-eco-ci-cd-main-nightly-4.20-telcov10n-metal-single-node-spoke"
-      }
+      },
+      "disabled": true
     },
     "telcov10n-metal-single-node-spoke-kpis": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-kni-eco-ci-cd-main-nightly-4.20-telcov10n-metal-single-node-spoke-kpis"
-      }
+      },
+      "disabled": true
     },
     "upgrade-minor-ovn": {
       "optional": true,
@@ -467,19 +517,22 @@
           "stream": "nightly",
           "version": "4.19"
         }
-      }
+      },
+      "disabled": true
     },
     "vsphere-ovn-csi": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-nightly-4.20-e2e-vsphere-ovn-csi"
-      }
+      },
+      "disabled": true
     },
     "vsphere-ovn-serial": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-nightly-4.20-e2e-vsphere-ovn-serial"
-      }
+      },
+      "disabled": true
     },
     "vsphere-ovn-upgrade-minor": {
       "optional": true,
@@ -492,44 +545,51 @@
           "stream": "nightly",
           "version": "4.19"
         }
-      }
+      },
+      "disabled": true
     },
     "vsphere-ovn-upgrade-micro": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-ci-4.20-e2e-vsphere-ovn-upgrade"
       },
-      "upgrade": true
+      "upgrade": true,
+      "disabled": true
     },
     "vsphere-ovn-upi": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-nightly-4.20-e2e-vsphere-ovn-upi"
-      }
+      },
+      "disabled": true
     },
     "vsphere-ovn-upi-serial": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-nightly-4.20-e2e-vsphere-ovn-upi-serial"
-      }
+      },
+      "disabled": true
     },
     "vsphere-ovn": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-nightly-4.20-e2e-vsphere-ovn"
-      }
+      },
+      "disabled": true
     },
     "vsphere-static-ovn": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-nightly-4.20-e2e-vsphere-static-ovn"
-      }
+      },
+      "disabled": true
     },
     "metal-ovn-single-node-recert-cluster-rename": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-nightly-4.20-metal-ovn-single-node-recert-cluster-rename"
-      }
+      },
+      "disabled": true
     },
     "fips-scan": {
       "maxRetries": 1,

--- a/core-services/release-controller/_releases/release-okd-scos-4.20.json
+++ b/core-services/release-controller/_releases/release-okd-scos-4.20.json
@@ -20,13 +20,14 @@
         "name": "periodic-ci-openshift-release-main-okd-scos-4.20-e2e-aws-ovn"
       }
     },
-    "aws-upgrade":{
+    "aws-upgrade": {
       "maxRetries": 1,
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-okd-scos-4.20-e2e-aws-ovn-upgrade"
       },
-      "upgrade": true
+      "upgrade": true,
+      "disabled": true
     },
     "aws-upgrade-minor": {
       "optional": true,
@@ -39,33 +40,38 @@
           "stream": "okd",
           "version": "4.19"
         }
-      }
+      },
+      "disabled": true
     },
     "aws-ovn-techpreview": {
       "optional": true,
       "maxRetries": 1,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-okd-scos-4.20-e2e-aws-ovn-techpreview"
-      }
+      },
+      "disabled": true
     },
-     "agent-single-node-ipv6": {
+    "agent-single-node-ipv6": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-okd-scos-4.20-e2e-agent-single-node-ipv6"
-      }
+      },
+      "disabled": true
     },
     "gcp": {
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-okd-scos-4.20-e2e-gcp"
-      }
+      },
+      "disabled": true
     },
     "vsphere": {
       "maxRetries": 0,
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-okd-scos-4.20-e2e-vsphere-ovn"
-      }
+      },
+      "disabled": true
     }
   }
 }


### PR DESCRIPTION
## Summary
- Disables all informing (optional) jobs across the 4.20 nightly, multi, and OKD SCOS release controllers by adding `"disabled": true`
- Disables `install-analysis-all` and `overall-analysis-all` blocking analysis jobs on the nightly controller, since they aggregate results from informing jobs that will no longer run (consistent with the 4.17 and 4.18 pattern)
- The 4.20 CI release controller's only optional job (`upgrade-minor-aws-ovn`) was already disabled — no change needed
- The arm64, ppc64le, and s390x controllers have no verify jobs — no change needed

## Affected files
- `core-services/release-controller/_releases/release-ocp-4.20.json`
- `core-services/release-controller/_releases/release-ocp-4.20-multi.json`
- `core-services/release-controller/_releases/release-okd-scos-4.20.json`

## Test plan
- [ ] Verify JSON is valid and `make release-controllers` succeeds
- [ ] Confirm all optional jobs have `"disabled": true`
- [ ] Confirm blocking jobs (non-optional, non-analysis) remain unchanged
- [ ] Confirm `install-analysis-all` and `overall-analysis-all` are disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Disabled multiple platform conformance, upgrade, and infrastructure verification jobs across OCP 4.20, OCP 4.20 multi-architecture, and OKD releases to streamline CI/CD operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->