### PR TITLE
Add rebase and CI failure handling to review agent

### DIFF
--- a/ci-operator/step-registry/hypershift/review-agent/README.md
+++ b/ci-operator/step-registry/hypershift/review-agent/README.md
@@ -1,15 +1,21 @@
 # HyperShift Review Agent Workflow
 
-Automated periodic job that addresses review comments on PRs created by the HyperShift Jira Agent using Claude Code.
+Automated periodic job that addresses review comments, rebases branches, and fixes CI failures on PRs created by the HyperShift Jira Agent using Claude Code.
 
 ## Overview
 
-This workflow implements a fully automated system for addressing PR review comments:
+This workflow implements a fully automated system for PR maintenance:
 
 1. **Query**: Searches GitHub for open PRs from the hypershift-community fork that were created by the Jira Agent
-2. **Filter**: Identifies PRs with unresolved review threads that need attention
-3. **Process**: For each PR, runs the `/utils:address-reviews` command to analyze and address review comments
-4. **Push**: Commits and pushes changes back to the PR branch
+2. **Detect**: For each PR, checks three independent concerns (all API-only, no checkout needed):
+   - **Reviews**: Identifies unresolved review threads needing attention
+   - **Rebase**: Detects when the PR branch is behind its base branch
+   - **CI Failures**: Detects failing verify/unit/lint CI checks
+3. **Process**: Checks out the branch and handles each detected concern in order:
+   - Rebase onto upstream base branch (skip PR on conflict)
+   - Address review comments using `/utils:address-reviews`
+   - Reproduce and fix CI failures locally using Claude
+4. **Push**: Single force-push at the end if any phase made changes
 
 ## Data Flow Diagram
 
@@ -37,37 +43,58 @@ flowchart TD
 
         CheckPRs{PRs<br/>Found?}:::decision
         CheckMax{Processed <<br/>MAX_PRS<br/>Default: 10}:::decision
-        CheckReviews{Has Unresolved<br/>Reviews?}:::decision
-        CheckSuccess{Processing<br/>Successful?}:::decision
 
-        ProcessPR[Run Claude Code CLI<br/>/utils:address-reviews PR_NUMBER<br/>--max-turns 50]:::ai
+        %% Detection phase (API-only)
+        DetectReviews[Check review<br/>comments]:::process
+        DetectRebase[Check rebase<br/>status]:::process
+        DetectCI[Check CI<br/>status]:::process
+        CheckAnyAction{Any action<br/>needed?}:::decision
 
-        LogSuccess[Log success<br/>Push changes]:::success
-        LogSkip[Skip PR<br/>No pending reviews]:::skip
-        LogFailure[Log failure<br/>Will retry next run]:::failure
+        %% Processing phases
+        Checkout[Checkout<br/>PR branch]:::process
+        DoRebase{Needs<br/>rebase?}:::decision
+        PerformRebase[Rebase onto<br/>upstream base]:::process
+        RebaseConflict[Rebase conflict<br/>Skip PR]:::failure
+        DoReviews{Needs<br/>reviews?}:::decision
+        ProcessReviews[Claude: Address<br/>review comments]:::ai
+        DoCIFix{Needs<br/>CI fix?}:::decision
+        ProcessCIFix[Claude: Reproduce<br/>and fix CI failures]:::ai
+        Push[Push changes<br/>--force-with-lease]:::process
 
+        LogSkip[Skip PR<br/>Nothing to do]:::skip
         RateLimit[Wait 60 seconds<br/>Rate limiting]:::process
-        Summary[Print Summary<br/>Processed/Skipped/Failed counts]:::process
+        Summary[Print Summary]:::process
 
         QueryGitHub --> CheckPRs
         CheckPRs -->|No| Summary
         CheckPRs -->|Yes| CheckMax
         CheckMax -->|No| Summary
-        CheckMax -->|Yes| CheckReviews
-        CheckReviews -->|No| LogSkip
-        CheckReviews -->|Yes| ProcessPR
-        ProcessPR --> CheckSuccess
-        CheckSuccess -->|Yes| LogSuccess
-        CheckSuccess -->|No| LogFailure
-        LogSuccess --> RateLimit
+        CheckMax -->|Yes| DetectReviews
+        DetectReviews --> DetectRebase
+        DetectRebase --> DetectCI
+        DetectCI --> CheckAnyAction
+        CheckAnyAction -->|No| LogSkip
+        CheckAnyAction -->|Yes| Checkout
+        Checkout --> DoRebase
+        DoRebase -->|Yes| PerformRebase
+        DoRebase -->|No| DoReviews
+        PerformRebase -->|Conflict| RebaseConflict
+        PerformRebase -->|Success| DoReviews
+        DoReviews -->|Yes| ProcessReviews
+        DoReviews -->|No| DoCIFix
+        ProcessReviews --> DoCIFix
+        DoCIFix -->|Yes| ProcessCIFix
+        DoCIFix -->|No| Push
+        ProcessCIFix --> Push
+        Push --> RateLimit
         LogSkip --> RateLimit
-        LogFailure --> RateLimit
+        RebaseConflict --> RateLimit
         RateLimit --> CheckMax
     end
 
     %% External Systems
     GitHubAPI[(GitHub API<br/>openshift/hypershift)]:::external -.->|Return PRs & reviews| QueryGitHub
-    ClaudeAPI[(Claude API<br/>via Vertex AI)]:::external -.->|Address comments| ProcessPR
+    ClaudeAPI[(Claude API<br/>via Vertex AI)]:::external -.->|Address comments<br/>Fix CI failures| ProcessReviews
 
     TestPhase --> End([Workflow Complete]):::trigger
     Summary --> End
@@ -85,11 +112,27 @@ flowchart TD
     classDef secret fill:#ffebee,stroke:#b71c1c,stroke-width:2px,color:#000
 ```
 
+## Processing Order
+
+For each PR, phases execute in this order:
+
+1. **Rebase** (if branch is behind base)
+   - Fetches upstream and rebases
+   - On conflict: logs failure, skips remaining phases for this PR
+2. **Reviews** (if unresolved review threads exist)
+   - Uses existing `/utils:address-reviews` Claude invocation
+   - Posts replies and makes code changes as requested
+3. **CI Fixes** (if verify/unit/lint checks are failing and `REVIEW_AGENT_ENABLE_CI_FIXES=true`)
+   - Claude reproduces failures locally using `make verify`, `go test`, etc.
+   - Fixes code iteratively until checks pass
+4. **Push** (single push at end)
+   - `git push --force-with-lease` if any phase made changes
+
 ## Components
 
 ### Workflow
 - **File**: `hypershift-review-agent-workflow.yaml`
-- **Description**: Defines the two-phase workflow (pre/test)
+- **Description**: Defines the three-phase workflow (pre/test/post)
 
 ### Steps
 
@@ -100,15 +143,60 @@ flowchart TD
 #### 2. Process (`hypershift-review-agent-process`)
 - Clones ai-helpers and hypershift repositories
 - Queries GitHub API for agent-created PRs
-- Runs `comment_analyzer.py` to identify comments needing attention (prevents duplicate responses)
-- Runs `/utils:address-reviews` for each PR with pending reviews
-- Implements rate limiting (60s between PRs)
+- For each PR, detects needs (reviews, rebase, CI fixes)
+- Runs `comment_analyzer.py` to identify comments needing attention
+- Runs `/utils:address-reviews` for PRs with pending reviews
+- Runs Claude CI fix invocation for PRs with failing checks
+- Performs rebase for PRs with branches behind base
+- Single push at end of all phases
 
-#### 3. Comment Analyzer (`comment_analyzer.py`)
+#### 3. Report (`hypershift-review-agent-report`)
+- Reads per-PR actions JSON and Claude summaries
+- Generates HTML report with per-phase token usage and cost
+- Shows action badges (Rebased, Reviews, CI Fix) per PR
+
+#### 4. Comment Analyzer (`comment_analyzer.py`)
 - Python script that analyzes PR comments to prevent duplicate bot responses
 - Fetches review threads and issue comments via GitHub API
 - Compares timestamps to determine if bot already replied
 - Outputs JSON list of threads/comments that need attention
+
+## CI Failure Handling
+
+The agent detects and fixes CI check failures matching `verify`, `unit`, or `lint` patterns.
+
+### How It Works
+
+1. **Detection**: Uses `gh pr checks` to find failed checks matching the patterns
+2. **Local Reproduction**: Claude runs the same commands CI uses (`make verify`, `go test`, linters)
+3. **Fix**: Claude diagnoses the root cause and makes targeted code changes
+4. **Verification**: Claude re-runs the failing command to confirm the fix works
+
+### Available Build Tools
+
+The `claude-ai-helpers` container image is based on `ocp/builder:rhel-9-golang-1.25-openshift-4.22`, providing:
+- Go 1.25 toolchain
+- `make` and standard build tools
+- All dependencies needed to build and test HyperShift
+
+### Check Types Handled
+
+| Check Pattern | Reproduction Command | Common Fixes |
+|---------------|---------------------|--------------|
+| `verify` | `make verify` | Formatting, imports, generated files |
+| `unit` | `make test` / `go test ./...` | Test logic, API changes |
+| `lint` / `gitlint` | Linter / `gitlint` | Code style, commit messages |
+
+## Rebase Handling
+
+### When Triggered
+- PR's `mergeStateStatus` is `BEHIND` (branch behind base, no conflicts)
+- PR's `mergeStateStatus` is `DIRTY` (branch behind base, may have conflicts)
+
+### Conflict Handling
+- If `git rebase` fails, the rebase is aborted (`git rebase --abort`)
+- The PR is logged as `FAILED rebase_conflict`
+- Remaining phases (reviews, CI fix) are skipped for that PR
 
 ## Configuration
 
@@ -163,6 +251,10 @@ This is useful for:
   - Maximum number of PRs to process per run
   - Includes both processed and skipped PRs in the count
 
+- **`REVIEW_AGENT_ENABLE_CI_FIXES`** (default: `true`)
+  - Controls whether CI failure detection and fixing is active
+  - When enabled, the agent detects failing verify/unit/lint checks and invokes Claude to reproduce and fix failures locally
+
 - **`REVIEW_AGENT_TARGET_PR`** (optional)
   - Explicit PR number to process
   - If set, only this PR will be processed regardless of author
@@ -189,7 +281,7 @@ The workflow uses Claude Code CLI's non-interactive mode:
 claude -p "$PR_NUMBER. $REVIEW_CONTEXT" \
   --system-prompt "$SKILL_CONTENT" \
   --allowedTools "Bash Read Write Edit Grep Glob WebFetch" \
-  --max-turns 50 \
+  --max-turns 150 \
   --output-format stream-json
 ```
 
@@ -218,22 +310,6 @@ A comment/thread needs attention when:
 | Thread is resolved | Skip (marked complete by reviewer) |
 | Thread is outdated (code changed) | Skip (likely addressed by code change) |
 
