### PR TITLE
Tag image as latest on postsubmit push

### DIFF
--- a/ci-operator/step-registry/rosa-regional-platform/image-push/rosa-regional-platform-image-push-commands.sh
+++ b/ci-operator/step-registry/rosa-regional-platform/image-push/rosa-regional-platform-image-push-commands.sh
@@ -34,5 +34,11 @@ echo "  Destination: ${DEST}"
 
 oc image mirror "${CI_COMPONENT_IMAGE}" "${DEST}"
 
+if [[ -z "${PULL_NUMBER:-}" ]]; then
+  LATEST="${ROSA_REGIONAL_QUAY_DEST_REPO}:latest"
+  echo "Postsubmit: also tagging as ${LATEST}"
+  oc image mirror "${CI_COMPONENT_IMAGE}" "${LATEST}"
+fi
+
 echo "${DEST}" > "${SHARED_DIR}/component-image-override"
 echo "Image pushed successfully: ${DEST}"


### PR DESCRIPTION
## Summary
- Update `rosa-regional-platform-image-push` step to also tag the image as `:latest` on postsubmit runs (when `PULL_NUMBER` is unset)
- Consumers can reference a stable `latest` tag instead of build-specific tags

## Test plan
- [ ] Verify presubmit pushes still use `ci-<PR>-<BUILD_ID>` tag only
- [ ] Verify postsubmit pushes tag both `ci-0-<BUILD_ID>` and `latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ROSA regional platform image deployment now automatically tags and mirrors images as "latest" for production builds, enabling faster availability for production deployment scenarios while maintaining complete backward compatibility with all existing pull request validation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->