### PR TITLE
CONSOLE-5205: Remove console QE folks and cherry-pick-approved label

### DIFF
--- a/core-services/prow/02_config/openshift/console-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/console-operator/_pluginconfig.yaml
@@ -6,13 +6,6 @@ label:
       - TheRealJon
       - spadgett
       label: backport-risk-assessed
-    - allowed_users:
-      - yapei
-      - yanpzhan
-      - sanketpathak
-      assign_on:
-      - label: backport-risk-assessed
-      label: cherry-pick-approved
 plugins:
   openshift/console-operator:
     plugins:

--- a/core-services/prow/02_config/openshift/console/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/console/_pluginconfig.yaml
@@ -12,16 +12,7 @@ label:
       - sg00dwin
       - cajieh
       - Leo6Leo
-      - krishagarwal278
       label: backport-risk-assessed
-    - allowed_users:
-      - yapei
-      - yanpzhan
-      - XiyunZhao
-      - sanketpathak
-      assign_on:
-      - label: backport-risk-assessed
-      label: cherry-pick-approved
     - allowed_users:
       - jhadvig
       - vojtechszocs


### PR DESCRIPTION
Updating the configuration files to reflect the current team structure by removing inactive QE reviewers following their transition off the console team.

/cc @jhadvig 