### PR TITLE
chore: update control-plane component restricted label setters

### DIFF
--- a/core-services/prow/02_config/openshift/apiserver-library-go/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/apiserver-library-go/_pluginconfig.yaml
@@ -2,14 +2,20 @@ label:
   restricted_labels:
     openshift/apiserver-library-go:
     - allowed_users:
-      - tkashem
-      - p0lyn0mial
+      - everettraven
       - benluddy
-      - vrutkovs
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
       label: backport-risk-assessed
     - allowed_users:
-      - xingxingxia
-      - wangke19
+      - everettraven
+      - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
       - gangwgr
       assign_on:
       - label: backport-risk-assessed

--- a/core-services/prow/02_config/openshift/cli-manager-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/cli-manager-operator/_pluginconfig.yaml
@@ -7,12 +7,22 @@ label:
   restricted_labels:
     openshift/cli-manager-operator:
     - allowed_users:
-      - zhouying7780
+      - everettraven
+      - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
       assign_on:
       - label: backport-risk-assessed
       label: cherry-pick-approved
     - allowed_users:
+      - everettraven
+      - benluddy
+      - sjenning
+      - tjungblu
       - ardaguclu
+      - p0lyn0mial
       - ingvagabund
       label: backport-risk-assessed
 lgtm:

--- a/core-services/prow/02_config/openshift/cli-manager/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/cli-manager/_pluginconfig.yaml
@@ -7,13 +7,22 @@ label:
   restricted_labels:
     openshift/cli-manager:
     - allowed_users:
-      - wewang58
-      - zhouying7780
+      - everettraven
+      - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
       assign_on:
       - label: backport-risk-assessed
       label: cherry-pick-approved
     - allowed_users:
+      - everettraven
+      - benluddy
+      - sjenning
+      - tjungblu
       - ardaguclu
+      - p0lyn0mial
       - ingvagabund
       label: backport-risk-assessed
 lgtm:

--- a/core-services/prow/02_config/openshift/cluster-authentication-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/cluster-authentication-operator/_pluginconfig.yaml
@@ -2,13 +2,20 @@ label:
   restricted_labels:
     openshift/cluster-authentication-operator:
     - allowed_users:
-      - tkashem
-      - p0lyn0mial
+      - everettraven
       - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
       label: backport-risk-assessed
     - allowed_users:
-      - xingxingxia
-      - wangke19
+      - everettraven
+      - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
       label: cherry-pick-approved
 plugins:
   openshift/cluster-authentication-operator:

--- a/core-services/prow/02_config/openshift/cluster-bootstrap/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/cluster-bootstrap/_pluginconfig.yaml
@@ -2,15 +2,21 @@ label:
   restricted_labels:
     openshift/cluster-bootstrap:
     - allowed_users:
-      - tkashem
-      - p0lyn0mial
+      - everettraven
       - benluddy
-      - vrutkovs
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
       - ingvagabund
       label: backport-risk-assessed
     - allowed_users:
-      - xingxingxia
-      - wangke19
+      - everettraven
+      - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
       - gangwgr
       assign_on:
       - label: backport-risk-assessed

--- a/core-services/prow/02_config/openshift/cluster-etcd-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/cluster-etcd-operator/_pluginconfig.yaml
@@ -2,13 +2,23 @@ label:
   restricted_labels:
     openshift/cluster-etcd-operator:
     - allowed_users:
+      - everettraven
+      - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
       - hasbro17
       - dusk125
       - Elbehery
-      - tjungblu
       label: backport-risk-assessed
     - allowed_users:
-      - geliu2016
+      - everettraven
+      - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
       - sandeepknd
       label: cherry-pick-approved
 plugins:

--- a/core-services/prow/02_config/openshift/cluster-image-registry-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/cluster-image-registry-operator/_pluginconfig.yaml
@@ -2,12 +2,23 @@ label:
   restricted_labels:
     openshift/cluster-image-registry-operator:
     - allowed_users:
+      - everettraven
+      - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
       - xiuwang
