### PR TITLE
add jira config and label validation for 4.22

### DIFF
--- a/core-services/jira-lifecycle-plugin/config.yaml
+++ b/core-services/jira-lifecycle-plugin/config.yaml
@@ -1126,6 +1126,12 @@ orgs:
       release-4.21-compatibility:
         target_version: odf-4.21.3
         validate_by_default: true
+      release-4.22:
+        target_version: odf-4.22
+        validate_by_default: true
+      release-4.22-compatibility:
+        target_version: odf-4.22
+        validate_by_default: true
   openshift-kni:
     repos:
       eco-ci-cd:

--- a/core-services/prow/02_config/red-hat-storage/_prowconfig.yaml
+++ b/core-services/prow/02_config/red-hat-storage/_prowconfig.yaml
@@ -20,6 +20,8 @@ tide:
     - release-4.20-compatibility
     - release-4.21
     - release-4.21-compatibility
+    - release-4.22
+    - release-4.22-compatibility
     labels:
     - approved
     - jira/valid-bug
@@ -53,6 +55,8 @@ tide:
     - release-4.20-compatibility
     - release-4.21
     - release-4.21-compatibility
+    - release-4.22
+    - release-4.22-compatibility
     labels:
     - approved
     - lgtm


### PR DESCRIPTION
add jira config and label validation for all repos under red-hat-storage for version 4.22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for `release-4.22` and `release-4.22-compatibility` branches in build and lifecycle automation systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->