### PR TITLE
DNM: Fix management cluster dump being censored by Prow

### DIFF
--- a/ci-operator/step-registry/hypershift/destroy-nested-management-cluster/hypershift-destroy-nested-management-cluster-chain.yaml
+++ b/ci-operator/step-registry/hypershift/destroy-nested-management-cluster/hypershift-destroy-nested-management-cluster-chain.yaml
@@ -20,10 +20,7 @@ chain:
       fi
 
       CLUSTER_NAME="$(echo -n $PROW_JOB_ID|sha256sum|cut -c-10)-mgmt"
-      mkdir -p "${ARTIFACT_DIR}/output"
-      bin/hypershift dump cluster --dump-guest-cluster=true --artifact-dir="${ARTIFACT_DIR}/output" --name="${CLUSTER_NAME}" --namespace="${HYPERSHIFT_NAMESPACE}"
-      tar -cvzf "${ARTIFACT_DIR}/artifacts.tar.gz" "${ARTIFACT_DIR}/output"
-      rm -rf "${ARTIFACT_DIR}/output"
+      bin/hypershift dump cluster --dump-guest-cluster=true --artifact-dir="${ARTIFACT_DIR}" --archive-dump=false --name="${CLUSTER_NAME}" --namespace="${HYPERSHIFT_NAMESPACE}"
     credentials:
     - mount_path: /etc/hypershift-kubeconfig
       name: hypershift-ci-2


### PR DESCRIPTION
## Summary

The `dump-management-cluster` step packs all dump output into a single `artifacts.tar.gz` and deletes the raw files. Prow's `censor_secrets` detects credential material (from mounted kubeconfigs like `azure-hypershift-ci` and `hypershift-ci-2`) inside the compressed archive and, unable to censor individual entries within it, replaces the **entire file** with:

> "This file contained potentially sensitive information and has been removed."

This leaves zero diagnostic data from the management cluster for debugging test failures.

## Changes

- Write dump files directly into `$ARTIFACT_DIR` with `--archive-dump=false` instead of into a subdirectory that gets tarred and deleted
- Prow can now censor individual files that contain secret values while preserving the rest (pod YAML, events, deployments, operator status, container logs)

## Test plan

- [ ] Trigger a self-managed Azure e2e job and verify that the `dump-management-cluster` step produces individual artifact files instead of a single censored tar
- [ ] Verify that diagnostic artifacts (pod descriptions, events, deployment YAML, logs) are accessible in the job artifacts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified cluster artifact collection during nested management cluster destruction by streamlining the dump process to directly use artifact directory flags, eliminating intermediate file packaging and cleanup steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->