### PR TITLE
Add AWS Neuron operator Prow jobs for OCP 4.21

### DIFF
--- a/ci-operator/config/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main__4.21-stable.yaml
+++ b/ci-operator/config/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main__4.21-stable.yaml
@@ -1,0 +1,92 @@
+base_images:
+  ocm-cli:
+    name: ocm-cli
+    namespace: ci
+    tag: latest
+  rosa-aws-cli:
+    name: rosa-aws-cli
+    namespace: ci
+    tag: latest
+build_root:
+  image_stream_tag:
+    name: release
+    namespace: openshift
+    tag: rhel-8-release-golang-1.23-openshift-4.21
+images:
+  items:
+  - dockerfile_path: Containerfile
+    to: neuron-ci
+  - dockerfile_literal: |
+      FROM quay.io/ocp-edge-qe/eco-gotests:latest
+      USER 0
+      RUN chgrp -R 0 /home/testuser && chmod -R g=u /home/testuser
+      RUN ln -s /home/testuser/go/bin/ginkgo /usr/local/bin/ginkgo
+      RUN dnf install -y openssh-clients && dnf clean all
+    to: eco-gotests
+  run_if_changed: x^
+releases:
+  latest:
+    prerelease:
+      product: ocp
+      version_bounds:
+        lower: 4.21.0-0
+        stream: 4-stable
+        upper: 4.22.0-0
+resources:
+  '*':
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- always_run: false
+  as: aws-neuron-operator-e2e
+  steps:
+    allow_best_effort_post_steps: true
+    cluster_profile: aws-edge-infra
+    env:
+      ECO_HWACCEL_NEURON_DEVICE_PLUGIN_IMAGE: public.ecr.aws/neuron/neuron-device-plugin:2.29.94.0
+      ECO_HWACCEL_NEURON_DRIVER_VERSION: 2.25.4.0
+      ECO_HWACCEL_NEURON_DRIVERS_IMAGE: public.ecr.aws/os-partners/neuron-openshift/neuron-kernel-module:2.25.4.0
+      ECO_HWACCEL_NEURON_MODEL_NAME: TinyLlama/TinyLlama-1.1B-Chat-v1.0
+      ECO_HWACCEL_NEURON_NODE_METRICS_IMAGE: public.ecr.aws/neuron/neuron-monitor:1.3.0
+      ECO_HWACCEL_NEURON_SCHEDULER_EXTENSION_IMAGE: public.ecr.aws/neuron/neuron-scheduler:2.29.94.0
+      ECO_HWACCEL_NEURON_SCHEDULER_IMAGE: public.ecr.aws/eks-distro/kubernetes/kube-scheduler:v1.32.9-eks-1-32-24
+      ECO_HWACCEL_NEURON_UPGRADE_TARGET_DRIVERS_IMAGE: public.ecr.aws/os-partners/neuron-openshift/neuron-kernel-module:2.26.5.0
+      ECO_HWACCEL_NEURON_UPGRADE_TARGET_VERSION: 2.26.5.0
+      ECO_HWACCEL_NEURON_VLLM_IMAGE: public.ecr.aws/neuron/pytorch-inference-vllm-neuronx:0.7.2-neuronx-py310-sdk2.24.1-ubuntu22.04
+      ECO_TEST_FEATURES: neuron
+      ECO_TEST_LABELS: neuron
+      OCM_LOGIN_ENV: production
+      OPENSHIFT_VERSION: "4.21"
+      REGION: us-west-2
+    workflow: aws-neuron-operator-e2e-rosa
+- as: aws-neuron-operator-e2e-weekly
+  cron: 0 6 * * 2
+  steps:
+    allow_best_effort_post_steps: true
+    cluster_profile: aws-edge-infra
+    env:
+      ECO_HWACCEL_NEURON_DEVICE_PLUGIN_IMAGE: public.ecr.aws/neuron/neuron-device-plugin:2.29.94.0
+      ECO_HWACCEL_NEURON_DRIVER_VERSION: 2.25.4.0
+      ECO_HWACCEL_NEURON_DRIVERS_IMAGE: public.ecr.aws/os-partners/neuron-openshift/neuron-kernel-module:2.25.4.0
+      ECO_HWACCEL_NEURON_MODEL_NAME: TinyLlama/TinyLlama-1.1B-Chat-v1.0
+      ECO_HWACCEL_NEURON_NODE_METRICS_IMAGE: public.ecr.aws/neuron/neuron-monitor:1.3.0
+      ECO_HWACCEL_NEURON_SCHEDULER_EXTENSION_IMAGE: public.ecr.aws/neuron/neuron-scheduler:2.29.94.0
+      ECO_HWACCEL_NEURON_SCHEDULER_IMAGE: public.ecr.aws/eks-distro/kubernetes/kube-scheduler:v1.32.9-eks-1-32-24
+      ECO_HWACCEL_NEURON_UPGRADE_TARGET_DRIVERS_IMAGE: public.ecr.aws/os-partners/neuron-openshift/neuron-kernel-module:2.26.5.0
+      ECO_HWACCEL_NEURON_UPGRADE_TARGET_VERSION: 2.26.5.0
+      ECO_HWACCEL_NEURON_VLLM_IMAGE: public.ecr.aws/neuron/pytorch-inference-vllm-neuronx:0.7.2-neuronx-py310-sdk2.24.1-ubuntu22.04
+      ECO_TEST_FEATURES: neuron
+      ECO_TEST_LABELS: neuron
+      LAST_KNOWN_DTK_COMMIT: ""
+      OCM_LOGIN_ENV: production
+      OPENSHIFT_VERSION: "4.21"
+      REGION: us-west-2
+    workflow: aws-neuron-operator-conditional-e2e-rosa
+zz_generated_metadata:
+  branch: main
+  org: rh-ecosystem-edge
+  repo: neuron-ci
+  variant: 4.21-stable

