### PR TITLE
Add extended resources to the DRA test

### DIFF
--- a/ci-operator/config/openshift/kueue-operator/openshift-kueue-operator-main.yaml
+++ b/ci-operator/config/openshift/kueue-operator/openshift-kueue-operator-main.yaml
@@ -521,7 +521,7 @@ tests:
     env:
       BUNDLE_COMPONENT: kueue-bundle-main
       COMPUTE_NODE_REPLICAS: "1"
-      COMPUTE_NODE_TYPE: g4dn.xlarge
+      COMPUTE_NODE_TYPE: g4dn.12xlarge
       NVIDIA_DRA_DRIVER_VERSION: 25.12.0
       OPERAND_COMPONENT: kueue-operand-main
       OPERATOR_COMPONENT: kueue-operator-main

--- a/ci-operator/step-registry/kueue-operator/test/e2e/dra/disable-device-plugin/OWNERS
+++ b/ci-operator/step-registry/kueue-operator/test/e2e/dra/disable-device-plugin/OWNERS
@@ -1,0 +1,15 @@
+approvers:
+- PannagaRao
+- cpmeadors
+- kannon92
+- mrunalp
+- rphillips
+- sohankunkerkar
+
+reviewers:
+- PannagaRao
+- cpmeadors
+- kannon92
+- mrunalp
+- rphillips
+- sohankunkerkar

--- a/ci-operator/step-registry/kueue-operator/test/e2e/dra/disable-device-plugin/kueue-operator-test-e2e-dra-disable-device-plugin-commands.sh
+++ b/ci-operator/step-registry/kueue-operator/test/e2e/dra/disable-device-plugin/kueue-operator-test-e2e-dra-disable-device-plugin-commands.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -o nounset
+set -o errexit
+set -o pipefail
+
+echo "========================================="
+echo "Disabling NVIDIA device plugin"
+echo "========================================="
+echo ""
+
+export KUBECONFIG="${SHARED_DIR}/kubeconfig"
+
+echo "Patching ClusterPolicy to disable device plugin..."
+oc patch clusterpolicy gpu-cluster-policy --type=merge -p '{"spec":{"devicePlugin":{"enabled":false}}}'
+
+echo "Waiting for ClusterPolicy to be ready..."
+oc wait clusterpolicy --all --for=condition=Ready --timeout=10m
+
+echo ""
+echo "Device plugin disabled"
+echo ""

--- a/ci-operator/step-registry/kueue-operator/test/e2e/dra/disable-device-plugin/kueue-operator-test-e2e-dra-disable-device-plugin-ref.metadata.json
+++ b/ci-operator/step-registry/kueue-operator/test/e2e/dra/disable-device-plugin/kueue-operator-test-e2e-dra-disable-device-plugin-ref.metadata.json
@@ -1,0 +1,21 @@
+{
+	"path": "kueue-operator/test/e2e/dra/disable-device-plugin/kueue-operator-test-e2e-dra-disable-device-plugin-ref.yaml",
+	"owners": {
+		"approvers": [
+			"PannagaRao",
+			"cpmeadors",
+			"kannon92",
+			"mrunalp",
+			"rphillips",
+			"sohankunkerkar"
+		],
+		"reviewers": [
+			"PannagaRao",
+			"cpmeadors",
+			"kannon92",
+			"mrunalp",
+			"rphillips",
+			"sohankunkerkar"
+		]
+	}
+}

--- a/ci-operator/step-registry/kueue-operator/test/e2e/dra/disable-device-plugin/kueue-operator-test-e2e-dra-disable-device-plugin-ref.yaml
+++ b/ci-operator/step-registry/kueue-operator/test/e2e/dra/disable-device-plugin/kueue-operator-test-e2e-dra-disable-device-plugin-ref.yaml
@@ -1,0 +1,14 @@
+ref:
+  as: kueue-operator-test-e2e-dra-disable-device-plugin
+  from: cli
+  cli: latest
+  commands: kueue-operator-test-e2e-dra-disable-device-plugin-commands.sh
+  resources:
+    requests:
+      cpu: 100m
+      memory: 200Mi
+  documentation: |-
+    Disables the NVIDIA device plugin in the GPU Operator ClusterPolicy.
+    This ensures the kube-scheduler uses the DRA path for GPU allocation
+    instead of the device plugin path, which is required for
+    ExtendedResourceClaimStatus to be populated.

--- a/ci-operator/step-registry/kueue-operator/test/e2e/dra/kueue-operator-test-e2e-dra-chain.yaml
+++ b/ci-operator/step-registry/kueue-operator/test/e2e/dra/kueue-operator-test-e2e-dra-chain.yaml
@@ -1,20 +1,11 @@
 chain:
   as: kueue-operator-test-e2e-dra
   steps:
-  - as: enable-dra-feature-gate
-    cli: latest
-    from: cli
-    commands: |
-      oc patch featuregates cluster --type='merge' -p '{"spec":{"featureSet":"CustomNoUpgrade","customNoUpgrade":{"enabled":["DynamicResourceAllocation"]}}}'
-      oc wait co kube-apiserver --for='condition=Progressing=True' --timeout=5m || true
-      oc wait co kube-apiserver --for='condition=Progressing=False' --timeout=30m
-    resources:
-      requests:
-        cpu: 100m
-        memory: 200Mi
+  - ref: kueue-operator-test-e2e-dra-enable-feature-gate
   - ref: kueue-operator-image-env-setup
   - ref: nvidia-nfd-operator-install
   - ref: nvidia-gpu-operator-install
+  - ref: kueue-operator-test-e2e-dra-disable-device-plugin
   - ref: nvidia-dra-driver-install
   - ref: cert-manager-install-operator
   - as: run-sdk


### PR DESCRIPTION
Signed-off-by: Pannaga Rao Bhoja Ramamanohara

Summary:

- Upgrade instance to g4dn.12xlarge (4 GPUs) to support multi-GPU extended resources tests                                                                                                                        
- Add disable-device-plugin ref — disables the NVIDIA device plugin after GPU operator install so the kube-scheduler uses the DRA path for nvidia.com/gpu requests. Without this, the scheduler allocates GPUs via the device plugin and ExtendedResourceClaimStatus is never populated.                                                                                                                                            
- Add enable-feature-gate ref — enables the DRAExtendedResource OCP feature gate (alpha in K8s 1.34) and waits for kube-apiserver rollout                                                                         
- Replace inline chain steps with reusable refs — kueue-operator-test-e2e-dra-enable-feature-gate and kueue-operator-test-e2e-dra-disable-device-plugin


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI test infrastructure for DRA GPU testing with improved compute resources.
  * Updated end-to-end test configuration to enable advanced feature validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->