### PR TITLE
prow config: allow petr-muller to rerun jobs

### DIFF
--- a/core-services/prow/02_config/_config.yaml
+++ b/core-services/prow/02_config/_config.yaml
@@ -23,6 +23,7 @@ deck:
       - bparees
       - AlexNPavel
       - jupierce
+      - petr-muller
   - repo: openshift/multiarch-tuning-operator
     rerun_auth_configs:
       github_team_slugs:


### PR DESCRIPTION
I do a lot around OpenShift CI, occassionaly I need to rerun a job for one reason or another, and I never learned how to use Gangway.

/cc @jmguzik


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended authorization configuration to allow additional user permissions for job reruns in the deployment pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->