### PR TITLE
Add techpreview disruptive-longrunning jobs to the 4.21,5.0

### DIFF
--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.21.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.21.yaml
@@ -1886,6 +1886,110 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-aws-disruption
+- as: e2e-aws-disruptive-longrunning-techpreview
+  interval: 120h
+  shard_count: 2
+  steps:
+    cluster_profile: openshift-org-aws
+    env:
+      FEATURE_SET: TechPreviewNoUpgrade
+      TEST_SUITE: openshift/disruptive-longrunning
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: openshift-e2e-aws-disruption
+- as: e2e-azure-disruptive-longrunning-techpreview
+  interval: 120h
+  shard_count: 2
+  steps:
+    cluster_profile: openshift-org-azure
+    env:
+      FEATURE_SET: TechPreviewNoUpgrade
+      TEST_SUITE: openshift/disruptive-longrunning
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: openshift-e2e-azure
+- as: e2e-gcp-disruptive-longrunning-techpreview
+  interval: 120h
+  shard_count: 2
+  steps:
+    cluster_profile: openshift-org-gcp
+    env:
+      FEATURE_SET: TechPreviewNoUpgrade
+      TEST_SUITE: openshift/disruptive-longrunning
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: openshift-e2e-gcp
+- as: e2e-vsphere-disruptive-longrunning-techpreview
+  interval: 120h
+  steps:
+    cluster_profile: vsphere-elastic
+    env:
+      FEATURE_SET: TechPreviewNoUpgrade
+      TEST_SUITE: openshift/disruptive-longrunning
+    workflow: openshift-e2e-vsphere-ovn
+- as: e2e-metal-ipi-ovn-ipv4-disruptive-longrunning-techpreview
+  capabilities:
+  - intranet
+  interval: 120h
+  shard_count: 2
+  steps:
+    cluster_profile: equinix-ocp-metal
+    env:
+      DEVSCRIPTS_CONFIG: |
+        IP_STACK=v4
+        FEATURE_SET=TechPreviewNoUpgrade
+      TEST_SUITE: openshift/disruptive-longrunning
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: baremetalds-e2e-ovn-ipv4
+- as: e2e-metal-ipi-ovn-ipv6-disruptive-longrunning-techpreview
+  capabilities:
+  - intranet
+  interval: 120h
+  shard_count: 2
+  steps:
+    cluster_profile: equinix-ocp-metal
+    env:
+      DEVSCRIPTS_CONFIG: |
+        IP_STACK=v6
+        FEATURE_SET=TechPreviewNoUpgrade
+      TEST_SUITE: openshift/disruptive-longrunning
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: baremetalds-e2e-ovn-ipv6
+- as: e2e-metal-ipi-ovn-dual-disruptive-longrunning-techpreview
+  capabilities:
+  - intranet
+  interval: 120h
+  shard_count: 2
+  steps:
+    cluster_profile: equinix-ocp-metal
+    env:
+      DEVSCRIPTS_CONFIG: |
+        IP_STACK=v4v6
+        FEATURE_SET=TechPreviewNoUpgrade
+      TEST_SUITE: openshift/disruptive-longrunning
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: baremetalds-e2e-ovn-dualstack
+- as: e2e-aws-single-node-disruptive-longrunning-techpreview
+  interval: 120h
+  shard_count: 2
+  steps:
+    cluster_profile: openshift-org-aws
+    env:
+      FEATURE_SET: TechPreviewNoUpgrade
+      TEST_SUITE: openshift/disruptive-longrunning
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: openshift-e2e-aws-single-node
 zz_generated_metadata:
   branch: main
   org: openshift

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.23.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.23.yaml
@@ -2523,7 +2523,7 @@ tests:
       FEATURE_SET: TechPreviewNoUpgrade
       TEST_SUITE: openshift/disruptive-longrunning
     workflow: openshift-e2e-vsphere-ovn
-- as: e2e-metal-ipi-ovn-ipv4-disruptive-longrunning
+- as: e2e-metal-ipi-ovn-ipv4-disruptive-longrunning-techpreview
   capabilities:
   - intranet
   interval: 168h
@@ -2578,6 +2578,7 @@ tests:
     cluster_profile: openshift-org-aws
     env:
       FEATURE_SET: TechPreviewNoUpgrade
