### PR TITLE
HIVE-3154: Add periodic for e2e-vsphere

### DIFF
--- a/ci-operator/config/openshift/ci-tools/openshift-ci-tools-main.yaml
+++ b/ci-operator/config/openshift/ci-tools/openshift-ci-tools-main.yaml
@@ -941,7 +941,6 @@ tests:
         field: gsm-e2e-test-sa-key
         group: test-credentials
         mount_path: /tmp/gcp-creds
-        namespace: ""
       - bundle: hive-hive-credentials
         mount_path: /tmp/hive
         namespace: test-credentials
@@ -1197,7 +1196,6 @@ tests:
         field: api-token
         group: snyk-credentials
         mount_path: /snyk-credentials
-        namespace: ""
       env:
       - default: ci-tools
         name: PROJECT_NAME

--- a/ci-operator/config/openshift/hive/.config.prowgen
+++ b/ci-operator/config/openshift/hive/.config.prowgen
@@ -19,3 +19,4 @@ slack_reporter:
   report_template: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs>
   job_names:
   - e2e-openstack-weekly
+  - e2e-vsphere-weekly

--- a/ci-operator/config/openshift/hive/openshift-hive-master__periodic.yaml
+++ b/ci-operator/config/openshift/hive/openshift-hive-master__periodic.yaml
@@ -3,6 +3,10 @@ base_images:
     name: "4.21"
     namespace: ocp
     tag: openstack-installer
+  upi-installer:
+    name: "4.14"
+    namespace: ocp
+    tag: upi-installer
 binary_build_commands: GO_COMPLIANCE_INFO=0 make build
 build_root:
   image_stream_tag:
@@ -171,6 +175,43 @@ tests:
         requests:
           cpu: 100m
     workflow: ipi-azure
+- as: e2e-vsphere-weekly
+  cron: 5 4 * * 5
+  steps:
+    cluster_profile: vsphere-elastic
+    env:
+      NETWORK_TYPE: single-tenant
+      VSPHERE_ADDITIONAL_CLUSTER: "true"
+    test:
+    - as: test
+      cli: latest
+      commands: |
+        source $SHARED_DIR/vsphere_context.sh
+        source $SHARED_DIR/govc.sh
+        source $SHARED_DIR/additional_cluster.sh
+
+        export CLUSTER_NAME=$ADDITIONAL_CLUSTER_NAME
+        export VSPHERE_API_VIP=$ADDITIONAL_CLUSTER_API_VIP
+        export VSPHERE_INGRESS_VIP=$ADDITIONAL_CLUSTER_INGRESS_VIP
+        export VSPHERE_MACHINE_NETWORK=$(<"${SHARED_DIR}"/machinecidr.txt)
+        export BASE_DOMAIN=$(<"${SHARED_DIR}"/basedomain.txt)
+        export VSPHERE_INSTALLER_PLATFORM_SPEC_JSON=$(<"${SHARED_DIR}"/platform.json)
+
+        GO_COMPLIANCE_INFO=0 CLOUD=vsphere make test-e2e
+      credentials:
+      - mount_path: /var/run/vault/vsphere-ibmcloud-ci
+        name: vsphere-ibmcloud-ci
+        namespace: test-credentials
+      dependencies:
+      - env: HIVE_IMAGE
+        name: hive
+      - env: RELEASE_IMAGE
+        name: release:latest
+      from: src
+      resources:
+        requests:
+          cpu: 100m
+    workflow: ipi-vsphere
 - as: e2e-openstack-weekly
   cron: 10 23 * * 0
   steps:

--- a/ci-operator/jobs/openshift/hive/openshift-hive-master-periodics.yaml
+++ b/ci-operator/jobs/openshift/hive/openshift-hive-master-periodics.yaml
@@ -374,6 +374,99 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
+  cluster: vsphere02
+  cron: 5 4 * * 5
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: master
+    org: openshift
+    repo: hive
+  labels:
+    ci-operator.openshift.io/cloud: vsphere
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+    ci-operator.openshift.io/variant: periodic
+    ci.openshift.io/generator: prowgen
+    job-release: "4.21"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-hive-master-periodic-e2e-vsphere-weekly
+  reporter_config:
+    slack:
+      channel: '#team-hive-alert'
+      job_states_to_report:
+      - failure
+      - error
+      - aborted
+      - success
+      report_template: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+        logs>
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-vsphere-weekly
+      - --variant=periodic
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
   cluster: build11
   cron: 5 4 * * 1
   decorate: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a weekly vSphere E2E periodic job to run full end-to-end validation on vSphere.

* **Chores**
  * Configured the vSphere periodic job with cluster profile, network/base-domain inputs, credentials, scheduling, decoration and Slack reporting.
  * Cleaned up many Prow plugin approval configs by removing empty help-link entries and normalizing their structure.
  * Added a release-note guidelines URL to plugin configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->