### PR TITLE
update perfscale rosa classic and hcp jobs to aws-perfscale cluster profile

### DIFF
--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__rosa-4.21-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__rosa-4.21-nightly-x86.yaml
@@ -71,7 +71,7 @@ tests:
   as: control-plane-24nodes
   steps:
     allow_skip_on_success: true
-    cluster_profile: aws-perfscale-qe
+    cluster_profile: aws-perfscale
     env:
       ADDITIONAL_WORKER_NODES: "21"
       CHANNEL_GROUP: nightly
@@ -91,7 +91,7 @@ tests:
 - always_run: false
   as: data-path-9nodes
   steps:
-    cluster_profile: aws-perfscale-qe
+    cluster_profile: aws-perfscale
     env:
       ADDITIONAL_WORKER_NODES: "6"
       CHANNEL_GROUP: nightly
@@ -110,7 +110,7 @@ tests:
   as: node-density-heavy-24nodes
   steps:
     allow_skip_on_success: true
-    cluster_profile: aws-perfscale-qe
+    cluster_profile: aws-perfscale
     env:
       ADDITIONAL_WORKER_NODES: "21"
       CHANNEL_GROUP: nightly
@@ -128,7 +128,7 @@ tests:
   as: node-density-cni-24nodes
   steps:
     allow_skip_on_success: true
-    cluster_profile: aws-perfscale-qe
+    cluster_profile: aws-perfscale
     env:
       ADDITIONAL_WORKER_NODES: "21"
       CHANNEL_GROUP: nightly
@@ -146,7 +146,7 @@ tests:
   as: conc-builds-3nodes
   steps:
     allow_skip_on_success: true
-    cluster_profile: aws-perfscale-qe
+    cluster_profile: aws-perfscale
     env:
       CHANNEL_GROUP: nightly
       COMPUTE_MACHINE_TYPE: m6i.xlarge
@@ -168,7 +168,7 @@ tests:
   as: control-plane-3nodes
   steps:
     allow_skip_on_success: true
-    cluster_profile: aws-perfscale-qe
+    cluster_profile: aws-perfscale
     env:
       CHANNEL_GROUP: nightly
       COMPUTE_MACHINE_TYPE: m6i.xlarge

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__rosa-4.22-candidate-x86-loaded-upgrade-from-4.21.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__rosa-4.22-candidate-x86-loaded-upgrade-from-4.21.yaml
@@ -27,7 +27,7 @@ tests:
   as: loaded-upgrade-24nodes
   steps:
     allow_skip_on_success: true
-    cluster_profile: aws-perfscale-qe
+    cluster_profile: aws-perfscale
     env:
       AVAILABLE_UPGRADE: "yes"
       CHANNEL_GROUP: candidate
@@ -58,7 +58,7 @@ tests:
   as: loaded-upgrade-120nodes
   steps:
     allow_skip_on_success: true
-    cluster_profile: aws-perfscale-qe
+    cluster_profile: aws-perfscale
     env:
       AVAILABLE_UPGRADE: "yes"
       CHANNEL_GROUP: candidate
@@ -89,7 +89,7 @@ tests:
   as: loaded-upgrade-249nodes
   steps:
     allow_skip_on_success: true
-    cluster_profile: aws-perfscale-qe
+    cluster_profile: aws-perfscale
     env:
       AVAILABLE_UPGRADE: "yes"
       CHANNEL_GROUP: candidate

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__rosa-4.22-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__rosa-4.22-nightly-x86.yaml
@@ -87,7 +87,7 @@ tests:
   as: control-plane-24nodes
   steps:
     allow_skip_on_success: true
-    cluster_profile: aws-perfscale-qe
+    cluster_profile: aws-perfscale
     env:
       ADDITIONAL_WORKER_NODES: "21"
       CHANNEL_GROUP: nightly
@@ -106,7 +106,7 @@ tests:
 - always_run: false
   as: data-path-9nodes
   steps:
-    cluster_profile: aws-perfscale-qe
+    cluster_profile: aws-perfscale
     env:
       ADDITIONAL_WORKER_NODES: "6"
       CHANNEL_GROUP: nightly
@@ -125,7 +125,7 @@ tests:
   as: node-density-heavy-24nodes
   steps:
     allow_skip_on_success: true
-    cluster_profile: aws-perfscale-qe
+    cluster_profile: aws-perfscale
     env:
       ADDITIONAL_WORKER_NODES: "21"
       CHANNEL_GROUP: nightly
@@ -143,7 +143,7 @@ tests:
   as: node-density-cni-24nodes
   steps:
     allow_skip_on_success: true
-    cluster_profile: aws-perfscale-qe
+    cluster_profile: aws-perfscale
     env:
       ADDITIONAL_WORKER_NODES: "21"
       CHANNEL_GROUP: nightly
@@ -161,7 +161,7 @@ tests:
   as: conc-builds-3nodes
   steps:
     allow_skip_on_success: true
-    cluster_profile: aws-perfscale-qe
+    cluster_profile: aws-perfscale
     env:
       CHANNEL_GROUP: nightly
       COMPUTE_MACHINE_TYPE: m6i.xlarge
@@ -183,7 +183,7 @@ tests:
   as: control-plane-3nodes
   steps:
     allow_skip_on_success: true
-    cluster_profile: aws-perfscale-qe
+    cluster_profile: aws-perfscale
     env:
       CHANNEL_GROUP: nightly
       COMPUTE_MACHINE_TYPE: m6i.xlarge

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__rosa-4.23-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__rosa-4.23-nightly-x86.yaml
@@ -87,7 +87,7 @@ tests:
   as: control-plane-24nodes
   steps:
     allow_skip_on_success: true
-    cluster_profile: aws-perfscale-qe
+    cluster_profile: aws-perfscale
     env:
       ADDITIONAL_WORKER_NODES: "21"
       CHANNEL_GROUP: nightly
@@ -106,7 +106,7 @@ tests:
 - always_run: false
   as: data-path-9nodes
   steps:
-    cluster_profile: aws-perfscale-qe
+    cluster_profile: aws-perfscale
     env:
       ADDITIONAL_WORKER_NODES: "6"
       CHANNEL_GROUP: nightly
@@ -125,7 +125,7 @@ tests:
   as: node-density-heavy-24nodes
   steps:
     allow_skip_on_success: true
-    cluster_profile: aws-perfscale-qe
+    cluster_profile: aws-perfscale
     env:
       ADDITIONAL_WORKER_NODES: "21"
       CHANNEL_GROUP: nightly
@@ -143,7 +143,7 @@ tests:
   as: node-density-cni-24nodes
   steps:
     allow_skip_on_success: true
-    cluster_profile: aws-perfscale-qe
+    cluster_profile: aws-perfscale
     env:
       ADDITIONAL_WORKER_NODES: "21"
       CHANNEL_GROUP: nightly
@@ -161,7 +161,7 @@ tests:
   as: conc-builds-3nodes
   steps:
     allow_skip_on_success: true
-    cluster_profile: aws-perfscale-qe
+    cluster_profile: aws-perfscale
     env:
       CHANNEL_GROUP: nightly
       COMPUTE_MACHINE_TYPE: m6i.xlarge
@@ -183,7 +183,7 @@ tests:
   as: control-plane-3nodes
   steps:
     allow_skip_on_success: true
-    cluster_profile: aws-perfscale-qe
+    cluster_profile: aws-perfscale
     env:
       CHANNEL_GROUP: nightly
       COMPUTE_MACHINE_TYPE: m6i.xlarge

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__rosa_hcp-4.21-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__rosa_hcp-4.21-nightly-x86.yaml
@@ -28,7 +28,7 @@ tests:
   as: control-plane-24nodes
   steps:
     allow_skip_on_success: true
-    cluster_profile: aws-perfscale-qe
+    cluster_profile: aws-perfscale
     env:
       CHANNEL_GROUP: nightly
       COMPUTE_MACHINE_TYPE: m6i.xlarge
