### PR TITLE
CNF-22981: Fix Tide author field for red-hat-konflux GitHub App

### DIFF
--- a/core-services/prow/02_config/openshift-kni/o-cloud-operator-konflux/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift-kni/o-cloud-operator-konflux/_prowconfig.yaml
@@ -2,7 +2,7 @@ tide:
   merge_method:
     openshift-kni/o-cloud-operator-konflux: squash
   queries:
-  - author: red-hat-konflux
+  - author: red-hat-konflux[bot]
     labels:
     - allow-automatic-merge
     missingLabels:


### PR DESCRIPTION
The author field in the Tide query must use the [bot] suffix for GitHub Apps. Without it, GitHub search rejects the query with "user does not exist", preventing Tide from finding and merging PRs.

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated merge criteria for the o-cloud-operator-konflux project to refine pull request qualification requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->