### PR TITLE
fleetshift repos: change to image_stream_tag

### DIFF
--- a/ci-operator/config/fleetshift/fleetshift-poc/fleetshift-fleetshift-poc-main.yaml
+++ b/ci-operator/config/fleetshift/fleetshift-poc/fleetshift-fleetshift-poc-main.yaml
@@ -1,5 +1,8 @@
 build_root:
-  from_repository: true
+  image_stream_tag:
+    name: builder
+    namespace: stolostron
+    tag: go1.25-linux
 images:
   items:
   - dockerfile_path: Dockerfile

--- a/ci-operator/config/fleetshift/fleetshift-user-interface/fleetshift-fleetshift-user-interface-main.yaml
+++ b/ci-operator/config/fleetshift/fleetshift-user-interface/fleetshift-fleetshift-user-interface-main.yaml
@@ -1,5 +1,8 @@
 build_root:
-  from_repository: true
+  image_stream_tag:
+    name: builder
+    namespace: stolostron
+    tag: nodejs20-linux
 images:
   items:
   - dockerfile_path: Dockerfile.gui

--- a/ci-operator/jobs/fleetshift/fleetshift-poc/fleetshift-fleetshift-poc-main-postsubmits.yaml
+++ b/ci-operator/jobs/fleetshift/fleetshift-poc/fleetshift-fleetshift-poc-main-postsubmits.yaml
@@ -6,6 +6,8 @@ postsubmits:
     - ^main$
     cluster: build05
     decorate: true
+    decoration_config:
+      skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
     max_concurrency: 1

--- a/ci-operator/jobs/fleetshift/fleetshift-poc/fleetshift-fleetshift-poc-main-presubmits.yaml
+++ b/ci-operator/jobs/fleetshift/fleetshift-poc/fleetshift-fleetshift-poc-main-presubmits.yaml
@@ -8,6 +8,8 @@ presubmits:
     cluster: build08
     context: ci/prow/images
     decorate: true
+    decoration_config:
+      skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -61,6 +63,8 @@ presubmits:
     cluster: build08
     context: ci/prow/pr-image-mirror
     decorate: true
+    decoration_config:
+      skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"

--- a/ci-operator/jobs/fleetshift/fleetshift-user-interface/fleetshift-fleetshift-user-interface-main-postsubmits.yaml
+++ b/ci-operator/jobs/fleetshift/fleetshift-user-interface/fleetshift-fleetshift-user-interface-main-postsubmits.yaml
@@ -6,6 +6,8 @@ postsubmits:
     - ^main$
     cluster: build01
     decorate: true
+    decoration_config:
+      skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
@@ -73,6 +75,8 @@ postsubmits:
     - ^main$
     cluster: build01
     decorate: true
+    decoration_config:
+      skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
@@ -140,6 +144,8 @@ postsubmits:
     - ^main$
     cluster: build01
     decorate: true
+    decoration_config:
+      skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
     max_concurrency: 1

--- a/ci-operator/jobs/fleetshift/fleetshift-user-interface/fleetshift-fleetshift-user-interface-main-presubmits.yaml
+++ b/ci-operator/jobs/fleetshift/fleetshift-user-interface/fleetshift-fleetshift-user-interface-main-presubmits.yaml
@@ -8,6 +8,8 @@ presubmits:
     cluster: build01
     context: ci/prow/images
     decorate: true
+    decoration_config:
+      skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -61,6 +63,8 @@ presubmits:
     cluster: build01
     context: ci/prow/pr-image-mirror-gui
     decorate: true
+    decoration_config:
+      skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -132,6 +136,8 @@ presubmits:
     cluster: build01
     context: ci/prow/pr-image-mirror-mock-servers
     decorate: true
+    decoration_config:
+      skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -203,6 +209,8 @@ presubmits:
     cluster: build01
     context: ci/prow/pr-image-mirror-mock-ui-plugins
     decorate: true
+    decoration_config:
+      skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"


### PR DESCRIPTION
Changed fleetshift repo configs to image_stream_tag to resolve this ci error:
```
failed to generate steps from config: failed to get steps from configuration: failed to read buildRootImageStream from repository: failed to read .ci-operator.yaml file: open ./.ci-operator.yaml: no such file or directory
```

Continuation of https://github.com/openshift/release/pull/77996