### PR TITLE
ART-14263: Migrate OCP 4.12 RPM repos to R2 CloudFlare

### DIFF
--- a/core-services/release-controller/_repos/ocp-4.12-default.repo
+++ b/core-services/release-controller/_repos/ocp-4.12-default.repo
@@ -30,7 +30,7 @@ gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release ht
 
 [rhel-server-ose]
 name = rhel-server-ose
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.12/rhel-server-ose-rpms/
+baseurl = https://openshift-mirror-list.ci-systems.workers.dev/enterprise/reposync/4.12/rhel-server-ose-rpms/
 sslverify = false
 username_file=/tmp/mirror-enterprise-basic-auth/username
 password_file=/tmp/mirror-enterprise-basic-auth/password

--- a/core-services/release-controller/_repos/ocp-4.12-openstack-beta.repo
+++ b/core-services/release-controller/_repos/ocp-4.12-openstack-beta.repo
@@ -1,6 +1,6 @@
 [openstack-beta-rhel8]
 name = rhel-openstack
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.12/openstack-beta-for-rhel-8-rpms
+baseurl = https://openshift-mirror-list.ci-systems.workers.dev/enterprise/reposync/4.12/openstack-beta-for-rhel-8-rpms
 sslverify = false
 username_file=/tmp/mirror-enterprise-basic-auth/username
 password_file=/tmp/mirror-enterprise-basic-auth/password

--- a/core-services/release-controller/_repos/ocp-4.12-openstack.repo
+++ b/core-services/release-controller/_repos/ocp-4.12-openstack.repo
@@ -1,6 +1,6 @@
 [openstack-16-rhel8]
 name = rhel-openstack
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.12/openstack-16-for-rhel-8-rpms
+baseurl = https://openshift-mirror-list.ci-systems.workers.dev/enterprise/reposync/4.12/openstack-16-for-rhel-8-rpms
 sslverify = false
 username_file=/tmp/mirror-enterprise-basic-auth/username
 password_file=/tmp/mirror-enterprise-basic-auth/password

--- a/core-services/release-controller/_repos/ocp-4.12-ppc64le.repo
+++ b/core-services/release-controller/_repos/ocp-4.12-ppc64le.repo
@@ -30,7 +30,7 @@ gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release ht
 
 [rhel-server-ose]
 name = rhel-server-ose
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.12_ppc64le/rhel-server-ose-rpms/
+baseurl = https://openshift-mirror-list.ci-systems.workers.dev/enterprise/reposync/4.12_ppc64le/rhel-server-ose-rpms/
 sslverify = false
 username_file=/tmp/mirror-enterprise-basic-auth/username
 password_file=/tmp/mirror-enterprise-basic-auth/password

--- a/core-services/release-controller/_repos/ocp-4.12-rhel-8-ironic-prevalidation.repo
+++ b/core-services/release-controller/_repos/ocp-4.12-rhel-8-ironic-prevalidation.repo
@@ -1,6 +1,6 @@
 [rhel-8-ironic-prevalidation]
 name = rhel-8-ironic-prevalidation
-baseurl = https://mirror2.openshift.com/enterprise/reposync/ci-ironic/rhaos-4.12-rhel-8-ironic-prevalidation/x86_64/os/
+baseurl = https://openshift-mirror-list.ci-systems.workers.dev/enterprise/reposync/ci-ironic/rhaos-4.12-rhel-8-ironic-prevalidation/x86_64/os/
 enabled = 0
 sslverify = false
 username_file=/tmp/mirror-enterprise-basic-auth/username

--- a/core-services/release-controller/_repos/ocp-4.12-rhel-8-server-ironic.repo
+++ b/core-services/release-controller/_repos/ocp-4.12-rhel-8-server-ironic.repo
@@ -1,6 +1,6 @@
 [rhel-8-server-ironic-rpms]
 name = rhel-8-server-ironic-rpms
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.12/rhel-8-server-ironic-rpms/
+baseurl = https://openshift-mirror-list.ci-systems.workers.dev/enterprise/reposync/4.12/rhel-8-server-ironic-rpms/
 enabled = 1
 sslverify = false
 username_file=/tmp/mirror-enterprise-basic-auth/username

--- a/core-services/release-controller/_repos/ocp-4.12-rhel-9-ironic-prevalidation.repo
+++ b/core-services/release-controller/_repos/ocp-4.12-rhel-9-ironic-prevalidation.repo
@@ -1,6 +1,6 @@
 [rhel-9-ironic-prevalidation]
 name = rhel-9-ironic-prevalidation
-baseurl = https://mirror2.openshift.com/enterprise/reposync/ci-ironic/rhaos-4.12-ironic-rhel-9-prevalidation/x86_64/os/
+baseurl = https://openshift-mirror-list.ci-systems.workers.dev/enterprise/reposync/ci-ironic/rhaos-4.12-ironic-rhel-9-prevalidation/x86_64/os/
 enabled = 0
 sslverify = false
 username_file=/tmp/mirror-enterprise-basic-auth/username

