### PR TITLE
Decrease verbosity in orion output

### DIFF
--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.22-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.22-nightly-x86.yaml
@@ -35,7 +35,7 @@ tests:
     env:
       ADDITIONAL_WORKER_NODES: "3"
       BASE_DOMAIN: qe.devcluster.openshift.com
-      CD_V2_EXTRA_FLAGS: --churn-duration=20m --pod-ready-threshold=20s --service-latency
+      CD_V2_EXTRA_FLAGS: --churn-duration=20m --pod-ready-threshold=21s --service-latency
       CDV2_ITERATION_MULTIPLIER: "15"
       ENABLE_LAYER_3: "false"
       ES_TYPE: qe

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.22-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.22-nightly-x86.yaml
@@ -35,7 +35,7 @@ tests:
     env:
       ADDITIONAL_WORKER_NODES: "3"
       BASE_DOMAIN: qe.devcluster.openshift.com
-      CD_V2_EXTRA_FLAGS: --churn-duration=20m --pod-ready-threshold=21s --service-latency
+      CD_V2_EXTRA_FLAGS: --churn-duration=20m --pod-ready-threshold=20s --service-latency
       CDV2_ITERATION_MULTIPLIER: "15"
       ENABLE_LAYER_3: "false"
       ES_TYPE: qe

--- a/ci-operator/step-registry/openshift-qe/orion/openshift-qe-orion-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/orion/openshift-qe-orion-commands.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
-set -x
 
 if [ ${RUN_ORION} == false ]; then
   exit 0
 fi
 
+python --version
 pushd /tmp
+python -m virtualenv ./venv_qe
+source ./venv_qe/bin/activate
+cd /tmp
 
 if [[ $TAG == "latest" ]]; then
     LATEST_TAG=$(curl -s "https://api.github.com/repos/cloud-bulldozer/orion/releases/latest" | jq -r '.tag_name');
@@ -13,7 +16,7 @@ else
     LATEST_TAG=$TAG
 fi
 git clone -q --branch $LATEST_TAG $ORION_REPO --depth 1
-pushd orion
+cd orion
 
 # Invoked from orion repo by the openshift-ci bot
 if [[ -n "${PULL_NUMBER-}" ]] && [[ "${REPO_NAME}" == "orion" ]]; then

--- a/ci-operator/step-registry/openshift-qe/orion/openshift-qe-orion-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/orion/openshift-qe-orion-commands.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -x
+
 if [ ${RUN_ORION} == false ]; then
   exit 0
 fi

--- a/ci-operator/step-registry/openshift-qe/orion/openshift-qe-orion-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/orion/openshift-qe-orion-commands.sh
@@ -1,21 +1,16 @@
 #!/bin/bash
-set -x
-
 if [ ${RUN_ORION} == false ]; then
   exit 0
 fi
 
-python --version
 pushd /tmp
-python -m virtualenv ./venv_qe
-source ./venv_qe/bin/activate
 
 if [[ $TAG == "latest" ]]; then
     LATEST_TAG=$(curl -s "https://api.github.com/repos/cloud-bulldozer/orion/releases/latest" | jq -r '.tag_name');
 else
     LATEST_TAG=$TAG
 fi
-git clone --branch $LATEST_TAG $ORION_REPO --depth 1
+git clone -q --branch $LATEST_TAG $ORION_REPO --depth 1
 pushd orion
 
 # Invoked from orion repo by the openshift-ci bot
@@ -25,7 +20,7 @@ if [[ -n "${PULL_NUMBER-}" ]] && [[ "${REPO_NAME}" == "orion" ]]; then
   git switch ${PULL_NUMBER}
 fi
 
-pip install -r requirements.txt
+pip install -q -r requirements.txt
 
 case "$ES_TYPE" in
   qe)
@@ -57,9 +52,10 @@ esac
 
 export ES_SERVER
 
-pip install .
+pip install -q .
 
 if [[ -f "${SHARED_DIR}/proxy-conf.sh" ]]; then
+    echo "Loading proxy settings from ${SHARED_DIR}/proxy-conf.sh"
     source "${SHARED_DIR}/proxy-conf.sh"
 fi
 
@@ -94,15 +90,6 @@ export VERSION="${VERSION:-$(oc get clusterversion version -o jsonpath='{.status
 # Unset proxy so we can pip install, reach sippy, etc.
 if [[ -f "${SHARED_DIR}/proxy-conf.sh" ]]; then
     unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY no_proxy NO_PROXY
-fi
-
-# Print Orion version
-orion_version=$(orion --version 2>&1)
-orion_version_exit=$?
-if [ "$orion_version_exit" -ne 0 ]; then
-  echo "orion version prior to v0.1.7"
-else
-  echo "Orion version: $orion_version"
 fi
 
 EXTRA_FLAGS="${ORION_EXTRA_FLAGS:-} --lookback ${LOOKBACK}d --hunter-analyze"
@@ -192,12 +179,11 @@ fi
 
 set +e
 set -o pipefail
-FILENAME=$(basename ${ORION_CONFIG} | awk -F. '{print $1}')
 export es_metadata_index=${ES_METADATA_INDEX} es_benchmark_index=${ES_BENCHMARK_INDEX} VERSION=${VERSION} jobtype="${job_type}"
 if [[ -n $pull_number ]]; then
     export pull_number=${pull_number}
 fi
