### PR TITLE
NO-ISSUE: Degraded TNF lane should be ran against CONFORMANCE tests

### DIFF
--- a/ci-operator/step-registry/baremetalds/two-node/fencing/degraded/baremetalds-two-node-fencing-degraded-workflow.yaml
+++ b/ci-operator/step-registry/baremetalds/two-node/fencing/degraded/baremetalds-two-node-fencing-degraded-workflow.yaml
@@ -101,7 +101,7 @@ workflow:
         when running the oc adm must-gather command timeout\|\[sig-cli\] oc adm must-gather
         must-gather support since and since-time flags timeout\|\[sig-cli\] oc adm
         must-gather run the must-gather command with own name space\|\[sig-instrumentation]
-        Prometheus .* should start and expose a secured proxy and unsecured metrics\|\[Disruptive\]\|OOM score adjustment set to -997
+        Prometheus .* should start and expose a secured proxy and unsecured metrics\|\[Disruptive\]\|OOM score adjustment set to -997\|\cluster-version-operator should have correct runlevel and scc
       ENABLE_HYPERVISOR_SSH_CONFIG: "true"
   documentation: |-
     This workflow executes a Degraded (one node intentionally down) Two Node OpenShift with Fencing (TNF) cluster installation and running across unskipped CONFORMANCE tests.

--- a/ci-operator/step-registry/baremetalds/two-node/fencing/degraded/baremetalds-two-node-fencing-degraded-workflow.yaml
+++ b/ci-operator/step-registry/baremetalds/two-node/fencing/degraded/baremetalds-two-node-fencing-degraded-workflow.yaml
@@ -102,7 +102,6 @@ workflow:
         must-gather support since and since-time flags timeout\|\[sig-cli\] oc adm
         must-gather run the must-gather command with own name space\|\[sig-instrumentation]
         Prometheus .* should start and expose a secured proxy and unsecured metrics\|\[Disruptive\]\|OOM score adjustment set to -997
-      TEST_SUITE: openshift/two-node
       ENABLE_HYPERVISOR_SSH_CONFIG: "true"
   documentation: |-
-    This workflow executes a Two Node OpenShift with Fencing (TNF) cluster installation with degraded fencing.
+    This workflow executes a Degraded (one node intentionally down) Two Node OpenShift with Fencing (TNF) cluster installation and running across unskipped CONFORMANCE tests.


### PR DESCRIPTION
the modified workflow should target conformance (default) test suite and not two-node suite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted CI workflow for degraded-node testing: removed a hardcoded test-suite selection and updated skip rules to include an additional runlevel/SCC requirement.

* **Documentation**
  * Updated workflow title to "Degraded (one node intentionally down)" and clarified it runs across unskipped CONFORMANCE tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->