### PR TITLE
Add pre-submit job for AWS custom-dns when installed in multiple zones

### DIFF
--- a/ci-operator/config/openshift/installer/openshift-installer-release-4.21.yaml
+++ b/ci-operator/config/openshift/installer/openshift-installer-release-4.21.yaml
@@ -314,6 +314,17 @@ tests:
       USER_PROVISIONED_DNS: "yes"
     workflow: openshift-e2e-aws-custom-dns
 - always_run: false
+  as: e2e-aws-custom-dns-multi-zone
+  optional: true
+  steps:
+    cluster_profile: aws-qe
+    env:
+      AWS_INSTALL_USE_MINIMAL_PERMISSIONS: "yes"
+      FEATURE_SET: TechPreviewNoUpgrade
+      USER_PROVISIONED_DNS: "yes"
+      ZONES_COUNT: "3"
+    workflow: openshift-e2e-aws-custom-dns
+- always_run: false
   as: e2e-aws-upi-proxy
   optional: true
   steps:

--- a/ci-operator/config/openshift/installer/openshift-installer-release-4.22.yaml
+++ b/ci-operator/config/openshift/installer/openshift-installer-release-4.22.yaml
@@ -375,6 +375,17 @@ tests:
       USER_PROVISIONED_DNS: "yes"
     workflow: openshift-e2e-aws-custom-dns
 - always_run: false
+  as: e2e-aws-custom-dns-multi-zone
+  optional: true
+  steps:
+    cluster_profile: aws-qe
+    env:
+      AWS_INSTALL_USE_MINIMAL_PERMISSIONS: "yes"
+      FEATURE_SET: TechPreviewNoUpgrade
+      USER_PROVISIONED_DNS: "yes"
+      ZONES_COUNT: "3"
+    workflow: openshift-e2e-aws-custom-dns
+- always_run: false
   as: e2e-aws-upi-proxy
   optional: true
   steps:

--- a/ci-operator/config/openshift/installer/openshift-installer-release-4.23.yaml
+++ b/ci-operator/config/openshift/installer/openshift-installer-release-4.23.yaml
@@ -375,6 +375,17 @@ tests:
       USER_PROVISIONED_DNS: "yes"
     workflow: openshift-e2e-aws-custom-dns
 - always_run: false
+  as: e2e-aws-custom-dns-multi-zone
+  optional: true
+  steps:
+    cluster_profile: aws-qe
+    env:
+      AWS_INSTALL_USE_MINIMAL_PERMISSIONS: "yes"
+      FEATURE_SET: TechPreviewNoUpgrade
+      USER_PROVISIONED_DNS: "yes"
+      ZONES_COUNT: "3"
+    workflow: openshift-e2e-aws-custom-dns
+- always_run: false
   as: e2e-aws-upi-proxy
   optional: true
   steps:

--- a/ci-operator/config/openshift/installer/openshift-installer-release-5.0.yaml
+++ b/ci-operator/config/openshift/installer/openshift-installer-release-5.0.yaml
@@ -376,6 +376,17 @@ tests:
       USER_PROVISIONED_DNS: "yes"
     workflow: openshift-e2e-aws-custom-dns
 - always_run: false
+  as: e2e-aws-custom-dns-multi-zone
+  optional: true
+  steps:
+    cluster_profile: aws-qe
+    env:
+      AWS_INSTALL_USE_MINIMAL_PERMISSIONS: "yes"
+      FEATURE_SET: TechPreviewNoUpgrade
+      USER_PROVISIONED_DNS: "yes"
+      ZONES_COUNT: "3"
+    workflow: openshift-e2e-aws-custom-dns
+- always_run: false
   as: e2e-aws-upi-proxy
   optional: true
   steps:

--- a/ci-operator/jobs/openshift/installer/openshift-installer-release-4.21-presubmits.yaml
+++ b/ci-operator/jobs/openshift/installer/openshift-installer-release-4.21-presubmits.yaml
@@ -1219,6 +1219,87 @@ presubmits:
     - ^release-4\.21$
     - ^release-4\.21-
     cluster: build01
+    context: ci/prow/e2e-aws-custom-dns-multi-zone
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: aws-qe
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-installer-release-4.21-e2e-aws-custom-dns-multi-zone
+    optional: true
+    rerun_command: /test e2e-aws-custom-dns-multi-zone
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-aws-custom-dns-multi-zone
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-aws-custom-dns-multi-zone,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.21$
+    - ^release-4\.21-
+    cluster: build01
     context: ci/prow/e2e-aws-custom-dns-techpreview
     decorate: true
     labels:

--- a/ci-operator/jobs/openshift/installer/openshift-installer-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift/installer/openshift-installer-release-4.22-presubmits.yaml
@@ -1302,6 +1302,87 @@ presubmits:
     - ^release-4\.22$
     - ^release-4\.22-
     cluster: build01
+    context: ci/prow/e2e-aws-custom-dns-multi-zone
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: aws-qe
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-installer-release-4.22-e2e-aws-custom-dns-multi-zone
+    optional: true
+    rerun_command: /test e2e-aws-custom-dns-multi-zone
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-aws-custom-dns-multi-zone
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-aws-custom-dns-multi-zone,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.22$
+    - ^release-4\.22-
+    cluster: build01
     context: ci/prow/e2e-aws-custom-dns-techpreview
     decorate: true
     labels:

--- a/ci-operator/jobs/openshift/installer/openshift-installer-release-4.23-presubmits.yaml
+++ b/ci-operator/jobs/openshift/installer/openshift-installer-release-4.23-presubmits.yaml
@@ -1302,6 +1302,87 @@ presubmits:
     - ^release-4\.23$
     - ^release-4\.23-
     cluster: build01
+    context: ci/prow/e2e-aws-custom-dns-multi-zone
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: aws-qe
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-installer-release-4.23-e2e-aws-custom-dns-multi-zone
+    optional: true
+    rerun_command: /test e2e-aws-custom-dns-multi-zone
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-aws-custom-dns-multi-zone
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-aws-custom-dns-multi-zone,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.23$
+    - ^release-4\.23-
+    cluster: build01
     context: ci/prow/e2e-aws-custom-dns-techpreview
     decorate: true
     labels:

--- a/ci-operator/jobs/openshift/installer/openshift-installer-release-5.0-presubmits.yaml
+++ b/ci-operator/jobs/openshift/installer/openshift-installer-release-5.0-presubmits.yaml
@@ -1301,6 +1301,87 @@ presubmits:
     - ^release-5\.0$
     - ^release-5\.0-
     cluster: build11
+    context: ci/prow/e2e-aws-custom-dns-multi-zone
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: aws-qe
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-installer-release-5.0-e2e-aws-custom-dns-multi-zone
+    optional: true
+    rerun_command: /test e2e-aws-custom-dns-multi-zone
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-aws-custom-dns-multi-zone
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-aws-custom-dns-multi-zone,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-5\.0$
+    - ^release-5\.0-
+    cluster: build11
     context: ci/prow/e2e-aws-custom-dns-techpreview
     decorate: true
     labels:


### PR DESCRIPTION
Added them as presubmits for 4.21, 4.22, 4.23 and 5.0. Currently, adding a periodic job for this seems unnecessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new end-to-end test coverage for custom DNS configurations in multi-zone AWS deployments. These tests validate user-provisioned DNS scenarios with minimal AWS permissions across all supported OpenShift releases (4.21, 4.22, 4.23, and 5.0), improving installer quality assurance and reliability verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->