### PR TITLE
vsphere upi: remove folder from install-config

### DIFF
--- a/ci-operator/step-registry/upi/conf/vsphere/upi-conf-vsphere-commands.sh
+++ b/ci-operator/step-registry/upi/conf/vsphere/upi-conf-vsphere-commands.sh
@@ -267,7 +267,6 @@ platform:
     network: "${vsphere_portgroup}"
     password: "${GOVC_PASSWORD}"
     username: "${GOVC_USERNAME}"
-    folder: "/${vsphere_datacenter}/vm/${cluster_name}"
 EOF
 
 #set machine cidr if proxy is enabled

--- a/ci-operator/step-registry/upi/conf/vsphere/vcm/upi-conf-vsphere-vcm-commands.sh
+++ b/ci-operator/step-registry/upi/conf/vsphere/vcm/upi-conf-vsphere-vcm-commands.sh
@@ -443,7 +443,6 @@ platform:
     network: "${vsphere_portgroup}"
     password: "${GOVC_PASSWORD}"
     username: "${GOVC_USERNAME}"
-    folder: "/${vsphere_datacenter}/vm/${cluster_name}"
 EOF
 else
 ${platform_required} && cat >>"${install_config}" <<EOF

--- a/ci-operator/step-registry/upi/conf/vsphere/zones/upi-conf-vsphere-zones-commands.sh
+++ b/ci-operator/step-registry/upi/conf/vsphere/zones/upi-conf-vsphere-zones-commands.sh
@@ -257,7 +257,6 @@ platform:
     datacenter: "IBMCloud"
     cluster: vcs-mdcnc-workload-1
     defaultDatastore: mdcnc-ds-shared
-    folder: "/IBMCloud/vm/${cluster_name}"
     failureDomains:
     - name: us-east-1
       region: us-east
@@ -292,7 +291,6 @@ platform:
         networks:
         - ${vsphere_portgroup}
         datastore: mdcnc-ds-4
-        folder: "/datacenter-2/vm/${cluster_name}"
 
 networking:
   machineNetwork:


### PR DESCRIPTION
The UPI install-config was setting folder to
/${datacenter}/vm/${cluster_name}, but the UPI PowerShell scripts create the VM folder using the infraID from metadata.json. This mismatch caused the in-cluster vsphere-problem-detector to fail finding the folder since it reads the folder path from the Infrastructure CR.

When folder is unset in the install-config, the installer generates the correct default /${datacenter}/vm/${infraID} in the cloud provider config, matching what UPI actually provisions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Removed explicit vSphere folder path specifications from installer configurations across standard deployments, legacy installer versions, and multi-datacenter cluster topologies. Folder paths are now managed through alternative mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->