### PR TITLE
DEBUG: Test WMCO 4.19.2 periodic jobs

### DIFF
--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.19__amd64-nightly-4.19-upgrade-from-stable-4.18.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.19__amd64-nightly-4.19-upgrade-from-stable-4.18.yaml
@@ -891,7 +891,7 @@ tests:
     test:
     - chain: openshift-upgrade-qe-test-canary
     workflow: cucushift-installer-rehearse-vsphere-upi-zones
-- as: aws-ipi-ovn-winc-f14
+- as: aws-ipi-ovn-winc-debug1-f14
   cron: 2 18 7,21 * *
   steps:
     cluster_profile: aws-qe

--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.19__amd64-nightly.yaml.bak
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.19__amd64-nightly.yaml.bak
@@ -2604,7 +2604,8 @@ tests:
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-azure-ipi-ovn-winc
-- as: vsphere-ipi-disconnected-ovn-winc-debug-f28
+<<<<<<< HEAD
+- as: vsphere-ipi-disconnected-ovn-winc-f28
   cron: 0 6 15 * *
   steps:
     cluster_profile: vsphere-dis-2
@@ -2618,7 +2619,10 @@ tests:
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-vsphere-ipi-disconnected-ovn-winc
-- as: vsphere-ipi-ovn-winc-debug-f14
+- as: vsphere-ipi-ovn-winc-f14
+=======
+- as: vsphere-ipi-ovn-winc-debug1-f14
+>>>>>>> 3df3c342cb5 (DEBUG: Test WMCO 4.19.2 periodic jobs)
   cron: 3 14 13,29 * *
   steps:
     cluster_profile: vsphere-connected-2
@@ -2629,7 +2633,7 @@ tests:
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-vsphere-ipi-ovn-winc
-- as: vsphere-ipi-proxy-ovn-winc-debug-f14
+- as: vsphere-ipi-proxy-ovn-winc-f14
   cron: 57 15 14 * *
   steps:
     cluster_profile: vsphere-connected-2

--- a/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.19-periodics.yaml
+++ b/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.19-periodics.yaml
@@ -1441,7 +1441,7 @@ periodics:
     ci-operator.openshift.io/variant: amd64-nightly-4.19-upgrade-from-stable-4.18
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-openshift-tests-private-release-4.19-amd64-nightly-4.19-upgrade-from-stable-4.18-aws-ipi-ovn-winc-f14
+  name: periodic-ci-openshift-openshift-tests-private-release-4.19-amd64-nightly-4.19-upgrade-from-stable-4.18-aws-ipi-ovn-winc-debug1-f14
   spec:
     containers:
     - args:
@@ -1451,7 +1451,7 @@ periodics:
       - --oauth-token-path=/usr/local/github-credentials/oauth
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=aws-ipi-ovn-winc-f14
+      - --target=aws-ipi-ovn-winc-debug1-f14
       - --variant=amd64-nightly-4.19-upgrade-from-stable-4.18
       command:
       - ci-operator
@@ -21505,7 +21505,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.19"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-openshift-tests-private-release-4.19-amd64-nightly-aws-ipi-ovn-winc-f14
+  name: periodic-ci-openshift-openshift-tests-private-release-4.19-amd64-nightly-aws-ipi-ovn-winc-debug1-f14
   spec:
     containers:
     - args:
@@ -21515,7 +21515,7 @@ periodics:
       - --oauth-token-path=/usr/local/github-credentials/oauth
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=aws-ipi-ovn-winc-f14
+      - --target=aws-ipi-ovn-winc-debug1-f14
       - --variant=amd64-nightly
       command:
       - ci-operator
@@ -27888,7 +27888,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.19"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-openshift-tests-private-release-4.19-amd64-nightly-azure-ipi-ovn-winc-f14
+  name: periodic-ci-openshift-openshift-tests-private-release-4.19-amd64-nightly-azure-ipi-ovn-winc-debug1-f14
   spec:
     containers:
     - args:
@@ -27898,7 +27898,7 @@ periodics:
       - --oauth-token-path=/usr/local/github-credentials/oauth
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=azure-ipi-ovn-winc-f14
+      - --target=azure-ipi-ovn-winc-debug1-f14
       - --variant=amd64-nightly
       command:
       - ci-operator
@@ -31244,7 +31244,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.19"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-openshift-tests-private-release-4.19-amd64-nightly-gcp-ipi-ovn-winc-f14
+  name: periodic-ci-openshift-openshift-tests-private-release-4.19-amd64-nightly-gcp-ipi-ovn-winc-debug1-f14
   spec:
     containers:
     - args:
@@ -31254,7 +31254,7 @@ periodics:
       - --oauth-token-path=/usr/local/github-credentials/oauth
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=gcp-ipi-ovn-winc-f14
+      - --target=gcp-ipi-ovn-winc-debug1-f14
       - --variant=amd64-nightly
       command:
       - ci-operator
