### PR TITLE
remove the osde2e jobs from releasecontroller and run them cron based

### DIFF
--- a/core-services/release-controller/_releases/priv/release-ocp-4.20.json
+++ b/core-services/release-controller/_releases/priv/release-ocp-4.20.json
@@ -420,25 +420,11 @@
                 "name": "periodic-ci-openshift-microshift-release-4.20-periodics-e2e-aws-ovn-ocp-conformance-serial-priv"
             }
         },
-        "openshift-dedicated-aws": {
-            "disabled": true,
-            "optional": true,
-            "prowJob": {
-                "name": "periodic-ci-openshift-osde2e-main-nightly-4.20-osd-aws-priv"
-            }
-        },
         "openshift-dedicated-gcp-conformance": {
             "disabled": true,
             "optional": true,
             "prowJob": {
                 "name": "periodic-ci-openshift-release-main-nightly-4.20-e2e-osd-ccs-gcp-priv"
-            }
-        },
-        "openshift-dedicated-gcp-osde2e": {
-            "disabled": true,
-            "optional": true,
-            "prowJob": {
-                "name": "periodic-ci-openshift-osde2e-main-nightly-4.20-osd-gcp-priv"
             }
         },
         "overall-analysis-all": {
@@ -470,13 +456,6 @@
             "optional": true,
             "prowJob": {
                 "name": "periodic-ci-openshift-release-main-nightly-4.20-e2e-rosa-sts-ovn-priv"
-            }
-        },
-        "rosa-classic-sts-osde2e": {
-            "disabled": true,
-            "optional": true,
-            "prowJob": {
-                "name": "periodic-ci-openshift-osde2e-main-nightly-4.20-rosa-classic-sts-priv"
             }
         },
         "rosa-hcp-conformance": {

--- a/core-services/release-controller/_releases/priv/release-ocp-4.21.json
+++ b/core-services/release-controller/_releases/priv/release-ocp-4.21.json
@@ -428,25 +428,11 @@
                 "name": "periodic-ci-openshift-microshift-release-4.21-periodics-e2e-aws-ovn-ocp-conformance-serial-priv"
             }
         },
-        "openshift-dedicated-aws": {
-            "disabled": true,
-            "optional": true,
-            "prowJob": {
-                "name": "periodic-ci-openshift-osde2e-main-nightly-4.21-osd-aws-priv"
-            }
-        },
         "openshift-dedicated-gcp-conformance": {
             "disabled": true,
             "optional": true,
             "prowJob": {
                 "name": "periodic-ci-openshift-release-main-nightly-4.21-e2e-osd-ccs-gcp-priv"
-            }
-        },
-        "openshift-dedicated-gcp-osde2e": {
-            "disabled": true,
-            "optional": true,
-            "prowJob": {
-                "name": "periodic-ci-openshift-osde2e-main-nightly-4.21-osd-gcp-priv"
             }
         },
         "overall-analysis-all": {
@@ -485,13 +471,6 @@
             "optional": true,
             "prowJob": {
                 "name": "periodic-ci-openshift-release-main-nightly-4.21-e2e-rosa-sts-ovn-priv"
-            }
-        },
-        "rosa-classic-sts-osde2e": {
-            "disabled": true,
-            "optional": true,
-            "prowJob": {
-                "name": "periodic-ci-openshift-osde2e-main-nightly-4.21-rosa-classic-sts-priv"
             }
         },
         "telcov10n-metal-single-node-spoke": {

--- a/core-services/release-controller/_releases/priv/release-ocp-4.22.json
+++ b/core-services/release-controller/_releases/priv/release-ocp-4.22.json
@@ -548,25 +548,11 @@
                 "name": "periodic-ci-openshift-microshift-release-4.22-periodics-e2e-aws-ovn-ocp-conformance-serial-priv"
             }
         },
-        "openshift-dedicated-aws": {
-            "disabled": true,
-            "optional": true,
-            "prowJob": {
-                "name": "periodic-ci-openshift-osde2e-main-nightly-4.22-osd-aws-priv"
-            }
-        },
         "openshift-dedicated-gcp-conformance": {
             "disabled": true,
             "optional": true,
             "prowJob": {
                 "name": "periodic-ci-openshift-release-main-nightly-4.22-e2e-osd-ccs-gcp-priv"
-            }
-        },
-        "openshift-dedicated-gcp-osde2e": {
-            "disabled": true,
-            "optional": true,
-            "prowJob": {
-                "name": "periodic-ci-openshift-osde2e-main-nightly-4.22-osd-gcp-priv"
             }
         },
         "overall-analysis-all": {
@@ -605,13 +591,6 @@
             "optional": true,
             "prowJob": {
                 "name": "periodic-ci-openshift-release-main-nightly-4.22-e2e-rosa-sts-ovn-priv"
-            }
-        },
-        "rosa-classic-sts-osde2e": {
-            "disabled": true,
-            "optional": true,
-            "prowJob": {
-                "name": "periodic-ci-openshift-osde2e-main-nightly-4.22-rosa-classic-sts-priv"
             }
         },
         "telco5g": {

--- a/core-services/release-controller/_releases/release-ocp-4.20.json
+++ b/core-services/release-controller/_releases/release-ocp-4.20.json
@@ -426,20 +426,6 @@
         "name": "periodic-ci-openshift-microshift-release-4.20-periodics-e2e-aws-ovn-ocp-conformance-serial"
       }
     },
