### PR TITLE
origin: Update allow-missing-architectures images

### DIFF
--- a/ci-operator/config/openshift-priv/origin/openshift-priv-origin-main.yaml
+++ b/ci-operator/config/openshift-priv/origin/openshift-priv-origin-main.yaml
@@ -666,7 +666,7 @@ tests:
       --allow-missing-architectures=e2e-19-registry-k8s-io-e2e-test-images-node-perf-tf-wide-deep \
       --allow-missing-architectures=registry-k8s-io-cloud-provider-gcp-gcp-compute-persistent-disk-csi-driver \
       --allow-missing-architectures=e2e-quay-io-keycloak-keycloak \
-      --allow-missing-architectures=e2e-quay-io-crio-zstd-chunked-1 \
+      --allow-missing-architectures=e2e-quay-io-crio-artifact-subpath-8cuvQpZ0AoyNahYr \
       --allow-missing-architectures=e2e-quay-io-kubevirt-fedora-with-test-tooling-container-disk \
       --log-level=debug
   container:

--- a/ci-operator/config/openshift-priv/origin/openshift-priv-origin-release-4.22.yaml
+++ b/ci-operator/config/openshift-priv/origin/openshift-priv-origin-release-4.22.yaml
@@ -666,7 +666,7 @@ tests:
       --allow-missing-architectures=e2e-19-registry-k8s-io-e2e-test-images-node-perf-tf-wide-deep \
       --allow-missing-architectures=registry-k8s-io-cloud-provider-gcp-gcp-compute-persistent-disk-csi-driver \
       --allow-missing-architectures=e2e-quay-io-keycloak-keycloak \
-      --allow-missing-architectures=e2e-quay-io-crio-zstd-chunked-1 \
+      --allow-missing-architectures=e2e-quay-io-crio-artifact-subpath-8cuvQpZ0AoyNahYr \
       --allow-missing-architectures=e2e-quay-io-kubevirt-fedora-with-test-tooling-container-disk \
       --log-level=debug
   container:

--- a/ci-operator/config/openshift-priv/origin/openshift-priv-origin-release-4.23.yaml
+++ b/ci-operator/config/openshift-priv/origin/openshift-priv-origin-release-4.23.yaml
@@ -666,7 +666,7 @@ tests:
       --allow-missing-architectures=e2e-19-registry-k8s-io-e2e-test-images-node-perf-tf-wide-deep \
       --allow-missing-architectures=registry-k8s-io-cloud-provider-gcp-gcp-compute-persistent-disk-csi-driver \
       --allow-missing-architectures=e2e-quay-io-keycloak-keycloak \
-      --allow-missing-architectures=e2e-quay-io-crio-zstd-chunked-1 \
+      --allow-missing-architectures=e2e-quay-io-crio-artifact-subpath-8cuvQpZ0AoyNahYr \
       --allow-missing-architectures=e2e-quay-io-kubevirt-fedora-with-test-tooling-container-disk \
       --log-level=debug
   container:

--- a/ci-operator/config/openshift-priv/origin/openshift-priv-origin-release-5.0.yaml
+++ b/ci-operator/config/openshift-priv/origin/openshift-priv-origin-release-5.0.yaml
@@ -667,7 +667,7 @@ tests:
       --allow-missing-architectures=e2e-19-registry-k8s-io-e2e-test-images-node-perf-tf-wide-deep \
       --allow-missing-architectures=registry-k8s-io-cloud-provider-gcp-gcp-compute-persistent-disk-csi-driver \
       --allow-missing-architectures=e2e-quay-io-keycloak-keycloak \
-      --allow-missing-architectures=e2e-quay-io-crio-zstd-chunked-1 \
+      --allow-missing-architectures=e2e-quay-io-crio-artifact-subpath-8cuvQpZ0AoyNahYr \
       --allow-missing-architectures=e2e-quay-io-kubevirt-fedora-with-test-tooling-container-disk \
       --log-level=debug
   container:

--- a/ci-operator/config/openshift-priv/origin/openshift-priv-origin-release-5.1.yaml
+++ b/ci-operator/config/openshift-priv/origin/openshift-priv-origin-release-5.1.yaml
@@ -666,7 +666,7 @@ tests:
       --allow-missing-architectures=e2e-19-registry-k8s-io-e2e-test-images-node-perf-tf-wide-deep \
       --allow-missing-architectures=registry-k8s-io-cloud-provider-gcp-gcp-compute-persistent-disk-csi-driver \
       --allow-missing-architectures=e2e-quay-io-keycloak-keycloak \
-      --allow-missing-architectures=e2e-quay-io-crio-zstd-chunked-1 \
+      --allow-missing-architectures=e2e-quay-io-crio-artifact-subpath-8cuvQpZ0AoyNahYr \
       --allow-missing-architectures=e2e-quay-io-kubevirt-fedora-with-test-tooling-container-disk \
       --log-level=debug
   container:

--- a/ci-operator/config/openshift/origin/openshift-origin-main.yaml
+++ b/ci-operator/config/openshift/origin/openshift-origin-main.yaml
@@ -665,7 +665,7 @@ tests:
       --allow-missing-architectures=e2e-19-registry-k8s-io-e2e-test-images-node-perf-tf-wide-deep \
       --allow-missing-architectures=registry-k8s-io-cloud-provider-gcp-gcp-compute-persistent-disk-csi-driver \
       --allow-missing-architectures=e2e-quay-io-keycloak-keycloak \
-      --allow-missing-architectures=e2e-quay-io-crio-zstd-chunked-1 \
+      --allow-missing-architectures=e2e-quay-io-crio-artifact-subpath-8cuvQpZ0AoyNahYr \
       --allow-missing-architectures=e2e-quay-io-kubevirt-fedora-with-test-tooling-container-disk \
       --log-level=debug
   container:

--- a/ci-operator/config/openshift/origin/openshift-origin-release-4.22.yaml
+++ b/ci-operator/config/openshift/origin/openshift-origin-release-4.22.yaml
@@ -665,7 +665,7 @@ tests:
       --allow-missing-architectures=e2e-19-registry-k8s-io-e2e-test-images-node-perf-tf-wide-deep \
       --allow-missing-architectures=registry-k8s-io-cloud-provider-gcp-gcp-compute-persistent-disk-csi-driver \
       --allow-missing-architectures=e2e-quay-io-keycloak-keycloak \
-      --allow-missing-architectures=e2e-quay-io-crio-zstd-chunked-1 \
+      --allow-missing-architectures=e2e-quay-io-crio-artifact-subpath-8cuvQpZ0AoyNahYr \
       --allow-missing-architectures=e2e-quay-io-kubevirt-fedora-with-test-tooling-container-disk \
       --log-level=debug
   container:

--- a/ci-operator/config/openshift/origin/openshift-origin-release-4.23.yaml
+++ b/ci-operator/config/openshift/origin/openshift-origin-release-4.23.yaml
@@ -665,7 +665,7 @@ tests:
       --allow-missing-architectures=e2e-19-registry-k8s-io-e2e-test-images-node-perf-tf-wide-deep \
       --allow-missing-architectures=registry-k8s-io-cloud-provider-gcp-gcp-compute-persistent-disk-csi-driver \
       --allow-missing-architectures=e2e-quay-io-keycloak-keycloak \
-      --allow-missing-architectures=e2e-quay-io-crio-zstd-chunked-1 \
+      --allow-missing-architectures=e2e-quay-io-crio-artifact-subpath-8cuvQpZ0AoyNahYr \
       --allow-missing-architectures=e2e-quay-io-kubevirt-fedora-with-test-tooling-container-disk \
       --log-level=debug
   container:

--- a/ci-operator/config/openshift/origin/openshift-origin-release-5.0.yaml
+++ b/ci-operator/config/openshift/origin/openshift-origin-release-5.0.yaml
@@ -666,7 +666,7 @@ tests:
       --allow-missing-architectures=e2e-19-registry-k8s-io-e2e-test-images-node-perf-tf-wide-deep \
       --allow-missing-architectures=registry-k8s-io-cloud-provider-gcp-gcp-compute-persistent-disk-csi-driver \
       --allow-missing-architectures=e2e-quay-io-keycloak-keycloak \
-      --allow-missing-architectures=e2e-quay-io-crio-zstd-chunked-1 \
+      --allow-missing-architectures=e2e-quay-io-crio-artifact-subpath-8cuvQpZ0AoyNahYr \
       --allow-missing-architectures=e2e-quay-io-kubevirt-fedora-with-test-tooling-container-disk \
       --log-level=debug
   container:

--- a/ci-operator/config/openshift/origin/openshift-origin-release-5.1.yaml
+++ b/ci-operator/config/openshift/origin/openshift-origin-release-5.1.yaml
@@ -665,7 +665,7 @@ tests:
       --allow-missing-architectures=e2e-19-registry-k8s-io-e2e-test-images-node-perf-tf-wide-deep \
       --allow-missing-architectures=registry-k8s-io-cloud-provider-gcp-gcp-compute-persistent-disk-csi-driver \
       --allow-missing-architectures=e2e-quay-io-keycloak-keycloak \
-      --allow-missing-architectures=e2e-quay-io-crio-zstd-chunked-1 \
+      --allow-missing-architectures=e2e-quay-io-crio-artifact-subpath-8cuvQpZ0AoyNahYr \
       --allow-missing-architectures=e2e-quay-io-kubevirt-fedora-with-test-tooling-container-disk \
       --log-level=debug
   container:


### PR DESCRIPTION
Remove e2e-quay-io-crio-zstd-chunked-1 (it's no longer used https://github.com/openshift/origin/blob/c2bafd4224c64ba1160623876182ffefca11768c/test/extended/util/image/image.go#L72).
Add e2e-quay-io-crio-artifact-subpath-8cuvQpZ0AoyNahYr in the verify-image-manifest-lists test for 4.22+ and main.

Assisted-by: Claude Code <https://claude.com/claude-code>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI test configuration files across both OpenShift Origin and OpenShift Origin Private repositories to reference an updated container image identifier in image manifest list verification test steps. These configuration updates apply to the main development branch and all active release versions including 4.22, 4.23, 5.0, and 5.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->