### PR TITLE
Experiment ci

### DIFF
--- a/ci-operator/config/openshift/cluster-authentication-operator/openshift-cluster-authentication-operator-master.yaml
+++ b/ci-operator/config/openshift/cluster-authentication-operator/openshift-cluster-authentication-operator-master.yaml
@@ -314,6 +314,18 @@ tests:
     - ref: openshift-e2e-test
     workflow: ipi-aws
   timeout: 4h0m0s
+- always_run: false
+  as: e2e-aws-kas-encryption-kms-serial-ote
+  optional: true
+  steps:
+    cluster_profile: openshift-org-aws
+    env:
+      FEATURE_SET: TechPreviewNoUpgrade
+      TEST_SUITE: openshift/cluster-kube-apiserver-operator/operator/serial
+    test:
+    - ref: openshift-e2e-test
+    workflow: ipi-aws
+  timeout: 4h0m0s
 zz_generated_metadata:
   branch: master
   org: openshift

--- a/ci-operator/jobs/openshift/cluster-authentication-operator/openshift-cluster-authentication-operator-master-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-authentication-operator/openshift-cluster-authentication-operator-master-presubmits.yaml
@@ -409,6 +409,89 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-aws-external-oidc-conformance-serial,?($|\s.*)
   - agent: kubernetes
+    always_run: false
+    branches:
+    - ^master$
+    - ^master-
+    cluster: build01
+    context: ci/prow/e2e-aws-kas-encryption-kms-serial-ote
+    decorate: true
+    decoration_config:
+      timeout: 4h0m0s
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-authentication-operator-master-e2e-aws-kas-encryption-kms-serial-ote
+    optional: true
+    rerun_command: /test e2e-aws-kas-encryption-kms-serial-ote
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-aws-kas-encryption-kms-serial-ote
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-aws-kas-encryption-kms-serial-ote,?($|\s.*)
+  - agent: kubernetes
     always_run: true
     branches:
     - ^master$


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an optional end-to-end test for KAS encryption using KMS on AWS, with a presubmit job that can be manually triggered via a test command, targets master branches, uses an AWS cluster profile, and includes an extended 4-hour timeout for serial execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->