### PR TITLE
Add ready-for-human-review label for openshift org

### DIFF
--- a/core-services/prow/02_config/_labels.yaml
+++ b/core-services/prow/02_config/_labels.yaml
@@ -516,6 +516,11 @@ orgs:
         name: docs-approved
         target: both
         addedBy: label
+      - color: c3f7c5
+        description: Indicates a PR has been reviewed by automated tools and is ready for human review to reduce cognitive load
+        name: ready-for-human-review
+        target: prs
+        addedBy: label
       - color: 52809B
         description: Indicates the PR should not be rebased by the rebasebot.
         name: 'rebase/manual'


### PR DESCRIPTION
## Summary
Add a new `ready-for-human-review` label to the openshift org configuration to help engineering teams limit cognitive load when reviewing PRs.

## Details
The label supports a workflow where automated tools (like CodeRabbit) review PRs first, and once all automated comments are resolved, this label can be applied to signal that the PR is ready for human review. Teams can then filter PRs by this label to focus their review efforts.

## Label Configuration
- **Name**: `ready-for-human-review`
- **Color**: Pale green (`c3f7c5`)
- **Target**: PRs
- **Added by**: Both automation and humans
- **Description**: Indicates a PR has been reviewed by automated tools and is ready for human review to reduce cognitive load

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `ready-for-human-review` label for pull requests that have completed automated tool review and are ready for human review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->