### PR TITLE
HCO: fix optional-operators-ci-operator-sdk-azure flakiness

### DIFF
--- a/ci-operator/config/kubevirt/hyperconverged-cluster-operator/kubevirt-hyperconverged-cluster-operator-main.yaml
+++ b/ci-operator/config/kubevirt/hyperconverged-cluster-operator/kubevirt-hyperconverged-cluster-operator-main.yaml
@@ -457,7 +457,9 @@ tests:
         requests:
           cpu: 500m
           memory: 1Gi
+      timeout: 3h0m0s
     workflow: optional-operators-ci-operator-sdk-azure
+  timeout: 5h0m0s
 - as: hco-e2e-operator-sdk-aws
   run_if_changed: ^(api/.*|assets/.*|build/.*|ci-test-files/.*|config/.*|controllers/.*|cmd/.*|deploy/crds/.*|deploy/index-image/.*|hack/.*|pkg/.*|tests/.*|Makefile|go\.mod|go\.sum)$
   steps:

--- a/ci-operator/jobs/kubevirt/hyperconverged-cluster-operator/kubevirt-hyperconverged-cluster-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/kubevirt/hyperconverged-cluster-operator/kubevirt-hyperconverged-cluster-operator-main-presubmits.yaml
@@ -290,6 +290,7 @@ presubmits:
     decorate: true
     decoration_config:
       skip_cloning: true
+      timeout: 5h0m0s
     labels:
       ci-operator.openshift.io/cloud: azure4
       ci-operator.openshift.io/cloud-cluster-profile: azure-virtualization


### PR DESCRIPTION
This test sometimes timeouts. Extend the test timeout to fix that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased a specific CI test step timeout to 3h to accommodate longer-running validation tasks.
  * Increased a parent workflow timeout to 5h and added a 5h timeout to the corresponding presubmit CI job to ensure stable completion of extended test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->