### PR TITLE
backplane-tools: use from_repository for build root

### DIFF
--- a/ci-operator/config/openshift/backplane-tools/openshift-backplane-tools-main.yaml
+++ b/ci-operator/config/openshift/backplane-tools/openshift-backplane-tools-main.yaml
@@ -1,9 +1,6 @@
 binary_build_commands: make build
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-8-release-golang-1.21-openshift-4.16
+  from_repository: true
 resources:
   '*':
     limits:

--- a/ci-operator/jobs/openshift/backplane-tools/openshift-backplane-tools-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/backplane-tools/openshift-backplane-tools-main-postsubmits.yaml
@@ -6,8 +6,6 @@ postsubmits:
     - ^main$
     cluster: build05
     decorate: true
-    decoration_config:
-      skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
     max_concurrency: 1

--- a/ci-operator/jobs/openshift/backplane-tools/openshift-backplane-tools-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/backplane-tools/openshift-backplane-tools-main-presubmits.yaml
@@ -8,8 +8,6 @@ presubmits:
     cluster: build06
     context: ci/prow/coverage
     decorate: true
-    decoration_config:
-      skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -78,8 +76,6 @@ presubmits:
     cluster: build06
     context: ci/prow/lint
     decorate: true
-    decoration_config:
-      skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -141,8 +137,6 @@ presubmits:
     cluster: build06
     context: ci/prow/unit
     decorate: true
-    decoration_config:
-      skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"


### PR DESCRIPTION
Use from_repository: true so the build root image is defined by the repo's .ci-operator.yaml instead of being hardcoded here.

Enables https://github.com/openshift/backplane-tools/pull/89

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD build configuration to use repository-derived build root settings.
  * Streamlined CI job configurations by removing explicit cloning skip directives from pre and post-submit jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->