### PR TITLE
feat: Add OCP 4.14 cluster pool for RHDH

### DIFF
--- a/ci-operator/config/redhat-developer/rhdh/redhat-developer-rhdh-release-1.9.yaml
+++ b/ci-operator/config/redhat-developer/rhdh/redhat-developer-rhdh-release-1.9.yaml
@@ -19,6 +19,56 @@ resources:
       cpu: "2"
       memory: 2Gi
 tests:
+- always_run: false
+  as: e2e-ocp-v4-14-helm-nightly
+  cluster_claim:
+    architecture: amd64
+    cloud: aws
+    labels:
+      region: us-east-2
+    owner: rhdh
+    product: ocp
+    timeout: 1h0m0s
+    version: '4.14'
+  cron: 30 2 * * MON,WED,FRI
+  optional: true
+  presubmit: true
+  steps:
+    allow_skip_on_success: true
+    env:
+      OC_CLIENT_VERSION: stable-4.14
+    post:
+    - ref: redhat-developer-rhdh-send-data-router
+    - ref: redhat-developer-rhdh-send-alert
+    - chain: gather
+    test:
+    - ref: redhat-developer-rhdh-ocp-helm-nightly
+    workflow: generic-claim
+- always_run: false
+  as: e2e-ocp-v4-18-helm-nightly
+  cluster_claim:
+    architecture: amd64
+    cloud: aws
+    labels:
+      region: us-east-2
+    owner: rhdh
+    product: ocp
+    timeout: 1h0m0s
+    version: '4.18'
+  cron: 30 2 * * MON,WED,FRI
+  optional: true
+  presubmit: true
+  steps:
+    allow_skip_on_success: true
+    env:
+      OC_CLIENT_VERSION: stable-4.18
+    post:
+    - ref: redhat-developer-rhdh-send-data-router
+    - ref: redhat-developer-rhdh-send-alert
+    - chain: gather
+    test:
+    - ref: redhat-developer-rhdh-ocp-helm-nightly
+    workflow: generic-claim
 - as: e2e-ocp-helm
   cluster_claim:
     architecture: amd64

--- a/clusters/hosted-mgmt/hive/pools/rhdh/rhdh-ocp-4-14-0-amd64-aws-us-east-2_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/rhdh/rhdh-ocp-4-14-0-amd64-aws-us-east-2_clusterpool.yaml
@@ -1,0 +1,41 @@
+apiVersion: hive.openshift.io/v1
+kind: ClusterPool
+metadata:
+  creationTimestamp: null
+  labels:
+    architecture: amd64
+    cloud: aws
+    owner: rhdh
+    product: ocp
+    region: us-east-2
+    version: '4.14'
+    version_lower: 4.14.0-0
+    version_stream: 4-stable
+    version_upper: 4.15.0-0
+  name: rhdh-4-14-us-east-2
+  namespace: rhdh-cluster-pool
+spec:
+  baseDomain: rhdh-qe.devcluster.openshift.com
+  hibernationConfig:
+    resumeTimeout: 30m0s
+  imageSetRef:
+    name: ocp-release-4.14.0-multi-for-4.14.0-0-to-4.15.0-0
+  installAttemptsLimit: 1
+  installConfigSecretTemplateRef:
+    name: rhdh-aws-us-east-2
+  labels:
+    tp.openshift.io/owner: rhdh
+  maxSize: 2
+  platform:
+    aws:
+      credentialsSecretRef:
+        name: rhdh-aws-credentials
+      region: us-east-2
+  pullSecretRef:
+    name: pull-secret
+  size: 1
+  skipMachinePools: true
+status:
+  ready: 0
+  size: 0
+  standby: 0


### PR DESCRIPTION
This PR adds a cluster pool for OCP 4.14 for RHDH.

**NOTE:** The `imageSetRef` name in the generated YAML uses a placeholder z-stream version and should be updated to match the latest available image set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added nightly automated test runs for OpenShift 4.14 and 4.18 environments using AWS infrastructure
  * Configured cluster pool resources with hibernation support for test environment provisioning

<!-- end of auto-generated comment: release notes by coderabbit.ai -->