### PR TITLE
Refactor tls-scanner PQC readiness and adherence jobs

### DIFF
--- a/ci-operator/config/openshift-priv/tls-scanner/openshift-priv-tls-scanner-main.yaml
+++ b/ci-operator/config/openshift-priv/tls-scanner/openshift-priv-tls-scanner-main.yaml
@@ -91,10 +91,10 @@ tests:
   steps:
     cluster_profile: openshift-org-aws
     env:
+      COMPUTE_NODE_TYPE: m5.4xlarge
       PQC_CHECK: "true"
     test:
     - ref: tls-scanner-run
-    - ref: openshift-e2e-test
     workflow: openshift-e2e-aws-ovn-tls-13
 zz_generated_metadata:
   branch: main

--- a/ci-operator/config/openshift-priv/tls-scanner/openshift-priv-tls-scanner-release-4.23.yaml
+++ b/ci-operator/config/openshift-priv/tls-scanner/openshift-priv-tls-scanner-release-4.23.yaml
@@ -91,10 +91,10 @@ tests:
   steps:
     cluster_profile: openshift-org-aws
     env:
+      COMPUTE_NODE_TYPE: m5.4xlarge
       PQC_CHECK: "true"
     test:
     - ref: tls-scanner-run
-    - ref: openshift-e2e-test
     workflow: openshift-e2e-aws-ovn-tls-13
 zz_generated_metadata:
   branch: release-4.23

--- a/ci-operator/config/openshift-priv/tls-scanner/openshift-priv-tls-scanner-release-5.0.yaml
+++ b/ci-operator/config/openshift-priv/tls-scanner/openshift-priv-tls-scanner-release-5.0.yaml
@@ -92,10 +92,10 @@ tests:
   steps:
     cluster_profile: openshift-org-aws
     env:
+      COMPUTE_NODE_TYPE: m5.4xlarge
       PQC_CHECK: "true"
     test:
     - ref: tls-scanner-run
-    - ref: openshift-e2e-test
     workflow: openshift-e2e-aws-ovn-tls-13
 zz_generated_metadata:
   branch: release-5.0

--- a/ci-operator/config/openshift-priv/tls-scanner/openshift-priv-tls-scanner-release-5.1.yaml
+++ b/ci-operator/config/openshift-priv/tls-scanner/openshift-priv-tls-scanner-release-5.1.yaml
@@ -91,10 +91,10 @@ tests:
   steps:
     cluster_profile: openshift-org-aws
     env:
+      COMPUTE_NODE_TYPE: m5.4xlarge
       PQC_CHECK: "true"
     test:
     - ref: tls-scanner-run
-    - ref: openshift-e2e-test
     workflow: openshift-e2e-aws-ovn-tls-13
 zz_generated_metadata:
   branch: release-5.1

--- a/ci-operator/config/openshift/tls-scanner/openshift-tls-scanner-main.yaml
+++ b/ci-operator/config/openshift/tls-scanner/openshift-tls-scanner-main.yaml
@@ -73,15 +73,17 @@ tests:
     test:
     - ref: tls-scanner-run
     workflow: ipi-aws
-- as: tls13-conformance
+- as: tls13-adherence
   optional: true
   steps:
     cluster_profile: openshift-org-aws
     env:
       COMPUTE_NODE_TYPE: m5.4xlarge
+      PQC_CHECK: "false"
+      TLS_13_ENABLE_TLS_ADHERENCE: "true"
+      TLS_13_TLS_ADHERENCE_POLICY: StrictAllComponents
     test:
     - ref: tls-scanner-run
-    - ref: openshift-e2e-test
     workflow: openshift-e2e-aws-ovn-tls-13
 - as: periodic-default-tls
   interval: 72h
@@ -92,25 +94,37 @@ tests:
     test:
     - ref: tls-scanner-run
     workflow: ipi-aws
-- as: periodic-tls13-conformance
+- as: periodic-pqc-readiness
   interval: 72h
   steps:
     cluster_profile: openshift-org-aws
     env:
       COMPUTE_NODE_TYPE: m5.4xlarge
+      PQC_CHECK: "true"
     test:
     - ref: tls-scanner-run
-    - ref: openshift-e2e-test
+    workflow: openshift-e2e-aws-ovn-tls-13
+- as: periodic-tls13-adherence
+  interval: 72h
+  steps:
+    cluster_profile: openshift-org-aws
+    env:
+      COMPUTE_NODE_TYPE: m5.4xlarge
+      PQC_CHECK: "false"
+      TLS_13_ENABLE_TLS_ADHERENCE: "true"
+      TLS_13_TLS_ADHERENCE_POLICY: StrictAllComponents
+    test:
+    - ref: tls-scanner-run
     workflow: openshift-e2e-aws-ovn-tls-13
 - as: tls13-pqc-readiness
   optional: true
   steps:
     cluster_profile: openshift-org-aws
     env:
+      COMPUTE_NODE_TYPE: m5.4xlarge
       PQC_CHECK: "true"
     test:
     - ref: tls-scanner-run
-    - ref: openshift-e2e-test
     workflow: openshift-e2e-aws-ovn-tls-13
 zz_generated_metadata:
   branch: main

--- a/ci-operator/config/openshift/tls-scanner/openshift-tls-scanner-release-4.23.yaml
+++ b/ci-operator/config/openshift/tls-scanner/openshift-tls-scanner-release-4.23.yaml
@@ -88,10 +88,10 @@ tests:
   steps:
     cluster_profile: openshift-org-aws
     env:
+      COMPUTE_NODE_TYPE: m5.4xlarge
       PQC_CHECK: "true"
     test:
     - ref: tls-scanner-run
-    - ref: openshift-e2e-test
     workflow: openshift-e2e-aws-ovn-tls-13
 zz_generated_metadata:
   branch: release-4.23

--- a/ci-operator/config/openshift/tls-scanner/openshift-tls-scanner-release-5.0.yaml
+++ b/ci-operator/config/openshift/tls-scanner/openshift-tls-scanner-release-5.0.yaml
@@ -89,10 +89,10 @@ tests:
   steps:
     cluster_profile: openshift-org-aws
     env:
+      COMPUTE_NODE_TYPE: m5.4xlarge
       PQC_CHECK: "true"
     test:
     - ref: tls-scanner-run
-    - ref: openshift-e2e-test
     workflow: openshift-e2e-aws-ovn-tls-13
 zz_generated_metadata:
   branch: release-5.0

--- a/ci-operator/config/openshift/tls-scanner/openshift-tls-scanner-release-5.1.yaml
+++ b/ci-operator/config/openshift/tls-scanner/openshift-tls-scanner-release-5.1.yaml
@@ -88,10 +88,10 @@ tests:
   steps:
     cluster_profile: openshift-org-aws
     env:
+      COMPUTE_NODE_TYPE: m5.4xlarge
       PQC_CHECK: "true"
     test:
     - ref: tls-scanner-run
-    - ref: openshift-e2e-test
     workflow: openshift-e2e-aws-ovn-tls-13
 zz_generated_metadata:
   branch: release-5.1

--- a/ci-operator/jobs/openshift/tls-scanner/openshift-tls-scanner-main-periodics.yaml
+++ b/ci-operator/jobs/openshift/tls-scanner/openshift-tls-scanner-main-periodics.yaml
@@ -94,7 +94,7 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-tls-scanner-main-periodic-tls13-conformance
+  name: periodic-ci-openshift-tls-scanner-main-periodic-pqc-readiness
   spec:
     containers:
     - args:
@@ -103,7 +103,87 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=periodic-tls13-conformance
+      - --target=periodic-pqc-readiness
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build03
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: tls-scanner
+  interval: 72h
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-tls-scanner-main-periodic-tls13-adherence
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=periodic-tls13-adherence
       command:
       - ci-operator
       env:

--- a/ci-operator/jobs/openshift/tls-scanner/openshift-tls-scanner-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/tls-scanner/openshift-tls-scanner-main-presubmits.yaml
@@ -233,7 +233,7 @@ presubmits:
     - ^main$
     - ^main-
     cluster: build05
-    context: ci/prow/tls13-conformance
+    context: ci/prow/tls13-adherence
     decorate: true
     decoration_config:
       skip_cloning: true
@@ -242,9 +242,9 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-tls-scanner-main-tls13-conformance
+    name: pull-ci-openshift-tls-scanner-main-tls13-adherence
     optional: true
-    rerun_command: /test tls13-conformance
+    rerun_command: /test tls13-adherence
     spec:
       containers:
       - args:
@@ -253,7 +253,7 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=tls13-conformance
+        - --target=tls13-adherence
         command:
         - ci-operator
         env:
@@ -309,7 +309,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )tls13-conformance,?($|\s.*)
+    trigger: (?m)^/test( | .* )tls13-adherence,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:


### PR DESCRIPTION
- Renamed `periodic-tls13-conformance` to `periodic-tls13-pqc-readiness` and `PQC_CHECK=true`
- Added `periodic-tls13-adherence` periodic job to check strict adherence feature gate with `PQC_CHECK=false`
- Renamed `tls13-conformance` presubmit to `tls13-adherence` to match the periodic job

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Split TLS 1.3 testing into "adherence" and "PQC readiness" workflows to clarify validation roles.
  * Renamed presubmit and periodic jobs and updated CI triggers to reference the new test targets.
  * Added a new periodic adherence run (72h) and a dedicated PQC-readiness periodic job to run scanner + end-to-end checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->