### PR TITLE
OCPBUGS-84248: Wire additional pull secret for HyperShift EnsureGlobalPullSecret e2e test

### DIFF
--- a/ci-operator/step-registry/hypershift/aws/run-e2e/external/hypershift-aws-run-e2e-external-commands.sh
+++ b/ci-operator/step-registry/hypershift/aws/run-e2e/external/hypershift-aws-run-e2e-external-commands.sh
@@ -64,6 +64,11 @@ if [[ ${OCP_IMAGE_N4} != "${OCP_IMAGE_LATEST}" ]]; then
 fi
 
 
+ADDITIONAL_PULL_SECRET_PARAMS=""
+if check_e2e_flag 'e2e.additional-pull-secret-file' && [[ -f /etc/hypershift-additional-pull-secret/.dockerconfigjson ]]; then
+  ADDITIONAL_PULL_SECRET_PARAMS="--e2e.additional-pull-secret-file=/etc/hypershift-additional-pull-secret/.dockerconfigjson"
+fi
+
 OAUTH_EXTERNAL_OIDC_PARAM=""
 if [[ "${OAUTH_EXTERNAL_OIDC_PROVIDER}" != "" ]]; then
   case "${OAUTH_EXTERNAL_OIDC_PROVIDER}" in
@@ -112,5 +117,6 @@ hack/ci-test-e2e.sh -test.v \
   --e2e.external-dns-domain=service.ci.hypershift.devcluster.openshift.com \
   ${AWS_MULTI_ARCH_PARAMS:-} \
   ${REQUEST_SERVING_COMPONENT_PARAMS:-} \
-  ${OAUTH_EXTERNAL_OIDC_PARAM:-} &
+  ${OAUTH_EXTERNAL_OIDC_PARAM:-} \
+  ${ADDITIONAL_PULL_SECRET_PARAMS:-} &
 wait $!

--- a/ci-operator/step-registry/hypershift/aws/run-e2e/external/hypershift-aws-run-e2e-external-ref.yaml
+++ b/ci-operator/step-registry/hypershift/aws/run-e2e/external/hypershift-aws-run-e2e-external-ref.yaml
@@ -9,6 +9,9 @@ ref:
     - mount_path: /etc/ci-pull-credentials
       name: ci-pull-credentials
       namespace: test-credentials
+    - mount_path: /etc/hypershift-additional-pull-secret
+      name: hypershift-additional-pull-secret
+      namespace: test-credentials
   dependencies:
     - env: OCP_IMAGE_LATEST
       name: release:latest

--- a/ci-operator/step-registry/hypershift/aws/run-e2e/nested/hypershift-aws-run-e2e-nested-commands.sh
+++ b/ci-operator/step-registry/hypershift/aws/run-e2e/nested/hypershift-aws-run-e2e-nested-commands.sh
@@ -68,6 +68,11 @@ if [[ "${RUN_UPGRADE_TEST:-}" == "true" ]] && check_e2e_flag "upgrade.run-tests"
   RUN_UPGRADE_PARAM="--upgrade.run-tests --e2e.private-platform=AWS --e2e.ho-enable-ci-debug-output=true --e2e.hypershift-operator-latest-image=${CI_HYPERSHIFT_OPERATOR}"
 fi
 
+ADDITIONAL_PULL_SECRET_PARAMS=""
+if check_e2e_flag 'e2e.additional-pull-secret-file' && [[ -f /etc/hypershift-additional-pull-secret/.dockerconfigjson ]]; then
+  ADDITIONAL_PULL_SECRET_PARAMS="--e2e.additional-pull-secret-file=/etc/hypershift-additional-pull-secret/.dockerconfigjson"
+fi
+
 OAUTH_EXTERNAL_OIDC_PARAM=""
 if [[ "${OAUTH_EXTERNAL_OIDC_PROVIDER}" != "" ]]; then
   case "${OAUTH_EXTERNAL_OIDC_PROVIDER}" in
@@ -117,5 +122,6 @@ hack/ci-test-e2e.sh -test.v \
   ${AWS_MULTI_ARCH_PARAMS:-} \
   ${REQUEST_SERVING_COMPONENT_PARAMS:-} \
   ${OAUTH_EXTERNAL_OIDC_PARAM:-} \
-  ${RUN_UPGRADE_PARAM} &
+  ${RUN_UPGRADE_PARAM} \
+  ${ADDITIONAL_PULL_SECRET_PARAMS:-} &
 wait $!

