### PR TITLE
feat: Add OCP 4.18 helm nightly test for release-1.9

### DIFF
--- a/ci-operator/config/redhat-developer/rhdh/redhat-developer-rhdh-release-1.9.yaml
+++ b/ci-operator/config/redhat-developer/rhdh/redhat-developer-rhdh-release-1.9.yaml
@@ -334,6 +334,31 @@ tests:
     test:
     - ref: redhat-developer-rhdh-ocp-helm-upgrade-nightly
     workflow: generic-claim
+- always_run: false
+  as: e2e-ocp-v4-18-helm-nightly
+  cluster_claim:
+    architecture: amd64
+    cloud: aws
+    labels:
+      region: us-east-2
+    owner: rhdh
+    product: ocp
+    timeout: 1h0m0s
+    version: '4.18'
+  cron: 30 2 * * MON,WED,FRI
+  optional: true
+  presubmit: true
+  steps:
+    allow_skip_on_success: true
+    env:
+      OC_CLIENT_VERSION: stable-4.18
+    post:
+    - ref: redhat-developer-rhdh-send-data-router
+    - ref: redhat-developer-rhdh-send-alert
+    - chain: gather
+    test:
+    - ref: redhat-developer-rhdh-ocp-helm-nightly
+    workflow: generic-claim
 zz_generated_metadata:
   branch: release-1.9
   org: redhat-developer

--- a/ci-operator/config/redhat-developer/rhdh/redhat-developer-rhdh-release-1.9.yaml
+++ b/ci-operator/config/redhat-developer/rhdh/redhat-developer-rhdh-release-1.9.yaml
@@ -9,14 +9,14 @@ releases:
     release:
       architecture: amd64
       channel: fast
-      version: "4.15"
+      version: \"4.15\"
 resources:
-  '*':
+  \'*\':
     limits:
-      cpu: "2"
+      cpu: \"2\"
       memory: 5Gi
     requests:
-      cpu: "2"
+      cpu: \"2\"
       memory: 2Gi
 tests:
 - as: e2e-ocp-helm
@@ -28,8 +28,8 @@ tests:
     owner: rhdh
     product: ocp
     timeout: 1h0m0s
-    version: "4.18"
-  skip_if_only_changed: ^docs/|rpms\.lock\.yaml|showcase-docs/|^\.changeset/|CONTRIBUTING\.md|OWNERS|README\.md|USAGE_DATA\.md|^scripts/|^\.github/|\.threatmodel/|^ui/|\.md|\\.mdc|\\.toml$
+    version: \"4.18\"
+  skip_if_only_changed: ^docs/|rpms\\.lock\\.yaml|showcase-docs/|^\\.changeset/|CONTRIBUTING\\.md|OWNERS|README\\.md|USAGE_DATA\\.md|^scripts/|^\\.github/|\\.threatmodel/|^ui/|\\.md|\\\\.mdc|\\\\.toml$
   steps:
     allow_skip_on_success: true
     post:
@@ -48,7 +48,7 @@ tests:
     owner: rhdh
     product: ocp
     timeout: 1h0m0s
-    version: "4.18"
+    version: \"4.18\"
   cron: 0 5 * * *
   optional: true
   presubmit: true
@@ -71,7 +71,7 @@ tests:
     owner: rhdh
     product: ocp
     timeout: 1h0m0s
-    version: "4.16"
+    version: \"4.16\"
   cron: 0 3 * * MON,WED,FRI
   optional: true
   presubmit: true
@@ -96,7 +96,7 @@ tests:
     owner: rhdh
     product: ocp
     timeout: 1h0m0s
-    version: "4.19"
+    version: \"4.19\"
   cron: 30 5 * * MON,WED,FRI
   optional: true
   presubmit: true
@@ -121,7 +121,7 @@ tests:
     owner: rhdh
     product: ocp
     timeout: 1h0m0s
-    version: "4.20"
+    version: \"4.20\"
   cron: 30 5 * * MON,WED,FRI
   optional: true
   presubmit: true
@@ -146,7 +146,7 @@ tests:
     owner: rhdh
     product: ocp
     timeout: 1h0m0s
-    version: "4.21"
+    version: \"4.21\"
   cron: 30 2 * * MON,WED,FRI
   optional: true
   presubmit: true
@@ -251,7 +251,7 @@ tests:
     owner: rhdh
     product: ocp
     timeout: 1h0m0s
-    version: "4.18"
+    version: \"4.18\"
   cron: 30 4 * * MON,WED,FRI
   optional: true
   presubmit: true
@@ -306,10 +306,9 @@ tests:
     owner: rhdh
     product: ocp
     timeout: 1h0m0s
-    version: "4.18"
+    version: \"4.18\"
   cron: 30 5 * * MON,WED,FRI
-  optional: true
-  presubmit: true
+  optional: true\  presubmit: true
   steps:
     allow_skip_on_success: true
     test:
@@ -325,7 +324,7 @@ tests:
     owner: rhdh
     product: ocp
     timeout: 1h0m0s
-    version: "4.18"
+    version: \"4.18\"
   cron: 30 4 * * MON,WED,FRI
   optional: true
   presubmit: true
@@ -344,7 +343,7 @@ tests:
     owner: rhdh
     product: ocp
     timeout: 1h0m0s
-    version: '4.18'
+    version: \'4.18\'
   cron: 30 2 * * MON,WED,FRI
   optional: true
   presubmit: true


### PR DESCRIPTION
This PR adds the e2e-ocp-v4-18-helm-nightly test entry for the release-1.9 product branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added nightly Helm e2e test configuration for OpenShift Container Platform v4.18.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->