### PR TITLE
wmco: konflux skip images job for 4.21 and below

### DIFF
--- a/ci-operator/config/openshift/windows-machine-config-operator/openshift-windows-machine-config-operator-release-4.18.yaml
+++ b/ci-operator/config/openshift/windows-machine-config-operator/openshift-windows-machine-config-operator-release-4.18.yaml
@@ -19,7 +19,7 @@ images:
   items:
   - dockerfile_path: build/Dockerfile.ci
     to: windows-machine-config-operator-test
-  skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
+  skip_if_only_changed: ^(?:docs|\.github|\.tekton)/|\.md$|^(?:\.gitignore|renovate\.json|OWNERS|PROJECT|LICENSE|Containerfile|Containerfile.bundle)$
 operator:
   bundles:
   - as: wmco-bundle

--- a/ci-operator/config/openshift/windows-machine-config-operator/openshift-windows-machine-config-operator-release-4.19.yaml
+++ b/ci-operator/config/openshift/windows-machine-config-operator/openshift-windows-machine-config-operator-release-4.19.yaml
@@ -19,7 +19,7 @@ images:
   items:
   - dockerfile_path: build/Dockerfile.ci
     to: windows-machine-config-operator-test
-  skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
+  skip_if_only_changed: ^(?:docs|\.github|\.tekton)/|\.md$|^(?:\.gitignore|renovate\.json|OWNERS|PROJECT|LICENSE|Containerfile|Containerfile.bundle)$
 operator:
   bundles:
   - as: wmco-bundle

--- a/ci-operator/config/openshift/windows-machine-config-operator/openshift-windows-machine-config-operator-release-4.20.yaml
+++ b/ci-operator/config/openshift/windows-machine-config-operator/openshift-windows-machine-config-operator-release-4.20.yaml
@@ -19,7 +19,7 @@ images:
   items:
   - dockerfile_path: build/Dockerfile.ci
     to: windows-machine-config-operator-test
-  skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
+  skip_if_only_changed: ^(?:docs|\.github|\.tekton)/|\.md$|^(?:\.gitignore|renovate\.json|OWNERS|PROJECT|LICENSE|Containerfile|Containerfile.bundle)$
 operator:
   bundles:
   - as: wmco-bundle

--- a/ci-operator/config/openshift/windows-machine-config-operator/openshift-windows-machine-config-operator-release-4.21.yaml
+++ b/ci-operator/config/openshift/windows-machine-config-operator/openshift-windows-machine-config-operator-release-4.21.yaml
@@ -19,7 +19,7 @@ images:
   items:
   - dockerfile_path: build/Dockerfile.ci
     to: windows-machine-config-operator-test
-  skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
+  skip_if_only_changed: ^(?:docs|\.github|\.tekton)/|\.md$|^(?:\.gitignore|renovate\.json|OWNERS|PROJECT|LICENSE|Containerfile|Containerfile.bundle)$
 operator:
   bundles:
   - as: wmco-bundle

--- a/ci-operator/jobs/openshift/windows-machine-config-operator/openshift-windows-machine-config-operator-release-4.18-presubmits.yaml
+++ b/ci-operator/jobs/openshift/windows-machine-config-operator/openshift-windows-machine-config-operator-release-4.18-presubmits.yaml
@@ -390,7 +390,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-windows-machine-config-operator-release-4.18-images
     rerun_command: /test images
-    skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
+    skip_if_only_changed: ^(?:docs|\.github|\.tekton)/|\.md$|^(?:\.gitignore|renovate\.json|OWNERS|PROJECT|LICENSE|Containerfile|Containerfile.bundle)$
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift/windows-machine-config-operator/openshift-windows-machine-config-operator-release-4.19-presubmits.yaml
+++ b/ci-operator/jobs/openshift/windows-machine-config-operator/openshift-windows-machine-config-operator-release-4.19-presubmits.yaml
@@ -390,7 +390,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-windows-machine-config-operator-release-4.19-images
     rerun_command: /test images
-    skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
+    skip_if_only_changed: ^(?:docs|\.github|\.tekton)/|\.md$|^(?:\.gitignore|renovate\.json|OWNERS|PROJECT|LICENSE|Containerfile|Containerfile.bundle)$
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift/windows-machine-config-operator/openshift-windows-machine-config-operator-release-4.20-presubmits.yaml
+++ b/ci-operator/jobs/openshift/windows-machine-config-operator/openshift-windows-machine-config-operator-release-4.20-presubmits.yaml
@@ -390,7 +390,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-windows-machine-config-operator-release-4.20-images
     rerun_command: /test images
-    skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
+    skip_if_only_changed: ^(?:docs|\.github|\.tekton)/|\.md$|^(?:\.gitignore|renovate\.json|OWNERS|PROJECT|LICENSE|Containerfile|Containerfile.bundle)$
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift/windows-machine-config-operator/openshift-windows-machine-config-operator-release-4.21-presubmits.yaml
+++ b/ci-operator/jobs/openshift/windows-machine-config-operator/openshift-windows-machine-config-operator-release-4.21-presubmits.yaml
@@ -390,7 +390,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-windows-machine-config-operator-release-4.21-images
     rerun_command: /test images
-    skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
+    skip_if_only_changed: ^(?:docs|\.github|\.tekton)/|\.md$|^(?:\.gitignore|renovate\.json|OWNERS|PROJECT|LICENSE|Containerfile|Containerfile.bundle)$
     spec:
       containers:
       - args:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI build skip logic across release versions (4.18–4.21) to better recognize documentation and configuration-only changes, preventing unnecessary test builds when changes are limited to documentation directories, GitHub workflows, or container configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->