### PR TITLE
Update base image tags for kube-rbac-proxy on 2.11

### DIFF
--- a/ci-operator/config/stolostron/kube-rbac-proxy/stolostron-kube-rbac-proxy-release-2.11.yaml
+++ b/ci-operator/config/stolostron/kube-rbac-proxy/stolostron-kube-rbac-proxy-release-2.11.yaml
@@ -2,12 +2,12 @@ base_images:
   base:
     name: ubi-minimal
     namespace: ocp
-    tag: "8"
+    tag: "9"
 build_root:
   image_stream_tag:
     name: builder
     namespace: stolostron
-    tag: go1.18-linux
+    tag: go1.25-linux
 images:
   items:
   - dockerfile_path: Dockerfile.prow


### PR DESCRIPTION
resolves [ACM-32741](https://redhat.atlassian.net/browse/ACM-32741)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/build configuration to use newer base image and compiler toolchain versions for improved build environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[ACM-32741]: https://redhat.atlassian.net/browse/ACM-32741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