### PR TITLE
NO-JIRA: Mirror also postgresql-15 and postgresql-16 for disconnected env

### DIFF
--- a/ci-operator/step-registry/hypershift/mce/agent/create/agentserviceconfig/hypershift-mce-agent-create-agentserviceconfig-commands.sh
+++ b/ci-operator/step-registry/hypershift/mce/agent/create/agentserviceconfig/hypershift-mce-agent-create-agentserviceconfig-commands.sh
@@ -91,6 +91,12 @@ spec:
   - mirrors:
     - ${mirror}/rhel9/postgresql-13
     source: registry.redhat.io/rhel9/postgresql-13
+  - mirrors:
+    - ${mirror}/rhel9/postgresql-15
+    source: registry.redhat.io/rhel9/postgresql-15
+  - mirrors:
+    - ${mirror}/rhel9/postgresql-16
+    source: registry.redhat.io/rhel9/postgresql-16
 END
 }
 


### PR DESCRIPTION
Fixes https://redhat.atlassian.net/browse/OCPBUGS-84087

A similar fix was done for older versions some time ago in https://github.com/openshift/release/commit/694781355cd946a76cef718527226e567a88a1d9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for PostgreSQL 15 and 16 image mirrors in deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->