### PR TITLE
feat: add periodic to execute pr checks for edge team

### DIFF
--- a/ci-operator/config/openshift-eng/edge-tooling/.config.prowgen
+++ b/ci-operator/config/openshift-eng/edge-tooling/.config.prowgen
@@ -1,0 +1,2 @@
+private: true
+expose: true

--- a/ci-operator/config/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main.yaml
+++ b/ci-operator/config/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main.yaml
@@ -3,6 +3,22 @@ build_root:
     name: release
     namespace: openshift
     tag: rhel-9-release-golang-1.25-openshift-4.22
+images:
+  items:
+  - dockerfile_literal: |
+      FROM src
+      USER 0:0
+      RUN GH_TOKEN_VER=2.0.8 && GH_TOKEN_SHA=867d9ebf7dd18e67e2599f0f890f3f41b8673e88c4394a32a05476024c41ea0f && \
+          curl -sSL --connect-timeout 10 --max-time 120 --fail \
+            "https://github.com/Link-/gh-token/releases/download/v${GH_TOKEN_VER}/linux-amd64" \
+            -o /usr/local/bin/gh-token && \
+          echo "${GH_TOKEN_SHA}  /usr/local/bin/gh-token" | sha256sum -c - && \
+          chmod +x /usr/local/bin/gh-token
+      RUN dnf install -y --nodocs jq python3 python3-pip && dnf clean all
+      COPY . /opt/app-root/src/
+      WORKDIR /opt/app-root/src/edge-tooling
+    from: src
+    to: edge-tooling
 resources:
   '*':
     requests:
@@ -13,6 +29,15 @@ tests:
   cron: 0 9 * * *
   steps:
     workflow: openshift-edge-tooling-ci-monitor
+- as: pr-notifier
+  cron: 0 3 * * 0-5
+  restrict_network_access: false
+  steps:
+    env:
+      FORBIDDEN_LABELS: jira/invalid-bug
+      GITHUB_REPOS: openshift/origin,openshift-eng/two-node-toolbox,openshift/microshift,openshift-eng/edge-tooling
+      REQUIRED_LABELS: lgtm,approved,verified
+    workflow: openshift-edge-tooling-gh-notifier
 zz_generated_metadata:
   branch: main
   org: openshift-eng

--- a/ci-operator/config/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main.yaml
+++ b/ci-operator/config/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main.yaml
@@ -20,11 +20,12 @@ images:
           echo "${GH_TOKEN_SHA}  /usr/local/bin/gh-token" | sha256sum -c - && \
           chmod +x /usr/local/bin/gh-token
       COPY . /opt/app-root/src/
-      WORKDIR /opt/app-root/src/edge-tooling
+      WORKDIR /opt/app-root/src/
     from: src
     to: edge-tooling
   - dockerfile_literal: |
       FROM pipeline:claude-ai-helpers
+      USER 0:0
       COPY gotoken/gh-token /usr/local/bin/gh-token
       RUN chmod +x /usr/local/bin/gh-token
       COPY repo/ /opt/app-root/src/edge-tooling

--- a/ci-operator/config/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main.yaml
+++ b/ci-operator/config/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main.yaml
@@ -1,3 +1,8 @@
+base_images:
+  claude-ai-helpers:
+    name: claude-ai-helpers
+    namespace: ci
+    tag: latest
 build_root:
   image_stream_tag:
     name: release
@@ -14,11 +19,27 @@ images:
             -o /usr/local/bin/gh-token && \
           echo "${GH_TOKEN_SHA}  /usr/local/bin/gh-token" | sha256sum -c - && \
           chmod +x /usr/local/bin/gh-token
-      RUN dnf install -y --nodocs jq python3 python3-pip && dnf clean all
       COPY . /opt/app-root/src/
       WORKDIR /opt/app-root/src/edge-tooling
     from: src
     to: edge-tooling
+  - dockerfile_literal: |
+      FROM pipeline:claude-ai-helpers
+      COPY gotoken/gh-token /usr/local/bin/gh-token
+      RUN chmod +x /usr/local/bin/gh-token
+      COPY repo/ /opt/app-root/src/edge-tooling
+      WORKDIR /opt/app-root/src/edge-tooling
+    from: claude-ai-helpers
+    inputs:
+      edge-tooling:
+        paths:
+        - destination_dir: gotoken
+          source_path: /usr/local/bin/gh-token
+      src:
+        paths:
+        - destination_dir: repo
+          source_path: /go/src/github.com/openshift-eng/edge-tooling/.
+    to: edge-tooling-ai-helpers
 resources:
   '*':
     requests:

--- a/ci-operator/jobs/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main-periodics.yaml
@@ -28,6 +28,7 @@ periodics:
       - --gcs-upload-secret=/secrets/gcs/service-account.json
       - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
       - --lease-server-credentials-file=/etc/boskos/credentials
+      - --oauth-token-path=/usr/local/github-credentials/oauth
       - --report-credentials-file=/etc/report/credentials
       - --target=ocp-ci-monitor
       command:
@@ -53,6 +54,9 @@ periodics:
       - mountPath: /secrets/gcs
         name: gcs-credentials
         readOnly: true
+      - mountPath: /usr/local/github-credentials
+        name: github-credentials-openshift-ci-robot-private-git-cloner
+        readOnly: true
       - mountPath: /secrets/manifest-tool
         name: manifest-tool-local-pusher
         readOnly: true
@@ -70,6 +74,87 @@ periodics:
         - key: credentials
           path: credentials
         secretName: boskos-credentials
+    - name: github-credentials-openshift-ci-robot-private-git-cloner
+      secret:
+        secretName: github-credentials-openshift-ci-robot-private-git-cloner
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build05
+  cron: 0 3 * * 0-5
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-eng
+    repo: edge-tooling
+  labels:
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-eng-edge-tooling-main-pr-notifier
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --oauth-token-path=/usr/local/github-credentials/oauth
+      - --report-credentials-file=/etc/report/credentials
+      - --target=pr-notifier
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /usr/local/github-credentials
+        name: github-credentials-openshift-ci-robot-private-git-cloner
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: github-credentials-openshift-ci-robot-private-git-cloner
+      secret:
+        secretName: github-credentials-openshift-ci-robot-private-git-cloner
     - name: manifest-tool-local-pusher
       secret:
         secretName: manifest-tool-local-pusher

--- a/ci-operator/jobs/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main-presubmits.yaml
@@ -1,0 +1,64 @@
+presubmits:
+  openshift-eng/edge-tooling:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build01
+    context: ci/prow/images
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-eng-edge-tooling-main-images
+    rerun_command: /test images
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --target=[images]
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: github-credentials-openshift-ci-robot-private-git-cloner
+        secret:
+          secretName: github-credentials-openshift-ci-robot-private-git-cloner
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )images,?($|\s.*)

--- a/ci-operator/step-registry/openshift/edge-tooling/gh-notifier/OWNERS
+++ b/ci-operator/step-registry/openshift/edge-tooling/gh-notifier/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+  - edge-enablement-approvers
+reviewers:
+  - edge-enablement-reviewers
+  - microshift-reviewers

