### PR TITLE
ci: set 4h timeout for ARO-HCP integration and stage E2E periodic jobs

### DIFF
--- a/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__periodic.yaml
+++ b/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__periodic.yaml
@@ -146,6 +146,7 @@ tests:
       env: LEASED_MSI_CONTAINERS
       resource_type: aro-hcp-test-msi-containers-stg
     workflow: aro-hcp-e2e
+  timeout: 4h0m0s
 - as: stage-e2e-parallel-ocp-nightly
   cron: 0 4 * * *
   steps:

--- a/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__periodic.yaml
+++ b/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__periodic.yaml
@@ -109,6 +109,7 @@ tests:
       env: LEASED_MSI_CONTAINERS
       resource_type: aro-hcp-test-msi-containers-int
     workflow: aro-hcp-e2e
+  timeout: 4h0m0s
 - as: integration-e2e-parallel-ocp-nightly
   cron: 0 4 * * *
   steps:

--- a/ci-operator/jobs/Azure/ARO-HCP/Azure-ARO-HCP-main-periodics.yaml
+++ b/ci-operator/jobs/Azure/ARO-HCP/Azure-ARO-HCP-main-periodics.yaml
@@ -856,6 +856,7 @@ periodics:
   decorate: true
   decoration_config:
     skip_cloning: true
+    timeout: 4h0m0s
   extra_refs:
   - base_ref: main
     org: Azure
@@ -1181,6 +1182,7 @@ periodics:
   decorate: true
   decoration_config:
     skip_cloning: true
+    timeout: 4h0m0s
   extra_refs:
   - base_ref: main
     org: Azure


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-695

### What

Set `timeout: 4h0m0s` on two ARO-HCP periodic E2E jobs that were relying on Prow's default 2h timeout:
- `integration-e2e-parallel`
- `stage-e2e-parallel`

The `prod-e2e-parallel` and all `ocp-nightly` variants already have `timeout: 4h0m0s`.

### Why

Prow's default pod timeout is 2 hours. ARO-HCP E2E tests create real Azure clusters, run upgrades, and clean up resources — a single spec can take 60-90 minutes. Combined with identity container pool starvation (up to 40 minutes waiting for a free container before a test can even start), the total runtime regularly exceeds 2h.

When the timeout fires, Prow sends SIGTERM and Ginkgo reports `Interrupted by User`, which hides the actual test outcome and prevents proper diagnostics. Setting 4h gives enough headroom for identity wait + test execution + cleanup while still catching genuinely stuck tests.

Observed in two consecutive INT periodic runs:
- [2046927318231814144](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-Azure-ARO-HCP-main-periodic-integration-e2e-parallel/2046927318231814144) (2026-04-22): 40 min identity wait + upgrade stuck at 4.20.17 Partial for 40 min → suite killed at 1h41m
- [2046283743831789568](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-Azure-ARO-HCP-main-periodic-integration-e2e-parallel/2046283743831789568) (2026-04-20): identity pool starvation → 2 nodepool upgrade tests killed at 2h02m

### Companion PR

ARO-HCP: https://github.com/Azure/ARO-HCP/pull/4985 (adds `TestTimeout: 150 min` to integration suites, matching stage and prod)

### Testing

CI config change only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI periodic job configurations with explicit timeout settings of 4 hours for integration and stage end-to-end parallel test jobs to improve job execution reliability and resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->