--- a/core-services/release-controller/_repos/ocp-4.12-rhel-9-server-ironic.repo
+++ b/core-services/release-controller/_repos/ocp-4.12-rhel-9-server-ironic.repo
@@ -1,6 +1,6 @@
 [rhel-9-server-ironic-rpms]
 name = rhel-9-server-ironic-rpms
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.12/rhel-9-server-ironic-rpms/
+baseurl = https://openshift-mirror-list.ci-systems.workers.dev/enterprise/reposync/4.12/rhel-9-server-ironic-rpms/
 enabled = 1
 sslverify = false
 username_file=/tmp/mirror-enterprise-basic-auth/username

--- a/core-services/release-controller/_repos/ocp-4.12-rhel8-aarch64.repo
+++ b/core-services/release-controller/_repos/ocp-4.12-rhel8-aarch64.repo
@@ -38,7 +38,7 @@ failovermethod = priority
 name = rhel-8-server-ose
 # Using mirror until aarch64 content released to CDN
 # See: https://github.com/openshift/release/pull/23111#discussion_r739417374
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.12_aarch64/rhel-8-server-ose-rpms
+baseurl = https://openshift-mirror-list.ci-systems.workers.dev/enterprise/reposync/4.12_aarch64/rhel-8-server-ose-rpms
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0

--- a/core-services/release-controller/_repos/ocp-4.12-rhel8.repo
+++ b/core-services/release-controller/_repos/ocp-4.12-rhel8.repo
@@ -48,7 +48,7 @@ failovermethod = priority
 
 [rhel-8-server-ose]
 name = rhel-8-server-ose
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.12/rhel-8-server-ose-rpms
+baseurl = https://openshift-mirror-list.ci-systems.workers.dev/enterprise/reposync/4.12/rhel-8-server-ose-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false

--- a/core-services/release-controller/_repos/ocp-4.12-rhel86.repo
+++ b/core-services/release-controller/_repos/ocp-4.12-rhel86.repo
@@ -48,7 +48,7 @@ failovermethod = priority
 
 [rhel-8.6-server-ose-4.12]
 name = rhel-8.6-server-ose-4.12
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.12/rhel-8-server-ose-rpms
+baseurl = https://openshift-mirror-list.ci-systems.workers.dev/enterprise/reposync/4.12/rhel-8-server-ose-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false

--- a/core-services/release-controller/_repos/ocp-4.12-rhel9.repo
+++ b/core-services/release-controller/_repos/ocp-4.12-rhel9.repo
@@ -48,7 +48,7 @@ failovermethod = priority
 
 [rhel-9-server-ose]
 name = rhel-9-server-ose
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.12/rhel-9-server-ose-rpms
+baseurl = https://openshift-mirror-list.ci-systems.workers.dev/enterprise/reposync/4.12/rhel-9-server-ose-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false

--- a/core-services/release-controller/_repos/ocp-4.12-rhel90.repo
+++ b/core-services/release-controller/_repos/ocp-4.12-rhel90.repo
@@ -48,7 +48,7 @@ failovermethod = priority
 
 [rhel-9.0-server-ose]
 name = rhel-9.0-server-ose-4.12
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.12/rhel-9-server-ose-rpms
+baseurl = https://openshift-mirror-list.ci-systems.workers.dev/enterprise/reposync/4.12/rhel-9-server-ose-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false

--- a/core-services/release-controller/_repos/ocp-4.12-s390x.repo
+++ b/core-services/release-controller/_repos/ocp-4.12-s390x.repo
@@ -30,7 +30,7 @@ gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release ht
 
 [rhel-server-ose]
 name = rhel-server-ose
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.12_s390x/rhel-server-ose-rpms/
+baseurl = https://openshift-mirror-list.ci-systems.workers.dev/enterprise/reposync/4.12_s390x/rhel-server-ose-rpms/
 sslverify = false
 username_file=/tmp/mirror-enterprise-basic-auth/username
 password_file=/tmp/mirror-enterprise-basic-auth/password


### PR DESCRIPTION
## Summary

This PR migrates OCP 4.12 RPM repository downloads from `mirror2.openshift.com` to the Cloudflare Workers R2 endpoint (`openshift-mirror-list.ci-systems.workers.dev`) to eliminate CloudFront egress costs.

## Changes

- Updated `baseurl` in 14 `ocp-4.12-*.repo` files under `core-services/release-controller/_repos/`
- Replaced `https://mirror2.openshift.com` with `https://openshift-mirror-list.ci-systems.workers.dev`
- Preserved all path structures and authentication configuration (username_file/password_file)

## Scope

This is a **pilot migration for OCP 4.12 only**. The affected files include:
- Default, multi-arch variants (ppc64le, s390x, aarch64)
- RHEL 8/9 variants and Ironic repos
- OpenStack and OpenStack-beta repos

## Next Steps

Once validated in CI, the same change will be rolled out to remaining OCP versions (3.11, 4.13-4.23, 5.0) in follow-up PRs.

## Testing

CI will validate that RPM downloads from the new R2 endpoint work correctly with the existing basic auth credentials.

## Related

- Jira: https://redhat.atlassian.net/browse/ART-14263
- Slack thread: https://redhat-internal.slack.com/archives/C07RAB68T5G/p1775654448595089

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package repository mirror endpoints across OpenShift Container Platform 4.12 configurations for multiple architectures (x86_64, ppc64le, aarch64, s390x) and RHEL versions (8, 8.6, 9, 9.0) to use a new mirror list service, optimizing package delivery infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->