### PR TITLE
increase CPU and memory resources for nmstate and networking console plugin jobs across all releases

### DIFF
--- a/ci-operator/config/openshift/networking-console-plugin/openshift-networking-console-plugin-main.yaml
+++ b/ci-operator/config/openshift/networking-console-plugin/openshift-networking-console-plugin-main.yaml
@@ -24,10 +24,10 @@ releases:
 resources:
   '*':
     limits:
-      memory: 4Gi
+      memory: 6Gi
     requests:
       cpu: 1000m
-      memory: 4Gi
+      memory: 6Gi
 tests:
 - as: lint
   steps:
@@ -68,7 +68,7 @@ tests:
       resources:
         requests:
           cpu: 1000m
-          memory: 1Gi
+          memory: 4Gi
       timeout: 3h0m0s
     workflow: openshift-e2e-aws
 zz_generated_metadata:

--- a/ci-operator/config/openshift/networking-console-plugin/openshift-networking-console-plugin-release-4.16.yaml
+++ b/ci-operator/config/openshift/networking-console-plugin/openshift-networking-console-plugin-release-4.16.yaml
@@ -24,10 +24,10 @@ releases:
 resources:
   '*':
     limits:
-      memory: 4Gi
+      memory: 6Gi
     requests:
-      cpu: 100m
-      memory: 200Mi
+      cpu: 1000m
+      memory: 6Gi
 tests:
 - as: lint
   steps:
@@ -67,7 +67,8 @@ tests:
       grace_period: 30m0s
       resources:
         requests:
-          cpu: 100m
+          cpu: 1000m
+          memory: 4Gi
       timeout: 3h0m0s
     workflow: openshift-e2e-aws
 zz_generated_metadata:

--- a/ci-operator/config/openshift/networking-console-plugin/openshift-networking-console-plugin-release-4.17.yaml
+++ b/ci-operator/config/openshift/networking-console-plugin/openshift-networking-console-plugin-release-4.17.yaml
@@ -24,10 +24,10 @@ releases:
 resources:
   '*':
     limits:
-      memory: 4Gi
+      memory: 6Gi
     requests:
       cpu: 1000m
-      memory: 4Gi
+      memory: 6Gi
 tests:
 - as: lint
   steps:
@@ -68,7 +68,7 @@ tests:
       resources:
         requests:
           cpu: 1000m
-          memory: 1Gi
+          memory: 4Gi
       timeout: 3h0m0s
     workflow: openshift-e2e-aws
 zz_generated_metadata:

--- a/ci-operator/config/openshift/networking-console-plugin/openshift-networking-console-plugin-release-4.18.yaml
+++ b/ci-operator/config/openshift/networking-console-plugin/openshift-networking-console-plugin-release-4.18.yaml
@@ -24,10 +24,10 @@ releases:
 resources:
   '*':
     limits:
-      memory: 4Gi
+      memory: 6Gi
     requests:
       cpu: 1000m
-      memory: 4Gi
+      memory: 6Gi
 tests:
 - as: lint
   steps:
@@ -68,7 +68,7 @@ tests:
       resources:
         requests:
           cpu: 1000m
-          memory: 1Gi
+          memory: 4Gi
       timeout: 3h0m0s
     workflow: openshift-e2e-aws
 zz_generated_metadata:

--- a/ci-operator/config/openshift/networking-console-plugin/openshift-networking-console-plugin-release-4.19.yaml
+++ b/ci-operator/config/openshift/networking-console-plugin/openshift-networking-console-plugin-release-4.19.yaml
@@ -24,10 +24,10 @@ releases:
 resources:
   '*':
     limits:
-      memory: 4Gi
+      memory: 6Gi
     requests:
       cpu: 1000m
-      memory: 4Gi
+      memory: 6Gi
 tests:
 - as: lint
   steps:
@@ -68,7 +68,7 @@ tests:
       resources:
         requests:
           cpu: 1000m