-orion --node-count ${IGNORE_JOB_ITERATIONS} --config ${ORION_CONFIG} ${EXTRA_FLAGS} --viz | tee ${ARTIFACT_DIR}/${FILENAME}.txt
+orion --node-count ${IGNORE_JOB_ITERATIONS} --config ${ORION_CONFIG} ${EXTRA_FLAGS} --viz | tee ${ARTIFACT_DIR}/orion-output.txt
 orion_exit_status=$?
 set -e
 

--- a/ci-operator/step-registry/openshift-qe/orion/openshift-qe-orion-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/orion/openshift-qe-orion-commands.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -x
 
 if [ ${RUN_ORION} == false ]; then
   exit 0

--- a/ci-operator/step-registry/openshift-qe/orion/openshift-qe-orion-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/orion/openshift-qe-orion-commands.sh
@@ -9,7 +9,6 @@ python --version
 pushd /tmp
 python -m virtualenv ./venv_qe
 source ./venv_qe/bin/activate
-cd /tmp
 
 if [[ $TAG == "latest" ]]; then
     LATEST_TAG=$(curl -s "https://api.github.com/repos/cloud-bulldozer/orion/releases/latest" | jq -r '.tag_name');
@@ -17,7 +16,7 @@ else
     LATEST_TAG=$TAG
 fi
 git clone -q --branch $LATEST_TAG $ORION_REPO --depth 1
-cd orion
+pushd orion
 
 # Invoked from orion repo by the openshift-ci bot
 if [[ -n "${PULL_NUMBER-}" ]] && [[ "${REPO_NAME}" == "orion" ]]; then

--- a/ci-operator/step-registry/openshift-qe/orion/report/openshift-qe-orion-report-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/orion/report/openshift-qe-orion-report-commands.sh
@@ -56,10 +56,10 @@ else
     LATEST_TAG=$TAG
 fi
 git clone -q --branch "$LATEST_TAG" "$ORION_REPO" --depth 1
-cd orion
+pushd orion
 pip install -q -r requirements.txt
 pip install -q .
-cd /tmp
+popd && popd
 
 # Build comma-separated file list for orion --report
 json_file_list=""

--- a/ci-operator/step-registry/openshift-qe/orion/report/openshift-qe-orion-report-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/orion/report/openshift-qe-orion-report-commands.sh
@@ -46,7 +46,6 @@ fi
 cp "${json_files[@]}" "${ARTIFACT_DIR}/" 2>/dev/null || true
 
 # Set up Python environment and install orion
-python --version
 pushd /tmp
 python -m virtualenv ./venv_report
 source ./venv_report/bin/activate
@@ -56,11 +55,11 @@ if [[ $TAG == "latest" ]]; then
 else
     LATEST_TAG=$TAG
 fi
-git clone --branch "$LATEST_TAG" "$ORION_REPO" --depth 1
-pushd orion
-pip install -r requirements.txt
-pip install .
-popd && popd
+git clone -q --branch "$LATEST_TAG" "$ORION_REPO" --depth 1
+cd orion
+pip install -q -r requirements.txt
+pip install -q .
+cd /tmp
 
 # Build comma-separated file list for orion --report
 json_file_list=""


### PR DESCRIPTION
Having a smaller output helps humans and LLMs to understand the output better (and to consume fewer time/tokens).
For that reason I'm disabling bash `set -x` and using quiet mode in both `git clone` and `pip install` commands.

Also, I'm renaming the output file to something fixed `orion-output.txt`, to make this path more predictable. Im not sure if the previous path was consumed by 3rd parties like bugzooka.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Release Notes

* **Chore**
  * Reduce CI log verbosity by disabling shell xtrace and making git/pip operations quiet.
  * Standardize Orion visualization output to a fixed artifact file: ${ARTIFACT_DIR}/orion-output.txt.
  * Install and run Orion from a predictable temporary workspace during the report step.
  * Emit an informational message when loading proxy settings and remove the prior Orion version probe.

## Overview
This PR reduces noisy output in the OpenShift QE Orion test steps used by OpenShift CI (nightly/periodic runs). It makes clone/install steps quieter and makes the visualization/report artifacts and runtime environment more predictable.

## What changed (practical impact)
- Affects CI step-registry for the openshift-qe Orion workflow (two step scripts under ci-operator/step-registry/openshift-qe/orion/*).
- CI logs will be less cluttered because bash tracing (`set -x`) and verbose pip/git output are suppressed.
- The Orion visualization output is now written to a fixed artifact: ${ARTIFACT_DIR}/orion-output.txt — consumers should verify they don’t rely on the previous, config-derived filename.
- The report step now creates and uses a temporary virtualenv in /tmp, performs a shallow, quiet clone of the Orion repo at the requested tag, and installs dependencies and the package with quiet pip installs. Existing behavior for downloading deferred JSONs, running `orion --report`, interpreting exit codes, and archiving the report is preserved.

## Notes / Risks
- The author calls out uncertainty whether external consumers (e.g., Bugzooka) depend on the previous output path; validate downstream consumers before merging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->