### PR TITLE
fleetshift: multi-arch builds and custom image mirror workflow

### DIFF
--- a/ci-operator/config/fleetshift/fleetshift-poc/fleetshift-fleetshift-poc-main.yaml
+++ b/ci-operator/config/fleetshift/fleetshift-poc/fleetshift-fleetshift-poc-main.yaml
@@ -5,7 +5,9 @@ build_root:
     tag: go1.25-linux
 images:
   items:
-  - dockerfile_path: Dockerfile
+  - additional_architectures:
+    - arm64
+    dockerfile_path: Dockerfile
     to: fleetshift-server
 resources:
   '*':
@@ -14,14 +16,18 @@ resources:
       memory: 200Mi
 tests:
 - as: pr-image-mirror
+  capabilities:
+  - arm64
   steps:
     dependencies:
       SOURCE_IMAGE_REF: fleetshift-server
     env:
       IMAGE_REPO: fleetshift-server
       REGISTRY_ORG: stolostron
-    workflow: ocm-ci-image-mirror
-- as: pr-merge-image-mirror
+    workflow: fleetshift-ci-image-mirror
+- as: pr-merge-image-mirror-latest
+  capabilities:
+  - arm64
   postsubmit: true
   steps:
     dependencies:
@@ -30,7 +36,18 @@ tests:
       IMAGE_REPO: fleetshift-server
       IMAGE_TAG: latest
       REGISTRY_ORG: stolostron
-    workflow: ocm-ci-image-mirror
+    workflow: fleetshift-ci-image-mirror
+- as: pr-merge-image-mirror-sha
+  capabilities:
+  - arm64
+  postsubmit: true
+  steps:
+    dependencies:
+      SOURCE_IMAGE_REF: fleetshift-server
+    env:
+      IMAGE_REPO: fleetshift-server
+      REGISTRY_ORG: stolostron
+    workflow: fleetshift-ci-image-mirror
 zz_generated_metadata:
   branch: main
   org: fleetshift

--- a/ci-operator/config/fleetshift/fleetshift-user-interface/fleetshift-fleetshift-user-interface-main.yaml
+++ b/ci-operator/config/fleetshift/fleetshift-user-interface/fleetshift-fleetshift-user-interface-main.yaml
@@ -5,11 +5,17 @@ build_root:
     tag: nodejs20-linux
 images:
   items:
-  - dockerfile_path: Dockerfile.gui
+  - additional_architectures:
+    - arm64
+    dockerfile_path: Dockerfile.gui
     to: fleetshift-gui
-  - dockerfile_path: Dockerfile.mock-servers
+  - additional_architectures:
+    - arm64
+    dockerfile_path: Dockerfile.mock-servers
     to: fleetshift-mock-servers
-  - dockerfile_path: Dockerfile.mock-ui-plugins
+  - additional_architectures:
+    - arm64
+    dockerfile_path: Dockerfile.mock-ui-plugins
     to: fleetshift-mock-ui-plugins
 resources:
   '*':
@@ -18,14 +24,18 @@ resources:
       memory: 200Mi
 tests:
 - as: pr-image-mirror-gui
+  capabilities:
+  - arm64
   steps:
     dependencies:
       SOURCE_IMAGE_REF: fleetshift-gui
     env:
       IMAGE_REPO: fleetshift-gui
       REGISTRY_ORG: stolostron
-    workflow: ocm-ci-image-mirror
-- as: pr-merge-image-mirror-gui
+    workflow: fleetshift-ci-image-mirror
+- as: pr-merge-image-mirror-latest-gui
+  capabilities:
+  - arm64
   postsubmit: true
   steps:
     dependencies:
@@ -34,16 +44,20 @@ tests:
       IMAGE_REPO: fleetshift-gui
       IMAGE_TAG: latest
       REGISTRY_ORG: stolostron
-    workflow: ocm-ci-image-mirror
+    workflow: fleetshift-ci-image-mirror
 - as: pr-image-mirror-mock-servers
