### PR TITLE
TRT-2635: Enable prototype `boxship` external plugin for origin and sippy

### DIFF
--- a/core-services/prow/02_config/openshift/origin/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/origin/_pluginconfig.yaml
@@ -1,3 +1,11 @@
+external_plugins:
+  openshift/origin:
+  - endpoint: http://muller-boxship
+    events:
+    - pull_request
+    - pull_request_review
+    - issue_comment
+    name: muller-boxship
 label:
   restricted_labels:
     openshift/origin:

--- a/core-services/prow/02_config/openshift/sippy/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/sippy/_pluginconfig.yaml
@@ -4,6 +4,14 @@ approve:
   lgtm_acts_as_approve: true
   repos:
   - openshift/sippy
+external_plugins:
+  openshift/sippy:
+  - endpoint: http://muller-boxship
+    events:
+    - pull_request
+    - pull_request_review
+    - issue_comment
+    name: muller-boxship
 lgtm:
 - repos:
   - openshift/sippy


### PR DESCRIPTION
Let Hook pass webhooks to an experimental deployment of https://github.com/petr-muller/boxship

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Integrated a new external plugin (`muller-boxship`) into CI/CD configuration for processing pull requests, pull request reviews, and issue comments across multiple project repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->