### PR TITLE
cnf ran: added two_sno lane for ocp 4.22

### DIFF
--- a/ci-operator/config/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main__cnf-ran-two-sno-4.22.yaml
+++ b/ci-operator/config/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main__cnf-ran-two-sno-4.22.yaml
@@ -1,0 +1,63 @@
+build_root:
+  image_stream_tag:
+    name: eco-ci-cd
+    namespace: telcov10n-ci
+    tag: eco-ci-cd
+releases:
+  latest:
+    candidate:
+      product: ocp
+      stream: nightly
+      version: "4.22"
+resources:
+  '*':
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: cnf-ran-ztp-tests
+  capabilities:
+  - intranet
+  cron: 0 23 31 2 *
+  steps:
+    env:
+      CLUSTER_NAME: fthub-01
+      HUB_OPERATORS: |
+        [
+          {"name":"local-storage-operator","catalog":"redhat-operators-storage-art","fbc_iib_repo":"ose-local-storage-rhel9-operator","nsname":"openshift-local-storage","channel":"stable","og_name":"local-operator-group","subscription_name":"local-storage-operator","deploy_default_config":false,"ns_labels":{"workload.openshift.io/allowed":"management"}},
+          {"name":"openshift-gitops-operator","catalog":"redhat-operators","nsname":"openshift-gitops-operator","channel":"latest","catalog_version_override":"4.21","og_name":"openshift-gitops-operator","subscription_name":"openshift-gitops-operator","deploy_default_config":false,"og_spec":{"targetNamespaces":[]}},
+          {"name":"advanced-cluster-management","catalog":"redhat-operators-acm-fbc","fbc_iib_repo":"latest-2.17","bundle_version":"v2.17","ocp_operator_mirror_fbc_image_base":"quay.io:443/acm-d/acm-dev-catalog","nsname":"open-cluster-management","channel":"release-2.17","og_name":"open-cluster-management","subscription_name":"acm-operator-subscription","deploy_default_config":false,"multifile_catalog":true,"og_spec":{"targetNamespaces":["open-cluster-management"]}},
+          {"name":"multicluster-engine","catalog":"redhat-operators-mce-fbc","nsname":"multicluster-engine","fbc_iib_repo":"latest-2.17","bundle_version":"v2.17","ocp_operator_mirror_fbc_image_base":"quay.io:443/acm-d/mce-dev-catalog","channel":"stable-2.17","og_name":"multicluster-engine","subscription_name":"multicluster-engine","deploy_default_config":true,"multifile_catalog":true,"og_spec":{}},
+          {"name":"topology-aware-lifecycle-manager","catalog":"topology-aware-lifecycle-manager-fbc","og_name":"global-operators","nsname":"openshift-operators","fbc_iib_repo":"latest","channel":"stable","deploy_default_config":false,"ocp_operator_mirror_fbc_image_base":"quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-fbc-4-22"}
+        ]
+      RAN_METRICS_LIST: spoke_general_ocp,hub_general_ocp,sriov,sriov_fec,ptp,acm,talm,gitops,local_storage,logging
+      REPORTER_TEMPLATE_NAME: Telco 5G RAN Regression 4_22 - Telco 5G RAN Regression
+        - <build> - 4.22
+      REPORTPORTAL_FILES: .reportportal_url_Two_Sno
+      REPORTS_PORTAL_ATTRIBUTES_ENV: ci-lane:telco-ft-ran-two-sno;spoke_ocp_version:4.22
+      SPOKE_CLUSTER: '[''worker-0'',''worker-1'']'
+      SPOKE_OPERATORS: |
+        [
+          {"name":"sriov-fec","catalog":"certified-operators","catalog_version_override":"4.21","nsname":"vran-acceleration-operators","channel":"stable"},
+          {"name":"ptp-operator","catalog":"redhat-operators-ptp-art","fbc_iib_repo":"ose-ptp-rhel9-operator","nsname":"openshift-ptp","channel":"stable","ns_labels":{"workload.openshift.io/allowed":"management","name":"openshift-ptp"}},
+          {"name":"sriov-network-operator","catalog":"redhat-operators-sriov-art","fbc_iib_repo":"ose-sriov-network-rhel9-operator","nsname":"openshift-sriov-network-operator","channel":"stable","og_name":"sriov-network-operators","subscription_name":"sriov-network-operator-subscription"},
+          {"name":"cluster-logging","catalog":"redhat-operators","catalog_version_override":"4.21","nsname":"openshift-logging","channel":"stable-6.5","og_name":"cluster-logging","subscription_name":"cluster-logging","og_spec":{"targetNamespaces":[]}},
+          {"name":"local-storage-operator","fbc_iib_repo":"ose-local-storage-rhel9-operator","catalog":"redhat-operators-storage-art","nsname":"openshift-local-storage","channel":"stable","og_name":"local-operator-group","subscription_name":"local-storage-operator","deploy_default_config":false,"ns_labels":{"workload.openshift.io/allowed":"management"}}
+        ]
+      VERSION: "4.22"
+      ZTP_GIT_BRANCH: two_sno
+    pre:
+    - ref: telcov10n-functional-cnf-ran-hub-deploy
+    - ref: telcov10n-functional-cnf-ran-hub-config
+    - ref: telcov10n-functional-cnf-ran-mirror-spoke-operators
+    - ref: telcov10n-functional-cnf-ran-deploy-spoke-sno
+    - ref: telcov10n-functional-cnf-ran-eco-gotests-two-sno
+    - ref: telcov10n-functional-cnf-ran-report-compact
+    - ref: telcov10n-functional-cnf-ran-send-slack-notification
+zz_generated_metadata:
+  branch: main
+  org: openshift-kni
+  repo: eco-ci-cd
+  variant: cnf-ran-two-sno-4.22

