### PR TITLE
OCPEDGE-2480: Added slack webhook for ocp-ci-monitor

### DIFF
--- a/ci-operator/jobs/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main-periodics.yaml
@@ -13,15 +13,6 @@ periodics:
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-eng-edge-tooling-main-ocp-ci-monitor
-  reporter_config:
-    slack:
-      channel: '#vimauro-test-ci-monitor'
-      job_states_to_report:
-      - success
-      - failure
-      - error
-      report_template: |
-        {{if eq .Status.State "success"}} :large_green_circle: {{else}} :red_circle: {{end}} *Edge OCP CI Monitor* ended with *{{.Status.State}}*. <https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/{{.Spec.Job}}/{{.Status.BuildID}}/artifacts/ocp-ci-monitor/openshift-edge-tooling-ci-monitor/artifacts/edge-ci-monitor-summary.html|View Dashboard>
   spec:
     containers:
     - args:

--- a/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-commands.sh
+++ b/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-commands.sh
@@ -130,6 +130,9 @@ copy_artifacts() {
         cp "${report_dir}"/*.json "${ARTIFACT_DIR}/" 2>/dev/null || true
     fi
 
+    # Share the analysis log with downstream steps (e.g. Slack notification)
+    cp "${ARTIFACT_DIR}/claude-analysis.log" "${SHARED_DIR}/" 2>/dev/null || true
+
     # Archive Claude session for local continuation
     if [[ -d "${CLAUDE_HOME}/projects" ]]; then
         echo "Archiving Claude session..."

--- a/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-commands.sh
+++ b/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-commands.sh
@@ -131,7 +131,12 @@ copy_artifacts() {
     fi
 
     # Share the analysis log with downstream steps (e.g. Slack notification)
-    cp "${ARTIFACT_DIR}/claude-analysis.log" "${SHARED_DIR}/" 2>/dev/null || true
+    if [[ -r "${ARTIFACT_DIR}/claude-analysis.log" ]]; then
+        cp "${ARTIFACT_DIR}/claude-analysis.log" "${SHARED_DIR}/" || \
+            echo "ERROR: failed to copy claude-analysis.log to SHARED_DIR" >&2
+    else
+        echo "Warning: ${ARTIFACT_DIR}/claude-analysis.log not found or unreadable" >&2
+    fi
 
     # Archive Claude session for local continuation
     if [[ -d "${CLAUDE_HOME}/projects" ]]; then

--- a/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-commands.sh
+++ b/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-commands.sh
@@ -130,12 +130,13 @@ copy_artifacts() {
         cp "${report_dir}"/*.json "${ARTIFACT_DIR}/" 2>/dev/null || true
     fi
 
-    # Share the analysis log with downstream steps (e.g. Slack notification)
+    # Extract blocking-jobs summary for downstream steps.
+    # SHARED_DIR is backed by a K8s Secret (1 MB limit) so only the extracted
+    # data is shared — not the full multi-MB stream-JSON log.
     if [[ -r "${ARTIFACT_DIR}/claude-analysis.log" ]]; then
-        cp "${ARTIFACT_DIR}/claude-analysis.log" "${SHARED_DIR}/" || \
-            echo "ERROR: failed to copy claude-analysis.log to SHARED_DIR" >&2
-    else
-        echo "Warning: ${ARTIFACT_DIR}/claude-analysis.log not found or unreadable" >&2
+        sed -n '/BLOCKING_JOBS_START/,/BLOCKING_JOBS_END/p' "${ARTIFACT_DIR}/claude-analysis.log" \
+            | grep -oE 'BLOCKING\|[^|]+\|https://[^|]+\|[^|]+\|[0-9]+\.[0-9]+\|[^|"\\]+' \
+            | sort -u > "${SHARED_DIR}/blocking-jobs.txt" || true
     fi
 
     # Archive Claude session for local continuation

--- a/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-workflow.yaml
+++ b/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-workflow.yaml
@@ -4,6 +4,7 @@ workflow:
     test:
     - ref: openshift-edge-tooling-ci-monitor
     post:
+    - ref: openshift-edge-tooling-ci-monitor-send-slack
     - ref: openshift-claude-post
   documentation: |-
     Runs the Edge Enablement Payload Monitor to generate an interactive

--- a/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/send-slack/OWNERS
+++ b/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/send-slack/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+  - edge-enablement-approvers
+reviewers:
+  - edge-enablement-reviewers
+  - microshift-reviewers

--- a/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/send-slack/openshift-edge-tooling-ci-monitor-send-slack-commands.sh
+++ b/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/send-slack/openshift-edge-tooling-ci-monitor-send-slack-commands.sh
@@ -24,6 +24,7 @@ LOG_FILE="${SHARED_DIR}/claude-analysis.log"
 BLOCKING_COUNT=0
 VERSIONS=""
 TOPOLOGIES=""
+DATA_AVAILABLE=false
 
 if [[ -f "${LOG_FILE}" ]]; then
     BLOCKING_LINES=$(sed -n '/BLOCKING_JOBS_START/,/BLOCKING_JOBS_END/p' "${LOG_FILE}" \
@@ -32,6 +33,7 @@ if [[ -f "${LOG_FILE}" ]]; then
         | sed '/^[[:space:]]*$/d')
 
     if [[ -n "${BLOCKING_LINES}" ]]; then
+        DATA_AVAILABLE=true
         BLOCKING_COUNT=$(echo "${BLOCKING_LINES}" | wc -l)
         VERSIONS=$(echo "${BLOCKING_LINES}" | awk -F'|' '{print $5}' | sort -uV | paste -sd ', ')
         TOPOLOGIES=$(echo "${BLOCKING_LINES}" | awk -F'|' '{print $4}' | sort -u | paste -sd ', ')
@@ -43,7 +45,10 @@ fi
 # ---------------------------------------------------------------------------
 # Compose the Slack message
 # ---------------------------------------------------------------------------
-if [[ "${BLOCKING_COUNT}" -eq 0 ]]; then
+if [[ "${DATA_AVAILABLE}" != "true" ]]; then
+    ICON=":warning:"
+    MESSAGE="${ICON} *Edge OCP CI Monitor* — Blocking jobs data unavailable. Please investigate the artifacts."
+elif [[ "${BLOCKING_COUNT}" -eq 0 ]]; then
     ICON=":large_green_circle:"
     MESSAGE="${ICON} *Edge OCP CI Monitor* — No blocking jobs found."
 else
@@ -58,8 +63,10 @@ MESSAGE+="\n<${DASHBOARD_URL}|View Dashboard> | <${JOB_URL}|Prow Logs> | @edge-e
 # ---------------------------------------------------------------------------
 # Send to Slack
 # ---------------------------------------------------------------------------
+PAYLOAD=$(jq -nc --arg text "${MESSAGE}" '{"text": $text}')
+
 curl -sf -X POST -H 'Content-type: application/json' \
-    --data "{\"text\":\"${MESSAGE}\"}" \
+    --data "${PAYLOAD}" \
     "${WEBHOOK_URL}"
 
 echo "Slack notification sent (${BLOCKING_COUNT} blocking jobs found)."

--- a/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/send-slack/openshift-edge-tooling-ci-monitor-send-slack-commands.sh
+++ b/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/send-slack/openshift-edge-tooling-ci-monitor-send-slack-commands.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Read webhook URL (tracing disabled — secret handling)
+# ---------------------------------------------------------------------------
+WEBHOOK_URL=$(cat /var/run/slack-webhook/ocp-ci-monitor)
+
+# ---------------------------------------------------------------------------
+# Build URLs
+# ---------------------------------------------------------------------------
+JOB_URL="https://prow.ci.openshift.org/view/gs/test-platform-results/logs/${JOB_NAME}/${BUILD_ID}"
+GCS_BASE="https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results"
+DASHBOARD_URL="${GCS_BASE}/logs/${JOB_NAME}/${BUILD_ID}/artifacts/ocp-ci-monitor/openshift-edge-tooling-ci-monitor/artifacts/edge-ci-monitor-summary.html"
+
+# ---------------------------------------------------------------------------
+# Extract blocking jobs from the analysis log
+#
+# Format between BLOCKING_JOBS_START/END:
+#   BLOCKING|<job_name>|<prow_url>|<topology>|<version>|<payload>
+# ---------------------------------------------------------------------------
+LOG_FILE="${SHARED_DIR}/claude-analysis.log"
+
+BLOCKING_COUNT=0
+VERSIONS=""
+TOPOLOGIES=""
+
+if [[ -f "${LOG_FILE}" ]]; then
+    BLOCKING_LINES=$(sed -n '/BLOCKING_JOBS_START/,/BLOCKING_JOBS_END/p' "${LOG_FILE}" \
+        | grep -v 'BLOCKING_JOBS_START\|BLOCKING_JOBS_END' \
+        | sed 's/^[0-9]*\t//' \
+        | sed '/^[[:space:]]*$/d')
+
+    if [[ -n "${BLOCKING_LINES}" ]]; then
+        BLOCKING_COUNT=$(echo "${BLOCKING_LINES}" | wc -l)
+        VERSIONS=$(echo "${BLOCKING_LINES}" | awk -F'|' '{print $5}' | sort -uV | paste -sd ', ')
+        TOPOLOGIES=$(echo "${BLOCKING_LINES}" | awk -F'|' '{print $4}' | sort -u | paste -sd ', ')
+    fi
+else
+    echo "Warning: ${LOG_FILE} not found."
+fi
+
+# ---------------------------------------------------------------------------
+# Compose the Slack message
+# ---------------------------------------------------------------------------
+if [[ "${BLOCKING_COUNT}" -eq 0 ]]; then
+    ICON=":large_green_circle:"
+    MESSAGE="${ICON} *Edge OCP CI Monitor* — No blocking jobs found."
+else
+    ICON=":red_circle:"
+    MESSAGE="${ICON} *Edge OCP CI Monitor* — *${BLOCKING_COUNT}* blocking job(s) found."
+    MESSAGE+="\n• *Versions:* ${VERSIONS}"
+    MESSAGE+="\n• *Topologies:* ${TOPOLOGIES}"
+fi
+
+MESSAGE+="\n<${DASHBOARD_URL}|View Dashboard> | <${JOB_URL}|Prow Logs> | @edge-enablement-payload-manager"
+
+# ---------------------------------------------------------------------------
+# Send to Slack
+# ---------------------------------------------------------------------------
+curl -sf -X POST -H 'Content-type: application/json' \
+    --data "{\"text\":\"${MESSAGE}\"}" \
+    "${WEBHOOK_URL}"
+
+echo "Slack notification sent (${BLOCKING_COUNT} blocking jobs found)."

--- a/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/send-slack/openshift-edge-tooling-ci-monitor-send-slack-commands.sh
+++ b/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/send-slack/openshift-edge-tooling-ci-monitor-send-slack-commands.sh
@@ -28,7 +28,7 @@ DATA_AVAILABLE=false
 
 if [[ -f "${LOG_FILE}" ]]; then
     BLOCKING_LINES=$(sed -n '/BLOCKING_JOBS_START/,/BLOCKING_JOBS_END/p' "${LOG_FILE}" \
-        | grep -v 'BLOCKING_JOBS_START\|BLOCKING_JOBS_END' \
+        | { grep -v 'BLOCKING_JOBS_START\|BLOCKING_JOBS_END' || true; } \
         | sed 's/^[0-9]*\t//' \
         | sed '/^[[:space:]]*$/d')
 

--- a/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/send-slack/openshift-edge-tooling-ci-monitor-send-slack-commands.sh
+++ b/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/send-slack/openshift-edge-tooling-ci-monitor-send-slack-commands.sh
@@ -14,9 +14,9 @@ GCS_BASE="https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-
 DASHBOARD_URL="${GCS_BASE}/logs/${JOB_NAME}/${BUILD_ID}/artifacts/ocp-ci-monitor/openshift-edge-tooling-ci-monitor/artifacts/edge-ci-monitor-summary.html"
 
 # ---------------------------------------------------------------------------
-# Extract blocking jobs from the analysis log
+# Extract blocking jobs from the analysis log (stream-JSON format)
 #
-# Format between BLOCKING_JOBS_START/END:
+# Entries between BLOCKING_JOBS_START/END delimiters, pipe-separated:
 #   BLOCKING|<job_name>|<prow_url>|<topology>|<version>|<payload>
 # ---------------------------------------------------------------------------
 LOG_FILE="${SHARED_DIR}/claude-analysis.log"
@@ -31,15 +31,15 @@ if [[ -f "${LOG_FILE}" ]]; then
         DATA_AVAILABLE=true
     fi
 
+    # Scope to the delimited block, then extract structured entries from stream-JSON.
     BLOCKING_LINES=$(sed -n '/BLOCKING_JOBS_START/,/BLOCKING_JOBS_END/p' "${LOG_FILE}" \
-        | { grep -v 'BLOCKING_JOBS_START\|BLOCKING_JOBS_END' || true; } \
-        | sed 's/^[0-9]*\t//' \
-        | sed '/^[[:space:]]*$/d')
+        | { grep -oE 'BLOCKING\|[^|]+\|https://[^|]+\|[^|]+\|[0-9]+\.[0-9]+\|[^|"\\]+' || true; } \
+        | sort -u)
 
     if [[ -n "${BLOCKING_LINES}" ]]; then
         BLOCKING_COUNT=$(echo "${BLOCKING_LINES}" | wc -l)
-        VERSIONS=$(echo "${BLOCKING_LINES}" | awk -F'|' '{print $5}' | sort -uV | paste -sd ', ')
-        TOPOLOGIES=$(echo "${BLOCKING_LINES}" | awk -F'|' '{print $4}' | sort -u | paste -sd ', ')
+        VERSIONS=$(echo "${BLOCKING_LINES}" | awk -F'|' '{print $5}' | sort -uV | tr '\n' ',' | sed 's/,/, /g; s/, $//')
+        TOPOLOGIES=$(echo "${BLOCKING_LINES}" | awk -F'|' '{print $4}' | sort -u | tr '\n' ',' | sed 's/,/, /g; s/, $//')
     fi
 else
     echo "Warning: ${LOG_FILE} not found."
@@ -48,6 +48,8 @@ fi
 # ---------------------------------------------------------------------------
 # Compose the Slack message
 # ---------------------------------------------------------------------------
+NL=$'\n'
+
 if [[ "${DATA_AVAILABLE}" != "true" ]]; then
     ICON=":warning:"
     MESSAGE="${ICON} *Edge OCP CI Monitor* — Blocking jobs data unavailable. Please investigate the artifacts."
@@ -57,11 +59,11 @@ elif [[ "${BLOCKING_COUNT}" -eq 0 ]]; then
 else
     ICON=":red_circle:"
     MESSAGE="${ICON} *Edge OCP CI Monitor* — *${BLOCKING_COUNT}* blocking job(s) found."
-    MESSAGE+="\n• *Versions:* ${VERSIONS}"
-    MESSAGE+="\n• *Topologies:* ${TOPOLOGIES}"
+    MESSAGE+="${NL}• *Versions:* ${VERSIONS}"
+    MESSAGE+="${NL}• *Topologies:* ${TOPOLOGIES}"
 fi
 
-MESSAGE+="\n<${DASHBOARD_URL}|View Dashboard> | <${JOB_URL}|Prow Logs> | @edge-enablement-payload-manager"
+MESSAGE+="${NL}<${DASHBOARD_URL}|View Dashboard> | <${JOB_URL}|Prow Logs> | @edge-enablement-payload-manager"
 
 # ---------------------------------------------------------------------------
 # Send to Slack

--- a/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/send-slack/openshift-edge-tooling-ci-monitor-send-slack-commands.sh
+++ b/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/send-slack/openshift-edge-tooling-ci-monitor-send-slack-commands.sh
@@ -27,13 +27,16 @@ TOPOLOGIES=""
 DATA_AVAILABLE=false
 
 if [[ -f "${LOG_FILE}" ]]; then
+    if grep -q 'BLOCKING_JOBS_START' "${LOG_FILE}" && grep -q 'BLOCKING_JOBS_END' "${LOG_FILE}"; then
+        DATA_AVAILABLE=true
+    fi
+
     BLOCKING_LINES=$(sed -n '/BLOCKING_JOBS_START/,/BLOCKING_JOBS_END/p' "${LOG_FILE}" \
         | { grep -v 'BLOCKING_JOBS_START\|BLOCKING_JOBS_END' || true; } \
         | sed 's/^[0-9]*\t//' \
         | sed '/^[[:space:]]*$/d')
 
     if [[ -n "${BLOCKING_LINES}" ]]; then
-        DATA_AVAILABLE=true
         BLOCKING_COUNT=$(echo "${BLOCKING_LINES}" | wc -l)
         VERSIONS=$(echo "${BLOCKING_LINES}" | awk -F'|' '{print $5}' | sort -uV | paste -sd ', ')
         TOPOLOGIES=$(echo "${BLOCKING_LINES}" | awk -F'|' '{print $4}' | sort -u | paste -sd ', ')

--- a/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/send-slack/openshift-edge-tooling-ci-monitor-send-slack-commands.sh
+++ b/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/send-slack/openshift-edge-tooling-ci-monitor-send-slack-commands.sh
@@ -14,27 +14,21 @@ GCS_BASE="https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-
 DASHBOARD_URL="${GCS_BASE}/logs/${JOB_NAME}/${BUILD_ID}/artifacts/ocp-ci-monitor/openshift-edge-tooling-ci-monitor/artifacts/edge-ci-monitor-summary.html"
 
 # ---------------------------------------------------------------------------
-# Extract blocking jobs from the analysis log (stream-JSON format)
+# Read pre-extracted blocking jobs from SHARED_DIR
 #
-# Entries between BLOCKING_JOBS_START/END delimiters, pipe-separated:
+# The monitor step extracts pipe-separated entries into blocking-jobs.txt:
 #   BLOCKING|<job_name>|<prow_url>|<topology>|<version>|<payload>
 # ---------------------------------------------------------------------------
-LOG_FILE="${SHARED_DIR}/claude-analysis.log"
+JOBS_FILE="${SHARED_DIR}/blocking-jobs.txt"
 
 BLOCKING_COUNT=0
 VERSIONS=""
 TOPOLOGIES=""
 DATA_AVAILABLE=false
 
-if [[ -f "${LOG_FILE}" ]]; then
-    if grep -q 'BLOCKING_JOBS_START' "${LOG_FILE}" && grep -q 'BLOCKING_JOBS_END' "${LOG_FILE}"; then
-        DATA_AVAILABLE=true
-    fi
-
-    # Scope to the delimited block, then extract structured entries from stream-JSON.
-    BLOCKING_LINES=$(sed -n '/BLOCKING_JOBS_START/,/BLOCKING_JOBS_END/p' "${LOG_FILE}" \
-        | { grep -oE 'BLOCKING\|[^|]+\|https://[^|]+\|[^|]+\|[0-9]+\.[0-9]+\|[^|"\\]+' || true; } \
-        | sort -u)
+if [[ -f "${JOBS_FILE}" ]]; then
+    DATA_AVAILABLE=true
+    BLOCKING_LINES=$(<"${JOBS_FILE}")
 
     if [[ -n "${BLOCKING_LINES}" ]]; then
         BLOCKING_COUNT=$(echo "${BLOCKING_LINES}" | wc -l)
@@ -42,7 +36,7 @@ if [[ -f "${LOG_FILE}" ]]; then
         TOPOLOGIES=$(echo "${BLOCKING_LINES}" | awk -F'|' '{print $4}' | sort -u | tr '\n' ',' | sed 's/,/, /g; s/, $//')
     fi
 else
-    echo "Warning: ${LOG_FILE} not found."
+    echo "Warning: ${JOBS_FILE} not found."
 fi
 
 # ---------------------------------------------------------------------------

--- a/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/send-slack/openshift-edge-tooling-ci-monitor-send-slack-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/send-slack/openshift-edge-tooling-ci-monitor-send-slack-ref.metadata.json
@@ -1,0 +1,12 @@
+{
+	"path": "openshift/edge-tooling/ci-monitor/send-slack/openshift-edge-tooling-ci-monitor-send-slack-ref.yaml",
+	"owners": {
+		"approvers": [
+			"edge-enablement-approvers"
+		],
+		"reviewers": [
+			"edge-enablement-reviewers",
+			"microshift-reviewers"
+		]
+	}
+}

--- a/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/send-slack/openshift-edge-tooling-ci-monitor-send-slack-ref.yaml
+++ b/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/send-slack/openshift-edge-tooling-ci-monitor-send-slack-ref.yaml
@@ -1,0 +1,19 @@
+ref:
+  as: openshift-edge-tooling-ci-monitor-send-slack
+  commands: openshift-edge-tooling-ci-monitor-send-slack-commands.sh
+  from: cli
+  best_effort: true
+  timeout: 2m
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+  credentials:
+  - namespace: test-credentials
+    name: edge-tooling-ci-monitor-slack-webhook
+    mount_path: /var/run/slack-webhook
+  documentation: |-
+    Sends a Slack notification with blocking job counts extracted from the
+    CI monitor analysis log. Reads claude-analysis.log from SHARED_DIR,
+    parses content between BLOCKING_JOBS_START/END delimiters, and posts
+    a summary to the configured Slack channel via webhook.

--- a/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/send-slack/openshift-edge-tooling-ci-monitor-send-slack-ref.yaml
+++ b/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/send-slack/openshift-edge-tooling-ci-monitor-send-slack-ref.yaml
@@ -16,7 +16,7 @@ ref:
     name: edge-tooling-ci-monitor-slack-webhook
     mount_path: /var/run/slack-webhook
   documentation: |-
-    Sends a Slack notification with blocking job counts extracted from the
-    CI monitor analysis log. Reads claude-analysis.log from SHARED_DIR,
-    parses content between BLOCKING_JOBS_START/END delimiters, and posts
-    a summary to the configured Slack channel via webhook.
+    Sends a Slack notification with blocking job counts extracted by the
+    CI monitor step. Reads blocking-jobs.txt from SHARED_DIR (pre-extracted
+    pipe-delimited entries) and posts a summary to the configured Slack
+    channel via webhook.

--- a/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/send-slack/openshift-edge-tooling-ci-monitor-send-slack-ref.yaml
+++ b/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/send-slack/openshift-edge-tooling-ci-monitor-send-slack-ref.yaml
@@ -1,7 +1,10 @@
 ref:
   as: openshift-edge-tooling-ci-monitor-send-slack
   commands: openshift-edge-tooling-ci-monitor-send-slack-commands.sh
-  from: cli
+  from_image:
+    namespace: ci
+    name: claude-ai-helpers
+    tag: latest
   best_effort: true
   timeout: 2m
   resources:

--- a/core-services/ci-secret-bootstrap/_config.yaml
+++ b/core-services/ci-secret-bootstrap/_config.yaml
@@ -2711,15 +2711,6 @@ secret_configs:
     name: cluster-secrets-equinix-edge-enablement
     namespace: ci
 - from:
-    ocp-ci-monitor:
-      field: ocp-ci-monitor
-      item: selfservice/equinix-edge-enablement/slack-webhooks
-  to:
-  - cluster_groups:
-    - non_app_ci
-    name: edge-tooling-ci-monitor-slack-webhook
-    namespace: test-credentials
-- from:
     pull-secret:
       dockerconfigJSON:
       - auth_field: token_image-puller_app.ci_reg_auth_value.txt

--- a/core-services/ci-secret-bootstrap/_config.yaml
+++ b/core-services/ci-secret-bootstrap/_config.yaml
@@ -2711,6 +2711,15 @@ secret_configs:
     name: cluster-secrets-equinix-edge-enablement
     namespace: ci
 - from:
+    ocp-ci-monitor:
+      field: ocp-ci-monitor
+      item: selfservice/equinix-edge-enablement/slack-webhooks
+  to:
+  - cluster_groups:
+    - non_app_ci
+    name: edge-tooling-ci-monitor-slack-webhook
+    namespace: test-credentials
+- from:
     pull-secret:
       dockerconfigJSON:
       - auth_field: token_image-puller_app.ci_reg_auth_value.txt


### PR DESCRIPTION
### Summary

- Replace Prow `reporter_config` Slack notifications with a dedicated send-slack step that posts richer messages using a Slack webhook.
- Add new step-registry ref openshift-edge-tooling-ci-monitor-send-slack that reads the analysis log, extracts blocking job data, and sends a formatted Slack notification via webhook
- Bootstrap the Slack webhook secret from Vault (selfservice/equinix-edge-enablement/slack-webhooks) into test-credentials on build-farm clusters
- Copy claude-analysis.log to `SHARED_DIR` so the downstream Slack step can consume it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CI monitor now sends Slack notifications summarizing blocking jobs (count, affected versions/topologies) with links to logs and dashboard; message content adapts when analysis data is unavailable.
  * Analysis logs are now captured for downstream steps and surfaced to the Slack sender.
* **Chores**
  * Removed the prior periodic Slack reporter configuration for the periodic CI job.
* **Tests/Ownership**
  * Added ownership entries for the new Slack-sending step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->