### PR TITLE
openshift/crio: bump image to 4.23

### DIFF
--- a/ci-operator/config/openshift/cri-o/openshift-cri-o-main.yaml
+++ b/ci-operator/config/openshift/cri-o/openshift-cri-o-main.yaml
@@ -11,7 +11,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: rhel-9-release-golang-1.25-openshift-4.22
+    tag: rhel-9-release-golang-1.25-openshift-4.23
 images:
   items:
   - dockerfile_literal: |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI pipeline base release used for container image builds: moved the referenced OpenShift base from 4.22 to 4.23 to align image build payloads. No other build steps, image definitions, promotions, resources, or tests were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->