### PR TITLE
Fix subscription name

### DIFF
--- a/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__periodic.yaml
+++ b/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__periodic.yaml
@@ -74,7 +74,7 @@ tests:
   steps:
     env:
       CLEANUP_SWEEPER_POLICY: tooling/cleanup-sweeper/resourcegroups.policy.yaml
-      CLEANUP_SWEEPER_SUBSCRIPTION_NAMES: ARO HCP E2E Service Clusters (EA Subscription),
+      CLEANUP_SWEEPER_SUBSCRIPTION_NAMES: ARO HCP E2E Infrastructure (EA Subscription),
         ARO HCP E2E Hosted Clusters (EA Subscription), ARO HCP E2E Management Clusters
         (EA Subscription), ARO Hosted Control Planes (EA Subscription 1)
       CLEANUP_SWEEPER_WAIT: "false"
@@ -85,7 +85,7 @@ tests:
   cron: 35 * * * *
   steps:
     env:
-      CLEANUP_SWEEPER_SUBSCRIPTION_NAMES: ARO HCP E2E Service Clusters (EA Subscription),
+      CLEANUP_SWEEPER_SUBSCRIPTION_NAMES: ARO HCP E2E Infrastructure (EA Subscription),
         ARO HCP E2E Hosted Clusters (EA Subscription), ARO HCP E2E Management Clusters
         (EA Subscription), ARO Hosted Control Planes (EA Subscription 1)
       CLEANUP_SWEEPER_VERBOSITY: "1"


### PR DESCRIPTION
The subscription name has changed from `ARO HCP E2E Service Clusters (EA Subscription)` to `ARO HCP E2E Infrastructure (EA Subscription)` and the script is choking on that as it cannot resolve the ID. This updates the name to fix the problem.

To be followed up by a PR that makes the script more resilient.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated periodic cleanup configuration for ARO HCP E2E infrastructure to ensure proper targeting of resource groups during maintenance operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->