### PR TITLE
Enable assign plugin for openshift-eng/cyborg

### DIFF
--- a/core-services/prow/02_config/openshift-eng/cyborg/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-eng/cyborg/_pluginconfig.yaml
@@ -19,6 +19,7 @@ plugins:
   openshift-eng/cyborg:
     plugins:
     - approve
+    - assign
     - blunderbuss
     - hold
     - label


### PR DESCRIPTION
## Summary
- Re-enables the `assign` Prow plugin for `openshift-eng/cyborg`
- Without it, `/cc` and `/assign` commands do not work on the repository

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal plugin configuration for automated workflow processing.

**Note:** This release contains infrastructure updates with no direct impact on end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->