### PR TITLE
 Enable upstream kueue e2e by installing dra-example-driver

### DIFF
--- a/ci-operator/config/openshift/kueue-operator/openshift-kueue-operator-main.yaml
+++ b/ci-operator/config/openshift/kueue-operator/openshift-kueue-operator-main.yaml
@@ -331,11 +331,13 @@ tests:
   steps:
     env:
       BUNDLE_COMPONENT: kueue-bundle-main
+      E2E_TARGET_FOLDERS: singlecluster certmanager dra
       OPERAND_COMPONENT: kueue-operand-main
       OPERATOR_COMPONENT: kueue-operator-main
     post:
     - chain: kueue-operator-post
     test:
+    - ref: dra-example-driver-install
     - chain: kueue-operator-test-e2e-upstream
 - always_run: false
   as: test-e2e-downstream-4-20-disruptive

--- a/ci-operator/config/openshift/kueue-operator/openshift-kueue-operator-main.yaml
+++ b/ci-operator/config/openshift/kueue-operator/openshift-kueue-operator-main.yaml
@@ -172,6 +172,45 @@ tests:
           cpu: "4"
           memory: 4Gi
     workflow: ipi-aws
+- always_run: false
+  as: test-e2e-ci-build-upstream-4-21
+  optional: true
+  steps:
+    cluster_profile: openshift-org-aws
+    dependencies:
+      OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: release:4-21-latest
+    post:
+    - chain: kueue-operator-post
+    test:
+    - ref: cert-manager-install-operator
+    - as: run-sdk
+      cli: latest
+      commands: |
+        oc create namespace openshift-kueue-operator || true
+        oc label ns openshift-kueue-operator openshift.io/cluster-monitoring=true --overwrite
+        operator-sdk run bundle --timeout=10m -n openshift-kueue-operator "$OO_BUNDLE" --security-context-config=restricted
+      dependencies:
+      - env: OO_BUNDLE
+        name: kueue-bundle
+      from: operator-sdk
+      resources:
+        requests:
+          cpu: 100m
+    - ref: jobset-install-operator
+    - ref: leader-worker-set-install-operator
+    - ref: dra-example-driver-install
+    - as: e2e-kueue-upstream
+      cli: latest
+      commands: make e2e-upstream-test
+      env:
+      - default: singlecluster certmanager dra
+        name: E2E_TARGET_FOLDERS
+      from: kueue-operator-src
+      resources:
+        requests:
+          cpu: "4"
+          memory: 4Gi
+    workflow: ipi-aws
 - as: test-e2e-4-18
   capabilities:
   - arm64
@@ -331,13 +370,11 @@ tests:
   steps:
     env:
       BUNDLE_COMPONENT: kueue-bundle-main
-      E2E_TARGET_FOLDERS: singlecluster certmanager dra
       OPERAND_COMPONENT: kueue-operand-main
       OPERATOR_COMPONENT: kueue-operator-main
     post:
     - chain: kueue-operator-post
     test:
-    - ref: dra-example-driver-install
     - chain: kueue-operator-test-e2e-upstream
 - always_run: false
   as: test-e2e-downstream-4-20-disruptive

--- a/ci-operator/config/openshift/kueue-operator/openshift-kueue-operator-main.yaml
+++ b/ci-operator/config/openshift/kueue-operator/openshift-kueue-operator-main.yaml
@@ -198,6 +198,7 @@ tests:
           cpu: 100m
     - ref: jobset-install-operator
     - ref: leader-worker-set-install-operator
+    - ref: kueue-operator-test-e2e-dra-enable-feature-gate
     - ref: dra-example-driver-install
     - as: e2e-kueue-upstream
       cli: latest

--- a/ci-operator/jobs/openshift/kueue-operator/openshift-kueue-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/kueue-operator/openshift-kueue-operator-main-presubmits.yaml
@@ -635,6 +635,87 @@ presubmits:
     - ^main$
     - ^main-
     cluster: build09
+    context: ci/prow/test-e2e-ci-build-upstream-4-21
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-kueue-operator-main-test-e2e-ci-build-upstream-4-21
+    optional: true
+    rerun_command: /test test-e2e-ci-build-upstream-4-21
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=test-e2e-ci-build-upstream-4-21
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )test-e2e-ci-build-upstream-4-21,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build09
     context: ci/prow/test-e2e-downstream-4-20-disruptive
     decorate: true
     labels:

