### PR TITLE
Deprecate plugins ConfigMap: hook, needs-rebase, qe-private-deck, statusreconciler

### DIFF
--- a/clusters/app.ci/prow/03_deployment/hook.yaml
+++ b/clusters/app.ci/prow/03_deployment/hook.yaml
@@ -148,7 +148,8 @@ spec:
         - --jira-username=aos-team-dp-testplatform@redhat.com
         - --jira-password-file=/etc/jira/password
         - --projected-token-file=/var/sa-token/token
-        - --supplemental-plugin-config-dir=/etc/plugins
+        - --plugin-config=/var/repo/release/core-services/prow/02_config/_plugins.yaml
+        - --supplemental-plugin-config-dir=/var/repo/release/core-services/prow/02_config
         - --kubeconfig-dir=/etc/build-farm-credentials
         - --kubeconfig-suffix=config
         env:
@@ -179,9 +180,6 @@ spec:
           readOnly: true
         - name: unsplash-api
           mountPath: /etc/unsplash-api
-          readOnly: true
-        - name: plugins
-          mountPath: /etc/plugins
           readOnly: true
         - name: tmp
           mountPath: /tmp
@@ -243,9 +241,6 @@ spec:
       - name: config
         configMap:
           name: config
-      - name: plugins
-        configMap:
-          name: plugins
       - name: release
         emptyDir: {}
       - name: build-farm-credentials

--- a/clusters/app.ci/prow/03_deployment/needs_rebase.yaml
+++ b/clusters/app.ci/prow/03_deployment/needs_rebase.yaml
@@ -34,6 +34,21 @@ spec:
         app: prow
         component: needs-rebase
     spec:
+      initContainers:
+      - name: git-sync-init
+        command:
+        - /git-sync
+        args:
+        - --repo=https://github.com/openshift/release.git
+        - --ref=main
+        - --root=/tmp/git-sync
+        - --one-time=true
+        - --depth=1
+        - --link=release
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_git-sync_v4.3.0
+        volumeMounts:
+        - name: release
+          mountPath: /tmp/git-sync
       containers:
       - name: needs-rebase
         image: us-docker.pkg.dev/k8s-infra-prow/images/needs-rebase:v20260414-6691f5aff
@@ -41,8 +56,8 @@ spec:
         - --github-app-id=$(GITHUB_APP_ID)
         - --github-app-private-key-path=/etc/github/cert
         - --hmac-secret-file=/etc/webhook/hmac.yaml
-        - --plugin-config=/etc/plugins/plugins.yaml
-        - --supplemental-plugin-config-dir=/etc/plugins
+        - --plugin-config=/var/repo/release/core-services/prow/02_config/_plugins.yaml
+        - --supplemental-plugin-config-dir=/var/repo/release/core-services/prow/02_config
         - --dry-run=false
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
@@ -55,6 +70,9 @@ spec:
             secretKeyRef:
               name: openshift-prow-github-app
               key: appid
+        volumeMounts:
+        - name: release
+          mountPath: /var/repo
         ports:
           - name: http
             containerPort: 8888
@@ -64,9 +82,6 @@ spec:
           readOnly: true
         - name: github-app-credentials
           mountPath: /etc/github
-          readOnly: true
-        - name: plugins
-          mountPath: /etc/plugins
           readOnly: true
         resources:
           requests:
@@ -82,6 +97,24 @@ spec:
           httpGet:
             path: /healthz/ready
             port: 8081
+      - name: git-sync
+        command:
+        - /git-sync
+        args:
+        - --repo=https://github.com/openshift/release.git
+        - --ref=main
+        - --period=30s
+        - --root=/tmp/git-sync
+        - --max-failures=3
+        - --link=release
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_git-sync_v4.3.0
+        volumeMounts:
+        - name: release
+          mountPath: /tmp/git-sync
+        resources:
+          requests:
+            memory: "1Gi"
+            cpu: "0.5"
       volumes:
       - name: hmac
         secret:
@@ -89,6 +122,5 @@ spec:
       - name: github-app-credentials
         secret:
           secretName: openshift-prow-github-app
-      - name: plugins
-        configMap:
-          name: plugins
+      - name: release
+        emptyDir: {}

--- a/clusters/app.ci/prow/03_deployment/qe_private_deck.yaml
+++ b/clusters/app.ci/prow/03_deployment/qe_private_deck.yaml
@@ -123,8 +123,8 @@ objects:
                 - --gcs-credentials-file=/etc/gce-sa-credentials-gcs-qe-private-deck/service-account.json
                 - --projected-token-file=/var/sa-token/token
                 - --rerun-creates-job=true
-                - --plugin-config=/etc/plugins/plugins.yaml
-                - --supplemental-plugin-config-dir=/etc/plugins
+                - --plugin-config=/var/repo/release/core-services/prow/02_config/_plugins.yaml
+                - --supplemental-plugin-config-dir=/var/repo/release/core-services/prow/02_config
                 - --kubeconfig-dir=/etc/build-farm-credentials
                 - --kubeconfig-suffix=config
                 - --tenant-id=qe-private
@@ -166,9 +166,6 @@ objects:
                   name: session-secret
                 - name: config
                   mountPath: /etc/config
-                  readOnly: true
-                - name: plugins
-                  mountPath: /etc/plugins
                   readOnly: true
                 - name: extensions
                   mountPath: /var/run/ko/static/extensions
@@ -242,9 +239,6 @@ objects:
             - name: config
               configMap:
                 name: config
-            - name: plugins
-              configMap:
-                name: plugins
             - name: extensions
               configMap:
                 name: qe-private-deck-extensions

--- a/clusters/app.ci/prow/03_deployment/statusreconciler.yaml
+++ b/clusters/app.ci/prow/03_deployment/statusreconciler.yaml
@@ -42,8 +42,8 @@ spec:
         args:
         - --dry-run=false
         - --continue-on-error=true
-        - --plugin-config=/etc/plugins/plugins.yaml
-        - --supplemental-plugin-config-dir=/etc/plugins
+        - --plugin-config=/var/repo/release/core-services/prow/02_config/_plugins.yaml
+        - --supplemental-plugin-config-dir=/var/repo/release/core-services/prow/02_config
         - --config-path=/etc/config/config.yaml
         - --supplemental-prow-config-dir=/etc/config
         - --github-app-id=$(GITHUB_APP_ID)
@@ -73,9 +73,6 @@ spec:
           readOnly: true
         - name: release
           mountPath: /var/repo
-        - name: plugins
-          mountPath: /etc/plugins
-          readOnly: true
         resources:
           requests:
             memory: "12Gi"
@@ -112,6 +109,3 @@ spec:
           name: config
       - name: release
         emptyDir: {}
-      - name: plugins
-        configMap:
-          name: plugins


### PR DESCRIPTION
Same as https://github.com/openshift/release/pull/78101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched multiple Prow components to read plugin configuration from a git-synced repository volume instead of in-cluster ConfigMap mounts.
  * Added repo sync tooling (init + sidecar) to keep configuration updated from the released repository.
  * Removed ConfigMap-backed plugin mounts from affected deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->