### PR TITLE
DPTP-4801: clusters/app.ci/prow/03_deployment/deck: Bump to 20GiB and 2vCPU

### DIFF
--- a/clusters/app.ci/prow/03_deployment/deck.yaml
+++ b/clusters/app.ci/prow/03_deployment/deck.yaml
@@ -191,8 +191,8 @@ objects:
             readOnly: true
           resources:
             requests:
-              memory: "11Gi"
-              cpu: "500m"
+              memory: "20Gi"
+              cpu: "2"
         - name: git-sync
           command:
           - /git-sync
@@ -447,8 +447,8 @@ objects:
             readOnly: true
           resources:
             requests:
-              memory: "11Gi"
-              cpu: "500m"
+              memory: "20Gi"
+              cpu: "2"
         volumes:
         - name: github-app-credentials
           secret:


### PR DESCRIPTION
Like a5fe7aec2a (#77632) and 40156497aa (#77012), bring the requests in line with actual usage, so the scheduler has a chance at finding a workable packing, and so configured-limit or noisy-neighbor contention is less likely to take down this important workload.

This time:

    max by (pod) (pod:container_cpu_usage:sum{pod=~"deck-.*", pod!~"deck-internal-.*"})

shows 1.5 to 2 vCPU, and:

    max by (name) (container_memory_rss{pod=~"deck-.*", pod!~"deck-internal-.*", container="deck"})

shows around 14 GB steady, with spikes I'm ignoring up beyond 50 GB.

As with the other commits, I'm rounding up a bit to give headroom for future growth, because slightly more cloud-infra spend is still lower cost than humans assembling to debug resource-contention flakes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment resource configurations to enhance performance and system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->