### PR TITLE
OTA-1978: core-services/prow/02_config/openshift/agentic-skills: Initialize directory

### DIFF
--- a/core-services/prow/02_config/openshift/agentic-skills/OWNERS
+++ b/core-services/prow/02_config/openshift/agentic-skills/OWNERS
@@ -1,0 +1,13 @@
+# DO NOT EDIT; this file is auto-generated using https://github.com/openshift/ci-tools.
+# Fetched from https://github.com/openshift/agentic-skills root OWNERS
+# If the repo had OWNERS_ALIASES then the aliases were expanded
+# Logins who are not members of 'openshift' organization were filtered out
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+- harche
+- mrunalp
+options: {}
+reviewers:
+- harche
+- mrunalp

--- a/core-services/prow/02_config/openshift/agentic-skills/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/agentic-skills/_pluginconfig.yaml
@@ -1,0 +1,13 @@
+approve:
+- commandHelpLink: ""
+  repos:
+  - openshift/agentic-skills
+  require_self_approval: false
+lgtm:
+- repos:
+  - openshift/agentic-skills
+  review_acts_as_lgtm: true
+plugins:
+  openshift/agentic-skills:
+    plugins:
+    - approve

--- a/core-services/prow/02_config/openshift/agentic-skills/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/agentic-skills/_prowconfig.yaml
@@ -1,0 +1,16 @@
+tide:
+  queries:
+  - labels:
+    - approved
+    - jira/valid-reference
+    - lgtm
+    - verified
+    missingLabels:
+    - backports/unvalidated-commits
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - jira/invalid-bug
+    - needs-rebase
+    repos:
+    - openshift/agentic-skills


### PR DESCRIPTION
Based on similar content for the similarly-new `cluster-update-console-plugin` repository which landed in de87d744b63 (#77093), but with the appropriate repo name (`agentic-skills`) and the current agentic-skills root owner/approvers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Configured repository-level PR approval workflow with designated approvers and reviewers; enabled approve and lgtm plugin behaviors.
  * Added automated merge criteria: PRs must have approved, lgtm, verified, and valid-JIRA labels and are blocked from merging when specific do-not-merge or backport-related labels are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->