### PR TITLE
ART-14776: whitelist redhat-cne/downstream-ptp-operator-monorepo

### DIFF
--- a/core-services/openshift-priv/_whitelist.yaml
+++ b/core-services/openshift-priv/_whitelist.yaml
@@ -3,6 +3,7 @@ whitelist:
     - operator-marketplace
   redhat-cne:
     - cloud-event-proxy
+    - downstream-ptp-operator-monorepo
   openshift-eng:
     - ocp-build-data
   openshift:


### PR DESCRIPTION
Signed-off-by: Rayford Johnson <rayfordj@users.noreply.github.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated system whitelist to authorize a new operator, enabling its deployment and operation in the infrastructure environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->