### PR TITLE
CCO: e2e-gcp-manual-oidc to run when specific files changed

### DIFF
--- a/ci-operator/config/openshift/cloud-credential-operator/openshift-cloud-credential-operator-master.yaml
+++ b/ci-operator/config/openshift/cloud-credential-operator/openshift-cloud-credential-operator-master.yaml
@@ -128,9 +128,8 @@ tests:
   steps:
     cluster_profile: openshift-org-azure
     workflow: openshift-e2e-azure-manual-oidc-workload-identity
-- always_run: false
-  as: e2e-gcp-manual-oidc
-  optional: true
+- as: e2e-gcp-manual-oidc
+  run_if_changed: pkg/cmd/provisioning/gcp/
   steps:
     cluster_profile: gcp
     workflow: openshift-e2e-gcp-manual-oidc-workload-identity

--- a/ci-operator/config/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-4.16.yaml
+++ b/ci-operator/config/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-4.16.yaml
@@ -128,9 +128,8 @@ tests:
   steps:
     cluster_profile: openshift-org-azure
     workflow: openshift-e2e-azure-manual-oidc-workload-identity
-- always_run: false
-  as: e2e-gcp-manual-oidc
-  optional: true
+- as: e2e-gcp-manual-oidc
+  run_if_changed: pkg/cmd/provisioning/gcp/
   steps:
     cluster_profile: gcp
     workflow: openshift-e2e-gcp-manual-oidc-workload-identity

--- a/ci-operator/config/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-4.17.yaml
+++ b/ci-operator/config/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-4.17.yaml
@@ -128,9 +128,8 @@ tests:
   steps:
     cluster_profile: openshift-org-azure
     workflow: openshift-e2e-azure-manual-oidc-workload-identity
-- always_run: false
-  as: e2e-gcp-manual-oidc
-  optional: true
+- as: e2e-gcp-manual-oidc
+  run_if_changed: pkg/cmd/provisioning/gcp/
   steps:
     cluster_profile: gcp
     workflow: openshift-e2e-gcp-manual-oidc-workload-identity

--- a/ci-operator/config/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-4.18.yaml
+++ b/ci-operator/config/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-4.18.yaml
@@ -128,9 +128,8 @@ tests:
   steps:
     cluster_profile: openshift-org-azure
     workflow: openshift-e2e-azure-manual-oidc-workload-identity
-- always_run: false
-  as: e2e-gcp-manual-oidc
-  optional: true
+- as: e2e-gcp-manual-oidc
+  run_if_changed: pkg/cmd/provisioning/gcp/
   steps:
     cluster_profile: gcp
     workflow: openshift-e2e-gcp-manual-oidc-workload-identity

--- a/ci-operator/config/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-4.19.yaml
+++ b/ci-operator/config/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-4.19.yaml
@@ -128,9 +128,8 @@ tests:
   steps:
     cluster_profile: openshift-org-azure
     workflow: openshift-e2e-azure-manual-oidc-workload-identity
-- always_run: false
-  as: e2e-gcp-manual-oidc
-  optional: true
+- as: e2e-gcp-manual-oidc
+  run_if_changed: pkg/cmd/provisioning/gcp/
   steps:
     cluster_profile: gcp
     workflow: openshift-e2e-gcp-manual-oidc-workload-identity

--- a/ci-operator/config/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-4.20.yaml
+++ b/ci-operator/config/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-4.20.yaml
@@ -128,9 +128,8 @@ tests:
   steps:
     cluster_profile: openshift-org-azure
     workflow: openshift-e2e-azure-manual-oidc-workload-identity
-- always_run: false
-  as: e2e-gcp-manual-oidc
-  optional: true
+- as: e2e-gcp-manual-oidc
+  run_if_changed: pkg/cmd/provisioning/gcp/
   steps:
     cluster_profile: gcp
     workflow: openshift-e2e-gcp-manual-oidc-workload-identity

--- a/ci-operator/config/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-4.21.yaml
+++ b/ci-operator/config/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-4.21.yaml
@@ -128,9 +128,8 @@ tests:
   steps:
     cluster_profile: openshift-org-azure
     workflow: openshift-e2e-azure-manual-oidc-workload-identity
-- always_run: false
-  as: e2e-gcp-manual-oidc
-  optional: true
+- as: e2e-gcp-manual-oidc
+  run_if_changed: pkg/cmd/provisioning/gcp/
   steps:
     cluster_profile: gcp
     workflow: openshift-e2e-gcp-manual-oidc-workload-identity

--- a/ci-operator/config/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-4.22.yaml
+++ b/ci-operator/config/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-4.22.yaml
@@ -129,9 +129,8 @@ tests:
   steps:
     cluster_profile: openshift-org-azure
     workflow: openshift-e2e-azure-manual-oidc-workload-identity
-- always_run: false
-  as: e2e-gcp-manual-oidc
-  optional: true
+- as: e2e-gcp-manual-oidc
+  run_if_changed: pkg/cmd/provisioning/gcp/
   steps:
     cluster_profile: gcp
     workflow: openshift-e2e-gcp-manual-oidc-workload-identity

