### PR TITLE
Add AWS UPI WINC periodic job for release-4.19

### DIFF
--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.19__amd64-nightly.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.19__amd64-nightly.yaml
@@ -983,6 +983,18 @@ tests:
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-aws-ipi-ovn-winc
+- as: aws-upi-ovn-winc-f14
+  cron: 0 23 4,11,18,27 * *
+  steps:
+    cluster_profile: aws-qe
+    env:
+      BASE_DOMAIN: qe.devcluster.openshift.com
+      TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;Smokerun&
+      TEST_SCENARIOS: Windows_Containers
+      TEST_TIMEOUT: "50"
+    test:
+    - ref: openshift-extended-test
+    workflow: cucushift-installer-rehearse-aws-upi-ovn-winc
 - as: aws-ipi-private-fips-f28-disasterrecovery
   cron: 11 11 20 * *
   steps:

--- a/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.19-periodics.yaml
+++ b/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.19-periodics.yaml
@@ -24647,6 +24647,96 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
+  cluster: build09
+  cron: 0 23 4,11,18,27 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: release-4.19
+    org: openshift
+    repo: openshift-tests-private
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-qe
+    ci-operator.openshift.io/variant: amd64-nightly
+    ci.openshift.io/generator: prowgen
+    job-release: "4.19"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-openshift-tests-private-release-4.19-amd64-nightly-aws-upi-ovn-winc-f14
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --oauth-token-path=/usr/local/github-credentials/oauth
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=aws-upi-ovn-winc-f14
+      - --variant=amd64-nightly
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /usr/local/github-credentials
+        name: github-credentials-openshift-ci-robot-private-git-cloner
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: github-credentials-openshift-ci-robot-private-git-cloner
+      secret:
+        secretName: github-credentials-openshift-ci-robot-private-git-cloner
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
   cluster: build10
   cron: 21 21 7,21 * *
   decorate: true


### PR DESCRIPTION
## Summary
Adds `aws-upi-ovn-winc-f14` periodic job to release-4.19 nightly config.

## Problem
Currently, AWS UPI WINC testing on 4.19 only has a presubmit job (`debug-winc-aws-upi`), but no periodic/nightly job. This creates inconsistency with 4.22+ which has both presubmit and periodic jobs.

## Solution
Add the periodic job to 4.19 amd64-nightly config, matching the configuration used in 4.22.

## Changes
- **Config:** `ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.19__amd64-nightly.yaml`
  - Added `aws-upi-ovn-winc-f14` test definition
  - Schedule: `cron: 0 23 4,11,18,27 * *` (runs on 4th, 11th, 18th, 27th of each month at 23:00 UTC)
  - Uses `cucushift-installer-rehearse-aws-upi-ovn-winc` workflow
  - Runs `Windows_Containers` test scenario with `Smokerun` filter

- **Generated Job:** `ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.19-periodics.yaml`
  - Job name: `periodic-ci-openshift-openshift-tests-private-release-4.19-amd64-nightly-aws-upi-ovn-winc-f14`

## Testing
Validated that:
- Job configuration matches 4.22 format
- `make update` successfully generated the periodic job
- Job name follows standard naming convention

## Related
- Original PR that added AWS UPI WINC: #75983 (added to 4.18-4.22, but only added periodic to 4.22)
- This PR completes the coverage by adding the periodic job to 4.19

/hold

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added a new scheduled test job for Windows Containers validation. The job executes on the 4th, 11th, 18th, and 27th of each month, running comprehensive tests with configurable filters and a 50-minute timeout window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->