### PR TITLE
updating 4.22 clusterimageset to rc.0 and adjusting pools accordingly

### DIFF
--- a/clusters/hosted-mgmt/hive/pools/cvp/cvp-fips-ocp-4-22-amd64-aws-eu-central-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/cvp/cvp-fips-ocp-4-22-amd64-aws-eu-central-1_clusterpool.yaml
@@ -20,7 +20,7 @@ spec:
   hibernationConfig:
     resumeTimeout: 15m0s
   imageSetRef:
-    name: ocp-release-4.22.0-ec.5-multi-for-4.22.0-0-to-4.23.0-0
+    name: ocp-release-4.22.0-rc.0-multi-for-4.22.0-0-to-4.23.0-0
   installAttemptsLimit: 1
   installConfigSecretTemplateRef:
     name: fips-install-config-aws-eu-central-1

--- a/clusters/hosted-mgmt/hive/pools/cvp/cvp-ocp-4-22-amd64-aws-eu-central-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/cvp/cvp-ocp-4-22-amd64-aws-eu-central-1_clusterpool.yaml
@@ -19,7 +19,7 @@ spec:
   hibernationConfig:
     resumeTimeout: 15m0s
   imageSetRef:
-    name: ocp-release-4.22.0-ec.5-multi-for-4.22.0-0-to-4.23.0-0
+    name: ocp-release-4.22.0-rc.0-multi-for-4.22.0-0-to-4.23.0-0
   installAttemptsLimit: 1
   installConfigSecretTemplateRef:
     name: install-config-aws-eu-central-1

--- a/clusters/hosted-mgmt/hive/pools/ocp-release-4.22.0-rc.0-multi-for-4.22.0-0-to-4.23.0-0_clusterimageset.yaml
+++ b/clusters/hosted-mgmt/hive/pools/ocp-release-4.22.0-rc.0-multi-for-4.22.0-0-to-4.23.0-0_clusterimageset.yaml
@@ -6,7 +6,7 @@ metadata:
     version_stream: 4-dev-preview
     version_upper: 4.23.0-0
   creationTimestamp: null
-  name: ocp-release-4.22.0-ec.5-multi-for-4.22.0-0-to-4.23.0-0
+  name: ocp-release-4.22.0-rc.0-multi-for-4.22.0-0-to-4.23.0-0
 spec:
-  releaseImage: quay.io/openshift-release-dev/ocp-release:4.22.0-ec.5-multi
+  releaseImage: quay.io/openshift-release-dev/ocp-release:4.22.0-rc.0-multi
 status: {}

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-22-0-amd64-aws-us-east-2_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-22-0-amd64-aws-us-east-2_clusterpool.yaml
@@ -19,7 +19,7 @@ spec:
   hibernationConfig:
     resumeTimeout: 20m0s
   imageSetRef:
-    name: ocp-release-4.22.0-ec.5-multi-for-4.22.0-0-to-4.23.0-0
+    name: ocp-release-4.22.0-rc.0-multi-for-4.22.0-0-to-4.23.0-0
   installAttemptsLimit: 1
   installConfigSecretTemplateRef:
     name: install-config-aws-us-east-2

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-22-0-fips-amd64-aws-us-east-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-22-0-fips-amd64-aws-us-east-1_clusterpool.yaml
@@ -20,7 +20,7 @@ spec:
   hibernationConfig:
     resumeTimeout: 20m0s
   imageSetRef:
-    name: ocp-release-4.22.0-ec.5-multi-for-4.22.0-0-to-4.23.0-0
+    name: ocp-release-4.22.0-rc.0-multi-for-4.22.0-0-to-4.23.0-0
   installAttemptsLimit: 1
   installConfigSecretTemplateRef:
     name: fips-install-config-aws-us-east-1

