### PR TITLE
change 4.22 rhel9 baseos to cloudflare

### DIFF
--- a/core-services/release-controller/_repos/ocp-4.22-rhel9.repo
+++ b/core-services/release-controller/_repos/ocp-4.22-rhel9.repo
@@ -1,6 +1,6 @@
 [rhel-9-baseos]
 name = rhel-9-baseos
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-9-baseos
+baseurl = https://openshift-mirror-list.ci-systems.workers.dev/enterprise/reposync/4.22/rhel-9-baseos
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -12,7 +12,7 @@ skip_if_unavailable = true
 
 [rhel-9-appstream]
 name = rhel-9-appstream
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-9-appstream
+baseurl = https://openshift-mirror-list.ci-systems.workers.dev/enterprise/reposync/4.22/rhel-9-appstream
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -25,7 +25,7 @@ excludepkgs=toolbox*
 
 [rhel-9-nfv]
 name = rhel-9-nfv
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-9-nfv
+baseurl = https://openshift-mirror-list.ci-systems.workers.dev/enterprise/reposync/4.22/rhel-9-nfv
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -37,7 +37,7 @@ skip_if_unavailable = true
 
 [rhel-9-highavailability]
 name = rhel-9-highavailability
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-9-highavailability
+baseurl = https://openshift-mirror-list.ci-systems.workers.dev/enterprise/reposync/4.22/rhel-9-highavailability
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -73,7 +73,7 @@ failovermethod = priority
 
 [rhel-9-server-ose]
 name = rhel-9-server-ose
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-9-server-ose-rpms
+baseurl = https://openshift-mirror-list.ci-systems.workers.dev/enterprise/reposync/4.22/rhel-9-server-ose-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -92,7 +92,7 @@ skip_if_unavailable = true
 # interested in.
 [rhel-9.8-early-kernel]
 name = rhel-9.8-early-kernel
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-9-server-ose-rpms
+baseurl = https://openshift-mirror-list.ci-systems.workers.dev/enterprise/reposync/4.22/rhel-9-server-ose-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -108,7 +108,7 @@ includepkgs=kernel,kernel-*,toolbox*,
 
 [rhel-9-baseos-ppc64le]
 name = rhel-9-baseos-ppc64le
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-9-baseos-ppc64le
+baseurl = https://openshift-mirror-list.ci-systems.workers.dev/enterprise/reposync/4.22/rhel-9-baseos-ppc64le
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -120,7 +120,7 @@ skip_if_unavailable = true
 
 [rhel-9-appstream-ppc64le]
 name = rhel-9-appstream-ppc64le
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-9-appstream-ppc64le
+baseurl = https://openshift-mirror-list.ci-systems.workers.dev/enterprise/reposync/4.22/rhel-9-appstream-ppc64le
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -144,7 +144,7 @@ failovermethod = priority
 
 [rhel-9-server-ose-ppc64le]
 name = rhel-9-server-ose-ppc64le
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22_ppc64le/rhel-9-server-ose-rpms
+baseurl = https://openshift-mirror-list.ci-systems.workers.dev/enterprise/reposync/4.22_ppc64le/rhel-9-server-ose-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -168,7 +168,7 @@ failovermethod = priority
 
 [rhel-9-baseos-s390x]
 name = rhel-9-baseos-s390x
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-9-baseos-s390x
+baseurl = https://openshift-mirror-list.ci-systems.workers.dev/enterprise/reposync/4.22/rhel-9-baseos-s390x
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -180,7 +180,7 @@ skip_if_unavailable = true
 
 [rhel-9-appstream-s390x]
 name = rhel-9-appstream-s390x
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-9-appstream-s390x
+baseurl = https://openshift-mirror-list.ci-systems.workers.dev/enterprise/reposync/4.22/rhel-9-appstream-s390x
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -204,7 +204,7 @@ failovermethod = priority
 
 [rhel-9-server-ose-s390x]
 name = rhel-9-server-ose-s390x
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22_s390x/rhel-9-server-ose-rpms
+baseurl = https://openshift-mirror-list.ci-systems.workers.dev/enterprise/reposync/4.22_s390x/rhel-9-server-ose-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -228,7 +228,7 @@ failovermethod = priority
 
 [rhel-9-baseos-aarch64]
 name = rhel-9-baseos-aarch64
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-9-baseos-aarch64
+baseurl = https://openshift-mirror-list.ci-systems.workers.dev/enterprise/reposync/4.22/rhel-9-baseos-aarch64
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -240,7 +240,7 @@ skip_if_unavailable = true
 
 [rhel-9-appstream-aarch64]
 name = rhel-9-appstream-aarch64
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-9-appstream-aarch64
+baseurl = https://openshift-mirror-list.ci-systems.workers.dev/enterprise/reposync/4.22/rhel-9-appstream-aarch64
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -264,7 +264,7 @@ failovermethod = priority
 
 [rhel-9-server-ose-aarch64]
 name = rhel-9-server-ose-aarch64
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22_aarch64/rhel-9-server-ose-rpms
+baseurl = https://openshift-mirror-list.ci-systems.workers.dev/enterprise/reposync/4.22_aarch64/rhel-9-server-ose-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository mirror URLs for OCP 4.22 RHEL9 across all supported architectures to improve accessibility and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->