### PR TITLE
Pin hypershift kubevirt management clusters to OCP 4.22

### DIFF
--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-main.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-main.yaml
@@ -317,6 +317,8 @@ tests:
   pipeline_skip_if_only_changed: (^(\.tekton|\.github|\.claude|docs|examples|enhancements|contrib|\.cursor|test/envtest)/)|(^[A-Z]+\.md$)|((^|/)OWNERS$)|(/overrides\.yaml$)|(^renovate\.json$)|(/\.testcoverage\.yml$)|(^\.gitlint$)|(^\.gitignore$)|(^\.coderabbit\.yaml$)|(^\.dockerignore$)|(^codecov\.yml$)
   steps:
     cluster_profile: openshift-org-aws
+    dependencies:
+      OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: release:latest-422
     env:
       COMPUTE_NODE_REPLICAS: "1"
       COMPUTE_NODE_TYPE: c5n.metal
@@ -332,6 +334,8 @@ tests:
   optional: true
   steps:
     cluster_profile: openshift-org-aws
+    dependencies:
+      OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: release:latest-422
     env:
       COMPUTE_NODE_REPLICAS: "1"
       COMPUTE_NODE_TYPE: c5n.metal
@@ -345,6 +349,8 @@ tests:
   optional: true
   steps:
     cluster_profile: openshift-org-azure
+    dependencies:
+      OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: release:latest-422
     env:
       COMPUTE_NODE_REPLICAS: "3"
       COMPUTE_NODE_TYPE: Standard_D16as_v5
@@ -373,6 +379,8 @@ tests:
   optional: true
   steps:
     cluster_profile: openshift-org-azure
+    dependencies:
+      OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: release:latest-422
     env:
       CNV_SUBSCRIPTION_SOURCE: redhat-operators
       HYPERSHIFT_NODE_COUNT: "2"


### PR DESCRIPTION
## Summary
- ODF 4.21 sets `maxOpenShiftVersion: 4.22`, which prevents the CSI RBD provisioner from deploying on management clusters running newer OCP versions
- Without the RBD provisioner, KubeVirt VM PVCs using `ocs-storagecluster-ceph-rbd-virtualization` stay Pending indefinitely, causing test timeouts (e.g. `e2e-kubevirt-aws-ovn-reduced` failure: 0/2 nodes ready after 45m)
- This pins the `e2e-kubevirt-aws-ovn` and `e2e-kubevirt-azure-ovn` management clusters to OCP 4.22 via `OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: release:latest-422`, following the same pattern used by `reqserving-e2e-aws`

## Test plan
- [ ] Verify `e2e-kubevirt-aws-ovn` provisions management cluster with OCP 4.22
- [ ] Verify ODF CSI RBD provisioner deploys successfully on 4.22 management cluster
- [ ] Verify KubeVirt VMs boot and tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI test configurations for KubeVirt OVN and Equinix metal-conformance jobs to use the latest OpenShift release image override (release:latest-422), ensuring tests run against the current release and improving consistency and reliability of validation across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->