### PR TITLE
[INTEROP-8947] OCP 4.22 CR and FIPS expansions for ACS stable 4.10

### DIFF
--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4.21-lp-interop-cr-acs-latest.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4.21-lp-interop-cr-acs-latest.yaml
@@ -36,7 +36,7 @@ tests:
               {"step": "stackrox-*", "failure_type": "all", "classification": "ACS Test Failure", "jira_assignee": "!default", "jira_additional_labels": ["!default","interop-tests"]}
             ]
         }
-      FIREWATCH_CONFIG_FILE_PATH: https://raw.githubusercontent.com/CSPI-QE/cspi-utils/refs/heads/main/firewatch-base-configs/cr/lp-interop.json
+      FIREWATCH_CONFIG_FILE_PATH: https://raw.githubusercontent.com/CSPI-QE/cspi-utils/main/firewatch-base-configs/cr/lp-interop.json
       FIREWATCH_DEFAULT_JIRA_ADDITIONAL_LABELS: '["4.21-lp-cr","self-managed-lp","acs-lp"]'
       FIREWATCH_DEFAULT_JIRA_ASSIGNEE: dahouse@redhat.com
       FIREWATCH_DEFAULT_JIRA_PROJECT: ROX

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-4.10__ocp-4-22-lp-interop.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-4.10__ocp-4-22-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: apollo-ci
     namespace: stackrox
-    tag: stackrox-ui-test-stable
+    tag: stackrox-ui-test-0.4.9
 releases:
   latest:
     candidate:
@@ -21,7 +21,7 @@ resources:
       memory: 8000Mi
 test_binary_build_commands: .openshift-ci/dispatch.sh test-binary-build-commands
 tests:
-- as: cr-acs-latest-tests-aws
+- as: cr-acs-tests-aws
   cron: 0 3,15 * * *
   steps:
     cluster_profile: aws-cspi-qe
@@ -36,17 +36,18 @@ tests:
               {"step": "stackrox-*", "failure_type": "all", "classification": "ACS Test Failure", "jira_assignee": "!default", "jira_additional_labels": ["!default","interop-tests"]}
             ]
         }
-      FIREWATCH_CONFIG_FILE_PATH: https://raw.githubusercontent.com/CSPI-QE/cspi-utils/refs/heads/main/firewatch-base-configs/cr/lp-interop.json
-      FIREWATCH_DEFAULT_JIRA_ADDITIONAL_LABELS: '["4.22-lp-cr","self-managed-lp","acs-lp"]'
+      FIREWATCH_CONFIG_FILE_PATH: https://raw.githubusercontent.com/CSPI-QE/cspi-utils/main/firewatch-base-configs/cr/lp-interop.json
+      FIREWATCH_DEFAULT_JIRA_ADDITIONAL_LABELS: '["4.22-lp","self-managed-lp","acs-lp"]'
       FIREWATCH_DEFAULT_JIRA_ASSIGNEE: dahouse@redhat.com
       FIREWATCH_DEFAULT_JIRA_PROJECT: ROX
       MAP_TESTS: "true"
       OCP_VERSION: "4.22"
-      REPORTPORTAL_CMP: ACSLatest-lp-interop
+      REPORTPORTAL_CMP: ACS-lp-interop
+      TEST_SUITE: ocp-compliance-e2e-tests
       USER_TAGS: |
         scenario acs
     test:
-    - ref: stackrox-qa-e2e
+    - ref: stackrox-compliance-e2e
     workflow: firewatch-ipi-aws-cr
 - as: acs-tests-aws-fips
   cron: 0 23 31 2 *
@@ -65,22 +66,21 @@ tests:
               {"step": "stackrox-*", "failure_type": "test_failure", "classification": "ACS Test Failure", "jira_project": "ROX", "jira_assignee": "!default", "jira_additional_labels": ["!default","interop-tests"]}
             ]
         }
-      FIREWATCH_CONFIG_FILE_PATH: https://raw.githubusercontent.com/CSPI-QE/cspi-utils/main/firewatch-base-configs/cr/lp-interop.json
+      FIREWATCH_CONFIG_FILE_PATH: https://raw.githubusercontent.com/CSPI-QE/cspi-utils/main/firewatch-base-configs/aws-ipi/lp-interop.json
       FIREWATCH_DEFAULT_JIRA_ADDITIONAL_LABELS: '["4.22-lp","self-managed-lp","acs-lp","fips"]'
       FIREWATCH_DEFAULT_JIRA_ASSIGNEE: dahouse@redhat.com
       FIREWATCH_DEFAULT_JIRA_PROJECT: LPINTEROP
-      FIREWATCH_FAIL_WITH_TEST_FAILURES: "true"
       MAP_TESTS: "true"
       OCP_VERSION: "4.22"
