### PR TITLE
Fix neuron-ci OCP 4.21 build root: golang 1.23 to 1.24

### DIFF
--- a/ci-operator/config/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main__4.21-stable.yaml
+++ b/ci-operator/config/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main__4.21-stable.yaml
@@ -11,7 +11,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: rhel-8-release-golang-1.23-openshift-4.21
+    tag: rhel-8-release-golang-1.24-openshift-4.21
 images:
   items:
   - dockerfile_path: Containerfile


### PR DESCRIPTION
## Summary
- OCP 4.21 dropped golang 1.23 from the CI image registry — `rhel-8-release-golang-1.23-openshift-4.21` does not exist
- Updates build_root to `rhel-8-release-golang-1.24-openshift-4.21` which is available
- Fixes job failure at image tagging step: [failed run](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_neuron-ci/12/pull-ci-rh-ecosystem-edge-neuron-ci-main-4.21-stable-aws-neuron-operator-e2e/2046207024936521728)

## Test plan
- [ ] Rehearsal job passes image tagging step
- [ ] `/test 4.21-stable-aws-neuron-operator-e2e` succeeds on neuron-ci PR after merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure configuration to use Go 1.24 for OpenShift 4.21 builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->