### PR TITLE
Migrate networking-console-plugin 4.20 branch from yarn to npm

### DIFF
--- a/ci-operator/config/openshift/networking-console-plugin/openshift-networking-console-plugin-release-4.20.yaml
+++ b/ci-operator/config/openshift/networking-console-plugin/openshift-networking-console-plugin-release-4.20.yaml
@@ -2,7 +2,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: console-plugin-test-cypress-v18
+    tag: tectonic-console-builder-v29
 images:
   items:
   - dockerfile_path: Dockerfile
@@ -24,16 +24,16 @@ releases:
 resources:
   '*':
     limits:
-      memory: 4Gi
+      memory: 6Gi
     requests:
       cpu: 1000m
-      memory: 4Gi
+      memory: 6Gi
 tests:
 - as: lint
   steps:
     test:
     - as: lint
-      commands: yarn install && yarn run lint && yarn build
+      commands: npm install && npm run lint && npm run build
       from: src
       resources:
         requests:
@@ -41,7 +41,7 @@ tests:
           memory: 300Mi
     - as: i18n
       commands: |
-        yarn install && yarn i18n
+        npm install && npm run i18n
         GIT_STATUS="$(git status --short --untracked-files locales)"
         if [ -n "$GIT_STATUS" ]; then
           echo "i18n files are not up to date. Commit them to fix."
@@ -68,7 +68,7 @@ tests:
       resources:
         requests:
           cpu: 1000m
-          memory: 1Gi
+          memory: 4Gi
       timeout: 3h0m0s
     workflow: openshift-e2e-aws
 zz_generated_metadata:


### PR DESCRIPTION
## Summary

- Update `build_root` image tag to `tectonic-console-builder-v29` for `networking-console-plugin` release-4.20 CI configurations
- Replace `yarn` commands with `npm` equivalents in lint and i18n test steps as part of the yarn to npm migration

## Details

The networking-console-plugin repository is migrating from yarn to npm. This PR updates the CI configurations to:

1. Use the `tectonic-console-builder-v29` base image which includes npm support
2. Replace all yarn commands with their npm counterparts (`yarn install` -> `npm install`, `yarn run lint` -> `npm run lint`, `yarn build` -> `npm run build`, `yarn i18n` -> `npm i18n`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD build infrastructure with enhanced resource allocation and optimized build tooling to improve build performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->