### PR TITLE
ci: enable dco for terraform red hat repositories

### DIFF
--- a/core-services/prow/02_config/terraform-redhat/terraform-provider-rhcs/_pluginconfig.yaml
+++ b/core-services/prow/02_config/terraform-redhat/terraform-provider-rhcs/_pluginconfig.yaml
@@ -42,6 +42,7 @@ plugins:
     - assign
     - blunderbuss
     - cat
+    - dco
     - dog
     - heart
     - golint

--- a/core-services/prow/02_config/terraform-redhat/terraform-rhcs-rosa-classic/_pluginconfig.yaml
+++ b/core-services/prow/02_config/terraform-redhat/terraform-rhcs-rosa-classic/_pluginconfig.yaml
@@ -43,6 +43,7 @@ plugins:
     - assign
     - blunderbuss
     - cat
+    - dco
     - dog
     - heart
     - golint

--- a/core-services/prow/02_config/terraform-redhat/terraform-rhcs-rosa-hcp/_pluginconfig.yaml
+++ b/core-services/prow/02_config/terraform-redhat/terraform-rhcs-rosa-hcp/_pluginconfig.yaml
@@ -43,6 +43,7 @@ plugins:
     - assign
     - blunderbuss
     - cat
+    - dco
     - dog
     - heart
     - golint


### PR DESCRIPTION
We want to require explicit sign-off on each commit for the terraform Red Hat repositores. This PR enables the dco plugin to guarantee that for each PR.

Reference: https://source.redhat.com/departments/products_and_global_engineering/portfolio_and_delivery/pd_wiki/step_by_step_github_setup_for_red_hat_projects#understand-dco-vs-cla

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled Developer Certificate of Origin (DCO) verification plugin for terraform-provider-rhcs, terraform-rhcs-rosa-classic, and terraform-rhcs-rosa-hcp repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->