### PR TITLE
OCPBUGS-84142: vSphere DNS opt-in for public api-int record

### DIFF
--- a/ci-operator/step-registry/ipi/conf/vsphere/dns/ipi-conf-vsphere-dns-commands.py
+++ b/ci-operator/step-registry/ipi/conf/vsphere/dns/ipi-conf-vsphere-dns-commands.py
@@ -152,14 +152,16 @@ def main():
     # *.apps.<cluster_domain> wildcard
     resource_names = [f"api.{cluster_domain}", f"*.apps.{cluster_domain}"]
 
-    # Windows nodes _still_ require api-int.<cluster_domain>
-    # This _should_ _not_ be here as we are not properly testing
-    # static pod coredns
-    api_int_change = copy.deepcopy(change)
-    api_int_change['ResourceRecordSet']['Name'] = f"api-int.{cluster_domain}"
-    api_int_change['ResourceRecordSet']['Type'] = 'A'
-    api_int_change['ResourceRecordSet']['ResourceRecords'].append({'Value': vips[0].strip()})
-    upsert_change_batch['Changes'].append(api_int_change)
+    enable_api_int = os.environ.get("VSPHERE_ENABLE_API_INT", "false").lower() == "true"
+    if enable_api_int:
+        # Optional public api-int A record (same VIP as api) for scenarios that need it in Route53.
+        api_int_change = copy.deepcopy(change)
+        api_int_change['ResourceRecordSet']['Name'] = f"api-int.{cluster_domain}"
+        api_int_change['ResourceRecordSet']['Type'] = 'A'
+        api_int_change['ResourceRecordSet']['ResourceRecords'].append({'Value': vips[0].strip()})
+        upsert_change_batch['Changes'].append(api_int_change)
+    else:
+        logger.info("Skipping api-int.%s (set VSPHERE_ENABLE_API_INT=true to create)", cluster_domain)
 
     # loop through FQDN DNS records to generate change batches
     for i, rn in enumerate(resource_names):

--- a/ci-operator/step-registry/ipi/conf/vsphere/dns/ipi-conf-vsphere-dns-commands.sh
+++ b/ci-operator/step-registry/ipi/conf/vsphere/dns/ipi-conf-vsphere-dns-commands.sh
@@ -129,11 +129,13 @@ for ((i = 0; i < ${#HOSTNAMES[@]}; i++)); do
   fi
 done
 
-# Snowflake for the default api-int, which shares a vip with the default api.
-# api-int record is needed just for Windows nodes
-# TODO: Remove the api-int entry in future
-echo "Adding "api-int.$cluster_domain." to batch files"
-dns_reserve_and_defer_cleanup ${vips[0]} "api-int.$cluster_domain." "A"
+if [ "${VSPHERE_ENABLE_API_INT:-false}" = "true" ]; then
+  # Optional public api-int record (same VIP as api) for scenarios that need it in public DNS.
+  echo "Adding api-int.${cluster_domain}. to batch files"
+  dns_reserve_and_defer_cleanup "${vips[0]}" "api-int.${cluster_domain}." "A"
+else
+  echo "Skipping api-int.${cluster_domain}. (set VSPHERE_ENABLE_API_INT=true to create)"
+fi
 
 id=$(aws route53 change-resource-record-sets --hosted-zone-id "$hosted_zone_id" --change-batch file:///"${SHARED_DIR}"/dns-create.json --query '"ChangeInfo"."Id"' --output text)
 

--- a/ci-operator/step-registry/ipi/conf/vsphere/dns/ipi-conf-vsphere-dns-ref.yaml
+++ b/ci-operator/step-registry/ipi/conf/vsphere/dns/ipi-conf-vsphere-dns-ref.yaml
@@ -7,6 +7,12 @@ ref:
     default: "false"
     documentation: >-
       Allows for the ability to reserve an additional two vips in network. Currently used for hive e2e.
+  - name: VSPHERE_ENABLE_API_INT
+    default: "false"
+    documentation: >-
+      When "true", create a public Route53 A record for api-int.<cluster_domain> (same VIP as api) and the
+      matching delete entry. Default "false" applies to all jobs without per-job env; set "true" only when a
+      job needs that record (e.g. Windows nodes that do not resolve api-int via in-cluster DNS).
   resources:
     requests:
       cpu: 10m


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `VSPHERE_ENABLE_API_INT` environment variable to optionally create Route53 A records for internal API endpoints (`api-int.<cluster_domain>`) in vSphere clusters. Disabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->