### PR TITLE
ci: konflux DisasterRecovery on selected changes

### DIFF
--- a/ci-operator/config/redhat-appstudio/infra-deployments/redhat-appstudio-infra-deployments-main.yaml
+++ b/ci-operator/config/redhat-appstudio/infra-deployments/redhat-appstudio-infra-deployments-main.yaml
@@ -129,7 +129,7 @@ tests:
     timeout: 3h0m0s
     version: "4.17"
   optional: true
-  skip_if_only_changed: ^docs/|^\.github/|^\.tekton/|^infra-tools/|^openspec/|^argo-cd-apps/.*/(.*production|staging)|^components/(authentication|hac-pact-broker|konflux-ci|quality-dashboard|sandbox|smee|sprayproxy|tekton-ci|.*/(production|staging|production-downstream|staging-downstream))/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE|_config\.yml|staging-app\.yaml|index\.html)$
+  run_if_changed: ^components/disaster-recovery/.*
   steps:
     test:
     - ref: redhat-appstudio-konflux-disaster-recovery

--- a/ci-operator/jobs/redhat-appstudio/infra-deployments/redhat-appstudio-infra-deployments-main-presubmits.yaml
+++ b/ci-operator/jobs/redhat-appstudio/infra-deployments/redhat-appstudio-infra-deployments-main-presubmits.yaml
@@ -192,7 +192,7 @@ presubmits:
     name: pull-ci-redhat-appstudio-infra-deployments-main-appstudio-konflux-disaster-recovery
     optional: true
     rerun_command: /test appstudio-konflux-disaster-recovery
-    skip_if_only_changed: ^docs/|^\.github/|^\.tekton/|^infra-tools/|^openspec/|^argo-cd-apps/.*/(.*production|staging)|^components/(authentication|hac-pact-broker|konflux-ci|quality-dashboard|sandbox|smee|sprayproxy|tekton-ci|.*/(production|staging|production-downstream|staging-downstream))/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE|_config\.yml|staging-app\.yaml|index\.html)$
+    run_if_changed: ^components/disaster-recovery/.*
     spec:
       containers:
       - args:


### PR DESCRIPTION
We want to temporarily run the DisasterRecovery Job only when a change to the disaster-recovery component folder is proposed in the PR.

Signed-off-by: Francesco Ilario <filario@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI job trigger behavior so the disaster-recovery test now runs only when files under the disaster-recovery component are modified.
  * This reduces unnecessary test executions and improves CI pipeline efficiency by ensuring the job triggers only for relevant changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->