### PR TITLE
update ci _repo for ocp 4.22 / 5.0

### DIFF
--- a/core-services/release-controller/_repos/ocp-4.22-rhel9.repo
+++ b/core-services/release-controller/_repos/ocp-4.22-rhel9.repo
@@ -1,26 +1,27 @@
 [rhel-9-baseos]
 name = rhel-9-baseos
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-baseos
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
 [rhel-9-appstream]
 name = rhel-9-appstream
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-appstream
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
+excludepkgs=toolbox*
 
 [rhel-9-fast-datapath]
 name = rhel-9-fast-datapath
@@ -46,6 +47,18 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
+[rhel-9-highavailability]
+name = rhel-9-highavailability
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-highavailability
+enabled = 1
+gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
+sslverify = false
+gpgcheck = 0
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
+failovermethod = priority
+skip_if_unavailable = true
+
 [rhel-9-server-ose]
 name = rhel-9-server-ose
 baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-9-server-ose-rpms
@@ -60,7 +73,7 @@ skip_if_unavailable = true
 
 [rhel-9-codeready-builder-rpms]
 name = rhel-9-codeready-builder-rpms
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/x86_64/codeready-builder/os/
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/codeready-builder/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -72,27 +85,27 @@ failovermethod = priority
 
 [rhel-9-baseos-ppc64le]
 name = rhel-9-baseos-ppc64le
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-baseos-ppc64le
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
 [rhel-9-appstream-ppc64le]
 name = rhel-9-appstream-ppc64le
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-appstream-ppc64le
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
 [rhel-9-fast-datapath-ppc64le]
 name = rhel-9-fast-datapath-ppc64le
@@ -120,7 +133,7 @@ skip_if_unavailable = true
 
 [rhel-9-codeready-builder-rpms-ppc64le]
 name = rhel-9-codeready-builder-rpms-ppc64le
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/codeready-builder/os/
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/codeready-builder/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -132,27 +145,27 @@ failovermethod = priority
 
 [rhel-9-baseos-s390x]
 name = rhel-9-baseos-s390x
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/os/
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-baseos-s390x
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
 [rhel-9-appstream-s390x]
 name = rhel-9-appstream-s390x
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-appstream-s390x
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
 [rhel-9-fast-datapath-s390x]
 name = rhel-9-fast-datapath-s390x
@@ -180,7 +193,7 @@ skip_if_unavailable = true
 
 [rhel-9-codeready-builder-rpms-s390x]
 name = rhel-9-codeready-builder-rpms-s390x
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/s390x/codeready-builder/os/
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/codeready-builder/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -192,27 +205,27 @@ failovermethod = priority
 
 [rhel-9-baseos-aarch64]
 name = rhel-9-baseos-aarch64
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-baseos-aarch64
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
 [rhel-9-appstream-aarch64]
 name = rhel-9-appstream-aarch64
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-appstream-aarch64
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
 [rhel-9-fast-datapath-aarch64]
 name = rhel-9-fast-datapath-aarch64
@@ -240,7 +253,7 @@ skip_if_unavailable = true
 
 [rhel-9-codeready-builder-rpms-aarch64]
 name = rhel-9-codeready-builder-rpms-aarch64
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/aarch64/codeready-builder/os/
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/codeready-builder/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false

--- a/core-services/release-controller/_repos/ocp-5.0-rhel9.repo
+++ b/core-services/release-controller/_repos/ocp-5.0-rhel9.repo
@@ -1,26 +1,27 @@
 [rhel-9-baseos]
 name = rhel-9-baseos
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/
+baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0/rhel-98-baseos
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
 [rhel-9-appstream]
 name = rhel-9-appstream
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/
+baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0/rhel-98-appstream
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
+excludepkgs = toolbox*
 
 [rhel-9-fast-datapath]
 name = rhel-9-fast-datapath
@@ -46,6 +47,18 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
+[rhel-9-highavailability]
+name = rhel-9-highavailability
+baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0/rhel-98-highavailability
+enabled = 1
+gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
+sslverify = false
+gpgcheck = 0
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
+failovermethod = priority
+skip_if_unavailable = true
+
 [rhel-9-server-ose]
 name = rhel-9-server-ose
 baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0/rhel-9-server-ose-rpms
@@ -60,7 +73,7 @@ skip_if_unavailable = true
 
 [rhel-9-codeready-builder-rpms]
 name = rhel-9-codeready-builder-rpms
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/x86_64/codeready-builder/os/
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/codeready-builder/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -72,27 +85,27 @@ failovermethod = priority
 
 [rhel-9-baseos-ppc64le]
 name = rhel-9-baseos-ppc64le
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/
+baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0/rhel-98-baseos-ppc64le
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
 [rhel-9-appstream-ppc64le]
 name = rhel-9-appstream-ppc64le
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/
+baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0/rhel-98-appstream-ppc64le
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
 [rhel-9-fast-datapath-ppc64le]
 name = rhel-9-fast-datapath-ppc64le
@@ -120,7 +133,7 @@ skip_if_unavailable = true
 
 [rhel-9-codeready-builder-rpms-ppc64le]
 name = rhel-9-codeready-builder-rpms-ppc64le
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/codeready-builder/os/
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/codeready-builder/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -132,27 +145,27 @@ failovermethod = priority
 
 [rhel-9-baseos-s390x]
 name = rhel-9-baseos-s390x
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/os/
+baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0/rhel-98-baseos-s390x
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
 [rhel-9-appstream-s390x]
 name = rhel-9-appstream-s390x
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/
+baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0/rhel-98-appstream-s390x
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
 [rhel-9-fast-datapath-s390x]
 name = rhel-9-fast-datapath-s390x
@@ -180,7 +193,7 @@ skip_if_unavailable = true
 
 [rhel-9-codeready-builder-rpms-s390x]
 name = rhel-9-codeready-builder-rpms-s390x
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/s390x/codeready-builder/os/
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/codeready-builder/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -192,27 +205,27 @@ failovermethod = priority
 
 [rhel-9-baseos-aarch64]
 name = rhel-9-baseos-aarch64
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/
+baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0/rhel-98-baseos-aarch64
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
 [rhel-9-appstream-aarch64]
 name = rhel-9-appstream-aarch64
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/
+baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0/rhel-98-appstream-aarch64
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
 [rhel-9-fast-datapath-aarch64]
 name = rhel-9-fast-datapath-aarch64
@@ -240,7 +253,7 @@ skip_if_unavailable = true
 
 [rhel-9-codeready-builder-rpms-aarch64]
 name = rhel-9-codeready-builder-rpms-aarch64
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/aarch64/codeready-builder/os/
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/codeready-builder/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -249,4 +262,3 @@ gpgcheck = 0
 sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
-


### PR DESCRIPTION
follows 
https://github.com/openshift-eng/ocp-build-data/pull/10081
https://github.com/openshift-eng/ocp-build-data/pull/10082

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated RHEL 9 package repository sources to OpenShift mirrors for OpenShift 4.22 and 5.0
* Changed repository authentication from TLS client certificates to credential-file-based authentication
* Added new high availability repository section
* Enabled automatic failover and improved package availability handling across repository configurations
* Updated CodeReady Builder repository endpoints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->