### PR TITLE
Add RHDH OCP lifecycle and CI management agent skills

### DIFF
--- a/ci-operator/config/redhat-developer/rhdh/.claude/OWNERS
+++ b/ci-operator/config/redhat-developer/rhdh/.claude/OWNERS
@@ -1,0 +1,25 @@
+approvers:
+- albarbaro
+- christoph-jerolimov
+- davidfestal
+- durandom
+- hopehadfield
+- josephca
+- kadel
+- kim-tsao
+- nickboldt
+- rm3l
+- zaperex
+options: {}
+reviewers:
+- albarbaro
+- christoph-jerolimov
+- davidfestal
+- durandom
+- hopehadfield
+- josephca
+- kadel
+- kim-tsao
+- nickboldt
+- rm3l
+- zaperex

--- a/ci-operator/config/redhat-developer/rhdh/.claude/skills/OWNERS
+++ b/ci-operator/config/redhat-developer/rhdh/.claude/skills/OWNERS
@@ -1,0 +1,25 @@
+approvers:
+- albarbaro
+- christoph-jerolimov
+- davidfestal
+- durandom
+- hopehadfield
+- josephca
+- kadel
+- kim-tsao
+- nickboldt
+- rm3l
+- zaperex
+options: {}
+reviewers:
+- albarbaro
+- christoph-jerolimov
+- davidfestal
+- durandom
+- hopehadfield
+- josephca
+- kadel
+- kim-tsao
+- nickboldt
+- rm3l
+- zaperex

--- a/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-decommission-release/OWNERS
+++ b/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-decommission-release/OWNERS
@@ -1,0 +1,25 @@
+approvers:
+- albarbaro
+- christoph-jerolimov
+- davidfestal
+- durandom
+- hopehadfield
+- josephca
+- kadel
+- kim-tsao
+- nickboldt
+- rm3l
+- zaperex
+options: {}
+reviewers:
+- albarbaro
+- christoph-jerolimov
+- davidfestal
+- durandom
+- hopehadfield
+- josephca
+- kadel
+- kim-tsao
+- nickboldt
+- rm3l
+- zaperex

--- a/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-decommission-release/SKILL.md
+++ b/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-decommission-release/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Use when decommissioning an end-of-life RHDH release branch by removing CI
   config, generated Prow jobs, and branch protection from the openshift/release
   repository
-allowed-tools: Glob, Read, Edit, Bash(rm *redhat-developer-rhdh-*), AskUserQuestion
+allowed-tools: Read, Edit, Bash(ls ci-operator/config/redhat-developer/rhdh/redhat-developer-rhdh-release-*), Bash(find ci-operator/config/redhat-developer/rhdh -name 'redhat-developer-rhdh-release-*'), Bash(rm ci-operator/config/redhat-developer/rhdh/redhat-developer-rhdh-release-*), Bash(rm ci-operator/jobs/redhat-developer/rhdh/redhat-developer-rhdh-release-*), AskUserQuestion
 ---
 # Decommission RHDH Release Branch Jobs
 
@@ -20,7 +20,7 @@ Decommissioning removes all CI configuration for a given RHDH release branch. Th
    - If the user provided a version (e.g., "1.7", "1.8"), use it directly
    - If no version was provided, ask the user for the RHDH release version to decommission
    - List existing release configs to help the user choose:
-     - Glob for `ci-operator/config/redhat-developer/rhdh/redhat-developer-rhdh-release-*.yaml`
+     - `ls ci-operator/config/redhat-developer/rhdh/redhat-developer-rhdh-release-*.yaml`
 
 2. **Verify the files to be removed**:
    Show the user what will be deleted and ask for confirmation:

--- a/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-decommission-release/SKILL.md
+++ b/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-decommission-release/SKILL.md
@@ -4,6 +4,7 @@ description: >-
   Use when decommissioning an end-of-life RHDH release branch by removing CI
   config, generated Prow jobs, and branch protection from the openshift/release
   repository
+allowed-tools: Glob, Read, Edit, Bash(rm *redhat-developer-rhdh-*), AskUserQuestion
 ---
 # Decommission RHDH Release Branch Jobs
 

--- a/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-decommission-release/SKILL.md
+++ b/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-decommission-release/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: rhdh-decommission-release
+description: >-
+  Use when decommissioning an end-of-life RHDH release branch by removing CI
+  config, generated Prow jobs, and branch protection from the openshift/release
+  repository
+---
+# Decommission RHDH Release Branch Jobs
+
+You are helping the user decommission CI jobs for an end-of-life RHDH (Red Hat Developer Hub) release branch.
+
+## What This Command Does
+
+Decommissioning removes all CI configuration for a given RHDH release branch. This is done when a release reaches end-of-life and no longer needs CI jobs running. Based on the pattern from PR #71895.
+
+## Steps to follow:
+
+1. **Get the release version**:
+   - If the user provided a version (e.g., "1.7", "1.8"), use it directly
+   - If no version was provided, ask the user for the RHDH release version to decommission
+   - List existing release configs to help the user choose:
+     - Glob for `ci-operator/config/redhat-developer/rhdh/redhat-developer-rhdh-release-*.yaml`
+
+2. **Verify the files to be removed**:
+   Show the user what will be deleted and ask for confirmation:
+
+   - **CI config file**: `ci-operator/config/redhat-developer/rhdh/redhat-developer-rhdh-release-{version}.yaml`
+   - **Generated job files**: `ci-operator/jobs/redhat-developer/rhdh/redhat-developer-rhdh-release-{version}-*.yaml` (typically `-presubmits.yaml` and `-periodics.yaml`)
+   - **Branch protection entry**: The `release-{version}:` block in `core-services/prow/02_config/redhat-developer/rhdh/_prowconfig.yaml`
+
+   If the CI config file does not exist, warn the user that this release may have already been decommissioned and ask if they want to continue checking for leftover files.
+
+3. **Delete the CI config file**:
+   Remove `ci-operator/config/redhat-developer/rhdh/redhat-developer-rhdh-release-{version}.yaml`
+
+4. **Delete the generated job files**:
+   Remove all matching files: `ci-operator/jobs/redhat-developer/rhdh/redhat-developer-rhdh-release-{version}-*.yaml`
+
+5. **Remove branch protection configuration**:
+   Edit `core-services/prow/02_config/redhat-developer/rhdh/_prowconfig.yaml` to remove the entire `release-{version}:` block under `branch-protection.orgs.redhat-developer.repos.rhdh.branches`.
+
+   The block to remove looks like:
+   ```yaml
+               release-{version}:
+                 allow_deletions: false
+                 allow_force_pushes: false
+                 enforce_admins: true
+                 protect: true
+                 required_status_checks:
+                   contexts:
+                   - <context1>
+                   - <context2>
+                   - <context3>
+   ```
+
+   Be careful to:
+   - Only remove the block for the specified version
+   - Preserve indentation and formatting of surrounding blocks
+   - Not leave blank lines where the block was removed
+
+6. **Confirm completion**: Summarize what was removed:
+   - List deleted files
+   - Confirm branch protection entry was removed
+   - Remind the user to commit the changes and create a PR
+
+## Important Notes
+
+- **Do NOT run `make update`** -- since we are only deleting files and removing branch protection, there is nothing to regenerate
+- The generated job files in `ci-operator/jobs/` are normally auto-generated, but when decommissioning we simply delete them along with the source config
+- Always verify the files exist before attempting deletion
+- This operation is destructive -- always confirm with the user before proceeding

--- a/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-coverage/OWNERS
+++ b/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-coverage/OWNERS
@@ -1,0 +1,25 @@
+approvers:
+- albarbaro
+- christoph-jerolimov
+- davidfestal
+- durandom
+- hopehadfield
+- josephca
+- kadel
+- kim-tsao
+- nickboldt
+- rm3l
+- zaperex
+options: {}
+reviewers:
+- albarbaro
+- christoph-jerolimov
+- davidfestal
+- durandom
+- hopehadfield
+- josephca
+- kadel
+- kim-tsao
+- nickboldt
+- rm3l
+- zaperex

--- a/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-coverage/SKILL.md
+++ b/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-coverage/SKILL.md
@@ -4,6 +4,7 @@ description: >-
   Analyze RHDH OCP version coverage by cross-referencing cluster pools and CI
   test configs against both RHDH and OCP lifecycle APIs to find gaps, stale
   configurations, and compatibility mismatches
+allowed-tools: Bash(bash *analyze-coverage.sh*)
 ---
 # RHDH OCP Coverage Analysis
 
@@ -22,6 +23,7 @@ Use this skill when you need to:
 - `curl`, `jq`, and `yq` (v4+) must be available
 - Internet connectivity to reach `https://access.redhat.com`
 - Working directory must be the root of the `openshift/release` repository
+- `CLAUDE_SKILL_DIR` is set automatically by the Claude Code skill loader. For manual invocation, set it to this skill's directory (e.g., `CLAUDE_SKILL_DIR=ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-coverage`)
 
 ## Usage
 

--- a/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-coverage/SKILL.md
+++ b/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-coverage/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: rhdh-ocp-coverage
+description: >-
+  Analyze RHDH OCP version coverage by cross-referencing cluster pools and CI
+  test configs against both RHDH and OCP lifecycle APIs to find gaps, stale
+  configurations, and compatibility mismatches
+---
+# RHDH OCP Coverage Analysis
+
+Cross-reference RHDH cluster pools, CI test configurations, RHDH lifecycle data, and OCP lifecycle data to identify coverage gaps and stale configurations.
+
+## When to Use
+
+Use this skill when you need to:
+- Check if RHDH CI coverage matches the current RHDH-supported OCP versions
+- Find OCP versions that RHDH no longer supports but still have active pools or test entries
+- Find RHDH-supported OCP versions missing cluster pools or test entries
+- Plan OCP version additions or removals for a new RHDH release
+
+## Prerequisites
+
+- `curl`, `jq`, and `yq` (v4+) must be available
+- Internet connectivity to reach `https://access.redhat.com`
+- Working directory must be the root of the `openshift/release` repository
+
+## Usage
+
+Run the bundled analysis script from the repository root:
+
+```bash
+bash "${CLAUDE_SKILL_DIR}/scripts/analyze-coverage.sh"
+```
+
+## Two Dimensions of Support
+
+The analysis checks two independent dimensions for each OCP version:
+
+| Dimension | Source | Meaning |
+|-----------|--------|---------|
+| **OCP supported** | OCP lifecycle API | The OCP version itself is still receiving updates (Full, Maintenance, or EUS) |
+| **RHDH supported** | RHDH lifecycle API (`openshift_compatibility` field) | RHDH officially supports running on this OCP version |
+
+An OCP version must satisfy **both** to warrant a cluster pool and test entry:
+- An OCP-EOL version should always be removed (regardless of RHDH compatibility)
+- An OCP-supported but non-RHDH-supported version should be reviewed (e.g., old EUS versions RHDH has dropped)
+
+## How `main` Branch Is Handled
+
+The `main` branch targets the **next unreleased RHDH version**. Since it's unreleased, it doesn't appear in the RHDH lifecycle API. The script estimates its OCP support as:
+
+> Latest active RHDH release's OCP versions **+** any newer OCP versions that have reached GA
+
+For example, if RHDH 1.9 supports OCP 4.16-4.21 and OCP 4.22 just went GA, then `main` is estimated to support 4.16-4.22.
+
+## Output Sections
+
+### 1. Current State
+
+- Cluster pool versions with sizing
+- Test entry versions per product branch
+- RHDH lifecycle with per-release OCP compatibility
+- OCP lifecycle with supported/EOL versions
+
+### 2. OCP Version Matrix
+
+A combined view showing each relevant OCP version with:
+
+| Column | Description |
+|--------|-------------|
+| OCP | Version number |
+| OCP_SUPP | Is OCP itself still supported? |
+| RHDH_SUPP | Does any active RHDH release support this OCP? |
+| OCP_PHASE | Current OCP lifecycle phase |
+| RHDH_RELEASES | Which RHDH releases support this OCP |
+
+### 3. Analysis Results
+
+Actions are categorized by severity:
+
+- **REMOVE** — Definitive: OCP version is end-of-life, resources should be deleted
+- **REVIEW** — Needs judgment: OCP is supported but RHDH compatibility doesn't match, or vice versa
+- **ADD** — Missing: RHDH-supported OCP version lacks a pool or test entry
+
+Specific checks:
+- Pools for OCP-EOL versions (REMOVE)
+- Pools for OCP versions not in any RHDH release's compatibility list (REVIEW)
+- Test entries mismatched with the branch's RHDH compatibility (REMOVE/REVIEW)
+- RHDH-supported OCP versions missing pools (ADD)
+- RHDH-supported OCP versions missing test entries per branch (ADD)
+
+### 4. Summary
+
+Counts per action category plus the per-branch OCP support mapping.
+
+## Workflow
+
+After running the analysis:
+
+1. **Handle REMOVE items first** — delete pools/tests for OCP-EOL versions
+2. **Review REVIEW items** — decide based on context whether they need action
+3. **Handle ADD items** — use `rhdh-ocp-pool` and `rhdh-ocp-tests` skills
+4. **Run `make update`** after all changes
+5. **Commit both config and generated files** together
+
+## Data Sources
+
+- **RHDH lifecycle**: `https://access.redhat.com/product-life-cycles/api/v1/products?name=Red+Hat+Developer+Hub`
+- **OCP lifecycle**: `https://access.redhat.com/product-life-cycles/api/v1/products?name=OpenShift+Container+Platform+4`
+- **RHDH support policy**: `https://access.redhat.com/support/policy/updates/developerhub`
+
+## Related Skills
+
+- `rhdh-ocp-lifecycle` — Check RHDH and OCP version support status
+- `rhdh-ocp-pool` — List and generate OCP cluster pool configurations
+- `rhdh-ocp-tests` — List, generate, add, and remove OCP test entries

--- a/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-coverage/SKILL.md
+++ b/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-coverage/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Analyze RHDH OCP version coverage by cross-referencing cluster pools and CI
   test configs against both RHDH and OCP lifecycle APIs to find gaps, stale
   configurations, and compatibility mismatches
-allowed-tools: Bash(bash *analyze-coverage.sh*)
+allowed-tools: Read, Bash(bash *analyze-coverage.sh*)
 ---
 # RHDH OCP Coverage Analysis
 