--- a/ci-operator/step-registry/dra-example-driver/OWNERS
+++ b/ci-operator/step-registry/dra-example-driver/OWNERS
@@ -1,0 +1,15 @@
+approvers:
+- PannagaRao
+- cpmeadors
+- kannon92
+- mrunalp
+- rphillips
+- sohankunkerkar
+
+reviewers:
+- PannagaRao
+- cpmeadors
+- kannon92
+- mrunalp
+- rphillips
+- sohankunkerkar

--- a/ci-operator/step-registry/dra-example-driver/install/OWNERS
+++ b/ci-operator/step-registry/dra-example-driver/install/OWNERS
@@ -1,0 +1,15 @@
+approvers:
+- PannagaRao
+- cpmeadors
+- kannon92
+- mrunalp
+- rphillips
+- sohankunkerkar
+
+reviewers:
+- PannagaRao
+- cpmeadors
+- kannon92
+- mrunalp
+- rphillips
+- sohankunkerkar

--- a/ci-operator/step-registry/dra-example-driver/install/dra-example-driver-install-commands.sh
+++ b/ci-operator/step-registry/dra-example-driver/install/dra-example-driver-install-commands.sh
@@ -28,12 +28,19 @@ if ! command -v helm &> /dev/null; then
   HELM_VERSION="3.17.3"
   HELM_ARCHIVE="helm-v${HELM_VERSION}-linux-amd64.tar.gz"
   curl -fsSL "https://get.helm.sh/${HELM_ARCHIVE}" -o "/tmp/${HELM_ARCHIVE}"
+  curl -fsSL "https://get.helm.sh/${HELM_ARCHIVE}.sha256sum" -o "/tmp/${HELM_ARCHIVE}.sha256sum"
+  echo "Verifying checksum..."
+  (cd /tmp && sha256sum --check --status "${HELM_ARCHIVE}.sha256sum") || {
+    echo "ERROR: Helm checksum verification failed"
+    rm -rf "/tmp/${HELM_ARCHIVE}" "/tmp/${HELM_ARCHIVE}.sha256sum"
+    exit 1
+  }
   tar -xzf "/tmp/${HELM_ARCHIVE}" -C /tmp
   mkdir -p /tmp/bin
   mv /tmp/linux-amd64/helm /tmp/bin/helm
   chmod +x /tmp/bin/helm
   export PATH="/tmp/bin:$PATH"
-  rm -rf "/tmp/${HELM_ARCHIVE}" /tmp/linux-amd64
+  rm -rf "/tmp/${HELM_ARCHIVE}" "/tmp/${HELM_ARCHIVE}.sha256sum" /tmp/linux-amd64
   echo "Helm installed: $(helm version --short)"
 else
   echo "Helm already installed: $(helm version --short)"
@@ -55,9 +62,9 @@ echo ""
 echo "Creating namespace ${DRA_EXAMPLE_DRIVER_NAMESPACE}..."
 oc create namespace "${DRA_EXAMPLE_DRIVER_NAMESPACE}" 2>/dev/null || true
 
-# Grant privileged SCC to all service accounts in the namespace (required for OpenShift)
-echo "Granting privileged SCC for dra-example-driver namespace..."
-oc adm policy add-scc-to-group privileged "system:serviceaccounts:${DRA_EXAMPLE_DRIVER_NAMESPACE}"
+# Grant privileged SCC for dra-example-driver service account (required for OpenShift)
+echo "Adding privileged SCC for dra-example-driver service account..."
+oc adm policy add-scc-to-user privileged -z dra-example-driver-service-account -n "${DRA_EXAMPLE_DRIVER_NAMESPACE}"
 
 echo ""
 

--- a/ci-operator/step-registry/dra-example-driver/install/dra-example-driver-install-commands.sh
+++ b/ci-operator/step-registry/dra-example-driver/install/dra-example-driver-install-commands.sh
@@ -55,9 +55,9 @@ echo ""
 echo "Creating namespace ${DRA_EXAMPLE_DRIVER_NAMESPACE}..."
 oc create namespace "${DRA_EXAMPLE_DRIVER_NAMESPACE}" 2>/dev/null || true
 
-# Add privileged SCC for dra-example-driver service account (required for OpenShift)
-echo "Adding privileged SCC for dra-example-driver service account..."
-oc adm policy add-scc-to-user privileged -z dra-example-driver-service-account -n "${DRA_EXAMPLE_DRIVER_NAMESPACE}"
+# Grant privileged SCC to all service accounts in the namespace (required for OpenShift)
+echo "Granting privileged SCC for dra-example-driver namespace..."
+oc adm policy add-scc-to-group privileged "system:serviceaccounts:${DRA_EXAMPLE_DRIVER_NAMESPACE}"
 
 echo ""
 

