### PR TITLE
USHIFT-6793: Download MicroShift CI Doctor report from artifacts for Prow SpyGlass

### DIFF
--- a/ci-operator/step-registry/openshift/microshift/claude/ci-doctor/openshift-microshift-claude-ci-doctor-commands.sh
+++ b/ci-operator/step-registry/openshift/microshift/claude/ci-doctor/openshift-microshift-claude-ci-doctor-commands.sh
@@ -12,11 +12,10 @@ mkdir -p "${CLAUDE_HOME}"
 # The procedure to copy reports and session logs to artifacts, executed at exit
 atexit_handler() {
     if [[ -d "${WORKDIR:-}" ]]; then
-        echo "Copying reports to artifact and shared directories..."
+        echo "Copying report files to the artifact directory..."
         find "${WORKDIR}" -maxdepth 1 -name "*.html" -exec cp {} "${ARTIFACT_DIR}/" \; || true
         find "${WORKDIR}" -maxdepth 1 -name "*.json" -exec cp {} "${ARTIFACT_DIR}/" \; || true
         find "${WORKDIR}" -maxdepth 1 -name "*.txt"  -exec cp {} "${ARTIFACT_DIR}/" \; || true
-        find "${WORKDIR}" -maxdepth 1 -name "*.html" -exec cp {} "${SHARED_DIR}/"   \; || true
     fi
 
     # Archive the full Claude session directory (including subagent logs) for session continuation.
@@ -189,7 +188,9 @@ configure_claude() {
       "Read(//tmp/**)",
       "Write(//tmp/**)",
       "Bash(bash plugins/microshift-ci/scripts/*)",
+      "Bash(bash /tmp/edge-tooling/plugins/microshift-ci/scripts/*)",
       "Bash(python3 plugins/microshift-ci/scripts/*)",
+      "Bash(python3 /tmp/edge-tooling/plugins/microshift-ci/scripts/*)",
       "Bash(curl:*)",
       "Bash(date:*)",
       "Bash(cat:*)",

--- a/ci-operator/step-registry/openshift/microshift/claude/post/openshift-microshift-claude-post-commands.sh
+++ b/ci-operator/step-registry/openshift/microshift/claude/post/openshift-microshift-claude-post-commands.sh
@@ -2,13 +2,20 @@
 set -euo pipefail
 set -x
 
-copy_report_pages() {
-    echo "Copying report HTML files from shared directory to artifacts..."
-    for f in "${SHARED_DIR}"/*.html; do
-        local base
-        base="$(basename "${f}" .html)"
-        cp "${f}" "${ARTIFACT_DIR}/1-${base}-summary.html"
-    done
+if [ "${JOB_TYPE:-}" = "presubmit" ]; then
+    PROW_JOB_URL="https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/${REPO_OWNER}_${REPO_NAME}/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
+else
+    PROW_JOB_URL="https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/${JOB_NAME}/${BUILD_ID}"
+fi
+
+download_report() {
+    local -r report_name="microshift-ci-doctor-report.html"
+    local -r report_url="${PROW_JOB_URL}/artifacts/ci-doctor/openshift-microshift-claude-ci-doctor/artifacts/${report_name}"
+    local -r output_file="${ARTIFACT_DIR}/0-${report_name%.html}-summary.html"
+
+    echo "Downloading report from artifacts..."
+    curl -sSfL --retry 3 --max-time 300 -o "${output_file}" "${report_url}"
+    echo "Report downloaded successfully."
 }
 
 #
@@ -17,7 +24,7 @@ copy_report_pages() {
 echo "Generating the report pages..."
 
 if [[ -f "${SHARED_DIR}/claude-report-available" ]]; then
-    copy_report_pages
+    download_report
 else
     echo "No Claude report found. Skipping."
 fi

--- a/core-services/prow/02_config/openshift/microshift/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/microshift/_pluginconfig.yaml
@@ -3,6 +3,15 @@ label:
     openshift/microshift:
     - allowed_users:
       - microshift-rebase-script[bot]
+      - copejon
+      - eslutsky
+      - ggiguash
+      - jerpeter1
+      - pacevedom
+      - pmtk
+      label: bugzilla/valid-bug
+    - allowed_users:
+      - microshift-rebase-script[bot]
       - agullon
       - copejon
       - eslutsky
@@ -33,5 +42,5 @@ triggers:
 - repos:
   - openshift/microshift
   trusted_apps:
-  - microshift-rebase-script[bot]
+  - microshift-rebase-script
   - openshift-merge-bot

--- a/core-services/prow/02_config/openshift/microshift/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/microshift/_pluginconfig.yaml
@@ -3,15 +3,6 @@ label:
     openshift/microshift:
     - allowed_users:
       - microshift-rebase-script[bot]
-      - copejon
-      - eslutsky
-      - ggiguash
-      - jerpeter1
-      - pacevedom
-      - pmtk
-      label: bugzilla/valid-bug
-    - allowed_users:
-      - microshift-rebase-script[bot]
       - agullon
       - copejon
       - eslutsky
@@ -42,5 +33,5 @@ triggers:
 - repos:
   - openshift/microshift
   trusted_apps:
-  - microshift-rebase-script
+  - microshift-rebase-script[bot]
   - openshift-merge-bot


### PR DESCRIPTION
It's not possible to store the report in the secrets directory to pass it between steps because of the report size. 

Also fixed the permissions issue when Claude "decides" to use full path for running scripts.

Example of a [working report](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/78095/rehearse-78095-periodic-ci-openshift-microshift-main-ci-doctor/2046834449894608896).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Artifact handling now archives only HTML, JSON, and TXT report files and no longer copies HTML into the shared area; logs updated accordingly.
  * CI Doctor report is fetched from the prior-step artifact when available, with retries and a timeout for improved reliability.
  * Claude execution permissions expanded to allow additional local tooling scripts to run.

* **Chores**
  * CI plugin configuration updated: removed a restricted-label entry and adjusted the trusted application identity used by the plugin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->