-      REPORT_TO_DR: "true"
-      REPORTPORTAL_CMP: ACSLatest-lp-interop
+      REPORTPORTAL_CMP: ACS-lp-interop
+      TEST_SUITE: ocp-compliance-e2e-tests
       USER_TAGS: |
         scenario acs
     test:
-    - ref: stackrox-qa-e2e
+    - ref: stackrox-compliance-e2e
     workflow: firewatch-ipi-aws-cr
 zz_generated_metadata:
-  branch: master
+  branch: release-4.10
   org: stackrox
   repo: stackrox
-  variant: ocp-4.22-lp-interop-acs-latest
+  variant: ocp-4-22-lp-interop

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-4.10__ocp-4-22-lp-interop.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-4.10__ocp-4-22-lp-interop.yaml
@@ -40,8 +40,10 @@ tests:
       FIREWATCH_DEFAULT_JIRA_ADDITIONAL_LABELS: '["4.22-lp","self-managed-lp","acs-lp"]'
       FIREWATCH_DEFAULT_JIRA_ASSIGNEE: dahouse@redhat.com
       FIREWATCH_DEFAULT_JIRA_PROJECT: ROX
+      FIREWATCH_FAIL_WITH_TEST_FAILURES: "true"
       MAP_TESTS: "true"
       OCP_VERSION: "4.22"
+      REPORT_TO_DR: "true"
       REPORTPORTAL_CMP: ACS-lp-interop
       TEST_SUITE: ocp-compliance-e2e-tests
       USER_TAGS: |

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-4.9__ocp-4-21-lp-interop-cr.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-4.9__ocp-4-21-lp-interop-cr.yaml
@@ -36,7 +36,7 @@ tests:
               {"step": "stackrox-*", "failure_type": "all", "classification": "ACS Test Failure", "jira_assignee": "!default", "jira_additional_labels": ["!default","interop-tests"]}
             ]
         }
-      FIREWATCH_CONFIG_FILE_PATH: https://raw.githubusercontent.com/CSPI-QE/cspi-utils/refs/heads/main/firewatch-base-configs/cr/lp-interop.json
+      FIREWATCH_CONFIG_FILE_PATH: https://raw.githubusercontent.com/CSPI-QE/cspi-utils/main/firewatch-base-configs/cr/lp-interop.json
       FIREWATCH_DEFAULT_JIRA_ADDITIONAL_LABELS: '["4.21-lp","self-managed-lp","acs-lp"]'
       FIREWATCH_DEFAULT_JIRA_ASSIGNEE: dahouse@redhat.com
       FIREWATCH_DEFAULT_JIRA_PROJECT: ROX

--- a/ci-operator/jobs/stackrox/stackrox/stackrox-stackrox-release-4.10-periodics.yaml
+++ b/ci-operator/jobs/stackrox/stackrox/stackrox-stackrox-release-4.10-periodics.yaml
@@ -1,0 +1,189 @@
+periodics:
+- agent: kubernetes
+  cluster: build09
+  cron: 0 23 31 2 *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: release-4.10
+    org: stackrox
+    repo: stackrox
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-cspi-qe
+    ci-operator.openshift.io/variant: ocp-4-22-lp-interop
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-stackrox-stackrox-release-4.10-ocp-4-22-lp-interop-acs-tests-aws-fips
+  reporter_config:
+    slack:
+      channel: '#acs-interops-testing'
+      job_states_to_report:
+      - success
+      - failure
+      - error
+      report_template: '{{if eq .Status.State "success"}} :slack-green: Job *{{.Spec.Job}}*
+        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> {{else}} :failed:
+        Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+        logs> {{end}}'
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=acs-tests-aws-fips
+      - --variant=ocp-4-22-lp-interop
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build09
+  cron: 0 3,15 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: release-4.10
+    org: stackrox
+    repo: stackrox
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-cspi-qe
+    ci-operator.openshift.io/variant: ocp-4-22-lp-interop
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-stackrox-stackrox-release-4.10-ocp-4-22-lp-interop-cr-acs-tests-aws
+  reporter_config:
+    slack:
+      channel: '#acs-interops-testing'
+      job_states_to_report:
+      - success
+      - failure
+      - error
+      report_template: '{{if eq .Status.State "success"}} :slack-green: Job *{{.Spec.Job}}*
+        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> {{else}} :failed:
+        Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+        logs> {{end}}'
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=cr-acs-tests-aws
+      - --variant=ocp-4-22-lp-interop
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator


### PR DESCRIPTION
Previous changes to disable ACS-stable on OCP 4.21 and modify `.config.prowgen` have been merged in [PR#77933](https://github.com/openshift/release/pull/77933).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI testing infrastructure configuration paths for consistent resource referencing
  * Added new test workflow configurations for release-4.10 supporting OCP 4.22 interoperability testing
  * Established new periodic test jobs with scheduled execution for automated validation and monitoring
  * Configured FIPS-enabled testing variants for enhanced security compliance validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->