### PR TITLE
fix: set CNV_SUBSCRIPTION_SOURCE for kubevirt AWS e2e jobs

### DIFF
--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-main.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-main.yaml
@@ -317,6 +317,7 @@ tests:
   steps:
     cluster_profile: openshift-org-aws
     env:
+      CNV_SUBSCRIPTION_SOURCE: redhat-operators
       COMPUTE_NODE_REPLICAS: "1"
       COMPUTE_NODE_TYPE: c5n.metal
       E2E_TEST_REGEX: ^TestCreateCluster$|TestAutoscaling
@@ -332,6 +333,7 @@ tests:
   steps:
     cluster_profile: openshift-org-aws
     env:
+      CNV_SUBSCRIPTION_SOURCE: redhat-operators
       COMPUTE_NODE_REPLICAS: "1"
       COMPUTE_NODE_TYPE: c5n.metal
       ENABLE_HYPERSHIFT_CERT_ROTATION_SCALE: "true"


### PR DESCRIPTION
## Summary

- Set `CNV_SUBSCRIPTION_SOURCE: redhat-operators` in both `e2e-kubevirt-aws-ovn-reduced` and `e2e-kubevirt-aws-ovn` job configs

## Root Cause

[PR #77820](https://github.com/openshift/release/pull/77820) (merged 2026-04-20) switched these jobs from `workflow: hypershift-kubevirt-e2e-nested` to `workflow: hypershift-kubevirt-e2e-aws`. The old nested workflow set `CNV_SUBSCRIPTION_SOURCE: redhat-operators` in its `steps.env`, but the new aws workflow does **not**.

Without this override, the `hypershift-kubevirt-install` step ref defaults to `cnv-prerelease-catalog-source`. Since the jobs aren't triggered via gangway API, `CNV_PRERELEASE_CATALOG_IMAGE` and `CNV_SUBSCRIPTION_CHANNEL` are both empty, causing the install script to fall through to the `else` branch:

```bash
CNV_RELEASE_CHANNEL=nightly-$(ocp_version)
CNV_PRERELEASE_CATALOG_IMAGE=quay.io/openshift-cnv/nightly-catalog:$(ocp_version)
```

The IPI cluster runs OCP 5.0, so this constructs `quay.io/openshift-cnv/nightly-catalog:5.0` — an image tag that **does not exist**. The CatalogSource pod enters `ImagePullBackOff`, the OLM subscription never resolves a CSV, and the step exhausts 30 retries over ~15 minutes before failing.

## Evidence

All three most recent runs of `e2e-kubevirt-aws-ovn-reduced` (against PRs [#8278](https://github.com/openshift/hypershift/pull/8278), [#8288](https://github.com/openshift/hypershift/pull/8288), [#8247](https://github.com/openshift/hypershift/pull/8247)) show identical failure in `hypershift-kubevirt-install`:

```
+ [[ ! cnv-prerelease-catalog-source =~ ^(cnv-prerelease-catalog-source|redhat-operators)$ ]]
+ CNV_PRERELEASE_CATALOG_IMAGE=
+ CNV_SUBSCRIPTION_CHANNEL=
+ '[' cnv-prerelease-catalog-source == redhat-operators ']'
+ CNV_RELEASE_CHANNEL=nightly-5.0
+ CNV_PRERELEASE_CATALOG_IMAGE=quay.io/openshift-cnv/nightly-catalog:5.0
...
Try 30/30: can't get the CSV yet. Checking again in 30 seconds
Error: Failed to deploy CNV
```

No e2e tests ever ran — the failure is entirely in the pre-phase.

## Fix

Explicitly set `CNV_SUBSCRIPTION_SOURCE: redhat-operators` in both job configs, matching the pattern already used by `e2e-azure-kubevirt-ovn`. This causes the install script to use the `stable` channel from the `redhat-operators` catalog instead of the nonexistent nightly prerelease catalog image.

## Job History

- [e2e-kubevirt-aws-ovn-reduced job history](https://prow.ci.openshift.org/job-history/gs/test-platform-results/pr-logs/directory/pull-ci-openshift-hypershift-main-e2e-kubevirt-aws-ovn-reduced) — permafailing since PR #77820 merged

/cc @openshift/hypershift-maintainers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test infrastructure configuration to include CNV subscription source environment variable for KubeVirt-related test steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->