### PR TITLE
Ovn techpreview serial timeouts

### DIFF
--- a/ci-operator/config/openshift/release/openshift-release-main__ci-4.22.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__ci-4.22.yaml
@@ -62,6 +62,7 @@ tests:
     - chain: ipi-gcp-pre
     - ref: fips-check
     workflow: openshift-e2e-gcp-serial
+  timeout: 5h0m0s
 - as: e2e-aws-ovn-no-capabilities
   interval: 168h
   steps:
@@ -198,6 +199,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-azure-serial
+  timeout: 5h0m0s
 - as: e2e-azure-ovn-rhcos10-techpreview-serial
   interval: 12h
   steps:
@@ -209,6 +211,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-azure-serial
+  timeout: 5h0m0s
 - as: e2e-azure-ovn-upgrade
   interval: 168h
   steps:
@@ -325,6 +328,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-gcp-serial
+  timeout: 5h0m0s
 - as: e2e-gcp-ovn-rhcos10-techpreview-serial
   interval: 12h
   steps:
@@ -336,6 +340,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-gcp-serial
+  timeout: 5h0m0s
 - as: e2e-gcp-ovn-usernamespace
   cron: '@daily'
   steps:

--- a/ci-operator/config/openshift/release/openshift-release-main__ci-4.23.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__ci-4.23.yaml
@@ -62,6 +62,7 @@ tests:
     - chain: ipi-gcp-pre
     - ref: fips-check
     workflow: openshift-e2e-gcp-serial
+  timeout: 5h0m0s
 - as: e2e-aws-ovn-no-capabilities
   interval: 168h
   steps:
@@ -198,6 +199,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-azure-serial
+  timeout: 5h0m0s
 - as: e2e-azure-ovn-rhcos10-techpreview-serial
   interval: 168h
   steps:
@@ -209,6 +211,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-azure-serial
+  timeout: 5h0m0s
 - as: e2e-azure-ovn-upgrade
   interval: 168h
   steps:
@@ -325,6 +328,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-gcp-serial
+  timeout: 5h0m0s
 - as: e2e-gcp-ovn-rhcos10-techpreview-serial
   interval: 168h
   steps:
@@ -336,6 +340,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-gcp-serial
+  timeout: 5h0m0s
 - as: e2e-gcp-ovn-usernamespace
   cron: '@daily'
   steps:

--- a/ci-operator/config/openshift/release/openshift-release-main__ci-5.0.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__ci-5.0.yaml
@@ -62,6 +62,7 @@ tests:
     - chain: ipi-gcp-pre
     - ref: fips-check
     workflow: openshift-e2e-gcp-serial
+  timeout: 5h0m0s
 - as: e2e-aws-ovn-no-capabilities
   interval: 168h
   steps:
@@ -198,6 +199,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-azure-serial
+  timeout: 5h0m0s
 - as: e2e-azure-ovn-rhcos10-techpreview-serial
   interval: 168h
   steps:
@@ -209,6 +211,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-azure-serial
+  timeout: 5h0m0s
 - as: e2e-azure-ovn-upgrade
   interval: 168h
   steps:
@@ -325,6 +328,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-gcp-serial
+  timeout: 5h0m0s
 - as: e2e-gcp-ovn-rhcos10-techpreview-serial
   interval: 168h
   steps:
@@ -336,6 +340,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-gcp-serial
+  timeout: 5h0m0s
 - as: e2e-gcp-ovn-usernamespace
   cron: '@daily'
   steps:

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22.yaml
@@ -982,6 +982,7 @@ tests:
     env:
       FEATURE_SET: TechPreviewNoUpgrade
     workflow: openshift-e2e-vsphere-serial
+  timeout: 5h0m0s
 - as: e2e-vsphere-ovn-rhcos10-techpreview-serial
   cron: 31,46 4,20 * * *
   steps:
@@ -990,6 +991,7 @@ tests:
       FEATURE_SET: TechPreviewNoUpgrade
       OS_IMAGE_STREAM: rhel-10
     workflow: openshift-e2e-vsphere-serial
+  timeout: 5h0m0s
 - as: e2e-vsphere-ovn-upi
   cron: 19 10 * * 5
   steps:

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.23.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.23.yaml
@@ -945,6 +945,7 @@ tests:
     env:
       FEATURE_SET: TechPreviewNoUpgrade
     workflow: openshift-e2e-vsphere-serial
+  timeout: 5h0m0s
 - as: e2e-vsphere-ovn-rhcos10-techpreview-serial
   cron: 31,46 4,20 * * *
   steps:
@@ -953,6 +954,7 @@ tests:
       FEATURE_SET: TechPreviewNoUpgrade
       OS_IMAGE_STREAM: rhel-10
     workflow: openshift-e2e-vsphere-serial
+  timeout: 5h0m0s
 - as: e2e-vsphere-ovn-upi
   cron: 19 10 * * 5
   steps:

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
@@ -945,6 +945,7 @@ tests:
     env:
       FEATURE_SET: TechPreviewNoUpgrade
     workflow: openshift-e2e-vsphere-serial
+  timeout: 5h0m0s
 - as: e2e-vsphere-ovn-rhcos10-techpreview-serial
   cron: 3 4 * * 4
   steps:
@@ -953,6 +954,7 @@ tests:
       FEATURE_SET: TechPreviewNoUpgrade
       OS_IMAGE_STREAM: rhel-10
     workflow: openshift-e2e-vsphere-serial
+  timeout: 5h0m0s
 - as: e2e-vsphere-ovn-upi
   cron: 44 22 * * 0
   steps:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added explicit 5-hour timeouts to multiple TechPreview serial E2E tests across GCP and Azure run configurations in release branches to cap run time.
  * Added explicit 5-hour timeouts to vSphere TechPreview serial E2E tests in nightly builds.
  * Applied a 5-hour timeout decoration to periodic CI jobs to improve test reliability and resource management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->