### PR TITLE
ci: Pin older OVN-Kubernetes branches to version-matched CNV nightly

### DIFF
--- a/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.17.yaml
+++ b/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.17.yaml
@@ -555,7 +555,7 @@ tests:
   steps:
     cluster_profile: openshift-org-aws
     env:
-      CNV_PRERELEASE_LATEST_CHANNEL: "true"
+      CNV_PRERELEASE_LATEST_CHANNEL: "false"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: c5n.metal
       FEATURE_SET: TechPreviewNoUpgrade

--- a/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.19.yaml
+++ b/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.19.yaml
@@ -521,7 +521,7 @@ tests:
   steps:
     cluster_profile: openshift-org-aws
     env:
-      CNV_PRERELEASE_LATEST_CHANNEL: "true"
+      CNV_PRERELEASE_LATEST_CHANNEL: "false"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: c5n.metal
       EXTRA_MG_ARGS: --host-network

--- a/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.20.yaml
+++ b/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.20.yaml
@@ -525,7 +525,7 @@ tests:
   steps:
     cluster_profile: equinix-ocp-metal
     env:
-      CNV_PRERELEASE_LATEST_CHANNEL: "true"
+      CNV_PRERELEASE_LATEST_CHANNEL: "false"
     workflow: baremetalds-e2e-ovn-bgp-virt-dualstack
 - always_run: false
   as: e2e-metal-ipi-ovn-bgp-virt-dualstack-techpreview
@@ -535,7 +535,7 @@ tests:
   steps:
     cluster_profile: equinix-ocp-metal
     env:
-      CNV_PRERELEASE_LATEST_CHANNEL: "true"
+      CNV_PRERELEASE_LATEST_CHANNEL: "false"
       FEATURE_SET: TechPreviewNoUpgrade
     workflow: baremetalds-e2e-ovn-bgp-virt-dualstack
 - always_run: false

--- a/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.21.yaml
+++ b/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.21.yaml
@@ -554,7 +554,7 @@ tests:
   steps:
     cluster_profile: equinix-ocp-metal
     env:
-      CNV_PRERELEASE_LATEST_CHANNEL: "true"
+      CNV_PRERELEASE_LATEST_CHANNEL: "false"
     workflow: baremetalds-e2e-ovn-bgp-virt-dualstack
 - always_run: false
   as: e2e-metal-ipi-ovn-bgp-virt-dualstack-techpreview
@@ -565,7 +565,7 @@ tests:
   steps:
     cluster_profile: equinix-ocp-metal
     env:
-      CNV_PRERELEASE_LATEST_CHANNEL: "true"
+      CNV_PRERELEASE_LATEST_CHANNEL: "false"
       FEATURE_SET: TechPreviewNoUpgrade
     workflow: baremetalds-e2e-ovn-bgp-virt-dualstack
 - always_run: false

--- a/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.22.yaml
+++ b/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.22.yaml
@@ -599,7 +599,7 @@ tests:
   steps:
     cluster_profile: equinix-ocp-metal
     env:
-      CNV_PRERELEASE_LATEST_CHANNEL: "true"
+      CNV_PRERELEASE_LATEST_CHANNEL: "false"
     workflow: baremetalds-e2e-ovn-bgp-virt-dualstack
 - always_run: false
   as: e2e-metal-ipi-ovn-bgp-virt-dualstack-techpreview
@@ -609,7 +609,7 @@ tests:
   steps:
     cluster_profile: equinix-ocp-metal
     env:
-      CNV_PRERELEASE_LATEST_CHANNEL: "true"
+      CNV_PRERELEASE_LATEST_CHANNEL: "false"
       FEATURE_SET: TechPreviewNoUpgrade
     workflow: baremetalds-e2e-ovn-bgp-virt-dualstack
 - always_run: false

--- a/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.22__periodics.yaml
+++ b/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.22__periodics.yaml
@@ -78,7 +78,7 @@ tests:
   steps:
     cluster_profile: equinix-ocp-metal
     env:
-      CNV_PRERELEASE_LATEST_CHANNEL: "true"
+      CNV_PRERELEASE_LATEST_CHANNEL: "false"
     workflow: baremetalds-e2e-ovn-bgp-virt-dualstack
 - as: e2e-metal-ipi-ovn-bgp-virt-dualstack-techpreview
   capabilities:
@@ -87,7 +87,7 @@ tests:
   steps:
     cluster_profile: equinix-ocp-metal
     env:
-      CNV_PRERELEASE_LATEST_CHANNEL: "true"
+      CNV_PRERELEASE_LATEST_CHANNEL: "false"
       FEATURE_SET: TechPreviewNoUpgrade
     workflow: baremetalds-e2e-ovn-bgp-virt-dualstack
 - as: e2e-metal-ipi-ovn-bgp-virt-ipv4-techpreview
@@ -97,7 +97,7 @@ tests:
   steps:
     cluster_profile: equinix-ocp-metal
     env:
-      CNV_PRERELEASE_LATEST_CHANNEL: "true"
+      CNV_PRERELEASE_LATEST_CHANNEL: "false"
       FEATURE_SET: TechPreviewNoUpgrade
     workflow: baremetalds-e2e-ovn-bgp-virt-ipv4
 - as: e2e-metal-ipi-ovn-bgp-virt-ipv4
@@ -107,7 +107,7 @@ tests:
   steps:
     cluster_profile: equinix-ocp-metal
     env:
-      CNV_PRERELEASE_LATEST_CHANNEL: "true"
+      CNV_PRERELEASE_LATEST_CHANNEL: "false"
     workflow: baremetalds-e2e-ovn-bgp-virt-ipv4
 zz_generated_metadata:
   branch: release-4.22


### PR DESCRIPTION
Set CNV_PRERELEASE_LATEST_CHANNEL to false for release-4.17 through release-4.22 branches. This causes the kubevirt-install step to use version-matched CNV nightly (e.g. nightly-4.22 for OCP 4.22) instead of the bleeding-edge nightly-4.99.

CNV nightly-4.99 recently picked up QEMU from RHEL 9.8 which introduces the pc-q35-rhel9.8.0 machine type as the default. This machine type is not available on older OCP release nodes, causing virt-launcher pods to fail scheduling with:

  0/6 nodes are available: 6 node(s) didn't match Pod's node
  affinity/selector

The mismatch occurs because the CNV CSV sets the default machine type to pc-q35-rhel9.8.0, but the node's QEMU only supports up to pc-q35-rhel9.6.0, so the required node label
machine-type.node.kubevirt.io/pc-q35-rhel9.8.0 is never created.

Branches main, release-4.23, release-5.0, and release-5.1 continue to use nightly-4.99 as they track OCP versions compatible with the latest CNV builds.

Generated-by: OpenClaw 2026.4.15
AI-model: claude-opus-4.6 (Anthropic)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration test configuration for virtualization compatibility scenarios across multiple OpenShift release branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->