### PR TITLE
ARO HCP Base ci image smoke test

### DIFF
--- a/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__baseimage-generator.yaml
+++ b/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__baseimage-generator.yaml
@@ -23,6 +23,20 @@ resources:
     requests:
       cpu: "8"
       memory: 8Gi
+tests:
+- as: go-smoke-test
+  commands: |
+    set -euo pipefail
+    d=$(mktemp -d)
+    cd "$d"
+    go mod init smoke.example.com/nonroot
+    printf '%s\n' 'package main' 'func main() {}' > main.go
+    go build -o /dev/null .
+    go test .
+    echo "Go GOMODCACHE=$(go env GOMODCACHE) GOCACHE=$(go env GOCACHE) OK"
+  container:
+    from: aro-hcp-e2e-base-ci
+  run_if_changed: ^(dev-infrastructure/openshift-ci/Dockerfile$|\.ci-operator\.yaml$)
 zz_generated_metadata:
   branch: main
   org: Azure

--- a/ci-operator/jobs/Azure/ARO-HCP/Azure-ARO-HCP-main-presubmits.yaml
+++ b/ci-operator/jobs/Azure/ARO-HCP/Azure-ARO-HCP-main-presubmits.yaml
@@ -90,6 +90,10 @@ presubmits:
     cluster: build05
     context: ci/prow/baseimage-generator-go-smoke-test
     decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - .ci-operator.yaml
+      - dev-infrastructure/openshift-ci/Dockerfile
     labels:
       ci-operator.openshift.io/variant: baseimage-generator
       ci.openshift.io/generator: prowgen

--- a/ci-operator/jobs/Azure/ARO-HCP/Azure-ARO-HCP-main-presubmits.yaml
+++ b/ci-operator/jobs/Azure/ARO-HCP/Azure-ARO-HCP-main-presubmits.yaml
@@ -88,6 +88,70 @@ presubmits:
     - ^main$
     - ^main-
     cluster: build05
+    context: ci/prow/baseimage-generator-go-smoke-test
+    decorate: true
+    labels:
+      ci-operator.openshift.io/variant: baseimage-generator
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-Azure-ARO-HCP-main-baseimage-generator-go-smoke-test
+    rerun_command: /test baseimage-generator-go-smoke-test
+    run_if_changed: ^(dev-infrastructure/openshift-ci/Dockerfile$|\.ci-operator\.yaml$)
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=go-smoke-test
+        - --variant=baseimage-generator
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )baseimage-generator-go-smoke-test,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build05
     context: ci/prow/baseimage-generator-images
     decorate: true
     decoration_config:


### PR DESCRIPTION
Add a test for base CI image by building and testing smoke Go code as a non-root user.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Adds a non-root Go smoke test to the Azure/ARO-HCP ci-operator config to validate the ARO HCP base CI image. The test (as: go-smoke-test) runs inside the aro-hcp-e2e-base-ci image, creates a temp dir, runs `go mod init`, writes a minimal main.go, then runs `go build` and `go test`, and prints GOMODCACHE/GOCACHE. This verifies the base CI image can compile and execute Go code as a non-root user.
- Wires the test into ci-operator at ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__baseimage-generator.yaml and gates it with run_if_changed so it only triggers when dev-infrastructure/openshift-ci/Dockerfile or the ci-operator YAML change.
- Adds a presubmit Prow job pull-ci-Azure-ARO-HCP-main-baseimage-generator-go-smoke-test in ci-operator/jobs/Azure/ARO-HCP/Azure-ARO-HCP-main-presubmits.yaml. The job runs ci-operator with --target=go-smoke-test and --variant=baseimage-generator on the build05 cluster, is decorated, exposes port 8080, mounts standard CI secrets/volumes (gcs service account, manifest-tool local pusher, registry pull credentials, result-aggregator), and is triggerable via the `/test baseimage-generator-go-smoke-test` command. The job is limited by run_if_changed to changes to dev-infrastructure/openshift-ci/Dockerfile (and .ci-operator.yaml where applicable).
- Practical impact: the PR adds automated presubmit verification that changes to the base image definition do not break building/running Go as a non-root user, reducing the risk of regressions in the ARO HCP base CI image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->