### PR TITLE
OCPKUEUE-613 - Create presubmits for test-e2e-dra-gpu-4-21

### DIFF
--- a/ci-operator/config/openshift/kueue-operator/openshift-kueue-operator-main.yaml
+++ b/ci-operator/config/openshift/kueue-operator/openshift-kueue-operator-main.yaml
@@ -469,8 +469,11 @@ tests:
           cpu: 300m
           memory: 500Mi
     workflow: cucushift-installer-rehearse-gcp-ipi-disconnected
-- as: test-e2e-dra-gpu-4-21
+- always_run: false
+  as: test-e2e-dra-gpu-4-21
   cron: '@daily'
+  optional: true
+  presubmit: true
   steps:
     cluster_profile: openshift-org-aws
     dependencies:

--- a/ci-operator/jobs/openshift/kueue-operator/openshift-kueue-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/kueue-operator/openshift-kueue-operator-main-presubmits.yaml
@@ -802,6 +802,87 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )(test-e2e-downstream-4-21-disruptive|remaining-required),?($|\s.*)
   - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build09
+    context: ci/prow/test-e2e-dra-gpu-4-21
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-kueue-operator-main-test-e2e-dra-gpu-4-21
+    optional: true
+    rerun_command: /test test-e2e-dra-gpu-4-21
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=test-e2e-dra-gpu-4-21
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )test-e2e-dra-gpu-4-21,?($|\s.*)
+  - agent: kubernetes
     always_run: true
     branches:
     - ^main$


### PR DESCRIPTION
Update COMPUTE_NODE_REPLICAS to 2 for kueue-operator DRA GPU e2e test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an optional presubmit job for the GPU end-to-end test and broadened trigger patterns to allow alternate test invocations.
* **Chores**
  * Updated the GPU E2E workflow metadata to be optional/presubmit and disabled unconditional (always-run) execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->