### PR TITLE
SREP-4667: Fix STS version mismatch for nightly rosa-sts-ovn jobs

### DIFF
--- a/ci-operator/step-registry/rosa/cluster/provision/rosa-cluster-provision-commands.sh
+++ b/ci-operator/step-registry/rosa/cluster/provision/rosa-cluster-provision-commands.sh
@@ -259,6 +259,13 @@ fi
 versionList=$(eval $version_cmd)
 echo -e "Available cluster versions:\n${versionList}"
 
+# If account-roles-create fell back to a different version, use it. This overrides
+# release:latest resolution so the cluster version matches the account roles.
+if [[ -f "${SHARED_DIR}/openshift_version" ]]; then
+  OPENSHIFT_VERSION=$(cat "${SHARED_DIR}/openshift_version")
+  log "Using version ${OPENSHIFT_VERSION} from account-roles-create step (fallback)"
+fi
+
 # If OPENSHIFT_VERSION is set to "release:latest", look at the environment variable
 # supplied by CI for the payload to use. This only really works for nightlies. ROSA
 # SRE has a job that polls the release controller and syncs new nightlies every 15 minutes,

--- a/ci-operator/step-registry/rosa/sts/account-roles/create/rosa-sts-account-roles-create-commands.sh
+++ b/ci-operator/step-registry/rosa/sts/account-roles/create/rosa-sts-account-roles-create-commands.sh
@@ -78,19 +78,6 @@ if [[ "$CHANNEL_GROUP" != "stable" ]]; then
     CLUSTER_SWITCH="--hosted-cp"
   fi
 
-  # Verify the version has published policies. If not, fall back to the latest
-  # version that has existing account-role policies in the AWS account.
-  if ! rosa list account-roles --output json 2>/dev/null | jq -e --arg v "${OPENSHIFT_VERSION}" '.[] | select(.Version // "" | startswith($v))' > /dev/null 2>&1; then
-    echo "Version ${OPENSHIFT_VERSION} may not have published policies, checking account roles for available versions..."
-    available_version=$(rosa list account-roles --output json 2>/dev/null | jq -r '.[].Version // empty' 2>/dev/null | cut -d'.' -f1,2 | sort -Vu | tail -1 || true)
-    if [[ -n "${available_version}" && "${available_version}" != "${OPENSHIFT_VERSION}" ]]; then
-      echo "Falling back from ${OPENSHIFT_VERSION} to ${available_version} (latest with published policies)"
-      OPENSHIFT_VERSION="${available_version}"
-    else
-      echo "WARNING: No fallback version found in account roles, continuing with ${OPENSHIFT_VERSION}"
-    fi
-  fi
-
   VERSION_SWITCH="--version ${OPENSHIFT_VERSION} --channel-group ${CHANNEL_GROUP}"
 fi
 
@@ -104,16 +91,49 @@ if [[ ! -z "$PERMISSIONS_BOUNDARY" ]]; then
    PERMISSIONS_BOUNDARY_SWITCH="--permissions-boundary ${PERMISSIONS_BOUNDARY}"
 fi
 
-# Whatever the account roles with the prefix exist or not, do creation.
+# Create account roles, falling back to latest available version if target lacks published policies
 echo "Create the ${CLUSTER_SWITCH} account roles with the prefix '${ACCOUNT_ROLES_PREFIX}'"
 echo "rosa create account-roles -y --mode auto --prefix ${ACCOUNT_ROLES_PREFIX} ${CLUSTER_SWITCH} ${VERSION_SWITCH} ${ARN_PATH_SWITCH}"
+
+create_ret=0
 rosa create account-roles -y --mode auto \
                           --prefix ${ACCOUNT_ROLES_PREFIX} \
                           ${CLUSTER_SWITCH} \
                           ${VERSION_SWITCH} \
                           ${ARN_PATH_SWITCH} \
                           ${PERMISSIONS_BOUNDARY_SWITCH} \
