### PR TITLE
CCO-826: CCO: add e2e-gcp-manual-oidc-pool-jwk-file

### DIFF
--- a/ci-operator/config/openshift/cloud-credential-operator/openshift-cloud-credential-operator-master.yaml
+++ b/ci-operator/config/openshift/cloud-credential-operator/openshift-cloud-credential-operator-master.yaml
@@ -132,6 +132,16 @@ tests:
     cluster_profile: openshift-org-gcp
     workflow: openshift-e2e-gcp-manual-oidc-workload-identity
 - always_run: false
+  as: e2e-gcp-manual-oidc-pool-jwk-file
+  optional: true
+  steps:
+    cluster_profile: openshift-org-gcp
+    env:
+      KEY_STORAGE_METHOD: pool-jwk-file
+      TEST_SKIPS: ServiceAccountIssuerDiscovery should support OIDC discovery of service
+        account issuer
+    workflow: openshift-e2e-gcp-manual-oidc-workload-identity
+- always_run: false
   as: e2e-openstack
   optional: true
   steps:

--- a/ci-operator/config/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-4.22.yaml
+++ b/ci-operator/config/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-4.22.yaml
@@ -132,6 +132,16 @@ tests:
     cluster_profile: openshift-org-gcp
     workflow: openshift-e2e-gcp-manual-oidc-workload-identity
 - always_run: false
+  as: e2e-gcp-manual-oidc-pool-jwk-file
+  optional: true
+  steps:
+    cluster_profile: openshift-org-gcp
+    env:
+      KEY_STORAGE_METHOD: pool-jwk-file
+      TEST_SKIPS: ServiceAccountIssuerDiscovery should support OIDC discovery of service
+        account issuer
+    workflow: openshift-e2e-gcp-manual-oidc-workload-identity
+- always_run: false
   as: e2e-openstack
   optional: true
   steps:

--- a/ci-operator/config/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-4.23.yaml
+++ b/ci-operator/config/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-4.23.yaml
@@ -132,6 +132,16 @@ tests:
     cluster_profile: openshift-org-gcp
     workflow: openshift-e2e-gcp-manual-oidc-workload-identity
 - always_run: false
+  as: e2e-gcp-manual-oidc-pool-jwk-file
+  optional: true
+  steps:
+    cluster_profile: openshift-org-gcp
+    env:
+      KEY_STORAGE_METHOD: pool-jwk-file
+      TEST_SKIPS: ServiceAccountIssuerDiscovery should support OIDC discovery of service
+        account issuer
+    workflow: openshift-e2e-gcp-manual-oidc-workload-identity
+- always_run: false
   as: e2e-openstack
   optional: true
   steps:

--- a/ci-operator/config/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-5.0.yaml
+++ b/ci-operator/config/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-5.0.yaml
@@ -133,6 +133,16 @@ tests:
     cluster_profile: openshift-org-gcp
     workflow: openshift-e2e-gcp-manual-oidc-workload-identity
 - always_run: false
+  as: e2e-gcp-manual-oidc-pool-jwk-file
+  optional: true
+  steps:
+    cluster_profile: openshift-org-gcp
+    env:
+      KEY_STORAGE_METHOD: pool-jwk-file
+      TEST_SKIPS: ServiceAccountIssuerDiscovery should support OIDC discovery of service
+        account issuer
+    workflow: openshift-e2e-gcp-manual-oidc-workload-identity
+- always_run: false
   as: e2e-openstack
   optional: true
   steps:

--- a/ci-operator/config/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-5.1.yaml
+++ b/ci-operator/config/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-5.1.yaml
@@ -132,6 +132,16 @@ tests:
     cluster_profile: openshift-org-gcp
     workflow: openshift-e2e-gcp-manual-oidc-workload-identity
 - always_run: false
+  as: e2e-gcp-manual-oidc-pool-jwk-file
+  optional: true
+  steps:
+    cluster_profile: openshift-org-gcp
+    env:
+      KEY_STORAGE_METHOD: pool-jwk-file
+      TEST_SKIPS: ServiceAccountIssuerDiscovery should support OIDC discovery of service
+        account issuer
+    workflow: openshift-e2e-gcp-manual-oidc-workload-identity
+- always_run: false
   as: e2e-openstack
   optional: true
   steps:

--- a/ci-operator/jobs/openshift/cloud-credential-operator/openshift-cloud-credential-operator-master-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-credential-operator/openshift-cloud-credential-operator-master-presubmits.yaml
@@ -723,6 +723,87 @@ presubmits:
     branches:
     - ^master$
     - ^master-
+    cluster: build04
+    context: ci/prow/e2e-gcp-manual-oidc-pool-jwk-file
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: gcp
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cloud-credential-operator-master-e2e-gcp-manual-oidc-pool-jwk-file
+    optional: true
+    rerun_command: /test e2e-gcp-manual-oidc-pool-jwk-file
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-gcp-manual-oidc-pool-jwk-file
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-gcp-manual-oidc-pool-jwk-file,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^master$
+    - ^master-
     cluster: build05
     context: ci/prow/e2e-hypershift
     decorate: true

--- a/ci-operator/jobs/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-4.22-presubmits.yaml
@@ -723,6 +723,87 @@ presubmits:
     branches:
     - ^release-4\.22$
     - ^release-4\.22-
