### PR TITLE
Add --job-iterations=100 to ROSA build-farm jobs for 4.21, 4.22, 4.23

### DIFF
--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__rosa-4.21-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__rosa-4.21-nightly-x86.yaml
@@ -188,7 +188,7 @@ tests:
     allow_skip_on_success: true
     cluster_profile: aws-perfscale
     env:
-      BUILD_FARM_EXTRA_FLAGS: --alerting=false
+      BUILD_FARM_EXTRA_FLAGS: --alerting=false --job-iterations=100
       CHANNEL_GROUP: nightly
       CLUSTER_TAGS: TicketId:731
       COMPUTE_MACHINE_TYPE: m6i.xlarge

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__rosa-4.22-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__rosa-4.22-nightly-x86.yaml
@@ -30,7 +30,7 @@ tests:
     allow_skip_on_success: true
     cluster_profile: aws-perfscale
     env:
-      BUILD_FARM_EXTRA_FLAGS: --alerting=false
+      BUILD_FARM_EXTRA_FLAGS: --alerting=false --job-iterations=100
       CHANNEL_GROUP: nightly
       CLUSTER_TAGS: TicketId:731
       COMPUTE_MACHINE_TYPE: m6i.xlarge

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__rosa-4.23-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__rosa-4.23-nightly-x86.yaml
@@ -30,7 +30,7 @@ tests:
     allow_skip_on_success: true
     cluster_profile: aws-perfscale
     env:
-      BUILD_FARM_EXTRA_FLAGS: --alerting=false
+      BUILD_FARM_EXTRA_FLAGS: --alerting=false --job-iterations=100
       CHANNEL_GROUP: nightly
       CLUSTER_TAGS: TicketId:731
       COMPUTE_MACHINE_TYPE: m6i.xlarge


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build-farm test configurations for ROSA 4.21, 4.22, and 4.23 nightly environments with modified test execution parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->