### PR TITLE
CNTRLPLANE-1349: improve Azure self-managed e2e reliability

### DIFF
--- a/ci-operator/step-registry/hypershift/azure/e2e/self-managed/hypershift-azure-e2e-self-managed-workflow.yaml
+++ b/ci-operator/step-registry/hypershift/azure/e2e/self-managed/hypershift-azure-e2e-self-managed-workflow.yaml
@@ -36,3 +36,4 @@ workflow:
       AZURE_SELF_MANAGED: "true"
       HYPERSHIFT_EXTERNAL_DNS_DOMAIN: "aks-e2e.hypershift.azure.devcluster.openshift.com"
       HYPERSHIFT_AZURE_ZONES: "1,2,3"
+      HYPERSHIFT_ETCD_STORAGE_CLASS: "managed-csi-premium"

--- a/ci-operator/step-registry/hypershift/azure/e2e/self-managed/hypershift-azure-e2e-self-managed-workflow.yaml
+++ b/ci-operator/step-registry/hypershift/azure/e2e/self-managed/hypershift-azure-e2e-self-managed-workflow.yaml
@@ -35,3 +35,4 @@ workflow:
       HYPERSHIFT_AZURE_LOCATION: "centralus"
       AZURE_SELF_MANAGED: "true"
       HYPERSHIFT_EXTERNAL_DNS_DOMAIN: "aks-e2e.hypershift.azure.devcluster.openshift.com"
+      HYPERSHIFT_AZURE_ZONES: "1,2,3"

--- a/ci-operator/step-registry/hypershift/azure/e2e/self-managed/hypershift-azure-e2e-self-managed-workflow.yaml
+++ b/ci-operator/step-registry/hypershift/azure/e2e/self-managed/hypershift-azure-e2e-self-managed-workflow.yaml
@@ -36,4 +36,4 @@ workflow:
       AZURE_SELF_MANAGED: "true"
       HYPERSHIFT_EXTERNAL_DNS_DOMAIN: "aks-e2e.hypershift.azure.devcluster.openshift.com"
       HYPERSHIFT_AZURE_ZONES: "1,2,3"
-      HYPERSHIFT_ETCD_STORAGE_CLASS: "managed-csi-premium"
+      HYPERSHIFT_ETCD_STORAGE_CLASS: "managed-csi-premium-v2"

--- a/ci-operator/step-registry/hypershift/azure/e2e/self-managed/hypershift-azure-e2e-self-managed-workflow.yaml
+++ b/ci-operator/step-registry/hypershift/azure/e2e/self-managed/hypershift-azure-e2e-self-managed-workflow.yaml
@@ -31,7 +31,7 @@ workflow:
     - ref: hypershift-install
     env:
       CLOUD_PROVIDER: "Azure"
-      HYPERSHIFT_NODE_COUNT: "3"
+      HYPERSHIFT_NODE_COUNT: "6"
       HYPERSHIFT_AZURE_LOCATION: "centralus"
       AZURE_SELF_MANAGED: "true"
       HYPERSHIFT_EXTERNAL_DNS_DOMAIN: "aks-e2e.hypershift.azure.devcluster.openshift.com"

--- a/ci-operator/step-registry/hypershift/azure/e2e/self-managed/hypershift-azure-e2e-self-managed-workflow.yaml
+++ b/ci-operator/step-registry/hypershift/azure/e2e/self-managed/hypershift-azure-e2e-self-managed-workflow.yaml
@@ -35,5 +35,4 @@ workflow:
       HYPERSHIFT_AZURE_LOCATION: "centralus"
       AZURE_SELF_MANAGED: "true"
       HYPERSHIFT_EXTERNAL_DNS_DOMAIN: "aks-e2e.hypershift.azure.devcluster.openshift.com"
-      HYPERSHIFT_AZURE_ZONES: "1,2,3"
       HYPERSHIFT_ETCD_STORAGE_CLASS: "managed-csi-premium-v2"

