### PR TITLE
opendatahub: Set runningCount equal to size to disable hibernation

### DIFF
--- a/clusters/hosted-mgmt/hive/pools/opendatahub/opendatahub-ocp-4-20-amd64-aws_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/opendatahub/opendatahub-ocp-4-20-amd64-aws_clusterpool.yaml
@@ -34,7 +34,7 @@ spec:
       region: us-east-1
   pullSecretRef:
     name: pull-secret
-  runningCount: 6
+  runningCount: 12
   size: 12
   skipMachinePools: true
 status:


### PR DESCRIPTION
Set runningCount: 12 (equal to size: 12) on the 4.20 pool so all clusters stay running and never hibernate.

By keeping all clusters running, we eliminate the hibernation resume path entirely until the upstream bug is fixed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ClusterPool configuration to increase the number of concurrently running instances, enhancing overall system capacity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->