### PR TITLE
OCPERT-352: Update 4.22 automated release jobs to candidate release stream

### DIFF
--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.19__automated-release-stable-4.19-upgrade-from-stable-4.18.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.19__automated-release-stable-4.19-upgrade-from-stable-4.18.yaml
@@ -40,10 +40,12 @@ prowgen:
   private: true
 releases:
   latest:
-    release:
+    prerelease:
       architecture: amd64
-      channel: candidate
-      version: "4.18"
+      product: ocp
+      version_bounds:
+        lower: 4.18.0-0
+        upper: 4.19.0-0
   target:
     release:
       architecture: amd64

--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.19__automated-release-stable-4.19-upgrade-from-stable-4.18.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.19__automated-release-stable-4.19-upgrade-from-stable-4.18.yaml
@@ -40,12 +40,10 @@ prowgen:
   private: true
 releases:
   latest:
-    prerelease:
+    release:
       architecture: amd64
-      product: ocp
-      version_bounds:
-        lower: 4.18.0-0
-        upper: 4.19.0-0
+      channel: candidate
+      version: "4.18"
   target:
     release:
       architecture: amd64

--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22__automated-release-nightly-4.22-upgrade-from-stable-4.22.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22__automated-release-nightly-4.22-upgrade-from-stable-4.22.yaml
@@ -44,13 +44,10 @@ prowgen:
   private: true
 releases:
   latest:
-    prerelease:
+    release:
       architecture: amd64
-      product: ocp
-      version_bounds:
-        lower: 4.22.0-0
-        stream: 4-dev-preview
-        upper: 4.23.0-0
+      channel: candidate
+      version: "4.22"
   target:
     candidate:
       architecture: amd64

--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22__automated-release-nightly-4.22-upgrade-from-stable-4.22.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22__automated-release-nightly-4.22-upgrade-from-stable-4.22.yaml
@@ -44,10 +44,12 @@ prowgen:
   private: true
 releases:
   latest:
-    release:
+    prerelease:
       architecture: amd64
-      channel: candidate
-      version: "4.22"
+      product: ocp
+      version_bounds:
+        lower: 4.22.0-0
+        upper: 4.23.0-0
   target:
     candidate:
       architecture: amd64

--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22__automated-release-stable-4.22-upgrade-from-stable-4.21.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22__automated-release-stable-4.22-upgrade-from-stable-4.21.yaml
@@ -44,10 +44,12 @@ prowgen:
   private: true
 releases:
   latest:
-    release:
+    prerelease:
       architecture: amd64
-      channel: candidate
-      version: "4.21"
+      product: ocp
+      version_bounds:
+        lower: 4.21.0-0
+        upper: 4.22.0-0
   target:
     release:
       architecture: amd64

--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22__automated-release-stable-4.22-upgrade-from-stable-4.21.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22__automated-release-stable-4.22-upgrade-from-stable-4.21.yaml
@@ -49,13 +49,10 @@ releases:
       channel: candidate
       version: "4.21"
   target:
-    prerelease:
+    release:
       architecture: amd64
-      product: ocp
-      version_bounds:
-        lower: 4.22.0-0
-        stream: 4-dev-preview
-        upper: 4.23.0-0
+      channel: candidate
+      version: "4.22"
 resources:
   '*':
     requests:

--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22__automated-release-stable-4.22-upgrade-from-stable-4.22.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22__automated-release-stable-4.22-upgrade-from-stable-4.22.yaml
@@ -53,13 +53,10 @@ releases:
         stream: 4-dev-preview
         upper: 4.23.0-0
   target:
-    prerelease:
+    release:
       architecture: amd64
-      product: ocp
-      version_bounds:
-        lower: 4.22.0-0
-        stream: 4-dev-preview
-        upper: 4.23.0-0
+      channel: candidate
+      version: "4.22"
 resources:
   '*':
     requests:

--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22__automated-release-stable-4.22-upgrade-from-stable-4.22.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22__automated-release-stable-4.22-upgrade-from-stable-4.22.yaml
@@ -50,7 +50,6 @@ releases:
       relative: 1
       version_bounds:
         lower: 4.22.0-0
-        stream: 4-dev-preview
         upper: 4.23.0-0
   target:
     release:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Configuration Updates**
  * Updated release version specifications in OpenShift 4.22 automated testing configurations to use stable release channels and fixed version identifiers across upgrade test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->