### PR TITLE
fix rhel9 repo names for 4.22 and 5.0

### DIFF
--- a/core-services/release-controller/_repos/ocp-4.22-rhel9.repo
+++ b/core-services/release-controller/_repos/ocp-4.22-rhel9.repo
@@ -1,5 +1,5 @@
-[rhel-9.8-baseos]
-name = rhel-9.8-baseos
+[rhel-9-baseos]
+name = rhel-9-baseos
 baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-baseos
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -10,8 +10,8 @@ password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
 skip_if_unavailable = true
 
-[rhel-9.8-appstream]
-name = rhel-9.8-appstream
+[rhel-9-appstream]
+name = rhel-9-appstream
 baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-appstream
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -23,8 +23,8 @@ failovermethod = priority
 skip_if_unavailable = true
 excludepkgs=toolbox*
 
-[rhel-9.8-nfv]
-name = rhel-9.8-nfv
+[rhel-9-nfv]
+name = rhel-9-nfv
 baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-nfv
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -35,8 +35,8 @@ password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
 skip_if_unavailable = true
 
-[rhel-9.8-highavailability]
-name = rhel-9.8-highavailability
+[rhel-9-highavailability]
+name = rhel-9-highavailability
 baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-highavailability
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -47,8 +47,8 @@ password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
 skip_if_unavailable = true
 
-[rhel-9.8-fast-datapath]
-name = rhel-9.8-fast-datapath
+[rhel-9-fast-datapath]
+name = rhel-9-fast-datapath
 baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/fast-datapath/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -59,8 +59,8 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-98-codeready-builder-rpms]
-name = rhel-98-codeready-builder-rpms
+[rhel-9-codeready-builder-rpms]
+name = rhel-9-codeready-builder-rpms
 baseurl = https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/codeready-builder/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -71,8 +71,8 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-9.8-server-ose-4.22]
-name = rhel-9.8-server-ose-4.22
+[rhel-9-server-ose]
+name = rhel-9-server-ose
 baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-9-server-ose-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -106,8 +106,8 @@ skip_if_unavailable = true
 #   https://issues.redhat.com/browse/OCPBUGS-56600
 includepkgs=kernel,kernel-*,toolbox*,
 
-[rhel-9.8-baseos-ppc64le]
-name = rhel-9.8-baseos-ppc64le
+[rhel-9-baseos-ppc64le]
+name = rhel-9-baseos-ppc64le
 baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-baseos-ppc64le
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -118,8 +118,8 @@ password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
 skip_if_unavailable = true
 
-[rhel-9.8-appstream-ppc64le]
-name = rhel-9.8-appstream-ppc64le
+[rhel-9-appstream-ppc64le]
+name = rhel-9-appstream-ppc64le
 baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-appstream-ppc64le
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -130,8 +130,8 @@ password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
 skip_if_unavailable = true
 
-[rhel-9.8-fast-datapath-ppc64le]
-name = rhel-9.8-fast-datapath-ppc64le
+[rhel-9-fast-datapath-ppc64le]
+name = rhel-9-fast-datapath-ppc64le
 baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/ppc64le/fast-datapath/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -142,8 +142,8 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-9.8-server-ose-4.22-ppc64le]
-name = rhel-9.8-server-ose-4.22-ppc64le
+[rhel-9-server-ose-ppc64le]
+name = rhel-9-server-ose-ppc64le
 baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22_ppc64le/rhel-9-server-ose-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -154,8 +154,8 @@ password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
 skip_if_unavailable = true
 
-[rhel-98-codeready-builder-rpms-ppc64le]
-name = rhel-98-codeready-builder-rpms-ppc64le
+[rhel-9-codeready-builder-rpms-ppc64le]
+name = rhel-9-codeready-builder-rpms-ppc64le
 baseurl = https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/codeready-builder/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -166,8 +166,8 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-9.8-baseos-s390x]
-name = rhel-9.8-baseos-s390x
+[rhel-9-baseos-s390x]
+name = rhel-9-baseos-s390x
 baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-baseos-s390x
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -178,8 +178,8 @@ password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
 skip_if_unavailable = true
 
-[rhel-9.8-appstream-s390x]
-name = rhel-9.8-appstream-s390x
+[rhel-9-appstream-s390x]
+name = rhel-9-appstream-s390x
 baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-appstream-s390x
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -190,8 +190,8 @@ password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
 skip_if_unavailable = true
 
-[rhel-9.8-fast-datapath-s390x]
-name = rhel-9.8-fast-datapath-s390x
+[rhel-9-fast-datapath-s390x]
+name = rhel-9-fast-datapath-s390x
 baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/s390x/fast-datapath/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -202,8 +202,8 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-9.8-server-ose-4.22-s390x]