--- a/ci-operator/step-registry/dra-example-driver/install/dra-example-driver-install-commands.sh
+++ b/ci-operator/step-registry/dra-example-driver/install/dra-example-driver-install-commands.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+set -o nounset
+set -o errexit
+set -o pipefail
+
+echo "========================================="
+echo "dra-example-driver Installation via Helm"
+echo "========================================="
+echo "Version: ${DRA_EXAMPLE_DRIVER_VERSION}"
+echo ""
+
+export KUBECONFIG="${SHARED_DIR}/kubeconfig"
+
+DRA_EXAMPLE_DRIVER_NAMESPACE="dra-example-driver"
+
+# Check if dra-example-driver is already installed
+if oc get namespace "${DRA_EXAMPLE_DRIVER_NAMESPACE}" &>/dev/null; then
+  echo "INFO: ${DRA_EXAMPLE_DRIVER_NAMESPACE} namespace already exists"
+  if helm list -n "${DRA_EXAMPLE_DRIVER_NAMESPACE}" 2>/dev/null | grep -q dra-example-driver; then
+    echo "INFO: dra-example-driver is already installed, skipping installation"
+    exit 0
+  fi
+fi
+
+# Install Helm if not present
+if ! command -v helm &> /dev/null; then
+  echo "Installing Helm..."
+  HELM_VERSION="3.17.3"
+  HELM_ARCHIVE="helm-v${HELM_VERSION}-linux-amd64.tar.gz"
+  curl -fsSL "https://get.helm.sh/${HELM_ARCHIVE}" -o "/tmp/${HELM_ARCHIVE}"
+  tar -xzf "/tmp/${HELM_ARCHIVE}" -C /tmp
+  mkdir -p /tmp/bin
+  mv /tmp/linux-amd64/helm /tmp/bin/helm
+  chmod +x /tmp/bin/helm
+  export PATH="/tmp/bin:$PATH"
+  rm -rf "/tmp/${HELM_ARCHIVE}" /tmp/linux-amd64
+  echo "Helm installed: $(helm version --short)"
+else
+  echo "Helm already installed: $(helm version --short)"
+fi
+
+echo ""
+
+# Download dra-example-driver source tarball for the Helm chart
+echo "Downloading dra-example-driver ${DRA_EXAMPLE_DRIVER_VERSION}..."
+curl -fsSL "https://github.com/kubernetes-sigs/dra-example-driver/archive/refs/tags/${DRA_EXAMPLE_DRIVER_VERSION}.tar.gz" -o /tmp/dra-example-driver.tar.gz
+tar -xzf /tmp/dra-example-driver.tar.gz -C /tmp
+DRA_CHART_DIR="/tmp/dra-example-driver-${DRA_EXAMPLE_DRIVER_VERSION#v}/deployments/helm/dra-example-driver"
+echo "Chart directory: ${DRA_CHART_DIR}"
+ls "${DRA_CHART_DIR}/Chart.yaml"
+
+echo ""
+
+# Create namespace
+echo "Creating namespace ${DRA_EXAMPLE_DRIVER_NAMESPACE}..."
+oc create namespace "${DRA_EXAMPLE_DRIVER_NAMESPACE}" 2>/dev/null || true
+
+# Add privileged SCC for dra-example-driver service account (required for OpenShift)
+echo "Adding privileged SCC for dra-example-driver service account..."
+oc adm policy add-scc-to-user privileged -z dra-example-driver-service-account -n "${DRA_EXAMPLE_DRIVER_NAMESPACE}"
+
+echo ""
+
+# Install dra-example-driver via Helm from local chart
+echo "Installing dra-example-driver ${DRA_EXAMPLE_DRIVER_VERSION}..."
+helm upgrade --install \
+  --namespace "${DRA_EXAMPLE_DRIVER_NAMESPACE}" \
+  dra-example-driver \
+  "${DRA_CHART_DIR}" \
+  --set kubeletPlugin.containers.plugin.securityContext.privileged=true \
+  --wait \
+  --timeout 10m
+
+echo ""
+echo "dra-example-driver installed successfully"
+
+# Wait for dra-example-driver pods to be ready
+echo ""
+echo "Waiting for dra-example-driver pods to be ready..."
+oc wait --for=condition=Ready pods \
+  --all \
+  -n "${DRA_EXAMPLE_DRIVER_NAMESPACE}" \
+  --timeout=10m
+
+echo "All dra-example-driver pods are ready"
+
+# List pods
+echo ""
+echo "dra-example-driver pods:"
+oc get pods -n "${DRA_EXAMPLE_DRIVER_NAMESPACE}"
+
+# Wait for DeviceClass to be created
+echo ""
+echo "Waiting for DeviceClass to be created..."
+timeout 5m bash -c '
+while true; do
+  if oc get deviceclass gpu.example.com &>/dev/null; then
+    echo "DeviceClass created: gpu.example.com"
+    break
+  fi
+  echo "Waiting for DeviceClass..."
+  sleep 10
+done
+'
+
+# Wait for ResourceSlices to be published
+echo ""
+echo "Waiting for dra-example-driver ResourceSlices..."
+timeout 5m bash -c '
+while true; do
+  RESOURCE_SLICES=$(oc get resourceslice -o json 2>/dev/null | grep -c "example.com" || true)
+  if [ "${RESOURCE_SLICES}" -gt 0 ]; then
+    echo "Found dra-example-driver ResourceSlice(s)"
+    break
+  fi
+  echo "Waiting for ResourceSlices..."
+  sleep 10
+done
+'
+
+echo ""
+echo "ResourceSlices:"
+oc get resourceslice
+
+echo ""
+echo "========================================="
+echo "dra-example-driver Installation Complete"
+echo "========================================="
+echo ""
+echo "Summary:"
+echo "  - Namespace: ${DRA_EXAMPLE_DRIVER_NAMESPACE}"
+echo "  - Version: ${DRA_EXAMPLE_DRIVER_VERSION}"
+echo "  - DeviceClass: gpu.example.com"
+echo ""