+  capabilities:
+  - arm64
   steps:
     dependencies:
       SOURCE_IMAGE_REF: fleetshift-mock-servers
     env:
       IMAGE_REPO: fleetshift-mock-servers
       REGISTRY_ORG: stolostron
-    workflow: ocm-ci-image-mirror
-- as: pr-merge-image-mirror-mock-servers
+    workflow: fleetshift-ci-image-mirror
+- as: pr-merge-image-mirror-latest-mock-servers
+  capabilities:
+  - arm64
   postsubmit: true
   steps:
     dependencies:
@@ -52,16 +66,20 @@ tests:
       IMAGE_REPO: fleetshift-mock-servers
       IMAGE_TAG: latest
       REGISTRY_ORG: stolostron
-    workflow: ocm-ci-image-mirror
+    workflow: fleetshift-ci-image-mirror
 - as: pr-image-mirror-mock-ui-plugins
+  capabilities:
+  - arm64
   steps:
     dependencies:
       SOURCE_IMAGE_REF: fleetshift-mock-ui-plugins
     env:
       IMAGE_REPO: fleetshift-mock-ui-plugins
       REGISTRY_ORG: stolostron
-    workflow: ocm-ci-image-mirror
-- as: pr-merge-image-mirror-mock-ui-plugins
+    workflow: fleetshift-ci-image-mirror
+- as: pr-merge-image-mirror-latest-mock-ui-plugins
+  capabilities:
+  - arm64
   postsubmit: true
   steps:
     dependencies:
@@ -70,7 +88,40 @@ tests:
       IMAGE_REPO: fleetshift-mock-ui-plugins
       IMAGE_TAG: latest
       REGISTRY_ORG: stolostron
-    workflow: ocm-ci-image-mirror
+    workflow: fleetshift-ci-image-mirror
+- as: pr-merge-image-mirror-sha-gui
+  capabilities:
+  - arm64
+  postsubmit: true
+  steps:
+    dependencies:
+      SOURCE_IMAGE_REF: fleetshift-gui
+    env:
+      IMAGE_REPO: fleetshift-gui
+      REGISTRY_ORG: stolostron
+    workflow: fleetshift-ci-image-mirror
+- as: pr-merge-image-mirror-sha-mock-servers
+  capabilities:
+  - arm64
+  postsubmit: true
+  steps:
+    dependencies:
+      SOURCE_IMAGE_REF: fleetshift-mock-servers
+    env:
+      IMAGE_REPO: fleetshift-mock-servers
+      REGISTRY_ORG: stolostron
+    workflow: fleetshift-ci-image-mirror
+- as: pr-merge-image-mirror-sha-mock-ui-plugins
+  capabilities:
+  - arm64
+  postsubmit: true
+  steps:
+    dependencies:
+      SOURCE_IMAGE_REF: fleetshift-mock-ui-plugins
+    env:
+      IMAGE_REPO: fleetshift-mock-ui-plugins
+      REGISTRY_ORG: stolostron
+    workflow: fleetshift-ci-image-mirror
 zz_generated_metadata:
   branch: main
   org: fleetshift

--- a/ci-operator/jobs/fleetshift/fleetshift-poc/fleetshift-fleetshift-poc-main-postsubmits.yaml
+++ b/ci-operator/jobs/fleetshift/fleetshift-poc/fleetshift-fleetshift-poc-main-postsubmits.yaml
@@ -4,14 +4,15 @@ postsubmits:
     always_run: true
     branches:
     - ^main$
-    cluster: build05
+    cluster: build11
     decorate: true
     decoration_config:
       skip_cloning: true
     labels:
+      capability/arm64: arm64
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-fleetshift-fleetshift-poc-main-pr-merge-image-mirror
+    name: branch-ci-fleetshift-fleetshift-poc-main-pr-merge-image-mirror-latest
     spec:
       containers:
       - args:
@@ -19,7 +20,77 @@ postsubmits:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
-        - --target=pr-merge-image-mirror
+        - --target=pr-merge-image-mirror-latest
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    cluster: build11
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      capability/arm64: arm64
+      ci.openshift.io/generator: prowgen
+    max_concurrency: 1
+    name: branch-ci-fleetshift-fleetshift-poc-main-pr-merge-image-mirror-sha
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --target=pr-merge-image-mirror-sha
         command:
         - ci-operator
         env:

--- a/ci-operator/jobs/fleetshift/fleetshift-poc/fleetshift-fleetshift-poc-main-presubmits.yaml
+++ b/ci-operator/jobs/fleetshift/fleetshift-poc/fleetshift-fleetshift-poc-main-presubmits.yaml
@@ -11,6 +11,7 @@ presubmits:
     decoration_config:
       skip_cloning: true
     labels:
+      capability/arm64: arm64
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-fleetshift-fleetshift-poc-main-images
@@ -66,6 +67,7 @@ presubmits:
     decoration_config:
       skip_cloning: true
     labels:
+      capability/arm64: arm64
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-fleetshift-fleetshift-poc-main-pr-image-mirror

--- a/ci-operator/jobs/fleetshift/fleetshift-user-interface/fleetshift-fleetshift-user-interface-main-postsubmits.yaml
+++ b/ci-operator/jobs/fleetshift/fleetshift-user-interface/fleetshift-fleetshift-user-interface-main-postsubmits.yaml
@@ -4,14 +4,15 @@ postsubmits:
     always_run: true
     branches:
     - ^main$
-    cluster: build01
+    cluster: build05
     decorate: true
     decoration_config:
       skip_cloning: true
     labels:
+      capability/arm64: arm64
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-fleetshift-fleetshift-user-interface-main-pr-merge-image-mirror-gui
+    name: branch-ci-fleetshift-fleetshift-user-interface-main-pr-merge-image-mirror-latest-gui
     spec:
       containers:
       - args:
@@ -19,7 +20,7 @@ postsubmits:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
-        - --target=pr-merge-image-mirror-gui
+        - --target=pr-merge-image-mirror-latest-gui
         command:
         - ci-operator
         env:
@@ -73,14 +74,15 @@ postsubmits:
     always_run: true
     branches:
     - ^main$
-    cluster: build01
+    cluster: build05
     decorate: true
     decoration_config:
       skip_cloning: true
     labels:
+      capability/arm64: arm64
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-fleetshift-fleetshift-user-interface-main-pr-merge-image-mirror-mock-servers
+    name: branch-ci-fleetshift-fleetshift-user-interface-main-pr-merge-image-mirror-latest-mock-servers
     spec:
       containers:
       - args:
@@ -88,7 +90,7 @@ postsubmits:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
-        - --target=pr-merge-image-mirror-mock-servers
+        - --target=pr-merge-image-mirror-latest-mock-servers
         command:
         - ci-operator
         env:
@@ -142,14 +144,15 @@ postsubmits:
     always_run: true
     branches:
     - ^main$
-    cluster: build01
+    cluster: build05
     decorate: true
     decoration_config:
       skip_cloning: true
     labels:
+      capability/arm64: arm64
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-fleetshift-fleetshift-user-interface-main-pr-merge-image-mirror-mock-ui-plugins
+    name: branch-ci-fleetshift-fleetshift-user-interface-main-pr-merge-image-mirror-latest-mock-ui-plugins
     spec:
       containers:
       - args:
@@ -157,7 +160,217 @@ postsubmits:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
-        - --target=pr-merge-image-mirror-mock-ui-plugins
+        - --target=pr-merge-image-mirror-latest-mock-ui-plugins
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    cluster: build05
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      capability/arm64: arm64
+      ci.openshift.io/generator: prowgen
+    max_concurrency: 1
+    name: branch-ci-fleetshift-fleetshift-user-interface-main-pr-merge-image-mirror-sha-gui
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --target=pr-merge-image-mirror-sha-gui
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    cluster: build05
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      capability/arm64: arm64
+      ci.openshift.io/generator: prowgen
+    max_concurrency: 1
+    name: branch-ci-fleetshift-fleetshift-user-interface-main-pr-merge-image-mirror-sha-mock-servers
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --target=pr-merge-image-mirror-sha-mock-servers
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    cluster: build05
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      capability/arm64: arm64
+      ci.openshift.io/generator: prowgen
+    max_concurrency: 1
+    name: branch-ci-fleetshift-fleetshift-user-interface-main-pr-merge-image-mirror-sha-mock-ui-plugins
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --target=pr-merge-image-mirror-sha-mock-ui-plugins
         command:
         - ci-operator
         env:

