### PR TITLE
change the cron schedule for osde2e jobs

### DIFF
--- a/ci-operator/config/openshift/osde2e/openshift-osde2e-main__nightly-4.18.yaml
+++ b/ci-operator/config/openshift/osde2e/openshift-osde2e-main__nightly-4.18.yaml
@@ -16,7 +16,7 @@ resources:
       memory: 200Mi
 tests:
 - as: rosa-classic-sts
-  cron: 0 0 1 1 *
+  cron: 30 0 * * 1
   steps:
     env:
       CONFIGS: rosa,sts,stage,rosa-e2e-suite
@@ -29,7 +29,7 @@ tests:
     test:
     - ref: osde2e-test
 - as: osd-aws
-  cron: 0 0 1 1 *
+  cron: 30 2 * * 2
   steps:
     env:
       CONFIGS: aws,stage,e2e-suite
@@ -42,7 +42,7 @@ tests:
     test:
     - ref: osde2e-test
 - as: osd-gcp
-  cron: 0 0 1 1 *
+  cron: 30 4 * * 3
   steps:
     env:
       CONFIGS: gcp,stage,e2e-suite

--- a/ci-operator/config/openshift/osde2e/openshift-osde2e-main__nightly-4.19.yaml
+++ b/ci-operator/config/openshift/osde2e/openshift-osde2e-main__nightly-4.19.yaml
@@ -16,7 +16,7 @@ resources:
       memory: 200Mi
 tests:
 - as: rosa-classic-sts
-  cron: 0 0 1 1 *
+  cron: 15 4 * * 5
   steps:
     env:
       CONFIGS: rosa,sts,stage,rosa-e2e-suite
@@ -29,7 +29,7 @@ tests:
     test:
     - ref: osde2e-test
 - as: osd-aws
-  cron: 8 12 * * 6
+  cron: 15 12 * * 4
   steps:
     env:
       CONFIGS: aws,stage,e2e-suite
@@ -42,7 +42,7 @@ tests:
     test:
     - ref: osde2e-test
 - as: osd-gcp
-  cron: 0 0 1 1 *
+  cron: 15 2 * * 3
   steps:
     env:
       CONFIGS: gcp,stage,e2e-suite

--- a/ci-operator/config/openshift/osde2e/openshift-osde2e-main__nightly-4.20.yaml
+++ b/ci-operator/config/openshift/osde2e/openshift-osde2e-main__nightly-4.20.yaml
@@ -16,7 +16,7 @@ resources:
       memory: 200Mi
 tests:
 - as: rosa-classic-sts
-  cron: 0 0 1 1 *
+  cron: 5 2 * * *
   steps:
     env:
       CONFIGS: rosa,sts,stage,rosa-e2e-suite
@@ -28,8 +28,21 @@ tests:
     - ref: osde2e-cleanup
     test:
     - ref: osde2e-test
+- as: rosa-hcp
+  cron: 5 20 * * *
+  steps:
+    env:
+      CONFIGS: hypershift
+      INSTALL_LATEST_NIGHTLY: "4.20"
+      SECRET_LOCATIONS: /usr/local/rosa-e2e-prow-ci-01-osde2e
+      SKIP_MUST_GATHER: "true"
+    post:
+    - chain: gather
+    - ref: osde2e-cleanup
+    test:
+    - ref: osde2e-test
 - as: osd-aws
-  cron: 0 0 1 1 *
+  cron: 5 3 * * *
   steps:
     env:
       CONFIGS: aws,stage,e2e-suite
@@ -42,7 +55,7 @@ tests:
     test:
     - ref: osde2e-test
 - as: osd-gcp
-  cron: 0 0 1 1 *
+  cron: 5 4 * * *
   steps:
     env:
       CONFIGS: gcp,stage,e2e-suite

--- a/ci-operator/config/openshift/osde2e/openshift-osde2e-main__nightly-4.21.yaml
+++ b/ci-operator/config/openshift/osde2e/openshift-osde2e-main__nightly-4.21.yaml
@@ -16,7 +16,7 @@ resources:
       memory: 200Mi
 tests:
 - as: rosa-classic-sts
-  cron: 0 0 1 1 *
+  cron: 10 21 * * *
   steps:
     env:
       CONFIGS: rosa,sts,stage,rosa-e2e-suite
@@ -29,7 +29,7 @@ tests:
     test:
     - ref: osde2e-test
 - as: rosa-hcp
-  cron: 0 22 * * *
+  cron: 10 20 * * *
   steps:
     env:
       CONFIGS: hypershift
@@ -42,7 +42,7 @@ tests:
     test:
     - ref: osde2e-test
 - as: osd-aws
-  cron: 0 0 1 1 *
+  cron: 10 23 * * *
   steps:
     env:
       CONFIGS: aws,stage,e2e-suite
@@ -54,7 +54,7 @@ tests:
     test:
     - ref: osde2e-test
 - as: osd-gcp
