### PR TITLE
osde2e: Add INSTALL_LATEST_NIGHTLY to nightly osd-aws, osd-gcp, and rosa-classic-sts jobs

### DIFF
--- a/ci-operator/config/openshift/osde2e/openshift-osde2e-main__nightly-4.20.yaml
+++ b/ci-operator/config/openshift/osde2e/openshift-osde2e-main__nightly-4.20.yaml
@@ -20,6 +20,7 @@ tests:
   steps:
     env:
       CONFIGS: rosa,sts,stage,rosa-e2e-suite
+      INSTALL_LATEST_NIGHTLY: "4.20"
       SECRET_LOCATIONS: /usr/local/rosa-e2e-prow-ci-01-osde2e
       SKIP_DESTROY_CLUSTER: "true"
       SKIP_MUST_GATHER: "true"
@@ -46,6 +47,7 @@ tests:
   steps:
     env:
       CONFIGS: aws,stage,e2e-suite
+      INSTALL_LATEST_NIGHTLY: "4.20"
       SECRET_LOCATIONS: /usr/local/osde2e-common,/usr/local/osde2e-trt-credentials
       SKIP_DESTROY_CLUSTER: "true"
       SKIP_MUST_GATHER: "true"
@@ -59,6 +61,7 @@ tests:
   steps:
     env:
       CONFIGS: gcp,stage,e2e-suite
+      INSTALL_LATEST_NIGHTLY: "4.20"
       SECRET_LOCATIONS: /usr/local/osde2e-common,/usr/local/osde2e-trt-credentials
       SKIP_DESTROY_CLUSTER: "true"
       SKIP_MUST_GATHER: "true"

--- a/ci-operator/config/openshift/osde2e/openshift-osde2e-main__nightly-4.21.yaml
+++ b/ci-operator/config/openshift/osde2e/openshift-osde2e-main__nightly-4.21.yaml
@@ -46,6 +46,7 @@ tests:
   steps:
     env:
       CONFIGS: aws,stage,e2e-suite
+      INSTALL_LATEST_NIGHTLY: "4.21"
       SECRET_LOCATIONS: /usr/local/osde2e-common,/usr/local/osde2e-trt-credentials
       SKIP_MUST_GATHER: "true"
     post:
@@ -58,6 +59,7 @@ tests:
   steps:
     env:
       CONFIGS: gcp,stage,e2e-suite
+      INSTALL_LATEST_NIGHTLY: "4.21"
       SECRET_LOCATIONS: /usr/local/osde2e-common,/usr/local/osde2e-trt-credentials
       SKIP_MUST_GATHER: "true"
     post:

--- a/ci-operator/config/openshift/osde2e/openshift-osde2e-main__nightly-4.22.yaml
+++ b/ci-operator/config/openshift/osde2e/openshift-osde2e-main__nightly-4.22.yaml
@@ -20,6 +20,7 @@ tests:
   steps:
     env:
       CONFIGS: rosa,sts,stage,rosa-e2e-suite
+      INSTALL_LATEST_NIGHTLY: "4.22"
       SECRET_LOCATIONS: /usr/local/rosa-e2e-prow-ci-01-osde2e
       SKIP_DESTROY_CLUSTER: "true"
       SKIP_MUST_GATHER: "true"
@@ -46,6 +47,7 @@ tests:
   steps:
     env:
       CONFIGS: aws,stage,e2e-suite
+      INSTALL_LATEST_NIGHTLY: "4.22"
       SECRET_LOCATIONS: /usr/local/osde2e-common,/usr/local/osde2e-trt-credentials
       SKIP_DESTROY_CLUSTER: "true"
       SKIP_MUST_GATHER: "true"
@@ -59,6 +61,7 @@ tests:
   steps:
     env:
       CONFIGS: gcp,stage,e2e-suite
+      INSTALL_LATEST_NIGHTLY: "4.22"
       SECRET_LOCATIONS: /usr/local/osde2e-common,/usr/local/osde2e-trt-credentials
       SKIP_DESTROY_CLUSTER: "true"
       SKIP_MUST_GATHER: "true"


### PR DESCRIPTION
## Summary
- Adds `INSTALL_LATEST_NIGHTLY` to all osd-aws, osd-gcp, and rosa-classic-sts jobs in the active nightly configs (4.20, 4.21, 4.22) that were missing it
- Without this variable, the osde2e version selector chain falls through to `defaultVersion`, which constructs a non-existent nightly version string (e.g. `openshift-v4.21.9-nightly`) and causes OCM to reject cluster provisioning
- The variable was added to rosa-hcp jobs in PR #76497 but the existing osd-aws and osd-gcp jobs were not updated at the time

## Test plan
- [ ] Verify nightly osd-aws and osd-gcp periodic jobs provision clusters successfully with the correct nightly version
- [ ] Verify rosa-classic-sts periodic jobs in 4.20 and 4.22 provision correctly (4.21 already had the variable)
- [x] Confirm no change to rosa-hcp jobs (they already had `INSTALL_LATEST_NIGHTLY`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test job configurations for OpenShift automated testing across versions 4.20, 4.21, and 4.22 to include explicit nightly installer version specifications for test execution environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->