### PR TITLE
NO-ISSUE: Raise max-turns limit for MicroShift CI Doctor

### DIFF
--- a/ci-operator/step-registry/openshift/microshift/claude/ci-doctor/openshift-microshift-claude-ci-doctor-commands.sh
+++ b/ci-operator/step-registry/openshift/microshift/claude/ci-doctor/openshift-microshift-claude-ci-doctor-commands.sh
@@ -262,7 +262,7 @@ cd "${SRC_DIR}"
 echo "Running Claude to analyze MicroShift CI jobs and pull requests..."
 timeout 3600 claude \
     --model "${CLAUDE_MODEL}" \
-    --max-turns 50 \
+    --max-turns 100 \
     --output-format stream-json \
     -p "/microshift-ci:doctor ${RELEASE_VERSIONS}" \
     --verbose 2>&1 | tee "${WORKDIR}/claude-output.log"


### PR DESCRIPTION
When there are over 30 failed jobs, the original 50 turns are not enough to complete the run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Adjusted CI/CD infrastructure parameter for enhanced execution capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->