### PR TITLE
Allow dgemoli to generate api keys for ArgoCD

### DIFF
--- a/clusters/core-ci/argocd/openshift-gitops_argocd.yaml
+++ b/clusters/core-ci/argocd/openshift-gitops_argocd.yaml
@@ -34,6 +34,7 @@ spec:
       replicas: 15
   extraConfig:
     resource.sensitive.mask.annotations: openshift.io/token-secret.value, api-key, token
+    accounts.dgemoli: "login, apiKey"
   grafana:
     enabled: false
     ingress:


### PR DESCRIPTION
Sometimes it might be more convenient using the `argocd` cli and, in order to generate a token, the `apiKey` capability is required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended ArgoCD configuration to support additional account authentication methods, enabling login and API key credential access for enhanced access management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->