### PR TITLE
Add QBT variants and optimize Pipelines performance CI schedule

### DIFF
--- a/ci-operator/config/openshift-pipelines/performance/openshift-pipelines-performance-main.yaml
+++ b/ci-operator/config/openshift-pipelines/performance/openshift-pipelines-performance-main.yaml
@@ -38,21 +38,20 @@ resources:
       cpu: 1000m
       memory: 2Gi
 tests:
-- as: max-concurrency-downstream-nightly-daily
-  cron: 0 1 * * *
+- as: max-concurrency-downstream-nightly
+  cron: 0 1 * * 2,5
   steps:
     cluster_profile: aws-pipelines-performance
     env:
       DEPLOYMENT_TYPE: downstream
-      DEPLOYMENT_VERSION: "1.18"
       MUST_GATHER_TIMEOUT: 35m
       NIGHTLY_BUILD: "true"
       TEST_NAMESPACE: "5"
       TEST_SCENARIO: math
       TEST_SCENARIOS: 200/12 200/14 200/16 200/18 200/20
     workflow: openshift-pipelines-max-concurrency
-- as: max-concurrency-downstream-nightly-daily-ha-10
-  cron: 0 2 * * *
+- as: max-concurrency-downstream-nightly-ha-10
+  cron: 0 2 * * 2,5
   steps:
     cluster_profile: aws-pipelines-performance
     env:
@@ -64,8 +63,8 @@ tests:
       TEST_SCENARIO: math
       TEST_SCENARIOS: 200/12 200/14 200/16 200/18 200/20
     workflow: openshift-pipelines-max-concurrency
-- as: max-concurrency-downstream-nightly-daily-ha-10-state
-  cron: 0 3 * * *
+- as: max-concurrency-downstream-nightly-ha-10-state
+  cron: 0 3 * * 2,5
   steps:
     cluster_profile: aws-pipelines-performance
     env:
@@ -78,8 +77,39 @@ tests:
       TEST_SCENARIO: math
       TEST_SCENARIOS: 200/12 200/14 200/16 200/18 200/20
     workflow: openshift-pipelines-max-concurrency
-- as: max-concurrency-downstream-pipelines1-19-daily
-  cron: 0 4 * * *
+- as: max-concurrency-downstream-nightly-qbt
+  cron: 0 4 * * 2,5
+  steps:
+    cluster_profile: aws-pipelines-performance
+    env:
+      DEPLOYMENT_PIPELINES_KUBE_API_BURST: "50"
+      DEPLOYMENT_PIPELINES_KUBE_API_QPS: "50"
+      DEPLOYMENT_PIPELINES_THREADS_PER_CONTROLLER: "32"
+      DEPLOYMENT_TYPE: downstream
+      MUST_GATHER_TIMEOUT: 35m
+      NIGHTLY_BUILD: "true"
+      TEST_NAMESPACE: "5"
+      TEST_SCENARIO: math
+      TEST_SCENARIOS: 200/12 200/14 200/16 200/18 200/20
+    workflow: openshift-pipelines-max-concurrency
+- as: max-concurrency-downstream-nightly-ha-10-qbt
+  cron: 0 5 * * 2,5
+  steps:
+    cluster_profile: aws-pipelines-performance
+    env:
+      DEPLOYMENT_PIPELINES_CONTROLLER_HA_REPLICAS: "10"
+      DEPLOYMENT_PIPELINES_KUBE_API_BURST: "50"
+      DEPLOYMENT_PIPELINES_KUBE_API_QPS: "50"
+      DEPLOYMENT_PIPELINES_THREADS_PER_CONTROLLER: "32"
+      DEPLOYMENT_TYPE: downstream
+      MUST_GATHER_TIMEOUT: 35m
+      NIGHTLY_BUILD: "true"
+      TEST_NAMESPACE: "5"
+      TEST_SCENARIO: math
+      TEST_SCENARIOS: 200/12 200/14 200/16 200/18 200/20
+    workflow: openshift-pipelines-max-concurrency
+- as: max-concurrency-downstream-pipelines1-19
+  cron: 0 6 1,15 * *
   steps:
     cluster_profile: aws-pipelines-performance
     env:
