### PR TITLE
cnf ran: switched sno spokes for 4_20 lane

### DIFF
--- a/ci-operator/config/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main__cnf-ran-two-sno-4.20.yaml
+++ b/ci-operator/config/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main__cnf-ran-two-sno-4.20.yaml
@@ -30,21 +30,20 @@ tests:
           {"name":"openshift-gitops-operator","catalog":"redhat-operators","nsname":"openshift-gitops-operator","channel":"latest","og_name":"openshift-gitops-operator","subscription_name":"openshift-gitops-operator","deploy_default_config":false,"og_spec":{"targetNamespaces":[]}},
           {"name":"advanced-cluster-management","catalog":"redhat-operators","nsname":"open-cluster-management","channel":"release-2.15","default_channel":"release-2.16","og_name":"open-cluster-management","subscription_name":"acm-operator-subscription","deploy_default_config":false,"og_spec":{"targetNamespaces":["open-cluster-management"]}},
           {"name":"multicluster-engine","catalog":"redhat-operators","nsname":"multicluster-engine","channel":"stable-2.10","default_channel":"stable-2.11","og_name":"multicluster-engine","subscription_name":"multicluster-engine","deploy_default_config":true,"og_spec":{}},
-          {"name":"topology-aware-lifecycle-manager","catalog":"topology-aware-lifecycle-manager-fbc","og_name":"global-operators","nsname":"openshift-operators","fbc_iib_repo":"latest","channel":"stable","deploy_default_config":false,"ocp_operator_mirror_fbc_image_base":"quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-fbc-${VERSION_TAG}"},
-          {"name":"cluster-logging","catalog":"redhat-operators","nsname":"openshift-logging","channel":"stable-6.2","default_channel":"stable-6.4","og_name":"cluster-logging","subscription_name":"cluster-logging","og_spec":{"targetNamespaces":[]}}
+          {"name":"topology-aware-lifecycle-manager","catalog":"topology-aware-lifecycle-manager-fbc","og_name":"global-operators","nsname":"openshift-operators","fbc_iib_repo":"latest","channel":"stable","deploy_default_config":false,"ocp_operator_mirror_fbc_image_base":"quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-fbc-${VERSION_TAG}"}
         ]
       RAN_METRICS_LIST: spoke_general_ocp,hub_general_ocp,sriov,sriov_fec,ptp,acm,talm,gitops,local_storage,logging
       REPORTER_TEMPLATE_NAME: Telco 5G RAN Regression 4_20 - Telco 5G RAN Regression
         - <build> - 4.20
       REPORTPORTAL_FILES: .reportportal_url_Two_Sno
       REPORTS_PORTAL_ATTRIBUTES_ENV: ci-lane:telco-ft-ran-two-sno;spoke_ocp_version:4.20
-      SPOKE_CLUSTER: '[''helix56'',''kni-qe-66'']'
+      SPOKE_CLUSTER: '[''worker-0'',''worker-1'']'
       SPOKE_OPERATORS: |
         [
           {"name":"sriov-fec","catalog":"certified-operators","nsname":"vran-acceleration-operators","channel":"stable"},
           {"name":"ptp-operator","catalog":"redhat-operators-ptp-art","fbc_iib_repo":"ose-ptp-rhel9-operator","nsname":"openshift-ptp","channel":"stable","ns_labels":{"workload.openshift.io/allowed":"management","name":"openshift-ptp"}},
           {"name":"sriov-network-operator","catalog":"redhat-operators-sriov-art","fbc_iib_repo":"ose-sriov-network-rhel9-operator","nsname":"openshift-sriov-network-operator","channel":"stable","og_name":"sriov-network-operators","subscription_name":"sriov-network-operator-subscription"},
-          {"name":"cluster-logging","catalog":"redhat-operators","nsname":"openshift-logging","channel":"stable-6.2","default_channel":"stable-6.4","og_name":"cluster-logging","subscription_name":"cluster-logging","og_spec":{"targetNamespaces":[]}},
+          {"name":"cluster-logging","catalog":"redhat-operators","nsname":"openshift-logging","channel":"stable-6.2","default_channel":"stable-6.5","og_name":"cluster-logging","subscription_name":"cluster-logging","og_spec":{"targetNamespaces":[]}},
           {"name":"local-storage-operator","fbc_iib_repo":"ose-local-storage-rhel9-operator","catalog":"redhat-operators-storage-art","nsname":"openshift-local-storage","channel":"stable","og_name":"local-operator-group","subscription_name":"local-storage-operator","deploy_default_config":false,"ns_labels":{"workload.openshift.io/allowed":"management"}}
         ]
       VERSION: "4.20"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed the cluster-logging operator from the hub operator configuration.
  * Updated CI/CD job targeting to use new worker node instances for spoke cluster operations.
  * Bumped the spoke cluster's cluster-logging default release channel to a newer stable version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->