+      TEST_SUITE: openshift/disruptive-longrunning
     observers:
       enable:
       - observers-resource-watch

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
@@ -2663,6 +2663,110 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-aws-disruption
+- as: e2e-aws-disruptive-longrunning-techpreview
+  interval: 168h
+  shard_count: 2
+  steps:
+    cluster_profile: openshift-org-aws
+    env:
+      FEATURE_SET: TechPreviewNoUpgrade
+      TEST_SUITE: openshift/disruptive-longrunning
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: openshift-e2e-aws-disruption
+- as: e2e-azure-disruptive-longrunning-techpreview
+  interval: 168h
+  shard_count: 2
+  steps:
+    cluster_profile: openshift-org-azure
+    env:
+      FEATURE_SET: TechPreviewNoUpgrade
+      TEST_SUITE: openshift/disruptive-longrunning
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: openshift-e2e-azure
+- as: e2e-gcp-disruptive-longrunning-techpreview
+  interval: 168h
+  shard_count: 2
+  steps:
+    cluster_profile: openshift-org-gcp
+    env:
+      FEATURE_SET: TechPreviewNoUpgrade
+      TEST_SUITE: openshift/disruptive-longrunning
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: openshift-e2e-gcp
+- as: e2e-vsphere-disruptive-longrunning-techpreview
+  interval: 168h
+  steps:
+    cluster_profile: vsphere-elastic
+    env:
+      FEATURE_SET: TechPreviewNoUpgrade
+      TEST_SUITE: openshift/disruptive-longrunning
+    workflow: openshift-e2e-vsphere-ovn
+- as: e2e-metal-ipi-ovn-ipv4-disruptive-longrunning-techpreview
+  capabilities:
+  - intranet
+  interval: 168h
+  shard_count: 2
+  steps:
+    cluster_profile: equinix-ocp-metal
+    env:
+      DEVSCRIPTS_CONFIG: |
+        IP_STACK=v4
+        FEATURE_SET=TechPreviewNoUpgrade
+      TEST_SUITE: openshift/disruptive-longrunning
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: baremetalds-e2e-ovn-ipv4
+- as: e2e-metal-ipi-ovn-ipv6-disruptive-longrunning-techpreview
+  capabilities:
+  - intranet
+  interval: 168h
+  shard_count: 2
+  steps:
+    cluster_profile: equinix-ocp-metal
+    env:
+      DEVSCRIPTS_CONFIG: |
+        IP_STACK=v6
+        FEATURE_SET=TechPreviewNoUpgrade
+      TEST_SUITE: openshift/disruptive-longrunning
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: baremetalds-e2e-ovn-ipv6
+- as: e2e-metal-ipi-ovn-dual-disruptive-longrunning-techpreview
+  capabilities:
+  - intranet
+  interval: 168h
+  shard_count: 2
+  steps:
+    cluster_profile: equinix-ocp-metal
+    env:
+      DEVSCRIPTS_CONFIG: |
+        IP_STACK=v4v6
+        FEATURE_SET=TechPreviewNoUpgrade
+      TEST_SUITE: openshift/disruptive-longrunning
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: baremetalds-e2e-ovn-dualstack
+- as: e2e-aws-single-node-disruptive-longrunning-techpreview
+  interval: 168h
+  shard_count: 2
+  steps:
+    cluster_profile: openshift-org-aws
+    env:
+      FEATURE_SET: TechPreviewNoUpgrade
+      TEST_SUITE: openshift/disruptive-longrunning
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: openshift-e2e-aws-single-node
 zz_generated_metadata:
   branch: main
   org: openshift


### PR DESCRIPTION
Add the same kind of techpreview longrunning techpreview jobs as https://github.com/openshift/release/pull/75016, but for 4.21 and 5.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Added numerous nightly and periodic disruptive longrunning E2E tests in TechPreview across AWS, Azure, GCP, vSphere and bare metal (IPv4/IPv6/dual-stack), including AWS single-node and shard-based variants.
  * Expanded scheduling to regular long-interval runs and enabled observers where applicable to improve coverage and reliability.
  * Added intranet-capable baremetal OVN variants and removed explicit empty namespace values from two credential mounts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->