### PR TITLE
konflux-ci: run cleanup scripts twice per day

### DIFF
--- a/ci-operator/config/konflux-ci/e2e-tests/konflux-ci-e2e-tests-main.yaml
+++ b/ci-operator/config/konflux-ci/e2e-tests/konflux-ci-e2e-tests-main.yaml
@@ -48,7 +48,7 @@ tests:
     - ref: redhat-appstudio-e2e
     workflow: redhat-appstudio-claim
 - as: appstudio-dump-external-resources
-  cron: 0 */24 * * *
+  cron: 0 */12 * * *
   steps:
     test:
     - ref: redhat-appstudio-clean-external-resources

--- a/ci-operator/jobs/konflux-ci/e2e-tests/konflux-ci-e2e-tests-main-periodics.yaml
+++ b/ci-operator/jobs/konflux-ci/e2e-tests/konflux-ci-e2e-tests-main-periodics.yaml
@@ -1,7 +1,7 @@
 periodics:
 - agent: kubernetes
   cluster: build03
-  cron: 0 */24 * * *
+  cron: 0 */12 * * *
   decorate: true
   decoration_config:
     skip_cloning: true


### PR DESCRIPTION
Running once is not enough, we accumulate lot of repos

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased test job scheduling frequency from every 24 hours to every 12 hours for enhanced testing cadence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->