### PR TITLE
feat: Add OCP 4.14 cluster pool for RHDH

### DIFF
--- a/clusters/hosted-mgmt/hive/pools/rhdh/rhdh-ocp-4-14-0-amd64-aws-us-east-2_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/rhdh/rhdh-ocp-4-14-0-amd64-aws-us-east-2_clusterpool.yaml
@@ -1,0 +1,41 @@
+apiVersion: hive.openshift.io/v1
+kind: ClusterPool
+metadata:
+  creationTimestamp: null
+  labels:
+    architecture: amd64
+    cloud: aws
+    owner: rhdh
+    product: ocp
+    region: us-east-2
+    version: '4.14'
+    version_lower: 4.14.0-0
+    version_stream: 4-stable
+    version_upper: 4.15.0-0
+  name: rhdh-4-14-us-east-2
+  namespace: rhdh-cluster-pool
+spec:
+  baseDomain: rhdh-qe.devcluster.openshift.com
+  hibernationConfig:
+    resumeTimeout: 30m0s
+  imageSetRef:
+    name: ocp-release-4.14.0-multi-for-4.14.0-0-to-4.15.0-0
+  installAttemptsLimit: 1
+  installConfigSecretTemplateRef:
+    name: rhdh-aws-us-east-2
+  labels:
+    tp.openshift.io/owner: rhdh
+  maxSize: 2
+  platform:
+    aws:
+      credentialsSecretRef:
+        name: rhdh-aws-credentials
+      region: us-east-2
+  pullSecretRef:
+    name: pull-secret
+  size: 1
+  skipMachinePools: true
+status:
+  ready: 0
+  size: 0
+  standby: 0


### PR DESCRIPTION
This PR adds a new Hive ClusterPool configuration for OCP 4.14 to support RHDH, as OCP 4.14 is currently in Extended Update Support Term 2. The configuration was generated based on OCP 4.21.