### PR TITLE
Revert "Fix 4.22 rhel9 repos"

### DIFF
--- a/core-services/release-controller/_repos/ocp-4.22-rhel9.repo
+++ b/core-services/release-controller/_repos/ocp-4.22-rhel9.repo
@@ -1,6 +1,6 @@
 [rhel-9-baseos]
 name = rhel-9-baseos
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-9-baseos
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-baseos
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -12,7 +12,7 @@ skip_if_unavailable = true
 
 [rhel-9-appstream]
 name = rhel-9-appstream
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-9-appstream
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-appstream
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -25,7 +25,7 @@ excludepkgs=toolbox*
 
 [rhel-9-nfv]
 name = rhel-9-nfv
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-9-nfv
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-nfv
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -37,7 +37,7 @@ skip_if_unavailable = true
 
 [rhel-9-highavailability]
 name = rhel-9-highavailability
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-9-highavailability
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-highavailability
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -108,7 +108,7 @@ includepkgs=kernel,kernel-*,toolbox*,
 
 [rhel-9-baseos-ppc64le]
 name = rhel-9-baseos-ppc64le
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-9-baseos-ppc64le
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-baseos-ppc64le
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -120,7 +120,7 @@ skip_if_unavailable = true
 
 [rhel-9-appstream-ppc64le]
 name = rhel-9-appstream-ppc64le
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-9-appstream-ppc64le
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-appstream-ppc64le
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -168,7 +168,7 @@ failovermethod = priority
 
 [rhel-9-baseos-s390x]
 name = rhel-9-baseos-s390x
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-9-baseos-s390x
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-baseos-s390x
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -180,7 +180,7 @@ skip_if_unavailable = true
 
 [rhel-9-appstream-s390x]
 name = rhel-9-appstream-s390x
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-9-appstream-s390x
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-appstream-s390x
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -228,7 +228,7 @@ failovermethod = priority
 
 [rhel-9-baseos-aarch64]
 name = rhel-9-baseos-aarch64
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-9-baseos-aarch64
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-baseos-aarch64
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -240,7 +240,7 @@ skip_if_unavailable = true
 
 [rhel-9-appstream-aarch64]
 name = rhel-9-appstream-aarch64
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-9-appstream-aarch64
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-appstream-aarch64
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false


### PR DESCRIPTION
Reverts openshift/release#78260

https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-9-baseos does not exist. Reverting until we know the intent. 

https://redhat-internal.slack.com/archives/C01CQA76KMX/p1776990417201329?thread_ts=1776968270.118349&cid=C01CQA76KMX 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration references for improved compatibility across multiple system architectures and package repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->