### PR TITLE
[WIP] TEST: Reduce test parallelism for PowerVS to improve monitor test reliability

### DIFF
--- a/ci-operator/step-registry/openshift/e2e/libvirt/test/openshift-e2e-libvirt-test-commands.sh
+++ b/ci-operator/step-registry/openshift/e2e/libvirt/test/openshift-e2e-libvirt-test-commands.sh
@@ -329,7 +329,7 @@ export KUBE_TEST_REPO_LIST=${SHARED_DIR}/kube-test-repo-list
 	# Disabling the test until https://issues.redhat.com/browse/OCPBUGS-55458 is fixed.
 	case "${CLUSTER_TYPE}" in
 	powervs*)
-	    TEST_ARGS="${TEST_ARGS:-} --disable-monitor=external-aws-cloud-service-availability,external-azure-cloud-service-availability,external-gcp-cloud-service-availability,service-type-load-balancer-availability --max-parallel-tests 10"
+	    TEST_ARGS="${TEST_ARGS:-} --disable-monitor=external-aws-cloud-service-availability,external-azure-cloud-service-availability,external-gcp-cloud-service-availability,service-type-load-balancer-availability --max-parallel-tests 15"
 		;;
 	libvirt-ppc64le*)
         TEST_ARGS="${TEST_ARGS:-} --disable-monitor=external-aws-cloud-service-availability,external-azure-cloud-service-availability,external-gcp-cloud-service-availability"

--- a/ci-operator/step-registry/openshift/e2e/libvirt/test/openshift-e2e-libvirt-test-commands.sh
+++ b/ci-operator/step-registry/openshift/e2e/libvirt/test/openshift-e2e-libvirt-test-commands.sh
@@ -329,7 +329,7 @@ export KUBE_TEST_REPO_LIST=${SHARED_DIR}/kube-test-repo-list
 	# Disabling the test until https://issues.redhat.com/browse/OCPBUGS-55458 is fixed.
 	case "${CLUSTER_TYPE}" in
 	powervs*)
-	    TEST_ARGS="${TEST_ARGS:-} --disable-monitor=external-aws-cloud-service-availability,external-azure-cloud-service-availability,external-gcp-cloud-service-availability,service-type-load-balancer-availability"
+	    TEST_ARGS="${TEST_ARGS:-} --disable-monitor=external-aws-cloud-service-availability,external-azure-cloud-service-availability,external-gcp-cloud-service-availability,service-type-load-balancer-availability --max-parallel-tests 10"
 		;;
 	libvirt-ppc64le*)
         TEST_ARGS="${TEST_ARGS:-} --disable-monitor=external-aws-cloud-service-availability,external-azure-cloud-service-availability,external-gcp-cloud-service-availability"


### PR DESCRIPTION
This is a test PR to evaluate the impact of reducing test parallelism for PowerVS OpenShift installations to address monitor test failures.

## Current Configuration
- **Test Parallelism:** 30 (default)
- **Result:** pod-network-availability monitor tests timeout (pods take ~12 min to start, timeout is 10 min)

## New Configuration  
- **Test Parallelism:** 15
- **Expected Result:** Monitor pods start within timeout window


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test execution configuration to limit parallel test runs to a maximum of 10 tests for PowerVS cluster deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->