### PR TITLE
add osde2e ocm account cluster cleanup job for integration env

### DIFF
--- a/ci-operator/config/openshift/osde2e/openshift-osde2e-main.yaml
+++ b/ci-operator/config/openshift/osde2e/openshift-osde2e-main.yaml
@@ -144,7 +144,7 @@ tests:
   container:
     clone: true
     from: osde2e
-  cron: 0 0 * * 2
+  cron: 0 1 * * 0
   secrets:
   - mount_path: /usr/local/osde2e-common
     name: osde2e-common
@@ -160,7 +160,23 @@ tests:
   container:
     clone: true
     from: osde2e
-  cron: 45 0 * * 2
+  cron: 0 2 * * 0
+  secrets:
+  - mount_path: /usr/local/osde2e-common
+    name: osde2e-common
+  - mount_path: /usr/local/osde2e-credentials
+    name: osde2e-credentials
+- as: int-clusters-cleanup
+  commands: |
+    export REPORT_DIR="$ARTIFACT_DIR"
+    export CONFIGS="int"
+    export SECRET_LOCATIONS="/usr/local/osde2e-common,/usr/local/osde2e-credentials"
+
+    /osde2e cleanup --secret-locations ${SECRET_LOCATIONS} --configs ${CONFIGS} --clusters --dry-run=false
+  container:
+    clone: true
+    from: osde2e
+  cron: 0 3 * * 0
   secrets:
   - mount_path: /usr/local/osde2e-common
     name: osde2e-common

--- a/ci-operator/jobs/openshift/osde2e/openshift-osde2e-main-periodics.yaml
+++ b/ci-operator/jobs/openshift/osde2e/openshift-osde2e-main-periodics.yaml
@@ -623,6 +623,79 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
+  cron: 0 3 * * 0
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: osde2e
+  labels:
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-osde2e-main-int-clusters-cleanup
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/osde2e-common
+      - --secret-dir=/secrets/osde2e-credentials
+      - --target=int-clusters-cleanup
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /secrets/osde2e-common
+        name: osde2e-common
+        readOnly: true
+      - mountPath: /secrets/osde2e-credentials
+        name: osde2e-credentials
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: osde2e-common
+      secret:
+        secretName: osde2e-common
+    - name: osde2e-credentials
+      secret:
+        secretName: osde2e-credentials
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build11
   cron: 0 0 1 1 *
   decorate: true
   decoration_config:
@@ -3470,7 +3543,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 45 0 * * 2
+  cron: 0 2 * * 0
   decorate: true
   extra_refs:
   - base_ref: main
@@ -3737,7 +3810,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 0 0 * * 2
+  cron: 0 1 * * 0
   decorate: true
   extra_refs:
   - base_ref: main


### PR DESCRIPTION
in addition to prod and stage we should also cleanup int clusters

trace https://redhat-internal.slack.com/archives/CMK13BP4J/p1776698450137439?thread_ts=1776697197.624019&cid=CMK13BP4J

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated cleanup job execution schedules for stage and production environments
  * Added new automated cleanup job for integration environment with weekly scheduled runs
  * Infrastructure maintenance operations now distributed across optimized time windows for improved resource management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->