-name = rhel-9.8-server-ose-4.22-s390x
+[rhel-9-server-ose-s390x]
+name = rhel-9-server-ose-s390x
 baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22_s390x/rhel-9-server-ose-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -214,8 +214,8 @@ password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
 skip_if_unavailable = true
 
-[rhel-98-codeready-builder-rpms-s390x]
-name = rhel-98-codeready-builder-rpms-s390x
+[rhel-9-codeready-builder-rpms-s390x]
+name = rhel-9-codeready-builder-rpms-s390x
 baseurl = https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/codeready-builder/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -226,8 +226,8 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-9.8-baseos-aarch64]
-name = rhel-9.8-baseos-aarch64
+[rhel-9-baseos-aarch64]
+name = rhel-9-baseos-aarch64
 baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-baseos-aarch64
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -238,8 +238,8 @@ password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
 skip_if_unavailable = true
 
-[rhel-9.8-appstream-aarch64]
-name = rhel-9.8-appstream-aarch64
+[rhel-9-appstream-aarch64]
+name = rhel-9-appstream-aarch64
 baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-appstream-aarch64
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -250,8 +250,8 @@ password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
 skip_if_unavailable = true
 
-[rhel-9.8-fast-datapath-aarch64]
-name = rhel-9.8-fast-datapath-aarch64
+[rhel-9-fast-datapath-aarch64]
+name = rhel-9-fast-datapath-aarch64
 baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/aarch64/fast-datapath/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -262,8 +262,8 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-9.8-server-ose-4.22-aarch64]
-name = rhel-9.8-server-ose-4.22-aarch64
+[rhel-9-server-ose-aarch64]
+name = rhel-9-server-ose-aarch64
 baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22_aarch64/rhel-9-server-ose-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -274,8 +274,8 @@ password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
 skip_if_unavailable = true
 
-[rhel-98-codeready-builder-rpms-aarch64]
-name = rhel-98-codeready-builder-rpms-aarch64
+[rhel-9-codeready-builder-rpms-aarch64]
+name = rhel-9-codeready-builder-rpms-aarch64
 baseurl = https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/codeready-builder/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted

--- a/core-services/release-controller/_repos/ocp-5.0-rhel9.repo
+++ b/core-services/release-controller/_repos/ocp-5.0-rhel9.repo
@@ -1,5 +1,5 @@
-[rhel-9.8-baseos]
-name = rhel-9.8-baseos
+[rhel-9-baseos]
+name = rhel-9-baseos
 baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0/rhel-98-baseos
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -10,8 +10,8 @@ password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
 skip_if_unavailable = true
 
-[rhel-9.8-appstream]
-name = rhel-9.8-appstream
+[rhel-9-appstream]
+name = rhel-9-appstream
 baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0/rhel-98-appstream
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -23,8 +23,8 @@ failovermethod = priority
 skip_if_unavailable = true
 excludepkgs = toolbox*
 
-[rhel-9.8-nfv]
-name = rhel-9.8-nfv
+[rhel-9-nfv]
+name = rhel-9-nfv
 baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0/rhel-98-nfv
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -35,8 +35,8 @@ password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
 skip_if_unavailable = true
 
-[rhel-9.8-highavailability]
-name = rhel-9.8-highavailability
+[rhel-9-highavailability]
+name = rhel-9-highavailability
 baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0/rhel-98-highavailability
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -47,8 +47,8 @@ password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
 skip_if_unavailable = true
 
-[rhel-9.8-fast-datapath]
-name = rhel-9.8-fast-datapath
+[rhel-9-fast-datapath]
+name = rhel-9-fast-datapath
 baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/fast-datapath/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -59,8 +59,8 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-98-codeready-builder-rpms]
-name = rhel-98-codeready-builder-rpms
+[rhel-9-codeready-builder-rpms]
+name = rhel-9-codeready-builder-rpms
 baseurl = https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/codeready-builder/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -71,8 +71,8 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-9.8-server-ose-5.0]
-name = rhel-9.8-server-ose-5.0
+[rhel-9-server-ose]
+name = rhel-9-server-ose
 baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0/rhel-9-server-ose-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -107,8 +107,8 @@ skip_if_unavailable = true
 includepkgs = kernel,kernel-*,toolbox*,
 
 
-[rhel-9.8-baseos-ppc64le]
-name = rhel-9.8-baseos-ppc64le
+[rhel-9-baseos-ppc64le]
+name = rhel-9-baseos-ppc64le
 baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0/rhel-98-baseos-ppc64le
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -119,8 +119,8 @@ password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
 skip_if_unavailable = true
 