--- a/clusters/hosted-mgmt/hive/pools/rh-openshift-ecosystem/rhoe-ocp-4-22-amd64-aws-us-west-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/rh-openshift-ecosystem/rhoe-ocp-4-22-amd64-aws-us-west-1_clusterpool.yaml
@@ -11,17 +11,17 @@ metadata:
     version_lower: 4.22.0-0
     version_stream: 4-dev-preview
     version_upper: 4.23.0-0
-  name: rhoe-ocp-4-22-amd64-aws-us-west-2
+  name: rhoe-ocp-4-22-amd64-aws-us-west-1
   namespace: rhoe-cluster-pool
 spec:
   baseDomain: certification-pipeline.opdev.io
   hibernationConfig:
     resumeTimeout: 20m0s
   imageSetRef:
-    name: ocp-release-4.22.0-ec.5-multi-for-4.22.0-0-to-4.23.0-0
+    name: ocp-release-4.22.0-rc.0-multi-for-4.22.0-0-to-4.23.0-0
   installAttemptsLimit: 1
   installConfigSecretTemplateRef:
-    name: install-config-4-22-amd64-aws-us-west-2
+    name: install-config-4-22-amd64-aws-us-west-1
   labels:
     tp.openshift.io/owner: rh-openshift-ecosystem
   maxSize: 10
@@ -29,7 +29,7 @@ spec:
     aws:
       credentialsSecretRef:
         name: rh-openshift-ecosystem-aws-credentials
-      region: us-west-2
+      region: us-west-1
   pullSecretRef:
     name: pull-secret
   runningCount: 1

--- a/clusters/hosted-mgmt/hive/pools/rh-openshift-ecosystem/rhoe-ocp-4-22-amd64-aws-us-west-2_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/rh-openshift-ecosystem/rhoe-ocp-4-22-amd64-aws-us-west-2_clusterpool.yaml
@@ -11,17 +11,17 @@ metadata:
     version_lower: 4.22.0-0
     version_stream: 4-dev-preview
     version_upper: 4.23.0-0
-  name: rhoe-ocp-4-22-amd64-aws-us-west-1
+  name: rhoe-ocp-4-22-amd64-aws-us-west-2
   namespace: rhoe-cluster-pool
 spec:
   baseDomain: certification-pipeline.opdev.io
   hibernationConfig:
     resumeTimeout: 20m0s
   imageSetRef:
-    name: ocp-release-4.22.0-ec.5-multi-for-4.22.0-0-to-4.23.0-0
+    name: ocp-release-4.22.0-rc.0-multi-for-4.22.0-0-to-4.23.0-0
   installAttemptsLimit: 1
   installConfigSecretTemplateRef:
-    name: install-config-4-22-amd64-aws-us-west-1
+    name: install-config-4-22-amd64-aws-us-west-2
   labels:
     tp.openshift.io/owner: rh-openshift-ecosystem
   maxSize: 10
@@ -29,7 +29,7 @@ spec:
     aws:
       credentialsSecretRef:
         name: rh-openshift-ecosystem-aws-credentials
-      region: us-west-1
+      region: us-west-2
   pullSecretRef:
     name: pull-secret
   runningCount: 1


### PR DESCRIPTION
```
? podman pull quay.io/openshift-release-dev/ocp-release:4.22.0-rc.0-multi
Trying to pull quay.io/openshift-release-dev/ocp-release:4.22.0-rc.0-multi...
Getting image source signatures
Copying blob 58608b2185d4 done   | 
Copying blob 5ab75c710693 done   | 
Copying blob 48273a5df50d done   | 
Copying blob bffa3b717baa done   | 
Copying blob 2920d84eafa0 skipped: already exists  
Copying blob 244e1b6bb5fc done   | 
Copying config bd455f307f done   | 
Writing manifest to image destination
bd455f307fbcc8c6d4faee1d52f4ac8b15205ab31d0d1b2e90e5b837b54e0b5f
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenShift release image references across multiple cluster pools to use a newer release candidate version. Configuration changes affect cluster provisioning and rollout operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->