--- a/ci-operator/step-registry/hypershift/aws/run-e2e/nested/hypershift-aws-run-e2e-nested-ref.yaml
+++ b/ci-operator/step-registry/hypershift/aws/run-e2e/nested/hypershift-aws-run-e2e-nested-ref.yaml
@@ -9,6 +9,9 @@ ref:
     - mount_path: /etc/ci-pull-credentials
       name: ci-pull-credentials
       namespace: test-credentials
+    - mount_path: /etc/hypershift-additional-pull-secret
+      name: hypershift-additional-pull-secret
+      namespace: test-credentials
     - mount_path: /etc/hypershift-kubeconfig
       name: hypershift-ci-2
       namespace: test-credentials

--- a/ci-operator/step-registry/hypershift/azure/run-e2e-self-managed/hypershift-azure-run-e2e-self-managed-commands.sh
+++ b/ci-operator/step-registry/hypershift/azure/run-e2e-self-managed/hypershift-azure-run-e2e-self-managed-commands.sh
@@ -31,6 +31,11 @@ trap cleanup EXIT
 
 export EVENTUALLY_VERBOSE="false"
 
+check_e2e_flag() {
+  grep -q "$1" <<<"$( bin/test-e2e -h 2>&1 )"
+  return $?
+}
+
 N1_NP_VERSION_TEST_ARGS=""
 if [[ ${OCP_IMAGE_N1} != "${OCP_IMAGE_LATEST}" ]]; then
   N1_NP_VERSION_TEST_ARGS="--e2e.n1-minor-release-image=${OCP_IMAGE_N1}"
@@ -72,6 +77,11 @@ if [[ -n "${PRIVATE_CREDS}" && -n "${PLS_RG}" ]]; then
 fi
 export AZURE_PRIVATE_NAT_SUBNET_ID="${NAT_SUBNET}"
 
+ADDITIONAL_PULL_SECRET_PARAMS=""
+if check_e2e_flag 'e2e.additional-pull-secret-file' && [[ -f /etc/hypershift-additional-pull-secret/.dockerconfigjson ]]; then
+  ADDITIONAL_PULL_SECRET_PARAMS="--e2e.additional-pull-secret-file=/etc/hypershift-additional-pull-secret/.dockerconfigjson"
+fi
+
 hack/ci-test-e2e.sh -test.v \
   -test.run=${CI_TESTS_RUN:-} \
   -test.parallel=20 \
@@ -88,5 +98,6 @@ hack/ci-test-e2e.sh -test.v \
     ${EXTERNAL_DNS_ARGS:-} \
     ${AZURE_PRIVATE_ARGS:-} \
   --e2e.latest-release-image="${OCP_IMAGE_LATEST}" \
-  --e2e.previous-release-image="${OCP_IMAGE_PREVIOUS}" &
+  --e2e.previous-release-image="${OCP_IMAGE_PREVIOUS}" \
+  ${ADDITIONAL_PULL_SECRET_PARAMS:-} &
 wait $!

--- a/ci-operator/step-registry/hypershift/azure/run-e2e-self-managed/hypershift-azure-run-e2e-self-managed-ref.yaml
+++ b/ci-operator/step-registry/hypershift/azure/run-e2e-self-managed/hypershift-azure-run-e2e-self-managed-ref.yaml
@@ -6,6 +6,9 @@ ref:
     - mount_path: /etc/ci-pull-credentials
       name: ci-pull-credentials
       namespace: test-credentials
+    - mount_path: /etc/hypershift-additional-pull-secret
+      name: hypershift-additional-pull-secret
+      namespace: test-credentials
     - mount_path: /etc/hypershift-kubeconfig-azure
       name: azure-hypershift-ci
       namespace: test-credentials

--- a/ci-operator/step-registry/hypershift/azure/run-e2e/hypershift-azure-run-e2e-commands.sh
+++ b/ci-operator/step-registry/hypershift/azure/run-e2e/hypershift-azure-run-e2e-commands.sh
@@ -40,6 +40,11 @@ trap cleanup EXIT
 
 export EVENTUALLY_VERBOSE="false"
 
+check_e2e_flag() {
+  grep -q "$1" <<<"$( bin/test-e2e -h 2>&1 )"
+  return $?
+}
+
 EXTERNAL_DNS_ARGS=""
 if [[ "${HYPERSHIFT_EXTERNAL_DNS_DOMAIN:-}" != "" ]]; then
   EXTERNAL_DNS_ARGS="--e2e.external-dns-domain=${HYPERSHIFT_EXTERNAL_DNS_DOMAIN}"
