### PR TITLE
NO-JIRA: Upkeep edge tooling

### DIFF
--- a/ci-operator/config/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main.yaml
+++ b/ci-operator/config/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main.yaml
@@ -46,7 +46,31 @@ resources:
     requests:
       cpu: 100m
       memory: 200Mi
+test_binary_build_commands: |-
+  dnf -y module reset nodejs || true
+  dnf -y module enable nodejs:20
+  dnf -y install nodejs
+
+  npm install -g \
+  markdownlint@v0.40.0 \
+  markdownlint-cli2@v0.22.1 \
+  markdownlint-cli2-formatter-json \
+  markdownlint-cli2-formatter-pretty \
+  markdownlint-cli2-formatter-junit
 tests:
+- always_run: false
+  as: markdownlint
+  commands: |
+    set +e
+    make lint-markdown
+    rc=$?
+    if [[ -n "${ARTIFACT_DIR:-}" && -f markdownlint-cli2-junit.xml ]]; then
+      cp -f markdownlint-cli2-junit.xml "${ARTIFACT_DIR}/"
+    fi
+    exit "${rc}"
+  container:
+    from: test-bin
+  run_if_changed: (\.md|^Makefile|^hack/.*markdown.*|^\.markdown.*)$
 - as: ocp-ci-monitor
   cron: 0 9 * * *
   steps:

--- a/ci-operator/jobs/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main-presubmits.yaml
@@ -62,3 +62,74 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )images,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build01
+    context: ci/prow/markdownlint
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-eng-edge-tooling-main-markdownlint
+    rerun_command: /test markdownlint
+    run_if_changed: (\.md|^Makefile|^hack/.*markdown.*|^\.markdown.*)$
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --target=markdownlint
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: github-credentials-openshift-ci-robot-private-git-cloner
+        secret:
+          secretName: github-credentials-openshift-ci-robot-private-git-cloner
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )markdownlint,?($|\s.*)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a markdown lint presubmit that runs conditionally when markdown/build files change; disabled by default and can be manually triggered with "/test markdownlint".
* **Chores**
  * CI now provisions Node.js 20 and installs pinned markdownlint tooling for consistent lint checks.
* **Chores**
  * Notifications no longer include job log URLs for PR runs; URLs are provided only for non-PR executions.
  * PR notifier schedule shifted to a later daily time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->