### PR TITLE
NO-JIRA: Install MetalLB from konflux in MCE jobs

### DIFF
--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.22__periodics-mce.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.22__periodics-mce.yaml
@@ -72,8 +72,11 @@ tests:
   steps:
     cluster_profile: equinix-ocp-hcp
     env:
+      KONFLUX_DEPLOY_CATALOG_SOURCE: "true"
+      KONFLUX_DEPLOY_OPERATORS: "true"
       LVM_OPERATOR_SUB_CHANNEL: stable-4.22
       MCE_VERSION: "2.17"
+      METALLB_OPERATOR_SUB_SOURCE: metallb-konflux
     workflow: hypershift-mce-agent-manual-conformance
 - as: e2e-agent-connected-ovn-ipv4-metal-conformance
   capabilities:
@@ -96,7 +99,6 @@ tests:
       KONFLUX_DEPLOY_CATALOG_SOURCE: "true"
       KONFLUX_DEPLOY_OPERATORS: "true"
       LVM_OPERATOR_SUB_CHANNEL: stable-4.22
-      LVM_OPERATOR_SUB_SOURCE: lvm-catalogsource
       MCE_VERSION: "2.17"
       METALLB_OPERATOR_SUB_SOURCE: metallb-konflux
     workflow: hypershift-mce-agent-metal3-conformance
@@ -124,7 +126,6 @@ tests:
       KONFLUX_DEPLOY_CATALOG_SOURCE: "true"
       KONFLUX_DEPLOY_OPERATORS: "true"
       LVM_OPERATOR_SUB_CHANNEL: stable-4.22
-      LVM_OPERATOR_SUB_SOURCE: lvm-catalogsource
       MCE_VERSION: "2.17"
       METALLB_OPERATOR_SUB_SOURCE: metallb-konflux
     test:
@@ -242,7 +243,12 @@ tests:
     cluster_profile: equinix-ocp-hcp
     env:
       HYPERSHIFT_NODE_COUNT: "2"
+      KONFLUX_DEPLOY_CATALOG_SOURCE: "true"
+      KONFLUX_DEPLOY_OPERATORS: "true"
+      KONFLUX_DEPLOY_SUBSCRIPTION: "false"
+      LOCAL_STORAGE_OPERATOR_SUB_SOURCE: local-storage-konflux
       LVM_OPERATOR_SUB_CHANNEL: stable-4.22
+      METALLB_OPERATOR_SUB_SOURCE: metallb-konflux
       MCE_VERSION: "2.17"
       ODF_OPERATOR_SUB_CHANNEL: stable-4.21
       ODF_OPERATOR_SUB_SOURCE: redhat-operators-v4-21

--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.22__periodics-mce.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.22__periodics-mce.yaml
@@ -248,8 +248,8 @@ tests:
       KONFLUX_DEPLOY_SUBSCRIPTION: "false"
       LOCAL_STORAGE_OPERATOR_SUB_SOURCE: local-storage-konflux
       LVM_OPERATOR_SUB_CHANNEL: stable-4.22
-      METALLB_OPERATOR_SUB_SOURCE: metallb-konflux
       MCE_VERSION: "2.17"
+      METALLB_OPERATOR_SUB_SOURCE: metallb-konflux
       ODF_OPERATOR_SUB_CHANNEL: stable-4.21
       ODF_OPERATOR_SUB_SOURCE: redhat-operators-v4-21
       REDHAT_OPERATORS_INDEX_TAG: v4.21

--- a/ci-operator/step-registry/hypershift/agent/create/metallb/catalogsource/hypershift-agent-create-metallb-catalogsource-commands.sh
+++ b/ci-operator/step-registry/hypershift/agent/create/metallb/catalogsource/hypershift-agent-create-metallb-catalogsource-commands.sh
@@ -3,6 +3,8 @@
 set -eoux pipefail
 
 declare -r REGISTRY_PROXY_PORT="${KONFLUX_REGISTRY_PROXY_PORT:-6004}"
