### PR TITLE
Remove ARO-HCP OCP nightly job from INT and reschedule Stage and Prod

### DIFF
--- a/ci-operator/config/Azure/ARO-HCP/.config.prowgen
+++ b/ci-operator/config/Azure/ARO-HCP/.config.prowgen
@@ -16,7 +16,6 @@ slack_reporter:
   job_names:
   - integration-e2e-parallel
   - delete-expired-integration-resource-groups
-  - integration-e2e-parallel-ocp-nightly
 - channel: "#aro-hcp-failures-stg"
   job_states_to_report:
   - failure

--- a/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__periodic.yaml
+++ b/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__periodic.yaml
@@ -110,25 +110,6 @@ tests:
       resource_type: aro-hcp-test-msi-containers-int
     workflow: aro-hcp-e2e
   timeout: 4h0m0s
-- as: integration-e2e-parallel-ocp-nightly
-  cron: 0 4 * * *
-  steps:
-    env:
-      ARO_HCP_CLOUD: public
-      ARO_HCP_DEPLOY_ENV: int
-      ARO_HCP_OPENSHIFT_CHANNEL_GROUP: nightly
-      ARO_HCP_OPENSHIFT_NODEPOOL_CHANNEL_GROUP: nightly
-      ARO_HCP_SUITE_NAME: integration/parallel
-      LOCATION: uksouth
-      VAULT_SECRET_PROFILE: int
-    leases:
-    - count: 1
-      env: ENV_QUOTA_LEASED_RESOURCE
-      resource_type: aro-hcp-int-quota-slice
-    - count: 20
-      env: LEASED_MSI_CONTAINERS
-      resource_type: aro-hcp-test-msi-containers-int
-    workflow: aro-hcp-e2e
 - as: stage-e2e-parallel
   cron: 0 2 * * *
   steps:
@@ -148,7 +129,7 @@ tests:
     workflow: aro-hcp-e2e
   timeout: 4h0m0s
 - as: stage-e2e-parallel-ocp-nightly
-  cron: 0 4 * * *
+  cron: 0 23 * * *
   steps:
     env:
       ARO_HCP_CLOUD: public
@@ -185,7 +166,7 @@ tests:
     workflow: aro-hcp-e2e
   timeout: 4h0m0s
 - as: prod-e2e-parallel-ocp-nightly
-  cron: 0 4 * * *
+  cron: 0 23 * * *
   steps:
     env:
       ARO_HCP_CLOUD: public

--- a/ci-operator/jobs/Azure/ARO-HCP/Azure-ARO-HCP-main-periodics.yaml
+++ b/ci-operator/jobs/Azure/ARO-HCP/Azure-ARO-HCP-main-periodics.yaml
@@ -934,87 +934,6 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build04
-  cron: 0 4 * * *
-  decorate: true
-  decoration_config:
-    skip_cloning: true
-  extra_refs:
-  - base_ref: main
-    org: Azure
-    repo: ARO-HCP
-  labels:
-    ci-operator.openshift.io/variant: periodic
-    ci.openshift.io/generator: prowgen
-    pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-Azure-ARO-HCP-main-periodic-integration-e2e-parallel-ocp-nightly
-  reporter_config:
-    slack:
-      channel: '#aro-hcp-failures-int'
-      job_states_to_report:
-      - failure
-      - error
-      report_template: ':failed: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*.
-        <{{.Status.URL}}|View logs>'
-  spec:
-    containers:
-    - args:
-      - --gcs-upload-secret=/secrets/gcs/service-account.json
-      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-      - --lease-server-credentials-file=/etc/boskos/credentials
-      - --report-credentials-file=/etc/report/credentials
-      - --target=integration-e2e-parallel-ocp-nightly
-      - --variant=periodic
-      command:
-      - ci-operator
-      env:
-      - name: HTTP_SERVER_IP
-        valueFrom:
-          fieldRef:
-            fieldPath: status.podIP
-      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-      imagePullPolicy: Always
-      name: ""
-      ports:
-      - containerPort: 8080
-        name: http
-      resources:
-        requests:
-          cpu: 10m
-      volumeMounts:
-      - mountPath: /etc/boskos
-        name: boskos
-        readOnly: true
-      - mountPath: /secrets/gcs
-        name: gcs-credentials
-        readOnly: true
-      - mountPath: /secrets/manifest-tool
-        name: manifest-tool-local-pusher
-        readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
-      - mountPath: /etc/report
-        name: result-aggregator
-        readOnly: true
-    serviceAccountName: ci-operator
-    volumes:
-    - name: boskos
-      secret:
-        items:
-        - key: credentials
-          path: credentials
-        secretName: boskos-credentials
-    - name: manifest-tool-local-pusher
-      secret:
-        secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
-    - name: result-aggregator
-      secret:
-        secretName: result-aggregator
-- agent: kubernetes
-  cluster: build04
   cron: 0 2 * * *
   decorate: true
   decoration_config:
@@ -1097,7 +1016,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build04
-  cron: 0 4 * * *
+  cron: 0 23 * * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -1260,7 +1179,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build04
-  cron: 0 4 * * *
+  cron: 0 23 * * *
   decorate: true
   decoration_config:
     skip_cloning: true

--- a/ci-operator/jobs/Azure/ARO-HCP/Azure-ARO-HCP-main-presubmits.yaml
+++ b/ci-operator/jobs/Azure/ARO-HCP/Azure-ARO-HCP-main-presubmits.yaml
@@ -769,14 +769,6 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-Azure-ARO-HCP-main-integration-e2e-parallel-ocp-nightly
     optional: true
-    reporter_config:
-      slack:
-        channel: '#aro-hcp-failures-int'
-        job_states_to_report:
-        - failure
-        - error
-        report_template: ':failed: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*.
-          <{{.Status.URL}}|View logs>'
     rerun_command: /test integration-e2e-parallel-ocp-nightly
     spec:
       containers:


### PR DESCRIPTION
Don't run ARO-HCP tests with OCP nightly in INT. Reschedule STG and PROD nightly jobs so they don't collide with other jobs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed one nightly integration test job from the CI schedule.
  * Rescheduled remaining nightly tests from 4:00 AM to 11:00 PM.
  * Updated CI failure notification configuration to stop reporting for the removed presubmit job.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->