### PR TITLE
[rosa-claude-plugins] Add prek pre-commit hook runner to CI

### DIFF
--- a/ci-operator/config/openshift-online/rosa-claude-plugins/openshift-online-rosa-claude-plugins-main.yaml
+++ b/ci-operator/config/openshift-online/rosa-claude-plugins/openshift-online-rosa-claude-plugins-main.yaml
@@ -17,7 +17,8 @@ images:
       WORKDIR /workspace
       RUN dnf install -y git && dnf clean all
       RUN pip install -r /workspace/rosa-claude-plugins/requirements.txt
-      RUN PREK_VERSION=$(cat /workspace/rosa-claude-plugins/.prek-version 2>/dev/null || echo "v0.3.9") \
+      RUN PREK_VERSION="$(tr -d '[:space:]' < /workspace/rosa-claude-plugins/.prek-version 2>/dev/null || true)" \
+        && PREK_VERSION="${PREK_VERSION:-v0.3.9}" \
         && curl -fsSL "https://github.com/j178/prek/releases/download/${PREK_VERSION}/prek-x86_64-unknown-linux-gnu.tar.gz" \
         | tar xzf - --strip-components=1 -C /usr/local/bin/ prek-x86_64-unknown-linux-gnu/prek
     from: ubi-python

--- a/ci-operator/config/openshift-online/rosa-claude-plugins/openshift-online-rosa-claude-plugins-main.yaml
+++ b/ci-operator/config/openshift-online/rosa-claude-plugins/openshift-online-rosa-claude-plugins-main.yaml
@@ -12,16 +12,21 @@ images:
   items:
   - dockerfile_literal: |
       FROM ubi-python
+      USER 0
       COPY . /workspace/
       WORKDIR /workspace
+      RUN dnf install -y git && dnf clean all
       RUN pip install -r /workspace/rosa-claude-plugins/requirements.txt
+      RUN PREK_VERSION=$(cat /workspace/rosa-claude-plugins/.prek-version 2>/dev/null || echo "v0.3.9") \
+        && curl -fsSL "https://github.com/j178/prek/releases/download/${PREK_VERSION}/prek-x86_64-unknown-linux-gnu.tar.gz" \
+        | tar xzf - --strip-components=1 -C /usr/local/bin/ prek-x86_64-unknown-linux-gnu/prek
     from: ubi-python
     inputs:
       src:
         paths:
         - destination_dir: .
           source_path: /go/src/github.com/openshift-online/rosa-claude-plugins
-    to: python-runner
+    to: prek-runner
 resources:
   '*':
     limits:
@@ -30,11 +35,15 @@ resources:
       cpu: 100m
       memory: 200Mi
 tests:
-- as: validate-marketplace
-  commands: python3 /workspace/rosa-claude-plugins/validate_marketplace.py
+- as: prek
+  commands: |
+    export PREK_HOME=/tmp/prek
+    cd /workspace/rosa-claude-plugins
+    git init
+    git add -A
+    prek run --all-files
   container:
-    from: python-runner
-  optional: true
+    from: prek-runner
 zz_generated_metadata:
   branch: main
   org: openshift-online

--- a/ci-operator/jobs/openshift-online/rosa-claude-plugins/openshift-online-rosa-claude-plugins-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-online/rosa-claude-plugins/openshift-online-rosa-claude-plugins-main-presubmits.yaml
@@ -68,16 +68,15 @@ presubmits:
     - ^main$
     - ^main-
     cluster: build08
-    context: ci/prow/validate-marketplace
+    context: ci/prow/prek
     decorate: true
     decoration_config:
       skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-online-rosa-claude-plugins-main-validate-marketplace
-    optional: true
-    rerun_command: /test validate-marketplace
+    name: pull-ci-openshift-online-rosa-claude-plugins-main-prek
+    rerun_command: /test prek
     spec:
       containers:
       - args:
@@ -85,7 +84,7 @@ presubmits:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --oauth-token-path=/usr/local/github-credentials/oauth
         - --report-credentials-file=/etc/report/credentials
-        - --target=validate-marketplace
+        - --target=prek
         command:
         - ci-operator
         env:
@@ -132,4 +131,4 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )validate-marketplace,?($|\s.*)
+    trigger: (?m)^/test( | .* )prek,?($|\s.*)


### PR DESCRIPTION
## Summary
- Replace the optional `validate-marketplace` CI test with a required `prek` test that runs all pre-commit hooks defined in `prek.toml`
- Install prek binary directly from GitHub releases (pinned to v0.3.9, configurable via `.prek-version` file in the repo)
- Install `git` in the image so prek can operate on the repo checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD validation workflow to use `prek` for pull request checks instead of the previous Python-based validation method.
  * Modified test trigger commands: contributors should now use `/test prek` instead of `/test validate-marketplace` when requesting validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->