@@ -54,7 +54,7 @@ tests:
   as: node-density-heavy-24nodes
   steps:
     allow_skip_on_success: true
-    cluster_profile: aws-perfscale-qe
+    cluster_profile: aws-perfscale
     env:
       CHANNEL_GROUP: nightly
       COMPUTE_MACHINE_TYPE: m6i.xlarge
@@ -80,7 +80,7 @@ tests:
   as: node-density-24nodes
   steps:
     allow_skip_on_success: true
-    cluster_profile: aws-perfscale-qe
+    cluster_profile: aws-perfscale
     env:
       CHANNEL_GROUP: nightly
       COMPUTE_MACHINE_TYPE: m6i.2xlarge
@@ -103,7 +103,7 @@ tests:
   as: node-density-cni-24nodes
   steps:
     allow_skip_on_success: true
-    cluster_profile: aws-perfscale-qe
+    cluster_profile: aws-perfscale
     env:
       CHANNEL_GROUP: nightly
       COMPUTE_MACHINE_TYPE: m6i.xlarge
@@ -557,7 +557,7 @@ tests:
   as: data-path-9nodes
   steps:
     allow_skip_on_success: true
-    cluster_profile: aws-perfscale-qe
+    cluster_profile: aws-perfscale
     env:
       CHANNEL_GROUP: nightly
       COMPUTE_MACHINE_TYPE: m6i.xlarge
@@ -582,7 +582,7 @@ tests:
   as: control-plane-3nodes
   steps:
     allow_skip_on_success: true
-    cluster_profile: aws-perfscale-qe
+    cluster_profile: aws-perfscale
     env:
       CHANNEL_GROUP: nightly
       COMPUTE_MACHINE_TYPE: m6i.xlarge

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__rosa_hcp-4.22-candidate-x86-loaded-upgrade-from-4.21.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__rosa_hcp-4.22-candidate-x86-loaded-upgrade-from-4.21.yaml
@@ -26,7 +26,7 @@ tests:
 - always_run: false
   as: loaded-upgrade-24nodes
   steps:
-    cluster_profile: aws-perfscale-qe
+    cluster_profile: aws-perfscale
     env:
       AVAILABLE_UPGRADE: "yes"
       CHANNEL_GROUP: candidate
@@ -63,7 +63,7 @@ tests:
 - always_run: false
   as: loaded-upgrade-120nodes
   steps:
-    cluster_profile: aws-perfscale-qe
+    cluster_profile: aws-perfscale
     env:
       AVAILABLE_UPGRADE: "yes"
       CHANNEL_GROUP: candidate
@@ -100,7 +100,7 @@ tests:
 - always_run: false
   as: loaded-upgrade-249nodes
   steps:
-    cluster_profile: aws-perfscale-qe
+    cluster_profile: aws-perfscale
     env:
       AVAILABLE_UPGRADE: "yes"
       CHANNEL_GROUP: candidate
@@ -137,7 +137,7 @@ tests:
 - always_run: false
   as: loaded-upgrade-498nodes
   steps:
-    cluster_profile: aws-perfscale-qe
+    cluster_profile: aws-perfscale
     env:
       AVAILABLE_UPGRADE: "yes"
       CHANNEL_GROUP: candidate

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__rosa_hcp-4.22-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__rosa_hcp-4.22-nightly-x86.yaml
@@ -29,7 +29,7 @@ tests:
   cron: 0 2 * * 3
   steps:
     allow_skip_on_success: true
-    cluster_profile: aws-perfscale-qe
+    cluster_profile: aws-perfscale
     env:
       CHANNEL_GROUP: nightly
       COMPUTE_MACHINE_TYPE: m6i.xlarge
@@ -55,7 +55,7 @@ tests:
   as: node-density-heavy-24nodes
   steps:
     allow_skip_on_success: true
-    cluster_profile: aws-perfscale-qe
+    cluster_profile: aws-perfscale
     env:
       CHANNEL_GROUP: nightly
       COMPUTE_MACHINE_TYPE: m6i.xlarge
