### PR TITLE
sriov CI: enable mellanoxFirmwareReset featureflag

### DIFF
--- a/ci-operator/config/openshift/sriov-network-operator/openshift-sriov-network-operator-main.yaml
+++ b/ci-operator/config/openshift/sriov-network-operator/openshift-sriov-network-operator-main.yaml
@@ -208,6 +208,8 @@ tests:
           enableInjector: true
           enableOperatorWebhook: true
           logLevel: 2
+          featureGates:
+            mellanoxFirmwareReset: true
         EOF
       from: src
       resources:


### PR DESCRIPTION
with newer server we see more and more the need to have this featureflag enabled. without this the operator is not able to configure the MLX cards firmware as the server doesn't produce a full live cycle on reboot and the card doesn't get restarted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced SR-IOV operator e2e test configurations with additional feature gate validation across multiple test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->