### PR TITLE
quay: add Playwright Firefox e2e test presubmit

### DIFF
--- a/ci-operator/config/quay/quay/quay-quay-master.yaml
+++ b/ci-operator/config/quay/quay/quay-quay-master.yaml
@@ -27,6 +27,21 @@ images:
       RUN npx playwright install chromium
     from: src
     to: quay-playwright-runner
+  - dockerfile_literal: |
+      FROM src
+      RUN dnf module enable -y nodejs:20 && \
+          dnf install -y nodejs \
+          alsa-lib atk at-spi2-atk cups-libs libdrm libXcomposite \
+          libXdamage libXrandr mesa-libgbm pango nss nss-util nspr \
+          libxkbcommon libXfixes libXcursor libXext libXi libXtst \
+          libwayland-client && \
+          dnf clean all
+      WORKDIR /go/src/github.com/quay/quay/web
+      RUN npm ci
+      ENV PLAYWRIGHT_BROWSERS_PATH=/opt/playwright
+      RUN npx playwright install firefox
+    from: src
+    to: quay-playwright-firefox-runner
 releases:
   latest:
     candidate:
@@ -65,6 +80,31 @@ tests:
     - ref: quay-tests-deploy-quay-aws-s3
     - ref: quay-tests-deploy-quay-custom-image
     - ref: quay-tests-test-quay-playwright
+    workflow: cucushift-installer-rehearse-aws-ipi
+  timeout: 4h0m0s
+- always_run: false
+  as: playwright-e2e-firefox
+  steps:
+    cluster_profile: aws-quay-qe
+    dependencies:
+      QUAY_CI_IMAGE: pipeline:quay-server
+    env:
+      BASE_DOMAIN: quayqe.devcluster.openshift.com
+      COMPUTE_NODE_TYPE: m5.2xlarge
+      QUAY_EXTRA_CONFIG: |
+        FEATURE_REPO_MIRROR: true
+        FEATURE_USER_METADATA: true
+        FEATURE_IMMUTABLE_TAGS: true
+        SUPER_USERS:
+          - admin
+        GLOBAL_READONLY_SUPER_USERS:
+          - readonly
+      QUAY_OPERATOR_CHANNEL: stable-3.16
+      QUAY_OPERATOR_SOURCE: redhat-operators
+    test:
+    - ref: quay-tests-deploy-quay-aws-s3
+    - ref: quay-tests-deploy-quay-custom-image
+    - ref: quay-tests-test-quay-playwright-firefox
     workflow: cucushift-installer-rehearse-aws-ipi
   timeout: 4h0m0s
 zz_generated_metadata:

--- a/ci-operator/jobs/quay/quay/quay-quay-master-presubmits.yaml
+++ b/ci-operator/jobs/quay/quay/quay-quay-master-presubmits.yaml
@@ -140,3 +140,87 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )(playwright-e2e|remaining-required),?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^master$
+    - ^master-
+    cluster: build01
+    context: ci/prow/playwright-e2e-firefox
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+      timeout: 4h0m0s
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: aws-quay-qe
+      ci.openshift.io/generator: prowgen
+      job-release: "4.18"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-quay-quay-master-playwright-e2e-firefox
+    rerun_command: /test playwright-e2e-firefox
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=playwright-e2e-firefox
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )(playwright-e2e-firefox|remaining-required),?($|\s.*)

--- a/ci-operator/step-registry/quay-tests/test-quay-playwright-firefox/OWNERS
+++ b/ci-operator/step-registry/quay-tests/test-quay-playwright-firefox/OWNERS
@@ -1,0 +1,12 @@
+approvers:
+- BillDett
+- HammerMeetNail
+- LiZhang19817
+- Marcusk19
+- aroyoredhat
+- cubismod
+- jbpratt
+- kleesc
+- lechuk47
+- sunandadadi
+- syed

