### PR TITLE
Exclude generated files from CodeRabbit review

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,3 +1,5 @@
+inheritance: true
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 reviews:
   path_filters:
     - "!ci-operator/jobs/**"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,4 @@
+reviews:
+  path_filters:
+    - "!ci-operator/jobs/**"
+    - "!clusters/**/*_crd.yaml"


### PR DESCRIPTION
## Summary
- CodeRabbit is reviewing auto-generated files (prowgen job specs under `ci-operator/jobs/`, controller-gen CRDs under `clusters/`) and producing false positives
- Adds a `.coderabbit.yaml` config to exclude these paths from review via `path_filters`

## Test plan
- [ ] Verify CodeRabbit no longer comments on changes to `ci-operator/jobs/**`
- [ ] Verify CodeRabbit no longer comments on changes to `clusters/**/*_crd.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new review configuration enabling inherited settings and defining review-triggering rules.
  * Config updated to exclude CI operator job paths and cluster CRD YAML files from automated review consideration, reducing noise and focusing reviews on relevant changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->