+declare -r DISCONNECTED="${DISCONNECTED:-false}"
+declare -r KONFLUX_DEPLOY_CATALOG_SOURCE="${KONFLUX_DEPLOY_CATALOG_SOURCE:-false}"
 
 function create_marketplace_namespace () {
     # Since OCP 4.11, the marketplace is optional. If it is not installed, we need to create the namespace manually.

--- a/ci-operator/step-registry/hypershift/mce/agent/manual/conformance/hypershift-mce-agent-manual-conformance-workflow.yaml
+++ b/ci-operator/step-registry/hypershift/mce/agent/manual/conformance/hypershift-mce-agent-manual-conformance-workflow.yaml
@@ -8,6 +8,7 @@ workflow:
     allow_best_effort_post_steps: true
     allow_skip_on_success: true
     post:
+    - ref: wait
     - ref: hypershift-mce-dump
     - chain: hypershift-mce-agent-destroy
     - chain: baremetalds-ofcir-post

--- a/ci-operator/step-registry/hypershift/mce/agent/manual/conformance/hypershift-mce-agent-manual-conformance-workflow.yaml
+++ b/ci-operator/step-registry/hypershift/mce/agent/manual/conformance/hypershift-mce-agent-manual-conformance-workflow.yaml
@@ -17,20 +17,30 @@ workflow:
     pre:
     - chain: baremetalds-ofcir-pre
     - ref: enable-qe-catalogsource
+    - ref: deploy-konflux-operator
     - chain: hypershift-mce-agent-lvm
     - ref: hypershift-mce-install
     - chain: hypershift-mce-agent-manual-create
     env:
       CLUSTERTYPE: host_384gb_el9
-      TEST_SKIPS: etcd leader changes are not excessive
+      KONFLUX_DEPLOY_OPERATORS: "false"
+      KONFLUX_DEPLOY_CATALOG_SOURCE: "false"
+      KONFLUX_DEPLOY_SUBSCRIPTION: "false"
+      KONFLUX_TARGET_OPERATORS: metallb
       LVM_OPERATOR_SUB_SOURCE: lvm-catalogsource
       METALLB_OPERATOR_SUB_SOURCE: qe-app-registry
+      TEST_SKIPS: etcd leader changes are not excessive
       IP_STACK: v4
       DEVSCRIPTS_CONFIG: |
         IP_STACK=v4
+        NUM_WORKERS=4
         NETWORK_TYPE=OVNKubernetes
+        MASTER_MEMORY=32768
+        WORKER_MEMORY=32768
+        WORKER_VCPU=16
         VM_EXTRADISKS=true
         VM_EXTRADISKS_LIST=vda
         VM_EXTRADISKS_SIZE=500G
-        NUM_WORKERS=4
         NUM_EXTRA_WORKERS=3
+        PROVISIONING_NETWORK_PROFILE=Disabled
+        REDFISH_EMULATOR_IGNORE_BOOT_DEVICE=True

--- a/ci-operator/step-registry/hypershift/mce/agent/manual/create/hypershift-mce-agent-manual-create-chain.yaml
+++ b/ci-operator/step-registry/hypershift/mce/agent/manual/create/hypershift-mce-agent-manual-create-chain.yaml
@@ -8,5 +8,6 @@ chain:
   - ref: hypershift-agent-create-proxy
   - ref: hypershift-agent-create-add-worker-manual
   - ref: cucushift-hypershift-extended-enable-qe-catalogsource
+  - ref: hypershift-agent-create-metallb-catalogsource
   - ref: hypershift-agent-create-metallb
   - ref: hypershift-agent-check-conditions

--- a/ci-operator/step-registry/hypershift/mce/kubevirt/baremetalds/conformance/hypershift-mce-kubevirt-baremetalds-conformance-workflow.yaml
+++ b/ci-operator/step-registry/hypershift/mce/kubevirt/baremetalds/conformance/hypershift-mce-kubevirt-baremetalds-conformance-workflow.yaml
@@ -19,6 +19,7 @@ workflow:
     Track HyperShift's development here: https://issues.redhat.com/projects/HOSTEDCP
   steps:
     post:
+    - ref: wait
     - ref: hypershift-mce-dump
     - chain: gather-core-dump
     - chain: hypershift-mce-kubevirt-destroy


### PR DESCRIPTION
This should fix the following issues:
https://redhat.atlassian.net/browse/OCPBUGS-84086 - CI job for Agent with non-baremetal setup permanently fails
https://redhat.atlassian.net/browse/OCPBUGS-84112 - CI job for Kubevirt fails to install MetalLB operator
Note: OCPBUGS-84112 is fixed only partially here (the MetalLB installation), but there is a real bug waiting for a backport: https://github.com/openshift/hypershift/pull/8295

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated CI test configs to use Konflux-based catalog/operator sources for selected MCE scenarios, retarget MetalLB to Konflux variants, and remove specific operator sources in some metal conformance variants.
  * Tuned conformance workflows: added wait steps, refined worker counts and resource sizing, and adjusted provisioning/emulator flags for more reliable metal and KubeVirt testing.

* **Chores**
  * Added stable defaults for disconnected and Konflux catalog deployment flags and inserted a catalogsource preparation step before MetalLB installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->