--- a/ci-operator/step-registry/quay-tests/test-quay-playwright-firefox/quay-tests-test-quay-playwright-firefox-commands.sh
+++ b/ci-operator/step-registry/quay-tests/test-quay-playwright-firefox/quay-tests-test-quay-playwright-firefox-commands.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+set -euo pipefail
+set -x
+
+ARTIFACT_DIR=${ARTIFACT_DIR:=/tmp/artifacts}
+mkdir -p "${ARTIFACT_DIR}"
+
+# Read the Quay route written by the deploy step
+QUAY_ROUTE=$(cat "${SHARED_DIR}/quayroute")
+if [[ -z "${QUAY_ROUTE}" ]]; then
+  echo "ERROR: quayroute not found in SHARED_DIR" >&2
+  exit 1
+fi
+echo "Quay route: ${QUAY_ROUTE}"
+
+# Read credentials
+# Disable tracing due to password handling
+[[ $- == *x* ]] && WAS_TRACING=true || WAS_TRACING=false
+set +x
+QUAY_USERNAME=$(cat /var/run/quay-qe-quay-secret/username)
+QUAY_PASSWORD=$(cat /var/run/quay-qe-quay-secret/password)
+$WAS_TRACING && set -x
+
+# Configure Playwright environment
+# PLAYWRIGHT_BASE_URL: browser navigation URL (Quay UI)
+# REACT_QUAY_APP_API_URL: backend API URL (same as UI on OCP)
+export PLAYWRIGHT_BASE_URL="${QUAY_ROUTE}"
+export REACT_QUAY_APP_API_URL="${QUAY_ROUTE}"
+export PLAYWRIGHT_JUNIT_OUTPUT_NAME="${ARTIFACT_DIR}/junit_playwright_firefox.xml"
+export PLAYWRIGHT_BROWSERS_PATH=/opt/playwright
+export QUAY_USERNAME
+export QUAY_PASSWORD
+export CI=true
+
+# WORKDIR is already set to the web/ directory by the quay-playwright-firefox-runner image
+
+function copyArtifacts {
+  echo "Copying test artifacts..."
+  cp -r test-results/* "${ARTIFACT_DIR}/" 2>/dev/null || true
+  # Rename JUnit reports with junit_ prefix for Prow
+  for file in "${ARTIFACT_DIR}"/*.xml; do
+    if [[ -f "${file}" ]] && [[ ! "$(basename "${file}")" =~ ^junit_ ]]; then
+      mv "${file}" "${ARTIFACT_DIR}/junit_$(basename "${file}")"
+    fi
+  done
+  cp -r playwright-report/* "${ARTIFACT_DIR}/" 2>/dev/null || true
+}
+trap copyArtifacts EXIT
+
+echo "Running Playwright tests with Firefox..."
+npx playwright test \
+  --browser=firefox \
+  --reporter=junit,html \
+  2>&1 | tee "${ARTIFACT_DIR}/playwright-firefox-output.log"

--- a/ci-operator/step-registry/quay-tests/test-quay-playwright-firefox/quay-tests-test-quay-playwright-firefox-ref.metadata.json
+++ b/ci-operator/step-registry/quay-tests/test-quay-playwright-firefox/quay-tests-test-quay-playwright-firefox-ref.metadata.json
@@ -1,0 +1,18 @@
+{
+	"path": "quay-tests/test-quay-playwright-firefox/quay-tests-test-quay-playwright-firefox-ref.yaml",
+	"owners": {
+		"approvers": [
+			"BillDett",
+			"HammerMeetNail",
+			"LiZhang19817",
+			"Marcusk19",
+			"aroyoredhat",
+			"cubismod",
+			"jbpratt",
+			"kleesc",
+			"lechuk47",
+			"sunandadadi",
+			"syed"
+		]
+	}
+}

--- a/ci-operator/step-registry/quay-tests/test-quay-playwright-firefox/quay-tests-test-quay-playwright-firefox-ref.yaml
+++ b/ci-operator/step-registry/quay-tests/test-quay-playwright-firefox/quay-tests-test-quay-playwright-firefox-ref.yaml
@@ -1,0 +1,17 @@
+ref:
+  as: quay-tests-test-quay-playwright-firefox
+  cli: latest
+  from: quay-playwright-firefox-runner
+  commands: quay-tests-test-quay-playwright-firefox-commands.sh
+  resources:
+    requests:
+      cpu: "2"
+      memory: 4Gi
+  timeout: 2h0m0s
+  grace_period: 15m0s
+  credentials:
+  - namespace: test-credentials
+    name: quay-qe-quay-secret
+    mount_path: /var/run/quay-qe-quay-secret
+  documentation: |-
+    Execute Quay Playwright e2e tests with Firefox browser against a deployed Quay instance.


### PR DESCRIPTION
## Summary
- Adds a Firefox browser variant of the existing Playwright e2e test suite for `quay/quay`
- Creates a separate `quay-playwright-firefox-runner` image that installs Firefox via `npx playwright install firefox`
- Creates a new step-registry step `quay-tests-test-quay-playwright-firefox` that runs Playwright with `--browser=firefox`
- Adds `playwright-e2e-firefox` presubmit test (opt-in via `/test playwright-e2e-firefox`)

## Test plan
- [ ] Verify CI check jobs pass (config validation, prowgen)
- [ ] Trigger `/test playwright-e2e-firefox` on a quay/quay PR after merge to validate end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Firefox browser support for end-to-end testing in the CI pipeline
  * Implemented new automated test suite to validate Quay functionality across Firefox
  * Enhanced testing infrastructure with dedicated Firefox-specific test configuration and reporting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->