### PR TITLE
Improve ROSA CI daily Slack status links

### DIFF
--- a/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-periodics.yaml
@@ -340,20 +340,10 @@ periodics:
       - success
       - failure
       - error
-      report_template: '{{if eq .Status.State "success"}} :white_check_mark: ROSA
-        CI Daily Status: all tracked jobs healthy. <{{.Status.URL}}|Full report> |
-        <https://sippy.dptools.openshift.org/sippy-ng/release/rosa-stage|Sippy>
-
-        <https://prow.ci.openshift.org/?type=periodic&job=*rosa-hcp-e2e-nightly*|ROSA E2E>
-        | <https://prow.ci.openshift.org/?type=periodic&job=*ocm-fvt*rosa*|OCM FVT>
-        | <https://prow.ci.openshift.org/?type=periodic&job=*main-nightly-*e2e-rosa-*-ovn|Conformance>
-        {{else}} :x: ROSA CI Daily Status: some jobs failing. <{{.Status.URL}}|Full
-        report> | <https://sippy.dptools.openshift.org/sippy-ng/release/rosa-stage|Sippy>
-
-        <https://prow.ci.openshift.org/?type=periodic&job=*rosa-hcp-e2e-nightly*|ROSA E2E>
-        | <https://prow.ci.openshift.org/?type=periodic&job=*ocm-fvt*rosa*|OCM FVT>
-        | <https://prow.ci.openshift.org/?type=periodic&job=*main-nightly-*e2e-rosa-*-ovn|Conformance>
-        {{end}}'
+      report_template: |-
+        {{if eq .Status.State "success"}} :white_check_mark: ROSA CI Daily Status: all tracked jobs healthy. <{{.Status.URL}}|Full report> | <https://sippy.dptools.openshift.org/sippy-ng/release/rosa-stage|Sippy>
+        <https://prow.ci.openshift.org/?type=periodic&job=*rosa-hcp-e2e-nightly*|ROSA E2E> | <https://prow.ci.openshift.org/?type=periodic&job=*ocm-fvt*rosa*|OCM FVT> | <https://prow.ci.openshift.org/?type=periodic&job=*main-nightly-*e2e-rosa-*-ovn|Conformance> {{else}} :x: ROSA CI Daily Status: some jobs failing. <{{.Status.URL}}|Full report> | <https://sippy.dptools.openshift.org/sippy-ng/release/rosa-stage|Sippy>
+        <https://prow.ci.openshift.org/?type=periodic&job=*rosa-hcp-e2e-nightly*|ROSA E2E> | <https://prow.ci.openshift.org/?type=periodic&job=*ocm-fvt*rosa*|OCM FVT> | <https://prow.ci.openshift.org/?type=periodic&job=*main-nightly-*e2e-rosa-*-ovn|Conformance> {{end}}
   spec:
     containers:
     - args:

--- a/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-periodics.yaml
@@ -346,13 +346,13 @@ periodics:
 
         <https://prow.ci.openshift.org/?type=periodic&job=*rosa-hcp-e2e-nightly*|ROSA E2E>
         | <https://prow.ci.openshift.org/?type=periodic&job=*ocm-fvt*rosa*|OCM FVT>
-        | <https://prow.ci.openshift.org/?type=periodic&job=*e2e-rosa-*-ovn|Conformance>
+        | <https://prow.ci.openshift.org/?type=periodic&job=*main-nightly-*e2e-rosa-*-ovn|Conformance>
         {{else}} :x: ROSA CI Daily Status: some jobs failing. <{{.Status.URL}}|Full
         report> | <https://sippy.dptools.openshift.org/sippy-ng/release/rosa-stage|Sippy>
 
         <https://prow.ci.openshift.org/?type=periodic&job=*rosa-hcp-e2e-nightly*|ROSA E2E>
         | <https://prow.ci.openshift.org/?type=periodic&job=*ocm-fvt*rosa*|OCM FVT>
-        | <https://prow.ci.openshift.org/?type=periodic&job=*e2e-rosa-*-ovn|Conformance>
+        | <https://prow.ci.openshift.org/?type=periodic&job=*main-nightly-*e2e-rosa-*-ovn|Conformance>
         {{end}}'
   spec:
     containers:

--- a/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-periodics.yaml
@@ -342,11 +342,17 @@ periodics:
       - error
       report_template: '{{if eq .Status.State "success"}} :white_check_mark: ROSA
         CI Daily Status: all tracked jobs healthy. <{{.Status.URL}}|Full report> |
-        <https://sippy.dptools.openshift.org/sippy-ng/release/rosa-stage|Sippy> |
-        <https://prow.ci.openshift.org/?type=periodic&job=*rosa*|All ROSA jobs> {{else}}
-        :x: ROSA CI Daily Status: some jobs failing. <{{.Status.URL}}|Full report>
-        | <https://sippy.dptools.openshift.org/sippy-ng/release/rosa-stage|Sippy>
-        | <https://prow.ci.openshift.org/?type=periodic&job=*rosa*|All ROSA jobs>
+        <https://sippy.dptools.openshift.org/sippy-ng/release/rosa-stage|Sippy>
+
+        <https://prow.ci.openshift.org/?type=periodic&job=*rosa-hcp-e2e-nightly*|ROSA E2E>
+        | <https://prow.ci.openshift.org/?type=periodic&job=*ocm-fvt*rosa*|OCM FVT>
+        | <https://prow.ci.openshift.org/?type=periodic&job=*e2e-rosa-*-ovn|Conformance>
+        {{else}} :x: ROSA CI Daily Status: some jobs failing. <{{.Status.URL}}|Full
+        report> | <https://sippy.dptools.openshift.org/sippy-ng/release/rosa-stage|Sippy>
+
+        <https://prow.ci.openshift.org/?type=periodic&job=*rosa-hcp-e2e-nightly*|ROSA E2E>
+        | <https://prow.ci.openshift.org/?type=periodic&job=*ocm-fvt*rosa*|OCM FVT>
+        | <https://prow.ci.openshift.org/?type=periodic&job=*e2e-rosa-*-ovn|Conformance>
         {{end}}'
   spec:
     containers:


### PR DESCRIPTION
## Summary

- Replace the single "All ROSA jobs" Prow link in the daily CI status Slack message with three category-specific links
- The old `*rosa*` glob matched unrelated jobs

New links:
- **ROSA E2E** (`*rosa-hcp-e2e-nightly*`): 3 versioned nightly jobs
- **OCM FVT** (`*ocm-fvt*rosa*`): OCM clusters-service FVT jobs
- **Conformance** (`*e2e-rosa-*-ovn`): 8 jobs (4 HCP + 4 Classic STS)

## Test plan

- [ ] Verify next daily status Slack message renders correctly with the new links
- [ ] Confirm each Prow link filters to the correct set of jobs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Replaced a single aggregated ROSA link in daily Slack reports with three distinct test links: ROSA E2E, OCM FVT, and Conformance (applies to both success and failure messages).
  * Consolidated the Slack message template into a more compact single-block format and adjusted failure-state layout for clearer report rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->