--- a/ci-operator/config/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-4.23.yaml
+++ b/ci-operator/config/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-4.23.yaml
@@ -128,9 +128,8 @@ tests:
   steps:
     cluster_profile: openshift-org-azure
     workflow: openshift-e2e-azure-manual-oidc-workload-identity
-- always_run: false
-  as: e2e-gcp-manual-oidc
-  optional: true
+- as: e2e-gcp-manual-oidc
+  run_if_changed: pkg/cmd/provisioning/gcp/
   steps:
     cluster_profile: gcp
     workflow: openshift-e2e-gcp-manual-oidc-workload-identity

--- a/ci-operator/config/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-5.0.yaml
+++ b/ci-operator/config/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-5.0.yaml
@@ -128,9 +128,8 @@ tests:
   steps:
     cluster_profile: openshift-org-azure
     workflow: openshift-e2e-azure-manual-oidc-workload-identity
-- always_run: false
-  as: e2e-gcp-manual-oidc
-  optional: true
+- as: e2e-gcp-manual-oidc
+  run_if_changed: pkg/cmd/provisioning/gcp/
   steps:
     cluster_profile: gcp
     workflow: openshift-e2e-gcp-manual-oidc-workload-identity

--- a/ci-operator/jobs/openshift/cloud-credential-operator/openshift-cloud-credential-operator-master-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-credential-operator/openshift-cloud-credential-operator-master-presubmits.yaml
@@ -651,8 +651,8 @@ presubmits:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-cloud-credential-operator-master-e2e-gcp-manual-oidc
-    optional: true
     rerun_command: /test e2e-gcp-manual-oidc
+    run_if_changed: pkg/cmd/provisioning/gcp/
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-4.16-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-4.16-presubmits.yaml
@@ -651,8 +651,8 @@ presubmits:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-cloud-credential-operator-release-4.16-e2e-gcp-manual-oidc
-    optional: true
     rerun_command: /test e2e-gcp-manual-oidc
+    run_if_changed: pkg/cmd/provisioning/gcp/
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-4.17-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-4.17-presubmits.yaml
@@ -651,8 +651,8 @@ presubmits:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-cloud-credential-operator-release-4.17-e2e-gcp-manual-oidc
-    optional: true
     rerun_command: /test e2e-gcp-manual-oidc
+    run_if_changed: pkg/cmd/provisioning/gcp/
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-4.18-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-4.18-presubmits.yaml
@@ -651,8 +651,8 @@ presubmits:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-cloud-credential-operator-release-4.18-e2e-gcp-manual-oidc
-    optional: true
     rerun_command: /test e2e-gcp-manual-oidc
+    run_if_changed: pkg/cmd/provisioning/gcp/
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-4.19-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-4.19-presubmits.yaml
@@ -651,8 +651,8 @@ presubmits:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-cloud-credential-operator-release-4.19-e2e-gcp-manual-oidc
-    optional: true
     rerun_command: /test e2e-gcp-manual-oidc
+    run_if_changed: pkg/cmd/provisioning/gcp/
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-4.20-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-4.20-presubmits.yaml
@@ -651,8 +651,8 @@ presubmits:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-cloud-credential-operator-release-4.20-e2e-gcp-manual-oidc
-    optional: true
     rerun_command: /test e2e-gcp-manual-oidc
+    run_if_changed: pkg/cmd/provisioning/gcp/
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-4.21-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-4.21-presubmits.yaml
@@ -651,8 +651,8 @@ presubmits:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-cloud-credential-operator-release-4.21-e2e-gcp-manual-oidc
-    optional: true
     rerun_command: /test e2e-gcp-manual-oidc
+    run_if_changed: pkg/cmd/provisioning/gcp/
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-4.22-presubmits.yaml
@@ -651,8 +651,8 @@ presubmits:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-cloud-credential-operator-release-4.22-e2e-gcp-manual-oidc
-    optional: true
     rerun_command: /test e2e-gcp-manual-oidc
+    run_if_changed: pkg/cmd/provisioning/gcp/
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-4.23-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-4.23-presubmits.yaml
@@ -651,8 +651,8 @@ presubmits:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-cloud-credential-operator-release-4.23-e2e-gcp-manual-oidc
-    optional: true
     rerun_command: /test e2e-gcp-manual-oidc
+    run_if_changed: pkg/cmd/provisioning/gcp/
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-5.0-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-credential-operator/openshift-cloud-credential-operator-release-5.0-presubmits.yaml
@@ -651,8 +651,8 @@ presubmits:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-cloud-credential-operator-release-5.0-e2e-gcp-manual-oidc
-    optional: true
     rerun_command: /test e2e-gcp-manual-oidc
+    run_if_changed: pkg/cmd/provisioning/gcp/
     spec:
       containers:
       - args:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI test execution logic across multiple release branches and master. The GCP manual OIDC test now runs conditionally based on relevant code changes instead of using static execution flags, improving CI efficiency and resource utilization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->