### PR TITLE
Fix OPP policy compliance check race condition

### DIFF
--- a/ci-operator/step-registry/acm/policies/openshift-plus/acm-policies-openshift-plus-commands.sh
+++ b/ci-operator/step-registry/acm/policies/openshift-plus/acm-policies-openshift-plus-commands.sh
@@ -20,7 +20,6 @@ sleep 120
 
 # wait for policies to be compliant
 RETRIES=40
-SECONDARY_FILTER="grep -v policy-acs | grep -v policy-advanced-managed-cluster-status | grep -v policy-hub-quay-bridge | grep -v policy-quay-status"
 for try in $(seq "${RETRIES}"); do
   results=$(oc get policies -n policies)
   data_rows=$(echo "$results" | tail -n +2)

--- a/ci-operator/step-registry/acm/policies/openshift-plus/acm-policies-openshift-plus-commands.sh
+++ b/ci-operator/step-registry/acm/policies/openshift-plus/acm-policies-openshift-plus-commands.sh
@@ -23,14 +23,15 @@ RETRIES=40
 for try in $(seq "${RETRIES}"); do
   results=$(oc get policies -n policies)
   notready=$(echo "$results" | grep -E 'NonCompliant|Pending' || true)
-  if [ "$notready" == "" ]; then
+  unevaluated=$(echo "$results" | tail -n +2 | grep -v 'Compliant' || true)
+  if [ "$notready" == "" ] && [ "$unevaluated" == "" ]; then
     echo "OPP policyset is applied and compliant"
     break
   else
     if [ $try == $RETRIES ]; then
       if [ "$IGNORE_SECONDARY_POLICIES" == "true" ]; then
         CANDIDATES=$(echo "$notready" | grep -v policy-acs | grep -v policy-advanced-managed-cluster-status | grep -v policy-hub-quay-bridge | grep -v policy-quay-status || true)
-        if [ -z "$CANDIDATES" ]; then
+        if [ -z "$CANDIDATES" ] && [ -z "$unevaluated" ]; then
           echo "Warning: Proceeding with OPP QE tests with some policy failures"
           exit 0
         else
@@ -42,7 +43,11 @@ for try in $(seq "${RETRIES}"); do
         exit 1
       fi
     fi
-    echo "Try ${try}/${RETRIES}: Policies are not compliant. Checking again in 30 seconds"
+    if [ "$notready" != "" ]; then
+      echo "Try ${try}/${RETRIES}: Policies are not compliant. Checking again in 30 seconds"
+    else
+      echo "Try ${try}/${RETRIES}: Policies have not been evaluated yet. Checking again in 30 seconds"
+    fi
     sleep 30
   fi
 done

--- a/ci-operator/step-registry/acm/policies/openshift-plus/acm-policies-openshift-plus-commands.sh
+++ b/ci-operator/step-registry/acm/policies/openshift-plus/acm-policies-openshift-plus-commands.sh
@@ -20,18 +20,27 @@ sleep 120
 
 # wait for policies to be compliant
 RETRIES=40
+SECONDARY_FILTER="grep -v policy-acs | grep -v policy-advanced-managed-cluster-status | grep -v policy-hub-quay-bridge | grep -v policy-quay-status"
 for try in $(seq "${RETRIES}"); do
   results=$(oc get policies -n policies)
+  data_rows=$(echo "$results" | tail -n +2)
+  row_count=$(echo "$data_rows" | grep -c . || true)
+  if [ "$row_count" -eq 0 ]; then
+    echo "Try ${try}/${RETRIES}: No policy rows found. Checking again in 30 seconds"
+    sleep 30
+    continue
+  fi
   notready=$(echo "$results" | grep -E 'NonCompliant|Pending' || true)
-  unevaluated=$(echo "$results" | tail -n +2 | grep -v 'Compliant' || true)
+  unevaluated=$(echo "$data_rows" | grep -v 'Compliant' || true)
   if [ "$notready" == "" ] && [ "$unevaluated" == "" ]; then
     echo "OPP policyset is applied and compliant"
     break
   else
     if [ $try == $RETRIES ]; then
       if [ "$IGNORE_SECONDARY_POLICIES" == "true" ]; then
-        CANDIDATES=$(echo "$notready" | grep -v policy-acs | grep -v policy-advanced-managed-cluster-status | grep -v policy-hub-quay-bridge | grep -v policy-quay-status || true)
-        if [ -z "$CANDIDATES" ] && [ -z "$unevaluated" ]; then
+        filtered_notready=$(echo "$notready" | grep -v policy-acs | grep -v policy-advanced-managed-cluster-status | grep -v policy-hub-quay-bridge | grep -v policy-quay-status || true)
+        filtered_unevaluated=$(echo "$unevaluated" | grep -v policy-acs | grep -v policy-advanced-managed-cluster-status | grep -v policy-hub-quay-bridge | grep -v policy-quay-status || true)
+        if [ -z "$filtered_notready" ] && [ -z "$filtered_unevaluated" ]; then
           echo "Warning: Proceeding with OPP QE tests with some policy failures"
           exit 0
         else

