### PR TITLE
HIVE-3152: e2e-gcp: discover correct baseDomain

### DIFF
--- a/ci-operator/config/openshift/hive/openshift-hive-master.yaml
+++ b/ci-operator/config/openshift/hive/openshift-hive-master.yaml
@@ -189,7 +189,9 @@ tests:
     test:
     - as: test
       cli: latest
-      commands: GO_COMPLIANCE_INFO=0 CLOUD=gcp make test-e2e
+      commands: |
+        export BASE_DOMAIN=$(< "${CLUSTER_PROFILE_DIR}/public_hosted_zone")
+        GO_COMPLIANCE_INFO=0 CLOUD=gcp make test-e2e
       dependencies:
       - env: HIVE_IMAGE
         name: hive

--- a/ci-operator/config/openshift/hive/openshift-hive-master__periodic.yaml
+++ b/ci-operator/config/openshift/hive/openshift-hive-master__periodic.yaml
@@ -138,7 +138,9 @@ tests:
     test:
     - as: test
       cli: latest
-      commands: CLOUD=gcp make test-e2e
+      commands: |
+        export BASE_DOMAIN=$(< "${CLUSTER_PROFILE_DIR}/public_hosted_zone")
+        CLOUD=gcp make test-e2e
       dependencies:
       - env: HIVE_IMAGE
         name: hive


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GCP end-to-end test configurations to properly initialize base domain settings from cluster profile directory during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->