-#### What Counts as an Unresolved Review Thread
-
-A review thread is considered **unresolved** when:
-
-1. **Inline code comments**: A reviewer left a comment on a specific line of code in the "Files changed" tab, and no one has clicked "Resolve conversation"
-2. **Review comments with suggestions**: Comments that include suggested code changes that haven't been resolved
-3. **Threaded discussions**: Any reply chain started from a code review that remains open
-
-A review thread is **NOT** created by:
-
-- General PR comments (comments in the main "Conversation" tab that aren't attached to code)
-- PR reviews that only contain an approval/request changes without inline comments
-- Commit comments
-
-**Visual indicator**: In GitHub's UI, unresolved threads show an "Unresolved" label and a "Resolve conversation" button. Resolved threads are collapsed and show "Resolved".
-
 #### Response Rules
 
 When addressing feedback, the bot follows these rules:
@@ -244,7 +320,7 @@ When addressing feedback, the bot follows these rules:
 ### Rate Limiting
 
 - 60 seconds between processing each PR
-- Maximum 50 agentic turns per PR
+- Maximum 150 agentic turns per PR per phase
 - Maximum PRs per run: configurable via `REVIEW_AGENT_MAX_PRS`
 - Runs once daily at 10:00 AM UTC (1 hour after jira-agent)
 
@@ -253,6 +329,7 @@ When addressing feedback, the bot follows these rules:
 Uses the `claude-ai-helpers` image from OpenShift CI containing:
 - Claude Code CLI
 - GitHub CLI (gh)
+- Go 1.25 toolchain, make, and standard build tools
 - jq, git, curl
 - Required dependencies
 
@@ -262,11 +339,11 @@ This workflow is a companion to the `hypershift-jira-agent` workflow:
 
 | Aspect | Jira Agent | Review Agent |
 |--------|------------|--------------|
-| Purpose | Create PRs from Jira issues | Address review comments on PRs |
+| Purpose | Create PRs from Jira issues | Address reviews, rebase, fix CI |
 | Schedule | Daily 9:00 AM UTC | Daily 10:00 AM UTC |
 | Input | Jira issues with `issue-for-agent` label | PRs created by Jira Agent |
 | Output | Draft PRs | Updated PR branches |
-| Command | `/jira-solve` | `/utils:address-reviews` |
+| Command | `/jira-solve` | `/utils:address-reviews` + CI fix |
 
 ## Monitoring
 
@@ -274,16 +351,20 @@ This workflow is a companion to the `hypershift-jira-agent` workflow:
 - PRs processed successfully with changes pushed
 - No authentication errors
 - Review comments addressed
+- CI failures fixed
+- Branches rebased
 
 ### Failure Indicators
 - Failed to authenticate with Claude API
 - Failed to push changes (GitHub auth issues)
+- Rebase conflicts
 - Individual PR processing failures
 
 ### Logs
 Check Prow job logs for:
 - GitHub query results
-- Processing output for each PR
+- Detection phase results (reviews, rebase, CI status)
+- Processing output for each PR and phase
 - Error messages
 
 ## Troubleshooting
@@ -292,9 +373,18 @@ Check Prow job logs for:
 - Check that jira-agent has created PRs
 - Verify PRs are open and authored by `app/hypershift-jira-solve-ci`
 
-### Issue: PRs skipped (no pending reviews)
-- This is normal - PRs without unresolved review threads are skipped
-- Check GitHub for actual review status
+### Issue: PRs skipped (no action needed)
+- This is normal - PRs without reviews, rebase needs, or CI failures are skipped
+- Check GitHub for actual review/CI/merge status
+
+### Issue: Rebase conflicts
+- The agent will abort the rebase and skip the PR
+- Manual intervention is needed to resolve conflicts
+
+### Issue: CI fixes not working
+- Verify `REVIEW_AGENT_ENABLE_CI_FIXES` is set to `true`
+- Check that the failing checks match `verify|unit|lint` patterns
+- Review Claude's CI fix output in the HTML report for diagnosis details
 
 ### Issue: Authentication failures
 - Verify secrets are mounted correctly
@@ -304,10 +394,3 @@ Check Prow job logs for:
 ### Issue: Push fails
 - Check GitHub App installation permissions for fork
 - Verify branch exists and is not protected
-
-## Future Enhancements
-
-- Slack notifications for addressed reviews
-- Priority-based processing (older reviews first)
-- Automatic retry for transient failures
-- Metrics push to Prometheus

--- a/ci-operator/step-registry/hypershift/review-agent/hypershift-review-agent-workflow.yaml
+++ b/ci-operator/step-registry/hypershift/review-agent/hypershift-review-agent-workflow.yaml
@@ -8,12 +8,17 @@ workflow:
     post:
       - ref: hypershift-review-agent-report
   documentation: |-
-    HyperShift Review Agent workflow for automated PR review comment handling.
+    HyperShift Review Agent workflow for automated PR review comment handling,
+    rebase management, and CI failure fixing.
 
     This workflow:
     1. Setup: Verifies Claude Code CLI is available and configures git credentials
-    2. Process: Queries GitHub for agent-created PRs with pending reviews, runs /utils:address-reviews for each
-    3. Report: Generates HTML report with token usage, cost estimates, tool calls, and errors
+    2. Process: For each agent-created PR, detects and handles three independent concerns:
+       a. Rebase: Detects when a PR branch is behind its base and rebases automatically
+       b. Reviews: Addresses pending review comments using /utils:address-reviews
+       c. CI Fixes: Detects failing verify/unit/lint checks and invokes Claude to
+          reproduce and fix failures locally (Go, make, and build tools are available)
+    3. Report: Generates HTML report with per-phase token usage, cost estimates, and action badges
 
-    The workflow uses the /utils:address-reviews command from ai-helpers in non-interactive mode.
-    PRs are identified by being created from the hypershift-community fork with Claude Code attribution.
+    PRs are identified by being created from the hypershift-community fork by the jira-agent app.
+    The workflow skips PRs that need none of the three actions.

--- a/ci-operator/step-registry/hypershift/review-agent/process/hypershift-review-agent-process-commands.sh
+++ b/ci-operator/step-registry/hypershift/review-agent/process/hypershift-review-agent-process-commands.sh
@@ -656,6 +656,119 @@ generate_github_token() {
     | jq -r '.token'
 }
 
+# Check if a PR needs rebase (branch behind base)
+# Returns: 0 = needs rebase, 1 = no rebase needed, 2 = API error
+check_rebase_needed() {
+  local pr_number=$1
+  local merge_state base_branch
+  local pr_json
+  if ! pr_json=$(gh pr view "$pr_number" --repo openshift/hypershift --json mergeStateStatus,baseRefName 2>/dev/null); then
+    echo "main"
+    return 2  # API error
+  fi
+  merge_state=$(echo "$pr_json" | jq -r '.mergeStateStatus // ""')
+  base_branch=$(echo "$pr_json" | jq -r '.baseRefName // "main"')
+
+  # GitHub evicts cached merge state for dormant PRs, returning UNKNOWN.
+  # The first query triggers recomputation; retry after a brief wait.
+  if [ "$merge_state" = "UNKNOWN" ]; then
+    sleep 5
+    if pr_json=$(gh pr view "$pr_number" --repo openshift/hypershift --json mergeStateStatus,baseRefName 2>/dev/null); then
+      merge_state=$(echo "$pr_json" | jq -r '.mergeStateStatus // ""')
+    fi
+  fi
+
+  echo "$base_branch"
+  if [ "$merge_state" = "BEHIND" ] || [ "$merge_state" = "DIRTY" ]; then
+    return 0  # needs rebase
+  fi
+  return 1  # no rebase needed
+}
+
+# Perform a rebase onto the upstream base branch
+# On conflict, invokes Claude to resolve before continuing.
+perform_rebase() {
+  local base_branch=$1
+  git fetch upstream "$base_branch"
+  if git rebase "upstream/$base_branch"; then
+    return 0
+  fi
+
+  echo "Rebase hit conflicts, invoking Claude to resolve..."
+  local conflicted_files
+  conflicted_files=$(git diff --name-only --diff-filter=U 2>/dev/null || true)
+  if [ -z "$conflicted_files" ]; then
+    echo "No conflicted files found, aborting rebase"
+    git rebase --abort
+    return 1
+  fi
+
+  echo "Conflicted files:"
+  echo "$conflicted_files" | sed 's/^/  - /'
+
+  # Set GIT_EDITOR so git rebase --continue doesn't try to open an interactive editor
+  export GIT_EDITOR=true
+
+  local resolve_prompt="You are resolving git rebase merge conflicts in the openshift/hypershift Go project.
+
+CONFLICTED FILES:
+$conflicted_files
+
+INSTRUCTIONS:
+1. For each conflicted file, read it and resolve the conflict markers (<<<<<<< / ======= / >>>>>>>).
+2. Resolve conflicts by keeping both sides where appropriate, or choosing the correct version.
+3. After resolving each file, run: git add <file>
+4. After ALL conflicts are resolved, run: GIT_EDITOR=true git rebase --continue
+5. Do NOT push — pushing is handled separately.
+6. Do NOT abort the rebase.
+7. If you truly cannot resolve a conflict, explain why."
+
+  set +e
+  claude -p "$resolve_prompt" \
+    --allowedTools "Bash Read Write Edit Grep Glob" \
+    --max-turns 30 \
+    --model "$CLAUDE_MODEL" \
+    --verbose \
+    --output-format stream-json \
+    < /dev/null \
+    2>&1 | tee "/tmp/claude-rebase-output.json"
+  local resolve_exit=$?
+  set -e
+
+  # Save artifact for debugging
+  if [ -f "/tmp/claude-rebase-output.json" ]; then
+    cp "/tmp/claude-rebase-output.json" "${ARTIFACT_DIR}/claude-rebase-output.json" 2>/dev/null || true
+  fi
+
+  # Check if rebase completed (no longer in rebase state)
+  if [ -d ".git/rebase-merge" ] || [ -d ".git/rebase-apply" ]; then
+    echo "Claude could not fully resolve conflicts, aborting rebase"
+    git rebase --abort
+    return 1
+  fi
+
+  if [ $resolve_exit -ne 0 ]; then
+    echo "Claude conflict resolution failed, aborting rebase"
+    git rebase --abort 2>/dev/null || true
+    return 1
+  fi
+
+  echo "Claude resolved conflicts successfully"
+  return 0
+}
+
+# Get failed CI checks matching verify/unit/lint patterns
+# Returns: 0 = success (outputs JSON), 2 = API error (outputs '[]')
+get_failed_ci_checks() {
+  local pr_number=$1
+  local checks_json
+  if ! checks_json=$(gh pr checks "$pr_number" --repo openshift/hypershift --json name,state 2>/dev/null); then
+    echo '[]'
+    return 2  # API error
+  fi
+  echo "$checks_json" | jq '[.[] | select(.state == "FAIL" or .state == "FAILURE" or .state == "fail" or .state == "failure") | select(.name | test("verify|unit|lint"; "i"))] // []'
+}
+
 # Generate token for fork (hypershift-community/hypershift) - for pushing branches
 echo "Generating GitHub App token for fork..."
 GITHUB_TOKEN_FORK=$(generate_github_token "$INSTALLATION_ID_FORK")
@@ -680,6 +793,24 @@ git config --global credential.helper "!f() { echo username=x-access-token; echo
 # Export upstream token as GITHUB_TOKEN for gh CLI (used for PR operations)
 export GITHUB_TOKEN="$GITHUB_TOKEN_UPSTREAM"
 echo "GitHub App tokens configured successfully"
+
+# Refresh both GitHub App tokens and reconfigure credentials
+refresh_github_tokens() {
+  echo "Refreshing GitHub App tokens..."
+  GITHUB_TOKEN_FORK=$(generate_github_token "$INSTALLATION_ID_FORK")
+  if [ -z "$GITHUB_TOKEN_FORK" ] || [ "$GITHUB_TOKEN_FORK" = "null" ]; then
+    echo "WARNING: Failed to refresh fork token, continuing with existing token"
+    return 1
+  fi
+  GITHUB_TOKEN_UPSTREAM=$(generate_github_token "$INSTALLATION_ID_UPSTREAM")
+  if [ -z "$GITHUB_TOKEN_UPSTREAM" ] || [ "$GITHUB_TOKEN_UPSTREAM" = "null" ]; then
+    echo "WARNING: Failed to refresh upstream token, continuing with existing token"
+    return 1
+  fi
+  git config --global credential.helper "!f() { echo username=x-access-token; echo password=${GITHUB_TOKEN_FORK}; }; f"
+  export GITHUB_TOKEN="$GITHUB_TOKEN_UPSTREAM"
+  echo "GitHub App tokens refreshed successfully"
+}
 
 # Configuration: maximum PRs to process per run (default: 10)
 MAX_PRS=${REVIEW_AGENT_MAX_PRS:-10}
@@ -743,138 +874,15 @@ echo "$PRS" | awk '{print "  - PR #" $1 ": " $3}'
 PROCESSED_COUNT=0
 SKIPPED_COUNT=0
 FAILED_COUNT=0
+REBASED_COUNT=0
+CI_FIX_COUNT=0
 TOTAL_PROCESSED=0
 
-# Process each PR
-while IFS= read -r line; do
-  # Stop if we've reached the max PRs limit
-  if [ $TOTAL_PROCESSED -ge $MAX_PRS ]; then
-    echo "Reached maximum PRs limit ($MAX_PRS). Stopping."
-    break
-  fi
-
-  PR_NUMBER=$(echo "$line" | awk '{print $1}')
-  BRANCH_NAME=$(echo "$line" | awk '{print $2}')
-  PR_TITLE=$(echo "$line" | cut -d' ' -f3-)
-
-  echo ""
-  echo "=========================================="
-  echo "Checking: PR #$PR_NUMBER"
-  echo "Branch: $BRANCH_NAME"
-  echo "Title: $PR_TITLE"
-  echo "=========================================="
-
-  # Capture timestamp early for consistent logging
-  TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-
-  # Run comment analyzer to identify which comments actually need attention
-  # This filters out threads where the bot has already replied and no human follow-up exists
-  echo "Running comment analyzer for PR #$PR_NUMBER..."
-  set +e
-  # Capture stderr separately to preserve JSON output integrity
-  ANALYSIS_STDERR_FILE="/tmp/pr-${PR_NUMBER}-analysis-stderr.txt"
-  ANALYSIS_OUTPUT=$(python3 /tmp/comment_analyzer.py "$PR_NUMBER" 2>"$ANALYSIS_STDERR_FILE")
-  ANALYSIS_EXIT=$?
-  set -e
-
-  # Log stderr (authorization decisions) for debugging
-  if [ -s "$ANALYSIS_STDERR_FILE" ]; then
-    echo "Authorization log for PR #$PR_NUMBER:"
-    cat "$ANALYSIS_STDERR_FILE"
-  fi
-
-  if [ $ANALYSIS_EXIT -ne 0 ]; then
-    echo "Comment analyzer failed for PR #$PR_NUMBER: $ANALYSIS_OUTPUT"
-    echo "Stderr: $(cat "$ANALYSIS_STDERR_FILE" 2>/dev/null || echo 'none')"
-    FAILED_COUNT=$((FAILED_COUNT + 1))
-    TOTAL_PROCESSED=$((TOTAL_PROCESSED + 1))
-    echo "$PR_NUMBER $TIMESTAMP FAILED analyzer_error" >> "$STATE_FILE"
-    continue
-  fi
-
-  # Extract summary counts from analysis
-  NEEDS_ATTENTION_COUNT=$(echo "$ANALYSIS_OUTPUT" | jq -r '.summary.total // 0')
-  REVIEW_THREADS=$(echo "$ANALYSIS_OUTPUT" | jq -r '.summary.review_threads // 0')
-  REVIEW_BODIES=$(echo "$ANALYSIS_OUTPUT" | jq -r '.summary.review_bodies // 0')
-  ISSUE_COMMENTS=$(echo "$ANALYSIS_OUTPUT" | jq -r '.summary.issue_comments // 0')
-
-  if [ "$NEEDS_ATTENTION_COUNT" = "0" ] || [ -z "$NEEDS_ATTENTION_COUNT" ]; then
-    echo "No comments need attention for PR #$PR_NUMBER (bot already replied to all threads), skipping"
-    SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
-    TOTAL_PROCESSED=$((TOTAL_PROCESSED + 1))
-    continue
-  fi
-
-  echo "Found $REVIEW_THREADS review threads, $REVIEW_BODIES review bodies, and $ISSUE_COMMENTS issue comments needing attention for PR #$PR_NUMBER"
-
-  # Save analysis for Claude context
-  echo "$ANALYSIS_OUTPUT" > "/tmp/pr-${PR_NUMBER}-analysis.json"
-
-  # Reset working directory and checkout the PR branch
-  echo "Checking out branch: $BRANCH_NAME"
-  git reset --hard HEAD
-  git clean -fd
-  git fetch origin "$BRANCH_NAME"
-  git checkout -B "$BRANCH_NAME" "origin/$BRANCH_NAME"
-
-  # Run address-reviews command non-interactively
-  echo "Running: /utils:address-reviews $PR_NUMBER"
-
-  # Load the skill content as system prompt
-  SKILL_CONTENT=$(cat /tmp/address-reviews.md)
-
-  # Load the analysis results for context
-  NEEDS_ATTENTION_JSON=$(cat "/tmp/pr-${PR_NUMBER}-analysis.json")
-
-  # Context for the review agent with filtered comments
-  REVIEW_CONTEXT="IMPORTANT: You are addressing review comments on PR #$PR_NUMBER in the openshift/hypershift repository. The PR was created from the hypershift-community fork. The gh CLI is authenticated to openshift/hypershift for reading PR information. SECURITY: Do NOT run commands that reveal git credentials. Do NOT push changes - pushing will be handled automatically after you finish.
-
-ENVIRONMENT: The check_replied.py deduplication script is at /tmp/ai-helpers/plugins/utils/scripts/check_replied.py - use this path directly instead of relying on CLAUDE_PLUGIN_ROOT or find commands.
-
-WITHIN-SESSION DUPLICATE PREVENTION: Before posting ANY reply:
-1. At session start, run: touch /tmp/pr-${PR_NUMBER}-posted-replies.txt
-2. Before each reply, check: grep -q '<comment_or_thread_id>' /tmp/pr-${PR_NUMBER}-posted-replies.txt
-3. If the ID is found, SKIP that reply (already posted this session)
-4. After each successful reply, run: echo '<comment_or_thread_id>' >> /tmp/pr-${PR_NUMBER}-posted-replies.txt
-
-CRITICAL - DUPLICATE PREVENTION: The following JSON contains ONLY the comments that need your attention. These are comments where either (1) you have not replied yet, or (2) a human has replied after your last response. ONLY address these specific comments. Ignore all other threads - they have already been addressed.
-
-COMMENTS NEEDING ATTENTION:
-$NEEDS_ATTENTION_JSON
-
-RESPONSE RULES:
-1. For each piece of feedback, choose ONE response mechanism only - never respond to the same feedback via both inline reply AND general PR comment
-2. Only make code changes when explicitly requested (look for imperative language like 'change', 'fix', 'update', 'remove')
-3. For questions or clarifications, reply with an explanation only - do not change code unless asked
-4. COMMENT LINKAGE: When replying to a flat comment (type: issue_comment or review_body), you MUST include a reference so the system knows which comment you addressed:
-   - For issue_comment: include the html_url from the JSON in your reply. Format: start with 'Re: <html_url>' on its own line
-   - For review_body: include the review url from the JSON in your reply. Format: start with 'Re: <url>' on its own line
-
-${SUBAGENT_PROMPT}"
-
-  set +e  # Don't exit on error for individual PRs
-  echo "Starting Claude processing with streaming output..."
-  # Redirect stdin from /dev/null to prevent Claude from consuming the while loop's here-string input
-  RESULT=$(claude -p "$PR_NUMBER. $REVIEW_CONTEXT" \
-    --system-prompt "$SKILL_CONTENT" \
-    --allowedTools "Bash Read Write Edit Grep Glob WebFetch" \
-    --max-turns 100 \
-    --model "$CLAUDE_MODEL" \
-    --verbose \
-    --output-format stream-json \
-    < /dev/null \
-    2>&1 | tee "/tmp/claude-pr-${PR_NUMBER}-output.json")
-  EXIT_CODE=$?
-  set -e
-  echo "Claude processing complete. Full output saved to /tmp/claude-pr-${PR_NUMBER}-output.json"
-
-  if [ -f "/tmp/claude-pr-${PR_NUMBER}-output.json" ]; then
-    # Full output to ARTIFACT_DIR (GCS-backed, no size limit)
-    cp "/tmp/claude-pr-${PR_NUMBER}-output.json" "${ARTIFACT_DIR}/claude-pr-${PR_NUMBER}-output.json"
-    # Compact summary to SHARED_DIR for the report step.
-    # SHARED_DIR is backed by a Kubernetes secret (1MB limit), so we
-    # extract only the fields the report needs into a small JSON file.
-    python3 -c "
+# Helper: extract compact summary from stream-json output
+extract_claude_summary() {
+  local input_file=$1
+  local output_file=$2
+  python3 -c "
 import json, sys
 f = sys.argv[1]
 result_line = system_line = None
@@ -913,40 +921,366 @@ if system_line:
 summary['tool_calls'] = tool_calls
 summary['tool_errors'] = tool_errors
 print(json.dumps(summary))
-" "/tmp/claude-pr-${PR_NUMBER}-output.json" \
-      > "${SHARED_DIR}/claude-pr-${PR_NUMBER}-summary.json" 2>/dev/null || true
+" "$input_file" > "$output_file" 2>/dev/null || true
+}
+
+# Process each PR
+while IFS= read -r line; do
+  # Stop if we've reached the max PRs limit
+  if [ $TOTAL_PROCESSED -ge $MAX_PRS ]; then
+    echo "Reached maximum PRs limit ($MAX_PRS). Stopping."
+    break
   fi
 
-  if [ $EXIT_CODE -eq 0 ]; then
-    echo "Successfully processed PR #$PR_NUMBER"
-    echo ""
-    echo "--- Claude output for PR #$PR_NUMBER ---"
-    echo "$RESULT" | tail -50
-    echo "--- End Claude output ---"
-    echo ""
+  # Refresh tokens every 5 PRs to avoid expiry during long runs
+  if [ $TOTAL_PROCESSED -gt 0 ] && [ $((TOTAL_PROCESSED % 5)) -eq 0 ]; then
+    refresh_github_tokens
+  fi
 
-    # Push changes AFTER Claude finishes (comments already posted).
-    # This must be the last step so that a force-push does not abort
-    # the CI job while it is still posting review replies.
-    if ! git diff --quiet HEAD "origin/$BRANCH_NAME" 2>/dev/null; then
-      echo "Pushing code changes for PR #$PR_NUMBER..."
-      git push --force-with-lease origin "$BRANCH_NAME"
-      echo "Push completed for PR #$PR_NUMBER"
-    else
-      echo "No code changes to push for PR #$PR_NUMBER"
+  PR_NUMBER=$(echo "$line" | awk '{print $1}')
+  BRANCH_NAME=$(echo "$line" | awk '{print $2}')
+  PR_TITLE=$(echo "$line" | cut -d' ' -f3-)
+
+  echo ""
+  echo "=========================================="
+  echo "Checking: PR #$PR_NUMBER"
+  echo "Branch: $BRANCH_NAME"
+  echo "Title: $PR_TITLE"
+  echo "=========================================="
+
+  # Capture timestamp early for consistent logging
+  TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+  # Initialize per-PR action tracking
+  NEEDS_REVIEWS=false
+  NEEDS_REBASE=false
+  NEEDS_CI_FIX=false
+  BASE_BRANCH="main"
+  FAILED_CHECKS_JSON="[]"
+
+  # ---- PHASE 1: DETECT (API-only, no checkout needed) ----
+
+  # 1a. Check for pending review comments
+  echo "Running comment analyzer for PR #$PR_NUMBER..."
+  set +e
+  ANALYSIS_STDERR_FILE="/tmp/pr-${PR_NUMBER}-analysis-stderr.txt"
+  ANALYSIS_OUTPUT=$(python3 /tmp/comment_analyzer.py "$PR_NUMBER" 2>"$ANALYSIS_STDERR_FILE")
+  ANALYSIS_EXIT=$?
+  set -e
+
+  if [ -s "$ANALYSIS_STDERR_FILE" ]; then
+    echo "Authorization log for PR #$PR_NUMBER:"
+    cat "$ANALYSIS_STDERR_FILE"
+  fi
+
+  if [ $ANALYSIS_EXIT -ne 0 ]; then
+    echo "Comment analyzer failed for PR #$PR_NUMBER: $ANALYSIS_OUTPUT"
+    echo "Stderr: $(cat "$ANALYSIS_STDERR_FILE" 2>/dev/null || echo 'none')"
+    FAILED_COUNT=$((FAILED_COUNT + 1))
+    TOTAL_PROCESSED=$((TOTAL_PROCESSED + 1))
+    echo "$PR_NUMBER $TIMESTAMP FAILED analyzer_error" >> "$STATE_FILE"
+    continue
+  fi
+
+  NEEDS_ATTENTION_COUNT=$(echo "$ANALYSIS_OUTPUT" | jq -r '.summary.total // 0')
+  REVIEW_THREADS=$(echo "$ANALYSIS_OUTPUT" | jq -r '.summary.review_threads // 0')
+  REVIEW_BODIES=$(echo "$ANALYSIS_OUTPUT" | jq -r '.summary.review_bodies // 0')
+  ISSUE_COMMENTS=$(echo "$ANALYSIS_OUTPUT" | jq -r '.summary.issue_comments // 0')
+
+  if [ "$NEEDS_ATTENTION_COUNT" != "0" ] && [ -n "$NEEDS_ATTENTION_COUNT" ]; then
+    NEEDS_REVIEWS=true
+    echo "Found $REVIEW_THREADS review threads, $REVIEW_BODIES review bodies, and $ISSUE_COMMENTS issue comments needing attention"
+    echo "$ANALYSIS_OUTPUT" > "/tmp/pr-${PR_NUMBER}-analysis.json"
+  else
+    echo "No review comments need attention"
+  fi
+
+  # 1b. Check if rebase is needed
+  echo "Checking rebase status for PR #$PR_NUMBER..."
+  set +e
+  BASE_BRANCH=$(check_rebase_needed "$PR_NUMBER")
+  REBASE_CHECK_EXIT=$?
+  set -e
+
+  if [ $REBASE_CHECK_EXIT -eq 0 ]; then
+    NEEDS_REBASE=true
+    echo "PR #$PR_NUMBER needs rebase onto $BASE_BRANCH"
+  elif [ $REBASE_CHECK_EXIT -eq 2 ]; then
+    echo "WARNING: Failed to check rebase status (API error), skipping rebase detection"
+  else
+    echo "No rebase needed"
+  fi
+
+  # 1c. Check for failed CI checks (verify/unit/lint)
+  if [ "${REVIEW_AGENT_ENABLE_CI_FIXES:-true}" = "true" ]; then
+    echo "Checking CI status for PR #$PR_NUMBER..."
+    set +e
+    FAILED_CHECKS_JSON=$(get_failed_ci_checks "$PR_NUMBER")
+    CI_CHECK_EXIT=$?
+    set -e
+
+    if [ $CI_CHECK_EXIT -eq 2 ]; then
+      echo "WARNING: Failed to check CI status (API error), skipping CI fix detection"
+      FAILED_CHECKS_JSON="[]"
     fi
 
-    PROCESSED_COUNT=$((PROCESSED_COUNT + 1))
-    echo "$PR_NUMBER $TIMESTAMP SUCCESS" >> "$STATE_FILE"
-  else
-    echo "Failed to process PR #$PR_NUMBER"
-    echo "Error output (last 20 lines):"
-    echo "$RESULT" | tail -20
-    FAILED_COUNT=$((FAILED_COUNT + 1))
-    echo "$PR_NUMBER $TIMESTAMP FAILED" >> "$STATE_FILE"
+    FAILED_CHECK_COUNT=$(echo "$FAILED_CHECKS_JSON" | jq 'length' 2>/dev/null || echo "0")
+
+    if [ "$FAILED_CHECK_COUNT" -gt 0 ]; then
+      NEEDS_CI_FIX=true
+      echo "Found $FAILED_CHECK_COUNT failed CI checks:"
+      echo "$FAILED_CHECKS_JSON" | jq -r '.[].name' 2>/dev/null | sed 's/^/  - /'
+    else
+      echo "No failed CI checks matching verify/unit/lint"
+    fi
   fi
 
-  # Increment total counter
+  # ---- SKIP if nothing to do ----
+  if [ "$NEEDS_REVIEWS" = "false" ] && [ "$NEEDS_REBASE" = "false" ] && [ "$NEEDS_CI_FIX" = "false" ]; then
+    echo "No reviews, rebase, or CI fixes needed for PR #$PR_NUMBER, skipping"
+    SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
+    TOTAL_PROCESSED=$((TOTAL_PROCESSED + 1))
+    continue
+  fi
+
+  # ---- PHASE 2: CHECKOUT ----
+  echo "Checking out branch: $BRANCH_NAME"
+  git reset --hard HEAD
+  git clean -fd
+  git fetch origin "$BRANCH_NAME"
+  git checkout -B "$BRANCH_NAME" "origin/$BRANCH_NAME"
+
+  # Initialize per-PR actions JSON
+  PR_ACTIONS='{"rebase":{"attempted":false},"reviews":{"attempted":false},"ci_fixes":{"attempted":false}}'
+  PR_HAD_ERROR=false
+
+  # ---- PHASE 3: REBASE (if needed) ----
+  if [ "$NEEDS_REBASE" = "true" ]; then
+    echo "Rebasing PR #$PR_NUMBER onto upstream/$BASE_BRANCH..."
+    PR_ACTIONS=$(echo "$PR_ACTIONS" | jq '.rebase.attempted = true')
+    set +e
+    perform_rebase "$BASE_BRANCH"
+    REBASE_EXIT=$?
+    set -e
+
+    if [ $REBASE_EXIT -ne 0 ]; then
+      echo "Rebase failed for PR #$PR_NUMBER (conflicts), skipping remaining phases"
+      PR_ACTIONS=$(echo "$PR_ACTIONS" | jq '.rebase.result = "conflict"')
+      echo "$PR_ACTIONS" > "${SHARED_DIR}/pr-${PR_NUMBER}-actions.json"
+      FAILED_COUNT=$((FAILED_COUNT + 1))
+      TOTAL_PROCESSED=$((TOTAL_PROCESSED + 1))
+      echo "$PR_NUMBER $TIMESTAMP FAILED rebase_conflict" >> "$STATE_FILE"
+      continue
+    fi
+
+    echo "Rebase successful"
+    PR_ACTIONS=$(echo "$PR_ACTIONS" | jq '.rebase.result = "success"')
+    REBASED_COUNT=$((REBASED_COUNT + 1))
+  fi
+
+  # ---- PHASE 4: REVIEWS (if needed) ----
+  if [ "$NEEDS_REVIEWS" = "true" ]; then
+    echo "Running: /utils:address-reviews $PR_NUMBER"
+    PR_ACTIONS=$(echo "$PR_ACTIONS" | jq '.reviews.attempted = true')
+
+    SKILL_CONTENT=$(cat /tmp/address-reviews.md)
+    NEEDS_ATTENTION_JSON=$(cat "/tmp/pr-${PR_NUMBER}-analysis.json")
+
+    REVIEW_CONTEXT="IMPORTANT: You are addressing review comments on PR #$PR_NUMBER in the openshift/hypershift repository. The PR was created from the hypershift-community fork. The gh CLI is authenticated to openshift/hypershift for reading PR information. SECURITY: Do NOT run commands that reveal git credentials. Do NOT push changes - pushing will be handled automatically after you finish.
+
+ENVIRONMENT: The check_replied.py deduplication script is at /tmp/ai-helpers/plugins/utils/scripts/check_replied.py - use this path directly instead of relying on CLAUDE_PLUGIN_ROOT or find commands.
+
+WITHIN-SESSION DUPLICATE PREVENTION: Before posting ANY reply:
+1. At session start, run: touch /tmp/pr-${PR_NUMBER}-posted-replies.txt
+2. Before each reply, check: grep -q '<comment_or_thread_id>' /tmp/pr-${PR_NUMBER}-posted-replies.txt
+3. If the ID is found, SKIP that reply (already posted this session)
+4. After each successful reply, run: echo '<comment_or_thread_id>' >> /tmp/pr-${PR_NUMBER}-posted-replies.txt
+
+CRITICAL - DUPLICATE PREVENTION: The following JSON contains ONLY the comments that need your attention. These are comments where either (1) you have not replied yet, or (2) a human has replied after your last response. ONLY address these specific comments. Ignore all other threads - they have already been addressed.
+
+COMMENTS NEEDING ATTENTION:
+$NEEDS_ATTENTION_JSON
+
+RESPONSE RULES:
+1. For each piece of feedback, choose ONE response mechanism only - never respond to the same feedback via both inline reply AND general PR comment
+2. Only make code changes when explicitly requested (look for imperative language like 'change', 'fix', 'update', 'remove')
+3. For questions or clarifications, reply with an explanation only - do not change code unless asked
+4. COMMENT LINKAGE: When replying to a flat comment (type: issue_comment or review_body), you MUST include a reference so the system knows which comment you addressed:
+   - For issue_comment: include the html_url from the JSON in your reply. Format: start with 'Re: <html_url>' on its own line
+   - For review_body: include the review url from the JSON in your reply. Format: start with 'Re: <url>' on its own line
+
+${SUBAGENT_PROMPT}"
+
+    set +e
+    echo "Starting Claude review processing..."
+    RESULT=$(claude -p "$PR_NUMBER. $REVIEW_CONTEXT" \
+      --system-prompt "$SKILL_CONTENT" \
+      --allowedTools "Bash Read Write Edit Grep Glob WebFetch" \
+      --max-turns 150 \
+      --model "$CLAUDE_MODEL" \
+      --verbose \
+      --output-format stream-json \
+      < /dev/null \
+      2>&1 | tee "/tmp/claude-pr-${PR_NUMBER}-output.json")
+    REVIEW_EXIT=$?
+    set -e
+    echo "Review processing complete. Output saved to /tmp/claude-pr-${PR_NUMBER}-output.json"
+
+    if [ -f "/tmp/claude-pr-${PR_NUMBER}-output.json" ]; then
+      cp "/tmp/claude-pr-${PR_NUMBER}-output.json" "${ARTIFACT_DIR}/claude-pr-${PR_NUMBER}-output.json"
+      extract_claude_summary "/tmp/claude-pr-${PR_NUMBER}-output.json" "${SHARED_DIR}/claude-pr-${PR_NUMBER}-summary.json"
+    fi
+
+    if [ $REVIEW_EXIT -eq 0 ]; then
+      PR_ACTIONS=$(echo "$PR_ACTIONS" | jq '.reviews.result = "success"')
+      echo "Review phase succeeded for PR #$PR_NUMBER"
+      echo ""
+      echo "--- Claude review output for PR #$PR_NUMBER ---"
+      echo "$RESULT" | tail -50
+      echo "--- End Claude review output ---"
+      echo ""
+    else
+      PR_ACTIONS=$(echo "$PR_ACTIONS" | jq '.reviews.result = "failed"')
+      PR_HAD_ERROR=true
+      echo "Review phase failed for PR #$PR_NUMBER"
+      echo "Error output (last 20 lines):"
+      echo "$RESULT" | tail -20
+    fi
+  fi
+
+  # ---- PHASE 5: CI FIX (if needed and enabled) ----
+  if [ "$NEEDS_CI_FIX" = "true" ] && [ "${REVIEW_AGENT_ENABLE_CI_FIXES:-true}" = "true" ]; then
+    echo "Running CI fix phase for PR #$PR_NUMBER..."
+    PR_ACTIONS=$(echo "$PR_ACTIONS" | jq '.ci_fixes.attempted = true')
+
+    # Build list of failed check names for the prompt
+    FAILED_CHECK_NAMES=$(echo "$FAILED_CHECKS_JSON" | jq -r '.[].name' 2>/dev/null | sed 's/^/- /')
+    PR_ACTIONS=$(echo "$PR_ACTIONS" | jq --argjson checks "$FAILED_CHECKS_JSON" '.ci_fixes.checks = [$checks[].name]')
+
+    CI_FIX_SYSTEM="You are a CI failure debugging assistant for the openshift/hypershift Go project.
+You are fixing failed CI checks on PR #$PR_NUMBER.
+
+ENVIRONMENT:
+- This is a Go project. Go, make, and standard build tools are available.
+- You are in the hypershift repository clone at /tmp/hypershift.
+- You can reproduce failures locally using make targets and go test.
+
+TASK:
+The following CI checks are failing on this PR. Reproduce each failure locally,
+diagnose the root cause, and fix the code.
+
+APPROACH PER CHECK TYPE:
+- verify: Run \`make verify\` to reproduce. Fix formatting, imports, generated
+  files, or whatever the verify output indicates. Re-run to confirm the fix.
+- unit: Run \`make test\` or \`go test ./path/to/package/...\` for the failing
+  package. Read the test failure, fix the code or test, and re-run to confirm.
+- lint/gitlint: For Go lint issues, run the linter and fix. For commit message
+  lint (gitlint), fix the message with \`git commit --amend\`.
+
+RULES:
+- Do NOT push changes — pushing is handled automatically after you finish.
+- After fixing each check, commit your changes with a descriptive message using
+  conventional commit format (e.g., \`fix(lint): reorder imports per gci config\`).
+  Amend the relevant existing commit if appropriate, or create a new fixup commit.
+- Reproduce each failure first, then fix, then verify the fix passes.
+- Keep changes minimal and targeted — fix only what the failing checks require.
+- If a fix requires understanding broader context, use Grep/Glob/Read to
+  explore the codebase before making changes.
+- If you cannot fix a failure after reasonable effort, explain what you tried
+  and move on to the next check."
+
+    CI_FIX_PROMPT="Fix the following CI failures for PR #$PR_NUMBER:
+
+Failed checks:
+$FAILED_CHECK_NAMES
+
+Reproduce each failure, fix the code, and verify the fix passes."
+
+    set +e
+    echo "Starting Claude CI fix processing..."
+    CI_RESULT=$(claude -p "$CI_FIX_PROMPT" \
+      --system-prompt "$CI_FIX_SYSTEM" \
+      --allowedTools "Bash Read Write Edit Grep Glob" \
+      --max-turns 150 \
+      --model "$CLAUDE_MODEL" \
+      --verbose \
+      --output-format stream-json \
+      < /dev/null \
+      2>&1 | tee "/tmp/claude-pr-${PR_NUMBER}-cifix-output.json")
+    CI_FIX_EXIT=$?
+    set -e
+    echo "CI fix processing complete. Output saved to /tmp/claude-pr-${PR_NUMBER}-cifix-output.json"
+
+    if [ -f "/tmp/claude-pr-${PR_NUMBER}-cifix-output.json" ]; then
+      cp "/tmp/claude-pr-${PR_NUMBER}-cifix-output.json" "${ARTIFACT_DIR}/claude-pr-${PR_NUMBER}-cifix-output.json"
+      extract_claude_summary "/tmp/claude-pr-${PR_NUMBER}-cifix-output.json" "${SHARED_DIR}/claude-pr-${PR_NUMBER}-cifix-summary.json"
+    fi
+
+    if [ $CI_FIX_EXIT -eq 0 ]; then
+      PR_ACTIONS=$(echo "$PR_ACTIONS" | jq '.ci_fixes.result = "success"')
+      CI_FIX_COUNT=$((CI_FIX_COUNT + 1))
+      echo "CI fix phase succeeded for PR #$PR_NUMBER"
+    else
+      PR_ACTIONS=$(echo "$PR_ACTIONS" | jq '.ci_fixes.result = "failed"')
+      PR_HAD_ERROR=true
+      echo "CI fix phase failed for PR #$PR_NUMBER"
+      echo "Error output (last 20 lines):"
+      echo "$CI_RESULT" | tail -20
+    fi
+  fi
+
+  # ---- PHASE 6: PUSH (single push at end if any phase made changes) ----
+  # Commit any uncommitted changes left by Claude (safety net)
+  if ! git diff --quiet 2>/dev/null || ! git diff --cached --quiet 2>/dev/null; then
+    echo "Committing uncommitted changes left by Claude for PR #$PR_NUMBER..."
+    git add -A
+    git commit -m "fix: address CI check failures
+
+Automated fix for failing CI checks on PR #$PR_NUMBER.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+  fi
+
+  PUSH_NEEDED=false
+  if ! git diff --quiet HEAD "origin/$BRANCH_NAME" 2>/dev/null; then
+    PUSH_NEEDED=true
+  fi
+
+  if [ "$NEEDS_REBASE" = "true" ]; then
+    # Rebase always requires a push even if no file diff (history changed)
+    PUSH_NEEDED=true
+  fi
+
+  if [ "$PR_HAD_ERROR" = "true" ]; then
+    echo "Skipping push for PR #$PR_NUMBER because an earlier phase failed"
+  elif [ "$PUSH_NEEDED" = "true" ]; then
+    echo "Pushing changes for PR #$PR_NUMBER..."
+    set +e
+    git push --force-with-lease origin "$BRANCH_NAME"
+    PUSH_EXIT=$?
+    set -e
+
+    if [ $PUSH_EXIT -eq 0 ]; then
+      echo "Push completed for PR #$PR_NUMBER"
+    else
+      echo "Push failed for PR #$PR_NUMBER"
+      PR_HAD_ERROR=true
+    fi
+  else
+    echo "No changes to push for PR #$PR_NUMBER"
+  fi
+
+  # ---- Write per-PR actions JSON ----
+  echo "$PR_ACTIONS" > "${SHARED_DIR}/pr-${PR_NUMBER}-actions.json"
+
+  if [ "$PR_HAD_ERROR" = "true" ]; then
+    FAILED_COUNT=$((FAILED_COUNT + 1))
+    echo "$PR_NUMBER $TIMESTAMP FAILED" >> "$STATE_FILE"
+  else
+    PROCESSED_COUNT=$((PROCESSED_COUNT + 1))
+    echo "$PR_NUMBER $TIMESTAMP SUCCESS" >> "$STATE_FILE"
+  fi
+
   TOTAL_PROCESSED=$((TOTAL_PROCESSED + 1))
 
   # Rate limiting between PRs (60 seconds)
@@ -960,6 +1294,8 @@ done <<< "$PRS"
 echo ""
 echo "=== Processing Summary ==="
 echo "Processed: $PROCESSED_COUNT"
-echo "Skipped (no pending reviews): $SKIPPED_COUNT"
+echo "Skipped (no action needed): $SKIPPED_COUNT"
+echo "Rebased: $REBASED_COUNT"
+echo "CI Fixes: $CI_FIX_COUNT"
 echo "Failed: $FAILED_COUNT"
 echo "=========================="

--- a/ci-operator/step-registry/hypershift/review-agent/process/hypershift-review-agent-process-ref.yaml
+++ b/ci-operator/step-registry/hypershift/review-agent/process/hypershift-review-agent-process-ref.yaml
@@ -29,6 +29,12 @@ ref:
       When set to "true", forces batch mode and ignores PULL_NUMBER.
       Use this for periodic jobs to prevent rehearsal failures when
       PULL_NUMBER refers to a release repo PR instead of a HyperShift PR.
+  - name: REVIEW_AGENT_ENABLE_CI_FIXES
+    default: "true"
+    documentation: |-
+      Controls whether CI failure detection and fixing is active.
+      When enabled, the agent detects failing verify/unit/lint checks
+      and invokes Claude to reproduce and fix failures locally.
   - name: CLAUDE_MODEL
     default: "claude-opus-4-6"
     documentation: |-

--- a/ci-operator/step-registry/hypershift/review-agent/report/hypershift-review-agent-report-commands.sh
+++ b/ci-operator/step-registry/hypershift/review-agent/report/hypershift-review-agent-report-commands.sh
@@ -133,6 +133,78 @@ extract_from_stream_json() {
   esac
 }
 
+# Helper: read token/cost data from a summary file (compact or legacy format)
+read_phase_summary() {
+  local summary_file=$1
+  # Output variables are set via nameref-like pattern using eval
+  local prefix=$2
+
+  local input=0 output=0 cache_read=0 cache_create=0 duration_ms=0 duration_api_ms=0 num_turns=0 cost_raw=0 model="unknown" session_id="unknown" result_text="" tools_available=""
+
+  if [ -f "$summary_file" ] && grep -q '"result"' "$summary_file" 2>/dev/null && ! grep -q '"type":"result"' "$summary_file" 2>/dev/null; then
+    result_text=$(jq -r '.result // empty' "$summary_file" 2>/dev/null | html_escape)
+    input=$(jq -r '.usage.input_tokens // 0' "$summary_file" 2>/dev/null)
+    output=$(jq -r '.usage.output_tokens // 0' "$summary_file" 2>/dev/null)
+    cache_read=$(jq -r '.usage.cache_read_input_tokens // 0' "$summary_file" 2>/dev/null)
+    cache_create=$(jq -r '.usage.cache_creation_input_tokens // (.usage.cache_creation.ephemeral_5m_input_tokens // 0)' "$summary_file" 2>/dev/null)
+    duration_ms=$(jq -r '.duration_ms // 0' "$summary_file" 2>/dev/null)
+    duration_api_ms=$(jq -r '.duration_api_ms // 0' "$summary_file" 2>/dev/null)
+    num_turns=$(jq -r '.num_turns // 0' "$summary_file" 2>/dev/null)
+    model=$(jq -r '.model // "unknown"' "$summary_file" 2>/dev/null)
+    session_id=$(jq -r '.session_id // "unknown"' "$summary_file" 2>/dev/null)
+    cost_raw=$(jq -r '.total_cost_usd // 0' "$summary_file" 2>/dev/null)
+    tools_available=$(jq -r '.tools // [] | join(",")' "$summary_file" 2>/dev/null)
+  elif [ -f "$summary_file" ] && [ -s "$summary_file" ]; then
+    result_text=$(extract_from_stream_json "$summary_file" "text" | html_escape)
+    input=$(extract_from_stream_json "$summary_file" "input_tokens")
+    output=$(extract_from_stream_json "$summary_file" "output_tokens")
+    cache_read=$(extract_from_stream_json "$summary_file" "cache_read")
+    cache_create=$(extract_from_stream_json "$summary_file" "cache_create")
+    duration_ms=$(extract_from_stream_json "$summary_file" "duration_ms")
+    duration_api_ms=$(extract_from_stream_json "$summary_file" "duration_api_ms")
+    num_turns=$(extract_from_stream_json "$summary_file" "num_turns")
+    model=$(extract_from_stream_json "$summary_file" "model")
+    session_id=$(extract_from_stream_json "$summary_file" "session_id")
+    cost_raw=$(extract_from_stream_json "$summary_file" "cost_usd")
+    tools_available=$(extract_from_stream_json "$summary_file" "tools_available")
+  fi
+
+  : "${input:=0}" ; : "${output:=0}" ; : "${cache_read:=0}" ; : "${cache_create:=0}"
+  : "${duration_ms:=0}" ; : "${duration_api_ms:=0}" ; : "${num_turns:=0}" ; : "${cost_raw:=0}"
+
+  printf -v "${prefix}_INPUT" '%s' "$input"
+  printf -v "${prefix}_OUTPUT" '%s' "$output"
+  printf -v "${prefix}_CACHE_READ" '%s' "$cache_read"
+  printf -v "${prefix}_CACHE_CREATE" '%s' "$cache_create"
+  printf -v "${prefix}_DURATION_MS" '%s' "$duration_ms"
+  printf -v "${prefix}_DURATION_API_MS" '%s' "$duration_api_ms"
+  printf -v "${prefix}_NUM_TURNS" '%s' "$num_turns"
+  printf -v "${prefix}_COST_RAW" '%s' "$cost_raw"
+  printf -v "${prefix}_MODEL" '%s' "$model"
+  printf -v "${prefix}_SESSION_ID" '%s' "$session_id"
+  printf -v "${prefix}_RESULT_TEXT" '%s' "$result_text"
+  printf -v "${prefix}_TOOLS_AVAILABLE" '%s' "$tools_available"
+}
+
+# Helper: extract tool calls/errors from a summary file
+read_phase_tools() {
+  local summary_file=$1
+  local prefix=$2
+
+  local tool_calls_raw="" tool_errors_raw=""
+
+  if [ -f "$summary_file" ] && grep -q '"result"' "$summary_file" 2>/dev/null && ! grep -q '"type":"result"' "$summary_file" 2>/dev/null; then
+    tool_calls_raw=$(jq -r '.tool_calls[]? // empty' "$summary_file" 2>/dev/null | sed 's/^/  /' || echo "")
+    tool_errors_raw=$(jq -r '.tool_errors[]? // empty' "$summary_file" 2>/dev/null || echo "")
+  elif [ -f "$summary_file" ] && [ -s "$summary_file" ]; then
+    tool_calls_raw=$(jq -r 'select(.type == "assistant") | .message.content[]? | select(.type == "tool_use") | "  \(.name)(\(.input | tostring | .[0:120])...)"' "$summary_file" 2>/dev/null || echo "")
+    tool_errors_raw=$(jq -r 'select(.type == "user") | .tool_use_result | select(type == "string") | select(startswith("Error:")) | gsub("\n"; "⏎")' "$summary_file" 2>/dev/null | sed 's/⏎/\n/g' || echo "")
+  fi
+
+  printf -v "${prefix}_TOOL_CALLS_RAW" '%s' "$tool_calls_raw"
+  printf -v "${prefix}_TOOL_ERRORS_RAW" '%s' "$tool_errors_raw"
+}
+
 # Build PR rows for summary table and detail sections
 SUMMARY_ROWS=""
 DETAIL_SECTIONS=""
@@ -141,6 +213,8 @@ GRAND_TOTAL_OUTPUT=0
 GRAND_TOTAL_CACHE_READ=0
 GRAND_TOTAL_CACHE_CREATE=0
 GRAND_TOTAL_COST_USD="0"
+GRAND_REBASED_COUNT=0
+GRAND_CI_FIX_COUNT=0
 
 while IFS= read -r line; do
   PR_NUMBER=$(echo "$line" | awk '{print $1}')
@@ -157,60 +231,86 @@ while IFS= read -r line; do
     STATUS_LABEL="Failed"
   fi
 
-  # Read from compact summary JSON (written by process step)
-  SUMMARY_FILE="${SHARED_DIR}/claude-pr-${PR_NUMBER}-summary.json"
-  if [ ! -f "$SUMMARY_FILE" ]; then
-    # Fallback to legacy stream-json format
-    SUMMARY_FILE="${SHARED_DIR}/claude-pr-${PR_NUMBER}-output.json"
+  # ---- Read per-PR actions JSON ----
+  ACTIONS_FILE="${SHARED_DIR}/pr-${PR_NUMBER}-actions.json"
+  REBASE_ATTEMPTED="false"
+  REBASE_RESULT=""
+  REVIEWS_ATTEMPTED="false"
+  REVIEWS_RESULT=""
+  CI_FIX_ATTEMPTED="false"
+  CI_FIX_RESULT=""
+  CI_FIX_CHECKS=""
+
+  if [ -f "$ACTIONS_FILE" ]; then
+    REBASE_ATTEMPTED=$(jq -r '.rebase.attempted // false' "$ACTIONS_FILE" 2>/dev/null)
+    REBASE_RESULT=$(jq -r '.rebase.result // empty' "$ACTIONS_FILE" 2>/dev/null)
+    REVIEWS_ATTEMPTED=$(jq -r '.reviews.attempted // false' "$ACTIONS_FILE" 2>/dev/null)
+    REVIEWS_RESULT=$(jq -r '.reviews.result // empty' "$ACTIONS_FILE" 2>/dev/null)
+    CI_FIX_ATTEMPTED=$(jq -r '.ci_fixes.attempted // false' "$ACTIONS_FILE" 2>/dev/null)
+    CI_FIX_RESULT=$(jq -r '.ci_fixes.result // empty' "$ACTIONS_FILE" 2>/dev/null)
+    CI_FIX_CHECKS=$(jq -r '.ci_fixes.checks // [] | join(", ")' "$ACTIONS_FILE" 2>/dev/null)
   fi
 
-  if [ -f "$SUMMARY_FILE" ] && grep -q '"result"' "$SUMMARY_FILE" 2>/dev/null && ! grep -q '"type":"result"' "$SUMMARY_FILE" 2>/dev/null; then
-    # New compact summary format
-    RESULT_TEXT=$(jq -r '.result // empty' "$SUMMARY_FILE" 2>/dev/null | html_escape)
-    PR_INPUT=$(jq -r '.usage.input_tokens // 0' "$SUMMARY_FILE" 2>/dev/null)
-    PR_OUTPUT=$(jq -r '.usage.output_tokens // 0' "$SUMMARY_FILE" 2>/dev/null)
-    PR_CACHE_READ=$(jq -r '.usage.cache_read_input_tokens // 0' "$SUMMARY_FILE" 2>/dev/null)
-    PR_CACHE_CREATE=$(jq -r '.usage.cache_creation_input_tokens // (.usage.cache_creation.ephemeral_5m_input_tokens // 0)' "$SUMMARY_FILE" 2>/dev/null)
-    DURATION_MS=$(jq -r '.duration_ms // 0' "$SUMMARY_FILE" 2>/dev/null)
-    DURATION_API_MS=$(jq -r '.duration_api_ms // 0' "$SUMMARY_FILE" 2>/dev/null)
-    NUM_TURNS=$(jq -r '.num_turns // 0' "$SUMMARY_FILE" 2>/dev/null)
-    MODEL=$(jq -r '.model // "unknown"' "$SUMMARY_FILE" 2>/dev/null)
-    SESSION_ID=$(jq -r '.session_id // "unknown"' "$SUMMARY_FILE" 2>/dev/null)
-    TOOLS_AVAILABLE=$(jq -r '.tools // [] | join(",")' "$SUMMARY_FILE" 2>/dev/null)
-  else
-    # Legacy stream-json format
-    OUTPUT_FILE="$SUMMARY_FILE"
-    RESULT_TEXT=$(extract_from_stream_json "$OUTPUT_FILE" "text" | html_escape)
-    PR_INPUT=$(extract_from_stream_json "$OUTPUT_FILE" "input_tokens")
-    PR_OUTPUT=$(extract_from_stream_json "$OUTPUT_FILE" "output_tokens")
-    PR_CACHE_READ=$(extract_from_stream_json "$OUTPUT_FILE" "cache_read")
-    PR_CACHE_CREATE=$(extract_from_stream_json "$OUTPUT_FILE" "cache_create")
-    DURATION_MS=$(extract_from_stream_json "$OUTPUT_FILE" "duration_ms")
-    DURATION_API_MS=$(extract_from_stream_json "$OUTPUT_FILE" "duration_api_ms")
-    NUM_TURNS=$(extract_from_stream_json "$OUTPUT_FILE" "num_turns")
-    MODEL=$(extract_from_stream_json "$OUTPUT_FILE" "model")
-    SESSION_ID=$(extract_from_stream_json "$OUTPUT_FILE" "session_id")
-    TOOLS_AVAILABLE=$(extract_from_stream_json "$OUTPUT_FILE" "tools_available")
+  # Count rebases and CI fixes for summary stats
+  if [ "$REBASE_ATTEMPTED" = "true" ] && [ "$REBASE_RESULT" = "success" ]; then
+    GRAND_REBASED_COUNT=$((GRAND_REBASED_COUNT + 1))
+  fi
+  if [ "$CI_FIX_ATTEMPTED" = "true" ] && [ "$CI_FIX_RESULT" = "success" ]; then
+    GRAND_CI_FIX_COUNT=$((GRAND_CI_FIX_COUNT + 1))
   fi
 
-  : "${PR_INPUT:=0}"
-  : "${PR_OUTPUT:=0}"
-  : "${PR_CACHE_READ:=0}"
-  : "${PR_CACHE_CREATE:=0}"
-  : "${DURATION_MS:=0}"
-  : "${NUM_TURNS:=0}"
-
-  DURATION_SECS=$((DURATION_MS / 1000))
-  DURATION_API_SECS=$((DURATION_API_MS / 1000))
-
-  # Cost - try summary format first, then legacy
-  if [ -f "$SUMMARY_FILE" ] && ! grep -q '"type":"result"' "$SUMMARY_FILE" 2>/dev/null; then
-    PR_COST_RAW=$(jq -r '.total_cost_usd // 0' "$SUMMARY_FILE" 2>/dev/null)
-  else
-    PR_COST_RAW=$(extract_from_stream_json "${OUTPUT_FILE:-$SUMMARY_FILE}" "cost_usd")
+  # Build action badges for summary table
+  ACTION_BADGES=""
+  if [ "$REBASE_ATTEMPTED" = "true" ]; then
+    if [ "$REBASE_RESULT" = "success" ]; then
+      ACTION_BADGES="${ACTION_BADGES}<span class=\"badge rebase\">Rebased</span> "
+    else
+      ACTION_BADGES="${ACTION_BADGES}<span class=\"badge failed\">Rebase Failed</span> "
+    fi
   fi
-  : "${PR_COST_RAW:=0}"
+  if [ "$REVIEWS_ATTEMPTED" = "true" ]; then
+    if [ "$REVIEWS_RESULT" = "success" ]; then
+      ACTION_BADGES="${ACTION_BADGES}<span class=\"badge reviews\">Reviews</span> "
+    else
+      ACTION_BADGES="${ACTION_BADGES}<span class=\"badge failed\">Reviews Failed</span> "
+    fi
+  fi
+  if [ "$CI_FIX_ATTEMPTED" = "true" ]; then
+    if [ "$CI_FIX_RESULT" = "success" ]; then
+      ACTION_BADGES="${ACTION_BADGES}<span class=\"badge cifix\">CI Fix</span> "
+    else
+      ACTION_BADGES="${ACTION_BADGES}<span class=\"badge failed\">CI Fix Failed</span> "
+    fi
+  fi
+  : "${ACTION_BADGES:=-}"
+
+  # ---- Read review phase summary ----
+  REVIEW_SUMMARY_FILE="${SHARED_DIR}/claude-pr-${PR_NUMBER}-summary.json"
+  if [ ! -f "$REVIEW_SUMMARY_FILE" ]; then
+    REVIEW_SUMMARY_FILE="${SHARED_DIR}/claude-pr-${PR_NUMBER}-output.json"
+  fi
+
+  read_phase_summary "$REVIEW_SUMMARY_FILE" "REV"
+  read_phase_tools "$REVIEW_SUMMARY_FILE" "REV"
+
+  # ---- Read CI fix phase summary ----
+  CIFIX_SUMMARY_FILE="${SHARED_DIR}/claude-pr-${PR_NUMBER}-cifix-summary.json"
+  read_phase_summary "$CIFIX_SUMMARY_FILE" "CIFIX"
+  read_phase_tools "$CIFIX_SUMMARY_FILE" "CIFIX"
+
+  # ---- Compute per-PR totals (review + CI fix) ----
+  PR_INPUT=$((REV_INPUT + CIFIX_INPUT))
+  PR_OUTPUT=$((REV_OUTPUT + CIFIX_OUTPUT))
+  PR_CACHE_READ=$((REV_CACHE_READ + CIFIX_CACHE_READ))
+  PR_CACHE_CREATE=$((REV_CACHE_CREATE + CIFIX_CACHE_CREATE))
+  PR_DURATION_MS=$((REV_DURATION_MS + CIFIX_DURATION_MS))
+  PR_COST_RAW=$(sum_costs "$REV_COST_RAW" "$CIFIX_COST_RAW")
   PR_COST=$(format_cost "$PR_COST_RAW")
+
+  PR_DURATION_SECS=$((PR_DURATION_MS / 1000))
+  REV_DURATION_SECS=$((REV_DURATION_MS / 1000))
+  REV_DURATION_API_SECS=$((REV_DURATION_API_MS / 1000))
+  CIFIX_DURATION_SECS=$((CIFIX_DURATION_MS / 1000))
 
   # Accumulate grand totals
   GRAND_TOTAL_INPUT=$((GRAND_TOTAL_INPUT + PR_INPUT))
@@ -219,39 +319,34 @@ while IFS= read -r line; do
   GRAND_TOTAL_CACHE_CREATE=$((GRAND_TOTAL_CACHE_CREATE + PR_CACHE_CREATE))
   GRAND_TOTAL_COST_USD=$(sum_costs "$GRAND_TOTAL_COST_USD" "$PR_COST_RAW")
 
-  # Extract tool calls and errors
-  TOOL_CALLS_RAW=""
-  TOOL_ERRORS_RAW=""
-  if [ -f "$SUMMARY_FILE" ] && ! grep -q '"type":"result"' "$SUMMARY_FILE" 2>/dev/null; then
-    # New compact summary format - tool_calls is a list of names, tool_errors is a list of strings
-    TOOL_CALLS_RAW=$(jq -r '.tool_calls[]? // empty' "$SUMMARY_FILE" 2>/dev/null | sed 's/^/  /' || echo "")
-    TOOL_ERRORS_RAW=$(jq -r '.tool_errors[]? // empty' "$SUMMARY_FILE" 2>/dev/null || echo "")
-  elif [ -f "${OUTPUT_FILE:-}" ] && [ -s "${OUTPUT_FILE:-}" ]; then
-    # Legacy stream-json format - tool_use is nested inside assistant messages
-    TOOL_CALLS_RAW=$(jq -r 'select(.type == "assistant") | .message.content[]? | select(.type == "tool_use") | "  \(.name)(\(.input | tostring | .[0:120])...)"' "$OUTPUT_FILE" 2>/dev/null \
-      || echo "")
-    TOOL_ERRORS_RAW=$(jq -r 'select(.type == "user") | .tool_use_result | select(type == "string") | select(startswith("Error:")) | gsub("\n"; "⏎")' "$OUTPUT_FILE" 2>/dev/null \
-      | sed 's/⏎/\n/g' \
-      || echo "")
+  # Extract tool calls and errors for review phase
+  REV_TOOL_CALLS_ESCAPED=$(echo "$REV_TOOL_CALLS_RAW" | html_escape)
+  REV_TOOL_ERRORS_ESCAPED=$(echo "$REV_TOOL_ERRORS_RAW" | html_escape)
+  REV_TOOL_CALL_COUNT=0
+  if [ -n "$REV_TOOL_CALLS_RAW" ]; then
+    REV_TOOL_CALL_COUNT=$(echo "$REV_TOOL_CALLS_RAW" | grep -c '.' || true)
+  fi
+  REV_TOOL_ERROR_COUNT=0
+  if [ -n "$REV_TOOL_ERRORS_RAW" ]; then
+    REV_TOOL_ERROR_COUNT=$(echo "$REV_TOOL_ERRORS_RAW" | grep -c '.' || true)
   fi
 
-  TOOL_CALLS_ESCAPED=$(echo "$TOOL_CALLS_RAW" | html_escape)
-  TOOL_ERRORS_ESCAPED=$(echo "$TOOL_ERRORS_RAW" | html_escape)
-
-  TOOL_CALL_COUNT=0
-  if [ -n "$TOOL_CALLS_RAW" ]; then
-    TOOL_CALL_COUNT=$(echo "$TOOL_CALLS_RAW" | grep -c '.' || true)
+  # Extract tool calls and errors for CI fix phase
+  CIFIX_TOOL_CALLS_ESCAPED=$(echo "$CIFIX_TOOL_CALLS_RAW" | html_escape)
+  CIFIX_TOOL_ERRORS_ESCAPED=$(echo "$CIFIX_TOOL_ERRORS_RAW" | html_escape)
+  CIFIX_TOOL_CALL_COUNT=0
+  if [ -n "$CIFIX_TOOL_CALLS_RAW" ]; then
+    CIFIX_TOOL_CALL_COUNT=$(echo "$CIFIX_TOOL_CALLS_RAW" | grep -c '.' || true)
+  fi
+  CIFIX_TOOL_ERROR_COUNT=0
+  if [ -n "$CIFIX_TOOL_ERRORS_RAW" ]; then
+    CIFIX_TOOL_ERROR_COUNT=$(echo "$CIFIX_TOOL_ERRORS_RAW" | grep -c '.' || true)
   fi
 
-  TOOL_ERROR_COUNT=0
-  if [ -n "$TOOL_ERRORS_RAW" ]; then
-    TOOL_ERROR_COUNT=$(echo "$TOOL_ERRORS_RAW" | grep -c '.' || true)
-  fi
-
-  # Build available tools chips
+  # Build available tools chips (from review phase)
   TOOLS_CHIPS=""
-  if [ -n "$TOOLS_AVAILABLE" ]; then
-    IFS=',' read -ra TOOLS_ARRAY <<< "$TOOLS_AVAILABLE"
+  if [ -n "$REV_TOOLS_AVAILABLE" ]; then
+    IFS=',' read -ra TOOLS_ARRAY <<< "$REV_TOOLS_AVAILABLE"
     TOOLS_LOADED=${#TOOLS_ARRAY[@]}
     for tool in "${TOOLS_ARRAY[@]}"; do
       TOOLS_CHIPS="${TOOLS_CHIPS}<span class=\"tool-chip\">${tool}</span>"
@@ -263,25 +358,18 @@ while IFS= read -r line; do
   # PR link
   PR_LINK="<a href=\"https://github.com/openshift/hypershift/pull/${PR_NUMBER}\">#${PR_NUMBER}</a>"
 
-  # Get PR title from analysis file if available
-  PR_TITLE=""
-  ANALYSIS_FILE="${SHARED_DIR}/pr-${PR_NUMBER}-analysis.json"
-  if [ ! -f "$ANALYSIS_FILE" ]; then
-    ANALYSIS_FILE="/tmp/pr-${PR_NUMBER}-analysis.json"
-  fi
-
-  # Get PR title via git log or state file
+  # Get PR title
   PR_TITLE_RAW=$(gh pr view "$PR_NUMBER" --repo openshift/hypershift --json title --jq '.title' 2>/dev/null || echo "PR #${PR_NUMBER}")
   PR_TITLE=$(echo "$PR_TITLE_RAW" | html_escape)
   PR_TITLE_LINKED=$(linkify_jira "$PR_TITLE")
 
-  # Token usage table
-  # Build per-model breakdown rows
+  # ---- Token usage table with per-phase rows ----
+  # Build per-model breakdown rows from review phase
   MODEL_BREAKDOWN_ROWS=""
-  if [ -f "$SUMMARY_FILE" ] && ! grep -q '"type":"result"' "$SUMMARY_FILE" 2>/dev/null; then
-    MODEL_BREAKDOWN_RAW=$(jq -r '.modelUsage // {} | to_entries[] | "\(.key)|\(.value.inputTokens // .value.input_tokens // 0)|\(.value.outputTokens // .value.output_tokens // 0)|\(.value.cacheReadInputTokens // .value.cache_read_input_tokens // 0)|\(.value.cacheCreationInputTokens // .value.cache_creation_input_tokens // 0)"' "$SUMMARY_FILE" 2>/dev/null | head -20 || echo "")
+  if [ -f "$REVIEW_SUMMARY_FILE" ] && ! grep -q '"type":"result"' "$REVIEW_SUMMARY_FILE" 2>/dev/null; then
+    MODEL_BREAKDOWN_RAW=$(jq -r '.modelUsage // {} | to_entries[] | "\(.key)|\(.value.inputTokens // .value.input_tokens // 0)|\(.value.outputTokens // .value.output_tokens // 0)|\(.value.cacheReadInputTokens // .value.cache_read_input_tokens // 0)|\(.value.cacheCreationInputTokens // .value.cache_creation_input_tokens // 0)"' "$REVIEW_SUMMARY_FILE" 2>/dev/null | head -20 || echo "")
   else
-    MODEL_BREAKDOWN_RAW=$(extract_from_stream_json "${OUTPUT_FILE:-$SUMMARY_FILE}" "model_usage")
+    MODEL_BREAKDOWN_RAW=$(extract_from_stream_json "${REVIEW_SUMMARY_FILE}" "model_usage")
   fi
   if [ -n "$MODEL_BREAKDOWN_RAW" ]; then
     MODEL_BREAKDOWN_ROWS="<tr><td colspan=\"7\" style=\"background:#f0f0f0; font-size:0.85em; color:#666; padding:0.3em 1em;\"><em>Per-model breakdown</em></td></tr>"
@@ -295,36 +383,76 @@ while IFS= read -r line; do
 
   TOKEN_TABLE=""
   if [ "$PR_INPUT" -gt 0 ] || [ "$PR_OUTPUT" -gt 0 ] || [ "$PR_CACHE_CREATE" -gt 0 ]; then
+    REV_COST=$(format_cost "$REV_COST_RAW")
+    CIFIX_COST=$(format_cost "$CIFIX_COST_RAW")
+
+    # Build CI Fix row only if CI fix was attempted
+    CIFIX_ROW=""
+    if [ "$CI_FIX_ATTEMPTED" = "true" ]; then
+      CIFIX_ROW="<tr><td>CI Fix</td><td>$(format_duration "$CIFIX_DURATION_SECS")</td><td>$(format_number "$CIFIX_INPUT")</td><td>$(format_number "$CIFIX_OUTPUT")</td><td>$(format_number "$CIFIX_CACHE_READ")</td><td>$(format_number "$CIFIX_CACHE_CREATE")</td><td>${CIFIX_COST}</td></tr>"
+    fi
+
     TOKEN_TABLE="
   <h3>Token Usage &amp; Cost</h3>
   <table class=\"token-table\">
   <thead><tr><th>Phase</th><th>Duration</th><th>Input Tokens</th><th>Output Tokens</th><th>Cache Read</th><th>Cache Create</th><th>Cost</th></tr></thead>
   <tbody>
-  <tr><td>Comment Analysis</td><td>$(format_duration "$DURATION_SECS")</td><td>$(format_number "$PR_INPUT")</td><td>$(format_number "$PR_OUTPUT")</td><td>$(format_number "$PR_CACHE_READ")</td><td>$(format_number "$PR_CACHE_CREATE")</td><td>${PR_COST}</td></tr>
-  <tr class=\"total-row\"><td><strong>Total</strong></td><td><strong>$(format_duration "$DURATION_SECS")</strong></td><td><strong>$(format_number "$PR_INPUT")</strong></td><td><strong>$(format_number "$PR_OUTPUT")</strong></td><td><strong>$(format_number "$PR_CACHE_READ")</strong></td><td><strong>$(format_number "$PR_CACHE_CREATE")</strong></td><td><strong>${PR_COST}</strong></td></tr>
+  <tr><td>Review Analysis</td><td>$(format_duration "$REV_DURATION_SECS")</td><td>$(format_number "$REV_INPUT")</td><td>$(format_number "$REV_OUTPUT")</td><td>$(format_number "$REV_CACHE_READ")</td><td>$(format_number "$REV_CACHE_CREATE")</td><td>${REV_COST}</td></tr>
+  ${CIFIX_ROW}
+  <tr class=\"total-row\"><td><strong>Total</strong></td><td><strong>$(format_duration "$PR_DURATION_SECS")</strong></td><td><strong>$(format_number "$PR_INPUT")</strong></td><td><strong>$(format_number "$PR_OUTPUT")</strong></td><td><strong>$(format_number "$PR_CACHE_READ")</strong></td><td><strong>$(format_number "$PR_CACHE_CREATE")</strong></td><td><strong>${PR_COST}</strong></td></tr>
   ${MODEL_BREAKDOWN_ROWS}
   </tbody>
   </table>
-  <p class=\"model-info\">Model: ${MODEL} &middot; Duration: $(format_duration "$DURATION_SECS") (API: $(format_duration "$DURATION_API_SECS")) &middot; ${NUM_TURNS} turn(s) &middot; Session: ${SESSION_ID}</p>"
+  <p class=\"model-info\">Model: ${REV_MODEL} &middot; Duration: $(format_duration "$PR_DURATION_SECS") (Review API: $(format_duration "$REV_DURATION_API_SECS")) &middot; ${REV_NUM_TURNS} review turn(s) &middot; Session: ${REV_SESSION_ID}</p>"
   fi
 
-  # Summary table row
-  SUMMARY_ROWS="${SUMMARY_ROWS}<tr><td>${PR_LINK}</td><td>${PR_TITLE_LINKED}</td><td>${PR_TIMESTAMP}</td><td><span class=\"badge ${STATUS_CLASS}\">${STATUS_LABEL}</span></td><td>${PR_COST}</td></tr>"
+  # Summary table row (with Actions column)
+  SUMMARY_ROWS="${SUMMARY_ROWS}<tr><td>${PR_LINK}</td><td>${PR_TITLE_LINKED}</td><td>${PR_TIMESTAMP}</td><td><span class=\"badge ${STATUS_CLASS}\">${STATUS_LABEL}</span></td><td>${ACTION_BADGES}</td><td>${PR_COST}</td></tr>"
 
-  # Detail section
+  # ---- Build detail section ----
+  # Phase: Rebase
+  REBASE_SECTION=""
+  if [ "$REBASE_ATTEMPTED" = "true" ]; then
+    if [ "$REBASE_RESULT" = "success" ]; then
+      REBASE_SECTION="<h3>Phase: Rebase</h3><p><span class=\"badge success\">Success</span> Rebased onto upstream base branch.</p>"
+    else
+      REBASE_SECTION="<h3>Phase: Rebase</h3><p><span class=\"badge failed\">Conflict</span> Rebase failed due to merge conflicts. Remaining phases were skipped.</p>"
+    fi
+  fi
+
+  # Phase: Review Analysis
+  REVIEW_SECTION=""
+  if [ "$REVIEWS_ATTEMPTED" = "true" ]; then
+    REVIEW_SECTION="
+  <h3>Phase: Review Analysis</h3>
+  <div class=\"phase-output\"><pre>${REV_RESULT_TEXT:-"(no output captured)"}</pre></div>
+  <details><summary>Tool calls (${REV_TOOL_CALL_COUNT})</summary><pre>${REV_TOOL_CALLS_ESCAPED:-"(no tool calls)"}</pre></details>
+  <details><summary>Tool errors (${REV_TOOL_ERROR_COUNT})</summary><pre class=\"error-pre\">${REV_TOOL_ERRORS_ESCAPED:-"(no tool errors)"}</pre></details>"
+  fi
+
+  # Phase: CI Fix
+  CIFIX_SECTION=""
+  if [ "$CI_FIX_ATTEMPTED" = "true" ]; then
+    CI_FIX_CHECKS_ESCAPED=$(echo "$CI_FIX_CHECKS" | html_escape)
+    CIFIX_SECTION="
+  <h3>Phase: CI Fix</h3>
+  <p>Failed checks: <code>${CI_FIX_CHECKS_ESCAPED:-"(unknown)"}</code></p>
+  <div class=\"phase-output\"><pre>${CIFIX_RESULT_TEXT:-"(no output captured)"}</pre></div>
+  <details><summary>Tool calls (${CIFIX_TOOL_CALL_COUNT})</summary><pre>${CIFIX_TOOL_CALLS_ESCAPED:-"(no tool calls)"}</pre></details>
+  <details><summary>Tool errors (${CIFIX_TOOL_ERROR_COUNT})</summary><pre class=\"error-pre\">${CIFIX_TOOL_ERRORS_ESCAPED:-"(no tool errors)"}</pre></details>"
+  fi
+
   DETAIL_SECTIONS="${DETAIL_SECTIONS}
 <div class=\"pr-card\">
   <h2>${PR_LINK} <span class=\"badge ${STATUS_CLASS}\">${STATUS_LABEL}</span></h2>
   <p style=\"margin:0.3em 0 0 0; color:#666\">${PR_TITLE_LINKED}</p>
   ${TOKEN_TABLE}
-
-  <h3>Phase: Comment Analysis</h3>
-  <div class=\"phase-output\"><pre>${RESULT_TEXT:-"(no output captured)"}</pre></div>
-  <details><summary>Tool calls (${TOOL_CALL_COUNT})</summary><pre>${TOOL_CALLS_ESCAPED:-"(no tool calls)"}</pre></details>
-  <details><summary>Tool errors (${TOOL_ERROR_COUNT})</summary><pre class=\"error-pre\">${TOOL_ERRORS_ESCAPED:-"(no tool errors)"}</pre></details>
+  ${REBASE_SECTION}
+  ${REVIEW_SECTION}
+  ${CIFIX_SECTION}
 
   <details>
-    <summary>Available tools (${TOOLS_LOADED} loaded, ${TOOL_CALL_COUNT} used)</summary>
+    <summary>Available tools (${TOOLS_LOADED} loaded)</summary>
     <div class=\"tools-available\">${TOOLS_CHIPS:-"(no tools data available)"}</div>
   </details>
 </div>"
@@ -357,6 +485,9 @@ cat > "$REPORT_FILE" <<EOF
   .badge { padding: 0.25em 0.7em; border-radius: 12px; font-size: 0.8em; font-weight: 600; display: inline-block; }
   .badge.success { background: #dcffe4; color: #22863a; }
   .badge.failed { background: #ffdce0; color: #cb2431; }
+  .badge.rebase { background: #e1f5fe; color: #01579b; }
+  .badge.reviews { background: #f3e5f5; color: #4a148c; }
+  .badge.cifix { background: #fff3e0; color: #e65100; }
   .pr-card { background: #fff; border-radius: 8px; padding: 1.5em; margin: 1.5em 0; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
   .pr-card h2 { margin-top: 0; }
   .pr-card h3 { color: #555; margin-top: 1.5em; margin-bottom: 0.5em; }
@@ -387,6 +518,8 @@ cat > "$REPORT_FILE" <<EOF
   <div class="stat"><div class="value">${TOTAL}</div><div class="label">PRs Processed</div></div>
   <div class="stat"><div class="value" style="color:#22863a">${SUCCESS_COUNT}</div><div class="label">Succeeded</div></div>
   <div class="stat"><div class="value" style="color:#cb2431">${FAILED_COUNT}</div><div class="label">Failed</div></div>
+  <div class="stat"><div class="value" style="color:#01579b">${GRAND_REBASED_COUNT}</div><div class="label">Rebased</div></div>
+  <div class="stat"><div class="value" style="color:#e65100">${GRAND_CI_FIX_COUNT}</div><div class="label">CI Fixes</div></div>
   <div class="stat"><div class="value">$(format_number "$GRAND_TOTAL_INPUT")</div><div class="label">Input Tokens</div></div>
   <div class="stat"><div class="value">$(format_number "$GRAND_TOTAL_OUTPUT")</div><div class="label">Output Tokens</div></div>
   <div class="stat"><div class="value">${GRAND_TOTAL_COST}</div><div class="label">Cost</div></div>
@@ -394,7 +527,7 @@ cat > "$REPORT_FILE" <<EOF
 
 <h2>Summary</h2>
 <table>
-<thead><tr><th>PR</th><th>Title</th><th>Timestamp</th><th>Status</th><th>Cost</th></tr></thead>
+<thead><tr><th>PR</th><th>Title</th><th>Timestamp</th><th>Status</th><th>Actions</th><th>Cost</th></tr></thead>
 <tbody>
 ${SUMMARY_ROWS}
 </tbody>


### PR DESCRIPTION
## Summary

- Adds rebase detection and automatic rebasing (with Claude-driven conflict resolution) to the HyperShift review agent periodic job
- Adds CI failure detection (verify/unit/lint) with Claude-driven local reproduction and fixing
- Restructures the main loop into detect → skip → checkout → rebase → reviews → CI fix → push phases
- Updates the HTML report with per-phase token usage, action badges, and new summary stats
- Refreshes GitHub App tokens every 5 PRs to prevent expiry during long runs

## Rehearsal Results

**Latest successful run:** [review-agent-report.html](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_release/78145/rehearse-78145-periodic-ci-openshift-hypershift-main-periodic-review-agent/2046966075257524224/artifacts/periodic-review-agent/hypershift-review-agent-report/artifacts/review-agent-report.html)

| PR | Actions | Result |
|----|---------|--------|
| #8280 | Reviews → Push | ✅ `Lint` fixed (was `FAILURE`, now `SUCCESS`) |
| #8249 | Skipped | ✅ No action needed |
| #8233 | Reviews | ✅ No actionable comments |
| #8226 | Rebase + Reviews + CI Fix → Push | ✅ Makefile conflict resolved by Claude, `verify-workflows` fixed |
| #8224 | Reviews | ✅ No actionable comments |
| #8223 | Reviews | ✅ No actionable comments |
| #8211 | Reviews + CI Fix → Push | ✅ `Verify` fixed (synced GitHub Actions workflows) |
| #8106 | Reviews | ✅ All comments previously addressed |
| #7943 | Reviews → Push failed | ⚠️ GitHub App token expired at ~60min mark |
| #7810 | Failed at comment analyzer | ⚠️ Same token expiry (401) |

**Token expiry failures (#7943, #7810):** The GitHub App token has a 1-hour lifetime. This run took ~70 minutes, so the last two PRs hit expired credentials. **Remediated** by adding `refresh_github_tokens()` which regenerates both fork and upstream tokens every 5 PRs processed.

## Details

The review agent previously skipped PRs entirely when there were no pending review comments, leaving PRs that needed a rebase or had failing CI checks unattended. Now the agent detects all three concerns (reviews, rebase, CI failures) via API before checkout, and only skips when none apply.

**New helper functions:**
- `check_rebase_needed()` — checks `mergeStateStatus` via `gh pr view`, retries on `UNKNOWN` (GitHub evicts cached state for dormant PRs)
- `perform_rebase()` — rebases onto upstream base branch; on conflict, invokes Claude to resolve before continuing; aborts only if Claude cannot resolve
- `get_failed_ci_checks()` — filters `gh pr checks` for failing verify/unit/lint (matches both `FAIL` and `FAILURE` states)
- `refresh_github_tokens()` — regenerates GitHub App tokens mid-run to prevent 1-hour expiry

**New env var:**
- `REVIEW_AGENT_ENABLE_CI_FIXES` (default: `true`) — controls CI fix phase

**Report enhancements:**
- Rebased / CI Fixes stat boxes
- Actions column with colored badges per PR (with failure states)
- Per-phase token usage rows in the cost table
- Separate detail sections for each phase (rebase, reviews, CI fix)

## Test plan

- [x] `bash -n` syntax check passes on both scripts
- [x] `shellcheck -S warning` passes on both scripts
- [x] YAML validation passes on ref and workflow files
- [x] `make registry-metadata` produces no unexpected changes
- [x] Rehearse the job — rebase with conflict resolution verified on PR #8226
- [x] Rehearse the job — CI fix detection and commit verified on PRs #8280, #8211, #8226
- [x] Token expiry remediated with periodic refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded workflow docs: per-PR phased processing (Rebase → Reviews → CI Fix), updated reporting, diagrams, logging, troubleshooting, and removed the old "unresolved review thread" section.

* **New Features**
  * Automatic rebase detection and conditional rebase (skips remaining phases on conflict).
  * Optional detection and reproduce-and-fix loop for failing verify/unit/lint checks.
  * Deferred single push at end when changes occurred.

* **Configuration**
  * New toggle to enable/disable automated CI fixes (enabled by default).

* **Chores**
  * Enhanced HTML reports with per-phase token/cost, badges, totals; increased conversational turn limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->