### PR TITLE
OTA-1979: Revert "ci-operator/config/openshift/cluster-version-operator: Build cluster-update-lightspeed-skills

### DIFF
--- a/ci-operator/config/openshift/cluster-version-operator/openshift-cluster-version-operator-main.yaml
+++ b/ci-operator/config/openshift/cluster-version-operator/openshift-cluster-version-operator-main.yaml
@@ -25,9 +25,6 @@ images:
   items:
   - dockerfile_path: Dockerfile.rhel
     to: cluster-version-operator
-  - context_dir: lightspeed
-    dockerfile_path: Containerfile.skills
-    to: cluster-update-lightspeed-skills
 promotion:
   to:
   - name: "5.0"


### PR DESCRIPTION
This reverts commit 74f03b181bc867f7a4bf952aa04cb2e2498c669e, #77811.

I'd initially thought we would use per-component skills images, so the skills could be maintained alongside the component they helped operate.  However, Mrunal suggested a consolidated, OCP-scoped skills image for easier mounting into agents, and now we have [openshift/agentic-skills][1] (which already includes the placeholder `update-advisor` I'd started over here).

[1]: https://github.com/openshift/agentic-skills

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unused build image target from the continuous integration pipeline configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->