--- a/ci-operator/step-registry/hypershift/azure/run-e2e-self-managed/hypershift-azure-run-e2e-self-managed-commands.sh
+++ b/ci-operator/step-registry/hypershift/azure/run-e2e-self-managed/hypershift-azure-run-e2e-self-managed-commands.sh
@@ -51,6 +51,11 @@ if [[ "${HYPERSHIFT_AZURE_ZONES:-}" != "" ]]; then
   ZONES_ARGS="--e2e.availability-zones=${HYPERSHIFT_AZURE_ZONES}"
 fi
 
+ETCD_STORAGE_CLASS_ARGS=""
+if [[ "${HYPERSHIFT_ETCD_STORAGE_CLASS:-}" != "" ]]; then
+  ETCD_STORAGE_CLASS_ARGS="--e2e.etcd-storage-class=${HYPERSHIFT_ETCD_STORAGE_CLASS}"
+fi
+
 # Azure private platform args - pass credentials and resource group to the e2e test framework
 # so the HO upgrade test can reinstall with private platform support.
 # Values can come from env vars or from SHARED_DIR files written by the
@@ -92,6 +97,7 @@ hack/ci-test-e2e.sh -test.v \
     ${N2_NP_VERSION_TEST_ARGS:-} \
     ${EXTERNAL_DNS_ARGS:-} \
     ${ZONES_ARGS:-} \
+    ${ETCD_STORAGE_CLASS_ARGS:-} \
     ${AZURE_PRIVATE_ARGS:-} \
   --e2e.latest-release-image="${OCP_IMAGE_LATEST}" \
   --e2e.previous-release-image="${OCP_IMAGE_PREVIOUS}" &

--- a/ci-operator/step-registry/hypershift/azure/run-e2e-self-managed/hypershift-azure-run-e2e-self-managed-commands.sh
+++ b/ci-operator/step-registry/hypershift/azure/run-e2e-self-managed/hypershift-azure-run-e2e-self-managed-commands.sh
@@ -46,6 +46,11 @@ if [[ "${HYPERSHIFT_EXTERNAL_DNS_DOMAIN:-}" != "" ]]; then
   EXTERNAL_DNS_ARGS="--e2e.external-dns-domain=${HYPERSHIFT_EXTERNAL_DNS_DOMAIN}"
 fi
 
+ZONES_ARGS=""
+if [[ "${HYPERSHIFT_AZURE_ZONES:-}" != "" ]]; then
+  ZONES_ARGS="--e2e.availability-zones=${HYPERSHIFT_AZURE_ZONES}"
+fi
+
 # Azure private platform args - pass credentials and resource group to the e2e test framework
 # so the HO upgrade test can reinstall with private platform support.
 # Values can come from env vars or from SHARED_DIR files written by the
@@ -86,6 +91,7 @@ hack/ci-test-e2e.sh -test.v \
     ${N1_NP_VERSION_TEST_ARGS:-} \
     ${N2_NP_VERSION_TEST_ARGS:-} \
     ${EXTERNAL_DNS_ARGS:-} \
+    ${ZONES_ARGS:-} \
     ${AZURE_PRIVATE_ARGS:-} \
   --e2e.latest-release-image="${OCP_IMAGE_LATEST}" \
   --e2e.previous-release-image="${OCP_IMAGE_PREVIOUS}" &

--- a/ci-operator/step-registry/hypershift/azure/run-e2e-self-managed/hypershift-azure-run-e2e-self-managed-ref.yaml
+++ b/ci-operator/step-registry/hypershift/azure/run-e2e-self-managed/hypershift-azure-run-e2e-self-managed-ref.yaml
@@ -46,6 +46,9 @@ ref:
       name: HYPERSHIFT_AZURE_ZONES
       documentation: "Comma-separated list of Azure availability zones for hosted clusters (e.g., '1,2,3'). Passed as --e2e.availability-zones."
     - default: ""
+      name: HYPERSHIFT_ETCD_STORAGE_CLASS
+      documentation: "Storage class for etcd persistent volumes (e.g., 'managed-csi-premium'). Passed as --e2e.etcd-storage-class."
+    - default: ""
       name: AZURE_PRIVATE_CREDS_FILE
       documentation: "Path to Azure credentials file for managing Private Link Service resources. Passed as --e2e.azure-private-credentials-file."
     - default: ""

