### PR TITLE
feat(redhat-appstudio): add cleanup for forgejo test repos

### DIFF
--- a/ci-operator/step-registry/redhat-appstudio/clean-external-resources/redhat-appstudio-clean-external-resources-commands.sh
+++ b/ci-operator/step-registry/redhat-appstudio/clean-external-resources/redhat-appstudio-clean-external-resources-commands.sh
@@ -4,7 +4,7 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
-export GITHUB_USER GITHUB_TOKEN GITHUB_ACCOUNTS_ARRAY PREVIOUS_RATE_REMAINING GITHUB_USERNAME_ARRAY GH_RATE_REMAINING CLEAN_REPOS_STATUS CLEAN_WEBHOOK_STATUS CLEAN_GITLAB_WEBHOOK_STATUS DEFAULT_QUAY_ORG DEFAULT_QUAY_ORG_TOKEN QE_SPRAYPROXY_HOST QE_SPRAYPROXY_TOKEN GITLAB_BOT_TOKEN GITLAB_PROJECT_ID CLEANUP_GITLAB_REPOS_STATUS
+export GITHUB_USER GITHUB_TOKEN GITHUB_ACCOUNTS_ARRAY PREVIOUS_RATE_REMAINING GITHUB_USERNAME_ARRAY GH_RATE_REMAINING CLEAN_REPOS_STATUS CLEAN_WEBHOOK_STATUS CLEAN_GITLAB_WEBHOOK_STATUS DEFAULT_QUAY_ORG DEFAULT_QUAY_ORG_TOKEN QE_SPRAYPROXY_HOST QE_SPRAYPROXY_TOKEN GITLAB_BOT_TOKEN GITLAB_PROJECT_ID CLEANUP_GITLAB_REPOS_STATUS CODEBERG_BOT_TOKEN CLEANUP_FORGEJO_REPOS_STATUS
 
 GITHUB_USER=""
 GITHUB_TOKEN=""
@@ -16,6 +16,7 @@ CLEAN_QUAY_TAGS_STATUS=0
 CLEAN_PRIVATE_REPO_STATUS=0
 CLEAN_REGISTERED_SERVERS_STATUS=0
 CLEANUP_GITLAB_REPOS_STATUS=0
+CLEANUP_FORGEJO_REPOS_STATUS=0
 PREVIOUS_RATE_REMAINING=0
 DEFAULT_QUAY_ORG=redhat-appstudio-qe
 DEFAULT_QUAY_ORG_TOKEN=$(cat /usr/local/konflux-ci-secrets-new/redhat-appstudio-qe/default-quay-org-token)
@@ -23,6 +24,7 @@ QE_SPRAYPROXY_HOST=$(cat /usr/local/konflux-ci-secrets-new/redhat-appstudio-qe/q
 QE_SPRAYPROXY_TOKEN=$(cat /usr/local/konflux-ci-secrets-new/redhat-appstudio-qe/qe-sprayproxy-token)
 GITLAB_BOT_TOKEN=$(cat /usr/local/konflux-ci-secrets-new/redhat-appstudio-qe/gitlab-bot-token)
 GITLAB_PROJECT_ID=$(cat /usr/local/konflux-ci-secrets-new/redhat-appstudio-qe/gitlab-project-id)
+CODEBERG_BOT_TOKEN=$(cat /usr/local/konflux-ci-secrets-new/redhat-appstudio-qe/codeberg-bot-token)
 
 # user stored: username:token,username:token
 IFS=',' read -r -a GITHUB_ACCOUNTS_ARRAY <<<"$(cat /usr/local/konflux-ci-secrets-new/redhat-appstudio-qe/github_accounts)"
@@ -57,7 +59,8 @@ make clean-quay-tags || CLEAN_QUAY_TAGS_STATUS=$?
 make clean-private-repos || CLEAN_PRIVATE_REPO_STATUS=$?
 make clean-registered-servers || CLEAN_REGISTERED_SERVERS_STATUS=$?
 make clean-gitlab-repos || CLEANUP_GITLAB_REPOS_STATUS=$?
+make clean-forgejo-repos || CLEANUP_FORGEJO_REPOS_STATUS=$?
 
-if [[ "${CLEAN_REPOS_STATUS}" -ne 0 || "${CLEAN_WEBHOOK_STATUS}" -ne 0 || "${CLEAN_GITLAB_WEBHOOK_STATUS}" -ne 0 || "${CLEAN_QUAY_REPOS_AND_ROBOTS_STATUS}" -ne 0 || "${CLEAN_QUAY_TAGS_STATUS}" -ne 0 || "${CLEAN_PRIVATE_REPO_STATUS}" -ne 0 || "${CLEAN_REGISTERED_SERVERS_STATUS}" -ne 0 || "${CLEANUP_GITLAB_REPOS_STATUS}" -ne 0 ]]; then
+if [[ "${CLEAN_REPOS_STATUS}" -ne 0 || "${CLEAN_WEBHOOK_STATUS}" -ne 0 || "${CLEAN_GITLAB_WEBHOOK_STATUS}" -ne 0 || "${CLEAN_QUAY_REPOS_AND_ROBOTS_STATUS}" -ne 0 || "${CLEAN_QUAY_TAGS_STATUS}" -ne 0 || "${CLEAN_PRIVATE_REPO_STATUS}" -ne 0 || "${CLEAN_REGISTERED_SERVERS_STATUS}" -ne 0 || "${CLEANUP_GITLAB_REPOS_STATUS}" -ne 0 || "${CLEANUP_FORGEJO_REPOS_STATUS}" -ne 0 ]]; then
     exit 1
 fi


### PR DESCRIPTION
Auto cleanup of Frogejo test repos for e2e tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended the cleanup process to now include Forgejo repository cleanup operations, with improved status tracking for cleanup tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->