### PR TITLE
feat: Add e2e-ocp-v4-18-helm-nightly test entry to main branch

### DIFF
--- a/ci-operator/config/redhat-developer/rhdh/redhat-developer-rhdh-main.yaml
+++ b/ci-operator/config/redhat-developer/rhdh/redhat-developer-rhdh-main.yaml
@@ -309,6 +309,31 @@ tests:
     test:
     - ref: redhat-developer-rhdh-nightly
     workflow: generic-claim
+- always_run: false
+  as: e2e-ocp-v4-18-helm-nightly
+  cluster_claim:
+    architecture: amd64
+    cloud: aws
+    labels:
+      region: us-east-2
+    owner: rhdh
+    product: ocp
+    timeout: 1h0m0s
+    version: '4.18'
+  cron: 0 2 * * TUE,THU,SAT,SUN
+  optional: true
+  presubmit: true
+  steps:
+    allow_skip_on_success: true
+    env:
+      OC_CLIENT_VERSION: stable-4.18
+    post:
+    - ref: redhat-developer-rhdh-send-data-router
+    - ref: redhat-developer-rhdh-send-alert
+    - chain: gather
+    test:
+    - ref: redhat-developer-rhdh-ocp-helm-nightly
+    workflow: generic-claim
 zz_generated_metadata:
   branch: main
   org: redhat-developer


### PR DESCRIPTION
This PR adds the e2e-ocp-v4-18-helm-nightly test entry to the main branch's ci-operator configuration for RHDH, ensuring coverage for OCP 4.18.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated nightly E2E testing job for OpenShift Container Platform 4.18 environments with Helm integration. The scheduled test runs multiple times weekly (Tuesday, Thursday, Saturday, Sunday) to enhance CI/CD pipeline coverage and improve platform stability assurance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->