### PR TITLE
Update kubevirt-plugin CI to test against OCP 4.22

### DIFF
--- a/ci-operator/config/kubevirt-ui/kubevirt-plugin/kubevirt-ui-kubevirt-plugin-main.yaml
+++ b/ci-operator/config/kubevirt-ui/kubevirt-plugin/kubevirt-ui-kubevirt-plugin-main.yaml
@@ -10,12 +10,12 @@ images:
 releases:
   initial:
     integration:
-      name: "4.19"
+      name: "4.22"
       namespace: ocp
   latest:
     integration:
       include_built_images: true
-      name: "4.19"
+      name: "4.22"
       namespace: ocp
 resources:
   '*':


### PR DESCRIPTION
Update `kubevirt-plugin` CI to test against OCP 4.22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated integration release configuration to support newer versions in the build and testing pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->