### PR TITLE
CMP-4271: Update file-integrity-operator build_root to golang 1.25

### DIFF
--- a/ci-operator/config/openshift/file-integrity-operator/openshift-file-integrity-operator-master.yaml
+++ b/ci-operator/config/openshift/file-integrity-operator/openshift-file-integrity-operator-master.yaml
@@ -13,9 +13,9 @@ base_images:
     tag: release
 build_root:
   image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-9-release-golang-1.22-openshift-4.17
+    name: builder
+    namespace: ocp
+    tag: rhel-9-golang-1.25-openshift-4.22
 images:
   items:
   - dockerfile_path: Dockerfile.ci


### PR DESCRIPTION
## Summary
- Bump `build_root` to `ocp/builder:rhel-9-golang-1.25-openshift-4.22` to match the in-repo [Dockerfile.ci bump](https://github.com/openshift/file-integrity-operator/commit/bb7df7b93) and the FIO go.mod update to Go 1.25.8.
- Follows the same pattern as the compliance-operator bump in #72371 / #72421, pulling in a newer go that addresses CVEs in the go standard library.

## Test plan
- [ ] Prow presubmits on this PR pass with the new 1.25 builder image
- [ ] `images/file-integrity-operator` build succeeds against the new base

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure configuration to use a newer build environment and toolchain version, improving build compatibility and support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->