--- a/ci-operator/jobs/fleetshift/fleetshift-user-interface/fleetshift-fleetshift-user-interface-main-presubmits.yaml
+++ b/ci-operator/jobs/fleetshift/fleetshift-user-interface/fleetshift-fleetshift-user-interface-main-presubmits.yaml
@@ -11,6 +11,7 @@ presubmits:
     decoration_config:
       skip_cloning: true
     labels:
+      capability/arm64: arm64
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-fleetshift-fleetshift-user-interface-main-images
@@ -66,6 +67,7 @@ presubmits:
     decoration_config:
       skip_cloning: true
     labels:
+      capability/arm64: arm64
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-fleetshift-fleetshift-user-interface-main-pr-image-mirror-gui
@@ -139,6 +141,7 @@ presubmits:
     decoration_config:
       skip_cloning: true
     labels:
+      capability/arm64: arm64
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-fleetshift-fleetshift-user-interface-main-pr-image-mirror-mock-servers
@@ -212,6 +215,7 @@ presubmits:
     decoration_config:
       skip_cloning: true
     labels:
+      capability/arm64: arm64
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-fleetshift-fleetshift-user-interface-main-pr-image-mirror-mock-ui-plugins

--- a/ci-operator/step-registry/fleetshift/OWNERS
+++ b/ci-operator/step-registry/fleetshift/OWNERS
@@ -1,0 +1,15 @@
+# DO NOT EDIT; this file is auto-generated using https://github.com/openshift/ci-tools.
+# Fetched from https://github.com/fleetshift/fleetshift-poc root OWNERS
+# If the repo had OWNERS_ALIASES then the aliases were expanded
+# Logins who are not members of 'openshift' organization were filtered out
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+- alechenninger
+- hyperkid123
+- mshort55
+options: {}
+reviewers:
+- alechenninger
+- hyperkid123
+- mshort55

--- a/ci-operator/step-registry/fleetshift/ci/OWNERS
+++ b/ci-operator/step-registry/fleetshift/ci/OWNERS
@@ -1,0 +1,15 @@
+# DO NOT EDIT; this file is auto-generated using https://github.com/openshift/ci-tools.
+# Fetched from https://github.com/fleetshift/fleetshift-poc root OWNERS
+# If the repo had OWNERS_ALIASES then the aliases were expanded
+# Logins who are not members of 'openshift' organization were filtered out
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+- alechenninger
+- hyperkid123
+- mshort55
+options: {}
+reviewers:
+- alechenninger
+- hyperkid123
+- mshort55

--- a/ci-operator/step-registry/fleetshift/ci/image-mirror/OWNERS
+++ b/ci-operator/step-registry/fleetshift/ci/image-mirror/OWNERS
@@ -1,0 +1,15 @@
+# DO NOT EDIT; this file is auto-generated using https://github.com/openshift/ci-tools.
+# Fetched from https://github.com/fleetshift/fleetshift-poc root OWNERS
+# If the repo had OWNERS_ALIASES then the aliases were expanded
+# Logins who are not members of 'openshift' organization were filtered out
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+- alechenninger
+- hyperkid123
+- mshort55
+options: {}
+reviewers:
+- alechenninger
+- hyperkid123
+- mshort55

