### PR TITLE
openshift/os: update ci-operator configs for build-args changes

### DIFF
--- a/ci-operator/config/openshift/os/openshift-os-master.yaml
+++ b/ci-operator/config/openshift/os/openshift-os-master.yaml
@@ -13,11 +13,16 @@ images:
   - build_args:
     - name: OPENSHIFT_CI
       value: "1"
+    - name: IMAGE_NAME
+      value: openshift/ose-rhel-coreos-9
+    - name: IMAGE_CPE
+      value: cpe:/a:redhat:openshift:4.22::el9
     dockerfile_path: Containerfile
     inputs:
       rhel-coreos-base:
         as:
         - quay.io/openshift-release-dev/ocp-v4.0-art-dev:c9s-coreos
+        - ${IMAGE_FROM}
     to: rhel-coreos
   - build_args:
     - name: OPENSHIFT_CI

--- a/ci-operator/config/openshift/os/openshift-os-master__okd-scos.yaml
+++ b/ci-operator/config/openshift/os/openshift-os-master__okd-scos.yaml
@@ -22,6 +22,7 @@ images:
       stream-coreos-base:
         as:
         - quay.io/openshift-release-dev/ocp-v4.0-art-dev:c9s-coreos
+        - ${IMAGE_FROM}
     to: os-image
   - build_args:
     - name: OPENSHIFT_CI


### PR DESCRIPTION
In https://github.com/openshift/os/pull/1919, we're changing the openshift/os Containerfile to use ARG IMAGE_FROM=overridden instead of a hardcoded FROM, and to require IMAGE_NAME/IMAGE_CPE build args for RHCOS builds.

So we need to adapt the `as` substitution here accordingly.

Unfortunately, ci-operator (but really, Builds v1) doesn't support build args files so here we're just hardcoding values for the parameter for CI to build. This is something we'd be able to fix once CI also uses Konflux.

Yes, the literal `${IMAGE_FROM}` is intended because the substitution needs to match against the raw string in the Dockerfile AIUI.

Keep the old value too so that we can merge this
PR and not break openshift/os CI before merging
https://github.com/openshift/os/pull/1919.

Assisted-by: OpenCode (Claude Opus 4.6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced container image build configuration to support flexible source resolution with dynamic image inputs.
  * Added build arguments and metadata for RHEL CoreOS 9 image builds to improve tracking and management capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->