### PR TITLE
TRT-2635: Allow `/label ready-for-human-review`

### DIFF
--- a/core-services/prow/02_config/_plugins.yaml
+++ b/core-services/prow/02_config/_plugins.yaml
@@ -616,6 +616,7 @@ label:
   - cluster-config-api-changed
   - run-integration-tests
   - verified
+  - ready-for-human-review
   restricted_labels:
     '*':
     - allowed_teams:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated label management configuration to include `ready-for-human-review` as a recognized label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->