--- a/ci-operator/step-registry/openshift/edge-tooling/gh-notifier/openshift-edge-tooling-gh-notifier-commands.sh
+++ b/ci-operator/step-registry/openshift/edge-tooling/gh-notifier/openshift-edge-tooling-gh-notifier-commands.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -o nounset
+set -o errexit
+set -o pipefail
+
+echo "=== openshift-eng/edge-tooling gh-notifier ==="
+echo "Started at $(date -u '+%Y-%m-%d %H:%M UTC')"
+
+# ---------------------------------------------------------------------------
+# GitHub App token (same flow as openshift-edge-tooling-ci-monitor-commands.sh)
+# xtrace off so credentials are not logged
+# ---------------------------------------------------------------------------
+set +x
+
+if [[ -f "${GITHUB_APP_ID_PATH}" ]] && [[ -f "${GITHUB_KEY_PATH}" ]]; then
+    GH_TOKEN_EXE="${GH_TOKEN_EXE:-/usr/local/bin/gh-token}"
+    if [[ ! -x "${GH_TOKEN_EXE}" ]]; then
+        echo "ERROR: gh-token not found or not executable at ${GH_TOKEN_EXE} (expected from gh-notifier image build)."
+        exit 1
+    fi
+
+    if command -v jq >/dev/null 2>&1; then
+        GITHUB_TOKEN="$("${GH_TOKEN_EXE}" generate --app-id "$(< "${GITHUB_APP_ID_PATH}")" --key "${GITHUB_KEY_PATH}" | jq -r '.token')"
+    else
+        GITHUB_TOKEN="$("${GH_TOKEN_EXE}" generate --app-id "$(< "${GITHUB_APP_ID_PATH}")" --key "${GITHUB_KEY_PATH}" | python3 -c 'import json,sys; print(json.load(sys.stdin)["token"])')"
+    fi
+    if [[ -z "${GITHUB_TOKEN}" ]] || [[ "${GITHUB_TOKEN}" == "null" ]]; then
+        echo "ERROR: Failed to generate GitHub token from App credentials."
+        exit 1
+    fi
+    export GITHUB_TOKEN
+    echo "GitHub token generated."
+else
+    echo "ERROR: GitHub App credentials not found at GITHUB_APP_ID_PATH / GITHUB_KEY_PATH."
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Slack credential → env (script reads env; do not log values)
+# ---------------------------------------------------------------------------
+if [[ -n "${SLACK_WEBHOOK_SECRET_FILE:-}" ]] && [[ -f "${SLACK_WEBHOOK_SECRET_FILE}" ]]; then
+    SLACK_WEBHOOK_URL="$(<"${SLACK_WEBHOOK_SECRET_FILE}")"
+    export SLACK_WEBHOOK_URL
+fi
+
+echo "Working directory: ${PWD}"
+sleep 3000
+GH_NOTIFIER_INVOKE="${GH_NOTIFIER_INVOKE:-python3 gh-notifier/gh-notifier.py}"
+bash -c "set -euo pipefail; ${GH_NOTIFIER_INVOKE}"
+
+# ---------------------------------------------------------------------------
+# Prow / GCS: publish pr-dashboard.html (ci-operator sets ARTIFACT_DIR)
+# ---------------------------------------------------------------------------
+cp -f "./gh-notifier/pr-dashboard.html" "${ARTIFACT_DIR}/pr-dashboard.html"
+echo "Copied ./gh-notifier/pr-dashboard.html to ${ARTIFACT_DIR}/pr-dashboard.html (job artifacts / GCS)."
+