@@ -39581,7 +39581,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.19"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-openshift-tests-private-release-4.19-amd64-nightly-nutanix-ipi-ovn-winc-f14
+  name: periodic-ci-openshift-openshift-tests-private-release-4.19-amd64-nightly-nutanix-ipi-ovn-winc-debug1-f14
   spec:
     containers:
     - args:
@@ -39591,7 +39591,7 @@ periodics:
       - --oauth-token-path=/usr/local/github-credentials/oauth
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=nutanix-ipi-ovn-winc-f14
+      - --target=nutanix-ipi-ovn-winc-debug1-f14
       - --variant=amd64-nightly
       command:
       - ci-operator
@@ -41901,7 +41901,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.19"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-openshift-tests-private-release-4.19-amd64-nightly-vsphere-ipi-disconnected-ovn-winc-f28
+  name: periodic-ci-openshift-openshift-tests-private-release-4.19-amd64-nightly-vsphere-ipi-disconnected-ovn-winc-debug-f28
   spec:
     containers:
     - args:
@@ -41911,7 +41911,7 @@ periodics:
       - --oauth-token-path=/usr/local/github-credentials/oauth
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=vsphere-ipi-disconnected-ovn-winc-f28
+      - --target=vsphere-ipi-disconnected-ovn-winc-debug-f28
       - --variant=amd64-nightly
       command:
       - ci-operator
@@ -44464,7 +44464,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.19"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-openshift-tests-private-release-4.19-amd64-nightly-vsphere-ipi-ovn-winc-f14
+  name: periodic-ci-openshift-openshift-tests-private-release-4.19-amd64-nightly-vsphere-ipi-ovn-winc-debug-f14
   spec:
     containers:
     - args:
@@ -44474,7 +44474,7 @@ periodics:
       - --oauth-token-path=/usr/local/github-credentials/oauth
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=vsphere-ipi-ovn-winc-f14
+      - --target=vsphere-ipi-ovn-winc-debug-f14
       - --variant=amd64-nightly
       command:
       - ci-operator
@@ -44835,6 +44835,96 @@ periodics:
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
       - --target=vsphere-ipi-proxy-fips-regen-cert-f14
+      - --variant=amd64-nightly
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /usr/local/github-credentials
+        name: github-credentials-openshift-ci-robot-private-git-cloner
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: github-credentials-openshift-ci-robot-private-git-cloner
+      secret:
+        secretName: github-credentials-openshift-ci-robot-private-git-cloner
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: vsphere02
+  cron: 57 15 14 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: release-4.19
+    org: openshift
+    repo: openshift-tests-private
+  labels:
+    ci-operator.openshift.io/cloud: vsphere
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-connected-2
+    ci-operator.openshift.io/variant: amd64-nightly
+    ci.openshift.io/generator: prowgen
+    job-release: "4.19"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-openshift-tests-private-release-4.19-amd64-nightly-vsphere-ipi-proxy-ovn-winc-debug-f14
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --oauth-token-path=/usr/local/github-credentials/oauth
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=vsphere-ipi-proxy-ovn-winc-debug-f14
       - --variant=amd64-nightly
       command:
       - ci-operator


### PR DESCRIPTION
Testing WMCO 4.19.2 with all available 4.19 WINC periodic jobs.

All 7 WINC periodic jobs renamed with -debug suffix to trigger rehearsal:
- periodic-ci-openshift-openshift-tests-private-release-4.19-amd64-nightly-aws-ipi-ovn-winc-debug-f14
- periodic-ci-openshift-openshift-tests-private-release-4.19-amd64-nightly-azure-ipi-ovn-winc-debug-f14
- periodic-ci-openshift-openshift-tests-private-release-4.19-amd64-nightly-gcp-ipi-ovn-winc-debug-f14
- periodic-ci-openshift-openshift-tests-private-release-4.19-amd64-nightly-vsphere-ipi-ovn-winc-debug-f14
- periodic-ci-openshift-openshift-tests-private-release-4.19-amd64-nightly-vsphere-ipi-proxy-ovn-winc-debug-f14 (newly added)
- periodic-ci-openshift-openshift-tests-private-release-4.19-amd64-nightly-nutanix-ipi-ovn-winc-debug-f14
- periodic-ci-openshift-openshift-tests-private-release-4.19-amd64-nightly-4.19-upgrade-from-stable-4.18-aws-ipi-ovn-winc-debug-f14

Triggered via: /pj-rehearse (auto-detects all affected jobs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Converted Windows container installation tests to debug variants across AWS, Azure, GCP, Nutanix and vSphere.
  * Added a new vSphere proxy-based Windows container installation test.
  * Updated periodic test job definitions to match the renamed debug test configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->