@@ -81,7 +81,7 @@ tests:
   as: node-density-24nodes
   steps:
     allow_skip_on_success: true
-    cluster_profile: aws-perfscale-qe
+    cluster_profile: aws-perfscale
     env:
       CHANNEL_GROUP: nightly
       COMPUTE_MACHINE_TYPE: m6i.2xlarge
@@ -104,7 +104,7 @@ tests:
   as: node-density-cni-24nodes
   steps:
     allow_skip_on_success: true
-    cluster_profile: aws-perfscale-qe
+    cluster_profile: aws-perfscale
     env:
       CHANNEL_GROUP: nightly
       COMPUTE_MACHINE_TYPE: m6i.xlarge
@@ -558,7 +558,7 @@ tests:
   as: data-path-9nodes
   steps:
     allow_skip_on_success: true
-    cluster_profile: aws-perfscale-qe
+    cluster_profile: aws-perfscale
     env:
       CHANNEL_GROUP: nightly
       COMPUTE_MACHINE_TYPE: m6i.xlarge
@@ -583,7 +583,7 @@ tests:
   as: control-plane-3nodes
   steps:
     allow_skip_on_success: true
-    cluster_profile: aws-perfscale-qe
+    cluster_profile: aws-perfscale
     env:
       CHANNEL_GROUP: nightly
       COMPUTE_MACHINE_TYPE: m6i.xlarge

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__rosa_hcp-4.23-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__rosa_hcp-4.23-nightly-x86.yaml
@@ -28,7 +28,7 @@ tests:
   as: control-plane-24nodes
   steps:
     allow_skip_on_success: true
-    cluster_profile: aws-perfscale-qe
+    cluster_profile: aws-perfscale
     env:
       CHANNEL_GROUP: nightly
       COMPUTE_MACHINE_TYPE: m6i.xlarge
@@ -54,7 +54,7 @@ tests:
   as: node-density-heavy-24nodes
   steps:
     allow_skip_on_success: true
-    cluster_profile: aws-perfscale-qe
+    cluster_profile: aws-perfscale
     env:
       CHANNEL_GROUP: nightly
       COMPUTE_MACHINE_TYPE: m6i.xlarge
@@ -80,7 +80,7 @@ tests:
   as: node-density-24nodes
   steps:
     allow_skip_on_success: true
-    cluster_profile: aws-perfscale-qe
+    cluster_profile: aws-perfscale
     env:
       CHANNEL_GROUP: nightly
       COMPUTE_MACHINE_TYPE: m6i.2xlarge
@@ -103,7 +103,7 @@ tests:
   as: node-density-cni-24nodes
   steps:
     allow_skip_on_success: true
-    cluster_profile: aws-perfscale-qe
+    cluster_profile: aws-perfscale
     env:
       CHANNEL_GROUP: nightly
       COMPUTE_MACHINE_TYPE: m6i.xlarge
@@ -557,7 +557,7 @@ tests:
   as: data-path-9nodes
   steps:
     allow_skip_on_success: true
-    cluster_profile: aws-perfscale-qe
+    cluster_profile: aws-perfscale
     env:
       CHANNEL_GROUP: nightly
       COMPUTE_MACHINE_TYPE: m6i.xlarge
@@ -582,7 +582,7 @@ tests:
   as: control-plane-3nodes
   steps:
     allow_skip_on_success: true
-    cluster_profile: aws-perfscale-qe
+    cluster_profile: aws-perfscale
     env:
       CHANNEL_GROUP: nightly
       COMPUTE_MACHINE_TYPE: m6i.xlarge

--- a/ci-operator/jobs/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main-periodics.yaml
@@ -6885,7 +6885,7 @@ periodics:
     repo: ocp-qe-perfscale-ci
   labels:
     ci-operator.openshift.io/cloud: aws
-    ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+    ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
     ci-operator.openshift.io/variant: rosa_hcp-4.22-nightly-x86
     ci.openshift.io/generator: prowgen
     job-release: "4.22"