--- a/ci-operator/step-registry/dra-example-driver/install/dra-example-driver-install-ref.metadata.json
+++ b/ci-operator/step-registry/dra-example-driver/install/dra-example-driver-install-ref.metadata.json
@@ -1,0 +1,21 @@
+{
+	"path": "dra-example-driver/install/dra-example-driver-install-ref.yaml",
+	"owners": {
+		"approvers": [
+			"PannagaRao",
+			"cpmeadors",
+			"kannon92",
+			"mrunalp",
+			"rphillips",
+			"sohankunkerkar"
+		],
+		"reviewers": [
+			"PannagaRao",
+			"cpmeadors",
+			"kannon92",
+			"mrunalp",
+			"rphillips",
+			"sohankunkerkar"
+		]
+	}
+}

--- a/ci-operator/step-registry/dra-example-driver/install/dra-example-driver-install-ref.yaml
+++ b/ci-operator/step-registry/dra-example-driver/install/dra-example-driver-install-ref.yaml
@@ -1,0 +1,25 @@
+ref:
+  as: dra-example-driver-install
+  from: cli
+  cli: latest
+  commands: dra-example-driver-install-commands.sh
+  resources:
+    requests:
+      cpu: 100m
+      memory: 200Mi
+  env:
+  - name: DRA_EXAMPLE_DRIVER_VERSION
+    default: "v0.2.1"
+    documentation: |-
+      Version of dra-example-driver to install via Helm.
+      Check https://github.com/kubernetes-sigs/dra-example-driver/releases for available versions.
+  documentation: |-
+    Installs the dra-example-driver from kubernetes-sigs/dra-example-driver
+    via Helm from a local chart extracted from the source tarball.
+
+    dra-example-driver provides simulated DRA devices for testing Kueue's
+    DRA support without requiring GPU hardware. It creates a DeviceClass
+    gpu.example.com with virtual GPU devices.
+
+    Prerequisites:
+    - OCP 4.21+ (Kubernetes 1.34+) with DRA APIs available

--- a/ci-operator/step-registry/kueue-operator/test/e2e/dra/enable-feature-gate/OWNERS
+++ b/ci-operator/step-registry/kueue-operator/test/e2e/dra/enable-feature-gate/OWNERS
@@ -1,0 +1,15 @@
+approvers:
+- PannagaRao
+- cpmeadors
+- kannon92
+- mrunalp
+- rphillips
+- sohankunkerkar
+
+reviewers:
+- PannagaRao
+- cpmeadors
+- kannon92
+- mrunalp
+- rphillips
+- sohankunkerkar

