### PR TITLE
Fix OCS version detection for ODF operator rename

### DIFF
--- a/ci-operator/step-registry/interop-tests/ocs-tests/interop-tests-ocs-tests-commands.sh
+++ b/ci-operator/step-registry/interop-tests/ocs-tests/interop-tests-ocs-tests-commands.sh
@@ -8,7 +8,19 @@ CLUSTER_VERSION=$(oc get clusterVersion version -o jsonpath='{$.status.desired.v
 OCP_MAJOR_MINOR=$(echo "${CLUSTER_VERSION}" | cut -d '.' -f1,2)
 OCP_VERSION="${OCP_MAJOR_MINOR}"
 
-OCS_VERSION=$(oc get csv -n openshift-storage -o json | jq -r '.items[] | select(.metadata.name | startswith("ocs-operator")).spec.version' | cut -d. -f1,2)
+OCS_VERSION=$(
+  oc get csv -n openshift-storage -o json 2>/dev/null |
+    jq -r '
+      [ .items[] | select(.metadata.name | test("^(ocs-(client-)?|odf-)operator")) ] |
+      first | .spec.version // empty
+    ' | cut -d. -f1,2
+) || true
+if [[ -z "${OCS_VERSION}" ]]; then
+    echo "ERROR: OCS_VERSION not set or CSV lookup failed."
+    echo "Available CSVs in openshift-storage:"
+    oc get csv -n openshift-storage -o custom-columns=NAME:.metadata.name,VERSION:.spec.version,PHASE:.status.phase 2>&1 || echo "  (namespace may not exist)"
+    exit 1
+fi
 
 CLUSTER_NAME=$([[ -f "${SHARED_DIR}/CLUSTER_NAME" ]] && cat "${SHARED_DIR}/CLUSTER_NAME" || echo "cluster-name")
 CLUSTER_DOMAIN="${CLUSTER_DOMAIN:-release-ci.cnv-qe.rhood.us}"


### PR DESCRIPTION
## Summary

The \`interop-tests-ocs-tests\` step fails with \`run-ci: error: argument --ocs-version: invalid choice: ''\` when the \`ocs-operator\` CSV is not present in the \`openshift-storage\` namespace. This happens on ODF 4.17+ where the operator may be deployed as \`ocs-client-operator\` or \`odf-operator\` instead.

The fix updates the jq selector to match all three operator names via a regex (\`^(ocs-(client-)?|odf-)operator\`), and replaces the silent empty-string assignment with an explicit failure that prints available CSVs for easier diagnosis.

## Evidence

On the failing OCP 4.21 AWS run (build 2048493044440764416), the \`interop-tests-ocs-tests\` step ran \`run-ci --ocs-version ''\` and failed in 2 seconds. The \`acm-policies-openshift-plus\` step had passed (policies compliant), but no CSV starting with \`ocs-operator\` existed in \`openshift-storage\`.

## Affected Jobs

- \`periodic-ci-stolostron-policy-collection-main-ocp4.21-interop-opp-aws\`
- \`periodic-ci-stolostron-policy-collection-main-ocp4.22-interop-opp-aws\`
- \`periodic-ci-stolostron-policy-collection-main-ocp4.22-interop-opp-vsphere\`
- All ODF and CNV-ODF interop jobs using the \`interop-tests-ocs-tests\` step

## Related Jira Tickets

- [OCSQE-4716](https://redhat.atlassian.net/browse/OCSQE-4716)
- [OCSQE-4708](https://redhat.atlassian.net/browse/OCSQE-4708)

/cc @CSPI-QE

[OCSQE-4716]: https://redhat.atlassian.net/browse/OCSQE-4716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