+    cluster: build04
+    context: ci/prow/e2e-gcp-manual-oidc-pool-jwk-file
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: gcp
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cloud-credential-operator-release-4.22-e2e-gcp-manual-oidc-pool-jwk-file
+    optional: true
+    rerun_command: /test e2e-gcp-manual-oidc-pool-jwk-file
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-gcp-manual-oidc-pool-jwk-file
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-gcp-manual-oidc-pool-jwk-file,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.22$
+    - ^release-4\.22-
     cluster: build05
     context: ci/prow/e2e-hypershift
     decorate: true

--- a/ci-operator/jobs/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-4.23-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-4.23-presubmits.yaml
@@ -723,6 +723,87 @@ presubmits:
     branches:
     - ^release-4\.23$
     - ^release-4\.23-
+    cluster: build04
+    context: ci/prow/e2e-gcp-manual-oidc-pool-jwk-file
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: gcp
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cloud-credential-operator-release-4.23-e2e-gcp-manual-oidc-pool-jwk-file
+    optional: true
+    rerun_command: /test e2e-gcp-manual-oidc-pool-jwk-file
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-gcp-manual-oidc-pool-jwk-file
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-gcp-manual-oidc-pool-jwk-file,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.23$
+    - ^release-4\.23-
     cluster: build05
     context: ci/prow/e2e-hypershift
     decorate: true

--- a/ci-operator/jobs/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-5.0-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-5.0-presubmits.yaml
@@ -723,6 +723,87 @@ presubmits:
     branches:
     - ^release-5\.0$
     - ^release-5\.0-
+    cluster: build08
+    context: ci/prow/e2e-gcp-manual-oidc-pool-jwk-file
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: gcp
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cloud-credential-operator-release-5.0-e2e-gcp-manual-oidc-pool-jwk-file
+    optional: true
+    rerun_command: /test e2e-gcp-manual-oidc-pool-jwk-file
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-gcp-manual-oidc-pool-jwk-file
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-gcp-manual-oidc-pool-jwk-file,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-5\.0$
+    - ^release-5\.0-
     cluster: build05
     context: ci/prow/e2e-hypershift
     decorate: true

--- a/ci-operator/jobs/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-5.1-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-5.1-presubmits.yaml
@@ -723,6 +723,87 @@ presubmits:
     branches:
     - ^release-5\.1$
     - ^release-5\.1-
+    cluster: build08
+    context: ci/prow/e2e-gcp-manual-oidc-pool-jwk-file
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: gcp
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cloud-credential-operator-release-5.1-e2e-gcp-manual-oidc-pool-jwk-file
+    optional: true
+    rerun_command: /test e2e-gcp-manual-oidc-pool-jwk-file
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-gcp-manual-oidc-pool-jwk-file
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-gcp-manual-oidc-pool-jwk-file,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-5\.1$
+    - ^release-5\.1-
     cluster: build05
     context: ci/prow/e2e-hypershift
     decorate: true

--- a/ci-operator/step-registry/ipi/conf/gcp/oidc-creds-provision/ipi-conf-gcp-oidc-creds-provision-commands.sh
+++ b/ci-operator/step-registry/ipi/conf/gcp/oidc-creds-provision/ipi-conf-gcp-oidc-creds-provision-commands.sh
@@ -101,6 +101,9 @@ ADDITIONAL_CCOCTL_ARGS=""
 if [[ "${FEATURE_SET}" == "TechPreviewNoUpgrade" ]]; then
   ADDITIONAL_CCOCTL_ARGS="$ADDITIONAL_CCOCTL_ARGS --enable-tech-preview"
 fi
+if [[ -n "${KEY_STORAGE_METHOD:-}" ]]; then
+  ADDITIONAL_CCOCTL_ARGS="$ADDITIONAL_CCOCTL_ARGS --key-storage-method=${KEY_STORAGE_METHOD}"
+fi
 
 ccoctl_ouptut="/tmp/ccoctl_output"
 echo "> Create required credentials infrastructure and installer manifests for workload identity"

--- a/ci-operator/step-registry/ipi/conf/gcp/oidc-creds-provision/ipi-conf-gcp-oidc-creds-provision-ref.yaml
+++ b/ci-operator/step-registry/ipi/conf/gcp/oidc-creds-provision/ipi-conf-gcp-oidc-creds-provision-ref.yaml
@@ -23,6 +23,11 @@ ref:
     default: "false"
     documentation: |-
       Determine whether to exclude manifests that are not expected to be included in the cluster when extracting.
+  - name: KEY_STORAGE_METHOD
+    default: ""
+    documentation: |-
+      Pass --key-storage-method to ccoctl to select the key storage method (e.g., pool-jwk-file).
+      When empty, the option is not passed and ccoctl uses its default.
   documentation: |-
     The IPI oidc-creds-provision configure step adds a authentications.config.openshift.io/cluster object
     and secrets for each operator.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional GCP manual OIDC E2E variant that uses pool-jwk-file for JWK key storage and skips a specific OIDC discovery check.
  * Made the key storage method configurable for GCP credential provisioning via an env setting.

* **Chores**
  * Added presubmit jobs and Prow triggers across master and release branches to support running the new test variant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->