### PR TITLE
[ci-tools]: enforce mod mode on go run commands in the secret bootstrapper jobs

### DIFF
--- a/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-main-presubmits.yaml
@@ -767,6 +767,7 @@ presubmits:
         command:
         - go
         - run
+        - -mod=mod
         - -race
         - ./cmd/ci-secret-generator
         image: quay-proxy.ci.openshift.org/openshift/ci:ocp_builder_rhel-9-golang-1.25-openshift-4.23

--- a/hack/validate-ci-secret-boostrap.sh
+++ b/hack/validate-ci-secret-boostrap.sh
@@ -7,7 +7,7 @@ cd $(dirname $0)/..
 BOOTSTRAP_BINARY=${BOOTSTRAP_BINARY:-/usr/bin/ci-secret-bootstrap}
 
 if [[ ! -x ${BOOTSTRAP_BINARY} ]]; then
-  cd ../ci-tools && go build -race=true -o ${BOOTSTRAP_BINARY} ./cmd/ci-secret-bootstrap && cd -
+  cd ../ci-tools && go build -mod=mod -race=true -o ${BOOTSTRAP_BINARY} ./cmd/ci-secret-bootstrap && cd -
 fi
 
 exec ${BOOTSTRAP_BINARY} \


### PR DESCRIPTION
/cc @openshift/test-platform 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go module handling in CI pipeline configuration and build validation processes to ensure consistent module resolution behavior during automated testing and validation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->