### PR TITLE
rosa-claude-plugins: run hack/ci.sh if present in prek test

### DIFF
--- a/ci-operator/config/openshift-online/rosa-claude-plugins/openshift-online-rosa-claude-plugins-main.yaml
+++ b/ci-operator/config/openshift-online/rosa-claude-plugins/openshift-online-rosa-claude-plugins-main.yaml
@@ -42,7 +42,11 @@ tests:
     cd /workspace/rosa-claude-plugins
     git init
     git add -A
-    prek run --all-files
+    if [ -x hack/ci.sh ]; then
+      ./hack/ci.sh
+    else
+      prek run --all-files
+    fi
   container:
     from: prek-runner
 zz_generated_metadata:


### PR DESCRIPTION
## Summary
- Adds conditional execution of `hack/ci.sh` in the rosa-claude-plugins prek test
- When an executable `hack/ci.sh` exists in the repo, it runs instead of the default `prek run --all-files`
- When `hack/ci.sh` does not exist, the existing prek behavior is preserved unchanged

## Test plan
- [ ] CI rehearsal passes on this PR
- [ ] Verify current behavior (no `hack/ci.sh` in rosa-claude-plugins) still runs `prek run --all-files`
- [ ] Once `hack/ci.sh` is added to rosa-claude-plugins, verify it gets executed instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline configuration to support more flexible test execution workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->