--- a/ci-operator/step-registry/hypershift/azure/run-e2e-self-managed/hypershift-azure-run-e2e-self-managed-ref.yaml
+++ b/ci-operator/step-registry/hypershift/azure/run-e2e-self-managed/hypershift-azure-run-e2e-self-managed-ref.yaml
@@ -43,6 +43,9 @@ ref:
     - default: ""
       name: CI_TESTS_RUN
     - default: ""
+      name: HYPERSHIFT_AZURE_ZONES
+      documentation: "Comma-separated list of Azure availability zones for hosted clusters (e.g., '1,2,3'). Passed as --e2e.availability-zones."
+    - default: ""
       name: AZURE_PRIVATE_CREDS_FILE
       documentation: "Path to Azure credentials file for managing Private Link Service resources. Passed as --e2e.azure-private-credentials-file."
     - default: ""

--- a/ci-operator/step-registry/hypershift/setup-nested-management-cluster/hypershift-setup-nested-management-cluster-chain.yaml
+++ b/ci-operator/step-registry/hypershift/setup-nested-management-cluster/hypershift-setup-nested-management-cluster-chain.yaml
@@ -94,8 +94,7 @@ chain:
           --release-stream=${DEFAULT_RELEASE_STREAM} \
           --namespace=${HYPERSHIFT_NAMESPACE} \
           --assign-service-principal-roles \
-          --dns-zone-rg-name=os4-common \
-          --etcd-storage-class=managed-csi-premium-v2
+          --dns-zone-rg-name=os4-common
       else
         echo "Creating AWS management cluster ${CLUSTER_NAME} with $((${HYPERSHIFT_NODE_COUNT} * 3)) nodes"
         bin/hypershift create cluster aws \

--- a/ci-operator/step-registry/hypershift/setup-nested-management-cluster/hypershift-setup-nested-management-cluster-chain.yaml
+++ b/ci-operator/step-registry/hypershift/setup-nested-management-cluster/hypershift-setup-nested-management-cluster-chain.yaml
@@ -150,6 +150,23 @@ chain:
       done
       # Data for cluster bot.
       echo "https://$(oc -n openshift-console get routes console -o=jsonpath='{.spec.host}')" > "${SHARED_DIR}/console.url"
+
+      # Create a Premium SSD v2 storage class on Azure management clusters for etcd
+      if [[ "${CLOUD_PROVIDER}" == "Azure" ]]; then
+        echo "Creating managed-csi-premium-v2 StorageClass on management cluster"
+        oc apply -f - <<'EOF'
+      apiVersion: storage.k8s.io/v1
+      kind: StorageClass
+      metadata:
+        name: managed-csi-premium-v2
+      provisioner: disk.csi.azure.com
+      parameters:
+        skuName: PremiumV2_LRS
+      reclaimPolicy: Delete
+      volumeBindingMode: WaitForFirstConsumer
+      allowVolumeExpansion: true
+      EOF
+      fi
     credentials:
     - mount_path: /etc/hypershift-ci-jobs-awscreds
       name: hypershift-ci-jobs-awscreds

--- a/ci-operator/step-registry/hypershift/setup-nested-management-cluster/hypershift-setup-nested-management-cluster-chain.yaml
+++ b/ci-operator/step-registry/hypershift/setup-nested-management-cluster/hypershift-setup-nested-management-cluster-chain.yaml
@@ -162,6 +162,7 @@ chain:
       provisioner: disk.csi.azure.com
       parameters:
         skuName: PremiumV2_LRS
+        cachingMode: None
       reclaimPolicy: Delete
       volumeBindingMode: WaitForFirstConsumer
       allowVolumeExpansion: true

--- a/ci-operator/step-registry/hypershift/setup-nested-management-cluster/hypershift-setup-nested-management-cluster-chain.yaml
+++ b/ci-operator/step-registry/hypershift/setup-nested-management-cluster/hypershift-setup-nested-management-cluster-chain.yaml
@@ -94,7 +94,8 @@ chain:
           --release-stream=${DEFAULT_RELEASE_STREAM} \
           --namespace=${HYPERSHIFT_NAMESPACE} \
           --assign-service-principal-roles \
