### PR TITLE
Reverting openshift-observability cluster pools back to standard sizes

### DIFF
--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-logging-ocp-4-16-0-amd64-aws-us-east-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-logging-ocp-4-16-0-amd64-aws-us-east-1_clusterpool.yaml
@@ -33,7 +33,7 @@ spec:
       region: us-east-1
   pullSecretRef:
     name: pull-secret
-  size: 0
+  size: 1
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-logging-ocp-4-17-0-amd64-aws-us-east-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-logging-ocp-4-17-0-amd64-aws-us-east-1_clusterpool.yaml
@@ -33,7 +33,7 @@ spec:
       region: us-east-1
   pullSecretRef:
     name: pull-secret
-  size: 0
+  size: 1
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-logging-ocp-4-18-amd64-aws-us-east-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-logging-ocp-4-18-amd64-aws-us-east-1_clusterpool.yaml
@@ -33,7 +33,7 @@ spec:
       region: us-east-1
   pullSecretRef:
     name: pull-secret
-  size: 0
+  size: 2
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-logging-ocp-4-19-amd64-aws-us-east-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-logging-ocp-4-19-amd64-aws-us-east-1_clusterpool.yaml
@@ -33,7 +33,7 @@ spec:
       region: us-east-1
   pullSecretRef:
     name: pull-secret
-  size: 0
+  size: 2
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-logging-ocp-4-20-amd64-aws-us-east-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-logging-ocp-4-20-amd64-aws-us-east-1_clusterpool.yaml
@@ -33,7 +33,7 @@ spec:
       region: us-east-1
   pullSecretRef:
     name: pull-secret
-  size: 0
+  size: 2
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-logging-ocp-4-21-amd64-aws-us-east-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-logging-ocp-4-21-amd64-aws-us-east-1_clusterpool.yaml
@@ -33,7 +33,7 @@ spec:
       region: us-east-1
   pullSecretRef:
     name: pull-secret
-  size: 0
+  size: 2
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-13-0-amd64-aws-us-east-2_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-13-0-amd64-aws-us-east-2_clusterpool.yaml
@@ -33,7 +33,7 @@ spec:
       region: us-east-2
   pullSecretRef:
     name: pull-secret
-  size: 0
+  size: 1
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-13-0-fips-amd64-aws-us-east-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-13-0-fips-amd64-aws-us-east-1_clusterpool.yaml
@@ -34,7 +34,7 @@ spec:
       region: us-east-1
   pullSecretRef:
     name: pull-secret
-  size: 0
+  size: 1
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-14-0-amd64-aws-us-east-2_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-14-0-amd64-aws-us-east-2_clusterpool.yaml
@@ -33,7 +33,7 @@ spec:
       region: us-east-2
   pullSecretRef:
     name: pull-secret
-  size: 0
+  size: 1
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-14-0-fips-amd64-aws-us-east-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-14-0-fips-amd64-aws-us-east-1_clusterpool.yaml
@@ -34,7 +34,7 @@ spec:
       region: us-east-1
   pullSecretRef:
     name: pull-secret
-  size: 0
+  size: 1
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-15-0-amd64-aws-us-east-2_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-15-0-amd64-aws-us-east-2_clusterpool.yaml
@@ -33,7 +33,7 @@ spec:
       region: us-east-2
   pullSecretRef:
     name: pull-secret
-  size: 0
+  size: 1
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-15-0-fips-amd64-aws-us-east-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-15-0-fips-amd64-aws-us-east-1_clusterpool.yaml
@@ -34,7 +34,7 @@ spec:
       region: us-east-1
   pullSecretRef:
     name: pull-secret
-  size: 0
+  size: 1
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-16-0-amd64-aws-us-east-2_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-16-0-amd64-aws-us-east-2_clusterpool.yaml
@@ -33,7 +33,7 @@ spec:
       region: us-east-2
   pullSecretRef:
     name: pull-secret
