### PR TITLE
Increase concurrency limit on number of image push jobs

### DIFF
--- a/ci-operator/jobs/Azure/ARO-HCP/Azure-ARO-HCP-main-postsubmits.yaml
+++ b/ci-operator/jobs/Azure/ARO-HCP/Azure-ARO-HCP-main-postsubmits.yaml
@@ -512,7 +512,7 @@ postsubmits:
       skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
-    max_concurrency: 1
+    max_concurrency: 0
     name: branch-ci-Azure-ARO-HCP-main-images-push
     spec:
       containers:

--- a/ci-operator/jobs/Azure/ARO-HCP/Azure-ARO-HCP-main-postsubmits.yaml
+++ b/ci-operator/jobs/Azure/ARO-HCP/Azure-ARO-HCP-main-postsubmits.yaml
@@ -512,7 +512,6 @@ postsubmits:
       skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
-    max_concurrency: 0
     name: branch-ci-Azure-ARO-HCP-main-images-push
     spec:
       containers:

--- a/ci-operator/jobs/Azure/ARO-HCP/Azure-ARO-HCP-main-postsubmits.yaml
+++ b/ci-operator/jobs/Azure/ARO-HCP/Azure-ARO-HCP-main-postsubmits.yaml
@@ -512,6 +512,7 @@ postsubmits:
       skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
+    max_concurrency: 100
     name: branch-ci-Azure-ARO-HCP-main-images-push
     spec:
       containers:


### PR DESCRIPTION
By default, prowgen generates postsubmit jobs with `max_concurrency: 1`, meaning only one instance of a job can run at a time. During commit bursts to the ARO-HCP `main` branch, this causes image push jobs to queue and execute sequentially, significantly delaying when images land in ACR.

Setting concurrency limit to considerably higher value, allowing multiple image push jobs to run in parallel. 

This field is overridable as per https://docs.ci.openshift.org/how-tos/contributing-openshift-release/#tolerated-changes-to-generated-jobs