@@ -90,8 +120,8 @@ tests:
       TEST_SCENARIO: math
       TEST_SCENARIOS: 200/12 200/14 200/16 200/18 200/20
     workflow: openshift-pipelines-max-concurrency
-- as: max-concurrency-downstream-pipelines1-19-daily-ha-10
-  cron: 0 5 * * *
+- as: max-concurrency-downstream-pipelines1-19-ha-10
+  cron: 0 7 1,15 * *
   steps:
     cluster_profile: aws-pipelines-performance
     env:
@@ -103,8 +133,8 @@ tests:
       TEST_SCENARIO: math
       TEST_SCENARIOS: 200/12 200/14 200/16 200/18 200/20
     workflow: openshift-pipelines-max-concurrency
-- as: max-concurrency-downstream-pipelines1-19-daily-ha-10-state
-  cron: 0 6 * * *
+- as: max-concurrency-downstream-pipelines1-19-ha-10-state
+  cron: 0 8 1,15 * *
   steps:
     cluster_profile: aws-pipelines-performance
     env:
@@ -117,8 +147,39 @@ tests:
       TEST_SCENARIO: math
       TEST_SCENARIOS: 200/12 200/14 200/16 200/18 200/20
     workflow: openshift-pipelines-max-concurrency
-- as: max-concurrency-downstream-pipelines1-20-daily
-  cron: 0 7 * * *
+- as: max-concurrency-downstream-pipelines1-19-qbt
+  cron: 0 9 1,15 * *
+  steps:
+    cluster_profile: aws-pipelines-performance
+    env:
+      DEPLOYMENT_PIPELINES_KUBE_API_BURST: "50"
+      DEPLOYMENT_PIPELINES_KUBE_API_QPS: "50"
+      DEPLOYMENT_PIPELINES_THREADS_PER_CONTROLLER: "32"
+      DEPLOYMENT_TYPE: downstream
+      DEPLOYMENT_VERSION: "1.19"
+      MUST_GATHER_TIMEOUT: 35m
+      TEST_NAMESPACE: "5"
+      TEST_SCENARIO: math
+      TEST_SCENARIOS: 200/12 200/14 200/16 200/18 200/20
+    workflow: openshift-pipelines-max-concurrency
+- as: max-concurrency-downstream-pipelines1-19-ha-10-qbt
+  cron: 0 10 1,15 * *
+  steps:
+    cluster_profile: aws-pipelines-performance
+    env:
+      DEPLOYMENT_PIPELINES_CONTROLLER_HA_REPLICAS: "10"
+      DEPLOYMENT_PIPELINES_KUBE_API_BURST: "50"
+      DEPLOYMENT_PIPELINES_KUBE_API_QPS: "50"
+      DEPLOYMENT_PIPELINES_THREADS_PER_CONTROLLER: "32"
+      DEPLOYMENT_TYPE: downstream
+      DEPLOYMENT_VERSION: "1.19"
+      MUST_GATHER_TIMEOUT: 35m
+      TEST_NAMESPACE: "5"
+      TEST_SCENARIO: math
+      TEST_SCENARIOS: 200/12 200/14 200/16 200/18 200/20
+    workflow: openshift-pipelines-max-concurrency
+- as: max-concurrency-downstream-pipelines1-20
+  cron: 0 6 6,21 * *
   steps:
     cluster_profile: aws-pipelines-performance
     env:
@@ -129,8 +190,8 @@ tests:
       TEST_SCENARIO: math
       TEST_SCENARIOS: 200/12 200/14 200/16 200/18 200/20
     workflow: openshift-pipelines-max-concurrency
-- as: max-concurrency-downstream-pipelines1-20-daily-ha-10
-  cron: 0 8 * * *
+- as: max-concurrency-downstream-pipelines1-20-ha-10
+  cron: 0 7 6,21 * *
   steps:
     cluster_profile: aws-pipelines-performance
     env:
@@ -142,8 +203,8 @@ tests:
       TEST_SCENARIO: math
       TEST_SCENARIOS: 200/12 200/14 200/16 200/18 200/20
     workflow: openshift-pipelines-max-concurrency
-- as: max-concurrency-downstream-pipelines1-20-daily-ha-10-state
-  cron: 0 9 * * *
+- as: max-concurrency-downstream-pipelines1-20-ha-10-state
+  cron: 0 8 6,21 * *
   steps:
     cluster_profile: aws-pipelines-performance
     env:
