### PR TITLE
NO-JIRA: feat: add e2e-aws smoke test for openshift-mcp-server release-0.3

### DIFF
--- a/ci-operator/config/openshift/openshift-mcp-server/openshift-openshift-mcp-server-release-0.3.yaml
+++ b/ci-operator/config/openshift/openshift-mcp-server/openshift-openshift-mcp-server-release-0.3.yaml
@@ -4,6 +4,12 @@ images:
   items:
   - dockerfile_path: Dockerfile.ci
     to: openshift-mcp-server
+releases:
+  latest:
+    integration:
+      include_built_images: true
+      name: "4.22"
+      namespace: ocp
 resources:
   '*':
     requests:
@@ -19,6 +25,41 @@ tests:
   commands: GOFLAGS='-mod=readonly' XDG_DATA_HOME=/tmp/.local/share make test
   container:
     from: src
+- as: e2e-aws
+  optional: true
+  skip_if_only_changed: ^\.tekton/|\.md$|^(LICENSE|OWNERS)$
+  steps:
+    cluster_profile: openshift-org-aws
+    test:
+    - as: install-operator
+      cli: latest
+      commands: make -f Makefile-ocp.mk e2e-install-operator
+      from: src
+      resources:
+        requests:
+          cpu: 100m
+          memory: 200Mi
+    - as: deploy-mcp-server
+      cli: latest
+      commands: |
+        MCP_SERVER_IMAGE="${IMAGE_OPENSHIFT_MCP_SERVER}" make -f Makefile-ocp.mk e2e-deploy-mcp-server
+      dependencies:
+      - env: IMAGE_OPENSHIFT_MCP_SERVER
+        name: openshift-mcp-server
+      from: src
+      resources:
+        requests:
+          cpu: 100m
+          memory: 200Mi
+    - as: wait-ready
+      cli: latest
+      commands: make -f Makefile-ocp.mk e2e-wait-ready
+      from: src
+      resources:
+        requests:
+          cpu: 100m
+          memory: 200Mi
+    workflow: ipi-aws
 - as: security
   optional: true
   skip_if_only_changed: ^\.tekton/|\.md$|^(LICENSE|OWNERS)$

--- a/ci-operator/jobs/openshift/openshift-mcp-server/openshift-openshift-mcp-server-release-0.3-presubmits.yaml
+++ b/ci-operator/jobs/openshift/openshift-mcp-server/openshift-openshift-mcp-server-release-0.3-presubmits.yaml
@@ -1,6 +1,88 @@
 presubmits:
   openshift/openshift-mcp-server:
   - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-0\.3$
+    - ^release-0\.3-
+    cluster: build05
+    context: ci/prow/e2e-aws
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-openshift-mcp-server-release-0.3-e2e-aws
+    optional: true
+    rerun_command: /test e2e-aws
+    skip_if_only_changed: ^\.tekton/|\.md$|^(LICENSE|OWNERS)$
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-aws
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-aws,?($|\s.*)
+  - agent: kubernetes
     always_run: true
     branches:
     - ^release-0\.3$
@@ -136,6 +218,7 @@ presubmits:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
         - --target=security
         command:
         - ci-operator
@@ -157,6 +240,9 @@ presubmits:
         - mountPath: /etc/boskos
           name: boskos
           readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
@@ -177,6 +263,9 @@ presubmits:
           - key: credentials
             path: credentials
           secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end AWS test workflow that provisions an AWS cluster, installs the operator, deploys the MCP server image, waits for readiness, and uses explicit CPU/memory requests.
* **Chores**
  * Expanded CI to include validation against OpenShift 4.22 integration releases with built images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->