### PR TITLE
ROSAENG-336: Add lifecycle stale/rotten/close periodic jobs

### DIFF
--- a/ci-operator/jobs/infra-periodics.yaml
+++ b/ci-operator/jobs/infra-periodics.yaml
@@ -788,6 +788,157 @@ periodics:
         secretName: github-credentials-openshift-bot
 - agent: kubernetes
   cluster: app.ci
+  cron: 45 2,10 * * *
+  decorate: true
+  labels:
+    ci.openshift.io/role: infra
+  name: periodic-rosa-regional-platform-stale
+  spec:
+    containers:
+    - args:
+      - |-
+        --query=repo:openshift-online/rosa-regional-platform
+        repo:openshift-online/rosa-regional-platform-internal
+        repo:openshift-online/rosa-regional-platform-api
+        repo:openshift-online/rosa-regional-platform-cli
+        repo:openshift-online/aws-nuke-cf
+        comments:<2500
+        -label:lifecycle/frozen
+        -label:lifecycle/stale
+        -label:lifecycle/rotten
+        -label:tide/merge-blocker
+      - --updated=168h
+      - --token=/etc/oauth/oauth
+      - |-
+        --comment=Issues and PRs go stale after 7d of inactivity.
+
+        Mark the issue or PR as fresh by commenting `/remove-lifecycle stale`.
+        Stale issues and PRs rot after an additional 7d of inactivity and eventually close.
+        Exclude this issue or PR from closing by commenting `/lifecycle frozen`.
+
+        If this issue or PR is safe to close now please do so with `/close`.
+
+        /lifecycle stale
+      - --template
+      - --ceiling=10
+      - --confirm
+      command:
+      - /ko-app/commenter
+      image: quay.io/openshift/ci:ci_commenter_latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 500m
+      volumeMounts:
+      - mountPath: /etc/oauth
+        name: token
+    volumes:
+    - name: token
+      secret:
+        secretName: github-credentials-openshift-bot
+- agent: kubernetes
+  cluster: app.ci
+  cron: 0 3,11 * * *
+  decorate: true
+  labels:
+    ci.openshift.io/role: infra
+  name: periodic-rosa-regional-platform-rotten
+  spec:
+    containers:
+    - args:
+      - |-
+        --query=repo:openshift-online/rosa-regional-platform
+        repo:openshift-online/rosa-regional-platform-internal
+        repo:openshift-online/rosa-regional-platform-api
+        repo:openshift-online/rosa-regional-platform-cli
+        repo:openshift-online/aws-nuke-cf
+        comments:<2500
+        -label:tide/merge-blocker
+        -label:lifecycle/frozen
+        label:lifecycle/stale
+        -label:lifecycle/rotten
+      - --updated=168h
+      - --token=/etc/oauth/oauth
+      - |-
+        --comment=Stale issues and PRs rot after 7d of inactivity.
+
+        Mark the issue or PR as fresh by commenting `/remove-lifecycle rotten`.
+        Rotten issues and PRs close after an additional 7d of inactivity.
+        Exclude this issue or PR from closing by commenting `/lifecycle frozen`.
+
+        If this issue or PR is safe to close now please do so with `/close`.
+
+        /lifecycle rotten
+        /remove-lifecycle stale
+      - --template
+      - --ceiling=10
+      - --confirm
+      command:
+      - /ko-app/commenter
+      image: quay.io/openshift/ci:ci_commenter_latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 500m
+      volumeMounts:
+      - mountPath: /etc/oauth
+        name: token
+    volumes:
+    - name: token
+      secret:
+        secretName: github-credentials-openshift-bot
+- agent: kubernetes
+  cluster: app.ci
+  cron: 15 3,11 * * *
+  decorate: true
+  labels:
+    ci.openshift.io/role: infra
+  name: periodic-rosa-regional-platform-close
+  spec:
+    containers:
+    - args:
+      - |-
+        --query=repo:openshift-online/rosa-regional-platform
+        repo:openshift-online/rosa-regional-platform-internal
+        repo:openshift-online/rosa-regional-platform-api
+        repo:openshift-online/rosa-regional-platform-cli
+        repo:openshift-online/aws-nuke-cf
+        comments:<2500
+        -label:lifecycle/frozen
+        -label:tide/merge-blocker
+        label:lifecycle/rotten
+      - --updated=168h
+      - --token=/etc/oauth/oauth
+      - |-
+        --comment=Rotten issues and PRs close after 7d of inactivity.
+
+        Reopen the issue or PR by commenting `/reopen`.
+        Mark the issue or PR as fresh by commenting `/remove-lifecycle rotten`.
+        Exclude this issue or PR from closing again by commenting `/lifecycle frozen`.
+
+        /close not-planned
+      - --template
+      - --ceiling=10
+      - --confirm
+      command:
+      - /ko-app/commenter
+      image: quay.io/openshift/ci:ci_commenter_latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 500m
+      volumeMounts:
+      - mountPath: /etc/oauth
+        name: token
+    volumes:
+    - name: token
+      secret:
+        secretName: github-credentials-openshift-bot
+- agent: kubernetes
+  cluster: app.ci
   cron: 0 0 * * 3
   decorate: true
   decoration_config:


### PR DESCRIPTION
Adds periodic jobs to the rosa-regional-platform repos.

Add dedicated periodic Prow jobs to automatically manage issue and PR lifecycle for openshift-online/rosa-regional-platform, rosa-regional-platform-internal, rosa-regional-platform-api, rosa-regional-platform-cli, and aws-nuke-cf with a 7-day cadence for stale, rotten, and close stages.

I have explicitly created new jobs since I'd like to add a shorter feedback loop than 30d. At our current velocity, 7d is considered a stale issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic lifecycle management for pull requests and issues, including stale detection, rotten state transitions, and automated closure of inactive items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->