### PR TITLE
Update hypershift-oadp-plugin image for main

### DIFF
--- a/ci-operator/step-registry/hypershift/aws/oadp-setup/hypershift-aws-oadp-setup-commands.sh
+++ b/ci-operator/step-registry/hypershift/aws/oadp-setup/hypershift-aws-oadp-setup-commands.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 CLUSTER_NAME=$(cat "${SHARED_DIR}/cluster-name")
 REGION="${OADP_AWS_REGION:-us-east-1}"
 BUCKET_NAME="${OADP_S3_BUCKET_NAME:-hypershift-oadp-${CLUSTER_NAME}}"
-OADP_PLUGIN_IMAGE="${OADP_HYPERSHIFT_PLUGIN_IMAGE:-quay.io/redhat-user-workloads/ocp-art-tenant/oadp-hypershift-oadp-plugin-main:main}"
+OADP_PLUGIN_IMAGE="${OADP_HYPERSHIFT_PLUGIN_IMAGE:-quay.io/konveyor/hypershift-oadp-plugin:latest}"
 export AWS_SHARED_CREDENTIALS_FILE="/etc/hypershift-ci-jobs-awscreds/credentials"
 
 echo "Setting up OADP prerequisites for backup/restore tests"

--- a/ci-operator/step-registry/hypershift/aws/oadp-setup/hypershift-aws-oadp-setup-ref.yaml
+++ b/ci-operator/step-registry/hypershift/aws/oadp-setup/hypershift-aws-oadp-setup-ref.yaml
@@ -24,7 +24,7 @@ ref:
   - name: OADP_HYPERSHIFT_PLUGIN_IMAGE
     documentation: |-
       The image to use for the hypershift OADP plugin in the DataProtectionApplication.
-    default: quay.io/redhat-user-workloads/ocp-art-tenant/oadp-hypershift-oadp-plugin-main:main
+    default: quay.io/konveyor/hypershift-oadp-plugin:latest
   documentation: |-
     Sets up AWS-specific OADP prerequisites for HyperShift backup/restore tests:
     creates an S3 bucket, AWS credentials secret, DataProtectionApplication,


### PR DESCRIPTION
After merging https://github.com/openshift/release/pull/78204, this is a new location for the image that is built from main branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the default container image used for the OADP Hypershift plugin configuration.
  * Preserved existing environment-variable override behavior so custom images and prior workflows continue to work without change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->