### PR TITLE
quay: add OTEL smoke test presubmit for quay/quay

### DIFF
--- a/ci-operator/config/quay/quay/quay-quay-master.yaml
+++ b/ci-operator/config/quay/quay/quay-quay-master.yaml
@@ -75,7 +75,7 @@ tests:
       QUAY_CI_IMAGE: pipeline:quay-server
     env:
       BASE_DOMAIN: quayqe.devcluster.openshift.com
-      COMPUTE_NODE_TYPE: m5.2xlarge
+      COMPUTE_NODE_TYPE: m5.4xlarge
       QUAY_EXTRA_CONFIG: |
         FEATURE_OTEL_TRACING: true
         OTEL_CONFIG:

--- a/ci-operator/config/quay/quay/quay-quay-master.yaml
+++ b/ci-operator/config/quay/quay/quay-quay-master.yaml
@@ -67,6 +67,27 @@ tests:
     - ref: quay-tests-test-quay-playwright
     workflow: cucushift-installer-rehearse-aws-ipi
   timeout: 4h0m0s
+- always_run: false
+  as: otel-smoke
+  steps:
+    cluster_profile: aws-quay-qe
+    dependencies:
+      QUAY_CI_IMAGE: pipeline:quay-server
+    env:
+      BASE_DOMAIN: quayqe.devcluster.openshift.com
+      COMPUTE_NODE_TYPE: m5.2xlarge
+      QUAY_EXTRA_CONFIG: |
+        FEATURE_OTEL_TRACING: true
+        OTEL_CONFIG:
+          service_name: quay-ci
+      QUAY_OPERATOR_CHANNEL: stable-3.17
+      QUAY_OPERATOR_SOURCE: redhat-operators
+    test:
+    - ref: quay-tests-deploy-quay-aws-s3
+    - ref: quay-tests-deploy-quay-custom-image
+    - ref: quay-tests-test-quay-otel-smoke
+    workflow: cucushift-installer-rehearse-aws-ipi
+  timeout: 4h0m0s
 zz_generated_metadata:
   branch: master
   org: quay

--- a/ci-operator/jobs/quay/quay/quay-quay-master-presubmits.yaml
+++ b/ci-operator/jobs/quay/quay/quay-quay-master-presubmits.yaml
@@ -62,6 +62,90 @@ presubmits:
     - ^master$
     - ^master-
     cluster: build01
+    context: ci/prow/otel-smoke
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+      timeout: 4h0m0s
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: aws-quay-qe
+      ci.openshift.io/generator: prowgen
+      job-release: "4.18"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-quay-quay-master-otel-smoke
+    rerun_command: /test otel-smoke
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=otel-smoke
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )(otel-smoke|remaining-required),?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^master$
+    - ^master-
+    cluster: build01
     context: ci/prow/playwright-e2e
     decorate: true
     decoration_config:

--- a/ci-operator/step-registry/quay-tests/test/quay-otel-smoke/OWNERS
+++ b/ci-operator/step-registry/quay-tests/test/quay-otel-smoke/OWNERS
@@ -2,6 +2,7 @@ approvers:
 - BillDett
 - HammerMeetNail
 - LiZhang19817
+- Marcusk19
 - aroyoredhat
 - cubismod
 - jbpratt

--- a/ci-operator/step-registry/quay-tests/test/quay-otel-smoke/OWNERS
+++ b/ci-operator/step-registry/quay-tests/test/quay-otel-smoke/OWNERS
@@ -1,0 +1,11 @@
+approvers:
+- BillDett
+- HammerMeetNail
+- LiZhang19817
+- aroyoredhat
+- cubismod
+- jbpratt
+- kleesc
+- lechuk47
+- sunandadadi
+- syed

--- a/ci-operator/step-registry/quay-tests/test/quay-otel-smoke/quay-tests-test-quay-otel-smoke-commands.sh
+++ b/ci-operator/step-registry/quay-tests/test/quay-otel-smoke/quay-tests-test-quay-otel-smoke-commands.sh
@@ -6,11 +6,11 @@ NAMESPACE="quay-enterprise"
 ARTIFACT_DIR=${ARTIFACT_DIR:=/tmp/artifacts}
 mkdir -p "${ARTIFACT_DIR}"
 
