### PR TITLE
ota-tools: fix build root

### DIFF
--- a/ci-operator/config/openshift-eng/ota-tools/openshift-eng-ota-tools-main.yaml
+++ b/ci-operator/config/openshift-eng/ota-tools/openshift-eng-ota-tools-main.yaml
@@ -2,7 +2,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.25
+    tag: rhel-9-release-golang-1.25-openshift-5.0
 resources:
   '*':
     limits:


### PR DESCRIPTION
See a failure job here.

https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift-eng_ota-tools/1/pull-ci-openshift-eng-ota-tools-main-unit/2046334339414757376

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure configuration to use an updated release image tag for builds, ensuring compatibility with the latest base image configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->