### PR TITLE
CNF-22981: Enable Tide auto-merge for red-hat-konflux[bot] on openshi…

### DIFF
--- a/core-services/prow/02_config/openshift-kni/cluster-group-upgrades-operator/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift-kni/cluster-group-upgrades-operator/_prowconfig.yaml
@@ -1,3 +1,14 @@
 tide:
   merge_method:
     openshift-kni/cluster-group-upgrades-operator: squash
+  queries:
+  - author: red-hat-konflux[bot]
+    labels:
+    - allow-automatic-merge
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/hold
+    - do-not-merge/work-in-progress
+    - needs-rebase
+    repos:
+    - openshift-kni/cluster-group-upgrades-operator

--- a/core-services/prow/02_config/openshift-kni/cnf-features-deploy/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift-kni/cnf-features-deploy/_prowconfig.yaml
@@ -1,6 +1,4 @@
 tide:
-  merge_method:
-    openshift-kni/oran-o2ims: squash
   queries:
   - author: red-hat-konflux[bot]
     labels:
@@ -11,4 +9,4 @@ tide:
     - do-not-merge/work-in-progress
     - needs-rebase
     repos:
-    - openshift-kni/oran-o2ims
+    - openshift-kni/cnf-features-deploy

--- a/core-services/prow/02_config/openshift-kni/lifecycle-agent/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift-kni/lifecycle-agent/_prowconfig.yaml
@@ -1,5 +1,17 @@
 tide:
   queries:
+  - author: red-hat-konflux[bot]
+    labels:
+    - allow-automatic-merge
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - jira/invalid-bug
+    - needs-rebase
+    repos:
+    - openshift-kni/lifecycle-agent
   - labels:
     - approved
     - lgtm

--- a/core-services/prow/02_config/openshift-kni/numaresources-operator/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift-kni/numaresources-operator/_prowconfig.yaml
@@ -1,6 +1,4 @@
 tide:
-  merge_method:
-    openshift-kni/oran-o2ims: squash
   queries:
   - author: red-hat-konflux[bot]
     labels:
@@ -11,4 +9,4 @@ tide:
     - do-not-merge/work-in-progress
     - needs-rebase
     repos:
-    - openshift-kni/oran-o2ims
+    - openshift-kni/numaresources-operator

--- a/core-services/prow/02_config/openshift-kni/telco-reference/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift-kni/telco-reference/_prowconfig.yaml
@@ -1,6 +1,4 @@
 tide:
-  merge_method:
-    openshift-kni/oran-o2ims: squash
   queries:
   - author: red-hat-konflux[bot]
     labels:
@@ -11,4 +9,4 @@ tide:
     - do-not-merge/work-in-progress
     - needs-rebase
     repos:
-    - openshift-kni/oran-o2ims
+    - openshift-kni/telco-reference


### PR DESCRIPTION
…ft-kni repos

Add Tide query with author: red-hat-konflux[bot] and allow-automatic-merge label to enable automatic merging of Konflux dependency update PRs for:
- cnf-features-deploy
- cluster-group-upgrades-operator
- lifecycle-agent
- numaresources-operator
- oran-o2ims
- telco-reference

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated pull request merge capabilities across multiple OpenShift repositories. Pull requests from automation workflows can now be automatically merged when properly labeled and free of blocking markers, streamlining the merge workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->