--- a/ci-operator/step-registry/interop-tests/ocs-tests/interop-tests-ocs-tests-commands.sh
+++ b/ci-operator/step-registry/interop-tests/ocs-tests/interop-tests-ocs-tests-commands.sh
@@ -10,6 +10,13 @@ OCP_VERSION="${OCP_MAJOR_MINOR}"
 
 OCS_VERSION=$(oc get csv -n openshift-storage -o json | jq -r '.items[] | select(.metadata.name | startswith("ocs-operator")).spec.version' | cut -d. -f1,2)
 
+if [[ -z "${OCS_VERSION}" ]]; then
+    echo "ERROR: Could not determine OCS version. No CSV starting with 'ocs-operator' found in openshift-storage namespace."
+    echo "Available CSVs in openshift-storage:"
+    oc get csv -n openshift-storage -o custom-columns=NAME:.metadata.name,VERSION:.spec.version,PHASE:.status.phase 2>&1 || echo "  (namespace may not exist)"
+    exit 1
+fi
+
 CLUSTER_NAME=$([[ -f "${SHARED_DIR}/CLUSTER_NAME" ]] && cat "${SHARED_DIR}/CLUSTER_NAME" || echo "cluster-name")
 CLUSTER_DOMAIN="${CLUSTER_DOMAIN:-release-ci.cnv-qe.rhood.us}"
 LOGS_FOLDER="${ARTIFACT_DIR}/ocs-tests"

--- a/ci-operator/step-registry/interop-tests/ocs-tests/interop-tests-ocs-tests-commands.sh
+++ b/ci-operator/step-registry/interop-tests/ocs-tests/interop-tests-ocs-tests-commands.sh
@@ -8,7 +8,7 @@ CLUSTER_VERSION=$(oc get clusterVersion version -o jsonpath='{$.status.desired.v
 OCP_MAJOR_MINOR=$(echo "${CLUSTER_VERSION}" | cut -d '.' -f1,2)
 OCP_VERSION="${OCP_MAJOR_MINOR}"
 
-OCS_VERSION=$(oc get csv -n openshift-storage -o json | jq -r '.items[] | select(.metadata.name | startswith("ocs-operator")).spec.version' | cut -d. -f1,2)
+OCS_VERSION=$(oc get csv -n openshift-storage -o json 2>/dev/null | jq -r '.items[] | select(.metadata.name | startswith("ocs-operator")).spec.version' | cut -d. -f1,2 || true)
 
 if [[ -z "${OCS_VERSION}" ]]; then
     echo "ERROR: Could not determine OCS version. No CSV starting with 'ocs-operator' found in openshift-storage namespace."


### PR DESCRIPTION
## Summary

Fixes a race condition in the OPP policy compliance check that causes downstream test failures (`interop-tests-ocs-tests`, `acm-opp-app`) when policies haven't been evaluated yet.

**Root cause**: `acm-policies-openshift-plus-commands.sh` checks for `NonCompliant|Pending` policies, but freshly deployed policies have a **blank** compliance column (not yet evaluated). Blank doesn't match `NonCompliant|Pending`, so the loop exits on the first iteration declaring "compliant" when nothing has actually been checked.

**Evidence**: On the failing 4.22 AWS run, policies were only 117s old with all-blank compliance states. The working 4.21 AWS run had policies at 15 minutes with all showing `Compliant`, because at least one policy had evaluated to `NonCompliant` within the initial sleep, keeping the retry loop alive.

## Changes

### 1. `acm-policies-openshift-plus-commands.sh` (root cause fix)

Added a second check alongside the existing `NonCompliant|Pending` grep: any policy line that does not contain `Compliant` at all is treated as "not ready". This prevents the loop from short-circuiting when policies are freshly deployed and haven't been evaluated yet.

### 2. `interop-tests-ocs-tests-commands.sh` (defense in depth)

Added validation that `OCS_VERSION` is non-empty before calling `run-ci`. When ODF is not installed (consequence of the premature compliance check), the `ocs-operator` CSV query returns empty, and `run-ci --ocs-version ''` fails with a confusing argparse error. The new check fails fast with a clear message and dumps available CSVs for debugging.

## Affected Jobs

- `periodic-ci-stolostron-policy-collection-main-ocp4.22-interop-opp-aws`

## Related Jira Tickets

- [LPINTEROP-6646](https://redhat.atlassian.net/browse/LPINTEROP-6646) - ACM OPP app failure (QuayIntegration not found)
- [OCSQE-4716](https://redhat.atlassian.net/browse/OCSQE-4716) - OCS step failure (empty --ocs-version)
- [LPINTEROP-6574](https://redhat.atlassian.net/browse/LPINTEROP-6574) - Previous occurrence (March 30)
- [OCSQE-4708](https://redhat.atlassian.net/browse/OCSQE-4708) - Previous occurrence (March 30)

## Test plan

- [ ] Verify the compliance check loop does not exit early when policies have blank compliance state
- [ ] Verify the OCS test step fails with a clear error when OCS_VERSION is empty
- [ ] Confirm the fix does not change behavior when policies are properly evaluated (4.21 AWS, 4.22 vSphere)

/cc @CSPI-QE

[LPINTEROP-6646]: https://redhat.atlassian.net/browse/LPINTEROP-6646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced policy compliance validation to detect unevaluated policies
  * Added validation to prevent execution with missing required configuration values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->