### PR TITLE
Fix OPP policy compliance check race condition

### DIFF
--- a/ci-operator/step-registry/acm/policies/openshift-plus/acm-policies-openshift-plus-commands.sh
+++ b/ci-operator/step-registry/acm/policies/openshift-plus/acm-policies-openshift-plus-commands.sh
@@ -20,7 +20,6 @@ sleep 120
 
 # wait for policies to be compliant
 RETRIES=40
-SECONDARY_FILTER="grep -v policy-acs | grep -v policy-advanced-managed-cluster-status | grep -v policy-hub-quay-bridge | grep -v policy-quay-status"
 for try in $(seq "${RETRIES}"); do
   results=$(oc get policies -n policies)
   data_rows=$(echo "$results" | tail -n +2)

--- a/ci-operator/step-registry/acm/policies/openshift-plus/acm-policies-openshift-plus-commands.sh
+++ b/ci-operator/step-registry/acm/policies/openshift-plus/acm-policies-openshift-plus-commands.sh
@@ -23,14 +23,15 @@ RETRIES=40
 for try in $(seq "${RETRIES}"); do
   results=$(oc get policies -n policies)
   notready=$(echo "$results" | grep -E 'NonCompliant|Pending' || true)
-  if [ "$notready" == "" ]; then
+  unevaluated=$(echo "$results" | tail -n +2 | grep -v 'Compliant' || true)
+  if [ "$notready" == "" ] && [ "$unevaluated" == "" ]; then
     echo "OPP policyset is applied and compliant"
     break
   else
     if [ $try == $RETRIES ]; then
       if [ "$IGNORE_SECONDARY_POLICIES" == "true" ]; then
         CANDIDATES=$(echo "$notready" | grep -v policy-acs | grep -v policy-advanced-managed-cluster-status | grep -v policy-hub-quay-bridge | grep -v policy-quay-status || true)
-        if [ -z "$CANDIDATES" ]; then
+        if [ -z "$CANDIDATES" ] && [ -z "$unevaluated" ]; then
           echo "Warning: Proceeding with OPP QE tests with some policy failures"
           exit 0
         else
@@ -42,7 +43,11 @@ for try in $(seq "${RETRIES}"); do
         exit 1
       fi
     fi
-    echo "Try ${try}/${RETRIES}: Policies are not compliant. Checking again in 30 seconds"
+    if [ "$notready" != "" ]; then
+      echo "Try ${try}/${RETRIES}: Policies are not compliant. Checking again in 30 seconds"
+    else
+      echo "Try ${try}/${RETRIES}: Policies have not been evaluated yet. Checking again in 30 seconds"
+    fi
     sleep 30
   fi
 done

--- a/ci-operator/step-registry/acm/policies/openshift-plus/acm-policies-openshift-plus-commands.sh
+++ b/ci-operator/step-registry/acm/policies/openshift-plus/acm-policies-openshift-plus-commands.sh
@@ -20,18 +20,27 @@ sleep 120
 
 # wait for policies to be compliant
 RETRIES=40
+SECONDARY_FILTER="grep -v policy-acs | grep -v policy-advanced-managed-cluster-status | grep -v policy-hub-quay-bridge | grep -v policy-quay-status"
 for try in $(seq "${RETRIES}"); do
   results=$(oc get policies -n policies)
+  data_rows=$(echo "$results" | tail -n +2)
+  row_count=$(echo "$data_rows" | grep -c . || true)
+  if [ "$row_count" -eq 0 ]; then
+    echo "Try ${try}/${RETRIES}: No policy rows found. Checking again in 30 seconds"
+    sleep 30
+    continue
+  fi
   notready=$(echo "$results" | grep -E 'NonCompliant|Pending' || true)
-  unevaluated=$(echo "$results" | tail -n +2 | grep -v 'Compliant' || true)
+  unevaluated=$(echo "$data_rows" | grep -v 'Compliant' || true)
   if [ "$notready" == "" ] && [ "$unevaluated" == "" ]; then
     echo "OPP policyset is applied and compliant"
     break
   else
     if [ $try == $RETRIES ]; then
       if [ "$IGNORE_SECONDARY_POLICIES" == "true" ]; then
-        CANDIDATES=$(echo "$notready" | grep -v policy-acs | grep -v policy-advanced-managed-cluster-status | grep -v policy-hub-quay-bridge | grep -v policy-quay-status || true)
-        if [ -z "$CANDIDATES" ] && [ -z "$unevaluated" ]; then
+        filtered_notready=$(echo "$notready" | grep -v policy-acs | grep -v policy-advanced-managed-cluster-status | grep -v policy-hub-quay-bridge | grep -v policy-quay-status || true)
+        filtered_unevaluated=$(echo "$unevaluated" | grep -v policy-acs | grep -v policy-advanced-managed-cluster-status | grep -v policy-hub-quay-bridge | grep -v policy-quay-status || true)
+        if [ -z "$filtered_notready" ] && [ -z "$filtered_unevaluated" ]; then
           echo "Warning: Proceeding with OPP QE tests with some policy failures"
           exit 0
         else

