### PR TITLE
fix: review-agent push failures after rebase

### DIFF
--- a/ci-operator/step-registry/hypershift/review-agent/process/hypershift-review-agent-process-commands.sh
+++ b/ci-operator/step-registry/hypershift/review-agent/process/hypershift-review-agent-process-commands.sh
@@ -829,7 +829,7 @@ ${SUBAGENT_PROMPT}"
     # the CI job while it is still posting review replies.
     if ! git diff --quiet HEAD "origin/$BRANCH_NAME" 2>/dev/null; then
       echo "Pushing code changes for PR #$PR_NUMBER..."
-      git push origin "$BRANCH_NAME"
+      git push --force-with-lease origin "$BRANCH_NAME"
       echo "Push completed for PR #$PR_NUMBER"
     else
       echo "No code changes to push for PR #$PR_NUMBER"


### PR DESCRIPTION
## Summary

The review-agent's post-Claude push uses `git push` without `--force`, which fails when the address-reviews skill rebases the PR branch onto `upstream/main`.

Changed to `git push --force-with-lease` to safely handle rebased branches.

## Example failure

[periodic-ci-openshift-hypershift-main-periodic-review-agent/2046589976090513408](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-hypershift-main-periodic-review-agent/2046589976090513408)

The job processed PR #7810 (`fix-CNTRLPLANE-2800`). The address-reviews skill rebased the branch onto `upstream/main`, causing the local and remote branches to diverge ([process step build-log.txt](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-hypershift-main-periodic-review-agent/2046589976090513408/artifacts/periodic-review-agent/hypershift-review-agent-process/build-log.txt)):

```
On branch fix-CNTRLPLANE-2800
Your branch and 'origin/fix-CNTRLPLANE-2800' have diverged,
and have 10 and 8 different commits each, respectively.
```

The script then attempted a regular push, which was rejected ([process step build-log.txt](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-hypershift-main-periodic-review-agent/2046589976090513408/artifacts/periodic-review-agent/hypershift-review-agent-process/build-log.txt)):

```
Pushing code changes for PR #7810...
To https://github.com/hypershift-community/hypershift
 ! [rejected]            fix-CNTRLPLANE-2800 -> fix-CNTRLPLANE-2800 (stale info)
error: failed to push some refs to 'https://github.com/hypershift-community/hypershift'
```

This caused the process step to exit 1, failing the entire job ([junit_operator.xml](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-hypershift-main-periodic-review-agent/2046589976090513408/artifacts/junit_operator.xml)).

## Why `--force-with-lease`

- A rebase rewrites commit history, so a regular push is always rejected (non-fast-forward)
- `--force-with-lease` will refuse to push if the remote was updated by someone else since the last fetch, preventing accidental overwrites
- The branches are on the bot's fork (`hypershift-community/hypershift`), not `openshift/hypershift`

🤖 Generated with [Claude Code](https://claude.com/claude-code)