--- a/ci-operator/config/openshift/assisted-service/openshift-assisted-service-master__edge.yaml
+++ b/ci-operator/config/openshift/assisted-service/openshift-assisted-service-master__edge.yaml
@@ -1271,7 +1271,7 @@ tests:
         LOAD_BALANCER_TYPE=user-managed
       PLATFORM: vsphere
     workflow: assisted-vsphere-external-lb
-- as: e2e-metal-assisted-virtualization-4-21
+- as: e2e-metal-assisted-virtualization-4-20
   capabilities:
   - intranet
   run_if_changed: ^(internal/operators/.*\.go)$
@@ -1280,7 +1280,7 @@ tests:
     env:
       ASSISTED_CONFIG: |
         OLM_BUNDLES=virtualization
-        OPENSHIFT_VERSION=4.21
+        OPENSHIFT_VERSION=4.20
         MASTER_MEMORY=18700
         MASTER_CPU=10
         MASTER_DISK_COUNT=2

--- a/ci-operator/config/openshift/assisted-service/openshift-assisted-service-v2.52.yaml
+++ b/ci-operator/config/openshift/assisted-service/openshift-assisted-service-v2.52.yaml
@@ -269,7 +269,7 @@ tests:
       ASSISTED_CONFIG: |
         SERVICE_BASE_REF=v2.52
         OLM_BUNDLES=virtualization
-        OPENSHIFT_VERSION=4.22
+        OPENSHIFT_VERSION=4.20
         MASTER_MEMORY=18700
         MASTER_CPU=10
         MASTER_DISK_COUNT=2

--- a/ci-operator/config/openshift/assisted-test-infra/openshift-assisted-test-infra-master.yaml
+++ b/ci-operator/config/openshift/assisted-test-infra/openshift-assisted-test-infra-master.yaml
@@ -1015,7 +1015,7 @@ tests:
       PLATFORM: vsphere
     workflow: assisted-vsphere-external-lb
 - always_run: false
-  as: e2e-metal-assisted-virtualization-4-21
+  as: e2e-metal-assisted-virtualization-4-20
   capabilities:
   - intranet
   steps:
@@ -1023,7 +1023,7 @@ tests:
     env:
       ASSISTED_CONFIG: |
         OLM_BUNDLES=virtualization
-        OPENSHIFT_VERSION=4.21
+        OPENSHIFT_VERSION=4.20
         MASTER_MEMORY=18700
         MASTER_CPU=10
         MASTER_DISK_COUNT=2
@@ -1052,7 +1052,7 @@ tests:
       CLUSTERTYPE: assisted_large_el9
       REQUIRED_MEMORY_GIB: "400"
     workflow: assisted-ofcir-baremetal
-- as: e2e-metal-assisted-virtualization-4-21-periodic
+- as: e2e-metal-assisted-virtualization-4-20-periodic
   capabilities:
   - intranet
   cron: 30 11 * * 0,2,4
@@ -1061,7 +1061,7 @@ tests:
     env:
       ASSISTED_CONFIG: |
         OLM_BUNDLES=virtualization
-        OPENSHIFT_VERSION=4.21
+        OPENSHIFT_VERSION=4.20
         MASTER_MEMORY=18700
         MASTER_CPU=10
         MASTER_DISK_COUNT=2
@@ -1119,7 +1119,7 @@ tests:
         OPENSHIFT_VERSION=4.22
       CLUSTERTYPE: assisted_large_el9
     workflow: assisted-ofcir-baremetal
-- as: e2e-metal-assisted-openshift-ai-4-21-periodic
+- as: e2e-metal-assisted-openshift-ai-4-20-periodic
   capabilities:
   - intranet
   cron: 30 12 * * 0,2,4
@@ -1128,7 +1128,7 @@ tests:
     env:
       ASSISTED_CONFIG: |
         OLM_BUNDLES=openshift-ai
-        OPENSHIFT_VERSION=4.21
+        OPENSHIFT_VERSION=4.20
         NUM_WORKERS=3
         WORKER_MEMORY=65536
         WORKER_CPU=20

--- a/ci-operator/jobs/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main-periodics.yaml
@@ -3988,6 +3988,88 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build07
+  cron: 0 23 31 2 *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-kni
+    repo: eco-ci-cd
+  labels:
+    capability/intranet: intranet
+    ci-operator.openshift.io/variant: cnf-ran-two-sno-4.22
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-kni-eco-ci-cd-main-cnf-ran-two-sno-4.22-cnf-ran-ztp-tests
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=cnf-ran-ztp-tests
+      - --variant=cnf-ran-two-sno-4.22
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build07
   cron: 59 23 * * 6
   decorate: true
   decoration_config:

--- a/ci-operator/jobs/openshift/assisted-service/openshift-assisted-service-master-presubmits.yaml
+++ b/ci-operator/jobs/openshift/assisted-service/openshift-assisted-service-master-presubmits.yaml
@@ -5049,8 +5049,8 @@ presubmits:
     branches:
     - ^master$
     - ^master-
-    cluster: build05
-    context: ci/prow/edge-e2e-metal-assisted-virtualization-4-21
+    cluster: build03
+    context: ci/prow/edge-e2e-metal-assisted-virtualization-4-20
     decorate: true
     labels:
       capability/intranet: intranet
@@ -5060,8 +5060,8 @@ presubmits:
       ci.openshift.io/generator: prowgen
       job-release: "4.22"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-assisted-service-master-edge-e2e-metal-assisted-virtualization-4-21
-    rerun_command: /test edge-e2e-metal-assisted-virtualization-4-21
+    name: pull-ci-openshift-assisted-service-master-edge-e2e-metal-assisted-virtualization-4-20
+    rerun_command: /test edge-e2e-metal-assisted-virtualization-4-20
     run_if_changed: ^(internal/operators/.*\.go)$
     spec:
       containers:
@@ -5071,7 +5071,7 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-metal-assisted-virtualization-4-21
+        - --target=e2e-metal-assisted-virtualization-4-20
         - --variant=edge
         command:
         - ci-operator
@@ -5128,7 +5128,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )edge-e2e-metal-assisted-virtualization-4-21,?($|\s.*)
+    trigger: (?m)^/test( | .* )edge-e2e-metal-assisted-virtualization-4-20,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:

--- a/ci-operator/jobs/openshift/assisted-test-infra/openshift-assisted-test-infra-master-periodics.yaml
+++ b/ci-operator/jobs/openshift/assisted-test-infra/openshift-assisted-test-infra-master-periodics.yaml
@@ -2096,7 +2096,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-assisted-test-infra-master-e2e-metal-assisted-openshift-ai-4-21-periodic
+  name: periodic-ci-openshift-assisted-test-infra-master-e2e-metal-assisted-openshift-ai-4-20-periodic
   spec:
     containers:
     - args:
@@ -2105,7 +2105,7 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=e2e-metal-assisted-openshift-ai-4-21-periodic
+      - --target=e2e-metal-assisted-openshift-ai-4-20-periodic
       command:
       - ci-operator
       env:
@@ -2575,7 +2575,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-assisted-test-infra-master-e2e-metal-assisted-virtualization-4-21-periodic
+  name: periodic-ci-openshift-assisted-test-infra-master-e2e-metal-assisted-virtualization-4-20-periodic
   spec:
     containers:
     - args:
@@ -2584,7 +2584,7 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=e2e-metal-assisted-virtualization-4-21-periodic
+      - --target=e2e-metal-assisted-virtualization-4-20-periodic
       command:
       - ci-operator
       env:

--- a/ci-operator/jobs/openshift/assisted-test-infra/openshift-assisted-test-infra-master-presubmits.yaml
+++ b/ci-operator/jobs/openshift/assisted-test-infra/openshift-assisted-test-infra-master-presubmits.yaml
@@ -3053,8 +3053,8 @@ presubmits:
     branches:
     - ^master$
     - ^master-
-    cluster: build09
-    context: ci/prow/e2e-metal-assisted-virtualization-4-21
+    cluster: build07
+    context: ci/prow/e2e-metal-assisted-virtualization-4-20
     decorate: true
     labels:
       capability/intranet: intranet
@@ -3063,8 +3063,8 @@ presubmits:
       ci.openshift.io/generator: prowgen
       job-release: "4.22"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-assisted-test-infra-master-e2e-metal-assisted-virtualization-4-21
-    rerun_command: /test e2e-metal-assisted-virtualization-4-21
+    name: pull-ci-openshift-assisted-test-infra-master-e2e-metal-assisted-virtualization-4-20
+    rerun_command: /test e2e-metal-assisted-virtualization-4-20
     spec:
       containers:
       - args:
@@ -3073,7 +3073,7 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-metal-assisted-virtualization-4-21
+        - --target=e2e-metal-assisted-virtualization-4-20
         command:
         - ci-operator
         env:
@@ -3129,7 +3129,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )(e2e-metal-assisted-virtualization-4-21|remaining-required),?($|\s.*)
+    trigger: (?m)^/test( | .* )(e2e-metal-assisted-virtualization-4-20|remaining-required),?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added CI/CD configuration for a new cnf-ran-two-sno-4.22 test variant in the OpenShift/KNI ECO pipeline.
  * Introduced a scheduled ZTP test job (cnf-ran-ztp-tests) with environment, topology (two spoke workers), and reporting parameters for 4.22.
  * Replaced the previous periodic job with an updated cron schedule and release-targeting labels for automated runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->