--- a/ci-operator/jobs/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main-periodics.yaml
+++ b/ci-operator/jobs/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main-periodics.yaml
@@ -163,3 +163,85 @@ periodics:
     - name: result-aggregator
       secret:
         secretName: result-aggregator
+- agent: kubernetes
+  cluster: build11
+  cron: 0 6 * * 2
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: rh-ecosystem-edge
+    repo: neuron-ci
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-edge-infra
+    ci-operator.openshift.io/variant: 4.21-stable
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-rh-ecosystem-edge-neuron-ci-main-4.21-stable-aws-neuron-operator-e2e-weekly
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=aws-neuron-operator-e2e-weekly
+      - --variant=4.21-stable
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator

--- a/ci-operator/jobs/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main-presubmits.yaml
+++ b/ci-operator/jobs/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main-presubmits.yaml
@@ -283,3 +283,145 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )4.20-stable-images,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build01
+    context: ci/prow/4.21-stable-aws-neuron-operator-e2e
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: aws-edge-infra
+      ci-operator.openshift.io/variant: 4.21-stable
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-rh-ecosystem-edge-neuron-ci-main-4.21-stable-aws-neuron-operator-e2e
+    rerun_command: /test 4.21-stable-aws-neuron-operator-e2e
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=aws-neuron-operator-e2e
+        - --variant=4.21-stable
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )(4.21-stable-aws-neuron-operator-e2e|remaining-required),?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build01
+    context: ci/prow/4.21-stable-images
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/variant: 4.21-stable
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-rh-ecosystem-edge-neuron-ci-main-4.21-stable-images
+    rerun_command: /test 4.21-stable-images
+    run_if_changed: x^
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=[images]
+        - --variant=4.21-stable
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )4.21-stable-images,?($|\s.*)


### PR DESCRIPTION
## Summary
- Add ci-operator config for OCP 4.21 (version bounds 4.21.0-0 → 4.22.0-0, build root golang-1.23-openshift-4.21)
- Add weekly periodic job running Tuesday 6 AM UTC (continuing Sun=4.19, Mon=4.20, Tue=4.21 pattern)
- Add presubmit e2e and images jobs (manually triggerable via `/test 4.21-stable-aws-neuron-operator-e2e`)
- Same Neuron driver/plugin images, ROSA HCP workflow, and cluster profile as 4.19/4.20

## Test plan
- [ ] Prow config validation passes (ci-operator-prowgen)
- [ ] Rehearsal job can be triggered via `/test 4.21-stable-aws-neuron-operator-e2e` on this PR
- [ ] Verify periodic job appears in Prow after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Established continuous integration configuration for OpenShift 4.21-stable variant including build and base image setup.
  * Configured automated testing pipeline with weekly scheduled testing and presubmit validation checks for code changes.

* **Tests**
  * Introduced AWS Neuron operator E2E test workflows enabling comprehensive functional validation and compatibility testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->