-          --dns-zone-rg-name=os4-common
+          --dns-zone-rg-name=os4-common \
+          --etcd-storage-class=managed-csi-premium-v2
       else
         echo "Creating AWS management cluster ${CLUSTER_NAME} with $((${HYPERSHIFT_NODE_COUNT} * 3)) nodes"
         bin/hypershift create cluster aws \

--- a/ci-operator/step-registry/hypershift/setup-nested-management-cluster/hypershift-setup-nested-management-cluster-chain.yaml
+++ b/ci-operator/step-registry/hypershift/setup-nested-management-cluster/hypershift-setup-nested-management-cluster-chain.yaml
@@ -90,7 +90,7 @@ chain:
           --service-cidr=172.29.0.0/16 \
           --cluster-cidr=10.124.0.0/14 \
           --node-pool-replicas=${HYPERSHIFT_NODE_COUNT} \
-          --zones=1,2,3 \
+          --availability-zones=1,2,3 \
           --release-image=${HYPERSHIFT_HC_RELEASE_IMAGE} \
           --release-stream=${DEFAULT_RELEASE_STREAM} \
           --namespace=${HYPERSHIFT_NAMESPACE} \

--- a/ci-operator/step-registry/hypershift/setup-nested-management-cluster/hypershift-setup-nested-management-cluster-chain.yaml
+++ b/ci-operator/step-registry/hypershift/setup-nested-management-cluster/hypershift-setup-nested-management-cluster-chain.yaml
@@ -90,6 +90,7 @@ chain:
           --service-cidr=172.29.0.0/16 \
           --cluster-cidr=10.124.0.0/14 \
           --node-pool-replicas=${HYPERSHIFT_NODE_COUNT} \
+          --zones=1,2,3 \
           --release-image=${HYPERSHIFT_HC_RELEASE_IMAGE} \
           --release-stream=${DEFAULT_RELEASE_STREAM} \
           --namespace=${HYPERSHIFT_NAMESPACE} \


### PR DESCRIPTION
## Summary

- Increase `HYPERSHIFT_NODE_COUNT` from `3` to `6` for the `e2e-azure-self-managed` presubmit workflow
- Add availability zones (`1,2,3`) to spread hosted clusters across Azure AZs
- Use Premium SSD v2 (`PremiumV2_LRS`) for guest cluster etcd to address disk latency

## Problem

The `e2e-azure-self-managed` presubmit has a ~50% failure rate since April 14 when [commit 46e8bab865f](https://github.com/openshift/release/commit/46e8bab865f) expanded `CI_TESTS_RUN` from 3 tests to 7+, creating 9+ parallel hosted clusters on a 3-node management cluster (48 vCPU).

### Resource contention

9+ hosted clusters running in parallel on 3 nodes (48 vCPU total, ~5 vCPU per hosted cluster) causes resource contention that triggers liveness probe timeouts. Increasing to 6 nodes (96 vCPU, ~10 vCPU per hosted cluster) provides sufficient capacity.

### Etcd disk latency

Azure Premium SSD v1 IOPS scale with disk size. At 8 GiB (P2 tier), etcd disks get only **120 IOPS** — compared to AWS gp3's baseline of **3,000 IOPS**. This causes 3-5x worse etcd disk latency on Azure vs AWS:

| Cloud | p50 | p99 |
|-------|-----|-----|
| AWS (gp3) | 1.4ms | 3.2ms |
| Azure (Premium SSD v1) | 5.3ms | 17.8ms |

Premium SSD v2 (`PremiumV2_LRS`) decouples IOPS from disk size, providing 3,000 baseline IOPS regardless of volume size.

## Changes

1. **Increase node count**: 3 → 6 nodes for the management cluster
2. **Add availability zones**: Pass `--e2e.availability-zones=1,2,3` to spread hosted clusters across AZs
3. **Premium SSD v2 for etcd**: Create `managed-csi-premium-v2` StorageClass (`PremiumV2_LRS` with `cachingMode: None`) on the management cluster and pass `--e2e.etcd-storage-class=managed-csi-premium-v2` to the e2e tests
4. **New env vars**: `HYPERSHIFT_AZURE_ZONES` and `HYPERSHIFT_ETCD_STORAGE_CLASS` in the run-e2e-self-managed ref

## Test plan

- [ ] Verify `e2e-azure-self-managed` presubmit passes consistently with these changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)