### PR TITLE
SREP-4255: Add --security-group flag to osde2e cleanup jobs

### DIFF
--- a/ci-operator/config/openshift/osde2e/openshift-osde2e-main.yaml
+++ b/ci-operator/config/openshift/osde2e/openshift-osde2e-main.yaml
@@ -209,7 +209,7 @@ tests:
   commands: |
     export SECRET_LOCATIONS="/usr/local/osde2e-common,/usr/local/osde2e-tekton-copy,/usr/local/osde2e-credentials"
 
-    /osde2e cleanup --secret-locations ${SECRET_LOCATIONS} --ec2 --iam --s3 --elastic-ip --vpc --dry-run=false --send-cleanup-summary
+    /osde2e cleanup --secret-locations ${SECRET_LOCATIONS} --ec2 --iam --s3 --elastic-ip --security-group --vpc --dry-run=false --send-cleanup-summary
   container:
     clone: true
     from: osde2e
@@ -225,7 +225,7 @@ tests:
   commands: |
     export SECRET_LOCATIONS="/usr/local/osde2e-common,/usr/local/osde2e-selfservice-copy,/usr/local/osde2e-credentials"
 
-    /osde2e cleanup --secret-locations ${SECRET_LOCATIONS} --ec2 --iam --s3 --elastic-ip --vpc --dry-run=false --send-cleanup-summary
+    /osde2e cleanup --secret-locations ${SECRET_LOCATIONS} --ec2 --iam --s3 --elastic-ip --security-group --vpc --dry-run=false --send-cleanup-summary
   container:
     clone: true
     from: osde2e
@@ -241,7 +241,7 @@ tests:
   commands: |
     export SECRET_LOCATIONS="/usr/local/osde2e-common,/usr/local/osde2e-hypershift-credentials,/usr/local/osde2e-credentials"
 
-    /osde2e cleanup --secret-locations ${SECRET_LOCATIONS} --ec2 --iam --s3 --elastic-ip --vpc --dry-run=false  --send-cleanup-summary
+    /osde2e cleanup --secret-locations ${SECRET_LOCATIONS} --ec2 --iam --s3 --elastic-ip --security-group --vpc --dry-run=false  --send-cleanup-summary
   container:
     clone: true
     from: osde2e
@@ -257,7 +257,7 @@ tests:
   commands: |
     export SECRET_LOCATIONS="/usr/local/osde2e-common,/usr/local/osde2e-trt-credentials"
 
-    /osde2e cleanup --secret-locations ${SECRET_LOCATIONS} --ec2 --iam --s3 --elastic-ip --vpc --dry-run=false  --send-cleanup-summary
+    /osde2e cleanup --secret-locations ${SECRET_LOCATIONS} --ec2 --iam --s3 --elastic-ip --security-group --vpc --dry-run=false  --send-cleanup-summary
   container:
     clone: true
     from: osde2e
@@ -271,7 +271,7 @@ tests:
   commands: |
     export SECRET_LOCATIONS="/usr/local/rosa-e2e-prow-ci-01-osde2e"
 
-    /osde2e cleanup --secret-locations ${SECRET_LOCATIONS} --ec2 --iam --s3 --elastic-ip --vpc --dry-run=false --send-cleanup-summary
+    /osde2e cleanup --secret-locations ${SECRET_LOCATIONS} --ec2 --iam --s3 --elastic-ip --security-group --vpc --dry-run=false --send-cleanup-summary
   container:
     clone: true
     from: osde2e


### PR DESCRIPTION
## Summary
- Adds the `--security-group` flag to all 7 osde2e AWS cleanup periodic jobs
- Cleans up leftover security groups in orphaned VPCs with `DELETE_FAILED` CloudFormation stacks, unblocking subsequent VPC cleanup

## Test plan
- [ ] Verify CI jobs pass rehearsal
- [ ] Confirm cleanup jobs pick up the new flag on next periodic run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated CI/CD test cleanup operations to include security group cleanup across multiple scheduled test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->