--- a/ci-operator/jobs/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main-presubmits.yaml
@@ -12402,7 +12402,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci-operator.openshift.io/variant: rosa-4.21-nightly-x86
       ci.openshift.io/generator: prowgen
       job-release: "4.21"
@@ -12583,7 +12583,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci-operator.openshift.io/variant: rosa-4.21-nightly-x86
       ci.openshift.io/generator: prowgen
       job-release: "4.21"
@@ -12679,7 +12679,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci-operator.openshift.io/variant: rosa-4.21-nightly-x86
       ci.openshift.io/generator: prowgen
       job-release: "4.21"
@@ -12764,7 +12764,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci-operator.openshift.io/variant: rosa-4.21-nightly-x86
       ci.openshift.io/generator: prowgen
       job-release: "4.21"
@@ -12860,7 +12860,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci-operator.openshift.io/variant: rosa-4.21-nightly-x86
       ci.openshift.io/generator: prowgen
       job-release: "4.21"
@@ -12945,7 +12945,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci-operator.openshift.io/variant: rosa-4.21-nightly-x86
       ci.openshift.io/generator: prowgen
       job-release: "4.21"
@@ -13041,7 +13041,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci-operator.openshift.io/variant: rosa-4.22-candidate-x86-loaded-upgrade-from-4.21
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -13125,7 +13125,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci-operator.openshift.io/variant: rosa-4.22-candidate-x86-loaded-upgrade-from-4.21
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -13209,7 +13209,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci-operator.openshift.io/variant: rosa-4.22-candidate-x86-loaded-upgrade-from-4.21
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -13475,7 +13475,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci-operator.openshift.io/variant: rosa-4.22-nightly-x86
       ci.openshift.io/generator: prowgen
       job-release: "4.22"
@@ -13656,7 +13656,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci-operator.openshift.io/variant: rosa-4.22-nightly-x86
       ci.openshift.io/generator: prowgen
       job-release: "4.22"
@@ -13752,7 +13752,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci-operator.openshift.io/variant: rosa-4.22-nightly-x86
       ci.openshift.io/generator: prowgen
       job-release: "4.22"
@@ -13837,7 +13837,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci-operator.openshift.io/variant: rosa-4.22-nightly-x86
       ci.openshift.io/generator: prowgen
       job-release: "4.22"
@@ -13933,7 +13933,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci-operator.openshift.io/variant: rosa-4.22-nightly-x86
       ci.openshift.io/generator: prowgen
       job-release: "4.22"
@@ -14018,7 +14018,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci-operator.openshift.io/variant: rosa-4.22-nightly-x86
       ci.openshift.io/generator: prowgen
       job-release: "4.22"
@@ -14296,7 +14296,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci-operator.openshift.io/variant: rosa-4.23-nightly-x86
       ci.openshift.io/generator: prowgen
       job-release: "4.23"
@@ -14477,7 +14477,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci-operator.openshift.io/variant: rosa-4.23-nightly-x86
       ci.openshift.io/generator: prowgen
       job-release: "4.23"
@@ -14573,7 +14573,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci-operator.openshift.io/variant: rosa-4.23-nightly-x86
       ci.openshift.io/generator: prowgen
       job-release: "4.23"
@@ -14658,7 +14658,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci-operator.openshift.io/variant: rosa-4.23-nightly-x86
       ci.openshift.io/generator: prowgen
       job-release: "4.23"
@@ -14754,7 +14754,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci-operator.openshift.io/variant: rosa-4.23-nightly-x86
       ci.openshift.io/generator: prowgen
       job-release: "4.23"
@@ -14839,7 +14839,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci-operator.openshift.io/variant: rosa-4.23-nightly-x86
       ci.openshift.io/generator: prowgen
       job-release: "4.23"
@@ -15360,7 +15360,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci-operator.openshift.io/variant: rosa_hcp-4.21-nightly-x86
       ci.openshift.io/generator: prowgen
       job-release: "4.21"
