### PR TITLE
ci(hypershift): enable TechPreviewNoUpgrade for backup/restore e2e test

### DIFF
--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-main.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-main.yaml
@@ -220,6 +220,7 @@ tests:
   steps:
     cluster_profile: hypershift-aws
     env:
+      TECH_PREVIEW_NO_UPGRADE: "true"
       TEST_SUITE: openshift/conformance/parallel/minimal
     workflow: hypershift-aws-e2e-backuprestore
 - always_run: false


### PR DESCRIPTION
Set TECH_PREVIEW_NO_UPGRADE=true in the hypershift-aws-e2e-backuprestore test to run against a TechPreviewNoUpgrade cluster profile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Updated test environment configuration for the backup/restore workflow to align with other AWS-related test configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->