### PR TITLE
fix: Add --insecure flag to badfish in jetlag CI steps

### DIFF
--- a/ci-operator/step-registry/openshift-qe/installer/bm/deploy/openshift-qe-installer-bm-deploy-ref.yaml
+++ b/ci-operator/step-registry/openshift-qe/installer/bm/deploy/openshift-qe-installer-bm-deploy-ref.yaml
@@ -29,7 +29,7 @@ ref:
       documentation: |-
         Enable or disable fips
     - name: JETLAG_BRANCH
-      default: "v0.3.10"
+      default: "v0.3.11"
       documentation: |-
         Jetlag release tag
     - name: JETLAG_LATEST

--- a/ci-operator/step-registry/openshift-qe/installer/bm/foreman/openshift-qe-installer-bm-foreman-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/installer/bm/foreman/openshift-qe-installer-bm-foreman-commands.sh
@@ -34,7 +34,7 @@ for i in $(curl -sSk $OCPINV | jq -r ".nodes[$STARTING_NODE:$(($STARTING_NODE+$N
     BOOT_MODE="Bios"
     echo "SuperMicro server detected, setting boot mode to Bios"
   else
-    BOOT_MODE=$(podman run quay.io/quads/badfish:latest --get-bios-attribute --attribute BootMode -H mgmt-$i -u $USER -p $PSWD -o json 2>&1 | jq -r .CurrentValue)
+    BOOT_MODE=$(podman run quay.io/quads/badfish:latest --insecure --get-bios-attribute --attribute BootMode -H mgmt-$i -u $USER -p $PSWD -o json 2>&1 | jq -r .CurrentValue)
   fi
 
   # Set PXE loader based on boot mode
@@ -63,9 +63,9 @@ for i in $(curl -sSk $OCPINV | jq -r ".nodes[$STARTING_NODE:$(($STARTING_NODE+$N
   if echo "$i" | grep -qE "(1029u|1029p|5039ms|6018r|6029p|6029r|6048p|6048r|6049p)"; then
     podman run quay.io/ocp-edge-qe/ipmitool ipmitool -I lanplus -H mgmt-$i -U $USER -P $PSWD chassis bootdev pxe
   else
-    podman run quay.io/quads/badfish:latest -H mgmt-$i -u $USER -p $PSWD -i config/idrac_interfaces.yml -t foreman
+    podman run quay.io/quads/badfish:latest --insecure -H mgmt-$i -u $USER -p $PSWD -i config/idrac_interfaces.yml -t foreman
   fi
-  podman run quay.io/quads/badfish:latest --reboot-only -H mgmt-$i -u $USER -p $PSWD
+  podman run quay.io/quads/badfish:latest --insecure --reboot-only -H mgmt-$i -u $USER -p $PSWD
 done
 
 # Collect node lists and identify Dell vs SuperMicro
@@ -141,7 +141,7 @@ if [ ${#STUCK_DELL_NODES[@]} -gt 0 ]; then
   echo "Starting recovery for stuck Dell nodes: ${STUCK_DELL_NODES[*]}"
   for i in "${STUCK_DELL_NODES[@]}"; do
     echo "Recovery: clearing jobs on $i"
-    podman run quay.io/quads/badfish:latest -v -H mgmt-$i -u $USER -p $PSWD --clear-jobs --force
+    podman run quay.io/quads/badfish:latest -v --insecure -H mgmt-$i -u $USER -p $PSWD --clear-jobs --force
     sleep 30
 
     echo "Recovery: waiting for BIOS attributes to become accessible on $i"
@@ -164,7 +164,7 @@ if [ ${#STUCK_DELL_NODES[@]} -gt 0 ]; then
 
     echo "Recovery: setting boot device on $i"
     for attempt in $(seq 1 3); do
-      if podman run quay.io/quads/badfish:latest -H mgmt-$i -u $USER -p $PSWD -i config/idrac_interfaces.yml -t foreman; then
+      if podman run quay.io/quads/badfish:latest --insecure -H mgmt-$i -u $USER -p $PSWD -i config/idrac_interfaces.yml -t foreman; then
         echo "Boot device set successfully for $i"
         break
       fi
@@ -173,7 +173,7 @@ if [ ${#STUCK_DELL_NODES[@]} -gt 0 ]; then
     done
 
     echo "Recovery: rebooting $i"
-    podman run quay.io/quads/badfish:latest --reboot-only -H mgmt-$i -u $USER -p $PSWD
+    podman run quay.io/quads/badfish:latest --insecure --reboot-only -H mgmt-$i -u $USER -p $PSWD
   done
 else
   echo "All nodes came up successfully, no recovery needed"

--- a/ci-operator/step-registry/openshift-qe/installer/bm/poweroff/openshift-qe-installer-bm-poweroff-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/installer/bm/poweroff/openshift-qe-installer-bm-poweroff-commands.sh
@@ -26,7 +26,7 @@ OCPINV=$QUADS_INSTANCE/instack/$LAB_CLOUD\_ocpinventory.json
 USER=$(curl -sSk $OCPINV | jq -r ".nodes[0].pm_user")
 PWD=$(curl -sSk $OCPINV  | jq -r ".nodes[0].pm_password")
 for i in $(curl -sSk $OCPINV | jq -r ".nodes[1:][].name"); do
-   podman run quay.io/quads/badfish:latest -H mgmt-$i -u $USER -p $PWD --power-off
+   podman run quay.io/quads/badfish:latest -H mgmt-$i -u $USER -p $PWD --insecure --power-off
 done
 EOF
 envsubst '${LAB_CLOUD},${QUADS_INSTANCE}' < /tmp/poweroff.sh > /tmp/poweroff_updated-$LAB_CLOUD.sh

--- a/ci-operator/step-registry/openshift-qe/installer/bm/prereqs/openshift-qe-installer-bm-prereqs-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/installer/bm/prereqs/openshift-qe-installer-bm-prereqs-commands.sh
@@ -56,7 +56,7 @@ if [[ "$PRE_BOOT_ORDER" == "true" ]]; then
   echo "Cheking boot order ..."
   for i in $HOSTS; do
     # Until https://github.com/redhat-performance/badfish/issues/411 gets sorted
-    command_output=$(podman run quay.io/quads/badfish:latest -H mgmt-$i -u $USER -p $PWD -i config/idrac_interfaces.yml -t foreman 2>&1)
+    command_output=$(podman run quay.io/quads/badfish:latest -H mgmt-$i -u $USER -p $PWD --insecure -i config/idrac_interfaces.yml -t foreman 2>&1)
     desired_output="- WARNING  - No changes were made since the boot order already matches the requested."
     echo "Cheking boot order of server $i ..."
     echo $command_output
@@ -74,8 +74,8 @@ if [[ "$PRE_UEFI" == "true" ]]; then
   echo "Cheking UEFI setup ..."
   for i in $HOSTS; do
     echo "Cheking UEFI setup of server $i ..."
-    podman run quay.io/quads/badfish:latest -v -H mgmt-$i -u $USER -p $PWD --set-bios-attribute --attribute BootMode --value Uefi
-    if [[ $(podman run quay.io/quads/badfish -H mgmt-$i -u $USER -p $PWD --get-bios-attribute --attribute BootMode --value Uefi -o json 2>&1 | jq -r .CurrentValue) != "Uefi" ]]; then
+    podman run quay.io/quads/badfish:latest -v -H mgmt-$i -u $USER -p $PWD --insecure --set-bios-attribute --attribute BootMode --value Uefi
+    if [[ $(podman run quay.io/quads/badfish -H mgmt-$i -u $USER -p $PWD --insecure --get-bios-attribute --attribute BootMode --value Uefi -o json 2>&1 | jq -r .CurrentValue) != "Uefi" ]]; then
       echo "$i not in Uefi mode"
       sleep 10s
       continue


### PR DESCRIPTION
## Summary
- Add `--insecure` flag to all badfish invocations in jetlag bare-metal CI step scripts
- Lab BMCs/iDRACs use self-signed certificates, causing SSL verification failures that block all jetlag CI jobs
- Fixes 10 badfish calls across 3 scripts: poweroff, prereqs, and foreman

## Affected Scripts
- `ci-operator/step-registry/openshift-qe/installer/bm/poweroff/openshift-qe-installer-bm-poweroff-commands.sh`
- `ci-operator/step-registry/openshift-qe/installer/bm/prereqs/openshift-qe-installer-bm-prereqs-commands.sh`
- `ci-operator/step-registry/openshift-qe/installer/bm/foreman/openshift-qe-installer-bm-foreman-commands.sh`

## Companion PR
- redhat-performance/jetlag#812 — same fix for the Ansible badfish role

## Test Plan
- [ ] `deploy-sno` on jetlag PR #812 (currently blocked by this poweroff step failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated bare metal provisioning operations with enhanced security configurations for BIOS and power management workflows.
  * Upgraded Jetlag bare metal deployment tool version to v0.3.11.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->