### PR TITLE
Bump STS conformance to m5.2xlarge with 3 replicas for etcd stability

### DIFF
--- a/ci-operator/step-registry/rosa/aws/sts/conformance/rosa-aws-sts-conformance-workflow.yaml
+++ b/ci-operator/step-registry/rosa/aws/sts/conformance/rosa-aws-sts-conformance-workflow.yaml
@@ -3,7 +3,9 @@ workflow:
   steps:
     env:
       CHANNEL_GROUP: nightly
+      COMPUTE_MACHINE_TYPE: "m5.2xlarge"
       OPENSHIFT_VERSION: "release:latest"
+      REPLICAS: "3"
       TEST_SKIPS: >-
         users can manipulate groups\|
         well-known endpoint should be reachable\|


### PR DESCRIPTION
## Summary
- Bump `COMPUTE_MACHINE_TYPE` from m5.xlarge (default) to m5.2xlarge for Classic STS conformance
- Increase `REPLICAS` from 2 (default) to 3

## Problem
The Classic STS 4.21 conformance job (`periodic-ci-openshift-release-main-nightly-4.21-e2e-rosa-sts-ovn`) has a 43% pass rate (Sippy). The primary failure is etcdHighCommitDurations firing in 28% of runs vs 0.4% globally. Classic STS runs etcd on the worker nodes, and m5.xlarge (4 vCPU, 16GB) with only 2 replicas is undersized for control plane + conformance test workloads.

The general STS workflow (`rosa-aws-sts-workflow.yaml`) already uses m5.2xlarge, and HCP conformance uses 3 replicas. This change aligns the conformance workflow with those baselines.

## Test plan
- [ ] Verify STS conformance jobs provision successfully with the new sizing
- [ ] Monitor etcdHighCommitDurations alert rate over several runs (expect significant reduction)
- [ ] Confirm no increase in AWS quota/limit failures from larger instance type

Jira: https://redhat.atlassian.net/browse/SREP-4667

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure configuration parameters for improved testing resource allocation and scalability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->