### PR TITLE
fix rosa list version in account role creation step

### DIFF
--- a/ci-operator/step-registry/rosa/sts/account-roles/create/rosa-sts-account-roles-create-commands.sh
+++ b/ci-operator/step-registry/rosa/sts/account-roles/create/rosa-sts-account-roles-create-commands.sh
@@ -110,8 +110,13 @@ if [[ "${create_ret}" -ne 0 && "${CHANNEL_GROUP}" == "stable" ]]; then
   exit "${create_ret}"
 elif [[ "${create_ret}" -ne 0 ]]; then
   echo "Account role creation failed (exit ${create_ret}). Falling back to latest available version in channel-group ${CHANNEL_GROUP}..."
-  fallback_version=$(rosa list versions --channel-group "${CHANNEL_GROUP}" ${CLUSTER_SWITCH} -o json 2>/dev/null \
-    | jq -r '.[].raw_id' | cut -d'.' -f1,2 | sort -Vu | tail -1 || true)
+  if [[ "$HOSTED_CP" == "true" ]]; then
+    fallback_version=$(rosa list versions --channel-group "${CHANNEL_GROUP}" ${CLUSTER_SWITCH} -o json 2>/dev/null \
+      | jq -r '.[].raw_id' | cut -d'.' -f1,2 | sort -Vu | tail -1 || true)
+  else
+    fallback_version=$(rosa list versions --channel-group "${CHANNEL_GROUP}" -o json 2>/dev/null \
+      | jq -r '.[].raw_id' | cut -d'.' -f1,2 | sort -Vu | tail -1 || true)
+  fi
   if [[ -n "${fallback_version}" && "${fallback_version}" != "${OPENSHIFT_VERSION}" ]]; then
     echo "Retrying with version ${fallback_version} (was ${OPENSHIFT_VERSION})"
     OPENSHIFT_VERSION="${fallback_version}"


### PR DESCRIPTION
`rosa list versions` does not have --classic parameter, so set it only when hcp is true

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account role creation fallback logic to more reliably select versions based on cluster configuration during creation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->