### PR TITLE
prow: enable blunderbuss use_status_availability

### DIFF
--- a/core-services/prow/02_config/_plugins.yaml
+++ b/core-services/prow/02_config/_plugins.yaml
@@ -2,6 +2,7 @@ blunderbuss:
   ignore_drafts: true
   max_request_count: 2
   request_count: 2
+  use_status_availability: true
 branch_cleaner: {}
 bugzilla:
   default:


### PR DESCRIPTION
## Summary

- Adds `use_status_availability: true` to the global blunderbuss config
- Blunderbuss will now skip reviewers who have set their GitHub status to "Busy"
- Prevents review requests from being sent to unavailable users, reducing delays

## Test plan

- [x] Validate `make check` passes (core-services validation)
- [x] After merge, have a user set their GitHub status to "Busy" and confirm blunderbuss skips them when assigning reviewers on a test PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled status availability checking in the system configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->