--- a/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-coverage/scripts/OWNERS
+++ b/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-coverage/scripts/OWNERS
@@ -1,0 +1,25 @@
+approvers:
+- albarbaro
+- christoph-jerolimov
+- davidfestal
+- durandom
+- hopehadfield
+- josephca
+- kadel
+- kim-tsao
+- nickboldt
+- rm3l
+- zaperex
+options: {}
+reviewers:
+- albarbaro
+- christoph-jerolimov
+- davidfestal
+- durandom
+- hopehadfield
+- josephca
+- kadel
+- kim-tsao
+- nickboldt
+- rm3l
+- zaperex

--- a/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-coverage/scripts/analyze-coverage.sh
+++ b/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-coverage/scripts/analyze-coverage.sh
@@ -1,0 +1,463 @@
+#!/usr/bin/env bash
+# Analyze RHDH OCP version coverage: cross-reference cluster pools, CI test
+# configs, RHDH lifecycle, and OCP lifecycle data.
+#
+# Two dimensions are checked:
+#   1. OCP lifecycle — is the OCP version itself still supported? (Full, Maintenance, EUS)
+#   2. RHDH compatibility — does RHDH officially list this OCP version in its
+#      openshift_compatibility field?
+#
+# The RHDH lifecycle API is the source of truth for which OCP versions each
+# RHDH release supports. The "main" branch targets the next unreleased RHDH
+# release which typically supports the latest OCP versions that just went GA,
+# so main is mapped to a superset: the latest RHDH release's OCP list plus
+# any newer OCP versions that are supported (GA'd).
+#
+# Usage:
+#   analyze-coverage.sh
+#   analyze-coverage.sh --pool-dir <path> --config-dir <path>
+#
+# Must be run from the root of the openshift/release repository.
+# Requires: curl, jq, yq (v4+)
+
+set -euo pipefail
+
+# Resolve path to shared jq filter for OCP lifecycle classification
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OCP_LIFECYCLE_JQ="${SCRIPT_DIR}/../../rhdh-ocp-lifecycle/scripts/ocp-lifecycle.jq"
+
+POOL_DIR="clusters/hosted-mgmt/hive/pools/rhdh"
+CI_CONFIG_DIR="ci-operator/config/redhat-developer/rhdh"
+LIFECYCLE_API_URL="https://access.redhat.com/product-life-cycles/api/v1/products"
+
+usage() { echo "Usage: $0 [--pool-dir <path>] [--config-dir <path>]" >&2; exit 1; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --pool-dir)
+      [[ $# -ge 2 && "${2:0:2}" != "--" ]] || usage
+      POOL_DIR="$2"
+      shift 2
+      ;;
+    --config-dir)
+      [[ $# -ge 2 && "${2:0:2}" != "--" ]] || usage
+      CI_CONFIG_DIR="$2"
+      shift 2
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+# Validate prerequisites
+for cmd in curl jq yq; do
+  if ! command -v "$cmd" &>/dev/null; then
+    echo "ERROR: ${cmd} is required but not found" >&2
+    exit 1
+  fi
+done
+
+if [[ ! -d "$POOL_DIR" ]]; then
+  echo "ERROR: Pool directory not found: ${POOL_DIR}" >&2
+  exit 1
+fi
+
+if [[ ! -d "$CI_CONFIG_DIR" ]]; then
+  echo "ERROR: Config directory not found: ${CI_CONFIG_DIR}" >&2
+  exit 1
+fi
+
+echo "========================================================"
+echo "  RHDH OCP Coverage Analysis"
+echo "========================================================"
+echo ""
+echo "Pool directory:   ${POOL_DIR}"
+echo "Config directory: ${CI_CONFIG_DIR}"
+echo "Analysis time:    $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo ""
+
+# ---------------------------------------------------------------
+# 1. Gather cluster pool versions
+# ---------------------------------------------------------------
+echo "--- Cluster Pools ---"
+POOL_VERSIONS=()
+for pool_file in "${POOL_DIR}"/*_clusterpool.yaml; do
+  [[ -f "$pool_file" ]] || continue
+  ver=$(yq '.metadata.labels.version' "$pool_file" 2>/dev/null) || true
+  [[ -z "$ver" || "$ver" == "null" ]] && continue
+  pool_name=$(yq '.metadata.name // "unknown"' "$pool_file" 2>/dev/null) || true
+  size=$(yq '.spec.size // 0' "$pool_file" 2>/dev/null) || true
+  max=$(yq '.spec.maxSize // 0' "$pool_file" 2>/dev/null) || true
+  POOL_VERSIONS+=("$ver")
+  printf "  %-8s  %-25s  size=%s max=%s\n" "$ver" "$pool_name" "$size" "$max"
+done
+echo ""
+
+# ---------------------------------------------------------------
+# 2. Gather test config versions per branch
+# ---------------------------------------------------------------
+echo "--- Test Configs ---"
+# shellcheck disable=SC2206  # Intentional word-splitting on path separators (no spaces in paths)
+dir_parts=(${CI_CONFIG_DIR//\// })
+CONFIG_PREFIX="${dir_parts[-2]}-${dir_parts[-1]}-"
+
+declare -A BRANCH_VERSIONS  # branch -> space-separated versions
+ALL_TEST_VERSIONS=()
+
+for config_file in "${CI_CONFIG_DIR}/${CONFIG_PREFIX}"*.yaml; do
+  [[ -f "$config_file" ]] || continue
+  filename=$(basename "$config_file")
+  branch="${filename#"${CONFIG_PREFIX}"}"
+  branch="${branch%.yaml}"
+
+  # Extract OCP versions from cluster_claim.version (the source of truth),
+  # not from test names. Tests like e2e-ocp-helm-nightly don't encode the
+  # version in the name but use OCP 4.18 via cluster_claim.version.
+  versions=$(yq -o=json -I=0 \
+    '[.tests[] | select(.cluster_claim.version != null) | .cluster_claim.version] | unique | .[]' \
+    "$config_file" 2>/dev/null | tr -d '"' | sort -V || true)
+
+  if [[ -n "$versions" ]]; then
+    BRANCH_VERSIONS["$branch"]="$versions"
+    while IFS= read -r v; do
+      ALL_TEST_VERSIONS+=("$v")
+    done <<< "$versions"
+    echo "  ${branch}: $(echo "$versions" | tr '\n' ' ')"
+  fi
+done
+echo ""
+
+# shellcheck disable=SC2207  # Intentional word-splitting; version strings contain no spaces
+UNIQUE_TEST_VERSIONS=($(printf '%s\n' "${ALL_TEST_VERSIONS[@]}" | sort -uV))
+
+# ---------------------------------------------------------------
+# 3. Fetch RHDH lifecycle data
+# ---------------------------------------------------------------
+echo "--- RHDH Lifecycle ---"
+echo "  Fetching from Red Hat Product Life Cycles API..."
+
+NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+RHDH_RESPONSE=$(curl -s --fail \
+  "${LIFECYCLE_API_URL}?name=Red+Hat+Developer+Hub" \
+  -H "Accept: application/json")
+
+if [[ -z "$RHDH_RESPONSE" ]]; then
+  echo "ERROR: Failed to fetch RHDH lifecycle data" >&2
+  exit 1
+fi
+
+RHDH_DATA=$(echo "$RHDH_RESPONSE" | jq '
+  .data[0].versions | map({
+    version: .name,
+    type: .type,
+    supported: (.type != "End of life"),
+    ocp_versions: (.openshift_compatibility // "" | split(", ") | map(select(. != "")))
+  })
+  | sort_by(.version | split(".") | map(tonumber))
+')
+
+echo "$RHDH_DATA" | jq -r '.[] | select(.supported) | "  RHDH \(.version) (\(.type)): OCP \(.ocp_versions | join(", "))"'
+
+# Union of OCP versions supported by any active RHDH release
+RHDH_SUPPORTED_OCP=$(echo "$RHDH_DATA" | jq -r '
+  [.[] | select(.supported) | .ocp_versions[]] | unique
+  | sort_by(split(".") | map(tonumber))
+  | .[]
+')
+echo ""
+echo "  OCP versions supported by active RHDH releases: $(echo "$RHDH_SUPPORTED_OCP" | tr '\n' ' ')"
+echo ""
+
+# Build per-RHDH-release -> OCP version mapping
+# Maps RHDH version to product branch: 1.9 -> release-1.9, 1.8 -> release-1.8
+declare -A RHDH_BRANCH_OCP  # product_branch -> space-separated OCP versions
+LATEST_RHDH_OCP=""
+
+while IFS=$'\t' read -r rhdh_ver ocp_list; do
+  branch="release-${rhdh_ver}"
+  RHDH_BRANCH_OCP["$branch"]="$ocp_list"
+  LATEST_RHDH_OCP="$ocp_list"
+done < <(echo "$RHDH_DATA" | jq -r '.[] | select(.supported) | [.version, (.ocp_versions | join(" "))] | @tsv')
+
+# ---------------------------------------------------------------
+# 4. Fetch OCP lifecycle data
+# ---------------------------------------------------------------
+echo "--- OCP Lifecycle ---"
+echo "  Fetching from Red Hat Product Life Cycles API..."
+
+# Query the umbrella product which contains all OCP versions (4.x and future 5.x+).
+# The jq filter in ocp-lifecycle.jq handles version filtering (>= 4.x).
+OCP_RESPONSE=$(curl -s --fail \
+  "${LIFECYCLE_API_URL}?name=Red+Hat+OpenShift+Container+Platform" \
+  -H "Accept: application/json")
+
+if [[ -z "$OCP_RESPONSE" ]]; then
+  echo "ERROR: Failed to fetch OCP lifecycle data" >&2
+  exit 1
+fi
+
+# Use shared jq filter for OCP phase classification
+OCP_LIFECYCLE=$(echo "$OCP_RESPONSE" | jq --arg now "$NOW" -f "${OCP_LIFECYCLE_JQ}")
+
+OCP_SUPPORTED=$(echo "$OCP_LIFECYCLE" | jq -r '[.[] | select(.ocp_supported) | .version] | .[]')
+OCP_EOL=$(echo "$OCP_LIFECYCLE" | jq -r '[.[] | select(.ocp_supported | not) | .version] | .[]')
+
+echo "  OCP supported:     $(echo "$OCP_SUPPORTED" | tr '\n' ' ')"
+echo "  OCP end-of-life:   $(echo "$OCP_EOL" | tr '\n' ' ')"
+echo ""
+
+# Compute "main" branch OCP support:
+# main targets the next unreleased RHDH, which supports the latest RHDH release's
+# OCP versions PLUS any newer OCP versions that have reached GA (are supported).
+# This means: latest RHDH OCP list ∪ any OCP versions newer than the max in that list.
+if [[ -n "$LATEST_RHDH_OCP" ]]; then
+  # Find the highest OCP version in the latest RHDH release
+  MAX_RHDH_OCP=$(echo "$LATEST_RHDH_OCP" | tr ' ' '\n' | sort -V | tail -1)
+  MAX_MAJOR="${MAX_RHDH_OCP%%.*}"
+  MAX_MINOR="${MAX_RHDH_OCP#*.}"
+
+  # Start with the latest RHDH release's OCP versions
+  MAIN_OCP="$LATEST_RHDH_OCP"
+
+  # Add any supported OCP versions newer than the max
+  while IFS= read -r ocp_ver; do
+    [[ -z "$ocp_ver" ]] && continue
+    ver_major="${ocp_ver%%.*}"
+    ver_minor="${ocp_ver#*.}"
+    if [[ "$ver_major" -gt "$MAX_MAJOR" ]] || \
+       { [[ "$ver_major" -eq "$MAX_MAJOR" ]] && [[ "$ver_minor" -gt "$MAX_MINOR" ]]; }; then
+      MAIN_OCP="$MAIN_OCP $ocp_ver"
+    fi
+  done <<< "$OCP_SUPPORTED"
+
+  RHDH_BRANCH_OCP["main"]="$MAIN_OCP"
+fi
+
+# ---------------------------------------------------------------
+# 5. Combined OCP version matrix
+# ---------------------------------------------------------------
+echo "--- OCP Version Matrix ---"
+echo ""
+printf "  %-8s  %-10s  %-10s  %-30s  %s\n" \
+  "OCP" "OCP_SUPP" "RHDH_SUPP" "OCP_PHASE" "RHDH_RELEASES"
+printf "  %-8s  %-10s  %-10s  %-30s  %s\n" \
+  "---" "--------" "---------" "---------" "-------------"
+
+# Show all OCP versions that appear in pools, tests, or either lifecycle
+ALL_RELEVANT_OCP=$( {
+  printf '%s\n' "${POOL_VERSIONS[@]}" "${UNIQUE_TEST_VERSIONS[@]}"
+  printf '%s\n' "$RHDH_SUPPORTED_OCP"
+  printf '%s\n' "$OCP_SUPPORTED"
+} | sort -uV)
+
+while IFS= read -r ver; do
+  [[ -z "$ver" ]] && continue
+
+  # OCP supported?
+  ocp_sup="no"
+  ocp_phase="N/A"
+  phase_data=$(echo "$OCP_LIFECYCLE" | jq -r --arg v "$ver" '.[] | select(.version == $v) | "\(.ocp_supported)\t\(.phase)"' 2>/dev/null || true)
+  if [[ -n "$phase_data" ]]; then
+    ocp_sup_raw=$(echo "$phase_data" | cut -f1)
+    ocp_phase=$(echo "$phase_data" | cut -f2)
+    [[ "$ocp_sup_raw" == "true" ]] && ocp_sup="yes"
+  fi
+
+  # RHDH supported?
+  rhdh_sup="no"
+  rhdh_releases=""
+  if echo "$RHDH_SUPPORTED_OCP" | grep -Fxq "$ver"; then
+    rhdh_sup="yes"
+    rhdh_releases=$(echo "$RHDH_DATA" | jq -r --arg v "$ver" '[.[] | select(.supported) | select(.ocp_versions[] == $v) | .version] | join(", ")' 2>/dev/null || true)
+  fi
+
+  printf "  %-8s  %-10s  %-10s  %-30s  %s\n" "$ver" "$ocp_sup" "$rhdh_sup" "$ocp_phase" "$rhdh_releases"
+done <<< "$ALL_RELEVANT_OCP"
+echo ""
+
+# ---------------------------------------------------------------
+# 6. Cross-reference analysis
+# ---------------------------------------------------------------
+echo "========================================================"
+echo "  Analysis Results"
+echo "========================================================"
+echo ""
+
+HAS_ACTIONS=false
+
+# 6a. Pools for OCP versions that are OCP-EOL
+echo "--- Pools for OCP-EOL Versions (REMOVE) ---"
+EOL_POOL_COUNT=0
+for ver in "${POOL_VERSIONS[@]}"; do
+  if echo "$OCP_EOL" | grep -Fxq "$ver"; then
+    echo "  REMOVE pool: ${ver} (OCP end-of-life)"
+    EOL_POOL_COUNT=$((EOL_POOL_COUNT + 1))
+    HAS_ACTIONS=true
+  fi
+done
+if [[ $EOL_POOL_COUNT -eq 0 ]]; then
+  echo "  (none)"
+fi
+echo ""
+
+# 6b. Pools for OCP versions not supported by any active RHDH release
+echo "--- Pools for Non-RHDH-Supported OCP Versions (REVIEW) ---"
+NOTRHDH_POOL_COUNT=0
+for ver in "${POOL_VERSIONS[@]}"; do
+  # Skip if already flagged as OCP-EOL above
+  if echo "$OCP_EOL" | grep -Fxq "$ver"; then
+    continue
+  fi
+  if ! echo "$RHDH_SUPPORTED_OCP" | grep -Fxq "$ver"; then
+    echo "  REVIEW pool: ${ver} (OCP still supported, but not listed in any active RHDH release)"
+    NOTRHDH_POOL_COUNT=$((NOTRHDH_POOL_COUNT + 1))
+    HAS_ACTIONS=true
+  fi
+done
+if [[ $NOTRHDH_POOL_COUNT -eq 0 ]]; then
+  echo "  (none)"
+fi
+echo ""
+
+# 6c. Test entries for OCP versions not matching the branch's RHDH compatibility
+echo "--- Test Entries Mismatched With RHDH Compatibility (REVIEW) ---"
+MISMATCH_TEST_COUNT=0
+for branch in "${!BRANCH_VERSIONS[@]}"; do
+  branch_rhdh_ocp="${RHDH_BRANCH_OCP[$branch]:-}"
+  for ver in ${BRANCH_VERSIONS[$branch]}; do
+    # Flag if OCP-EOL
+    if echo "$OCP_EOL" | grep -Fxq "$ver"; then
+      echo "  REMOVE test: ${ver} from ${branch} (OCP end-of-life)"
+      MISMATCH_TEST_COUNT=$((MISMATCH_TEST_COUNT + 1))
+      HAS_ACTIONS=true
+      continue
+    fi
+    # Flag if not in RHDH compatibility for this branch
+    if [[ -n "$branch_rhdh_ocp" ]]; then
+      if ! echo "$branch_rhdh_ocp" | tr ' ' '\n' | grep -Fxq "$ver"; then
+        echo "  REVIEW test: ${ver} in ${branch} (not in RHDH openshift_compatibility for this release)"
+        MISMATCH_TEST_COUNT=$((MISMATCH_TEST_COUNT + 1))
+        HAS_ACTIONS=true
+      fi
+    fi
+  done
+done
+if [[ $MISMATCH_TEST_COUNT -eq 0 ]]; then
+  echo "  (none)"
+fi
+echo ""
+
+# 6d. RHDH-supported OCP versions missing cluster pools
+# Only recommend adding pools for versions that are BOTH RHDH-supported AND OCP-supported.
+# If OCP is EOL, there's no point adding a pool even if RHDH still lists it.
+# Iterate the union of RHDH_BRANCH_OCP values (includes main's computed extras).
+echo "--- RHDH-Supported OCP Versions Missing Pools (ADD) ---"
+MISSING_POOL_COUNT=0
+RHDH_ALL_OCP=$( {
+  for _b in "${!RHDH_BRANCH_OCP[@]}"; do printf '%s\n' ${RHDH_BRANCH_OCP[$_b]}; done
+} | sort -uV)
+while IFS= read -r ver; do
+  [[ -z "$ver" ]] && continue
+  # Skip OCP-EOL versions — no pool should be created for an EOL OCP
+  if echo "$OCP_EOL" | grep -Fxq "$ver"; then
+    continue
+  fi
+  found=false
+  for pv in "${POOL_VERSIONS[@]}"; do
+    if [[ "$pv" == "$ver" ]]; then
+      found=true
+      break
+    fi
+  done
+  if ! $found; then
+    needed_by=$(echo "$RHDH_DATA" | jq -r --arg v "$ver" '[.[] | select(.supported) | select(.ocp_versions[] == $v) | .version] | join(", ")')
+    echo "  ADD pool: ${ver} (needed by RHDH ${needed_by})"
+    MISSING_POOL_COUNT=$((MISSING_POOL_COUNT + 1))
+    HAS_ACTIONS=true
+  fi
+done <<< "$RHDH_ALL_OCP"
+if [[ $MISSING_POOL_COUNT -eq 0 ]]; then
+  echo "  (none)"
+fi
+echo ""
+
+# 6e. RHDH-supported OCP versions missing test entries per branch
+# Same rule: skip OCP-EOL versions.
+# Iterate RHDH_BRANCH_OCP keys (not BRANCH_VERSIONS) so branches with no
+# existing tests still produce ADD recommendations.
+echo "--- RHDH-Supported OCP Versions Missing Tests (ADD) ---"
+MISSING_TEST_COUNT=0
+for branch in "${!RHDH_BRANCH_OCP[@]}"; do
+  branch_rhdh_ocp="${RHDH_BRANCH_OCP[$branch]}"
+  branch_existing="${BRANCH_VERSIONS[$branch]:-}"
+  for ver in $branch_rhdh_ocp; do
+    # Skip OCP-EOL versions — no test should be added for an EOL OCP
+    if echo "$OCP_EOL" | grep -Fxq "$ver"; then
+      continue
+    fi
+    if [[ -z "$branch_existing" ]] || ! echo "$branch_existing" | tr ' ' '\n' | grep -Fxq "$ver"; then
+      echo "  ADD test: ${ver} to ${branch}"
+      MISSING_TEST_COUNT=$((MISSING_TEST_COUNT + 1))
+      HAS_ACTIONS=true
+    fi
+  done
+done
+if [[ $MISSING_TEST_COUNT -eq 0 ]]; then
+  echo "  (none)"
+fi
+echo ""
+
+# ---------------------------------------------------------------
+# 7. Summary
+# ---------------------------------------------------------------
+echo "========================================================"
+echo "  Summary"
+echo "========================================================"
+echo ""
+echo "  Pool versions:           $(printf '%s ' "${POOL_VERSIONS[@]}")"
+echo "  Test versions:           $(printf '%s ' "${UNIQUE_TEST_VERSIONS[@]}")"
+echo "  OCP supported:           $(echo "$OCP_SUPPORTED" | tr '\n' ' ')"
+echo "  RHDH-supported OCP:      $(echo "$RHDH_SUPPORTED_OCP" | tr '\n' ' ')"
+echo ""
+
+echo "  RHDH branch -> OCP support (excluding OCP-EOL):"
+for branch in $(echo "${!RHDH_BRANCH_OCP[@]}" | tr ' ' '\n' | sort); do
+  # Filter out OCP-EOL versions from the display
+  active_ocp=""
+  eol_ocp=""
+  for ver in ${RHDH_BRANCH_OCP[$branch]}; do
+    if echo "$OCP_EOL" | grep -Fxq "$ver"; then
+      eol_ocp="${eol_ocp} ${ver}"
+    else
+      active_ocp="${active_ocp} ${ver}"
+    fi
+  done
+  line="    ${branch}:${active_ocp}"
+  if [[ -n "${eol_ocp}" ]]; then
+    line="${line}  (RHDH lists but OCP-EOL:${eol_ocp})"
+  fi
+  echo "$line"
+done
+echo ""
+
+echo "  EOL pools to remove:         ${EOL_POOL_COUNT}"
+echo "  Non-RHDH pools to review:    ${NOTRHDH_POOL_COUNT}"
+echo "  Mismatched tests to review:  ${MISMATCH_TEST_COUNT}"
+echo "  Missing pools to add:        ${MISSING_POOL_COUNT}"
+echo "  Missing tests to add:        ${MISSING_TEST_COUNT}"
+echo ""
+
+if $HAS_ACTIONS; then
+  echo "  Data sources:"
+  echo "    RHDH lifecycle: https://access.redhat.com/support/policy/updates/developerhub"
+  echo "    OCP lifecycle:  https://access.redhat.com/product-life-cycles/?product=OpenShift+Container+Platform+4"
+  echo ""
+  echo "  NOTE: The 'main' branch targets the next unreleased RHDH version."
+  echo "  Its OCP support is estimated as: latest RHDH release's OCP list"
+  echo "  plus any newer OCP versions that have reached GA."
+  echo "  REVIEW items require judgment; REMOVE/ADD items are actionable."
+else
+  echo "  All clear -- no coverage gaps or stale configurations found."
+fi

--- a/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-coverage/scripts/analyze-coverage.sh
+++ b/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-coverage/scripts/analyze-coverage.sh
@@ -111,6 +111,10 @@ echo ""
 echo "--- Test Configs ---"
 # shellcheck disable=SC2206  # Intentional word-splitting on path separators (no spaces in paths)
 dir_parts=(${CI_CONFIG_DIR//\// })
+if [[ ${#dir_parts[@]} -lt 2 ]]; then
+  echo "ERROR: --config-dir must contain at least two path components (got: ${CI_CONFIG_DIR})" >&2
+  exit 1
+fi
 CONFIG_PREFIX="${dir_parts[-2]}-${dir_parts[-1]}-"
 
 declare -A BRANCH_VERSIONS  # branch -> space-separated versions
@@ -149,6 +153,7 @@ echo "--- RHDH Lifecycle ---"
 echo "  Fetching from Red Hat Product Life Cycles API..."
 
 NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+TODAY="${NOW%%T*}"
 
 RHDH_RESPONSE=$(curl -s --fail \
   "${LIFECYCLE_API_URL}?name=Red+Hat+Developer+Hub" \
@@ -210,7 +215,7 @@ if [[ -z "$OCP_RESPONSE" ]]; then
 fi
 
 # Use shared jq filter for OCP phase classification
-OCP_LIFECYCLE=$(echo "$OCP_RESPONSE" | jq --arg now "$NOW" -f "${OCP_LIFECYCLE_JQ}")
+OCP_LIFECYCLE=$(echo "$OCP_RESPONSE" | jq --arg today "$TODAY" -f "${OCP_LIFECYCLE_JQ}")
 
 OCP_SUPPORTED=$(echo "$OCP_LIFECYCLE" | jq -r '[.[] | select(.ocp_supported) | .version] | .[]')
 OCP_EOL=$(echo "$OCP_LIFECYCLE" | jq -r '[.[] | select(.ocp_supported | not) | .version] | .[]')

--- a/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-coverage/scripts/analyze-coverage.sh
+++ b/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-coverage/scripts/analyze-coverage.sh
@@ -22,7 +22,11 @@
 
 set -euo pipefail
 
-# Resolve path to shared jq filter for OCP lifecycle classification
+# Resolve path to the shared jq filter for OCP lifecycle classification.
+# This filter lives in the rhdh-ocp-lifecycle skill and is the single source
+# of truth for OCP phase classification. If that skill is moved or renamed,
+# this path must be updated.
+# See: rhdh-ocp-lifecycle/scripts/ocp-lifecycle.jq
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 OCP_LIFECYCLE_JQ="${SCRIPT_DIR}/../../rhdh-ocp-lifecycle/scripts/ocp-lifecycle.jq"
 
@@ -57,6 +61,13 @@ for cmd in curl jq yq; do
     exit 1
   fi
 done
+
+# Associative arrays require bash 4+; macOS ships bash 3.2 by default.
+if [[ "${BASH_VERSINFO[0]}" -lt 4 ]]; then
+  echo "ERROR: bash 4+ is required (associative arrays). Found: ${BASH_VERSION}" >&2
+  echo "On macOS, install a newer bash: brew install bash" >&2
+  exit 1
+fi
 
 if [[ ! -d "$POOL_DIR" ]]; then
   echo "ERROR: Pool directory not found: ${POOL_DIR}" >&2

--- a/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-lifecycle/OWNERS
+++ b/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-lifecycle/OWNERS
@@ -1,0 +1,25 @@
+approvers:
+- albarbaro
+- christoph-jerolimov
+- davidfestal
+- durandom
+- hopehadfield
+- josephca
+- kadel
+- kim-tsao
+- nickboldt
+- rm3l
+- zaperex
+options: {}
+reviewers:
+- albarbaro
+- christoph-jerolimov
+- davidfestal
+- durandom
+- hopehadfield
+- josephca
+- kadel
+- kim-tsao
+- nickboldt
+- rm3l
+- zaperex

--- a/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-lifecycle/SKILL.md
+++ b/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-lifecycle/SKILL.md
@@ -4,6 +4,7 @@ description: >-
   Check which OCP versions are supported by active RHDH releases and which are
   end-of-life, using the Red Hat Product Life Cycles API for both RHDH and OCP
   lifecycle data including EUS phases. Supports OCP 4.x and future 5.x+
+allowed-tools: Bash(bash *check-ocp-lifecycle.sh*)
 ---
 # Check RHDH and OCP Lifecycle Status
 
@@ -24,6 +25,7 @@ Use this skill when you need to check version support status before:
 
 - `curl` and `jq` must be available
 - Internet connectivity to reach `https://access.redhat.com`
+- `CLAUDE_SKILL_DIR` is set automatically by the Claude Code skill loader. For manual invocation, set it to this skill's directory (e.g., `CLAUDE_SKILL_DIR=ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-lifecycle`)
 
 ## Usage
 
@@ -97,7 +99,7 @@ A JSON object is written to stderr with:
 - **RHDH lifecycle**: `https://access.redhat.com/product-life-cycles/api/v1/products?name=Red+Hat+Developer+Hub`
   - Provides `openshift_compatibility` field per RHDH version (the authoritative source for which OCP versions RHDH supports)
   - Provides lifecycle phase and dates per RHDH version
-- **OCP lifecycle**: `https://access.redhat.com/product-life-cycles/api/v1/products?name=OpenShift+Container+Platform+4`
+- **OCP lifecycle**: `https://access.redhat.com/product-life-cycles/api/v1/products?name=Red+Hat+OpenShift+Container+Platform`
   - Provides lifecycle phase and dates per OCP version (Full, Maintenance, EUS Term 1/2)
 
 ## Key Concepts

--- a/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-lifecycle/SKILL.md
+++ b/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-lifecycle/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: rhdh-ocp-lifecycle
+description: >-
+  Check which OCP versions are supported by active RHDH releases and which are
+  end-of-life, using the Red Hat Product Life Cycles API for both RHDH and OCP
+  lifecycle data including EUS phases. Supports OCP 4.x and future 5.x+
+---
+# Check RHDH and OCP Lifecycle Status
+
+Query the Red Hat Product Life Cycles API to determine:
+- Which RHDH releases are currently supported (Full Support or Maintenance)
+- Which OCP versions each active RHDH release supports
+- Which OCP versions are still supported upstream (including EUS phases)
+
+## When to Use
+
+Use this skill when you need to check version support status before:
+- Adding or removing RHDH cluster pools
+- Adding or removing OCP-versioned CI test entries
+- Planning RHDH release branch OCP coverage
+- Running the `rhdh-ocp-coverage` analysis skill
+
+## Prerequisites
+
+- `curl` and `jq` must be available
+- Internet connectivity to reach `https://access.redhat.com`
+
+## Usage
+
+Run the bundled script from the repository root:
+
+```bash
+bash "${CLAUDE_SKILL_DIR}/scripts/check-ocp-lifecycle.sh"
+```
+
+### Check a specific OCP version
+
+```bash
+bash "${CLAUDE_SKILL_DIR}/scripts/check-ocp-lifecycle.sh" --version 4.16
+```
+
+### Check a specific RHDH version
+
+```bash
+bash "${CLAUDE_SKILL_DIR}/scripts/check-ocp-lifecycle.sh" --rhdh-version 1.9
+```
+
+### Show only RHDH lifecycle (skip OCP table)
+
+```bash
+bash "${CLAUDE_SKILL_DIR}/scripts/check-ocp-lifecycle.sh" --rhdh-only
+```
+
+## Output
+
+### RHDH Lifecycle Table
+
+Shows each RHDH release with:
+
+| Column | Description |
+|--------|-------------|
+| VERSION | RHDH release version (e.g., `1.9`) |
+| SUPPORTED | `yes` or `no` |
+| TYPE | `Full Support`, `Maintenance Support`, or `End of life` |
+| GA_DATE | General Availability date |
+| FULL_SUPPORT_END | End of Full Support phase |
+| MAINTENANCE_END | End of Maintenance Support phase |
+| SUPPORTED_OCP_VERSIONS | OCP versions this RHDH release officially supports |
+
+After the table, a summary shows:
+- The union of OCP versions supported across all active RHDH releases
+- Per-release OCP support breakdown
+
+### OCP Lifecycle Table
+
+Shows each OCP version (4.x and future 5.x+) with two support indicators:
+
+| Column | Description |
+|--------|-------------|
+| VERSION | OCP minor version (e.g., `4.16`) |
+| OCP_SUPP | `yes` if OCP version has upstream support (any phase) |
+| RHDH_SUPP | `yes` if any active RHDH release supports this OCP version |
+| PHASE | Current OCP lifecycle phase |
+| GA_DATE | OCP General Availability date |
+| END_DATE | Latest end-of-support date across all OCP phases |
+
+The **RHDH_SUPP** column is the key indicator for CI coverage decisions. An OCP version should only have cluster pools and test entries if `RHDH_SUPP=yes`.
+
+### JSON Summary (stderr)
+
+A JSON object is written to stderr with:
+- `rhdh_supported_versions`: Array of active RHDH releases with their OCP compatibility
+- `ocp_versions_supported_by_rhdh`: Deduplicated array of OCP versions supported by any active RHDH release
+
+## Data Sources
+
+- **RHDH lifecycle**: `https://access.redhat.com/product-life-cycles/api/v1/products?name=Red+Hat+Developer+Hub`
+  - Provides `openshift_compatibility` field per RHDH version (the authoritative source for which OCP versions RHDH supports)
+  - Provides lifecycle phase and dates per RHDH version
+- **OCP lifecycle**: `https://access.redhat.com/product-life-cycles/api/v1/products?name=OpenShift+Container+Platform+4`
+  - Provides lifecycle phase and dates per OCP version (Full, Maintenance, EUS Term 1/2)
+
+## Key Concepts
+
+- **RHDH-supported OCP versions** are the OCP versions listed in the `openshift_compatibility` field of active RHDH releases. This is the set that should have cluster pools and CI test entries.
+- **OCP-supported versions** include all OCP versions still receiving updates (Full, Maintenance, or EUS). This is a broader set — not all OCP-supported versions are relevant for RHDH.
+- An OCP version can be OCP-supported but not RHDH-supported (e.g., an older EUS version that RHDH has dropped).

--- a/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-lifecycle/scripts/OWNERS
+++ b/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-lifecycle/scripts/OWNERS
@@ -1,0 +1,25 @@
+approvers:
+- albarbaro
+- christoph-jerolimov
+- davidfestal
+- durandom
+- hopehadfield
+- josephca
+- kadel
+- kim-tsao
+- nickboldt
+- rm3l
+- zaperex
+options: {}
+reviewers:
+- albarbaro
+- christoph-jerolimov
+- davidfestal
+- durandom
+- hopehadfield
+- josephca
+- kadel
+- kim-tsao
+- nickboldt
+- rm3l
+- zaperex

--- a/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-lifecycle/scripts/check-ocp-lifecycle.sh
+++ b/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-lifecycle/scripts/check-ocp-lifecycle.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# Check OCP 4.x and RHDH lifecycle status using the Red Hat Product Life Cycles API.
+#
+# Usage:
+#   check-ocp-lifecycle.sh                          # Show all OCP + RHDH versions
+#   check-ocp-lifecycle.sh --version 4.16           # Check a specific OCP version
+#   check-ocp-lifecycle.sh --rhdh-version 1.9       # Check a specific RHDH version
+#   check-ocp-lifecycle.sh --rhdh-only              # Show only RHDH lifecycle + supported OCP
+#
+# Outputs human-readable tables to stdout and JSON summaries to stderr.
+# Requires: curl, jq
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIFECYCLE_API_URL="https://access.redhat.com/product-life-cycles/api/v1/products"
+FILTER_OCP_VERSION=""
+FILTER_RHDH_VERSION=""
+RHDH_ONLY=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version|-v)
+      FILTER_OCP_VERSION="$2"
+      shift 2
+      ;;
+    --rhdh-version)
+      FILTER_RHDH_VERSION="$2"
+      shift 2
+      ;;
+    --rhdh-only)
+      RHDH_ONLY=true
+      shift
+      ;;
+    *)
+      echo "Usage: $0 [--version X.Y] [--rhdh-version X.Y] [--rhdh-only]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+# ---------------------------------------------------------------
+# 1. Fetch RHDH lifecycle data
+# ---------------------------------------------------------------
+RHDH_RESPONSE=$(curl -s --fail \
+  "${LIFECYCLE_API_URL}?name=Red+Hat+Developer+Hub" \
+  -H "Accept: application/json")
+
+if [[ -z "$RHDH_RESPONSE" ]]; then
+  echo "ERROR: Failed to fetch RHDH lifecycle data from Red Hat API" >&2
+  exit 1
+fi
+
+RHDH_DATA=$(echo "$RHDH_RESPONSE" | jq --arg now "$NOW" --arg filter "$FILTER_RHDH_VERSION" '
+  def is_date: . and . != "N/A" and (test("^[0-9]{4}-[0-9]{2}-[0-9]{2}") // false);
+
+  .data[0].versions | map(
+    . as $ver |
+    {
+      version: $ver.name,
+      type: $ver.type,
+      supported: ($ver.type != "End of life"),
+      ga_date: ([$ver.phases[] | select(.name == "General availability") | .end_date | if is_date then split("T")[0] else "N/A" end] | first // "N/A"),
+      full_support_end: ([$ver.phases[] | select(.name == "Full support") | .end_date | if is_date then split("T")[0] else . end] | first // "N/A"),
+      maintenance_end: ([$ver.phases[] | select(.name == "Maintenance support") | .end_date | if is_date then split("T")[0] else . end] | first // "N/A"),
+      ocp_versions: ($ver.openshift_compatibility // "" | split(", ") | map(select(. != ""))),
+    }
+  )
+  | if $filter != "" then map(select(.version == $filter)) else . end
+  | sort_by(.version | split(".") | map(tonumber))
+')
+
+# Print RHDH lifecycle table
+echo "=== RHDH Lifecycle ==="
+echo ""
+printf "%-10s %-10s %-22s %-12s %-25s %-25s %s\n" \
+  "VERSION" "SUPPORTED" "TYPE" "GA_DATE" "FULL_SUPPORT_END" "MAINTENANCE_END" "SUPPORTED_OCP_VERSIONS"
+printf "%-10s %-10s %-22s %-12s %-25s %-25s %s\n" \
+  "-------" "---------" "----" "-------" "----------------" "---------------" "----------------------"
+
+echo "$RHDH_DATA" | jq -r '.[] | [
+  .version,
+  (if .supported then "yes" else "no" end),
+  .type,
+  .ga_date,
+  .full_support_end,
+  .maintenance_end,
+  (.ocp_versions | join(", "))
+] | @tsv' | \
+  while IFS=$'\t' read -r ver sup type ga full maint ocp; do
+    printf "%-10s %-10s %-22s %-12s %-25s %-25s %s\n" "$ver" "$sup" "$type" "$ga" "$full" "$maint" "$ocp"
+  done
+
+echo ""
+
+# Extract the union of OCP versions supported by active RHDH releases
+RHDH_SUPPORTED_OCP=$(echo "$RHDH_DATA" | jq -r '
+  [.[] | select(.supported) | .ocp_versions[]] | unique
+  | sort_by(split(".") | map(tonumber))
+  | .[]
+')
+
+echo "OCP versions supported by active RHDH releases: $(echo "$RHDH_SUPPORTED_OCP" | tr '\n' ' ')"
+echo ""
+
+# Per active RHDH release, show which OCP versions it supports
+echo "Per-release OCP support:"
+echo "$RHDH_DATA" | jq -r '.[] | select(.supported) | "  RHDH \(.version): \(.ocp_versions | join(", "))"'
+echo ""
+
+# ---------------------------------------------------------------
+# 2. Fetch OCP lifecycle data (unless --rhdh-only)
+# ---------------------------------------------------------------
+if ! $RHDH_ONLY; then
+  # Query the umbrella product which contains all OCP versions (4.x and future 5.x+).
+  # The jq filter in ocp-lifecycle.jq handles version filtering (>= 4.x).
+  OCP_RESPONSE=$(curl -s --fail \
+    "${LIFECYCLE_API_URL}?name=Red+Hat+OpenShift+Container+Platform" \
+    -H "Accept: application/json")
+
+  if [[ -z "$OCP_RESPONSE" ]]; then
+    echo "ERROR: Failed to fetch OCP lifecycle data from Red Hat API" >&2
+    exit 1
+  fi
+
+  # Use shared jq filter for OCP phase classification
+  OCP_DATA=$(echo "$OCP_RESPONSE" | jq --arg now "$NOW" -f "${SCRIPT_DIR}/ocp-lifecycle.jq")
+
+  # Apply version filter if specified
+  if [[ -n "$FILTER_OCP_VERSION" ]]; then
+    OCP_DATA=$(echo "$OCP_DATA" | jq --arg filter "$FILTER_OCP_VERSION" 'map(select(.version == $filter))')
+  fi
+
+  if [[ -z "$OCP_DATA" ]] || [[ "$OCP_DATA" == "[]" ]]; then
+    if [[ -n "$FILTER_OCP_VERSION" ]]; then
+      echo "ERROR: OCP version '${FILTER_OCP_VERSION}' not found in lifecycle data" >&2
+      exit 1
+    fi
+    echo "ERROR: No OCP version data found" >&2
+    exit 1
+  fi
+
+  echo "=== OCP Lifecycle ==="
+  echo ""
+  printf "%-10s %-10s %-10s %-35s %-12s %-12s\n" \
+    "VERSION" "OCP_SUPP" "RHDH_SUPP" "PHASE" "GA_DATE" "END_DATE"
+  printf "%-10s %-10s %-10s %-35s %-12s %-12s\n" \
+    "-------" "--------" "---------" "-----" "-------" "--------"
+
+  echo "$OCP_DATA" | jq -r '.[] | [.version, (if .ocp_supported then "yes" else "no" end), .phase, .ga_date, .end_of_support_date] | @tsv' | \
+    while IFS=$'\t' read -r ver sup phase ga end; do
+      rhdh_sup="no"
+      if echo "$RHDH_SUPPORTED_OCP" | grep -qx "$ver"; then
+        rhdh_sup="yes"
+      fi
+      printf "%-10s %-10s %-10s %-35s %-12s %-12s\n" "$ver" "$sup" "$rhdh_sup" "$phase" "$ga" "$end"
+    done
+  echo ""
+fi
+
+# ---------------------------------------------------------------
+# 3. JSON summary to stderr
+# ---------------------------------------------------------------
+RHDH_SUPPORTED_JSON=$(echo "$RHDH_DATA" | jq '[.[] | select(.supported)]')
+RHDH_EOL_JSON=$(echo "$RHDH_DATA" | jq '[.[] | select(.supported | not)]')
+RHDH_OCP_JSON=$(echo "$RHDH_SUPPORTED_OCP" | jq -R -s 'split("\n") | map(select(. != ""))')
+
+SUMMARY=$(jq -n \
+  --argjson rhdh_supported "$RHDH_SUPPORTED_JSON" \
+  --argjson rhdh_eol "$RHDH_EOL_JSON" \
+  --argjson rhdh_supported_ocp "$RHDH_OCP_JSON" \
+  --arg checked_at "$NOW" \
+  '{
+    checked_at: $checked_at,
+    rhdh_supported_count: ($rhdh_supported | length),
+    rhdh_eol_count: ($rhdh_eol | length),
+    rhdh_supported_versions: $rhdh_supported,
+    rhdh_eol_versions: $rhdh_eol,
+    ocp_versions_supported_by_rhdh: $rhdh_supported_ocp
+  }')
+
+echo "$SUMMARY" >&2

--- a/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-lifecycle/scripts/check-ocp-lifecycle.sh
+++ b/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-lifecycle/scripts/check-ocp-lifecycle.sh
@@ -40,6 +40,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+TODAY="${NOW%%T*}"
 
 # ---------------------------------------------------------------
 # 1. Fetch RHDH lifecycle data
@@ -71,6 +72,11 @@ RHDH_DATA=$(echo "$RHDH_RESPONSE" | jq --arg now "$NOW" --arg filter "$FILTER_RH
   | if $filter != "" then map(select(.version == $filter)) else . end
   | sort_by(.version | split(".") | map(tonumber))
 ')
+
+if [[ -n "$FILTER_RHDH_VERSION" ]] && jq -e 'length == 0' <<<"$RHDH_DATA" >/dev/null; then
+  echo "ERROR: RHDH version '${FILTER_RHDH_VERSION}' not found in lifecycle data" >&2
+  exit 1
+fi
 
 # Print RHDH lifecycle table
 echo "=== RHDH Lifecycle ==="
@@ -126,7 +132,7 @@ if ! $RHDH_ONLY; then
   fi
 
   # Use shared jq filter for OCP phase classification
-  OCP_DATA=$(echo "$OCP_RESPONSE" | jq --arg now "$NOW" -f "${SCRIPT_DIR}/ocp-lifecycle.jq")
+  OCP_DATA=$(echo "$OCP_RESPONSE" | jq --arg today "$TODAY" -f "${SCRIPT_DIR}/ocp-lifecycle.jq")
 
   # Apply version filter if specified
   if [[ -n "$FILTER_OCP_VERSION" ]]; then

--- a/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-lifecycle/scripts/ocp-lifecycle.jq
+++ b/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-lifecycle/scripts/ocp-lifecycle.jq
@@ -6,7 +6,7 @@
 # Supports OCP 4.x and future 5.x+ versions. Filters out non-X.Y names
 # (e.g., "3", "4.6 EUS") and versions older than 4.1.
 #
-# Requires --arg now "<ISO8601 timestamp>" to be passed to jq.
+# Requires --arg today "YYYY-MM-DD" to be passed to jq.
 #
 # This filter is the single source of truth for OCP phase classification.
 # It is used by:
@@ -15,10 +15,10 @@
 # If this file is moved or renamed, update both consumers.
 #
 # Usage:
-#   jq --arg now "$NOW" -f ocp-lifecycle.jq <<< "$API_RESPONSE"
+#   jq --arg today "$(date -u +%Y-%m-%d)" -f ocp-lifecycle.jq <<< "$API_RESPONSE"
 
 def is_date: . and . != "N/A" and (test("^[0-9]{4}-[0-9]{2}-[0-9]{2}") // false);
-def parse_date: if is_date then . | split("T")[0] + "T00:00:00Z" else null end;
+def to_date: if is_date then split("T")[0] else null end;
 
 .data[0].versions
 # Keep only clean X.Y version names, skip variants like "4.6 EUS" or bare "3"
@@ -30,20 +30,20 @@ def parse_date: if is_date then . | split("T")[0] + "T00:00:00Z" else null end;
   ["Extended update support Term 2", "Extended update support", "Maintenance support", "Full support"] as $phase_order |
 
   # Find latest end-of-support date across all support phases
-  ([$ver.phases[] | select(.name == ($phase_order[])) | .end_date | select(is_date) | parse_date] | sort | last // null) as $end_of_support |
+  ([$ver.phases[] | select(.name == ($phase_order[])) | .end_date | select(is_date) | to_date] | sort | last // null) as $end_of_support |
 
   # GA date
   ($ver.phases | map(select(.name == "General availability")) | first // {} | .end_date // "N/A") as $ga_raw |
 
-  # Determine current phase
+  # Determine current phase (date-only comparison so the final day is fully inclusive)
   (
     $phase_order | map(. as $pname |
       $ver.phases[] | select(.name == $pname) |
-      (.start_date | parse_date) as $start |
+      (.start_date | to_date) as $start |
       (.end_date) as $end_raw |
-      (.end_date | parse_date) as $end |
-      if $start and ($start <= $now) then
-        if $end and ($end >= $now) then $pname
+      (.end_date | to_date) as $end |
+      if $start and ($start <= $today) then
+        if $end and ($end >= $today) then $pname
         elif ($end_raw | is_date | not) and $end_raw != "N/A" and $end_raw != "" and $end_raw != null then $pname
         else empty end
       else empty end
@@ -55,7 +55,7 @@ def parse_date: if is_date then . | split("T")[0] + "T00:00:00Z" else null end;
     ocp_supported: ($current_phase != "End of life"),
     phase: $current_phase,
     ga_date: (if ($ga_raw | is_date) then $ga_raw | split("T")[0] else "N/A" end),
-    end_of_support_date: (if $end_of_support then $end_of_support | split("T")[0] else "N/A" end)
+    end_of_support_date: (if $end_of_support then $end_of_support else "N/A" end)
   }
 )
 | sort_by(.version | split(".") | map(tonumber))

--- a/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-lifecycle/scripts/ocp-lifecycle.jq
+++ b/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-lifecycle/scripts/ocp-lifecycle.jq
@@ -1,0 +1,55 @@
+# Shared jq filter for classifying OCP lifecycle versions.
+# Reads the raw API response (.data[0].versions) and outputs an array of
+# {version, ocp_supported, phase, ga_date, end_of_support_date} objects,
+# sorted by version.
+#
+# Supports OCP 4.x and future 5.x+ versions. Filters out non-X.Y names
+# (e.g., "3", "4.6 EUS") and versions older than 4.1.
+#
+# Requires --arg now "<ISO8601 timestamp>" to be passed to jq.
+#
+# Usage:
+#   jq --arg now "$NOW" -f ocp-lifecycle.jq <<< "$API_RESPONSE"
+
+def is_date: . and . != "N/A" and (test("^[0-9]{4}-[0-9]{2}-[0-9]{2}") // false);
+def parse_date: if is_date then . | split("T")[0] + "T00:00:00Z" else null end;
+
+.data[0].versions
+# Keep only clean X.Y version names, skip variants like "4.6 EUS" or bare "3"
+| map(select(.name | test("^[0-9]+\\.[0-9]+$")))
+# Filter to OCP 4.x and above (future-proof for 5.x+)
+| map(select(.name | split(".") | map(tonumber) | .[0] >= 4))
+| map(
+  . as $ver |
+  ["Extended update support Term 2", "Extended update support", "Maintenance support", "Full support"] as $phase_order |
+
+  # Find latest end-of-support date across all support phases
+  ([$ver.phases[] | select(.name == ($phase_order[])) | .end_date | select(is_date) | parse_date] | sort | last // null) as $end_of_support |
+
+  # GA date
+  ($ver.phases | map(select(.name == "General availability")) | first // {} | .end_date // "N/A") as $ga_raw |
+
+  # Determine current phase
+  (
+    $phase_order | map(. as $pname |
+      $ver.phases[] | select(.name == $pname) |
+      (.start_date | parse_date) as $start |
+      (.end_date) as $end_raw |
+      (.end_date | parse_date) as $end |
+      if $start and ($start <= $now) then
+        if $end and ($end >= $now) then $pname
+        elif ($end_raw | is_date | not) and $end_raw != "N/A" and $end_raw != "" and $end_raw != null then $pname
+        else empty end
+      else empty end
+    ) | first // "End of life"
+  ) as $current_phase |
+
+  {
+    version: $ver.name,
+    ocp_supported: ($current_phase != "End of life"),
+    phase: $current_phase,
+    ga_date: (if ($ga_raw | is_date) then $ga_raw | split("T")[0] else "N/A" end),
+    end_of_support_date: (if $end_of_support then $end_of_support | split("T")[0] else "N/A" end)
+  }
+)
+| sort_by(.version | split(".") | map(tonumber))

--- a/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-lifecycle/scripts/ocp-lifecycle.jq
+++ b/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-lifecycle/scripts/ocp-lifecycle.jq
@@ -8,6 +8,12 @@
 #
 # Requires --arg now "<ISO8601 timestamp>" to be passed to jq.
 #
+# This filter is the single source of truth for OCP phase classification.
+# It is used by:
+#   - rhdh-ocp-lifecycle/scripts/check-ocp-lifecycle.sh (same skill)
+#   - rhdh-ocp-coverage/scripts/analyze-coverage.sh (sibling skill)
+# If this file is moved or renamed, update both consumers.
+#
 # Usage:
 #   jq --arg now "$NOW" -f ocp-lifecycle.jq <<< "$API_RESPONSE"
 

--- a/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-pool/OWNERS
+++ b/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-pool/OWNERS
@@ -1,0 +1,25 @@
+approvers:
+- albarbaro
+- christoph-jerolimov
+- davidfestal
+- durandom
+- hopehadfield
+- josephca
+- kadel
+- kim-tsao
+- nickboldt
+- rm3l
+- zaperex
+options: {}
+reviewers:
+- albarbaro
+- christoph-jerolimov
+- davidfestal
+- durandom
+- hopehadfield
+- josephca
+- kadel
+- kim-tsao
+- nickboldt
+- rm3l
+- zaperex

--- a/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-pool/SKILL.md
+++ b/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-pool/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   List existing RHDH OCP Hive ClusterPool configurations and generate new pool
   YAML for a target OCP version, with imageSetRef aligned from other pools in
   the openshift/release repository. Covers OCP pools only, not K8s platforms
-allowed-tools: Read, Bash(bash *list-cluster-pools.sh*), Bash(bash *generate-cluster-pool.sh*), Bash(rm *_clusterpool.yaml)
+allowed-tools: Read, Bash(bash *list-cluster-pools.sh*), Bash(bash *generate-cluster-pool.sh*), Bash(rm clusters/hosted-mgmt/hive/pools/rhdh/*_clusterpool.yaml)
 ---
 # RHDH OCP Cluster Pool Management
 

--- a/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-pool/SKILL.md
+++ b/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-pool/SKILL.md
@@ -4,6 +4,7 @@ description: >-
   List existing RHDH OCP Hive ClusterPool configurations and generate new pool
   YAML for a target OCP version, with imageSetRef aligned from other pools in
   the openshift/release repository. Covers OCP pools only, not K8s platforms
+allowed-tools: Read, Bash(bash *list-cluster-pools.sh*), Bash(bash *generate-cluster-pool.sh*), Bash(rm *_clusterpool.yaml)
 ---
 # RHDH OCP Cluster Pool Management
 
@@ -21,6 +22,7 @@ Use this skill when you need to:
 
 - `yq` (v4+) must be available for YAML parsing
 - Working directory must be the root of the `openshift/release` repository
+- `CLAUDE_SKILL_DIR` is set automatically by the Claude Code skill loader. For manual invocation, set it to this skill's directory (e.g., `CLAUDE_SKILL_DIR=ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-pool`)
 
 ## Listing Cluster Pools
 
@@ -57,6 +59,14 @@ bash "${CLAUDE_SKILL_DIR}/scripts/generate-cluster-pool.sh" --version 4.22
 ```bash
 bash "${CLAUDE_SKILL_DIR}/scripts/generate-cluster-pool.sh" --version 4.22 --reference 4.21
 ```
+
+### Preview without writing (dry-run)
+
+```bash
+bash "${CLAUDE_SKILL_DIR}/scripts/generate-cluster-pool.sh" --version 4.22 --dry-run
+```
+
+With `--dry-run`, the script outputs the generated YAML to stdout but does not write the file to disk. Use this to review the output before committing to the change.
 
 ### What the script does
 

--- a/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-pool/SKILL.md
+++ b/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-pool/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: rhdh-ocp-pool
+description: >-
+  List existing RHDH OCP Hive ClusterPool configurations and generate new pool
+  YAML for a target OCP version, with imageSetRef aligned from other pools in
+  the openshift/release repository. Covers OCP pools only, not K8s platforms
+---
+# RHDH OCP Cluster Pool Management
+
+List and manage OCP Hive ClusterPool configurations for RHDH in the `openshift/release` repository. This skill covers OCP cluster pools only — K8s platform clusters (AKS, EKS, GKE) are provisioned via MAPT and OSD-GCP via a separate claim workflow.
+
+## When to Use
+
+Use this skill when you need to:
+- List current RHDH cluster pools and their OCP versions
+- Generate a new cluster pool YAML for a new OCP version
+- Review cluster pool capacity (size, maxSize, runningCount)
+- Remove a cluster pool for an end-of-life OCP version
+
+## Prerequisites
+
+- `yq` (v4+) must be available for YAML parsing
+- Working directory must be the root of the `openshift/release` repository
+
+## Listing Cluster Pools
+
+Run the bundled script from the repository root:
+
+```bash
+bash "${CLAUDE_SKILL_DIR}/scripts/list-cluster-pools.sh"
+```
+
+### Output format
+
+The script outputs a table with columns:
+
+| Column | Description |
+|--------|-------------|
+| VERSION | OCP minor version (e.g., `4.18`) |
+| POOL_NAME | Hive ClusterPool resource name |
+| SIZE | Desired pool size |
+| MAX | Maximum pool size |
+| RUNNING | Number of clusters kept running (hibernation bypass) |
+| IMAGE_SET | ClusterImageSet reference name |
+| FILENAME | Pool YAML filename |
+
+## Generating a New Cluster Pool
+
+Use the bundled generation script:
+
+```bash
+bash "${CLAUDE_SKILL_DIR}/scripts/generate-cluster-pool.sh" --version 4.22
+```
+
+### With a specific reference pool
+
+```bash
+bash "${CLAUDE_SKILL_DIR}/scripts/generate-cluster-pool.sh" --version 4.22 --reference 4.21
+```
+
+### What the script does
+
+1. **Looks up the `imageSetRef`** by scanning ALL cluster pools across the entire `clusters/hosted-mgmt/hive/pools/` directory (not just RHDH pools). This ensures alignment with other teams' pools for the same OCP version.
+2. **Copies an existing RHDH pool** as a structural template (defaults to the latest, or use `--reference` to pick one).
+3. **Updates version-specific fields**: `version`, `version_lower`, `version_upper`, pool `name`, and `imageSetRef`.
+4. **Sets conservative sizing**: `size: 1`, `maxSize: 2`, no `runningCount`.
+5. **Writes the file** directly to `clusters/hosted-mgmt/hive/pools/rhdh/`.
+6. **Prints the generated YAML** to stdout for review.
+
+### Error cases
+
+- If no existing pool in the repo uses the target OCP version, the script **errors out** rather than guessing a patch version. This means the OCP version hasn't been released yet or image sets haven't been added to the repo.
+- If an RHDH pool for the target version already exists, the script errors out.
+
+### imageSetRef alignment
+
+The `imageSetRef.name` follows the pattern:
+```
+ocp-release-<major>.<minor>.<patch>-multi-for-<major>.<minor>.0-0-to-<next_major>.<next_minor>.0-0
+```
+
+The patch version (e.g., `4.14.63`) is determined by what other pools in the repo already use, not by guessing. All pools for a given OCP version across all teams use the same imageSetRef.
+
+## Removing a Cluster Pool
+
+To remove a cluster pool for an end-of-life OCP version:
+
+1. Delete the `*_clusterpool.yaml` file
+2. Verify no CI jobs still reference this pool's version via `cluster_claim.version`
+3. Use the `rhdh-ocp-tests` skill to check for and remove any remaining OCP test entries
+
+## File Layout
+
+All cluster pool files live in:
+```
+clusters/hosted-mgmt/hive/pools/rhdh/
+├── OWNERS                                                    # Approvers/reviewers
+├── admins_rhdh-cluster-pool_rbac.yaml                        # RBAC for pool admins
+├── rhdh-aws-us-east-2.yaml                                   # Install config secret template
+└── rhdh-ocp-<major>-<minor>-0-amd64-aws-us-east-2_clusterpool.yaml  # One per OCP version
+```
+
+## Key Details
+
+- **Region**: All RHDH pools use `us-east-2`
+- **Architecture**: `amd64`
+- **Base domain**: `rhdh-qe.devcluster.openshift.com`
+- **Worker nodes**: `m6i.2xlarge` (configured in `rhdh-aws-us-east-2` install config)
+- **Credentials**: `rhdh-aws-credentials` secret
+- **Namespace**: `rhdh-cluster-pool`

--- a/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-pool/scripts/OWNERS
+++ b/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-pool/scripts/OWNERS
@@ -1,0 +1,25 @@
+approvers:
+- albarbaro
+- christoph-jerolimov
+- davidfestal
+- durandom
+- hopehadfield
+- josephca
+- kadel
+- kim-tsao
+- nickboldt
+- rm3l
+- zaperex
+options: {}
+reviewers:
+- albarbaro
+- christoph-jerolimov
+- davidfestal
+- durandom
+- hopehadfield
+- josephca
+- kadel
+- kim-tsao
+- nickboldt
+- rm3l
+- zaperex

--- a/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-pool/scripts/generate-cluster-pool.sh
+++ b/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-pool/scripts/generate-cluster-pool.sh
@@ -20,6 +20,7 @@ POOL_DIR="clusters/hosted-mgmt/hive/pools/rhdh"
 ALL_POOLS_DIR="clusters/hosted-mgmt/hive/pools"
 OCP_VERSION=""
 REFERENCE_VERSION=""
+DRY_RUN=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -39,8 +40,12 @@ while [[ $# -gt 0 ]]; do
       ALL_POOLS_DIR="$2"
       shift 2
       ;;
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
     *)
-      echo "Usage: $0 --version X.Y [--reference X.Y] [--pool-dir <path>] [--all-pools-dir <path>]" >&2
+      echo "Usage: $0 --version X.Y [--reference X.Y] [--dry-run] [--pool-dir <path>] [--all-pools-dir <path>]" >&2
       exit 1
       ;;
   esac
@@ -133,8 +138,15 @@ echo "Using reference pool: $(basename "$REF_FILE") (OCP ${REFERENCE_VERSION})" 
 # 3. Generate the new pool YAML
 # ---------------------------------------------------------------
 
-# Start with a copy of the reference
-cp "$REF_FILE" "$TARGET_FILE"
+if $DRY_RUN; then
+  # Dry-run: transform in a temp file, print to stdout, don't write to target
+  WORK_FILE=$(mktemp)
+  trap 'rm -f "$WORK_FILE"' EXIT
+  cp "$REF_FILE" "$WORK_FILE"
+else
+  cp "$REF_FILE" "$TARGET_FILE"
+  WORK_FILE="$TARGET_FILE"
+fi
 
 # Update version-specific fields
 yq -i "
@@ -146,10 +158,15 @@ yq -i "
   .spec.size = 1 |
   .spec.maxSize = 2 |
   del(.spec.runningCount)
-" "$TARGET_FILE"
+" "$WORK_FILE"
 
 echo "" >&2
-echo "Generated: ${TARGET_FILE}" >&2
+if $DRY_RUN; then
+  echo "Dry-run: showing generated YAML (no file written)" >&2
+  echo "Target would be: ${TARGET_FILE}" >&2
+else
+  echo "Generated: ${TARGET_FILE}" >&2
+fi
 echo "" >&2
 echo "Fields set:" >&2
 echo "  metadata.labels.version:      ${OCP_VERSION}" >&2
@@ -163,5 +180,5 @@ echo "  spec.runningCount:            (removed — lean start)" >&2
 echo "" >&2
 echo "imageSetRef aligned with other pools in the repo." >&2
 
-# Print the generated file to stdout
-cat "$TARGET_FILE"
+# Print the generated YAML to stdout
+cat "$WORK_FILE"

--- a/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-pool/scripts/generate-cluster-pool.sh
+++ b/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-pool/scripts/generate-cluster-pool.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# Generate a new RHDH Hive ClusterPool YAML for a target OCP version.
+#
+# The imageSetRef is looked up from existing cluster pools across the entire
+# openshift/release repository (not just RHDH pools) to ensure alignment.
+# If no pool for the target version exists anywhere in the repo, the script
+# errors out rather than guessing a patch version.
+#
+# Usage:
+#   generate-cluster-pool.sh --version 4.22
+#   generate-cluster-pool.sh --version 4.22 --reference 4.21
+#   generate-cluster-pool.sh --version 4.22 --pool-dir <path> --all-pools-dir <path>
+#
+# Must be run from the root of the openshift/release repository.
+# Requires: yq (v4+)
+
+set -euo pipefail
+
+POOL_DIR="clusters/hosted-mgmt/hive/pools/rhdh"
+ALL_POOLS_DIR="clusters/hosted-mgmt/hive/pools"
+OCP_VERSION=""
+REFERENCE_VERSION=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version|-v)
+      OCP_VERSION="$2"
+      shift 2
+      ;;
+    --reference|-r)
+      REFERENCE_VERSION="$2"
+      shift 2
+      ;;
+    --pool-dir|-d)
+      POOL_DIR="$2"
+      shift 2
+      ;;
+    --all-pools-dir)
+      ALL_POOLS_DIR="$2"
+      shift 2
+      ;;
+    *)
+      echo "Usage: $0 --version X.Y [--reference X.Y] [--pool-dir <path>] [--all-pools-dir <path>]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$OCP_VERSION" ]]; then
+  echo "ERROR: --version is required (e.g., --version 4.22)" >&2
+  exit 1
+fi
+
+if ! echo "$OCP_VERSION" | grep -qE '^[0-9]+\.[0-9]+$'; then
+  echo "ERROR: Version must be in X.Y format (e.g., 4.22), got: ${OCP_VERSION}" >&2
+  exit 1
+fi
+
+if ! command -v yq &>/dev/null; then
+  echo "ERROR: yq (v4+) is required but not found" >&2
+  exit 1
+fi
+
+if [[ ! -d "$POOL_DIR" ]]; then
+  echo "ERROR: Pool directory not found: ${POOL_DIR}" >&2
+  exit 1
+fi
+
+MAJOR="${OCP_VERSION%%.*}"
+MINOR="${OCP_VERSION#*.}"
+NEXT_MINOR=$((MINOR + 1))
+DASH_VER="${MAJOR}-${MINOR}"
+TARGET_FILE="${POOL_DIR}/rhdh-ocp-${DASH_VER}-0-amd64-aws-us-east-2_clusterpool.yaml"
+
+# Check if target already exists
+if [[ -f "$TARGET_FILE" ]]; then
+  echo "ERROR: Cluster pool already exists: ${TARGET_FILE}" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------
+# 1. Find the imageSetRef from existing pools across the ENTIRE repo
+# ---------------------------------------------------------------
+echo "Looking up imageSetRef for OCP ${OCP_VERSION} across ${ALL_POOLS_DIR}/ ..." >&2
+
+# Search all cluster pool YAML files for an imageSetRef matching the target version
+IMAGE_SET_REF=""
+if [[ -d "$ALL_POOLS_DIR" ]]; then
+  IMAGE_SET_REF=$(grep -rh "name: ocp-release-${MAJOR}\.${MINOR}\." \
+    "${ALL_POOLS_DIR}/" --include="*_clusterpool.yaml" 2>/dev/null | \
+    sed 's/^[[:space:]]*//' | sed 's/^name: //' | \
+    sort -V | tail -1 || true)
+fi
+
+if [[ -z "$IMAGE_SET_REF" ]]; then
+  echo "ERROR: No existing cluster pool in the repo uses OCP ${OCP_VERSION}." >&2
+  echo "Cannot determine the correct imageSetRef. A ClusterImageSet for ${OCP_VERSION}" >&2
+  echo "must exist on the cluster before a pool can be created." >&2
+  echo "" >&2
+  echo "Check if OCP ${OCP_VERSION} has been released and image sets have been" >&2
+  echo "added to the repo. You can search with:" >&2
+  echo "  grep -r 'ocp-release-${MAJOR}.${MINOR}' ${ALL_POOLS_DIR}/" >&2
+  exit 1
+fi
+
+echo "Found imageSetRef: ${IMAGE_SET_REF}" >&2
+
+# ---------------------------------------------------------------
+# 2. Find the reference RHDH pool to use as template
+# ---------------------------------------------------------------
+if [[ -n "$REFERENCE_VERSION" ]]; then
+  REF_MAJOR="${REFERENCE_VERSION%%.*}"
+  REF_MINOR="${REFERENCE_VERSION#*.}"
+  REF_FILE="${POOL_DIR}/rhdh-ocp-${REF_MAJOR}-${REF_MINOR}-0-amd64-aws-us-east-2_clusterpool.yaml"
+  if [[ ! -f "$REF_FILE" ]]; then
+    echo "ERROR: Reference pool not found: ${REF_FILE}" >&2
+    exit 1
+  fi
+else
+  # Use the latest existing RHDH pool as template
+  REF_FILE=$(find "$POOL_DIR" -name '*_clusterpool.yaml' -type f | sort -V | tail -1)
+  if [[ -z "$REF_FILE" ]]; then
+    echo "ERROR: No existing cluster pool files found in ${POOL_DIR}" >&2
+    exit 1
+  fi
+  # Extract reference version from the file
+  REFERENCE_VERSION=$(yq '.metadata.labels.version' "$REF_FILE" 2>/dev/null)
+fi
+
+echo "Using reference pool: $(basename "$REF_FILE") (OCP ${REFERENCE_VERSION})" >&2
+
+# ---------------------------------------------------------------
+# 3. Generate the new pool YAML
+# ---------------------------------------------------------------
+
+# Start with a copy of the reference
+cp "$REF_FILE" "$TARGET_FILE"
+
+# Update version-specific fields
+yq -i "
+  .metadata.labels.version = \"${OCP_VERSION}\" |
+  .metadata.labels.version_lower = \"${MAJOR}.${MINOR}.0-0\" |
+  .metadata.labels.version_upper = \"${MAJOR}.${NEXT_MINOR}.0-0\" |
+  .metadata.name = \"rhdh-${DASH_VER}-us-east-2\" |
+  .spec.imageSetRef.name = \"${IMAGE_SET_REF}\" |
+  .spec.size = 1 |
+  .spec.maxSize = 2 |
+  del(.spec.runningCount)
+" "$TARGET_FILE"
+
+echo "" >&2
+echo "Generated: ${TARGET_FILE}" >&2
+echo "" >&2
+echo "Fields set:" >&2
+echo "  metadata.labels.version:      ${OCP_VERSION}" >&2
+echo "  metadata.labels.version_lower: ${MAJOR}.${MINOR}.0-0" >&2
+echo "  metadata.labels.version_upper: ${MAJOR}.${NEXT_MINOR}.0-0" >&2
+echo "  metadata.name:                rhdh-${DASH_VER}-us-east-2" >&2
+echo "  spec.imageSetRef.name:        ${IMAGE_SET_REF}" >&2
+echo "  spec.size:                    1" >&2
+echo "  spec.maxSize:                 2" >&2
+echo "  spec.runningCount:            (removed — lean start)" >&2
+echo "" >&2
+echo "imageSetRef aligned with other pools in the repo." >&2
+
+# Print the generated file to stdout
+cat "$TARGET_FILE"

--- a/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-pool/scripts/list-cluster-pools.sh
+++ b/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-pool/scripts/list-cluster-pools.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# List all RHDH Hive ClusterPool configurations from local YAML files.
+#
+# Usage:
+#   list-cluster-pools.sh                       # Default RHDH pool dir
+#   list-cluster-pools.sh --pool-dir <path>     # Custom pool directory
+#
+# Must be run from the root of the openshift/release repository.
+# Requires: yq (v4+)
+
+set -euo pipefail
+
+POOL_DIR="clusters/hosted-mgmt/hive/pools/rhdh"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --pool-dir|-d)
+      POOL_DIR="$2"
+      shift 2
+      ;;
+    *)
+      echo "Usage: $0 [--pool-dir <path>]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ ! -d "$POOL_DIR" ]]; then
+  echo "ERROR: Pool directory not found: ${POOL_DIR}" >&2
+  echo "Are you running from the root of the openshift/release repository?" >&2
+  exit 1
+fi
+
+# Check for yq
+if ! command -v yq &>/dev/null; then
+  echo "ERROR: yq (v4+) is required but not found" >&2
+  exit 1
+fi
+
+# Find all cluster pool files
+POOL_FILES=()
+while IFS= read -r f; do
+  POOL_FILES+=("$f")
+done < <(find "$POOL_DIR" -name '*_clusterpool.yaml' -type f | sort)
+
+if [[ ${#POOL_FILES[@]} -eq 0 ]]; then
+  echo "No cluster pool files found in ${POOL_DIR}" >&2
+  exit 0
+fi
+
+# Print table header
+printf "%-10s %-25s %-6s %-6s %-8s %-65s %s\n" \
+  "VERSION" "POOL_NAME" "SIZE" "MAX" "RUNNING" "IMAGE_SET" "FILENAME"
+printf "%-10s %-25s %-6s %-6s %-8s %-65s %s\n" \
+  "-------" "---------" "----" "---" "-------" "---------" "--------"
+
+# Parse each pool file and output a row
+# Collect output into an array for sorting
+declare -a ROWS=()
+
+for pool_file in "${POOL_FILES[@]}"; do
+  filename=$(basename "$pool_file")
+
+  version=$(yq '.metadata.labels.version' "$pool_file" 2>/dev/null || echo "unknown")
+  pool_name=$(yq '.metadata.name' "$pool_file" 2>/dev/null || echo "unknown")
+  size=$(yq '.spec.size // 0' "$pool_file" 2>/dev/null || echo "0")
+  max_size=$(yq '.spec.maxSize // 0' "$pool_file" 2>/dev/null || echo "0")
+  running=$(yq '.spec.runningCount // 0' "$pool_file" 2>/dev/null || echo "0")
+  image_set=$(yq '.spec.imageSetRef.name // "N/A"' "$pool_file" 2>/dev/null || echo "N/A")
+
+  ROWS+=("$(printf "%-10s %-25s %-6s %-6s %-8s %-65s %s" \
+    "$version" "$pool_name" "$size" "$max_size" "$running" "$image_set" "$filename")")
+done
+
+# Sort by version and print
+printf '%s\n' "${ROWS[@]}" | sort -t. -k1,1n -k2,2n
+
+# Print summary to stderr
+echo "" >&2
+echo "Total pools: ${#POOL_FILES[@]}" >&2
+echo "Pool directory: ${POOL_DIR}" >&2

--- a/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-tests/OWNERS
+++ b/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-tests/OWNERS
@@ -1,0 +1,25 @@
+approvers:
+- albarbaro
+- christoph-jerolimov
+- davidfestal
+- durandom
+- hopehadfield
+- josephca
+- kadel
+- kim-tsao
+- nickboldt
+- rm3l
+- zaperex
+options: {}
+reviewers:
+- albarbaro
+- christoph-jerolimov
+- davidfestal
+- durandom
+- hopehadfield
+- josephca
+- kadel
+- kim-tsao
+- nickboldt
+- rm3l
+- zaperex

--- a/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-tests/SKILL.md
+++ b/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-tests/SKILL.md
@@ -4,6 +4,7 @@ description: >-
   List, generate, add, and remove OCP-versioned test entries (e2e-ocp-*) in RHDH
   ci-operator config files. Covers only OCP cluster-claim tests, not K8s platform
   tests (AKS, EKS, GKE, OSD)
+allowed-tools: Read, Edit, Bash(bash *list-ocp-test-configs.sh*), Bash(bash *generate-test-entry.sh*), Bash(*make update*)
 ---
 # RHDH OCP Test Management
 
@@ -21,6 +22,7 @@ Use this skill when you need to:
 
 - `yq` (v4+) must be available for YAML parsing
 - Working directory must be the root of the `openshift/release` repository
+- `CLAUDE_SKILL_DIR` is set automatically by the Claude Code skill loader. For manual invocation, set it to this skill's directory (e.g., `CLAUDE_SKILL_DIR=ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-tests`)
 
 ## Important: Branch Terminology
 

--- a/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-tests/SKILL.md
+++ b/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-tests/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: rhdh-ocp-tests
+description: >-
+  List, generate, add, and remove OCP-versioned test entries (e2e-ocp-*) in RHDH
+  ci-operator config files. Covers only OCP cluster-claim tests, not K8s platform
+  tests (AKS, EKS, GKE, OSD)
+---
+# RHDH OCP Test Management
+
+Manage OCP-specific test entries in RHDH ci-operator configuration files. This skill covers tests that use OCP cluster claims (`cluster_claim.version`), not K8s platform tests (AKS, EKS, GKE, OSD-GCP) which use different provisioning workflows.
+
+## When to Use
+
+Use this skill when you need to:
+- List which OCP versions have helm-nightly test entries per RHDH release branch
+- Add a new OCP version test entry to a config file
+- Remove an end-of-life OCP version test entry from a config file
+- Generate a test entry YAML block for review before adding it
+
+## Prerequisites
+
+- `yq` (v4+) must be available for YAML parsing
+- Working directory must be the root of the `openshift/release` repository
+
+## Important: Branch Terminology
+
+**"Branch" refers to the RHDH product branch encoded in the config filename** (e.g., `main`, `release-1.8`, `release-1.9`), **NOT** a git branch in the `openshift/release` repo. All CI config files live on the `main` git branch of `openshift/release`.
+
+| Config filename | Product branch | Git branch |
+|----------------|----------------|------------|
+| `redhat-developer-rhdh-main.yaml` | `main` | `main` |
+| `redhat-developer-rhdh-release-1.9.yaml` | `release-1.9` | `main` |
+| `redhat-developer-rhdh-release-1.8.yaml` | `release-1.8` | `main` |
+
+## Listing OCP Test Configs
+
+Run the bundled script from the repository root:
+
+```bash
+bash "${CLAUDE_SKILL_DIR}/scripts/list-ocp-test-configs.sh"
+```
+
+### Filter by product branch
+
+```bash
+bash "${CLAUDE_SKILL_DIR}/scripts/list-ocp-test-configs.sh" --branch main
+```
+
+### Output format
+
+The script extracts OCP versions from `cluster_claim.version` in each test entry (the source of truth), not from test names. This catches all OCP-targeted tests, including ones that don't encode the version in their name (e.g., `e2e-ocp-helm-nightly` targets 4.18).
+
+```
+=== Branch: main ===
+TEST_NAME                                      OCP_VERSION   CRON                           OPTIONAL
+e2e-ocp-helm                                   4.18          N/A                            false
+e2e-ocp-helm-nightly                           4.18          0 4 * * *                      true
+e2e-ocp-v4-19-helm-nightly                     4.19          0 5 * * TUE,THU,SAT,SUN        true
+e2e-ocp-v4-20-helm-nightly                     4.20          0 5 * * TUE,THU,SAT,SUN        true
+e2e-ocp-v4-21-helm-nightly                     4.21          0 2 * * TUE,THU,SAT,SUN        true
+e2e-ocp-operator-nightly                       4.18          0 5 * * TUE,THU,SAT,SUN        true
+
+  OCP versions tested: 4.18 4.19 4.20 4.21
+```
+
+## Generating a Test Entry
+
+Use the bundled script to generate a new test entry YAML block:
+
+```bash
+bash "${CLAUDE_SKILL_DIR}/scripts/generate-test-entry.sh" --version 4.22 --branch main
+```
+
+### With a specific reference version
+
+```bash
+bash "${CLAUDE_SKILL_DIR}/scripts/generate-test-entry.sh" --version 4.22 --branch main --reference 4.21
+```
+
+The script outputs a ready-to-insert YAML block based on an existing versioned test entry with all version-specific values substituted.
+
+## Adding a Test Entry
+
+After generating and reviewing the test entry:
+
+1. Open the target config file (e.g., `ci-operator/config/redhat-developer/rhdh/redhat-developer-rhdh-main.yaml`)
+2. Insert the new test entry in the `tests:` list, **before** `zz_generated_metadata:`
+3. Place it adjacent to other `e2e-ocp-v*-helm-nightly` entries for readability
+4. Run `make update` to regenerate Prow job configs
+5. Verify the generated jobs in `ci-operator/jobs/redhat-developer/rhdh/`
+
+### Test entry fields to update
+
+When creating a test entry for OCP version `X.Y`:
+
+| Field | Value |
+|-------|-------|
+| `as` | `e2e-ocp-vX-Y-helm-nightly` |
+| `cluster_claim.version` | `"X.Y"` |
+| `steps.env.OC_CLIENT_VERSION` | `stable-X.Y` |
+
+All other fields (cron schedule, owner, cloud, architecture, steps, workflow) remain the same as the reference entry.
+
+## Removing a Test Entry
+
+To remove an OCP version test entry:
+
+1. Open the target config file
+2. Remove the entire test block where `as: e2e-ocp-vX-Y-helm-nightly`
+3. Run `make update` to regenerate Prow job configs
+4. Verify the removed jobs are no longer in `ci-operator/jobs/redhat-developer/rhdh/`
+
+**IMPORTANT**: When removing an OCP version, check **all** product branch configs (main, release-1.9, release-1.8, etc.) for entries that need removal.
+
+## After Any Change
+
+Always run `make update` after modifying CI config files:
+
+```bash
+make update
+```
+
+This regenerates:
+- Prow job configs in `ci-operator/jobs/`
+- `zz_generated_metadata` sections
+- Other downstream artifacts
+
+## File Layout
+
+CI config files live in:
+```
+ci-operator/config/redhat-developer/rhdh/
+├── CLAUDE.md                                         # Release branch checklist
+├── OWNERS                                            # Approvers/reviewers
+├── redhat-developer-rhdh-main.yaml                   # Main branch config
+├── redhat-developer-rhdh-release-1.8.yaml            # Release 1.8 config
+└── redhat-developer-rhdh-release-1.9.yaml            # Release 1.9 config
+```
+
+Generated Prow jobs go to:
+```
+ci-operator/jobs/redhat-developer/rhdh/
+├── redhat-developer-rhdh-main-presubmits.yaml
+├── redhat-developer-rhdh-main-periodics.yaml
+├── redhat-developer-rhdh-release-1.8-presubmits.yaml
+├── redhat-developer-rhdh-release-1.8-periodics.yaml
+├── redhat-developer-rhdh-release-1.9-presubmits.yaml
+└── redhat-developer-rhdh-release-1.9-periodics.yaml
+```

--- a/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-tests/scripts/OWNERS
+++ b/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-tests/scripts/OWNERS
@@ -1,0 +1,25 @@
+approvers:
+- albarbaro
+- christoph-jerolimov
+- davidfestal
+- durandom
+- hopehadfield
+- josephca
+- kadel
+- kim-tsao
+- nickboldt
+- rm3l
+- zaperex
+options: {}
+reviewers:
+- albarbaro
+- christoph-jerolimov
+- davidfestal
+- durandom
+- hopehadfield
+- josephca
+- kadel
+- kim-tsao
+- nickboldt
+- rm3l
+- zaperex

--- a/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-tests/scripts/generate-test-entry.sh
+++ b/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-tests/scripts/generate-test-entry.sh
@@ -60,6 +60,10 @@ fi
 # Derive config file path
 # shellcheck disable=SC2206  # Intentional word-splitting on path separators (no spaces in paths)
 dir_parts=(${CI_CONFIG_DIR//\// })
+if [[ ${#dir_parts[@]} -lt 2 ]]; then
+  echo "ERROR: --config-dir must contain at least two path components (got: ${CI_CONFIG_DIR})" >&2
+  exit 1
+fi
 CONFIG_PREFIX="${dir_parts[-2]}-${dir_parts[-1]}-"
 CONFIG_FILE="${CI_CONFIG_DIR}/${CONFIG_PREFIX}${BRANCH}.yaml"
 
@@ -120,7 +124,7 @@ echo "#   cluster_claim.version: \"${REFERENCE_VERSION}\" -> \"${OCP_VERSION}\""
 echo "#   steps.env.OC_CLIENT_VERSION: stable-${REFERENCE_VERSION} -> stable-${OCP_VERSION}"
 echo ""
 
-yq -o=yaml ".tests[] | select(.as == \"${REF_TEST_NAME}\")" "$CONFIG_FILE" | \
+yq -o=yaml "[.tests[] | select(.as == \"${REF_TEST_NAME}\")]" "$CONFIG_FILE" | \
   sed "s|as: ${REF_TEST_NAME}|as: ${NEW_TEST_NAME}|g" | \
   sed "s|version: \"${REFERENCE_VERSION}\"|version: \"${OCP_VERSION}\"|g" | \
   sed "s|OC_CLIENT_VERSION: stable-${REFERENCE_VERSION}|OC_CLIENT_VERSION: stable-${OCP_VERSION}|g"

--- a/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-tests/scripts/generate-test-entry.sh
+++ b/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-tests/scripts/generate-test-entry.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Generate a new e2e-ocp-vX-YY-helm-nightly test entry YAML block.
+#
+# Usage:
+#   generate-test-entry.sh --version 4.22 --branch main
+#   generate-test-entry.sh --version 4.22 --branch main --reference 4.21
+#   generate-test-entry.sh --version 4.22 --branch release-1.9 --config-dir <path>
+#
+# Outputs the generated YAML block to stdout.
+# Must be run from the root of the openshift/release repository.
+# Requires: yq (v4+)
+
+set -euo pipefail
+
+CI_CONFIG_DIR="ci-operator/config/redhat-developer/rhdh"
+OCP_VERSION=""
+BRANCH="main"
+REFERENCE_VERSION=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version|-v)
+      OCP_VERSION="$2"
+      shift 2
+      ;;
+    --branch|-b)
+      BRANCH="$2"
+      shift 2
+      ;;
+    --reference|-r)
+      REFERENCE_VERSION="$2"
+      shift 2
+      ;;
+    --config-dir|-d)
+      CI_CONFIG_DIR="$2"
+      shift 2
+      ;;
+    *)
+      echo "Usage: $0 --version X.Y --branch <name> [--reference X.Y] [--config-dir <path>]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$OCP_VERSION" ]]; then
+  echo "ERROR: --version is required (e.g., --version 4.22)" >&2
+  exit 1
+fi
+
+if ! echo "$OCP_VERSION" | grep -qE '^[0-9]+\.[0-9]+$'; then
+  echo "ERROR: Version must be in X.Y format (e.g., 4.22), got: ${OCP_VERSION}" >&2
+  exit 1
+fi
+
+if ! command -v yq &>/dev/null; then
+  echo "ERROR: yq (v4+) is required but not found" >&2
+  exit 1
+fi
+
+# Derive config file path
+# shellcheck disable=SC2206  # Intentional word-splitting on path separators (no spaces in paths)
+dir_parts=(${CI_CONFIG_DIR//\// })
+CONFIG_PREFIX="${dir_parts[-2]}-${dir_parts[-1]}-"
+CONFIG_FILE="${CI_CONFIG_DIR}/${CONFIG_PREFIX}${BRANCH}.yaml"
+
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  echo "ERROR: Config file not found: ${CONFIG_FILE}" >&2
+  exit 1
+fi
+
+MAJOR="${OCP_VERSION%%.*}"
+MINOR="${OCP_VERSION#*.}"
+NEW_DASH="${MAJOR}-${MINOR}"
+NEW_TEST_NAME="e2e-ocp-v${NEW_DASH}-helm-nightly"
+
+# Check if entry already exists
+if yq -e ".tests[] | select(.as == \"${NEW_TEST_NAME}\")" "$CONFIG_FILE" &>/dev/null; then
+  echo "ERROR: Test entry '${NEW_TEST_NAME}' already exists in ${CONFIG_FILE}" >&2
+  exit 1
+fi
+
+# Find reference test entry
+if [[ -n "$REFERENCE_VERSION" ]]; then
+  REF_MAJOR="${REFERENCE_VERSION%%.*}"
+  REF_MINOR="${REFERENCE_VERSION#*.}"
+  REF_TEST_NAME="e2e-ocp-v${REF_MAJOR}-${REF_MINOR}-helm-nightly"
+else
+  # Find the latest versioned test entry
+  REF_TEST_NAME=$(yq -r '.tests[].as' "$CONFIG_FILE" 2>/dev/null | \
+    grep -E '^e2e-ocp-v[0-9]+-[0-9]+-helm-nightly$' | \
+    sort -V | tail -1)
+  if [[ -z "$REF_TEST_NAME" ]]; then
+    echo "ERROR: No versioned OCP test entries found in ${CONFIG_FILE}" >&2
+    exit 1
+  fi
+  REFERENCE_VERSION=$(echo "$REF_TEST_NAME" | sed -E 's/e2e-ocp-v([0-9]+)-([0-9]+)-helm-nightly/\1.\2/')
+fi
+
+# Check reference exists
+if ! yq -e ".tests[] | select(.as == \"${REF_TEST_NAME}\")" "$CONFIG_FILE" &>/dev/null; then
+  echo "ERROR: Reference test entry '${REF_TEST_NAME}' not found in ${CONFIG_FILE}" >&2
+  AVAILABLE=$(yq -r '.tests[].as' "$CONFIG_FILE" 2>/dev/null | grep -E '^e2e-ocp-v[0-9]+-[0-9]+-helm-nightly$' || true)
+  echo "Available versioned entries:" >&2
+  echo "$AVAILABLE" >&2
+  exit 1
+fi
+
+REF_MAJOR="${REFERENCE_VERSION%%.*}"
+REF_MINOR="${REFERENCE_VERSION#*.}"
+
+# Extract the reference entry and substitute version values
+echo "# Generated test entry for OCP ${OCP_VERSION}"
+echo "# Based on: ${REF_TEST_NAME} (OCP ${REFERENCE_VERSION})"
+echo "# Config file: ${CONFIG_FILE}"
+echo "# Insert this block into the 'tests:' list before 'zz_generated_metadata:'"
+echo "#"
+echo "# Fields changed from reference:"
+echo "#   as: ${REF_TEST_NAME} -> ${NEW_TEST_NAME}"
+echo "#   cluster_claim.version: \"${REFERENCE_VERSION}\" -> \"${OCP_VERSION}\""
+echo "#   steps.env.OC_CLIENT_VERSION: stable-${REFERENCE_VERSION} -> stable-${OCP_VERSION}"
+echo ""
+
+yq -o=yaml ".tests[] | select(.as == \"${REF_TEST_NAME}\")" "$CONFIG_FILE" | \
+  sed "s|as: ${REF_TEST_NAME}|as: ${NEW_TEST_NAME}|g" | \
+  sed "s|version: \"${REFERENCE_VERSION}\"|version: \"${OCP_VERSION}\"|g" | \
+  sed "s|OC_CLIENT_VERSION: stable-${REFERENCE_VERSION}|OC_CLIENT_VERSION: stable-${OCP_VERSION}|g"

--- a/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-tests/scripts/list-ocp-test-configs.sh
+++ b/ci-operator/config/redhat-developer/rhdh/.claude/skills/rhdh-ocp-tests/scripts/list-ocp-test-configs.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# List OCP versions used in RHDH CI test configs, extracted from cluster_claim.version.
+#
+# The source of truth for which OCP version a test uses is its cluster_claim.version
+# field, NOT the test name. Some tests encode the version in the name
+# (e.g., e2e-ocp-v4-19-helm-nightly) but many do not (e.g., e2e-ocp-helm-nightly
+# uses OCP 4.18 via cluster_claim.version).
+#
+# Usage:
+#   list-ocp-test-configs.sh                         # All branches
+#   list-ocp-test-configs.sh --branch main           # Specific branch
+#   list-ocp-test-configs.sh --config-dir <path>     # Custom config directory
+#
+# Must be run from the root of the openshift/release repository.
+# Requires: yq (v4+)
+
+set -euo pipefail
+
+CI_CONFIG_DIR="ci-operator/config/redhat-developer/rhdh"
+FILTER_BRANCH=""
+CONFIG_PREFIX="redhat-developer-rhdh-"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --branch|-b)
+      FILTER_BRANCH="$2"
+      shift 2
+      ;;
+    --config-dir|-d)
+      CI_CONFIG_DIR="$2"
+      shift 2
+      ;;
+    *)
+      echo "Usage: $0 [--branch <name>] [--config-dir <path>]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ ! -d "$CI_CONFIG_DIR" ]]; then
+  echo "ERROR: Config directory not found: ${CI_CONFIG_DIR}" >&2
+  echo "Are you running from the root of the openshift/release repository?" >&2
+  exit 1
+fi
+
+if ! command -v yq &>/dev/null; then
+  echo "ERROR: yq (v4+) is required but not found" >&2
+  exit 1
+fi
+
+# Derive prefix from directory path
+# shellcheck disable=SC2206  # Intentional word-splitting on path separators (no spaces in paths)
+dir_parts=(${CI_CONFIG_DIR//\// })
+if [[ ${#dir_parts[@]} -ge 2 ]]; then
+  CONFIG_PREFIX="${dir_parts[-2]}-${dir_parts[-1]}-"
+fi
+
+BRANCH_COUNT=0
+
+for config_file in "${CI_CONFIG_DIR}/${CONFIG_PREFIX}"*.yaml; do
+  [[ -f "$config_file" ]] || continue
+
+  filename=$(basename "$config_file")
+  branch="${filename#"${CONFIG_PREFIX}"}"
+  branch="${branch%.yaml}"
+
+  if [[ -n "$FILTER_BRANCH" && "$branch" != "$FILTER_BRANCH" ]]; then
+    continue
+  fi
+
+  # Extract all tests that have a cluster_claim with a version
+  entries=$(yq -o=json '.tests[] | select(.cluster_claim.version != null)' "$config_file" 2>/dev/null || true)
+
+  if [[ -z "$entries" ]]; then
+    continue
+  fi
+
+  BRANCH_COUNT=$((BRANCH_COUNT + 1))
+  echo ""
+  echo "=== Branch: ${branch} ==="
+  echo "    File: ${config_file}"
+  echo ""
+  printf "  %-45s %-13s %-30s %-10s\n" \
+    "TEST_NAME" "OCP_VERSION" "CRON" "OPTIONAL"
+  printf "  %-45s %-13s %-30s %-10s\n" \
+    "---------" "-----------" "----" "--------"
+
+  yq -o=json -I=0 '[.tests[] | select(.cluster_claim.version != null)]' "$config_file" 2>/dev/null | \
+    jq -r '.[] | [
+      .as,
+      .cluster_claim.version,
+      (.cron // "N/A"),
+      (.optional // false | tostring)
+    ] | @tsv' | sort -t$'\t' -k2 -V | \
+    while IFS=$'\t' read -r name ver cron opt; do
+      printf "  %-45s %-13s %-30s %-10s\n" "$name" "$ver" "$cron" "$opt"
+    done
+
+  # Show deduplicated OCP versions for this branch
+  ocp_versions=$(yq -o=json -I=0 '[.tests[] | select(.cluster_claim.version != null) | .cluster_claim.version] | unique | sort_by(split(".") | map(tonumber))' "$config_file" 2>/dev/null | jq -r '.[]')
+  echo ""
+  echo "  OCP versions tested: $(echo "$ocp_versions" | tr '\n' ' ')"
+done
+
+echo ""
+echo "---"
+echo "Branches scanned: ${BRANCH_COUNT}" >&2
+echo "Config directory: ${CI_CONFIG_DIR}" >&2

--- a/ci-operator/config/redhat-developer/rhdh/.opencode/OWNERS
+++ b/ci-operator/config/redhat-developer/rhdh/.opencode/OWNERS
@@ -1,0 +1,25 @@
+approvers:
+- albarbaro
+- christoph-jerolimov
+- davidfestal
+- durandom
+- hopehadfield
+- josephca
+- kadel
+- kim-tsao
+- nickboldt
+- rm3l
+- zaperex
+options: {}
+reviewers:
+- albarbaro
+- christoph-jerolimov
+- davidfestal
+- durandom
+- hopehadfield
+- josephca
+- kadel
+- kim-tsao
+- nickboldt
+- rm3l
+- zaperex

--- a/ci-operator/config/redhat-developer/rhdh/.opencode/skills
+++ b/ci-operator/config/redhat-developer/rhdh/.opencode/skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/ci-operator/config/redhat-developer/rhdh/AGENTS.md
+++ b/ci-operator/config/redhat-developer/rhdh/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/ci-operator/config/redhat-developer/rhdh/CLAUDE.md
+++ b/ci-operator/config/redhat-developer/rhdh/CLAUDE.md
@@ -1,5 +1,37 @@
 # RHDH CI Configuration
 
+## Available Skills
+
+Skills in `.claude/skills/` are loaded on demand by the agent. Use them when working with RHDH OCP version management in this repository.
+
+### `rhdh-ocp-lifecycle` — Check RHDH & OCP version support
+
+Query the Red Hat Product Life Cycles API to determine which OCP versions are supported by active RHDH releases and which are end-of-life. Shows both RHDH compatibility (`openshift_compatibility` field) and OCP upstream support (including EUS phases). Supports OCP 4.x and future 5.x+.
+
+**Scripts**: `check-ocp-lifecycle.sh [--version X.Y] [--rhdh-version X.Y] [--rhdh-only]`
+
+### `rhdh-ocp-pool` — Manage OCP Hive ClusterPools
+
+List existing RHDH OCP cluster pools or generate a new pool for a target OCP version. Covers Hive ClusterPools for OCP only — K8s platform clusters (AKS, EKS, GKE) use MAPT and OSD-GCP uses a separate claim workflow. The generation script looks up `imageSetRef` from other pools across the entire repo to ensure alignment.
+
+**Scripts**: `list-cluster-pools.sh`, `generate-cluster-pool.sh --version X.Y`
+
+### `rhdh-ocp-tests` — Manage OCP test entries
+
+List, generate, add, and remove OCP-versioned test entries (`e2e-ocp-*`) in CI config files. Covers only OCP cluster-claim tests, not K8s platform tests (AKS, EKS, GKE, OSD). OCP versions are extracted from `cluster_claim.version` (the source of truth), not from test names.
+
+**Scripts**: `list-ocp-test-configs.sh [--branch <name>]`, `generate-test-entry.sh --version X.Y --branch <name>`
+
+### `rhdh-ocp-coverage` — Analyze OCP version coverage
+
+Cross-reference cluster pools, CI test configs, RHDH lifecycle, and OCP lifecycle to find gaps, stale configs, and mismatches. Checks two dimensions: OCP lifecycle (is the OCP version still supported?) and RHDH compatibility (does RHDH officially support this OCP version?). OCP-EOL versions are never recommended for new pools or tests, even if RHDH still lists them.
+
+**Scripts**: `analyze-coverage.sh [--pool-dir <path>] [--config-dir <path>]`
+
+### `rhdh-decommission-release` — Decommission EOL release branch
+
+Remove all CI configuration for an end-of-life RHDH release branch: CI config file, generated Prow jobs, and branch protection entry.
+
 ## New Release Branch Checklist
 
 When creating a new release branch (e.g., `release-1.11`):


### PR DESCRIPTION
## Summary

- Add 5 agent skills for managing RHDH OCP version coverage in `ci-operator/config/redhat-developer/rhdh/.claude/skills/`
- Skills work with both Claude Code and OpenCode via the `.claude/skills/` format

### Skills

| Skill | Purpose |
|-------|---------|
| `rhdh-ocp-lifecycle` | Check OCP and RHDH lifecycle status via Red Hat Product Life Cycles API |
| `rhdh-ocp-pool` | List and manage Hive ClusterPool configurations |
| `rhdh-ocp-tests` | List, generate, and manage OCP-versioned CI test entries |
| `rhdh-ocp-coverage` | Cross-reference pools, tests, and lifecycle data to find gaps and stale configs |
| `rhdh-decommission-release` | Remove all CI config for an end-of-life RHDH release branch |

### Data Sources

- **RHDH lifecycle API** — authoritative source for which OCP versions each RHDH release supports (`openshift_compatibility` field)
- **OCP lifecycle API** — determines if an OCP version is still supported or end-of-life (hard boundary for CI resources)
- **Local YAML** — cluster pools and CI configs read from the repo checkout

### Key Design Decisions

- Each skill declares an `allowed-tools` allowlist restricting tool access to only what it needs
- OCP-EOL versions never get pools or test entries recommended, even if RHDH still lists them
- OCP versions for test coverage are extracted from `cluster_claim.version` (not test names)
- `main` branch OCP support is estimated as the latest RHDH release's list + any newer GA OCP versions
- `generate-cluster-pool.sh` supports `--dry-run` for previewing output without writing files
- `analyze-coverage.sh` checks for bash 4+ (required for associative arrays, not available on stock macOS)
- `ocp-lifecycle.jq` is shared between `rhdh-ocp-lifecycle` and `rhdh-ocp-coverage` skills, with cross-references documented

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new skills for managing OpenShift Container Platform (OCP) lifecycle in CI configurations
  * Introduced tooling for managing cluster pools, test configurations, and coverage analysis
  * Added workflow for analyzing OCP version compatibility across infrastructure
  * Introduced skill for decommissioning end-of-life releases

* **Documentation**
  * Expanded documentation describing available OCP management capabilities and workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->