-  cron: 0 0 1 1 *
+  cron: 10 0 * * *
   steps:
     env:
       CONFIGS: gcp,stage,e2e-suite

--- a/ci-operator/config/openshift/osde2e/openshift-osde2e-main__nightly-4.22.yaml
+++ b/ci-operator/config/openshift/osde2e/openshift-osde2e-main__nightly-4.22.yaml
@@ -16,7 +16,7 @@ resources:
       memory: 200Mi
 tests:
 - as: rosa-classic-sts
-  cron: 0 0 1 1 *
+  cron: 20 4 * * *
   steps:
     env:
       CONFIGS: rosa,sts,stage,rosa-e2e-suite
@@ -29,7 +29,7 @@ tests:
     test:
     - ref: osde2e-test
 - as: rosa-hcp
-  cron: 0 20 * * *
+  cron: 20 20 * * *
   steps:
     env:
       CONFIGS: hypershift
@@ -42,7 +42,7 @@ tests:
     test:
     - ref: osde2e-test
 - as: osd-aws
-  cron: 0 0 1 1 *
+  cron: 20 6 * * *
   steps:
     env:
       CONFIGS: aws,stage,e2e-suite
@@ -55,7 +55,7 @@ tests:
     test:
     - ref: osde2e-test
 - as: osd-gcp
-  cron: 0 0 1 1 *
+  cron: 20 3 * * *
   steps:
     env:
       CONFIGS: gcp,stage,e2e-suite

--- a/ci-operator/config/openshift/osde2e/openshift-osde2e-main__nightly-4.23.yaml
+++ b/ci-operator/config/openshift/osde2e/openshift-osde2e-main__nightly-4.23.yaml
@@ -29,7 +29,7 @@ tests:
     test:
     - ref: osde2e-test
 - as: rosa-hcp
-  cron: 0 19 * * *
+  cron: 0 0 1 1 *
   steps:
     env:
       CONFIGS: hypershift

--- a/ci-operator/jobs/openshift/osde2e/openshift-osde2e-main-periodics.yaml
+++ b/ci-operator/jobs/openshift/osde2e/openshift-osde2e-main-periodics.yaml
@@ -1109,7 +1109,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 0 0 1 1 *
+  cron: 30 2 * * 2
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -1190,7 +1190,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 0 0 1 1 *
+  cron: 30 4 * * 3
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -1271,7 +1271,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 0 0 1 1 *
+  cron: 30 0 * * 1
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -1352,7 +1352,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 8 12 * * 6
+  cron: 15 12 * * 4
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -1433,7 +1433,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 0 0 1 1 *
+  cron: 15 2 * * 3
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -1514,7 +1514,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 0 0 1 1 *
+  cron: 15 4 * * 5
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -1595,7 +1595,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 0 0 1 1 *
+  cron: 5 3 * * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -1676,7 +1676,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 0 0 1 1 *
+  cron: 5 4 * * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -1757,7 +1757,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 0 0 1 1 *
+  cron: 5 2 * * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -1838,7 +1838,88 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 0 0 1 1 *
+  cron: 5 20 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: osde2e
+  labels:
+    ci-operator.openshift.io/variant: nightly-4.20
+    ci.openshift.io/generator: prowgen
+    job-release: "4.20"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-osde2e-main-nightly-4.20-rosa-hcp
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=rosa-hcp
+      - --variant=nightly-4.20
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build11
+  cron: 10 23 * * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -1919,7 +2000,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 0 0 1 1 *
+  cron: 10 0 * * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -2000,7 +2081,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 0 0 1 1 *
+  cron: 10 21 * * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -2081,7 +2162,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 0 22 * * *
+  cron: 10 20 * * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -2162,7 +2243,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 0 0 1 1 *
+  cron: 20 6 * * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -2243,7 +2324,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 0 0 1 1 *
+  cron: 20 3 * * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -2324,7 +2405,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 0 0 1 1 *
+  cron: 20 4 * * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -2405,7 +2486,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 0 20 * * *
+  cron: 20 20 * * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -2729,7 +2810,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 0 19 * * *
+  cron: 0 0 1 1 *
   decorate: true
   decoration_config:
     skip_cloning: true


### PR DESCRIPTION
- Change the frequency for the job
  - for old versions 4.18, 4.19, will run weekly
  - for new versions 4.20, 4.21, 4.22, will run daily
- Add rosa-hcp job to 4.20
- Disable 4.23 jobs as they are not available yet

After the change merged, will remove the trigger from release controller, so that the jobs can be run time based

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated scheduled execution times for CI test jobs (rosa-classic-sts, osd-aws, osd-gcp) across OpenShift versions 4.18 through 4.23, changing when nightly tests are triggered
  * Added a new ROSA HCP test configuration to version 4.20 with dedicated scheduling
  * Reorganized periodic job definitions to optimize test execution distribution across different hours and days

<!-- end of auto-generated comment: release notes by coderabbit.ai -->