--- a/ci-operator/step-registry/fleetshift/ci/image-mirror/fleetshift-ci-image-mirror-commands.sh
+++ b/ci-operator/step-registry/fleetshift/ci/image-mirror/fleetshift-ci-image-mirror-commands.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+export HOME=/tmp/home
+mkdir -p "$HOME/.docker"
+cd "$HOME" || exit 1
+
+log_file="${ARTIFACT_DIR}/mirror.log"
+log() {
+    local ts
+    ts=$(date --iso-8601=seconds)
+    echo "$ts" "$@" | tee -a "$log_file"
+}
+
+# Setup registry credentials
+REGISTRY_TOKEN_FILE="$SECRETS_PATH/$REGISTRY_SECRET/$REGISTRY_SECRET_FILE"
+
+if [[ ! -r "$REGISTRY_TOKEN_FILE" ]]; then
+    log "ERROR Registry secret file not found: $REGISTRY_TOKEN_FILE"
+    exit 1
+fi
+
+config_file="$HOME/.docker/config.json"
+base64 -d <"$REGISTRY_TOKEN_FILE" >"$config_file" || {
+    log "ERROR Could not base64 decode registry secret file"
+    log "      From: $REGISTRY_TOKEN_FILE"
+    log "      To  : $config_file"
+    exit 1
+}
+
+# Get IMAGE_TAG if not provided
+if [[ -z "$IMAGE_TAG" ]]; then
+    case "$JOB_TYPE" in
+    presubmit)
+        log "INFO Building image tag for a $JOB_TYPE job"
+        IMAGE_TAG="PR${PULL_NUMBER}-${PULL_PULL_SHA}"
+        ;;
+    postsubmit)
+        log "INFO Building image tag for a $JOB_TYPE job"
+        IMAGE_TAG="${PULL_BASE_SHA}"
+        ;;
+    *)
+        log "ERROR Cannot publish an image from a $JOB_TYPE job"
+        exit 1
+        ;;
+    esac
+fi
+log "INFO Image tag is $IMAGE_TAG"
+
+# Build destination image reference
+DESTINATION_IMAGE_REF="$REGISTRY_HOST/$REGISTRY_ORG/$IMAGE_REPO:$IMAGE_TAG"
+
+log "INFO Mirroring Image"
+log "     From: $SOURCE_IMAGE_REF"
+log "     To  : $DESTINATION_IMAGE_REF"
+
+mirror_log="${ARTIFACT_DIR}/oc-mirror-output.log"
+
+for i in {1..6}; do
+    if ! oc image mirror --keep-manifest-list=true "$SOURCE_IMAGE_REF" "$DESTINATION_IMAGE_REF" 1>${mirror_log}; then
+        log "ERROR Unable to mirror image"
+    fi
+
+    if [[ -n "$(cat ${mirror_log})" ]]; then
+        break
+    fi
+
+    log "WARN Nothing mirrored: oc image mirror log is empty."
+
+    if [[ "${i}" == "6" ]]; then
+        log "ERROR failed to complete mirroring"
+        exit 1
+    fi
+
+    log "INFO Retrying (${i} of 5) ..."
+    sleep 60
+done
+
+log "INFO Mirroring complete."

--- a/ci-operator/step-registry/fleetshift/ci/image-mirror/fleetshift-ci-image-mirror-ref.metadata.json
+++ b/ci-operator/step-registry/fleetshift/ci/image-mirror/fleetshift-ci-image-mirror-ref.metadata.json
@@ -1,0 +1,15 @@
+{
+	"path": "fleetshift/ci/image-mirror/fleetshift-ci-image-mirror-ref.yaml",
+	"owners": {
+		"approvers": [
+			"alechenninger",
+			"hyperkid123",
+			"mshort55"
+		],
+		"reviewers": [
+			"alechenninger",
+			"hyperkid123",
+			"mshort55"
+		]
+	}
+}

