### PR TITLE
NO-JIRA: Add chrony MachineConfig for PowerVC CI

### DIFF
--- a/ci-operator/step-registry/ipi/conf/powervc/ipi-conf-powervc-commands.sh
+++ b/ci-operator/step-registry/ipi/conf/powervc/ipi-conf-powervc-commands.sh
@@ -270,6 +270,52 @@ sshKey: |
   $(<"${CLUSTER_PROFILE_DIR}/ssh-publickey")
 EOF
 
+# Add the chrony config
+# setting it to clock.corp.redhat.com
+echo "Saving chrony worker yaml config..."
+cat > "${SHARED_DIR}/99-chrony-worker.yaml" << EOF
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 99-chrony-worker
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,c2VydmVyIGNsb2NrLmNvcnAucmVkaGF0LmNvbSBpYnVyc3QKZHJpZnRmaWxlIC92YXIvbGliL2Nocm9ueS9kcmlmdAptYWtlc3RlcCAxLjAgMwpydGNzeW5jCmxvZ2RpciAvdmFyL2xvZy9jaHJvbnkK
+        filesystem: root
+        mode: 0644
+        overwrite: true
+        path: /etc/chrony.conf
+EOF
+
+echo "Saving chrony master yaml config..."
+cat > "${SHARED_DIR}/99-chrony-master.yaml" << EOF
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: 99-chrony-master
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,c2VydmVyIGNsb2NrLmNvcnAucmVkaGF0LmNvbSBpYnVyc3QKZHJpZnRmaWxlIC92YXIvbGliL2Nocm9ueS9kcmlmdAptYWtlc3RlcCAxLjAgMwpydGNzeW5jCmxvZ2RpciAvdmFyL2xvZy9jaHJvbnkK
+        filesystem: root
+        mode: 420
+        overwrite: true
+        path: /etc/chrony.conf
+EOF
+
 echo "OPTIONAL_INSTALL_CONFIG_PARMS=\"${OPTIONAL_INSTALL_CONFIG_PARMS}\""
 read -ra PARAMETERS <<< "${OPTIONAL_INSTALL_CONFIG_PARMS}"
 echo "count = ${#PARAMETERS[*]}"

--- a/ci-operator/step-registry/ipi/deprovision/deprovision/powervc/ipi-deprovision-deprovision-powervc-chain.yaml
+++ b/ci-operator/step-registry/ipi/deprovision/deprovision/powervc/ipi-deprovision-deprovision-powervc-chain.yaml
@@ -1,7 +1,7 @@
 chain:
   as: ipi-deprovision-deprovision-powervc
   steps:
-  # - chain: gather-powervc
+  - chain: gather
   - ref: ipi-deprovision-deprovision-powervc-deprovision
   documentation: |-
     The IPI deprovision step chain contains all the individual steps necessary to gather and deprovision an OpenShift cluster.

--- a/ci-operator/step-registry/ipi/install/powervc/install/ipi-install-powervc-install-commands.sh
+++ b/ci-operator/step-registry/ipi/install/powervc/install/ipi-install-powervc-install-commands.sh
@@ -366,6 +366,20 @@ openshift-install --dir="${DIR}" create manifests
 
 sed -i '/^  channel:/d' "${DIR}/manifests/cvo-overrides.yaml"
 
+# Sets up the chrony machineconfig for the worker nodes
+CHRONY_WORKER_YAML="${SHARED_DIR}/99-chrony-worker.yaml"
+if [ -f "${CHRONY_WORKER_YAML}" ]; then
+  echo "Saving ${CHRONY_WORKER_YAML} to the install directory..."
+  cp "${CHRONY_WORKER_YAML}" "${DIR}/manifests"
+fi
+
+# Sets up the chrony machineconfig for the master nodes
+CHRONY_MASTER_YAML="${SHARED_DIR}/99-chrony-master.yaml"
+if [ -f "${CHRONY_MASTER_YAML}" ]; then
+  echo "Saving ${CHRONY_MASTER_YAML} to the install directory..."
+  cp "${CHRONY_MASTER_YAML}" "${DIR}/manifests"
+fi
+
 echo "Will include manifests:"
 find "${SHARED_DIR}" \( -name "manifest_*.yml" -o -name "manifest_*.yaml" \)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chrony time-sync support for PowerVC deployments: chrony configs are automatically provisioned for master and worker nodes.
  * When present, chrony configs are included in installer manifests so time-sync is applied during installation.
 

* **Chores**
  * Deprovision flow updated to run the gather step before deprovisioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->