-          memory: 1Gi
+          memory: 4Gi
       timeout: 3h0m0s
     workflow: openshift-e2e-aws
 zz_generated_metadata:

--- a/ci-operator/config/openshift/networking-console-plugin/openshift-networking-console-plugin-release-4.20.yaml
+++ b/ci-operator/config/openshift/networking-console-plugin/openshift-networking-console-plugin-release-4.20.yaml
@@ -24,10 +24,10 @@ releases:
 resources:
   '*':
     limits:
-      memory: 4Gi
+      memory: 6Gi
     requests:
       cpu: 1000m
-      memory: 4Gi
+      memory: 6Gi
 tests:
 - as: lint
   steps:
@@ -68,7 +68,7 @@ tests:
       resources:
         requests:
           cpu: 1000m
-          memory: 1Gi
+          memory: 4Gi
       timeout: 3h0m0s
     workflow: openshift-e2e-aws
 zz_generated_metadata:

--- a/ci-operator/config/openshift/networking-console-plugin/openshift-networking-console-plugin-release-4.22.yaml
+++ b/ci-operator/config/openshift/networking-console-plugin/openshift-networking-console-plugin-release-4.22.yaml
@@ -24,10 +24,10 @@ releases:
 resources:
   '*':
     limits:
-      memory: 4Gi
+      memory: 6Gi
     requests:
       cpu: 1000m
-      memory: 4Gi
+      memory: 6Gi
 tests:
 - as: lint
   steps:
@@ -68,7 +68,7 @@ tests:
       resources:
         requests:
           cpu: 1000m
-          memory: 1Gi
+          memory: 4Gi
       timeout: 3h0m0s
     workflow: openshift-e2e-aws
 zz_generated_metadata:

--- a/ci-operator/config/openshift/networking-console-plugin/openshift-networking-console-plugin-release-4.23.yaml
+++ b/ci-operator/config/openshift/networking-console-plugin/openshift-networking-console-plugin-release-4.23.yaml
@@ -24,10 +24,10 @@ releases:
 resources:
   '*':
     limits:
-      memory: 4Gi
+      memory: 6Gi
     requests:
       cpu: 1000m
-      memory: 4Gi
+      memory: 6Gi
 tests:
 - as: lint
   steps:
@@ -68,7 +68,7 @@ tests:
       resources:
         requests:
           cpu: 1000m
-          memory: 1Gi
+          memory: 4Gi
       timeout: 3h0m0s
     workflow: openshift-e2e-aws
 zz_generated_metadata:

--- a/ci-operator/config/openshift/networking-console-plugin/openshift-networking-console-plugin-release-5.0.yaml
+++ b/ci-operator/config/openshift/networking-console-plugin/openshift-networking-console-plugin-release-5.0.yaml
@@ -25,10 +25,10 @@ releases:
 resources:
   '*':
     limits:
-      memory: 4Gi
+      memory: 6Gi
     requests:
       cpu: 1000m
-      memory: 4Gi
+      memory: 6Gi
 tests:
 - as: lint
   steps:
@@ -69,7 +69,7 @@ tests:
       resources:
         requests:
           cpu: 1000m
-          memory: 1Gi
+          memory: 4Gi
       timeout: 3h0m0s
     workflow: openshift-e2e-aws
 zz_generated_metadata:

--- a/ci-operator/config/openshift/networking-console-plugin/openshift-networking-console-plugin-release-5.1.yaml
+++ b/ci-operator/config/openshift/networking-console-plugin/openshift-networking-console-plugin-release-5.1.yaml
@@ -24,10 +24,10 @@ releases:
 resources:
   '*':
     limits:
-      memory: 4Gi
+      memory: 6Gi
     requests:
       cpu: 1000m
-      memory: 4Gi
+      memory: 6Gi
 tests:
 - as: lint
   steps:
@@ -68,7 +68,7 @@ tests:
       resources:
         requests:
           cpu: 1000m