-QUAY_ROUTE=$(cat "${SHARED_DIR}/quayroute")
-if [[ -z "${QUAY_ROUTE}" ]]; then
-    echo "ERROR: quayroute not found in SHARED_DIR" >&2
+if [[ ! -s "${SHARED_DIR}/quayroute" ]]; then
+    echo "ERROR: quayroute not found or empty in SHARED_DIR" >&2
     exit 1
 fi
+QUAY_ROUTE=$(cat "${SHARED_DIR}/quayroute")
 echo "Quay route: ${QUAY_ROUTE}"
 
 OAUTH_TOKEN=$(cat "${SHARED_DIR}/quay_oauth2_token" 2>/dev/null || true)
@@ -21,10 +21,10 @@ FAIL=0
 check_endpoint() {
     local name="$1"
     local url="$2"
-    local extra_args="${3:-}"
+    shift 2
 
     local http_code
-    http_code=$(curl -sk ${extra_args} -o /dev/null -w '%{http_code}' --max-time 30 "${url}")
+    http_code=$(curl -sk "$@" -o /dev/null -w '%{http_code}' --max-time 30 "${url}")
     if [[ "${http_code}" == "200" ]]; then
         echo "PASS: ${name} returned ${http_code}"
         PASS=$((PASS + 1))
@@ -44,7 +44,7 @@ check_endpoint "api/v1/discovery" "${QUAY_ROUTE}/api/v1/discovery"
 if [[ -n "${OAUTH_TOKEN}" ]]; then
     check_endpoint "api/v1/superuser/users (authed)" \
         "${QUAY_ROUTE}/api/v1/superuser/users/" \
-        "-H 'Authorization: Bearer ${OAUTH_TOKEN}'"
+        -H "Authorization: Bearer ${OAUTH_TOKEN}"
 else
     echo "SKIP: No OAuth token available, skipping authenticated API check"
 fi
@@ -52,22 +52,25 @@ fi
 # Check Quay pod logs for OTEL errors
 echo ""
 echo "Checking Quay pod logs for OTEL initialization errors..."
-OTEL_ERRORS=$(oc -n "${NAMESPACE}" logs -l quay-component=quay-app --tail=500 2>/dev/null \
-    | grep -iE "opentelemetry|otel|tracing" \
-    | grep -iE "error|exception|traceback|failed|fatal" || true)
 
-if [[ -n "${OTEL_ERRORS}" ]]; then
-    echo "FAIL: OTEL-related errors found in Quay pod logs:" >&2
-    echo "${OTEL_ERRORS}" >&2
+# Save Quay pod logs for debugging and analysis
+if ! oc -n "${NAMESPACE}" logs -l quay-component=quay-app --tail=1000 \
+    > "${ARTIFACT_DIR}/quay-app-logs.txt" 2>&1; then
+    echo "FAIL: Could not fetch Quay pod logs" >&2
     FAIL=$((FAIL + 1))
 else
-    echo "PASS: No OTEL errors in Quay pod logs"
-    PASS=$((PASS + 1))
-fi
+    OTEL_ERRORS=$(grep -iE "opentelemetry|otel" "${ARTIFACT_DIR}/quay-app-logs.txt" \
+        | grep -iE "\b(ERROR|CRITICAL|FATAL)\b|exception|traceback" || true)
 
-# Save Quay pod logs for debugging
-oc -n "${NAMESPACE}" logs -l quay-component=quay-app --tail=1000 \
-    > "${ARTIFACT_DIR}/quay-app-logs.txt" 2>&1 || true
+    if [[ -n "${OTEL_ERRORS}" ]]; then
+        echo "FAIL: OTEL-related errors found in Quay pod logs:" >&2
+        echo "${OTEL_ERRORS}" >&2
+        FAIL=$((FAIL + 1))
+    else
+        echo "PASS: No OTEL errors in Quay pod logs"
+        PASS=$((PASS + 1))
+    fi
+fi
 
 echo ""
 echo "Results: ${PASS} passed, ${FAIL} failed"

--- a/ci-operator/step-registry/quay-tests/test/quay-otel-smoke/quay-tests-test-quay-otel-smoke-commands.sh
+++ b/ci-operator/step-registry/quay-tests/test/quay-otel-smoke/quay-tests-test-quay-otel-smoke-commands.sh
@@ -13,67 +13,80 @@ fi
 QUAY_ROUTE=$(cat "${SHARED_DIR}/quayroute")
 echo "Quay route: ${QUAY_ROUTE}"
 
-OAUTH_TOKEN=$(cat "${SHARED_DIR}/quay_oauth2_token" 2>/dev/null || true)
+QUAY_REGISTRY="${QUAY_ROUTE#https://}"
+
+# Read credentials
+QUAY_USERNAME=$(cat /var/run/quay-qe-quay-secret/username)
+[[ -z "$QUAY_USERNAME" ]] && { echo "ERROR: No username in quay-qe-quay-secret" >&2; exit 1; }
+QUAY_PASSWORD=$(cat /var/run/quay-qe-quay-secret/password)
 
 PASS=0
 FAIL=0
 
-check_endpoint() {
+run_check() {
     local name="$1"
-    local url="$2"
-    shift 2
-
-    local http_code
-    http_code=$(curl -sk "$@" -o /dev/null -w '%{http_code}' --max-time 30 "${url}")
-    if [[ "${http_code}" == "200" ]]; then
-        echo "PASS: ${name} returned ${http_code}"
+    shift
+    if "$@"; then
+        echo "PASS: ${name}"
         PASS=$((PASS + 1))
     else
-        echo "FAIL: ${name} returned ${http_code}" >&2
+        echo "FAIL: ${name}" >&2
         FAIL=$((FAIL + 1))
     fi
 }
 
-# Health check
-check_endpoint "health/instance" "${QUAY_ROUTE}/health/instance"
+# --- Health checks ---
 
-# API discovery endpoint
-check_endpoint "api/v1/discovery" "${QUAY_ROUTE}/api/v1/discovery"
+check_http_200() {
+    local url="$1"
+    shift
+    local http_code
+    http_code=$(curl -sk "$@" -o /dev/null -w '%{http_code}' --max-time 30 "${url}")
+    [[ "${http_code}" == "200" ]]
+}
 
-# Authenticated API call (exercises Flask + DB instrumentation)
-if [[ -n "${OAUTH_TOKEN}" ]]; then
-    check_endpoint "api/v1/superuser/users (authed)" \
-        "${QUAY_ROUTE}/api/v1/superuser/users/" \
-        -H "Authorization: Bearer ${OAUTH_TOKEN}"
-else
-    echo "SKIP: No OAuth token available, skipping authenticated API check"
-fi
+run_check "health/instance returns 200" \
+    check_http_200 "${QUAY_ROUTE}/health/instance"
 
-# Check Quay pod logs for OTEL errors
-echo ""
-echo "Checking Quay pod logs for OTEL initialization errors..."
+run_check "api/v1/discovery returns 200" \
+    check_http_200 "${QUAY_ROUTE}/api/v1/discovery"
 
-# Save Quay pod logs for debugging and analysis
-if ! oc -n "${NAMESPACE}" logs -l quay-component=quay-app --tail=1000 \
-    > "${ARTIFACT_DIR}/quay-app-logs.txt" 2>&1; then
-    echo "FAIL: Could not fetch Quay pod logs" >&2
-    FAIL=$((FAIL + 1))
-else
-    OTEL_ERRORS=$(grep -iE "opentelemetry|otel" "${ARTIFACT_DIR}/quay-app-logs.txt" \
-        | grep -iE "\b(ERROR|CRITICAL|FATAL)\b|exception|traceback" || true)
+# --- Image push and pull ---
 
-    if [[ -n "${OTEL_ERRORS}" ]]; then
-        echo "FAIL: OTEL-related errors found in Quay pod logs:" >&2
-        echo "${OTEL_ERRORS}" >&2
-        FAIL=$((FAIL + 1))
-    else
-        echo "PASS: No OTEL errors in Quay pod logs"
-        PASS=$((PASS + 1))
-    fi
-fi
+export HOME="${HOME:-/tmp/home}"
+export XDG_RUNTIME_DIR="${HOME}/run"
+mkdir -p "${XDG_RUNTIME_DIR}/containers"
+
+AUTH_JSON="${XDG_RUNTIME_DIR}/containers/auth.json"
+oc registry login --registry "${QUAY_REGISTRY}" \
+    --auth-basic "${QUAY_USERNAME}:${QUAY_PASSWORD}" \
+    --to="${AUTH_JSON}"
+
+SOURCE_IMAGE="registry.access.redhat.com/ubi9/ubi-micro:latest"
+DEST_IMAGE="${QUAY_REGISTRY}/${QUAY_USERNAME}/otel-smoke-test:latest"
+
+push_image() {
+    oc image mirror --insecure=true -a "${AUTH_JSON}" \
+        "${SOURCE_IMAGE}" "${DEST_IMAGE}" \
+        --filter-by-os=linux/amd64 --keep-manifest-list=false
+}
+
+pull_image() {
+    skopeo inspect --tls-verify=false --authfile "${AUTH_JSON}" \
+        "docker://${DEST_IMAGE}" > /dev/null
+}
+
+run_check "image push to Quay" push_image
+run_check "image pull from Quay" pull_image
+
+# --- Results ---
 
 echo ""
 echo "Results: ${PASS} passed, ${FAIL} failed"
+
+# Save Quay pod logs for debugging
+oc -n "${NAMESPACE}" logs -l quay-component=quay-app --tail=1000 \
+    > "${ARTIFACT_DIR}/quay-app-logs.txt" 2>&1 || true
 
 if [[ "${FAIL}" -gt 0 ]]; then
     echo "OTEL smoke test failed" >&2

--- a/ci-operator/step-registry/quay-tests/test/quay-otel-smoke/quay-tests-test-quay-otel-smoke-commands.sh
+++ b/ci-operator/step-registry/quay-tests/test/quay-otel-smoke/quay-tests-test-quay-otel-smoke-commands.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+set -euo pipefail
+
+NAMESPACE="quay-enterprise"
+ARTIFACT_DIR=${ARTIFACT_DIR:=/tmp/artifacts}
+mkdir -p "${ARTIFACT_DIR}"
+
+QUAY_ROUTE=$(cat "${SHARED_DIR}/quayroute")
+if [[ -z "${QUAY_ROUTE}" ]]; then
+    echo "ERROR: quayroute not found in SHARED_DIR" >&2
+    exit 1
+fi
+echo "Quay route: ${QUAY_ROUTE}"
+
+OAUTH_TOKEN=$(cat "${SHARED_DIR}/quay_oauth2_token" 2>/dev/null || true)
+
+PASS=0
+FAIL=0
+
+check_endpoint() {
+    local name="$1"
+    local url="$2"
+    local extra_args="${3:-}"
+
+    local http_code
+    http_code=$(curl -sk ${extra_args} -o /dev/null -w '%{http_code}' --max-time 30 "${url}")
+    if [[ "${http_code}" == "200" ]]; then
+        echo "PASS: ${name} returned ${http_code}"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: ${name} returned ${http_code}" >&2
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Health check
+check_endpoint "health/instance" "${QUAY_ROUTE}/health/instance"
+
+# API discovery endpoint
+check_endpoint "api/v1/discovery" "${QUAY_ROUTE}/api/v1/discovery"
+
+# Authenticated API call (exercises Flask + DB instrumentation)
+if [[ -n "${OAUTH_TOKEN}" ]]; then
+    check_endpoint "api/v1/superuser/users (authed)" \
+        "${QUAY_ROUTE}/api/v1/superuser/users/" \
+        "-H 'Authorization: Bearer ${OAUTH_TOKEN}'"
+else
+    echo "SKIP: No OAuth token available, skipping authenticated API check"
+fi
+
+# Check Quay pod logs for OTEL errors
+echo ""
+echo "Checking Quay pod logs for OTEL initialization errors..."
+OTEL_ERRORS=$(oc -n "${NAMESPACE}" logs -l quay-component=quay-app --tail=500 2>/dev/null \
+    | grep -iE "opentelemetry|otel|tracing" \
+    | grep -iE "error|exception|traceback|failed|fatal" || true)
+
+if [[ -n "${OTEL_ERRORS}" ]]; then
+    echo "FAIL: OTEL-related errors found in Quay pod logs:" >&2
+    echo "${OTEL_ERRORS}" >&2
+    FAIL=$((FAIL + 1))
+else
+    echo "PASS: No OTEL errors in Quay pod logs"
+    PASS=$((PASS + 1))
+fi
+
+# Save Quay pod logs for debugging
+oc -n "${NAMESPACE}" logs -l quay-component=quay-app --tail=1000 \
+    > "${ARTIFACT_DIR}/quay-app-logs.txt" 2>&1 || true
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+
+if [[ "${FAIL}" -gt 0 ]]; then
+    echo "OTEL smoke test failed" >&2
+    exit 1
+fi
+
+echo "OTEL smoke test passed"

--- a/ci-operator/step-registry/quay-tests/test/quay-otel-smoke/quay-tests-test-quay-otel-smoke-ref.metadata.json
+++ b/ci-operator/step-registry/quay-tests/test/quay-otel-smoke/quay-tests-test-quay-otel-smoke-ref.metadata.json
@@ -1,0 +1,17 @@
+{
+	"path": "quay-tests/test/quay-otel-smoke/quay-tests-test-quay-otel-smoke-ref.yaml",
+	"owners": {
+		"approvers": [
+			"BillDett",
+			"HammerMeetNail",
+			"LiZhang19817",
+			"aroyoredhat",
+			"cubismod",
+			"jbpratt",
+			"kleesc",
+			"lechuk47",
+			"sunandadadi",
+			"syed"
+		]
+	}
+}

--- a/ci-operator/step-registry/quay-tests/test/quay-otel-smoke/quay-tests-test-quay-otel-smoke-ref.metadata.json
+++ b/ci-operator/step-registry/quay-tests/test/quay-otel-smoke/quay-tests-test-quay-otel-smoke-ref.metadata.json
@@ -5,6 +5,7 @@
 			"BillDett",
 			"HammerMeetNail",
 			"LiZhang19817",
+			"Marcusk19",
 			"aroyoredhat",
 			"cubismod",
 			"jbpratt",

--- a/ci-operator/step-registry/quay-tests/test/quay-otel-smoke/quay-tests-test-quay-otel-smoke-ref.yaml
+++ b/ci-operator/step-registry/quay-tests/test/quay-otel-smoke/quay-tests-test-quay-otel-smoke-ref.yaml
@@ -1,0 +1,19 @@
+ref:
+  as: quay-tests-test-quay-otel-smoke
+  cli: latest
+  from_image:
+    name: quay-test-console
+    namespace: ci
+    tag: latest
+  commands: quay-tests-test-quay-otel-smoke-commands.sh
+  resources:
+    requests:
+      cpu: 10m
+      memory: 100Mi
+  timeout: 15m0s
+  grace_period: 5m0s
+  documentation: |-
+    Smoke test validating Quay starts and serves traffic with
+    OpenTelemetry tracing enabled (FEATURE_OTEL_TRACING: true).
+    Verifies health endpoints, API functionality, and checks
+    pod logs for OTEL initialization errors.

--- a/ci-operator/step-registry/quay-tests/test/quay-otel-smoke/quay-tests-test-quay-otel-smoke-ref.yaml
+++ b/ci-operator/step-registry/quay-tests/test/quay-otel-smoke/quay-tests-test-quay-otel-smoke-ref.yaml
@@ -12,8 +12,13 @@ ref:
       memory: 100Mi
   timeout: 15m0s
   grace_period: 5m0s
+  credentials:
+  - namespace: test-credentials
+    name: quay-qe-quay-secret
+    mount_path: /var/run/quay-qe-quay-secret
   documentation: |-
     Smoke test validating Quay starts and serves traffic with
     OpenTelemetry tracing enabled (FEATURE_OTEL_TRACING: true).
-    Verifies health endpoints, API functionality, and checks
-    pod logs for OTEL initialization errors.
+    Verifies health endpoints, API functionality, and pushes/pulls
+    a container image through the registry to exercise the full
+    instrumented code path.


### PR DESCRIPTION
## Summary

- Adds a new `otel-smoke` presubmit test for `quay/quay` that deploys Quay with `FEATURE_OTEL_TRACING: true` and validates it starts and serves traffic correctly
- Creates a new step-registry component `quay-tests-test-quay-otel-smoke` that checks health endpoints, API functionality, and pod logs for OTEL initialization errors
- Triggered manually on quay/quay PRs via `/test otel-smoke`

## Motivation

Quay has OpenTelemetry tracing support but zero CI coverage for it. This smoke test catches regressions where OTEL dependencies or config changes break Quay startup.

## Test plan

- [ ] Prow rehearsal validates step-registry config
- [ ] Trigger `/test otel-smoke` on a quay/quay PR after merge to verify end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an OpenTelemetry (OTEL) smoke test suite validating Quay startup and traffic with tracing enabled
  * Checks health endpoints, discovery API, and a push/pull image workflow to exercise traced code paths
  * Collects Quay app logs for OTEL initialization troubleshooting
  * Runs automatically on pull requests and can be manually triggered via the otel-smoke test command
<!-- end of auto-generated comment: release notes by coderabbit.ai -->