@@ -15541,7 +15541,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci-operator.openshift.io/variant: rosa_hcp-4.21-nightly-x86
       ci.openshift.io/generator: prowgen
       job-release: "4.21"
@@ -15966,7 +15966,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci-operator.openshift.io/variant: rosa_hcp-4.21-nightly-x86
       ci.openshift.io/generator: prowgen
       job-release: "4.21"
@@ -16062,7 +16062,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci-operator.openshift.io/variant: rosa_hcp-4.21-nightly-x86
       ci.openshift.io/generator: prowgen
       job-release: "4.21"
@@ -16147,7 +16147,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci-operator.openshift.io/variant: rosa_hcp-4.21-nightly-x86
       ci.openshift.io/generator: prowgen
       job-release: "4.21"
@@ -16232,7 +16232,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci-operator.openshift.io/variant: rosa_hcp-4.21-nightly-x86
       ci.openshift.io/generator: prowgen
       job-release: "4.21"
@@ -16328,7 +16328,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci-operator.openshift.io/variant: rosa_hcp-4.22-candidate-x86-loaded-upgrade-from-4.21
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -16412,7 +16412,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci-operator.openshift.io/variant: rosa_hcp-4.22-candidate-x86-loaded-upgrade-from-4.21
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -16496,7 +16496,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci-operator.openshift.io/variant: rosa_hcp-4.22-candidate-x86-loaded-upgrade-from-4.21
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -16664,7 +16664,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci-operator.openshift.io/variant: rosa_hcp-4.22-candidate-x86-loaded-upgrade-from-4.21
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -17342,7 +17342,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci-operator.openshift.io/variant: rosa_hcp-4.22-nightly-x86
       ci.openshift.io/generator: prowgen
       job-release: "4.22"
@@ -17767,7 +17767,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci-operator.openshift.io/variant: rosa_hcp-4.22-nightly-x86
       ci.openshift.io/generator: prowgen
       job-release: "4.22"
@@ -17863,7 +17863,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci-operator.openshift.io/variant: rosa_hcp-4.22-nightly-x86
       ci.openshift.io/generator: prowgen
       job-release: "4.22"
@@ -17948,7 +17948,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci-operator.openshift.io/variant: rosa_hcp-4.22-nightly-x86
       ci.openshift.io/generator: prowgen
       job-release: "4.22"
@@ -18033,7 +18033,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci-operator.openshift.io/variant: rosa_hcp-4.22-nightly-x86
       ci.openshift.io/generator: prowgen
       job-release: "4.22"
@@ -18554,7 +18554,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci-operator.openshift.io/variant: rosa_hcp-4.23-nightly-x86
       ci.openshift.io/generator: prowgen
       job-release: "4.23"
@@ -18735,7 +18735,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci-operator.openshift.io/variant: rosa_hcp-4.23-nightly-x86
       ci.openshift.io/generator: prowgen
       job-release: "4.23"
@@ -19160,7 +19160,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci-operator.openshift.io/variant: rosa_hcp-4.23-nightly-x86
       ci.openshift.io/generator: prowgen
       job-release: "4.23"
@@ -19256,7 +19256,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci-operator.openshift.io/variant: rosa_hcp-4.23-nightly-x86
       ci.openshift.io/generator: prowgen
       job-release: "4.23"
@@ -19341,7 +19341,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci-operator.openshift.io/variant: rosa_hcp-4.23-nightly-x86
       ci.openshift.io/generator: prowgen
       job-release: "4.23"
@@ -19426,7 +19426,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
+      ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
       ci-operator.openshift.io/variant: rosa_hcp-4.23-nightly-x86
       ci.openshift.io/generator: prowgen
       job-release: "4.23"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated cluster profile values from aws-perfscale-qe to aws-perfscale across ROSA nightly and upgrade test definitions for 4.21, 4.22, and 4.23 (control-plane, data-path, node-density, concurrent-builds, loaded-upgrade).
  * Aligned periodic and presubmit job metadata labels to reflect the new cluster profile value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->