### PR TITLE
Add tsatam and wanghaoran1988 to aro-classic OWNERS

### DIFF
--- a/ci-operator/step-registry/aro-classic/OWNERS
+++ b/ci-operator/step-registry/aro-classic/OWNERS
@@ -1,6 +1,10 @@
 approvers:
 - mociarain
 - hlipsig
+- tsatam
+- wanghaoran1988
 reviewers:
 - mociarain
 - hlipsig
+- tsatam
+- wanghaoran1988

--- a/ci-operator/step-registry/aro-classic/e2e/OWNERS
+++ b/ci-operator/step-registry/aro-classic/e2e/OWNERS
@@ -1,6 +1,10 @@
 approvers:
 - mociarain
 - hlipsig
+- tsatam
+- wanghaoran1988
 reviewers:
 - mociarain
 - hlipsig
+- tsatam
+- wanghaoran1988

--- a/ci-operator/step-registry/aro-classic/e2e/aro-classic-e2e-workflow.metadata.json
+++ b/ci-operator/step-registry/aro-classic/e2e/aro-classic-e2e-workflow.metadata.json
@@ -2,12 +2,16 @@
 	"path": "aro-classic/e2e/aro-classic-e2e-workflow.yaml",
 	"owners": {
 		"approvers": [
+			"hlipsig",
 			"mociarain",
-			"hlipsig"
+			"tsatam",
+			"wanghaoran1988"
 		],
 		"reviewers": [
+			"hlipsig",
 			"mociarain",
-			"hlipsig"
+			"tsatam",
+			"wanghaoran1988"
 		]
 	}
 }

--- a/ci-operator/step-registry/aro-classic/e2e/aro-classic-e2e-workflow.metadata.json
+++ b/ci-operator/step-registry/aro-classic/e2e/aro-classic-e2e-workflow.metadata.json
@@ -2,14 +2,14 @@
 	"path": "aro-classic/e2e/aro-classic-e2e-workflow.yaml",
 	"owners": {
 		"approvers": [
-			"hlipsig",
 			"mociarain",
+			"hlipsig",
 			"tsatam",
 			"wanghaoran1988"
 		],
 		"reviewers": [
-			"hlipsig",
 			"mociarain",
+			"hlipsig",
 			"tsatam",
 			"wanghaoran1988"
 		]

--- a/ci-operator/step-registry/aro-classic/test/OWNERS
+++ b/ci-operator/step-registry/aro-classic/test/OWNERS
@@ -1,6 +1,10 @@
 approvers:
 - mociarain
 - hlipsig
+- tsatam
+- wanghaoran1988
 reviewers:
 - mociarain
 - hlipsig
+- tsatam
+- wanghaoran1988

--- a/ci-operator/step-registry/aro-classic/test/persistent/OWNERS
+++ b/ci-operator/step-registry/aro-classic/test/persistent/OWNERS
@@ -1,6 +1,10 @@
 approvers:
 - mociarain
 - hlipsig
+- tsatam
+- wanghaoran1988
 reviewers:
 - mociarain
 - hlipsig
+- tsatam
+- wanghaoran1988

--- a/ci-operator/step-registry/aro-classic/test/persistent/aro-classic-test-persistent-ref.metadata.json
+++ b/ci-operator/step-registry/aro-classic/test/persistent/aro-classic-test-persistent-ref.metadata.json
@@ -2,14 +2,14 @@
 	"path": "aro-classic/test/persistent/aro-classic-test-persistent-ref.yaml",
 	"owners": {
 		"approvers": [
-			"hlipsig",
 			"mociarain",
+			"hlipsig",
 			"tsatam",
 			"wanghaoran1988"
 		],
 		"reviewers": [
-			"hlipsig",
 			"mociarain",
+			"hlipsig",
 			"tsatam",
 			"wanghaoran1988"
 		]

--- a/ci-operator/step-registry/aro-classic/test/persistent/aro-classic-test-persistent-ref.metadata.json
+++ b/ci-operator/step-registry/aro-classic/test/persistent/aro-classic-test-persistent-ref.metadata.json
@@ -2,12 +2,16 @@
 	"path": "aro-classic/test/persistent/aro-classic-test-persistent-ref.yaml",
 	"owners": {
 		"approvers": [
+			"hlipsig",
 			"mociarain",
-			"hlipsig"
+			"tsatam",
+			"wanghaoran1988"
 		],
 		"reviewers": [
+			"hlipsig",
 			"mociarain",
-			"hlipsig"
+			"tsatam",
+			"wanghaoran1988"
 		]
 	}
 }


### PR DESCRIPTION
## Summary
- Add `tsatam` and `wanghaoran1988` to aro-classic OWNERS files (approvers and reviewers)
- Update step registry metadata JSON files to match the OWNERS changes

This is a replacement for #78147 which was missing the metadata updates, causing `step-registry-metadata` CI to fail.

## Test plan
- [ ] `ci/prow/step-registry-metadata` passes
- [ ] `ci/prow/owners` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review and approval assignments across continuous integration components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->