### PR TITLE
TRT-2588: add BigQuery credentials to `periodic-prow-auto-sippy-config-generator` in order to determine synthetic releases

### DIFF
--- a/ci-operator/jobs/infra-periodics.yaml
+++ b/ci-operator/jobs/infra-periodics.yaml
@@ -2672,6 +2672,9 @@ periodics:
         -pr-title="Automated - Update config ./config/openshift.yaml"
       command:
       - /bin/bash
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/bigquery/token
       image: quay-proxy.ci.openshift.org/openshift/ci:ci_auto-sippy-config-generator_latest
       imagePullPolicy: Always
       name: auto-sippy-config-generator
@@ -2682,10 +2685,16 @@ periodics:
       - mountPath: /etc/github
         name: token
         readOnly: true
+      - mountPath: /etc/bigquery
+        name: bigquery-token
+        readOnly: true
     volumes:
     - name: token
       secret:
         secretName: github-credentials-openshift-bot
+    - name: bigquery-token
+      secret:
+        secretName: ci-data-bigquery-readonly
 - agent: kubernetes
   cluster: app.ci
   cron: 0 1 * * 5


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Periodic job configuration updated to enable secure Google BigQuery authentication. The config generator can now access BigQuery for improved data ingestion, processing, and operational reporting across the infrastructure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->