### PR TITLE
osc: add tide configs to trigger merge automation

### DIFF
--- a/core-services/prow/02_config/openshift/sandboxed-containers-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/sandboxed-containers-operator/_pluginconfig.yaml
@@ -1,0 +1,10 @@
+approve:
+- commandHelpLink: https://go.k8s.io/bot-commands
+  ignore_review_state: true
+  repos:
+  - openshift/sandboxed-containers-operator
+  require_self_approval: true
+plugins:
+  openshift/sandboxed-containers-operator:
+    plugins:
+    - approve

--- a/core-services/prow/02_config/openshift/sandboxed-containers-operator/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/sandboxed-containers-operator/_prowconfig.yaml
@@ -10,3 +10,19 @@ branch-protection:
               protect: true
             osc-release-v1.11:
               protect: true
+tide:
+  merge_method:
+    openshift/sandboxed-containers-operator: merge
+  queries:
+  - labels:
+    - approved
+    - lgtm
+    missingLabels:
+    - backports/unvalidated-commits
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - jira/invalid-bug
+    - needs-rebase
+    repos:
+    - openshift/sandboxed-containers-operator


### PR DESCRIPTION
Add missing plugins and tide config to enable ease of merge..

This ensures all PR merges have a multi step approval process before merging. (as documented [here](https://docs.ci.openshift.org/how-tos/onboarding-a-new-component/#enabling-automatic-merges))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request automation configuration for the sandboxed-containers-operator repository with new approval requirements and merge policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->