### PR TITLE
DNM: Run aws-ipi-multi-cidr-arm-f14 with EC & RC arm64 image

### DIFF
--- a/ci-operator/config/openshift/verification-tests/openshift-verification-tests-main__installation-nightly-4.22.yaml
+++ b/ci-operator/config/openshift/verification-tests/openshift-verification-tests-main__installation-nightly-4.22.yaml
@@ -32,6 +32,11 @@ base_images:
     namespace: ci
     tag: latest
 releases:
+  arm64-candidate:
+    release:
+      architecture: arm64
+      channel: candidate
+      version: "4.22"
   arm64-latest:
     candidate:
       architecture: arm64
@@ -250,7 +255,7 @@ tests:
     allow_skip_on_success: true
     cluster_profile: aws-qe
     dependencies:
-      OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: release:arm64-latest
+      OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: release:arm64-candidate
     env:
       BASE_DOMAIN: qe.devcluster.openshift.com
       COMPUTE_NODE_TYPE: m6g.xlarge


### PR DESCRIPTION
Add ~arm64-ec5~ (arm64-candidate) release definition pointing to the ~4.22.0-ec.5~ (latest RC) candidate release and update the aws-ipi-multi-cidr-arm-f14 nightly job to use this specific EC release instead of the arm64-latest nightly stream.

**Updated**: RC release images are now available. We will focus on testing that.

DO_NOT_MERGE: This PR is only to perform full functional testing for the installer. Since the job ignores the image override, this is the only way.

/hold

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new arm64 candidate OpenShift release (4.22) channel.

* **Chores**
  * Updated AWS installer test configuration to use the arm64 candidate release override.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->