### PR TITLE
Skip known-failing NLB tests in HCP conformance

### DIFF
--- a/ci-operator/step-registry/rosa/aws/hcp/conformance/rosa-aws-hcp-conformance-workflow.yaml
+++ b/ci-operator/step-registry/rosa/aws/hcp/conformance/rosa-aws-hcp-conformance-workflow.yaml
@@ -28,7 +28,9 @@ workflow:
         NetworkPolicy between server and client should allow ingress access from updated pod\|
         In-tree Volumes.*local.*blockfs.*subPath should support file as subpath\|
         DRA.*kubelet.*DynamicResourceAllocation\|
-        CSI Mock volume expansion Expansion with recovery recovery should not be possible
+        CSI Mock volume expansion Expansion with recovery recovery should not be possible\|
+        cloud-provider-aws-e2e.*loadbalancer NLB internal should be reachable with hairpinning traffic\|
+        cloud-provider-aws-e2e.*loadbalancer NLB should be reachable with target-node-labels
     pre:
       - chain: rosa-aws-sts-hcp-provision
       - ref: osd-ccs-conf-idp-htpasswd-multi-users


### PR DESCRIPTION
## Summary

- Skip NLB `cloud-provider-aws-e2e` tests (hairpinning + target-node-labels) that fail on HCP due to VPC topology causing LB provisioning timeouts (OCPBUGS-74537). Already skipped in `e2e-hypershift-conformance` via #74032.

## Test plan

- [ ] Verify `rosa-aws-hcp-conformance` workflow parses correctly (`make validate-step-registry`)
- [ ] Confirm skipped tests no longer cause job failures in next nightly run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated conformance test skip configuration to exclude additional AWS cloud-provider e2e load‑balancer scenarios: internal NLB reachability with hairpinning and NLB reachability when using target‑node‑labels; retained the existing CSI Mock volume expansion skip.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->