### PR TITLE
prow: reapply registry-pull preset

### DIFF
--- a/core-services/prow/02_config/_config.yaml
+++ b/core-services/prow/02_config/_config.yaml
@@ -596,6 +596,18 @@ plank:
       index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}). [Your PR dashboard](https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/pr?query=is:pr+state:open+author:{{with
       index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).'
 pod_namespace: ci
+presets:
+- env: null
+  labels:
+    presets.ci.openshift.io/registry-pull: "true"
+  volumeMounts:
+  - mountPath: /etc/pull-secret
+    name: pull-secret
+    readOnly: true
+  volumes:
+  - name: pull-secret
+    secret:
+      secretName: registry-pull-credentials
 prowjob_default_entries:
 - cluster: '*'
   config:


### PR DESCRIPTION
On two previous attempts this change was [reverted](https://github.com/openshift/release/commit/416f39d47b6d65d08ed1791f0bbd4aacf281746e) by a misbehaving `private-prow-configs-mirror` tool. This should be fixed now, so we should be able to reapply.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI system configuration to support authenticated container image pulling from registries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->