### PR TITLE
Collect pprof data and metrics when kube-burner tests fail

### DIFF
--- a/ci-operator/step-registry/openshift-qe/cluster-density-v2/openshift-qe-cluster-density-v2-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/cluster-density-v2/openshift-qe-cluster-density-v2-commands.sh
@@ -75,7 +75,10 @@ fi
 export EXTRA_FLAGS UUID
 export ADDITIONAL_PARAMS
 
+set +o errexit
 ./run.sh
+RUN_EXIT_CODE=$?
+set -o errexit
 
 METRICS_FOLDER="collected-metrics-${UUID}"
 if [[ -f ${METRICS_FOLDER}/jobSummary.json ]]; then
@@ -95,3 +98,5 @@ fi
 if [[ ${PPROF} == "true" ]]; then
   cp -r pprof-data "${ARTIFACT_DIR}/"
 fi
+
+exit ${RUN_EXIT_CODE}

--- a/ci-operator/step-registry/openshift-qe/node-density-cni/openshift-qe-node-density-cni-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/node-density-cni/openshift-qe-node-density-cni-commands.sh
@@ -62,7 +62,10 @@ export ES_SERVER="https://$ES_USERNAME:$ES_PASSWORD@$ES_HOST"
 
 export EXTRA_FLAGS UUID
 
+set +o errexit
 ./run.sh
+RUN_EXIT_CODE=$?
+set -o errexit
 
 METRICS_FOLDER="collected-metrics-${UUID}"
 if [[ -f ${METRICS_FOLDER}/jobSummary.json ]]; then
@@ -82,3 +85,5 @@ fi
 if [[ ${PPROF} == "true" ]]; then
   cp -r pprof-data "${ARTIFACT_DIR}/"
 fi
+
+exit ${RUN_EXIT_CODE}

--- a/ci-operator/step-registry/openshift-qe/node-density-heavy/openshift-qe-node-density-heavy-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/node-density-heavy/openshift-qe-node-density-heavy-commands.sh
@@ -57,7 +57,10 @@ fi
 export EXTRA_FLAGS
 export ADDITIONAL_PARAMS
 
+set +o errexit
 ./run.sh
+RUN_EXIT_CODE=$?
+set -o errexit
 
 if [[ "${ENABLE_LOCAL_INDEX}" == "true" ]]; then
     metrics_folder_name=$(find . -maxdepth 1 -type d -name 'collected-metric*' | head -n 1)
@@ -68,3 +71,5 @@ fi
 if [[ ${PPROF} == "true" ]]; then
   cp -r pprof-data "${ARTIFACT_DIR}/"
 fi
+
+exit ${RUN_EXIT_CODE}

--- a/ci-operator/step-registry/openshift-qe/node-density/openshift-qe-node-density-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/node-density/openshift-qe-node-density-commands.sh
@@ -65,7 +65,10 @@ export ES_SERVER="https://$ES_USERNAME:$ES_PASSWORD@$ES_HOST"
 
 export EXTRA_FLAGS UUID
 
+set +o errexit
 ./run.sh
+RUN_EXIT_CODE=$?
+set -o errexit
 
 METRICS_FOLDER="collected-metrics-${UUID}"
 if [[ -f ${METRICS_FOLDER}/jobSummary.json ]]; then
@@ -85,3 +88,5 @@ fi
 if [[ ${PPROF} == "true" ]]; then
   cp -r pprof-data "${ARTIFACT_DIR}/"
 fi
+
+exit ${RUN_EXIT_CODE}

--- a/ci-operator/step-registry/openshift-qe/udn-density-pods/openshift-qe-udn-density-pods-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/udn-density-pods/openshift-qe-udn-density-pods-commands.sh
@@ -62,7 +62,10 @@ export ES_SERVER="https://$ES_USERNAME:$ES_PASSWORD@$ES_HOST"
 
 export EXTRA_FLAGS UUID
 
+set +o errexit
 ./run.sh
+RUN_EXIT_CODE=$?
+set -o errexit
 
 METRICS_FOLDER="collected-metrics-${UUID}"
 if [[ -f ${METRICS_FOLDER}/jobSummary.json ]]; then
@@ -82,3 +85,5 @@ fi
 if [[ ${PPROF} == "true" ]]; then
   cp -r pprof-data "${ARTIFACT_DIR}/"
 fi
+
+exit ${RUN_EXIT_CODE}


### PR DESCRIPTION
When kube-burner run.sh exits non-zero, set -o errexit causes the script to abort before collecting pprof data and metrics. Disable errexit around run.sh, capture the exit code, then re-enable errexit so artifact collection still runs. The original exit code is preserved.

Affected steps: cluster-density-v2, node-density, node-density-cni, node-density-heavy, udn-density-pods.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed exit status reporting in cluster density and node density test scripts to properly convey test results while allowing metrics and artifact collection to complete, ensuring test infrastructure behaves correctly during both success and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->