-    "openshift-dedicated-aws": {
-      "optional": true,
-      "prowJob": {
-        "name": "periodic-ci-openshift-osde2e-main-nightly-4.20-osd-aws"
-      },
-      "disabled": true
-    },
-    "openshift-dedicated-gcp-osde2e": {
-      "optional": true,
-      "prowJob": {
-        "name": "periodic-ci-openshift-osde2e-main-nightly-4.20-osd-gcp"
-      },
-      "disabled": true
-    },
     "openshift-dedicated-gcp-conformance": {
       "optional": true,
       "prowJob": {
@@ -467,13 +453,6 @@
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-nightly-4.20-e2e-metal-ovn-single-node-live-iso"
-      },
-      "disabled": true
-    },
-    "rosa-classic-sts-osde2e": {
-      "optional": true,
-      "prowJob": {
-        "name": "periodic-ci-openshift-osde2e-main-nightly-4.20-rosa-classic-sts"
       },
       "disabled": true
     },

--- a/core-services/release-controller/_releases/release-ocp-4.21.json
+++ b/core-services/release-controller/_releases/release-ocp-4.21.json
@@ -394,18 +394,6 @@
         "name": "periodic-ci-openshift-microshift-release-4.21-periodics-e2e-aws-ovn-ocp-conformance-serial"
       }
     },
-    "openshift-dedicated-aws": {
-      "optional": true,
-      "prowJob": {
-        "name": "periodic-ci-openshift-osde2e-main-nightly-4.21-osd-aws"
-      }
-    },
-    "openshift-dedicated-gcp-osde2e": {
-      "optional": true,
-      "prowJob": {
-        "name": "periodic-ci-openshift-osde2e-main-nightly-4.21-osd-gcp"
-      }
-    },
     "openshift-dedicated-gcp-conformance": {
       "optional": true,
       "prowJob": {
@@ -436,12 +424,6 @@
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-aws-4.21-nightly-x86-payload-control-plane-6nodes"
-      }
-    },
-    "rosa-classic-sts-osde2e": {
-      "optional": true,
-      "prowJob": {
-        "name": "periodic-ci-openshift-osde2e-main-nightly-4.21-rosa-classic-sts"
       }
     },
     "rosa-classic-sts-conformance": {

--- a/core-services/release-controller/_releases/release-ocp-4.22.json
+++ b/core-services/release-controller/_releases/release-ocp-4.22.json
@@ -500,18 +500,6 @@
         "name": "periodic-ci-openshift-microshift-release-4.22-periodics-e2e-aws-ovn-ocp-conformance-serial"
       }
     },
-    "openshift-dedicated-aws": {
-      "optional": true,
-      "prowJob": {
-        "name": "periodic-ci-openshift-osde2e-main-nightly-4.22-osd-aws"
-      }
-    },
-    "openshift-dedicated-gcp-osde2e": {
-      "optional": true,
-      "prowJob": {
-        "name": "periodic-ci-openshift-osde2e-main-nightly-4.22-osd-gcp"
-      }
-    },
     "openshift-dedicated-gcp-conformance": {
       "optional": true,
       "prowJob": {
@@ -542,12 +530,6 @@
       "optional": true,
       "prowJob": {
         "name": "periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-aws-4.22-nightly-x86-payload-control-plane-6nodes"
-      }
-    },
-    "rosa-classic-sts-osde2e": {
-      "optional": true,
-      "prowJob": {
-        "name": "periodic-ci-openshift-osde2e-main-nightly-4.22-rosa-classic-sts"
       }
     },
     "rosa-classic-sts-conformance": {


### PR DESCRIPTION
The jobs are configured to run daily via cron schedule.

Remove them from release controller so that they do not run duplicated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed verification entries for OpenShift Dedicated and ROSA Classic platform configurations in releases 4.20, 4.21, and 4.22.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->