### PR TITLE
HYPERFLEET-877 - ci: add commit message validation

### DIFF
--- a/ci-operator/config/openshift-hyperfleet/hyperfleet-adapter/openshift-hyperfleet-hyperfleet-adapter-main.yaml
+++ b/ci-operator/config/openshift-hyperfleet/hyperfleet-adapter/openshift-hyperfleet-hyperfleet-adapter-main.yaml
@@ -18,6 +18,10 @@ resources:
       cpu: 100m
       memory: 200Mi
 tests:
+- as: validate-commits
+  steps:
+    test:
+    - ref: hyperfleet-commitlint
 - as: lint
   commands: |
     export HOME=/tmp

--- a/ci-operator/config/openshift-hyperfleet/hyperfleet-api/openshift-hyperfleet-hyperfleet-api-main.yaml
+++ b/ci-operator/config/openshift-hyperfleet/hyperfleet-api/openshift-hyperfleet-hyperfleet-api-main.yaml
@@ -30,6 +30,10 @@ resources:
       cpu: 100m
       memory: 200Mi
 tests:
+- as: validate-commits
+  steps:
+    test:
+    - ref: hyperfleet-commitlint
 - as: lint
   capabilities:
   - nested-podman

--- a/ci-operator/config/openshift-hyperfleet/hyperfleet-broker/openshift-hyperfleet-hyperfleet-broker-main.yaml
+++ b/ci-operator/config/openshift-hyperfleet/hyperfleet-broker/openshift-hyperfleet-hyperfleet-broker-main.yaml
@@ -18,6 +18,10 @@ resources:
       cpu: 100m
       memory: 200Mi
 tests:
+- as: validate-commits
+  steps:
+    test:
+    - ref: hyperfleet-commitlint
 - as: lint
   commands: |
     export HOME=/tmp

--- a/ci-operator/config/openshift-hyperfleet/hyperfleet-sentinel/openshift-hyperfleet-hyperfleet-sentinel-main.yaml
+++ b/ci-operator/config/openshift-hyperfleet/hyperfleet-sentinel/openshift-hyperfleet-hyperfleet-sentinel-main.yaml
@@ -30,6 +30,10 @@ resources:
       cpu: 100m
       memory: 200Mi
 tests:
+- as: validate-commits
+  steps:
+    test:
+    - ref: hyperfleet-commitlint
 - as: lint
   capabilities:
   - nested-podman

--- a/ci-operator/jobs/openshift-hyperfleet/hyperfleet-adapter/openshift-hyperfleet-hyperfleet-adapter-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-hyperfleet/hyperfleet-adapter/openshift-hyperfleet-hyperfleet-adapter-main-presubmits.yaml
@@ -422,3 +422,83 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )unit,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build11
+    context: ci/prow/validate-commits
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-hyperfleet-hyperfleet-adapter-main-validate-commits
+    rerun_command: /test validate-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --target=validate-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: github-credentials-openshift-ci-robot-private-git-cloner
+        secret:
+          secretName: github-credentials-openshift-ci-robot-private-git-cloner
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )validate-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift-hyperfleet/hyperfleet-api/openshift-hyperfleet-hyperfleet-api-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-hyperfleet/hyperfleet-api/openshift-hyperfleet-hyperfleet-api-main-presubmits.yaml
@@ -476,3 +476,83 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )unit,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build11
+    context: ci/prow/validate-commits
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-hyperfleet-hyperfleet-api-main-validate-commits
+    rerun_command: /test validate-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --target=validate-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: github-credentials-openshift-ci-robot-private-git-cloner
+        secret:
+          secretName: github-credentials-openshift-ci-robot-private-git-cloner
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )validate-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift-hyperfleet/hyperfleet-broker/openshift-hyperfleet-hyperfleet-broker-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-hyperfleet/hyperfleet-broker/openshift-hyperfleet-hyperfleet-broker-main-presubmits.yaml
@@ -277,3 +277,83 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )unit,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build06
+    context: ci/prow/validate-commits
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-hyperfleet-hyperfleet-broker-main-validate-commits
+    rerun_command: /test validate-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --target=validate-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: github-credentials-openshift-ci-robot-private-git-cloner
+        secret:
+          secretName: github-credentials-openshift-ci-robot-private-git-cloner
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )validate-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift-hyperfleet/hyperfleet-sentinel/openshift-hyperfleet-hyperfleet-sentinel-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-hyperfleet/hyperfleet-sentinel/openshift-hyperfleet-hyperfleet-sentinel-main-presubmits.yaml
@@ -476,3 +476,83 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )unit,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build11
+    context: ci/prow/validate-commits
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-hyperfleet-hyperfleet-sentinel-main-validate-commits
+    rerun_command: /test validate-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --target=validate-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: github-credentials-openshift-ci-robot-private-git-cloner
+        secret:
+          secretName: github-credentials-openshift-ci-robot-private-git-cloner
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )validate-commits,?($|\s.*)

--- a/ci-operator/step-registry/hyperfleet/OWNERS
+++ b/ci-operator/step-registry/hyperfleet/OWNERS
@@ -1,0 +1,23 @@
+approvers:
+- aredenba-rh
+- ciaranroche
+- crizzo71
+- kuudori
+- ma-hill
+- mischulee
+- rafabene
+- rh-amarin
+- tirthct
+- vkareh
+options: {}
+reviewers:
+- aredenba-rh
+- ciaranroche
+- crizzo71
+- kuudori
+- ma-hill
+- mischulee
+- rafabene
+- rh-amarin
+- tirthct
+- vkareh

