### PR TITLE
NO-JIRA: Improve test/e2e-aws-ovn-upgrade-paused for 4.22

### DIFF
--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22-upgrade-from-stable-4.20.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22-upgrade-from-stable-4.20.yaml
@@ -31,6 +31,7 @@ tests:
     cluster_profile: openshift-org-aws
     env:
       TEST_ARGS: --disable-monitor=etcd-log-analyzer,node-lifecycle,on-prem-haproxy,on-prem-keepalived,initial-and-final-operator-log-scraper,apiserver-incluster-availability,kubelet-log-collector,audit-log-analyzer,metrics-endpoints-down,alert-summary-serializer,cpu-metric-collector,pod-network-avalibility,service-type-load-balancer-availability,ingress-availability,pathological-event-analyzer,legacy-test-framework-invariants,operator-state-analyzer,legacy-cvo-invariants,apiserver-external-availability,azure-metrics-collector,etcd-disk-metrics-intervals,termination-message-policy,legacy-test-framework-invariants-alerts,legacy-networking-invariants,oc-adm-upgrade-status
+      TEST_ARGS_2: --disable-monitor=legacy-cvo-invariants
       TEST_UPGRADE_OPTIONS: ""
     observers:
       enable:

--- a/ci-operator/step-registry/openshift/e2e/test/openshift-e2e-test-commands.sh
+++ b/ci-operator/step-registry/openshift/e2e/test/openshift-e2e-test-commands.sh
@@ -288,16 +288,12 @@ function upgrade_paused() {
     # Mimic https://github.com/openshift/installer/blob/98d5859f6cb6d2660cf9ffbed8885d9c9907ec56/pkg/asset/ignition/bootstrap/cvoignore.go#L142-L158
     # which is available from 4.21+
     installed_version=$(oc get clusterversion version -o jsonpath='{.status.history[-1].version}')
-    # remove --disable-monitor=oc-adm-upgrade-status when https://redhat.atlassian.net/browse/OTA-1977 is fixed
-    # TODO: define it from the job like TEST_ARGS
-    TEST_ARGS_2="--disable-monitor=oc-adm-upgrade-status"
     echo "The installed version is $installed_version"
     if [[ $installed_version == "4.20."* ]]; then
         echo "Overriding the cluster-scoped 'openshift' ClusterImagePolicy"
         oc patch clusterversion version --type json -p '[{"op": "add", "path": "/spec/overrides", "value": [{"group": "config.openshift.io", "kind": "ClusterImagePolicy", "name": "openshift", "namespace": "", "unmanaged": true}]}]'
         echo "Showing the ClusterVersion spec"
-        oc get clusterversion version -o jsonpath='{.spec}{"\n"}'
-        TEST_ARGS_2="--disable-monitor=oc-adm-upgrade-status,legacy-cvo-invariants"
+        oc get clusterversion version -o jsonpath-as-json='{.spec}'
     fi
 
     oc patch mcp/worker --type merge --patch '{"spec":{"paused":true}}'

--- a/ci-operator/step-registry/openshift/e2e/test/openshift-e2e-test-ref.yaml
+++ b/ci-operator/step-registry/openshift/e2e/test/openshift-e2e-test-ref.yaml
@@ -9,6 +9,10 @@ ref:
     default: ""
     documentation: |-
       Additional arguments to be passed to 'openshift-test'
+  - name: TEST_ARGS_2
+    default: ""
+    documentation: |-
+      Additional arguments to be passed to the 2nd call of 'openshift-test', e.g., when TEST_TYPE=upgrade-paused.
   - name: SHARD_ARGS
     default: ""
     documentation: |-


### PR DESCRIPTION
This is to follow up

* https://github.com/openshift/release/pull/77842#discussion_r3133063314
* https://github.com/openshift/release/pull/77842#issuecomment-4306852951

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test configuration and scripts for nightly upgrade testing. Modified how test arguments are passed during upgrade procedures to improve consistency in test execution and monitor disabling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->