### PR TITLE
CNTRLPLANE-3278: fix verify-workflows to check PR head, not merge commit

### DIFF
--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-main.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-main.yaml
@@ -490,12 +490,21 @@ tests:
       exit 1
     fi
     MAIN_REF="FETCH_HEAD"
-    BASE=$(git merge-base HEAD "$MAIN_REF")
+    # ci-operator runs on a merge commit (PR merged into base). HEAD is the
+    # merge result, so workflow files from main are already present. We need
+    # the actual PR head commit (second parent of the merge) to detect
+    # outdated files on the PR branch itself.
+    PR_HEAD=$(git rev-parse HEAD^2 2>/dev/null) || PR_HEAD="HEAD"
+    BASE=$(git merge-base "$PR_HEAD" "$MAIN_REF")
+    echo "PR_HEAD: $(git rev-parse "$PR_HEAD")"
+    echo "MAIN:    $(git rev-parse "$MAIN_REF")"
+    echo "BASE:    $BASE"
+    echo ""
     FAILED=0
     while IFS= read -r file; do
       [ -z "$file" ] && continue
       main_hash=$(git rev-parse "${MAIN_REF}:${file}" 2>/dev/null) || continue
-      head_hash=$(git rev-parse "HEAD:${file}" 2>/dev/null) || head_hash=""
+      head_hash=$(git rev-parse "${PR_HEAD}:${file}" 2>/dev/null) || head_hash=""
       if [ -z "$head_hash" ]; then
         echo "MISSING: $file exists on main but not on this branch."
         FAILED=1


### PR DESCRIPTION
## Summary

- Fixes the `verify-workflows` presubmit for `openshift/hypershift` that was introduced in #77164
- The script was always passing because ci-operator runs tests on a **merge commit** (PR merged into base branch), and `HEAD` in that context is the merge result — which always has main's workflow files

## Problem

ci-operator creates a merge commit when building the `src` image:
- `HEAD` = merge of PR into main
- `HEAD^1` = main (base branch)
- `HEAD^2` = actual PR head commit

The original script compared `HEAD:.github/workflows/*` against main, but since `HEAD` is the merge result, workflow files from main are always present — the check always passed regardless of the PR branch state.

Verified locally:
```
# On the merge result (HEAD), workflow files match main:
git rev-parse HEAD:.github/workflows/test.yaml == git rev-parse MAIN:.github/workflows/test.yaml  ✓

# But the actual PR branch (HEAD^2) has outdated files:
git rev-parse HEAD^2:.github/workflows/test.yaml != git rev-parse MAIN:.github/workflows/test.yaml  ✗
```

## Fix

Extract the actual PR head commit via `HEAD^2` (second parent of the merge commit) and compare that against main instead:

```bash
PR_HEAD=$(git rev-parse HEAD^2 2>/dev/null) || PR_HEAD="HEAD"
```

Falls back to `HEAD` if there's no second parent (e.g., non-merge context).

## Test plan

- [x] Tested locally: outdated branch correctly detected with `HEAD^2`
- [ ] Test PR [openshift/hypershift#8283](https://github.com/openshift/hypershift/pull/8283) should fail after this fix (it incorrectly passed before)
- [ ] Test PR [openshift/hypershift#8284](https://github.com/openshift/hypershift/pull/8284) should still pass (intentional workflow change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced PR verification workflow with improved git comparison logic for more accurate change detection
  * Added detailed logging for better visibility into the verification process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->