### PR TITLE
OCM-22871 | fix(ci): align rosa image variants to 4.22

### DIFF
--- a/ci-operator/config/openshift/rosa/openshift-rosa-master__e2e-presubmits.yaml
+++ b/ci-operator/config/openshift/rosa/openshift-rosa-master__e2e-presubmits.yaml
@@ -1,22 +1,22 @@
 base_images:
-  origin_4.21_cli:
-    name: scos-4.21
+  origin_4.22_cli:
+    name: scos-4.22
     namespace: origin
     tag: cli
 build_root:
   image_stream_tag:
     name: builder
     namespace: ocp
-    tag: rhel-9-golang-1.24-openshift-4.21
+    tag: rhel-9-golang-1.25-openshift-4.22
 images:
   items:
   - dockerfile_path: images/Dockerfile.e2e
-    from: origin_4.21_cli
+    from: origin_4.22_cli
     to: rosa-aws-cli
 releases:
   latest:
     integration:
-      name: "4.21"
+      name: "4.22"
       namespace: ocp
 resources:
   '*':

--- a/ci-operator/config/openshift/rosa/openshift-rosa-master__e2e.yaml
+++ b/ci-operator/config/openshift/rosa/openshift-rosa-master__e2e.yaml
@@ -7,11 +7,11 @@ build_root:
   image_stream_tag:
     name: builder
     namespace: ocp
-    tag: rhel-8-golang-1.24-openshift-4.21
+    tag: rhel-8-golang-1.25-openshift-4.22
 releases:
   latest:
     integration:
-      name: "4.21"
+      name: "4.22"
       namespace: ocp
 resources:
   '*':

--- a/ci-operator/config/openshift/rosa/openshift-rosa-master__images-release.yaml
+++ b/ci-operator/config/openshift/rosa/openshift-rosa-master__images-release.yaml
@@ -1,17 +1,17 @@
 base_images:
-  origin_4.21_cli:
-    name: scos-4.21
+  origin_4.22_cli:
+    name: scos-4.22
     namespace: origin
     tag: cli
 build_root:
   image_stream_tag:
     name: builder
     namespace: ocp
-    tag: rhel-9-golang-1.24-openshift-4.21
+    tag: rhel-9-golang-1.25-openshift-4.22
 images:
   items:
   - dockerfile_path: images/Dockerfile.release
-    from: origin_4.21_cli
+    from: origin_4.22_cli
     to: rosa-aws-cli
 promotion:
   to:

--- a/ci-operator/config/openshift/rosa/openshift-rosa-master__images.yaml
+++ b/ci-operator/config/openshift/rosa/openshift-rosa-master__images.yaml
@@ -1,17 +1,17 @@
 base_images:
-  origin_4.21_cli:
-    name: scos-4.21
+  origin_4.22_cli:
+    name: scos-4.22
     namespace: origin
     tag: cli
 build_root:
   image_stream_tag:
     name: builder
     namespace: ocp
-    tag: rhel-9-golang-1.24-openshift-4.21
+    tag: rhel-9-golang-1.25-openshift-4.22
 images:
   items:
   - dockerfile_path: images/Dockerfile.e2e
-    from: origin_4.21_cli
+    from: origin_4.22_cli
     to: rosa-aws-cli
 promotion:
   to:


### PR DESCRIPTION
## Summary
- move the ROSA `images`, `images-release`, `e2e-presubmits`, and `e2e` ci-operator variants to the 4.22 CLI/release and Go 1.25 build-root inputs
- keep the sibling ROSA configs in lockstep so the release-side CI inputs match the current master baseline consistently
- pair this with the ROSA repo change that pins the e2e Dockerfile to a verified Go 1.25.8 builder

## Test plan
- [x] `make jobs WHAT=openshift/rosa`
- [x] Confirm the updated ROSA variant configs now reference the expected 4.22 / Go 1.25 inputs
- [x] Re-run `make jobs WHAT=openshift/rosa` after the review follow-up fixes

## Related
- Jira: [OCM-22871](https://redhat.atlassian.net/browse/OCM-22871)
- Paired ROSA PR: openshift/rosa#3237

[OCM-22871]: https://redhat.atlassian.net/browse/OCM-22871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * ROSA CI and image build configurations updated to use OpenShift 4.22 platform assets.
  * Builder images bumped to Go 1.25 tags.
  * E2E image builds and base-image references switched to the new 4.22 variants.
  * CI release pointer (`releases.latest.integration`) updated from 4.21 to 4.22.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->