### PR TITLE
no-jira: disable sigstore verification for nightly verification test jobs

### DIFF
--- a/ci-operator/step-registry/cucushift/installer/rehearse/aws/cases/multi-cidr/provision/cucushift-installer-rehearse-aws-cases-multi-cidr-provision-ref.yaml
+++ b/ci-operator/step-registry/cucushift/installer/rehearse/aws/cases/multi-cidr/provision/cucushift-installer-rehearse-aws-cases-multi-cidr-provision-ref.yaml
@@ -27,5 +27,9 @@ ref:
     default: "amd64"
     documentation: |-
       The architecture of the control plane nodes (e.g., amd64, arm64).
+  - name: OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY
+    default: "true"
+    documentation: |-
+      Set to true to disable the Sigstore image signature policy to allow the installation of an unsigned release image. This is for internal CI testing only.
   documentation: >-
     Multi-CIDR test

--- a/ci-operator/step-registry/cucushift/installer/rehearse/aws/cases/multi-clusters-one-phz/provision/cucushift-installer-rehearse-aws-cases-multi-clusters-one-phz-provision-ref.yaml
+++ b/ci-operator/step-registry/cucushift/installer/rehearse/aws/cases/multi-clusters-one-phz/provision/cucushift-installer-rehearse-aws-cases-multi-clusters-one-phz-provision-ref.yaml
@@ -27,5 +27,9 @@ ref:
     default: "amd64"
     documentation: |-
       The architecture of the control plane nodes (e.g., amd64, arm64).
+  - name: OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY
+    default: "true"
+    documentation: |-
+      Set to true to disable the Sigstore image signature policy to allow the installation of an unsigned release image. This is for internal CI testing only.
   documentation: >-
     OCP-41246 - [ipi-on-aws] Create multiple clusters into one existing Route53 hosted zone


### PR DESCRIPTION
## Description

Add `OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY=true` to install step of private verification tests. Updated steps:
- cucushift-installer-rehearse-aws-cases-multi-cidr-provision
- cucushift-installer-rehearse-aws-cases-multi-clusters-one-phz-provision

**Why?** This disables OpenShift sigstore signature verification requirements for nightly builds that may not have signed images.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for an experimental image policy feature to AWS multi-CIDR ARM nightly test configurations and rehearsal workflows.
  * Added informational logging when the experimental image policy feature is enabled in test provisioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->