### PR TITLE
fix: validate org-level label descriptions in presubmit

### DIFF
--- a/hack/validate-labels.py
+++ b/hack/validate-labels.py
@@ -19,12 +19,19 @@ def main():
         if len(desc) > MAX_LENGTH:
             errors.append(f"default/{label['name']}: {len(desc)} chars - {desc}")
 
+    # Check org-level labels
+    for org, config in data.get("orgs", {}).items():
+        for label in config.get("labels", []):
+            desc = label.get("description", "")
+            if len(desc) > MAX_LENGTH:
+                errors.append(f"orgs/{org}/{label['name']}: {len(desc)} chars - {desc}")
+
     # Check repo-specific labels
     for repo, config in data.get("repos", {}).items():
         for label in config.get("labels", []):
             desc = label.get("description", "")
             if len(desc) > MAX_LENGTH:
-                errors.append(f"{repo}/{label['name']}: {len(desc)} chars - {desc}")
+                errors.append(f"repos/{repo}/{label['name']}: {len(desc)} chars - {desc}")
 
     if errors:
         print(f"Labels with descriptions exceeding {MAX_LENGTH} characters:")


### PR DESCRIPTION
- The `ci/prow/labels` presubmit (`hack/validate-labels.py`) only validated label descriptions in `default` and `repos` sections, skipping `orgs` entirely
- This allowed a too-long description under `orgs/openshift` to merge and break `label_sync`
- Added validation for org-level labels to catch this in presubmit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error message formatting for repository-specific labels to improve clarity.

* **Chores**
  * Extended validation to cover organization-level label configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->