--- a/ci-operator/step-registry/openshift/edge-tooling/gh-notifier/openshift-edge-tooling-gh-notifier-commands.sh
+++ b/ci-operator/step-registry/openshift/edge-tooling/gh-notifier/openshift-edge-tooling-gh-notifier-commands.sh
@@ -44,13 +44,24 @@ if [[ -n "${SLACK_WEBHOOK_SECRET_FILE:-}" ]] && [[ -f "${SLACK_WEBHOOK_SECRET_FI
 fi
 
 echo "Working directory: ${PWD}"
-sleep 3000
+
+job_base="https://prow.ci.openshift.org/view/gs/test-platform-results"
+if [[ -n "${PULL_NUMBER:-}" ]]; then
+  PROW_JOB_URL="${job_base}/pr-logs/pull/${REPO_OWNER}_${REPO_NAME}/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
+else
+  PROW_JOB_URL="${job_base}/logs/${JOB_NAME}/${BUILD_ID}"
+fi
+export PROW_JOB_URL
+
 GH_NOTIFIER_INVOKE="${GH_NOTIFIER_INVOKE:-python3 gh-notifier/gh-notifier.py}"
 bash -c "set -euo pipefail; ${GH_NOTIFIER_INVOKE}"
 
 # ---------------------------------------------------------------------------
-# Prow / GCS: publish pr-dashboard.html (ci-operator sets ARTIFACT_DIR)
+# Prow / GCS: publish dashboard HTML (ci-operator sets ARTIFACT_DIR).
+# Spyglass html lens only picks up paths matching deck's required_files regex
+# (see core-services/prow/02_config _config.yaml), e.g. *-summary*.html — same
+# idea as openshift-edge-tooling-ci-monitor (edge-ci-monitor-summary.html).
 # ---------------------------------------------------------------------------
-cp -f "./gh-notifier/pr-dashboard.html" "${ARTIFACT_DIR}/pr-dashboard.html"
-echo "Copied ./gh-notifier/pr-dashboard.html to ${ARTIFACT_DIR}/pr-dashboard.html (job artifacts / GCS)."
+cp -f "./gh-notifier/pr-dashboard.html" "${ARTIFACT_DIR}/edge-tooling-pr-summary.html"
+echo "Copied ./gh-notifier/pr-dashboard.html to ${ARTIFACT_DIR}/edge-tooling-pr-summary.html (Spyglass + GCS)."
 

--- a/ci-operator/step-registry/openshift/edge-tooling/gh-notifier/openshift-edge-tooling-gh-notifier-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/edge-tooling/gh-notifier/openshift-edge-tooling-gh-notifier-ref.metadata.json
@@ -1,0 +1,12 @@
+{
+	"path": "openshift/edge-tooling/gh-notifier/openshift-edge-tooling-gh-notifier-ref.yaml",
+	"owners": {
+		"approvers": [
+			"edge-enablement-approvers"
+		],
+		"reviewers": [
+			"edge-enablement-reviewers",
+			"microshift-reviewers"
+		]
+	}
+}

--- a/ci-operator/step-registry/openshift/edge-tooling/gh-notifier/openshift-edge-tooling-gh-notifier-ref.yaml
+++ b/ci-operator/step-registry/openshift/edge-tooling/gh-notifier/openshift-edge-tooling-gh-notifier-ref.yaml
@@ -1,0 +1,56 @@
+ref:
+  as: openshift-edge-tooling-gh-notifier
+  from: edge-tooling
+  commands: openshift-edge-tooling-gh-notifier-commands.sh
+  credentials:
+  - namespace: test-credentials
+    name: pr-creds
+    mount_path: /var/run/pr-creds
+  - namespace: test-credentials
+    name: edge-tooling-ci-monitor-slack-webhook
+    mount_path: /var/run/slack-notifier/team-ocp-edge
+  env:
+  - name: GITHUB_APP_ID_PATH
+    default: /var/run/pr-creds/app_id
+    documentation: Path to GitHub App ID file for gh-token.
+  - name: GITHUB_KEY_PATH
+    default: /var/run/pr-creds/key.pem
+    documentation: Path to GitHub App private key for gh-token.
+  - name: GITHUB_REPOS
+    default: openshift-eng/edge-tooling
+    documentation: |-
+      Comma- or whitespace-separated GitHub repositories to consider, each as org/repo (for example openshift/foo).
+      Optional; defaults to openshift-eng/edge-tooling.
+  - name: SLACK_WEBHOOK_SECRET_FILE
+    default: /var/run/slack-notifier/team-ocp-edge
+    documentation: |-
+      File containing Slack incoming webhook URL (plain text). Exported as SLACK_WEBHOOK_URL
+      for the notifier script if this file exists.
+  - name: EXCLUDE_LABELS
+    default: ""
+    documentation: |-
+      Comma- or semicolon-separated labels. If set, pull requests missing any of these labels are flagged. Optional;
+      empty means this check will default to, "do-not-merge/hold,do-not-merge/work-in-progress,wip,work in progress".
+  - name: REQUIRED_LABELS
+    default: ""
+    documentation: |-
+      Comma- or semicolon-separated labels. If set, pull requests missing any of these labels are flagged. Optional;
+      empty means this check is disabled.
+  - name: FORBIDDEN_LABELS
+    default: ""
+    documentation: |-
+      Comma- or semicolon-separated labels. If set, pull requests that have any of these labels are flagged. Optional;
+      empty means this check is disabled.
+  resources:
+    requests:
+      cpu: 200m
+      memory: 512Mi
+  timeout: 30m0s
+  grace_period: 5m0s
+  documentation: |-
+    Runs the gh-notifier image built from openshift-eng/edge-tooling (pipeline image gh-notifier via
+    dockerfile_literal in ci-operator config), exports GitHub App and Slack credentials, and executes
+    GH_NOTIFIER_INVOKE. No runtime git clone—the src checkout is in the image; optional pip install of ./gh-notifier
+    runs at image build when pyproject.toml or setup.py exists. gh-token is installed in the image at build time.
+    After the notifier succeeds, if ./gh-notifier/pr-dashboard.html exists, it is copied to
+    "${ARTIFACT_DIR}/pr-dashboard.html" for Prow GCS artifacts (link from reporter_config or the job artifacts browser).

--- a/ci-operator/step-registry/openshift/edge-tooling/gh-notifier/openshift-edge-tooling-gh-notifier-ref.yaml
+++ b/ci-operator/step-registry/openshift/edge-tooling/gh-notifier/openshift-edge-tooling-gh-notifier-ref.yaml
@@ -8,7 +8,7 @@ ref:
     mount_path: /var/run/pr-creds
   - namespace: test-credentials
     name: edge-tooling-ci-monitor-slack-webhook
-    mount_path: /var/run/slack-notifier/team-ocp-edge
+    mount_path: /var/run/slack-notifier/slack-webhooks
   env:
   - name: GITHUB_APP_ID_PATH
     default: /var/run/pr-creds/app_id
@@ -22,7 +22,7 @@ ref:
       Comma- or whitespace-separated GitHub repositories to consider, each as org/repo (for example openshift/foo).
       Optional; defaults to openshift-eng/edge-tooling.
   - name: SLACK_WEBHOOK_SECRET_FILE
-    default: /var/run/slack-notifier/team-ocp-edge
+    default: /var/run/slack-notifier/slack-webhooks/team-ocp-edge
     documentation: |-
       File containing Slack incoming webhook URL (plain text). Exported as SLACK_WEBHOOK_URL
       for the notifier script if this file exists.
@@ -52,5 +52,6 @@ ref:
     dockerfile_literal in ci-operator config), exports GitHub App and Slack credentials, and executes
     GH_NOTIFIER_INVOKE. No runtime git clone—the src checkout is in the image; optional pip install of ./gh-notifier
     runs at image build when pyproject.toml or setup.py exists. gh-token is installed in the image at build time.
-    After the notifier succeeds, if ./gh-notifier/pr-dashboard.html exists, it is copied to
-    "${ARTIFACT_DIR}/pr-dashboard.html" for Prow GCS artifacts (link from reporter_config or the job artifacts browser).
+    After the notifier succeeds, ./gh-notifier/pr-dashboard.html is copied to
+    "${ARTIFACT_DIR}/edge-tooling-pr-summary.html" so Spyglass can show it (html lens *-summary*.html) and GCS/deck
+    can link the same path as in slack reporter templates (see ocp-ci-monitor / microshift ci-doctor patterns).

--- a/ci-operator/step-registry/openshift/edge-tooling/gh-notifier/openshift-edge-tooling-gh-notifier-workflow.metadata.json
+++ b/ci-operator/step-registry/openshift/edge-tooling/gh-notifier/openshift-edge-tooling-gh-notifier-workflow.metadata.json
@@ -1,0 +1,12 @@
+{
+	"path": "openshift/edge-tooling/gh-notifier/openshift-edge-tooling-gh-notifier-workflow.yaml",
+	"owners": {
+		"approvers": [
+			"edge-enablement-approvers"
+		],
+		"reviewers": [
+			"edge-enablement-reviewers",
+			"microshift-reviewers"
+		]
+	}
+}

--- a/ci-operator/step-registry/openshift/edge-tooling/gh-notifier/openshift-edge-tooling-gh-notifier-workflow.yaml
+++ b/ci-operator/step-registry/openshift/edge-tooling/gh-notifier/openshift-edge-tooling-gh-notifier-workflow.yaml
@@ -1,0 +1,8 @@
+workflow:
+  as: openshift-edge-tooling-gh-notifier
+  steps:
+    test:
+    - ref: openshift-edge-tooling-gh-notifier
+  documentation: |-
+    Builds and runs the gh-notifier image from openshift-eng/edge-tooling (dockerfile_literal in ci-operator config),
+    wires GitHub App and Slack credentials, and runs GH_NOTIFIER_INVOKE (no runtime clone; repo tree comes from src).

--- a/core-services/prow/02_config/openshift-eng/edge-tooling/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-eng/edge-tooling/_pluginconfig.yaml
@@ -14,5 +14,11 @@ plugins:
     - hold
     - label
     - lgtm
+    - trigger
     - verify-owners
     - wip
+triggers:
+- repos:
+  - openshift-eng/edge-tooling
+  trusted_apps:
+  - openshift-merge-bot


### PR DESCRIPTION
/hold

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated GitHub PR notifier: cron-driven weekday early-morning runs, GitHub App auth, optional Slack webhook, env-driven repo/label filtering, network-enabled, publishes PR dashboard artifact.
  * New CI images: helper base image and an image to stage tooling and credentials.
  * Markdown linting presubmit that runs on markdown-related changes.

* **Chores**
  * Added presubmit and periodic CI jobs for image builds, notifier, and markdownlint; updated job mounts, token wiring, and trigger configuration.

* **Governance**
  * New ownership/reviewer configuration for the notifier workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->