### PR TITLE
release-controller: update ReleasePayloads CRD

### DIFF
--- a/clusters/app.ci/release-controller/admin_01_releasepayload_crd.yaml
+++ b/clusters/app.ci/release-controller/admin_01_releasepayload_crd.yaml
@@ -86,6 +86,13 @@ spec:
                     reason:
                       description: Reason is a human-readable string that specifies the reason for manually overriding the Acceptance/Rejections of a ReleasePayload
                       type: string
+                payloadType:
+                  description: PayloadType specifies how the release payload is stored. If "Local" (the default), the release is created in a local imagestream. If "Reference", the release is created directly in a remote repository with no local imagestream copy.
+                  type: string
+                  default: Local
+                  enum:
+                    - Local
+                    - Reference
                 payloadVerificationConfig:
                   description: PayloadVerificationConfig the configuration that will be used to verify this ReleasePayload
                   type: object


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new payload type configuration option for release management, allowing selection between Local and Reference storage modes. Defaults to Local mode for backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->