--- a/ci-operator/step-registry/hyperfleet/commitlint/OWNERS
+++ b/ci-operator/step-registry/hyperfleet/commitlint/OWNERS
@@ -1,0 +1,23 @@
+approvers:
+- aredenba-rh
+- ciaranroche
+- crizzo71
+- kuudori
+- ma-hill
+- mischulee
+- rafabene
+- rh-amarin
+- tirthct
+- vkareh
+options: {}
+reviewers:
+- aredenba-rh
+- ciaranroche
+- crizzo71
+- kuudori
+- ma-hill
+- mischulee
+- rafabene
+- rh-amarin
+- tirthct
+- vkareh

--- a/ci-operator/step-registry/hyperfleet/commitlint/hyperfleet-commitlint-commands.sh
+++ b/ci-operator/step-registry/hyperfleet/commitlint/hyperfleet-commitlint-commands.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "=== HyperFleet Commit Message Validation ==="
+
+if [ -z "${PULL_BASE_SHA:-}" ]; then
+    echo "ERROR: PULL_BASE_SHA is not set; presubmit checks must run in PR context."
+    exit 1
+fi
+
+export HOME=/tmp
+export GOPATH=/tmp/go
+export GOMODCACHE=/tmp/go-mod
+export GOCACHE=/tmp/go-build
+export PATH="$GOPATH/bin:$PATH"
+unset GOFLAGS
+
+echo "Installing hyperfleet-hooks..."
+go install github.com/openshift-hyperfleet/hyperfleet-hooks/cmd/hyperfleet-hooks@v0.1.1
+
+echo "Running commitlint validation..."
+hyperfleet-hooks commitlint --pr

--- a/ci-operator/step-registry/hyperfleet/commitlint/hyperfleet-commitlint-ref.metadata.json
+++ b/ci-operator/step-registry/hyperfleet/commitlint/hyperfleet-commitlint-ref.metadata.json
@@ -1,0 +1,29 @@
+{
+	"path": "hyperfleet/commitlint/hyperfleet-commitlint-ref.yaml",
+	"owners": {
+		"approvers": [
+			"aredenba-rh",
+			"ciaranroche",
+			"crizzo71",
+			"kuudori",
+			"ma-hill",
+			"mischulee",
+			"rafabene",
+			"rh-amarin",
+			"tirthct",
+			"vkareh"
+		],
+		"reviewers": [
+			"aredenba-rh",
+			"ciaranroche",
+			"crizzo71",
+			"kuudori",
+			"ma-hill",
+			"mischulee",
+			"rafabene",
+			"rh-amarin",
+			"tirthct",
+			"vkareh"
+		]
+	}
+}

--- a/ci-operator/step-registry/hyperfleet/commitlint/hyperfleet-commitlint-ref.yaml
+++ b/ci-operator/step-registry/hyperfleet/commitlint/hyperfleet-commitlint-ref.yaml
@@ -1,0 +1,10 @@
+ref:
+  as: hyperfleet-commitlint
+  commands: hyperfleet-commitlint-commands.sh
+  from: src
+  grace_period: 1m0s
+  resources:
+    requests:
+      cpu: 100m
+      memory: 200Mi
+  timeout: 5m0s


### PR DESCRIPTION
## Summary

- Add reusable step-registry ref `hyperfleet-commitlint` that installs and runs `hyperfleet-hooks commitlint --pr` (pinned to v0.1.0) to validate commit messages and PR titles against the [HyperFleet Commit Standard](https://github.com/openshift-hyperfleet/architecture/blob/main/hyperfleet/standards/commit-standard.md)
- Enable `validate-commits` presubmit job for **sentinel**, **api**, **adapter**, and **broker** repositories
- Non-compliant commit messages and PR titles will block PR merge
- Validation rules are sourced from [hyperfleet-hooks](https://github.com/openshift-hyperfleet/hyperfleet-hooks) — no rules duplicated in Prow job configuration

## Test plan

- [x] Rehearsal jobs pass for all 4 repositories
- [ ] Open a test PR on hyperfleet-sentinel with a non-compliant commit message and verify the `validate-commits` job fails
- [ ] Open a test PR with a compliant commit message and verify the job passes

## Tickets

- [HYPERFLEET-877](https://redhat.atlassian.net/browse/HYPERFLEET-877) — sentinel
- [HYPERFLEET-881](https://redhat.atlassian.net/browse/HYPERFLEET-881) — api
- [HYPERFLEET-883](https://redhat.atlassian.net/browse/HYPERFLEET-883) — adapter
- [HYPERFLEET-885](https://redhat.atlassian.net/browse/HYPERFLEET-885) — broker

[HYPERFLEET-877]: https://redhat.atlassian.net/browse/HYPERFLEET-877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HYPERFLEET-881]: https://redhat.atlassian.net/browse/HYPERFLEET-881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added automatic commit-message validation as a new CI presubmit step that runs before linting on PRs.
  * New presubmit jobs added across repositories to run the check; jobs run automatically on PRs and support reruns via test commands.

* **Chores**
  * Added the commit-validation step, execution script, metadata, and ownership entries to the CI step registry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->