-  size: 0
+  size: 1
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-16-0-fips-amd64-aws-us-east-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-16-0-fips-amd64-aws-us-east-1_clusterpool.yaml
@@ -34,7 +34,7 @@ spec:
       region: us-east-1
   pullSecretRef:
     name: pull-secret
-  size: 0
+  size: 1
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-17-0-amd64-aws-us-east-2_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-17-0-amd64-aws-us-east-2_clusterpool.yaml
@@ -33,7 +33,7 @@ spec:
       region: us-east-2
   pullSecretRef:
     name: pull-secret
-  size: 0
+  size: 1
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-17-0-fips-amd64-aws-us-east-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-17-0-fips-amd64-aws-us-east-1_clusterpool.yaml
@@ -34,7 +34,7 @@ spec:
       region: us-east-1
   pullSecretRef:
     name: pull-secret
-  size: 0
+  size: 1
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-18-0-amd64-aws-us-east-2_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-18-0-amd64-aws-us-east-2_clusterpool.yaml
@@ -33,7 +33,7 @@ spec:
       region: us-east-2
   pullSecretRef:
     name: pull-secret
-  size: 0
+  size: 1
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-18-0-fips-amd64-aws-us-east-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-18-0-fips-amd64-aws-us-east-1_clusterpool.yaml
@@ -34,7 +34,7 @@ spec:
       region: us-east-1
   pullSecretRef:
     name: pull-secret
-  size: 0
+  size: 1
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-19-0-amd64-aws-us-east-2_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-19-0-amd64-aws-us-east-2_clusterpool.yaml
@@ -33,7 +33,7 @@ spec:
       region: us-east-2
   pullSecretRef:
     name: pull-secret
-  size: 0
+  size: 1
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-19-0-fips-amd64-aws-us-east-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-19-0-fips-amd64-aws-us-east-1_clusterpool.yaml
@@ -34,7 +34,7 @@ spec:
       region: us-east-1
   pullSecretRef:
     name: pull-secret
-  size: 0
+  size: 1
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-20-0-amd64-aws-us-east-2_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-20-0-amd64-aws-us-east-2_clusterpool.yaml
@@ -33,7 +33,7 @@ spec:
       region: us-east-2
   pullSecretRef:
     name: pull-secret
-  size: 0
+  size: 1
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-20-0-fips-amd64-aws-us-east-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-20-0-fips-amd64-aws-us-east-1_clusterpool.yaml
@@ -34,7 +34,7 @@ spec:
       region: us-east-1
   pullSecretRef:
     name: pull-secret
-  size: 0
+  size: 1
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-21-0-amd64-aws-us-east-2_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-21-0-amd64-aws-us-east-2_clusterpool.yaml
@@ -36,6 +36,6 @@ spec:
   size: 1
   skipMachinePools: true
 status:
-  ready: 1
-  size: 1
+  ready: 0
+  size: 0
   standby: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-21-0-fips-amd64-aws-us-east-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-21-0-fips-amd64-aws-us-east-1_clusterpool.yaml
@@ -34,7 +34,7 @@ spec:
       region: us-east-1
   pullSecretRef:
     name: pull-secret
-  size: 0
+  size: 3
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-22-0-amd64-aws-us-east-2_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-22-0-amd64-aws-us-east-2_clusterpool.yaml
@@ -33,7 +33,7 @@ spec:
       region: us-east-2
   pullSecretRef:
     name: pull-secret
-  size: 0
+  size: 1
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-22-0-fips-amd64-aws-us-east-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-22-0-fips-amd64-aws-us-east-1_clusterpool.yaml
@@ -34,7 +34,7 @@ spec:
       region: us-east-1
   pullSecretRef:
     name: pull-secret
-  size: 0
+  size: 3
   skipMachinePools: true
 status:
   ready: 0


### PR DESCRIPTION
Reverts openshift/release#77731

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated cluster provisioning capacity configurations across multiple OpenShift versions (4.13–4.22).
  * Increased pool sizing parameters to improve resource availability and cluster provisioning capabilities.
  * Applied scaling updates across multiple deployment regions and configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->