-                          | sed "s/$AWS_ACCOUNT_ID/$AWS_ACCOUNT_ID_MASK/g"
+                          | sed "s/$AWS_ACCOUNT_ID/$AWS_ACCOUNT_ID_MASK/g" \
+  || create_ret=$?
+
+if [[ "${create_ret}" -ne 0 && "${CHANNEL_GROUP}" == "stable" ]]; then
+  echo "ERROR: Account role creation failed (exit ${create_ret}) on stable channel-group"
+  exit "${create_ret}"
+elif [[ "${create_ret}" -ne 0 ]]; then
+  echo "Account role creation failed (exit ${create_ret}). Falling back to latest available version in channel-group ${CHANNEL_GROUP}..."
+  fallback_version=$(rosa list versions --channel-group "${CHANNEL_GROUP}" ${CLUSTER_SWITCH} -o json 2>/dev/null \
+    | jq -r '.[].raw_id' | cut -d'.' -f1,2 | sort -Vu | tail -1 || true)
+  if [[ -n "${fallback_version}" && "${fallback_version}" != "${OPENSHIFT_VERSION}" ]]; then
+    echo "Retrying with version ${fallback_version} (was ${OPENSHIFT_VERSION})"
+    OPENSHIFT_VERSION="${fallback_version}"
+    VERSION_SWITCH="--version ${OPENSHIFT_VERSION} --channel-group ${CHANNEL_GROUP}"
+    rosa create account-roles -y --mode auto \
+                              --prefix ${ACCOUNT_ROLES_PREFIX} \
+                              ${CLUSTER_SWITCH} \
+                              ${VERSION_SWITCH} \
+                              ${ARN_PATH_SWITCH} \
+                              ${PERMISSIONS_BOUNDARY_SWITCH} \
+                              | sed "s/$AWS_ACCOUNT_ID/$AWS_ACCOUNT_ID_MASK/g"
+  else
+    echo "ERROR: No fallback version available in channel-group ${CHANNEL_GROUP}"
+    exit 1
+  fi
+fi
+
+# Share the resolved version (includes fallback if one was used)
+if [[ "${CHANNEL_GROUP}" != "stable" && -n "${OPENSHIFT_VERSION:-}" ]]; then
+  echo -n "${OPENSHIFT_VERSION}" > "${SHARED_DIR}/openshift_version"
+  echo "Stored resolved version ${OPENSHIFT_VERSION} to SHARED_DIR"
+fi
 
 # Store the account-role-prefix for the next pre steps and the account roles deletion
 echo -n "${ACCOUNT_ROLES_PREFIX}" > "${SHARED_DIR}/account-roles-prefix"


### PR DESCRIPTION
## Summary
- Fix version mismatch between account-roles-create and provision steps that causes 100% failure rate on 4.22 and 5.0 e2e-rosa-sts-ovn nightly jobs
- account-roles-create: try rosa create account-roles first, fall back to latest available version only on failure (non-stable channels). For stable channel, fail fast with a clear error
- account-roles-create: write the resolved version (including any fallback) to SHARED_DIR/openshift_version
- provision: read SHARED_DIR/openshift_version before the release:latest resolution loop, so the cluster version matches the account roles when a fallback occurred

## Problem
When CHANNEL_GROUP=nightly and the target version (e.g. 4.22) does not have published STS policies yet, the account-roles-create step falls back to 4.21. But the provision step independently resolves release:latest to the full 4.22 nightly tag. rosa create cluster then rejects the version/role mismatch.

## Test plan
- [ ] Rehearse periodic-ci-openshift-release-main-nightly-4.22-e2e-rosa-sts-ovn
- [ ] Verify stable channel jobs are unaffected (no SHARED_DIR file written)
- [ ] Verify jobs where account-roles succeeds on first try still work (SHARED_DIR version matches, release:latest skipped)

Jira: https://redhat.atlassian.net/browse/SREP-4667


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Honor an externally provided OpenShift version during provisioning and log its source for consistency.
  * Persist the resolved OpenShift version after successful account-role creation for non-stable channels to reduce mismatches.
* **Bug Fixes**
  * Improve account-role creation reliability by retrying once with a channel-specific fallback version when initial creation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->