### PR TITLE
NO-JIRA: Remove aws major upgrade job from 5.0 nightly

### DIFF
--- a/core-services/release-controller/_releases/priv/release-ocp-5.0.json
+++ b/core-services/release-controller/_releases/priv/release-ocp-5.0.json
@@ -624,20 +624,6 @@
                 "name": "periodic-ci-openshift-release-main-nightly-5.0-upgrade-analysis-all-priv"
             }
         },
-        "upgrade-major-ovn": {
-            "disabled": true,
-            "optional": false,
-            "prowJob": {
-                "name": "periodic-ci-openshift-release-main-ci-5.0-upgrade-from-stable-4.22-e2e-aws-ovn-upgrade-priv"
-            },
-            "upgrade": true,
-            "upgradeFromRelease": {
-                "candidate": {
-                    "stream": "nightly",
-                    "version": "4.22"
-                }
-            }
-        },
         "vsphere-ovn": {
             "disabled": true,
             "optional": true,

--- a/core-services/release-controller/_releases/release-ocp-5.0.json
+++ b/core-services/release-controller/_releases/release-ocp-5.0.json
@@ -172,19 +172,6 @@
         "name": "periodic-ci-openshift-release-main-nightly-5.0-fips-payload-scan"
       }
     },
-    "upgrade-major-ovn": {
-      "optional": false,
-      "prowJob": {
-        "name": "periodic-ci-openshift-release-main-ci-5.0-upgrade-from-stable-4.22-e2e-aws-ovn-upgrade"
-      },
-      "upgrade": true,
-      "upgradeFromRelease": {
-        "candidate": {
-          "stream": "nightly",
-          "version": "4.22"
-        }
-      }
-    },
     "aws-ovn-upgrade-5.0-micro-fips-no-nat-instance": {
       "optional": true,
       "prowJob": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed major version upgrade verification testing configuration from the 5.0 release pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->