-      - wewang58
       assign_on:
       - label: backport-risk-assessed
       label: cherry-pick-approved
     - allowed_users:
+      - everettraven
+      - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
       - flavianmissi
       - ricardomaraschini
       label: backport-risk-assessed

--- a/core-services/prow/02_config/openshift/cluster-kube-apiserver-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/cluster-kube-apiserver-operator/_pluginconfig.yaml
@@ -2,16 +2,24 @@ label:
   restricted_labels:
     openshift/cluster-kube-apiserver-operator:
     - allowed_users:
-      - xingxingxia
-      - wangke19
+      - everettraven
+      - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
       - gangwgr
       assign_on:
       - label: backport-risk-assessed
       label: cherry-pick-approved
     - allowed_users:
-      - tkashem
-      - ingvagabund
+      - everettraven
+      - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
       - p0lyn0mial
+      - ingvagabund
       label: backport-risk-assessed
 plugins:
   openshift/cluster-kube-apiserver-operator:

--- a/core-services/prow/02_config/openshift/cluster-kube-controller-manager-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/cluster-kube-controller-manager-operator/_pluginconfig.yaml
@@ -2,17 +2,23 @@ label:
   restricted_labels:
     openshift/cluster-kube-controller-manager-operator:
     - allowed_users:
-      - wangke19
-      - zhouying7780
-      - xingxingxia
+      - everettraven
+      - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
       assign_on:
       - label: backport-risk-assessed
       label: cherry-pick-approved
     - allowed_users:
-      - ingvagabund
-      - tkashem
-      - p0lyn0mial
+      - everettraven
       - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
+      - ingvagabund
       label: backport-risk-assessed
 plugins:
   openshift/cluster-kube-controller-manager-operator:

--- a/core-services/prow/02_config/openshift/cluster-kube-descheduler-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/cluster-kube-descheduler-operator/_pluginconfig.yaml
@@ -2,17 +2,23 @@ label:
   restricted_labels:
     openshift/cluster-kube-descheduler-operator:
     - allowed_users:
-      - wangke19
-      - zhouying7780
-      - xingxingxia
+      - everettraven
+      - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
       assign_on:
       - label: backport-risk-assessed
       label: cherry-pick-approved
     - allowed_users:
-      - ingvagabund
-      - tkashem
-      - p0lyn0mial
+      - everettraven
       - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
+      - ingvagabund
       label: backport-risk-assessed
 plugins:
   openshift/cluster-kube-descheduler-operator:

--- a/core-services/prow/02_config/openshift/cluster-kube-scheduler-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/cluster-kube-scheduler-operator/_pluginconfig.yaml
@@ -2,17 +2,23 @@ label:
   restricted_labels:
     openshift/cluster-kube-scheduler-operator:
     - allowed_users:
-      - wangke19
-      - zhouying7780
-      - xingxingxia
+      - everettraven
+      - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
       assign_on:
       - label: backport-risk-assessed
       label: cherry-pick-approved
     - allowed_users:
-      - ingvagabund
-      - tkashem
-      - p0lyn0mial
+      - everettraven
       - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
+      - ingvagabund
       label: backport-risk-assessed
 plugins:
   openshift/cluster-kube-scheduler-operator:

--- a/core-services/prow/02_config/openshift/cluster-kube-storage-version-migrator-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/cluster-kube-storage-version-migrator-operator/_pluginconfig.yaml
@@ -2,16 +2,23 @@ label:
   restricted_labels:
     openshift/cluster-kube-storage-version-migrator-operator:
     - allowed_users:
-      - xingxingxia
-      - wangke19
+      - everettraven
+      - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
       - gangwgr
       assign_on:
       - label: backport-risk-assessed
       label: cherry-pick-approved
     - allowed_users:
-      - tkashem
-      - p0lyn0mial
+      - everettraven
       - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
       label: backport-risk-assessed
 plugins:
   openshift/cluster-kube-storage-version-migrator-operator:

--- a/core-services/prow/02_config/openshift/cluster-openshift-apiserver-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/cluster-openshift-apiserver-operator/_pluginconfig.yaml
@@ -2,19 +2,24 @@ label:
   restricted_labels:
     openshift/cluster-openshift-apiserver-operator:
     - allowed_users:
-      - xingxingxia
-      - wangke19
+      - everettraven
+      - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
       - gangwgr
       assign_on:
       - label: backport-risk-assessed
       label: cherry-pick-approved
     - allowed_users:
-      - dmage
-      - ingvagabund
-      - tkashem
-      - p0lyn0mial
+      - everettraven
       - benluddy
-      - vrutkovs
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
+      - ingvagabund
       label: backport-risk-assessed
 plugins:
   openshift/cluster-openshift-apiserver-operator:

--- a/core-services/prow/02_config/openshift/cluster-openshift-controller-manager-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/cluster-openshift-controller-manager-operator/_pluginconfig.yaml
@@ -2,23 +2,31 @@ label:
   restricted_labels:
     openshift/cluster-openshift-controller-manager-operator:
     - allowed_users:
+      - everettraven
+      - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
       - adambkaplan
       - apoorvajagtap
       - sayan-biswas
       - ingvagabund
-      - tkashem
       - prabhapa
       - moebasim
       label: backport-risk-assessed
     - allowed_users:
+      - everettraven
+      - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
       - adambkaplan
       - apoorvajagtap
       - sayan-biswas
-      - wangke19
-      - zhouying7780
       - prabhapa
       - moebasim
-      - xingxingxia
       label: cherry-pick-approved
 plugins:
   openshift/cluster-openshift-controller-manager-operator:

--- a/core-services/prow/02_config/openshift/cluster-policy-controller/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/cluster-policy-controller/_pluginconfig.yaml
@@ -2,16 +2,23 @@ label:
   restricted_labels:
     openshift/cluster-policy-controller:
     - allowed_users:
-      - wangke19
-      - zhouying7780
-      - xingxingxia
+      - everettraven
+      - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
       assign_on:
       - label: backport-risk-assessed
       label: cherry-pick-approved
     - allowed_users:
-      - ingvagabund
-      - tkashem
+      - everettraven
       - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
+      - ingvagabund
       label: backport-risk-assessed
 plugins:
   openshift/cluster-policy-controller:

--- a/core-services/prow/02_config/openshift/jobset-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/jobset-operator/_pluginconfig.yaml
@@ -7,13 +7,22 @@ label:
   restricted_labels:
     openshift/jobset-operator:
     - allowed_users:
-      - wewang58
-      - zhouying7780
+      - everettraven
+      - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
       assign_on:
       - label: backport-risk-assessed
       label: cherry-pick-approved
     - allowed_users:
+      - everettraven
+      - benluddy
+      - sjenning
+      - tjungblu
       - ardaguclu
+      - p0lyn0mial
       - atiratree
       label: backport-risk-assessed
 lgtm:

--- a/core-services/prow/02_config/openshift/kube-rbac-proxy/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/kube-rbac-proxy/_pluginconfig.yaml
@@ -2,11 +2,21 @@ label:
   restricted_labels:
     openshift/kube-rbac-proxy:
     - allowed_users:
-      - tkashem
+      - everettraven
+      - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
       - ibihim
       label: backport-risk-assessed
     - allowed_users:
-      - xingxingxia
+      - everettraven
+      - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
       - dpuniaredhat
       label: cherry-pick-approved
 plugins:

--- a/core-services/prow/02_config/openshift/kubernetes/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/kubernetes/_pluginconfig.yaml
@@ -4,10 +4,13 @@ label:
     - allowed_teams:
       - openshift-staff-engineers
       allowed_users:
-      - xingxingxia
+      - everettraven
+      - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
       - kasturinarra
-      - wangke19
-      - zhouying7780
       - gangwgr
       - duanwei33
       - lyman9966
@@ -17,13 +20,16 @@ label:
     - allowed_teams:
       - openshift-staff-engineers
       allowed_users:
+      - everettraven
       - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
       - bertinatto
       - ingvagabund
       - jerpeter1
       - jsafrane
-      - p0lyn0mial
-      - tkashem
       - rphillips
       - mrunalp
       label: backport-risk-assessed

--- a/core-services/prow/02_config/openshift/library-go/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/library-go/_pluginconfig.yaml
@@ -2,17 +2,23 @@ label:
   restricted_labels:
     openshift/library-go:
     - allowed_users:
-      - ingvagabund
-      - tkashem
-      - p0lyn0mial
+      - everettraven
       - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
+      - ingvagabund
       label: backport-risk-assessed
     - allowed_users:
-      - xingxingxia
-      - wangke19
+      - everettraven
+      - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
       - kasturinarra
       - gangwgr
-      - zhouying7780
       assign_on:
       - label: backport-risk-assessed
       label: cherry-pick-approved

--- a/core-services/prow/02_config/openshift/lws-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/lws-operator/_pluginconfig.yaml
@@ -7,13 +7,22 @@ label:
   restricted_labels:
     openshift/lws-operator:
     - allowed_users:
-      - wewang58
-      - zhouying7780
+      - everettraven
+      - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
       assign_on:
       - label: backport-risk-assessed
       label: cherry-pick-approved
     - allowed_users:
+      - everettraven
+      - benluddy
+      - sjenning
+      - tjungblu
       - ardaguclu
+      - p0lyn0mial
       - atiratree
       label: backport-risk-assessed
 lgtm:

--- a/core-services/prow/02_config/openshift/oauth-apiserver/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/oauth-apiserver/_pluginconfig.yaml
@@ -2,13 +2,20 @@ label:
   restricted_labels:
     openshift/oauth-apiserver:
     - allowed_users:
-      - tkashem
-      - p0lyn0mial
+      - everettraven
       - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
       label: backport-risk-assessed
     - allowed_users:
-      - xingxingxia
-      - wangke19
+      - everettraven
+      - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
       label: cherry-pick-approved
 plugins:
   openshift/oauth-apiserver:

--- a/core-services/prow/02_config/openshift/oauth-proxy/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/oauth-proxy/_pluginconfig.yaml
@@ -2,11 +2,21 @@ label:
   restricted_labels:
     openshift/oauth-proxy:
     - allowed_users:
-      - tkashem
+      - everettraven
+      - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
       - ibihim
       label: backport-risk-assessed
     - allowed_users:
-      - xingxingxia
+      - everettraven
+      - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
       - dpuniaredhat
       label: cherry-pick-approved
 plugins:

--- a/core-services/prow/02_config/openshift/oauth-server/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/oauth-server/_pluginconfig.yaml
@@ -2,11 +2,21 @@ label:
   restricted_labels:
     openshift/oauth-server:
     - allowed_users:
+      - everettraven
+      - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
       - ibihim
-      - tkashem
       label: backport-risk-assessed
     - allowed_users:
-      - xingxingxia
+      - everettraven
+      - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
       - dpuniaredhat
       label: cherry-pick-approved
 plugins:

--- a/core-services/prow/02_config/openshift/openshift-apiserver/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/openshift-apiserver/_pluginconfig.yaml
@@ -2,21 +2,29 @@ label:
   restricted_labels:
     openshift/openshift-apiserver:
     - allowed_users:
-      - xingxingxia
-      - wangke19
+      - everettraven
+      - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
       - gangwgr
       assign_on:
       - label: backport-risk-assessed
       label: cherry-pick-approved
     - allowed_users:
+      - everettraven
+      - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
       - adambkaplan
       - sayan-biswas
       - dmage
       - ingvagabund
-      - tkashem
       - prabhapa
       - moebasim
-      - p0lyn0mial
       label: backport-risk-assessed
 plugins:
   openshift/openshift-apiserver:

--- a/core-services/prow/02_config/openshift/openshift-controller-manager/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/openshift-controller-manager/_pluginconfig.yaml
@@ -2,26 +2,32 @@ label:
   restricted_labels:
     openshift/openshift-controller-manager:
     - allowed_users:
+      - everettraven
+      - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
       - adambkaplan
       - apoorvajagtap
       - sayan-biswas
       - ingvagabund
-      - tkashem
-      - p0lyn0mial
-      - benluddy
       - prabhapa
       - moebasim
       label: backport-risk-assessed
     - allowed_users:
+      - everettraven
+      - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
       - adambkaplan
       - apoorvajagtap
       - sayan-biswas
       - jitendar-singh
-      - xingxingxia
-      - wangke19
       - gangwgr
       - kasturinarra
-      - zhouying7780
       - prabhapa
       - moebasim
       label: cherry-pick-approved

--- a/core-services/prow/02_config/openshift/run-once-duration-override-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/run-once-duration-override-operator/_pluginconfig.yaml
@@ -2,15 +2,21 @@ label:
   restricted_labels:
     openshift/run-once-duration-override-operator:
     - allowed_users:
-      - ingvagabund
-      - tkashem
-      - p0lyn0mial
+      - everettraven
       - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
+      - ingvagabund
       label: backport-risk-assessed
     - allowed_users:
-      - wangke19
-      - zhouying7780
-      - xingxingxia
+      - everettraven
+      - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
       assign_on:
       - label: backport-risk-assessed
       label: cherry-pick-approved

--- a/core-services/prow/02_config/openshift/run-once-duration-override/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/run-once-duration-override/_pluginconfig.yaml
@@ -2,13 +2,22 @@ label:
   restricted_labels:
     openshift/run-once-duration-override:
     - allowed_users:
+      - everettraven
+      - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
       - ingvagabund
-      - tkashem
       label: backport-risk-assessed
     - allowed_users:
+      - everettraven
+      - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
       - kasturinarra
-      - zhouying7780
-      - xingxingxia
       assign_on:
       - label: backport-risk-assessed
       label: cherry-pick-approved

--- a/core-services/prow/02_config/openshift/secondary-scheduler-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/secondary-scheduler-operator/_pluginconfig.yaml
@@ -7,17 +7,23 @@ label:
   restricted_labels:
     openshift/secondary-scheduler-operator:
     - allowed_users:
-      - wangke19
-      - zhouying7780
-      - xingxingxia
+      - everettraven
+      - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
       assign_on:
       - label: backport-risk-assessed
       label: cherry-pick-approved
     - allowed_users:
-      - ingvagabund
-      - tkashem
-      - p0lyn0mial
+      - everettraven
       - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
+      - ingvagabund
       label: backport-risk-assessed
 lgtm:
 - repos:

--- a/core-services/prow/02_config/openshift/service-ca-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/service-ca-operator/_pluginconfig.yaml
@@ -2,15 +2,21 @@ label:
   restricted_labels:
     openshift/service-ca-operator:
     - allowed_users:
-      - tkashem
-      - p0lyn0mial
+      - everettraven
       - benluddy
-      - vrutkovs
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
       - ingvagabund
       label: backport-risk-assessed
     - allowed_users:
-      - xingxingxia
-      - wangke19
+      - everettraven
+      - benluddy
+      - sjenning
+      - tjungblu
+      - ardaguclu
+      - p0lyn0mial
       - gangwgr
       label: cherry-pick-approved
 plugins:


### PR DESCRIPTION
# Description

This PR adjusts the set of folks who can apply the `backport-risk-assessed` and `cherry-pick-approved` label, adding folks that are a part of a new team process for backports and pruning a handful of folks that I know are no longer on the team and/or at the company.

>[!NOTE]
>This PR used Claude Code for generating the changes. All changes have been manually reviewed, verified, and are understood by me.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated access control for restricted labels (backport-risk-assessed, cherry-pick-approved) across 30+ OpenShift repositories. Rebalanced allowed-user lists by adding several maintainers and removing some prior entries, standardizing who can apply those labels across operators, API servers, and related components. No other plugin behavior or label semantics were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->