### PR TITLE
fix: review-agent dedup bot review bodies with inline comments

### DIFF
--- a/ci-operator/step-registry/hypershift/review-agent/process/hypershift-review-agent-process-commands.sh
+++ b/ci-operator/step-registry/hypershift/review-agent/process/hypershift-review-agent-process-commands.sh
@@ -417,6 +417,7 @@ def analyze_review_bodies(pr_number: int) -> list[dict]:
               body
               state
               submittedAt
+              comments(first: 0) { totalCount }
             }
           }
         }
@@ -461,6 +462,15 @@ def analyze_review_bodies(pr_number: int) -> list[dict]:
 
         # Check if author is authorized
         if not is_authorized_author(author):
+            continue
+
+        # Skip approved bot review bodies when inline comments exist.
+        # Bot review bodies (e.g. CodeRabbit's "Actionable comments posted: N")
+        # are machine-generated summaries of their inline comments. Those inline
+        # comments are already handled by analyze_review_threads, so flagging the
+        # body too causes Claude to address the same feedback twice.
+        inline_count = review.get("comments", {}).get("totalCount", 0)
+        if is_approved_bot(author) and inline_count > 0:
             continue
 
         review_id = review["id"]


### PR DESCRIPTION
## Summary

- Skip approved bot (e.g. CodeRabbit) review bodies in the comment analyzer when the review also has inline comments, since those are already handled by `analyze_review_threads`
- Adds `comments(first: 0) { totalCount }` to the reviews GraphQL query to check for inline comment existence

## Problem

The comment analyzer has three independent functions: `analyze_review_threads`, `analyze_review_bodies`, and `analyze_issue_comments`. When a bot like CodeRabbit submits a review with both a body ("Actionable comments posted: 1") and inline code comments, **both** get flagged as separate `needs_attention` items. Claude addresses each independently, producing duplicate responses.

**Observed on [openshift/hypershift#8280](https://github.com/openshift/hypershift/pull/8280):**

CodeRabbit review [`#4146142149`](https://github.com/openshift/hypershift/pull/8280#pullrequestreview-4146142149) had a body and one inline comment about trust bundle sync stalling. The analyzer flagged both. Claude posted:
- Inline reply at 11:04:10Z (correct — addresses the thread)
- [Issue comment at 11:04:20Z](https://github.com/openshift/hypershift/pull/8280#issuecomment-4288023242) (duplicate — summarizes the review)
- [Issue comment at 11:06:19Z](https://github.com/openshift/hypershift/pull/8280#issuecomment-4288036465) (duplicate — re-summarizes the review)

## Fix

Skip approved bot review bodies when `totalCount > 0` inline comments exist. Bot review bodies are machine-generated summaries of their inline comments. Human review bodies are always kept since they often contain distinct architectural feedback.

**Verified against PR #8280 data:**
| Review | Author | Type | inline_count | Result |
|--------|--------|------|-------------|--------|
| 4146142149 | coderabbitai | approved_bot | 1 | **SKIPPED** |
| 4138831511 | coderabbitai | approved_bot | 1 | **SKIPPED** |
| 4144456157 | csrwng | human | 2 | **KEPT** |

## Test plan

- [ ] Verify review-agent periodic job does not post duplicate responses for CodeRabbit reviews with inline comments
- [ ] Verify human review bodies (e.g. csrwng) are still addressed even when inline comments exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request review processing to eliminate duplicate flagging when inline review comments are present, reducing unnecessary notifications and redundant handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->