### PR TITLE
ARO-HCP: AZURE_TOKEN_CREDENTIALS env var for gather-observability

### DIFF
--- a/ci-operator/step-registry/aro-hcp/gather/observability/aro-hcp-gather-observability-commands.sh
+++ b/ci-operator/step-registry/aro-hcp/gather/observability/aro-hcp-gather-observability-commands.sh
@@ -20,6 +20,7 @@ if [[ -f "${SHARED_DIR}/write-config-timestamp-rfc3339" ]]; then
   START_TIME_FALLBACK_ARGS="--start-time-fallback $(cat "${SHARED_DIR}/write-config-timestamp-rfc3339")"
 fi
 
+export AZURE_TOKEN_CREDENTIALS=prod
 test/aro-hcp-tests gather-observability \
   --timing-input "${SHARED_DIR}" \
   --output "${ARTIFACT_DIR}/" \


### PR DESCRIPTION
AZURE_TOKEN_CREDENTIALS=prod is a required env var for gather-observability and execution fails otherwise

e.g. https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/Azure_ARO-HCP/4973/pull-ci-Azure-ARO-HCP-main-e2e-parallel/2046874868862947328

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  - Updated observability gathering configuration to use production environment credentials

<!-- end of auto-generated comment: release notes by coderabbit.ai -->