### PR TITLE
Change Vertex defaults to global instead of us-east5

### DIFF
--- a/ci-operator/step-registry/hypershift/agentic-qe/process/hypershift-agentic-qe-process-ref.yaml
+++ b/ci-operator/step-registry/hypershift/agentic-qe/process/hypershift-agentic-qe-process-ref.yaml
@@ -10,7 +10,7 @@ ref:
     documentation: |-
       Enable Vertex AI for Claude Code.
   - name: CLOUD_ML_REGION
-    default: "us-east5"
+    default: "global"
     documentation: |-
       Google Cloud region for Vertex AI.
   - name: ANTHROPIC_VERTEX_PROJECT_ID

--- a/ci-operator/step-registry/hypershift/analyze-e2e-failure/hypershift-analyze-e2e-failure-ref.yaml
+++ b/ci-operator/step-registry/hypershift/analyze-e2e-failure/hypershift-analyze-e2e-failure-ref.yaml
@@ -11,7 +11,7 @@ ref:
     documentation: |-
       Enable Vertex AI for Claude Code.
   - name: CLOUD_ML_REGION
-    default: "us-east5"
+    default: "global"
     documentation: |-
       Google Cloud region for Vertex AI.
   - name: ANTHROPIC_VERTEX_PROJECT_ID

--- a/ci-operator/step-registry/hypershift/dependabot-triage/process/hypershift-dependabot-triage-process-ref.yaml
+++ b/ci-operator/step-registry/hypershift/dependabot-triage/process/hypershift-dependabot-triage-process-ref.yaml
@@ -9,7 +9,7 @@ ref:
     documentation: |-
       Enable Vertex AI for Claude Code.
   - name: CLOUD_ML_REGION
-    default: "us-east5"
+    default: "global"
     documentation: |-
       Google Cloud region for Vertex AI.
   - name: ANTHROPIC_VERTEX_PROJECT_ID

--- a/ci-operator/step-registry/hypershift/dependabot-triage/setup/hypershift-dependabot-triage-setup-ref.yaml
+++ b/ci-operator/step-registry/hypershift/dependabot-triage/setup/hypershift-dependabot-triage-setup-ref.yaml
@@ -8,7 +8,7 @@ ref:
     documentation: |-
       Enable Vertex AI for Claude Code.
   - name: CLOUD_ML_REGION
-    default: "us-east5"
+    default: "global"
     documentation: |-
       Google Cloud region for Vertex AI.
   - name: ANTHROPIC_VERTEX_PROJECT_ID

--- a/ci-operator/step-registry/hypershift/jira-agent/process/hypershift-jira-agent-process-ref.yaml
+++ b/ci-operator/step-registry/hypershift/jira-agent/process/hypershift-jira-agent-process-ref.yaml
@@ -9,7 +9,7 @@ ref:
     documentation: |-
       Enable Vertex AI for Claude Code.
   - name: CLOUD_ML_REGION
-    default: "us-east5"
+    default: "global"
     documentation: |-
       Google Cloud region for Vertex AI.
   - name: ANTHROPIC_VERTEX_PROJECT_ID

--- a/ci-operator/step-registry/hypershift/jira-agent/setup/hypershift-jira-agent-setup-ref.yaml
+++ b/ci-operator/step-registry/hypershift/jira-agent/setup/hypershift-jira-agent-setup-ref.yaml
@@ -8,7 +8,7 @@ ref:
     documentation: |-
       Enable Vertex AI for Claude Code.
   - name: CLOUD_ML_REGION
-    default: "us-east5"
+    default: "global"
     documentation: |-
       Google Cloud region for Vertex AI.
   - name: ANTHROPIC_VERTEX_PROJECT_ID

--- a/ci-operator/step-registry/hypershift/review-agent/process/hypershift-review-agent-process-ref.yaml
+++ b/ci-operator/step-registry/hypershift/review-agent/process/hypershift-review-agent-process-ref.yaml
@@ -8,7 +8,7 @@ ref:
     documentation: |-
       Enable Vertex AI for Claude Code.
   - name: CLOUD_ML_REGION
-    default: "us-east5"
+    default: "global"
     documentation: |-
       Google Cloud region for Vertex AI.
   - name: ANTHROPIC_VERTEX_PROJECT_ID

--- a/ci-operator/step-registry/hypershift/review-agent/setup/hypershift-review-agent-setup-ref.yaml
+++ b/ci-operator/step-registry/hypershift/review-agent/setup/hypershift-review-agent-setup-ref.yaml
@@ -8,7 +8,7 @@ ref:
     documentation: |-
       Enable Vertex AI for Claude Code.
   - name: CLOUD_ML_REGION
-    default: "us-east5"
+    default: "global"
     documentation: |-
       Google Cloud region for Vertex AI.
   - name: ANTHROPIC_VERTEX_PROJECT_ID

--- a/ci-operator/step-registry/openshift/claude/payload/agent/openshift-claude-payload-agent-ref.yaml
+++ b/ci-operator/step-registry/openshift/claude/payload/agent/openshift-claude-payload-agent-ref.yaml
@@ -23,7 +23,7 @@ ref:
   - name: CLAUDE_CODE_USE_VERTEX
     default: "1"
   - name: CLOUD_ML_REGION
-    default: "us-east5"
+    default: "global"
   - name: ANTHROPIC_VERTEX_PROJECT_ID
     default: "itpc-gcp-hybrid-pe-eng-claude"
   - name: GOOGLE_APPLICATION_CREDENTIALS

--- a/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-ref.yaml
+++ b/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-ref.yaml
@@ -30,7 +30,7 @@ ref:
   - name: CLAUDE_CODE_USE_VERTEX
     default: "1"
   - name: CLOUD_ML_REGION
-    default: "us-east5"
+    default: "global"
   - name: ANTHROPIC_VERTEX_PROJECT_ID
     default: "itpc-gcp-hybrid-pe-eng-claude"
   - name: GOOGLE_APPLICATION_CREDENTIALS

--- a/ci-operator/step-registry/openshift/microshift/claude/ci-doctor/openshift-microshift-claude-ci-doctor-ref.yaml
+++ b/ci-operator/step-registry/openshift/microshift/claude/ci-doctor/openshift-microshift-claude-ci-doctor-ref.yaml
@@ -19,7 +19,7 @@ ref:
   - name: CLAUDE_CODE_USE_VERTEX
     default: "1"
   - name: CLOUD_ML_REGION
-    default: "us-east5"
+    default: "global"
   - name: ANTHROPIC_VERTEX_PROJECT_ID
     default: "itpc-gcp-hybrid-pe-eng-claude"
   - name: GOOGLE_APPLICATION_CREDENTIALS


### PR DESCRIPTION
It is cheaper to not be constrained to one region.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default cloud ML region configuration from `us-east5` to `global` across multiple CI/CD pipeline step references for HyperShift and OpenShift agent and monitoring processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->