@@ -103,6 +108,11 @@ if [[ -n "${HYPERSHIFT_AZURE_MARKETPLACE_IMAGE_PUBLISHER:-}" && -n "${HYPERSHIFT
   MARKETPLACE_IMAGE_PARAMS="--e2e.azure-marketplace-publisher ${HYPERSHIFT_AZURE_MARKETPLACE_IMAGE_PUBLISHER} --e2e.azure-marketplace-offer ${HYPERSHIFT_AZURE_MARKETPLACE_IMAGE_OFFER} --e2e.azure-marketplace-sku ${HYPERSHIFT_AZURE_MARKETPLACE_IMAGE_SKU} --e2e.azure-marketplace-version ${HYPERSHIFT_AZURE_MARKETPLACE_IMAGE_VERSION}"
 fi
 
+ADDITIONAL_PULL_SECRET_PARAMS=""
+if check_e2e_flag 'e2e.additional-pull-secret-file' && [[ -f /etc/hypershift-additional-pull-secret/.dockerconfigjson ]]; then
+  ADDITIONAL_PULL_SECRET_PARAMS="--e2e.additional-pull-secret-file=/etc/hypershift-additional-pull-secret/.dockerconfigjson"
+fi
+
 OAUTH_EXTERNAL_OIDC_PARAM=""
 if [ -f ${SHARED_DIR}/external-oidc-provider ] ; then
     source ${SHARED_DIR}/external-oidc-provider
@@ -155,5 +165,6 @@ hack/ci-test-e2e.sh -test.v \
   ${MARKETPLACE_IMAGE_PARAMS} \
   --e2e.latest-release-image="${OCP_IMAGE_LATEST}" \
   ${OAUTH_EXTERNAL_OIDC_PARAM:-} \
-  --e2e.previous-release-image="${OCP_IMAGE_PREVIOUS}" &
+  --e2e.previous-release-image="${OCP_IMAGE_PREVIOUS}" \
+  ${ADDITIONAL_PULL_SECRET_PARAMS:-} &
 wait $!

--- a/ci-operator/step-registry/hypershift/azure/run-e2e/hypershift-azure-run-e2e-ref.yaml
+++ b/ci-operator/step-registry/hypershift/azure/run-e2e/hypershift-azure-run-e2e-ref.yaml
@@ -6,6 +6,9 @@ ref:
     - mount_path: /etc/ci-pull-credentials
       name: ci-pull-credentials
       namespace: test-credentials
+    - mount_path: /etc/hypershift-additional-pull-secret
+      name: hypershift-additional-pull-secret
+      namespace: test-credentials
     - mount_path: /etc/hypershift-kubeconfig
       name: azure-hypershift-ci
       namespace: test-credentials


### PR DESCRIPTION
## What this PR does / why we need it:

Wires a new `hypershift-additional-pull-secret` credential into the HyperShift e2e CI steps so the `EnsureGlobalPullSecret` test can read real Quay pull secret credentials from a mounted file instead of using hardcoded credentials embedded in source code.

### Changes

**Step ref YAMLs** (credential mount added):
- `hypershift/aws/run-e2e/external/`
- `hypershift/aws/run-e2e/nested/`
- `hypershift/azure/run-e2e/`
- `hypershift/azure/run-e2e-self-managed/`

**Shell scripts** (flag passed conditionally):
- Each script sets `ADDITIONAL_PULL_SECRET_PARAMS` guarded by file existence (and `check_e2e_flag` where the function is available), then passes `--e2e.additional-pull-secret-file=/etc/hypershift-additional-pull-secret/.dockerconfigjson` to the test binary.

### Dependencies

This PR requires:
1. **openshift/hypershift#8320** — adds the `--e2e.additional-pull-secret-file` flag to the e2e test binary
2. **Vault secret provisioning** — the `hypershift-additional-pull-secret` secret must be created in the `test-credentials` namespace via ci-secret-bootstrap, containing a `.dockerconfigjson` file with the quay.io/hypershift pull secret

### Backward compatibility

- AWS scripts use `check_e2e_flag` to skip the flag on older branches that don't support it
- Azure scripts use file existence checks (`[[ -f ... ]]`), so the flag is only passed when the secret is mounted
- If the secret doesn't exist or the flag isn't supported, the test gracefully skips

## Which issue(s) this PR fixes:

Ref: https://issues.redhat.com/browse/OCPBUGS-84248

🤖 Generated with [Claude Code](https://claude.ai/claude-code) via `/jira:solve OCPBUGS-84248`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added optional support for an additional pull secret in HyperShift e2e tests (AWS external/nested and Azure self-managed/standard). When provided, test runs will use the extra pull secret to access container images from additional registries, improving test coverage for deployments that rely on custom image sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->