### PR TITLE
ci: set konflux DisasterRecovery optional

### DIFF
--- a/ci-operator/config/redhat-appstudio/infra-deployments/redhat-appstudio-infra-deployments-main.yaml
+++ b/ci-operator/config/redhat-appstudio/infra-deployments/redhat-appstudio-infra-deployments-main.yaml
@@ -128,8 +128,8 @@ tests:
     product: ocp
     timeout: 3h0m0s
     version: "4.17"
-  skip_if_only_changed: ^docs/|^\.github/|^\.tekton/|^infra-tools/|^openspec/|^argo-cd-apps/.*/(.*production|staging)|^components/(authentication|hac-pact-broker|konflux-ci|quality-dashboard|sandbox|smee|sprayproxy|tekton-ci|.*/(production|staging|production-downstream|staging-downstream))/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE|_config\.yml|staging-app\.yaml|index\.html)$
   optional: true
+  skip_if_only_changed: ^docs/|^\.github/|^\.tekton/|^infra-tools/|^openspec/|^argo-cd-apps/.*/(.*production|staging)|^components/(authentication|hac-pact-broker|konflux-ci|quality-dashboard|sandbox|smee|sprayproxy|tekton-ci|.*/(production|staging|production-downstream|staging-downstream))/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE|_config\.yml|staging-app\.yaml|index\.html)$
   steps:
     test:
     - ref: redhat-appstudio-konflux-disaster-recovery

--- a/ci-operator/config/redhat-appstudio/infra-deployments/redhat-appstudio-infra-deployments-main.yaml
+++ b/ci-operator/config/redhat-appstudio/infra-deployments/redhat-appstudio-infra-deployments-main.yaml
@@ -129,6 +129,7 @@ tests:
     timeout: 3h0m0s
     version: "4.17"
   skip_if_only_changed: ^docs/|^\.github/|^\.tekton/|^infra-tools/|^openspec/|^argo-cd-apps/.*/(.*production|staging)|^components/(authentication|hac-pact-broker|konflux-ci|quality-dashboard|sandbox|smee|sprayproxy|tekton-ci|.*/(production|staging|production-downstream|staging-downstream))/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE|_config\.yml|staging-app\.yaml|index\.html)$
+  optional: true
   steps:
     test:
     - ref: redhat-appstudio-konflux-disaster-recovery

--- a/ci-operator/jobs/redhat-appstudio/infra-deployments/redhat-appstudio-infra-deployments-main-presubmits.yaml
+++ b/ci-operator/jobs/redhat-appstudio/infra-deployments/redhat-appstudio-infra-deployments-main-presubmits.yaml
@@ -190,6 +190,7 @@ presubmits:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-redhat-appstudio-infra-deployments-main-appstudio-konflux-disaster-recovery
+    optional: true
     rerun_command: /test appstudio-konflux-disaster-recovery
     skip_if_only_changed: ^docs/|^\.github/|^\.tekton/|^infra-tools/|^openspec/|^argo-cd-apps/.*/(.*production|staging)|^components/(authentication|hac-pact-broker|konflux-ci|quality-dashboard|sandbox|smee|sprayproxy|tekton-ci|.*/(production|staging|production-downstream|staging-downstream))/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE|_config\.yml|staging-app\.yaml|index\.html)$
     spec:


### PR DESCRIPTION
We want to temporarily set the newly introduced CI Job for DisasterRecovery as optional until it's stable enough.

cf. https://docs.ci.openshift.org/architecture/ci-operator/#pre-submit-tests

Signed-off-by: Francesco Ilario <filario@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD test configuration to mark the disaster recovery test as optional in the build pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->