### PR TITLE
Modified vSphere hybrid jobs to not exclude sig-storage

### DIFF
--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22.yaml
@@ -1109,7 +1109,8 @@ tests:
       NETWORK_TYPE: multi-tenant
       PERSISTENT_MONITORING: "false"
       SETUP_IMAGE_REGISTRY_WITH_PVC: "false"
-      TEST_SKIPS: \[sig-storage\]\|\[sig-arch\]\[Early\] Operators low level operators
+      TEST_SKIPS: \[sig-storage\] In-tree Volumes\|\[sig-arch\]\[Early\] Operators
+        low level operators
     workflow: openshift-e2e-vsphere-hybrid-env
 - as: e2e-vsphere-ovn-hybrid-env-serial-techpreview
   cron: '@daily'
@@ -1121,7 +1122,7 @@ tests:
       NETWORK_TYPE: multi-tenant
       PERSISTENT_MONITORING: "false"
       SETUP_IMAGE_REGISTRY_WITH_PVC: "false"
-      TEST_SKIPS: \[sig-storage\]\|\[sig-arch\]\[Early\] Operators low level operators
+      TEST_SKIPS: \[sig-arch\]\[Early\] Operators low level operators
       TEST_SUITE: openshift/conformance/serial
     workflow: openshift-e2e-vsphere-hybrid-env
 - as: e2e-vsphere-ovn-upi-hybrid-env-techpreview
@@ -1133,7 +1134,8 @@ tests:
       FEATURE_SET: TechPreviewNoUpgrade
       NETWORK_TYPE: single-tenant
       STORAGE_CO_DEGRADE_CHECK: "true"
-      TEST_SKIPS: \[sig-storage\]\|\[sig-arch\]\[Early\] Operators low level operators
+      TEST_SKIPS: \[sig-storage\] In-tree Volumes\|\[sig-arch\]\[Early\] Operators
+        low level operators
     workflow: openshift-e2e-vsphere-upi-hybrid-env
 - as: e2e-vsphere-ovn-disk-setup-techpreview
   cron: 55 17 * * 1

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.23.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.23.yaml
@@ -1072,7 +1072,8 @@ tests:
       NETWORK_TYPE: multi-tenant
       PERSISTENT_MONITORING: "false"
       SETUP_IMAGE_REGISTRY_WITH_PVC: "false"
-      TEST_SKIPS: \[sig-storage\]\|\[sig-arch\]\[Early\] Operators low level operators
+      TEST_SKIPS: \[sig-storage\] In-tree Volumes\|\[sig-arch\]\[Early\] Operators
+        low level operators
     workflow: openshift-e2e-vsphere-hybrid-env
 - as: e2e-vsphere-ovn-hybrid-env-serial-techpreview
   cron: '@weekly'
@@ -1084,7 +1085,7 @@ tests:
       NETWORK_TYPE: multi-tenant
       PERSISTENT_MONITORING: "false"
       SETUP_IMAGE_REGISTRY_WITH_PVC: "false"
-      TEST_SKIPS: \[sig-storage\]\|\[sig-arch\]\[Early\] Operators low level operators
+      TEST_SKIPS: \[sig-arch\]\[Early\] Operators low level operators
       TEST_SUITE: openshift/conformance/serial
     workflow: openshift-e2e-vsphere-hybrid-env
 - as: e2e-vsphere-ovn-upi-hybrid-env-techpreview
@@ -1096,7 +1097,8 @@ tests:
       FEATURE_SET: TechPreviewNoUpgrade
       NETWORK_TYPE: single-tenant
       STORAGE_CO_DEGRADE_CHECK: "true"
-      TEST_SKIPS: \[sig-storage\]\|\[sig-arch\]\[Early\] Operators low level operators
+      TEST_SKIPS: \[sig-storage\] In-tree Volumes\|\[sig-arch\]\[Early\] Operators
+        low level operators
     workflow: openshift-e2e-vsphere-upi-hybrid-env
 - as: e2e-vsphere-ovn-disk-setup-techpreview
   cron: 55 17 * * 1

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
@@ -1072,7 +1072,8 @@ tests:
       NETWORK_TYPE: multi-tenant
       PERSISTENT_MONITORING: "false"
       SETUP_IMAGE_REGISTRY_WITH_PVC: "false"
-      TEST_SKIPS: \[sig-storage\]\|\[sig-arch\]\[Early\] Operators low level operators
+      TEST_SKIPS: \[sig-storage\] In-tree Volumes\|\[sig-arch\]\[Early\] Operators
+        low level operators
     workflow: openshift-e2e-vsphere-hybrid-env
 - as: e2e-vsphere-ovn-hybrid-env-serial-techpreview
   cron: '@daily'
@@ -1084,7 +1085,7 @@ tests:
       NETWORK_TYPE: multi-tenant
       PERSISTENT_MONITORING: "false"
       SETUP_IMAGE_REGISTRY_WITH_PVC: "false"
-      TEST_SKIPS: \[sig-storage\]\|\[sig-arch\]\[Early\] Operators low level operators
+      TEST_SKIPS: \[sig-arch\]\[Early\] Operators low level operators
       TEST_SUITE: openshift/conformance/serial
     workflow: openshift-e2e-vsphere-hybrid-env
 - as: e2e-vsphere-ovn-upi-hybrid-env-techpreview
@@ -1096,7 +1097,8 @@ tests:
       FEATURE_SET: TechPreviewNoUpgrade
       NETWORK_TYPE: single-tenant
       STORAGE_CO_DEGRADE_CHECK: "true"
-      TEST_SKIPS: \[sig-storage\]\|\[sig-arch\]\[Early\] Operators low level operators
+      TEST_SKIPS: \[sig-storage\] In-tree Volumes\|\[sig-arch\]\[Early\] Operators
+        low level operators
     workflow: openshift-e2e-vsphere-upi-hybrid-env
 - as: e2e-vsphere-ovn-disk-setup-techpreview
   cron: 48 4 * * 3


### PR DESCRIPTION
### Changes
- Removed [sig-storage] from test filter for vSphere hybrid jobs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated test configuration for vSphere hybrid environment tests across releases 4.22, 4.23, and 5.0: refined storage-related test skips to specifically exclude "In-tree Volumes" where appropriate, removed a broad storage skip in one serial job to allow additional storage tests to run, reformatted skip expressions for readability, and preserved the skip for early operator validation tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->