--- a/ci-operator/step-registry/fleetshift/ci/image-mirror/fleetshift-ci-image-mirror-ref.yaml
+++ b/ci-operator/step-registry/fleetshift/ci/image-mirror/fleetshift-ci-image-mirror-ref.yaml
@@ -1,0 +1,52 @@
+ref:
+  as: fleetshift-ci-image-mirror
+  from_image:
+    name: builder
+    namespace: stolostron
+    tag: go1.25-linux
+  commands: fleetshift-ci-image-mirror-commands.sh
+  credentials:
+  - mount_path: /secrets/acm-cicd-quay-push
+    name: acm-cicd-quay-push
+    namespace: test-credentials
+  dependencies:
+  - env: SOURCE_IMAGE_REF
+    name: src
+  env:
+  - name: SECRETS_PATH
+    default: /secrets
+    documentation: |-
+      The directory where credentials will be mounted.
+  - name: REGISTRY_SECRET
+    default: acm-cicd-quay-push
+    documentation: |-
+      The name of the kube secret that contains the registry token file.
+  - name: REGISTRY_SECRET_FILE
+    default: token
+    documentation: |-
+      The name of the file in REGISTRY_SECRET with the registry credentials.
+  - name: REGISTRY_HOST
+    default: quay.io
+    documentation: |-
+      The hostname of the destination registry.
+  - name: REGISTRY_ORG
+    default: stolostron
+    documentation: |-
+      The organization of the destination image reference.
+  - name: IMAGE_REPO
+    default: ''
+    documentation: |-
+      The repository name of the destination image reference.
+  - name: IMAGE_TAG
+    default: ''
+    documentation: |-
+      The tag for the destination image reference. If blank, the tag for
+      a presubmit will be PR<pull_num>-<commit_sha> and for a
+      postsubmit will be <commit_sha>.
+  resources:
+    requests:
+      cpu: 100m
+      memory: 100Mi
+  documentation: |-
+    Mirrors an image from the CI Registry to a destination registry.
+    Tags are based on PR number and commit SHA without a release version prefix.

--- a/ci-operator/step-registry/fleetshift/ci/image-mirror/fleetshift-ci-image-mirror-workflow.metadata.json
+++ b/ci-operator/step-registry/fleetshift/ci/image-mirror/fleetshift-ci-image-mirror-workflow.metadata.json
@@ -1,0 +1,15 @@
+{
+	"path": "fleetshift/ci/image-mirror/fleetshift-ci-image-mirror-workflow.yaml",
+	"owners": {
+		"approvers": [
+			"alechenninger",
+			"hyperkid123",
+			"mshort55"
+		],
+		"reviewers": [
+			"alechenninger",
+			"hyperkid123",
+			"mshort55"
+		]
+	}
+}

--- a/ci-operator/step-registry/fleetshift/ci/image-mirror/fleetshift-ci-image-mirror-workflow.yaml
+++ b/ci-operator/step-registry/fleetshift/ci/image-mirror/fleetshift-ci-image-mirror-workflow.yaml
@@ -1,0 +1,9 @@
+workflow:
+  as: fleetshift-ci-image-mirror
+  steps:
+    pre:
+    - ref: ocm-ci-rbac
+    - ref: fleetshift-ci-image-mirror
+  documentation: |-
+    Mirrors an image from the CI Registry to a destination registry.
+    Reuses ocm-ci-rbac for namespace access, with simplified image tagging.


### PR DESCRIPTION
## Summary
- Enable multi-arch (amd64 + arm64) builds for all fleetshift images
- Add custom `fleetshift-ci-image-mirror` step-registry workflow replacing `ocm-ci-image-mirror`, removing the stolostron `5.0.0` version prefix from image tags
- Add commit-SHA tagged postsubmit mirrors for immutable image references

## Image tags
- PR builds: `PR<number>-<commit-sha>`
- Merge builds: `latest` + `<commit-sha>`

## Test plan
- [x] Verify `make update` generates correct Prow jobs
- [x] Verify presubmit PR image mirror produces multi-arch manifest list
- [x] Verify postsubmit mirrors produce `latest` and SHA tags without version prefix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ARM64 architecture support for image builds across FleetShift projects
  * Introduced new image mirroring workflow with enhanced tagging capabilities

* **Chores**
  * Updated CI/CD configuration to optimize build and mirror job execution
  * Split image mirroring tests into separate latest and SHA-based variants for better versioning control
  * Migrated build jobs to updated infrastructure with ARM64 capability labeling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->