### PR TITLE
Disabling coderabbit for prowjob-dispatcher jobs

### DIFF
--- a/ci-operator/jobs/infra-periodics.yaml
+++ b/ci-operator/jobs/infra-periodics.yaml
@@ -997,6 +997,7 @@ periodics:
       - --self-approve=true
       - --prometheus-bearer-token-path=/etc/prometheus/token
       - --create-pr=true
+      - --pr-body=@coderabbitai ignore
       command:
       - /usr/bin/prow-job-dispatcher
       image: quay.io/openshift/ci-public:ci_prow-job-dispatcher_latest


### PR DESCRIPTION
This will disable coderabbit for dispatcher, there is no benefit analyzing something we already know.

Depends on https://github.com/openshift/ci-tools/pull/5131

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI automation for periodically-generated pull requests now includes the "@coderabbitai ignore" directive in the PR body.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->