@@ -156,25 +217,102 @@ tests:
       TEST_SCENARIO: math
       TEST_SCENARIOS: 200/12 200/14 200/16 200/18 200/20
     workflow: openshift-pipelines-max-concurrency
-- as: max-concurrency-downstream-pipelines1-18-daily
-  cron: 0 10 * * *
+- as: max-concurrency-downstream-pipelines1-20-qbt
+  cron: 0 9 6,21 * *
   steps:
     cluster_profile: aws-pipelines-performance
     env:
+      DEPLOYMENT_PIPELINES_KUBE_API_BURST: "50"
+      DEPLOYMENT_PIPELINES_KUBE_API_QPS: "50"
+      DEPLOYMENT_PIPELINES_THREADS_PER_CONTROLLER: "32"
       DEPLOYMENT_TYPE: downstream
-      DEPLOYMENT_VERSION: "1.18"
+      DEPLOYMENT_VERSION: "1.20"
       MUST_GATHER_TIMEOUT: 35m
       TEST_NAMESPACE: "5"
       TEST_SCENARIO: math
       TEST_SCENARIOS: 200/12 200/14 200/16 200/18 200/20
     workflow: openshift-pipelines-max-concurrency
-- as: max-concurrency-downstream-pipelines-1-17-daily
-  cron: 0 11 * * *
+- as: max-concurrency-downstream-pipelines1-20-ha-10-qbt
+  cron: 0 10 6,21 * *
+  steps:
+    cluster_profile: aws-pipelines-performance
+    env:
+      DEPLOYMENT_PIPELINES_CONTROLLER_HA_REPLICAS: "10"
+      DEPLOYMENT_PIPELINES_KUBE_API_BURST: "50"
+      DEPLOYMENT_PIPELINES_KUBE_API_QPS: "50"
+      DEPLOYMENT_PIPELINES_THREADS_PER_CONTROLLER: "32"
+      DEPLOYMENT_TYPE: downstream
+      DEPLOYMENT_VERSION: "1.20"
+      MUST_GATHER_TIMEOUT: 35m
+      TEST_NAMESPACE: "5"
+      TEST_SCENARIO: math
+      TEST_SCENARIOS: 200/12 200/14 200/16 200/18 200/20
+    workflow: openshift-pipelines-max-concurrency
+- as: max-concurrency-downstream-pipelines1-21
+  cron: 0 6 11,26 * *
   steps:
     cluster_profile: aws-pipelines-performance
     env:
       DEPLOYMENT_TYPE: downstream
