### PR TITLE
ROX-29577: Rename by dropping `ocp-` prefix from `ocp-vm-scanning-e2e-tests`

### DIFF
--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4-21.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4-21.yaml
@@ -102,7 +102,7 @@ tests:
       TEST_SUITE: ocp-nongroovy-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - always_run: false
-  as: ocp-vm-scanning-e2e-tests
+  as: vm-scanning-e2e-tests
   optional: true
   steps:
     env:

--- a/ci-operator/jobs/stackrox/stackrox/stackrox-stackrox-master-presubmits.yaml
+++ b/ci-operator/jobs/stackrox/stackrox/stackrox-stackrox-master-presubmits.yaml
@@ -3036,83 +3036,6 @@ presubmits:
     - ^master$
     - ^master-
     cluster: build01
-    context: ci/prow/ocp-4-21-ocp-vm-scanning-e2e-tests
-    decorate: true
-    decoration_config:
-      skip_cloning: true
-      timeout: 7h0m0s
-    labels:
-      ci-operator.openshift.io/variant: ocp-4-21
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-stackrox-stackrox-master-ocp-4-21-ocp-vm-scanning-e2e-tests
-    optional: true
-    rerun_command: /test ocp-4-21-ocp-vm-scanning-e2e-tests
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --report-credentials-file=/etc/report/credentials
-        - --target=ocp-vm-scanning-e2e-tests
-        - --variant=ocp-4-21
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )ocp-4-21-ocp-vm-scanning-e2e-tests,?($|\s.*)
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - ^master$
-    - ^master-
-    cluster: build01
     context: ci/prow/ocp-4-21-operator-e2e-tests
     decorate: true
     decoration_config:
@@ -3491,6 +3414,83 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )ocp-4-21-ui-e2e-tests,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^master$
+    - ^master-
+    cluster: build01
+    context: ci/prow/ocp-4-21-vm-scanning-e2e-tests
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+      timeout: 7h0m0s
+    labels:
+      ci-operator.openshift.io/variant: ocp-4-21
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-stackrox-stackrox-master-ocp-4-21-vm-scanning-e2e-tests
+    optional: true
+    rerun_command: /test ocp-4-21-vm-scanning-e2e-tests
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --target=vm-scanning-e2e-tests
+        - --variant=ocp-4-21
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )ocp-4-21-vm-scanning-e2e-tests,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:


### PR DESCRIPTION
This is to match the naming style of other e2e test targets in the repo.

1-line change + running the Makefile targets to regenerate files (and they sort alphabetically, so the diff is larger).

Follow-up to #77856

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline job configurations for test execution workflow optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->