-[rhel-9.8-appstream-ppc64le]
-name = rhel-9.8-appstream-ppc64le
+[rhel-9-appstream-ppc64le]
+name = rhel-9-appstream-ppc64le
 baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0/rhel-98-appstream-ppc64le
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -131,8 +131,8 @@ password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
 skip_if_unavailable = true
 
-[rhel-9.8-fast-datapath-ppc64le]
-name = rhel-9.8-fast-datapath-ppc64le
+[rhel-9-fast-datapath-ppc64le]
+name = rhel-9-fast-datapath-ppc64le
 baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/ppc64le/fast-datapath/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -143,8 +143,8 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-9.8-server-ose-5.0-ppc64le]
-name = rhel-9.8-server-ose-5.0-ppc64le
+[rhel-9-server-ose-ppc64le]
+name = rhel-9-server-ose-ppc64le
 baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0_ppc64le/rhel-9-server-ose-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -155,8 +155,8 @@ password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
 skip_if_unavailable = true
 
-[rhel-98-codeready-builder-rpms-ppc64le]
-name = rhel-98-codeready-builder-rpms-ppc64le
+[rhel-9-codeready-builder-rpms-ppc64le]
+name = rhel-9-codeready-builder-rpms-ppc64le
 baseurl = https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/codeready-builder/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -167,8 +167,8 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-9.8-baseos-s390x]
-name = rhel-9.8-baseos-s390x
+[rhel-9-baseos-s390x]
+name = rhel-9-baseos-s390x
 baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0/rhel-98-baseos-s390x
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -179,8 +179,8 @@ password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
 skip_if_unavailable = true
 
-[rhel-9.8-appstream-s390x]
-name = rhel-9.8-appstream-s390x
+[rhel-9-appstream-s390x]
+name = rhel-9-appstream-s390x
 baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0/rhel-98-appstream-s390x
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -191,8 +191,8 @@ password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
 skip_if_unavailable = true
 
-[rhel-9.8-fast-datapath-s390x]
-name = rhel-9.8-fast-datapath-s390x
+[rhel-9-fast-datapath-s390x]
+name = rhel-9-fast-datapath-s390x
 baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/s390x/fast-datapath/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -203,8 +203,8 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-9.8-server-ose-5.0-s390x]
-name = rhel-9.8-server-ose-5.0-s390x
+[rhel-9-server-ose-s390x]
+name = rhel-9-server-ose-s390x
 baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0_s390x/rhel-9-server-ose-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -215,8 +215,8 @@ password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
 skip_if_unavailable = true
 
-[rhel-98-codeready-builder-rpms-s390x]
-name = rhel-98-codeready-builder-rpms-s390x
+[rhel-9-codeready-builder-rpms-s390x]
+name = rhel-9-codeready-builder-rpms-s390x
 baseurl = https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/codeready-builder/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -227,8 +227,8 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-9.8-baseos-aarch64]
-name = rhel-9.8-baseos-aarch64
+[rhel-9-baseos-aarch64]
+name = rhel-9-baseos-aarch64
 baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0/rhel-98-baseos-aarch64
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -239,8 +239,8 @@ password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
 skip_if_unavailable = true
 
-[rhel-9.8-appstream-aarch64]
-name = rhel-9.8-appstream-aarch64
+[rhel-9-appstream-aarch64]
+name = rhel-9-appstream-aarch64
 baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0/rhel-98-appstream-aarch64
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -251,8 +251,8 @@ password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
 skip_if_unavailable = true
 
-[rhel-9.8-fast-datapath-aarch64]
-name = rhel-9.8-fast-datapath-aarch64
+[rhel-9-fast-datapath-aarch64]
+name = rhel-9-fast-datapath-aarch64
 baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/aarch64/fast-datapath/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -263,8 +263,8 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-9.8-server-ose-5.0-aarch64]
-name = rhel-9.8-server-ose-5.0-aarch64
+[rhel-9-server-ose-aarch64]
+name = rhel-9-server-ose-aarch64
 baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0_aarch64/rhel-9-server-ose-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
@@ -275,8 +275,8 @@ password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
 skip_if_unavailable = true
 
-[rhel-98-codeready-builder-rpms-aarch64]
-name = rhel-98-codeready-builder-rpms-aarch64
+[rhel-9-codeready-builder-rpms-aarch64]
+name = rhel-9-codeready-builder-rpms-aarch64
 baseurl = https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/codeready-builder/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted


### PR DESCRIPTION
follows https://github.com/openshift/release/pull/77982

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration identifiers across all supported architectures (x86_64, ppc64le, s390x, and aarch64) to use general RHEL 9 versioning. All repository access points, enabled settings, authentication mechanisms, and other configuration details remain unchanged. This is a maintenance update with no direct impact to system functionality or user operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->