-          memory: 1Gi
+          memory: 4Gi
       timeout: 3h0m0s
     workflow: openshift-e2e-aws
 zz_generated_metadata:

--- a/ci-operator/config/openshift/nmstate-console-plugin/openshift-nmstate-console-plugin-main.yaml
+++ b/ci-operator/config/openshift/nmstate-console-plugin/openshift-nmstate-console-plugin-main.yaml
@@ -24,10 +24,10 @@ releases:
 resources:
   '*':
     limits:
-      memory: 4Gi
+      memory: 6Gi
     requests:
       cpu: 1000m
-      memory: 4Gi
+      memory: 6Gi
 tests:
 - as: e2e-tests
   steps:
@@ -48,7 +48,7 @@ tests:
       resources:
         requests:
           cpu: 1000m
-          memory: 1Gi
+          memory: 4Gi
     workflow: ipi-aws
 zz_generated_metadata:
   branch: main

--- a/ci-operator/config/openshift/nmstate-console-plugin/openshift-nmstate-console-plugin-release-4.13.yaml
+++ b/ci-operator/config/openshift/nmstate-console-plugin/openshift-nmstate-console-plugin-release-4.13.yaml
@@ -24,10 +24,10 @@ releases:
 resources:
   '*':
     limits:
-      memory: 4Gi
+      memory: 6Gi
     requests:
-      cpu: 100m
-      memory: 200Mi
+      cpu: 1000m
+      memory: 6Gi
 tests:
 - as: e2e-tests
   steps:
@@ -47,7 +47,8 @@ tests:
       from: src
       resources:
         requests:
-          cpu: 100m
+          cpu: 1000m
+          memory: 4Gi
     workflow: ipi-aws
 zz_generated_metadata:
   branch: release-4.13

--- a/ci-operator/config/openshift/nmstate-console-plugin/openshift-nmstate-console-plugin-release-4.14.yaml
+++ b/ci-operator/config/openshift/nmstate-console-plugin/openshift-nmstate-console-plugin-release-4.14.yaml
@@ -24,10 +24,10 @@ releases:
 resources:
   '*':
     limits:
-      memory: 4Gi
+      memory: 6Gi
     requests:
-      cpu: 100m
-      memory: 200Mi
+      cpu: 1000m
+      memory: 6Gi
 tests:
 - as: e2e-tests
   steps:
@@ -47,7 +47,8 @@ tests:
       from: src
       resources:
         requests:
-          cpu: 100m
+          cpu: 1000m
+          memory: 4Gi
     workflow: ipi-aws
 zz_generated_metadata:
   branch: release-4.14

--- a/ci-operator/config/openshift/nmstate-console-plugin/openshift-nmstate-console-plugin-release-4.15.yaml
+++ b/ci-operator/config/openshift/nmstate-console-plugin/openshift-nmstate-console-plugin-release-4.15.yaml
@@ -24,10 +24,10 @@ releases:
 resources:
   '*':
     limits:
-      memory: 4Gi
+      memory: 6Gi
     requests:
-      cpu: 100m
-      memory: 200Mi
+      cpu: 1000m
+      memory: 6Gi
 tests:
 - as: e2e-tests
   steps:
@@ -47,7 +47,8 @@ tests:
       from: src
       resources:
         requests:
-          cpu: 100m
+          cpu: 1000m
+          memory: 4Gi
     workflow: ipi-aws
 zz_generated_metadata:
   branch: release-4.15

--- a/ci-operator/config/openshift/nmstate-console-plugin/openshift-nmstate-console-plugin-release-4.16.yaml
+++ b/ci-operator/config/openshift/nmstate-console-plugin/openshift-nmstate-console-plugin-release-4.16.yaml
@@ -24,10 +24,10 @@ releases:
 resources:
   '*':
     limits:
-      memory: 4Gi
+      memory: 6Gi
     requests:
-      cpu: 100m
-      memory: 200Mi
+      cpu: 1000m
+      memory: 6Gi
 tests:
 - as: e2e-tests
   steps:
@@ -47,7 +47,8 @@ tests:
       from: src
       resources:
         requests:
-          cpu: 100m
+          cpu: 1000m
+          memory: 4Gi
     workflow: ipi-aws
 zz_generated_metadata:
   branch: release-4.16

--- a/ci-operator/config/openshift/nmstate-console-plugin/openshift-nmstate-console-plugin-release-4.17.yaml
+++ b/ci-operator/config/openshift/nmstate-console-plugin/openshift-nmstate-console-plugin-release-4.17.yaml
@@ -24,10 +24,10 @@ releases:
 resources:
   '*':
     limits:
-      memory: 4Gi
+      memory: 6Gi
     requests:
       cpu: 1000m
-      memory: 4Gi
+      memory: 6Gi
 tests:
 - as: e2e-tests
   steps:
@@ -48,7 +48,7 @@ tests:
       resources:
         requests:
           cpu: 1000m
-          memory: 1Gi
+          memory: 4Gi
     workflow: ipi-aws
 zz_generated_metadata:
   branch: release-4.17

--- a/ci-operator/config/openshift/nmstate-console-plugin/openshift-nmstate-console-plugin-release-4.18.yaml
+++ b/ci-operator/config/openshift/nmstate-console-plugin/openshift-nmstate-console-plugin-release-4.18.yaml
@@ -24,10 +24,10 @@ releases:
 resources:
   '*':
     limits:
-      memory: 4Gi
+      memory: 6Gi
     requests:
       cpu: 1000m
-      memory: 4Gi
+      memory: 6Gi
 tests:
 - as: e2e-tests
   steps:
@@ -48,7 +48,7 @@ tests:
       resources:
         requests:
           cpu: 1000m
-          memory: 1Gi
+          memory: 4Gi
     workflow: ipi-aws
 zz_generated_metadata:
   branch: release-4.18

--- a/ci-operator/config/openshift/nmstate-console-plugin/openshift-nmstate-console-plugin-release-4.19.yaml
+++ b/ci-operator/config/openshift/nmstate-console-plugin/openshift-nmstate-console-plugin-release-4.19.yaml
@@ -24,10 +24,10 @@ releases:
 resources:
   '*':
     limits:
-      memory: 4Gi
+      memory: 6Gi
     requests:
       cpu: 1000m
-      memory: 4Gi
+      memory: 6Gi
 tests:
 - as: e2e-tests
   steps:
@@ -48,7 +48,7 @@ tests:
       resources:
         requests:
           cpu: 1000m
-          memory: 1Gi
+          memory: 4Gi
     workflow: ipi-aws
 zz_generated_metadata:
   branch: release-4.19

--- a/ci-operator/config/openshift/nmstate-console-plugin/openshift-nmstate-console-plugin-release-4.20.yaml
+++ b/ci-operator/config/openshift/nmstate-console-plugin/openshift-nmstate-console-plugin-release-4.20.yaml
@@ -24,10 +24,10 @@ releases:
 resources:
   '*':
     limits:
-      memory: 4Gi
+      memory: 6Gi
     requests:
       cpu: 1000m
-      memory: 4Gi
+      memory: 6Gi
 tests:
 - as: e2e-tests
   steps:
@@ -48,7 +48,7 @@ tests:
       resources:
         requests:
           cpu: 1000m
-          memory: 1Gi
+          memory: 4Gi
     workflow: ipi-aws
 zz_generated_metadata:
   branch: release-4.20

--- a/ci-operator/config/openshift/nmstate-console-plugin/openshift-nmstate-console-plugin-release-4.22.yaml
+++ b/ci-operator/config/openshift/nmstate-console-plugin/openshift-nmstate-console-plugin-release-4.22.yaml
@@ -24,10 +24,10 @@ releases:
 resources:
   '*':
     limits:
-      memory: 4Gi
+      memory: 6Gi
     requests:
       cpu: 1000m
-      memory: 4Gi
+      memory: 6Gi
 tests:
 - as: e2e-tests
   steps:
@@ -48,7 +48,7 @@ tests:
       resources:
         requests:
           cpu: 1000m
-          memory: 1Gi
+          memory: 4Gi
     workflow: ipi-aws
 zz_generated_metadata:
   branch: release-4.22

--- a/ci-operator/config/openshift/nmstate-console-plugin/openshift-nmstate-console-plugin-release-4.23.yaml
+++ b/ci-operator/config/openshift/nmstate-console-plugin/openshift-nmstate-console-plugin-release-4.23.yaml
@@ -24,10 +24,10 @@ releases:
 resources:
   '*':
     limits:
-      memory: 4Gi
+      memory: 6Gi
     requests:
       cpu: 1000m
-      memory: 4Gi
+      memory: 6Gi
 tests:
 - as: e2e-tests
   steps:
@@ -48,7 +48,7 @@ tests:
       resources:
         requests:
           cpu: 1000m
-          memory: 1Gi
+          memory: 4Gi
     workflow: ipi-aws
 zz_generated_metadata:
   branch: release-4.23

--- a/ci-operator/config/openshift/nmstate-console-plugin/openshift-nmstate-console-plugin-release-5.0.yaml
+++ b/ci-operator/config/openshift/nmstate-console-plugin/openshift-nmstate-console-plugin-release-5.0.yaml
@@ -25,10 +25,10 @@ releases:
 resources:
   '*':
     limits:
-      memory: 4Gi
+      memory: 6Gi
     requests:
       cpu: 1000m
-      memory: 4Gi
+      memory: 6Gi
 tests:
 - as: e2e-tests
   steps:
@@ -49,7 +49,7 @@ tests:
       resources:
         requests:
           cpu: 1000m
-          memory: 1Gi
+          memory: 4Gi
     workflow: ipi-aws
 zz_generated_metadata:
   branch: release-5.0

--- a/ci-operator/config/openshift/nmstate-console-plugin/openshift-nmstate-console-plugin-release-5.1.yaml
+++ b/ci-operator/config/openshift/nmstate-console-plugin/openshift-nmstate-console-plugin-release-5.1.yaml
@@ -24,10 +24,10 @@ releases:
 resources:
   '*':
     limits:
-      memory: 4Gi
+      memory: 6Gi
     requests:
       cpu: 1000m
-      memory: 4Gi
+      memory: 6Gi
 tests:
 - as: e2e-tests
   steps:
@@ -48,7 +48,7 @@ tests:
       resources:
         requests:
           cpu: 1000m
-          memory: 1Gi
+          memory: 4Gi
     workflow: ipi-aws
 zz_generated_metadata:
   branch: release-5.1


### PR DESCRIPTION
## Summary

- Align all release branches (4.13–5.1 and main) for both `nmstate-console-plugin` and `networking-console-plugin` with the resource settings already in place for release-4.21
- Top-level `resources['*']`: `limits.memory` and `requests.memory` raised to **6Gi**, `requests.cpu` raised to **1000m**
- e2e test step resources: `requests.memory` raised to **4Gi**, `requests.cpu` raised to **1000m**

## Files changed

- `ci-operator/config/openshift/nmstate-console-plugin/`: 4.13, 4.14, 4.15, 4.16, 4.17, 4.18, 4.19, 4.20, 4.22, 4.23, 5.0, 5.1, main
- `ci-operator/config/openshift/networking-console-plugin/`: 4.16, 4.17, 4.18, 4.19, 4.20, 4.22, 4.23, 5.0, 5.1, main

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated resource allocations across CI/operator configurations for multiple OpenShift releases of networking and nmstate console plugins.
  * Increased memory limits and requests for build and test pipelines to optimize resource availability and test stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->