--- a/ci-operator/step-registry/kueue-operator/test/e2e/dra/enable-feature-gate/kueue-operator-test-e2e-dra-enable-feature-gate-commands.sh
+++ b/ci-operator/step-registry/kueue-operator/test/e2e/dra/enable-feature-gate/kueue-operator-test-e2e-dra-enable-feature-gate-commands.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -o nounset
+set -o errexit
+set -o pipefail
+
+echo "========================================="
+echo "Enabling DRAExtendedResource feature gate"
+echo "========================================="
+echo ""
+
+export KUBECONFIG="${SHARED_DIR}/kubeconfig"
+
+echo "Patching featuregates..."
+oc patch featuregates cluster --type='merge' -p '{"spec":{"featureSet":"CustomNoUpgrade","customNoUpgrade":{"enabled":["DRAExtendedResource"]}}}'
+
+echo "Waiting for kube-apiserver to start rolling out..."
+oc wait co kube-apiserver --for='condition=Progressing=True' --timeout=5m || true
+
+echo "Waiting for kube-apiserver rollout to complete..."
+oc wait co kube-apiserver --for='condition=Progressing=False' --timeout=30m
+
+echo ""
+echo "DRAExtendedResource feature gate enabled"
+echo ""

--- a/ci-operator/step-registry/kueue-operator/test/e2e/dra/enable-feature-gate/kueue-operator-test-e2e-dra-enable-feature-gate-ref.metadata.json
+++ b/ci-operator/step-registry/kueue-operator/test/e2e/dra/enable-feature-gate/kueue-operator-test-e2e-dra-enable-feature-gate-ref.metadata.json
@@ -1,0 +1,21 @@
+{
+	"path": "kueue-operator/test/e2e/dra/enable-feature-gate/kueue-operator-test-e2e-dra-enable-feature-gate-ref.yaml",
+	"owners": {
+		"approvers": [
+			"PannagaRao",
+			"cpmeadors",
+			"kannon92",
+			"mrunalp",
+			"rphillips",
+			"sohankunkerkar"
+		],
+		"reviewers": [
+			"PannagaRao",
+			"cpmeadors",
+			"kannon92",
+			"mrunalp",
+			"rphillips",
+			"sohankunkerkar"
+		]
+	}
+}

--- a/ci-operator/step-registry/kueue-operator/test/e2e/dra/enable-feature-gate/kueue-operator-test-e2e-dra-enable-feature-gate-ref.yaml
+++ b/ci-operator/step-registry/kueue-operator/test/e2e/dra/enable-feature-gate/kueue-operator-test-e2e-dra-enable-feature-gate-ref.yaml
@@ -1,0 +1,12 @@
+ref:
+  as: kueue-operator-test-e2e-dra-enable-feature-gate
+  from: cli
+  cli: latest
+  commands: kueue-operator-test-e2e-dra-enable-feature-gate-commands.sh
+  resources:
+    requests:
+      cpu: 100m
+      memory: 200Mi
+  documentation: |-
+    Enables the DRAExtendedResources OCP feature gate via CustomNoUpgrade
+    and waits for kube-apiserver rollout to complete.

--- a/ci-operator/step-registry/kueue-operator/test/e2e/upstream/kueue-operator-test-e2e-upstream-chain.yaml
+++ b/ci-operator/step-registry/kueue-operator/test/e2e/upstream/kueue-operator-test-e2e-upstream-chain.yaml
@@ -18,6 +18,12 @@ chain:
   - chain: leader-worker-set-install
   - as: e2e-kueue-upstream
     cli: latest
+    env:
+    - name: E2E_TARGET_FOLDERS
+      default: "singlecluster certmanager"
+      documentation: |-
+        Space-separated list of upstream e2e test folders to run.
+        Available folders: singlecluster, certmanager, dra.
     commands: |
       source "${SHARED_DIR}/env"
       make e2e-upstream-test


### PR DESCRIPTION
Signed-off-by: Pannaga Rao Bhoja Ramamanohara

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a DRA example driver installer and a DRA feature-gate enablement step as CI prerequisites.
  * Added an optional upstream e2e presubmit job targeting 4.21.

* **Tests**
  * Integrated driver and feature-gate prerequisite steps into upstream e2e workflows.
  * Made e2e target folder selection configurable (singlecluster, certmanager, dra).

* **Chores**
  * Added ownership metadata for the new step registry entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->