### PR TITLE
ci-tools: drop manifest-tool from ci-operator image

### DIFF
--- a/ci-operator/config/openshift/ci-tools/openshift-ci-tools-main.yaml
+++ b/ci-operator/config/openshift/ci-tools/openshift-ci-tools-main.yaml
@@ -141,8 +141,6 @@ images:
         paths:
         - destination_dir: .
           source_path: /go/bin/ci-operator
-        - destination_dir: .
-          source_path: /usr/bin/manifest-tool
     to: ci-operator
   - additional_architectures:
     - arm64


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified CI pipeline configuration by removing an unnecessary artifact dependency from the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->