-      DEPLOYMENT_VERSION: "1.17"
+      DEPLOYMENT_VERSION: "1.21"
+      MUST_GATHER_TIMEOUT: 35m
+      TEST_NAMESPACE: "5"
+      TEST_SCENARIO: math
+      TEST_SCENARIOS: 200/12 200/14 200/16 200/18 200/20
+    workflow: openshift-pipelines-max-concurrency
+- as: max-concurrency-downstream-pipelines1-21-ha-10
+  cron: 0 7 11,26 * *
+  steps:
+    cluster_profile: aws-pipelines-performance
+    env:
+      DEPLOYMENT_PIPELINES_CONTROLLER_HA_REPLICAS: "10"
+      DEPLOYMENT_TYPE: downstream
+      DEPLOYMENT_VERSION: "1.21"
+      MUST_GATHER_TIMEOUT: 35m
+      TEST_NAMESPACE: "5"
+      TEST_SCENARIO: math
+      TEST_SCENARIOS: 200/12 200/14 200/16 200/18 200/20
+    workflow: openshift-pipelines-max-concurrency
+- as: max-concurrency-downstream-pipelines1-21-ha-10-state
+  cron: 0 8 11,26 * *
+  steps:
+    cluster_profile: aws-pipelines-performance
+    env:
+      DEPLOYMENT_PIPELINES_CONTROLLER_HA_REPLICAS: "10"
+      DEPLOYMENT_PIPELINES_CONTROLLER_TYPE: statefulSets
+      DEPLOYMENT_TYPE: downstream
+      DEPLOYMENT_VERSION: "1.21"
+      MUST_GATHER_TIMEOUT: 35m
+      TEST_NAMESPACE: "5"
+      TEST_SCENARIO: math
+      TEST_SCENARIOS: 200/12 200/14 200/16 200/18 200/20
+    workflow: openshift-pipelines-max-concurrency
+- as: max-concurrency-downstream-pipelines1-21-qbt
+  cron: 0 9 11,26 * *
+  steps:
+    cluster_profile: aws-pipelines-performance
+    env:
+      DEPLOYMENT_PIPELINES_KUBE_API_BURST: "50"
+      DEPLOYMENT_PIPELINES_KUBE_API_QPS: "50"
+      DEPLOYMENT_PIPELINES_THREADS_PER_CONTROLLER: "32"
+      DEPLOYMENT_TYPE: downstream
+      DEPLOYMENT_VERSION: "1.21"
+      MUST_GATHER_TIMEOUT: 35m
+      TEST_NAMESPACE: "5"
+      TEST_SCENARIO: math
+      TEST_SCENARIOS: 200/12 200/14 200/16 200/18 200/20
+    workflow: openshift-pipelines-max-concurrency
+- as: max-concurrency-downstream-pipelines1-21-ha-10-qbt
+  cron: 0 10 11,26 * *
+  steps:
+    cluster_profile: aws-pipelines-performance
+    env:
+      DEPLOYMENT_PIPELINES_CONTROLLER_HA_REPLICAS: "10"
+      DEPLOYMENT_PIPELINES_KUBE_API_BURST: "50"
+      DEPLOYMENT_PIPELINES_KUBE_API_QPS: "50"
+      DEPLOYMENT_PIPELINES_THREADS_PER_CONTROLLER: "32"
+      DEPLOYMENT_TYPE: downstream
+      DEPLOYMENT_VERSION: "1.21"
       MUST_GATHER_TIMEOUT: 35m
       TEST_NAMESPACE: "5"
       TEST_SCENARIO: math

--- a/ci-operator/jobs/openshift-pipelines/performance/openshift-pipelines-performance-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-pipelines/performance/openshift-pipelines-performance-main-periodics.yaml
@@ -1,7 +1,7 @@
 periodics:
 - agent: kubernetes
   cluster: build06
-  cron: 0 1 * * *
+  cron: 0 1 * * 2,5
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -14,7 +14,7 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-pipelines-performance
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-pipelines-performance-main-max-concurrency-downstream-nightly-daily
+  name: periodic-ci-openshift-pipelines-performance-main-max-concurrency-downstream-nightly
   spec:
     containers:
     - args:
@@ -23,7 +23,7 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=max-concurrency-downstream-nightly-daily
+      - --target=max-concurrency-downstream-nightly
       command:
       - ci-operator
       env:
@@ -81,7 +81,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build06
-  cron: 0 2 * * *
+  cron: 0 2 * * 2,5
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -94,7 +94,7 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-pipelines-performance
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-pipelines-performance-main-max-concurrency-downstream-nightly-daily-ha-10
+  name: periodic-ci-openshift-pipelines-performance-main-max-concurrency-downstream-nightly-ha-10
   spec:
     containers:
     - args:
@@ -103,7 +103,7 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=max-concurrency-downstream-nightly-daily-ha-10
+      - --target=max-concurrency-downstream-nightly-ha-10
       command:
       - ci-operator
       env:
@@ -161,7 +161,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build06
-  cron: 0 3 * * *
+  cron: 0 5 * * 2,5
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -174,7 +174,7 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-pipelines-performance
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-pipelines-performance-main-max-concurrency-downstream-nightly-daily-ha-10-state
+  name: periodic-ci-openshift-pipelines-performance-main-max-concurrency-downstream-nightly-ha-10-qbt
   spec:
     containers:
     - args:
@@ -183,7 +183,7 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=max-concurrency-downstream-nightly-daily-ha-10-state
+      - --target=max-concurrency-downstream-nightly-ha-10-qbt
       command:
       - ci-operator
       env:
@@ -241,7 +241,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build06
-  cron: 0 11 * * *
+  cron: 0 3 * * 2,5
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -254,7 +254,7 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-pipelines-performance
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-pipelines-performance-main-max-concurrency-downstream-pipelines-1-17-daily
+  name: periodic-ci-openshift-pipelines-performance-main-max-concurrency-downstream-nightly-ha-10-state
   spec:
     containers:
     - args:
@@ -263,7 +263,7 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=max-concurrency-downstream-pipelines-1-17-daily
+      - --target=max-concurrency-downstream-nightly-ha-10-state
       command:
       - ci-operator
       env:
@@ -321,7 +321,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build06
-  cron: 0 10 * * *
+  cron: 0 4 * * 2,5
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -334,7 +334,7 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-pipelines-performance
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-pipelines-performance-main-max-concurrency-downstream-pipelines1-18-daily
+  name: periodic-ci-openshift-pipelines-performance-main-max-concurrency-downstream-nightly-qbt
   spec:
     containers:
     - args:
@@ -343,7 +343,7 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=max-concurrency-downstream-pipelines1-18-daily
+      - --target=max-concurrency-downstream-nightly-qbt
       command:
       - ci-operator
       env:
@@ -401,7 +401,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build06
-  cron: 0 4 * * *
+  cron: 0 6 1,15 * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -414,7 +414,7 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-pipelines-performance
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-pipelines-performance-main-max-concurrency-downstream-pipelines1-19-daily
+  name: periodic-ci-openshift-pipelines-performance-main-max-concurrency-downstream-pipelines1-19
   spec:
     containers:
     - args:
@@ -423,7 +423,7 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=max-concurrency-downstream-pipelines1-19-daily
+      - --target=max-concurrency-downstream-pipelines1-19
       command:
       - ci-operator
       env:
@@ -481,7 +481,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build06
-  cron: 0 5 * * *
+  cron: 0 7 1,15 * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -494,7 +494,7 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-pipelines-performance
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-pipelines-performance-main-max-concurrency-downstream-pipelines1-19-daily-ha-10
+  name: periodic-ci-openshift-pipelines-performance-main-max-concurrency-downstream-pipelines1-19-ha-10
   spec:
     containers:
     - args:
@@ -503,7 +503,7 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=max-concurrency-downstream-pipelines1-19-daily-ha-10
+      - --target=max-concurrency-downstream-pipelines1-19-ha-10
       command:
       - ci-operator
       env:
@@ -561,7 +561,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build06
-  cron: 0 6 * * *
+  cron: 0 10 1,15 * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -574,7 +574,7 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-pipelines-performance
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-pipelines-performance-main-max-concurrency-downstream-pipelines1-19-daily-ha-10-state
+  name: periodic-ci-openshift-pipelines-performance-main-max-concurrency-downstream-pipelines1-19-ha-10-qbt
   spec:
     containers:
     - args:
@@ -583,7 +583,7 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=max-concurrency-downstream-pipelines1-19-daily-ha-10-state
+      - --target=max-concurrency-downstream-pipelines1-19-ha-10-qbt
       command:
       - ci-operator
       env:
@@ -641,7 +641,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build06
-  cron: 0 7 * * *
+  cron: 0 8 1,15 * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -654,7 +654,7 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-pipelines-performance
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-pipelines-performance-main-max-concurrency-downstream-pipelines1-20-daily
+  name: periodic-ci-openshift-pipelines-performance-main-max-concurrency-downstream-pipelines1-19-ha-10-state
   spec:
     containers:
     - args:
@@ -663,7 +663,7 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=max-concurrency-downstream-pipelines1-20-daily
+      - --target=max-concurrency-downstream-pipelines1-19-ha-10-state
       command:
       - ci-operator
       env:
@@ -721,7 +721,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build06
-  cron: 0 8 * * *
+  cron: 0 9 1,15 * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -734,7 +734,7 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-pipelines-performance
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-pipelines-performance-main-max-concurrency-downstream-pipelines1-20-daily-ha-10
+  name: periodic-ci-openshift-pipelines-performance-main-max-concurrency-downstream-pipelines1-19-qbt
   spec:
     containers:
     - args:
@@ -743,7 +743,7 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=max-concurrency-downstream-pipelines1-20-daily-ha-10
+      - --target=max-concurrency-downstream-pipelines1-19-qbt
       command:
       - ci-operator
       env:
@@ -801,7 +801,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build06
-  cron: 0 9 * * *
+  cron: 0 6 6,21 * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -814,7 +814,7 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-pipelines-performance
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-pipelines-performance-main-max-concurrency-downstream-pipelines1-20-daily-ha-10-state
+  name: periodic-ci-openshift-pipelines-performance-main-max-concurrency-downstream-pipelines1-20
   spec:
     containers:
     - args:
@@ -823,7 +823,727 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=max-concurrency-downstream-pipelines1-20-daily-ha-10-state
+      - --target=max-concurrency-downstream-pipelines1-20
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build06
+  cron: 0 7 6,21 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-pipelines
+    repo: performance
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-pipelines-performance
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-pipelines-performance-main-max-concurrency-downstream-pipelines1-20-ha-10
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=max-concurrency-downstream-pipelines1-20-ha-10
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build06
+  cron: 0 10 6,21 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-pipelines
+    repo: performance
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-pipelines-performance
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-pipelines-performance-main-max-concurrency-downstream-pipelines1-20-ha-10-qbt
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=max-concurrency-downstream-pipelines1-20-ha-10-qbt
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build06
+  cron: 0 8 6,21 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-pipelines
+    repo: performance
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-pipelines-performance
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-pipelines-performance-main-max-concurrency-downstream-pipelines1-20-ha-10-state
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=max-concurrency-downstream-pipelines1-20-ha-10-state
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build06
+  cron: 0 9 6,21 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-pipelines
+    repo: performance
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-pipelines-performance
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-pipelines-performance-main-max-concurrency-downstream-pipelines1-20-qbt
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=max-concurrency-downstream-pipelines1-20-qbt
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build06
+  cron: 0 6 11,26 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-pipelines
+    repo: performance
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-pipelines-performance
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-pipelines-performance-main-max-concurrency-downstream-pipelines1-21
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=max-concurrency-downstream-pipelines1-21
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build06
+  cron: 0 7 11,26 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-pipelines
+    repo: performance
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-pipelines-performance
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-pipelines-performance-main-max-concurrency-downstream-pipelines1-21-ha-10
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=max-concurrency-downstream-pipelines1-21-ha-10
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build06
+  cron: 0 10 11,26 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-pipelines
+    repo: performance
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-pipelines-performance
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-pipelines-performance-main-max-concurrency-downstream-pipelines1-21-ha-10-qbt
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=max-concurrency-downstream-pipelines1-21-ha-10-qbt
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build06
+  cron: 0 8 11,26 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-pipelines
+    repo: performance
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-pipelines-performance
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-pipelines-performance-main-max-concurrency-downstream-pipelines1-21-ha-10-state
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=max-concurrency-downstream-pipelines1-21-ha-10-state
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build06
+  cron: 0 9 11,26 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-pipelines
+    repo: performance
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-pipelines-performance
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-pipelines-performance-main-max-concurrency-downstream-pipelines1-21-qbt
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=max-concurrency-downstream-pipelines1-21-qbt
       command:
       - ci-operator
       env:


### PR DESCRIPTION
## Summary

Add QBT (QPS/Burst/Threads) performance tuning test variants and optimize CI job schedule for OpenShift Pipelines performance tests to reduce infrastructure load.

## Changes

### Added QBT Test Variants
  - **QBT-only**: Performance tuning with `QPS:50, Burst:50, Threads:32`
  - **HA-10 + QBT**: High availability + performance tuning
  - Applied to all versions (nightly, 1.19, 1.20, 1.21)

### Optimized Schedule
  **Nightly jobs:**
  - Changed from daily → twice weekly (Tuesday & Friday, 1-5 AM)

  **Version-specific jobs:**
  - Changed from daily → semimonthly, staggered throughout month
    - 1.19: 1st & 15th (6-10 AM)
    - 1.20: 6th & 21st (6-10 AM)
    - 1.21: 11th & 26th (6-10 AM)

  **Removed:**
  - Standalone 1.17 and 1.18 version tests

  **Naming:**
  - Simplified job names by removing frequency suffixes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized performance testing schedules with updated frequency patterns.
  * Added new test variants for high-availability configurations and enhanced performance scenarios.
  * Introduced product version 1.21 to the testing matrix.
  * Removed legacy version tests (1.18, 1.19, 1.20) from regular rotation.
  * Expanded test coverage for controller deployment modes and resource configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->