--- a/ci-operator/step-registry/acm/policies/openshift-plus/acm-policies-openshift-plus-commands.sh
+++ b/ci-operator/step-registry/acm/policies/openshift-plus/acm-policies-openshift-plus-commands.sh
@@ -18,7 +18,8 @@ echo 'y' | ./deploy.sh -p policygenerator/policy-sets/stable/openshift-plus -n p
 
 sleep 120
 
-# wait for policies to be compliant
+SECONDARY_POLICIES='policy-acs|policy-advanced-managed-cluster-security|policy-advanced-managed-cluster-status|policy-hub-quay-bridge|policy-quay-bridge|policy-quay-status'
+
 RETRIES=40
 for try in $(seq "${RETRIES}"); do
   results=$(oc get policies -n policies)
@@ -30,16 +31,15 @@ for try in $(seq "${RETRIES}"); do
     continue
   fi
   notready=$(echo "$results" | grep -E 'NonCompliant|Pending' || true)
-  unevaluated=$(echo "$data_rows" | grep -v 'Compliant' || true)
+  unevaluated=$(echo "$data_rows" | grep -v 'Compliant' | grep -vE "$SECONDARY_POLICIES" || true)
   if [ "$notready" == "" ] && [ "$unevaluated" == "" ]; then
     echo "OPP policyset is applied and compliant"
     break
   else
     if [ $try == $RETRIES ]; then
       if [ "$IGNORE_SECONDARY_POLICIES" == "true" ]; then
-        filtered_notready=$(echo "$notready" | grep -v policy-acs | grep -v policy-advanced-managed-cluster-status | grep -v policy-hub-quay-bridge | grep -v policy-quay-status || true)
-        filtered_unevaluated=$(echo "$unevaluated" | grep -v policy-acs | grep -v policy-advanced-managed-cluster-status | grep -v policy-hub-quay-bridge | grep -v policy-quay-status || true)
-        if [ -z "$filtered_notready" ] && [ -z "$filtered_unevaluated" ]; then
+        filtered_notready=$(echo "$notready" | grep -vE "$SECONDARY_POLICIES" || true)
+        if [ -z "$filtered_notready" ]; then
           echo "Warning: Proceeding with OPP QE tests with some policy failures"
           exit 0
         else


### PR DESCRIPTION
## Summary

Fixes a race condition in the OPP policy compliance check that causes downstream test failures when policies haven't been evaluated yet.

**Root cause**: `acm-policies-openshift-plus-commands.sh` checks for `NonCompliant|Pending` policies, but freshly deployed policies have a **blank** compliance column (not yet evaluated). Blank doesn't match `NonCompliant|Pending`, so the loop exits on the first iteration declaring "compliant" when nothing has actually been checked.

**Evidence**: On the failing 4.22 AWS run, policies were only 117s old with all-blank compliance states. The working 4.21 AWS run had policies at 15 minutes with all showing `Compliant`, because at least one policy had evaluated to `NonCompliant` within the initial sleep, keeping the retry loop alive.

## Changes

- Added a check for zero policy rows (freshly deployed, nothing returned yet)
- Added a second check alongside the existing `NonCompliant|Pending` grep: any policy line that does not contain `Compliant` at all is treated as "not ready"
- Applied the same `IGNORE_SECONDARY_POLICIES` filtering to unevaluated policies
- Improved retry messaging to distinguish between non-compliant and unevaluated states

## Affected Jobs

- `periodic-ci-stolostron-policy-collection-main-ocp4.22-interop-opp-aws`
- `periodic-ci-stolostron-policy-collection-main-ocp4.22-interop-opp-vsphere`
- `periodic-ci-stolostron-policy-collection-main-ocp4.21-interop-opp-aws`

## Related Jira Tickets

- [LPINTEROP-6646](https://redhat.atlassian.net/browse/LPINTEROP-6646) - ACM OPP app failure (QuayIntegration not found)
- [LPINTEROP-6574](https://redhat.atlassian.net/browse/LPINTEROP-6574) - Previous occurrence (March 30)

Split from #78052 (policy compliance fix only; OCS version guard is in a separate PR).

/cc @CSPI-QE

[LPINTEROP-6646]: https://redhat.atlassian.net/browse/LPINTEROP-6646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced policy compliance validation to more accurately assess policy readiness, including better handling of policies that are not yet evaluated.
  * Improved retry logic with clearer status messaging to distinguish between policies that are non-compliant versus those still being evaluated.
  * Refined secondary policy filtering during the compliance verification process for more precise results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->