### PR TITLE
WIP instaslice-operator: increase operator-sdk timeout for 4.19 and 4.20

### DIFF
--- a/ci-operator/config/openshift/instaslice-operator/openshift-instaslice-operator-next__4.19-periodics.yaml
+++ b/ci-operator/config/openshift/instaslice-operator/openshift-instaslice-operator-next__4.19-periodics.yaml
@@ -114,7 +114,7 @@ tests:
     - as: run-sdk
       cli: latest
       commands: |
-        operator-sdk run bundle -n das-operator "$OO_BUNDLE" --timeout 10m0s
+        operator-sdk run bundle -n das-operator "$OO_BUNDLE" --timeout 11m0s
       dependencies:
       - env: OO_BUNDLE
         name: das-operator-bundle
@@ -155,7 +155,7 @@ tests:
     - as: run-sdk
       cli: latest
       commands: |
-        operator-sdk run bundle -n das-operator "$OO_BUNDLE" --timeout 10m0s
+        operator-sdk run bundle -n das-operator "$OO_BUNDLE" --timeout 11m0s
       dependencies:
       - env: OO_BUNDLE
         name: das-operator-bundle

--- a/ci-operator/config/openshift/instaslice-operator/openshift-instaslice-operator-next__4.20-periodics.yaml
+++ b/ci-operator/config/openshift/instaslice-operator/openshift-instaslice-operator-next__4.20-periodics.yaml
@@ -114,7 +114,7 @@ tests:
     - as: run-sdk
       cli: latest
       commands: |
-        operator-sdk run bundle -n das-operator "$OO_BUNDLE" --timeout 10m0s
+        operator-sdk run bundle -n das-operator "$OO_BUNDLE" --timeout 11m0s
       dependencies:
       - env: OO_BUNDLE
         name: das-operator-bundle
@@ -155,7 +155,7 @@ tests:
     - as: run-sdk
       cli: latest
       commands: |
-        operator-sdk run bundle -n das-operator "$OO_BUNDLE" --timeout 10m0s
+        operator-sdk run bundle -n das-operator "$OO_BUNDLE" --timeout 11m0s
       dependencies:
       - env: OO_BUNDLE
         name: das-operator-bundle


### PR DESCRIPTION
Increase the operator-sdk run bundle timeout from 10m to 11m for both 4.19 and 4.20 periodic test configurations to verify OCPBUGS-65805 fix.