### PR TITLE
WIP: DO_NOT_MERGE: Test CI job operator-e2e

### DIFF
--- a/ci-operator/step-registry/storage/create/csi-gcp-filestore/storage-create-csi-gcp-filestore-commands.sh
+++ b/ci-operator/step-registry/storage/create/csi-gcp-filestore/storage-create-csi-gcp-filestore-commands.sh
@@ -3,6 +3,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+echo "NOOP: DUMMY CHANGE"
+
 # For disconnected or otherwise unreachable environments, we want to
 # have steps use an HTTP(S) proxy to reach the API server. This proxy
 # configuration file should export HTTP_PROXY, HTTPS_PROXY, and NO_PROXY


### PR DESCRIPTION
Test if CI job `ci/rehearse/openshift/gcp-filestore-csi-driver-operator/release-4.22/operator-e2e` can succeed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor internal maintenance update with no changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->