### PR TITLE
Add OMR V2 testing with latest Konflux build for OCP 4.21

### DIFF
--- a/ci-operator/config/quay/quay-tests/quay-quay-tests-master__omr-ocp421-unreleased.yaml
+++ b/ci-operator/config/quay/quay-tests/quay-quay-tests-master__omr-ocp421-unreleased.yaml
@@ -1,20 +1,20 @@
 base_images:
   upi-installer:
-    name: "4.20"
+    name: "4.21"
     namespace: ocp
     tag: upi-installer
 build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: rhel-8-release-golang-1.18-openshift-4.12
+    tag: rhel-9-release-golang-1.24-openshift-4.21
 releases:
   latest:
     candidate:
       architecture: amd64
       product: ocp
       stream: nightly
-      version: "4.20"
+      version: "4.21"
 resources:
   '*':
     limits:
@@ -23,13 +23,13 @@ resources:
       cpu: 100m
       memory: 200Mi
 tests:
-- as: quay-omr-tests-omr-ocp420-disconnected-unreleased
+- as: quay-omr-tests-omr-ocp421-disconnected-unreleased
   cron: 0 0 4 * *
   steps:
     cluster_profile: aws-quay-qe
     env:
       BASE_DOMAIN: quayqe.devcluster.openshift.com
-      OMR_IMAGE: quay.io/redhat-user-workloads/quay-eng-tenant/mirror-registry-v2-0@sha256:a6966203f3dc24888ec0a0434f843a6cced20befff474cd59aad0830d2eec1ef
+      OMR_IMAGE: quay.io/redhat-user-workloads/quay-eng-tenant/mirror-registry-v2-0@sha256:818541781e701376b633ec03c1965a30bcbe2a2b8b6bd9309a5f8a7048a2eb97
       OMR_RELEASE: "false"
     post:
     - chain: quay-tests-aws-ipi-disconnected-private-deprovision
@@ -39,4 +39,4 @@ zz_generated_metadata:
   branch: master
   org: quay
   repo: quay-tests
-  variant: omr-ocp420-unreleased
+  variant: omr-ocp421-unreleased

--- a/ci-operator/jobs/quay/quay-tests/quay-quay-tests-master-periodics.yaml
+++ b/ci-operator/jobs/quay/quay-tests/quay-quay-tests-master-periodics.yaml
@@ -6988,11 +6988,11 @@ periodics:
   labels:
     ci-operator.openshift.io/cloud: aws
     ci-operator.openshift.io/cloud-cluster-profile: aws-quay-qe
-    ci-operator.openshift.io/variant: omr-ocp420-unreleased
+    ci-operator.openshift.io/variant: omr-ocp421-unreleased
     ci.openshift.io/generator: prowgen
-    job-release: "4.20"
+    job-release: "4.21"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-quay-quay-tests-master-omr-ocp420-unreleased-quay-omr-tests-omr-ocp420-disconnected-unreleased
+  name: periodic-ci-quay-quay-tests-master-omr-ocp421-unreleased-quay-omr-tests-omr-ocp421-disconnected-unreleased
   spec:
     containers:
     - args:
@@ -7002,8 +7002,8 @@ periodics:
       - --oauth-token-path=/usr/local/github-credentials/oauth
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=quay-omr-tests-omr-ocp420-disconnected-unreleased
-      - --variant=omr-ocp420-unreleased
+      - --target=quay-omr-tests-omr-ocp421-disconnected-unreleased
+      - --variant=omr-ocp421-unreleased
       command:
       - ci-operator
       env:

--- a/ci-operator/step-registry/quay-tests/mirror-images-oc-adm/quay-tests-mirror-images-oc-adm-commands.sh
+++ b/ci-operator/step-registry/quay-tests/mirror-images-oc-adm/quay-tests-mirror-images-oc-adm-commands.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 set -o nounset
-set -o errexit
 set -o pipefail
 
 trap 'CHILDREN=$(jobs -p); if test -n "${CHILDREN}"; then kill ${CHILDREN} && wait; fi' TERM
@@ -59,10 +58,27 @@ else
 fi
 
 # MIRROR IMAGES
-oc adm release -a "${new_pull_secret}" mirror ${mirror_options} \
- --from=${OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE} \
- --to=${target_release_image_repo} \
- --to-release-image=${target_release_image} | tee "${mirror_output}"
+MAX_ATTEMPTS=5
+ATTEMPT=0
+SUCCESS=false
+while [[ "${SUCCESS}" == "false" ]] && (( ATTEMPT++ < MAX_ATTEMPTS )); do
+  echo "Mirroring images attempt ${ATTEMPT}/${MAX_ATTEMPTS}..."
+  if oc adm release -a "${new_pull_secret}" mirror ${mirror_options} \
+   --from=${OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE} \
+   --to=${target_release_image_repo} \
+   --to-release-image=${target_release_image} | tee "${mirror_output}"; then
+    echo "Mirroring images succeeded on attempt ${ATTEMPT}"
+    SUCCESS=true
+  else
+    echo "Mirroring images attempt ${ATTEMPT} failed, retrying in 120s..."
+    sleep 120
+  fi
+done
+
+if [[ "${SUCCESS}" == "false" ]]; then
+  echo "Mirroring images failed after ${MAX_ATTEMPTS} attempts"
+  exit 1
+fi
 
 grep -B 1 -A 10 "kind: ImageContentSourcePolicy" ${mirror_output} > "${icsp_file}"
 grep -A 6 "imageContentSources" ${mirror_output} > "${install_config_icsp_patch}"

--- a/ci-operator/step-registry/quay-tests/provisioning-omr-disconnected/quay-tests-provisioning-omr-disconnected-commands.sh
+++ b/ci-operator/step-registry/quay-tests/provisioning-omr-disconnected/quay-tests-provisioning-omr-disconnected-commands.sh
@@ -128,7 +128,7 @@ resource "aws_security_group" "quaybuilder" {
 resource "aws_instance" "quaybuilder" {
   key_name      = aws_key_pair.quaybuilder0710.key_name
   ami           = "${ami_id}"
-  instance_type = "m4.xlarge"
+  instance_type = "m6i.xlarge"
   associate_public_ip_address = true
   vpc_security_group_ids = [aws_security_group.quaybuilder.id]
   subnet_id = "${PublicSubnet}"


### PR DESCRIPTION
## Summary
- Add OMR v2 unreleased disconnected testing job targeting OCP 4.21 nightly, replacing the previous OCP 4.20 config
- Update build_root to use `rhel-9-release-golang-1.24-openshift-4.21`
- Upgrade OMR disconnected EC2 instance type from `m4.xlarge` to `m6i.xlarge` for better network throughput during OCP release image mirroring
- Add retry logic (5 attempts, 120s backoff) to the OMR mirror step to handle transient network failures during the ~21 GB release payload upload

## Test plan
- [ ] Verify the periodic job `periodic-ci-quay-quay-tests-master-omr-ocp421-unreleased-quay-omr-tests-omr-ocp421-disconnected-unreleased` is generated correctly
- [ ] Rehearse the job to confirm it runs successfully
- [ ] Verify the OMR EC2 instance is provisioned with `m6i.xlarge` instance type
- [ ] Verify the mirror step retries on transient network failures