### PR TITLE
Update OMR V2 image name for Konflux ITS testing and Quay 3.18 API testing

### DIFF
--- a/ci-operator/config/quay/quay-tests/quay-quay-tests-master__omr-ocp412-unreleased.yaml
+++ b/ci-operator/config/quay/quay-tests/quay-quay-tests-master__omr-ocp412-unreleased.yaml
@@ -31,7 +31,7 @@ tests:
   steps:
     cluster_profile: aws-quay-qe
     env:
-      OMR_IMAGE: quay.io/redhat-user-workloads/quay-eng-tenant/mirror-registry-v2-0@sha256:a6966203f3dc24888ec0a0434f843a6cced20befff474cd59aad0830d2eec1ef
+      MULTISTAGE_PARAM_OVERRIDE_OMR_IMAGE: quay.io/redhat-user-workloads/quay-eng-tenant/mirror-registry-v2-0@sha256:a6966203f3dc24888ec0a0434f843a6cced20befff474cd59aad0830d2eec1ef
       OMR_RELEASE: "false"
     post:
     - chain: quay-tests-aws-ipi-disconnected-private-deprovision

--- a/ci-operator/config/quay/quay-tests/quay-quay-tests-master__omr-ocp412.yaml
+++ b/ci-operator/config/quay/quay-tests/quay-quay-tests-master__omr-ocp412.yaml
@@ -30,6 +30,8 @@ tests:
   cron: 0 12 * * 5
   steps:
     cluster_profile: aws-qe
+    env:
+      OMR_RELEASE: "true"
     post:
     - chain: quay-tests-aws-ipi-disconnected-private-deprovision
     test:

--- a/ci-operator/config/quay/quay-tests/quay-quay-tests-master__omr-ocp414-unreleased.yaml
+++ b/ci-operator/config/quay/quay-tests/quay-quay-tests-master__omr-ocp414-unreleased.yaml
@@ -32,7 +32,7 @@ tests:
     cluster_profile: aws-quay-qe
     env:
       EXTRACT_MANIFEST_INCLUDED: "true"
-      OMR_IMAGE: quay.io/redhat-user-workloads/quay-eng-tenant/mirror-registry-v2-0@sha256:a6966203f3dc24888ec0a0434f843a6cced20befff474cd59aad0830d2eec1ef
+      MULTISTAGE_PARAM_OVERRIDE_OMR_IMAGE: quay.io/redhat-user-workloads/quay-eng-tenant/mirror-registry-v2-0@sha256:a6966203f3dc24888ec0a0434f843a6cced20befff474cd59aad0830d2eec1ef
       OMR_RELEASE: "false"
     post:
     - chain: quay-tests-aws-ipi-disconnected-private-deprovision

--- a/ci-operator/config/quay/quay-tests/quay-quay-tests-master__omr-ocp414.yaml
+++ b/ci-operator/config/quay/quay-tests/quay-quay-tests-master__omr-ocp414.yaml
@@ -32,6 +32,7 @@ tests:
     cluster_profile: aws-qe
     env:
       EXTRACT_MANIFEST_INCLUDED: "true"
+      OMR_RELEASE: "true"
     post:
     - chain: quay-tests-aws-ipi-disconnected-private-deprovision
     test:

--- a/ci-operator/config/quay/quay-tests/quay-quay-tests-master__omr-ocp415-unreleased.yaml
+++ b/ci-operator/config/quay/quay-tests/quay-quay-tests-master__omr-ocp415-unreleased.yaml
@@ -32,7 +32,7 @@ tests:
     cluster_profile: aws-qe
     env:
       EXTRACT_MANIFEST_INCLUDED: "true"
-      OMR_IMAGE: openshift-mirror-registry-rhel8:v2.0.6-9
+      MULTISTAGE_PARAM_OVERRIDE_OMR_IMAGE: openshift-mirror-registry-rhel8:v2.0.6-9
       OMR_RELEASE: "false"
     post:
     - chain: quay-tests-aws-ipi-disconnected-private-deprovision

--- a/ci-operator/config/quay/quay-tests/quay-quay-tests-master__omr-ocp415.yaml
+++ b/ci-operator/config/quay/quay-tests/quay-quay-tests-master__omr-ocp415.yaml
@@ -32,6 +32,7 @@ tests:
     cluster_profile: aws-qe
     env:
       EXTRACT_MANIFEST_INCLUDED: "true"
+      OMR_RELEASE: "true"
     post:
     - chain: quay-tests-aws-ipi-disconnected-private-deprovision
     test:

--- a/ci-operator/config/quay/quay-tests/quay-quay-tests-master__omr-ocp416.yaml
+++ b/ci-operator/config/quay/quay-tests/quay-quay-tests-master__omr-ocp416.yaml
@@ -74,6 +74,8 @@ tests:
   cron: 0 12 * * 5
   steps:
     cluster_profile: aws-quay-qe
+    env:
+      OMR_RELEASE: "true"
     post:
     - chain: quay-tests-aws-ipi-disconnected-private-deprovision
     test:

--- a/ci-operator/config/quay/quay-tests/quay-quay-tests-master__omr-ocp417-unreleased.yaml
+++ b/ci-operator/config/quay/quay-tests/quay-quay-tests-master__omr-ocp417-unreleased.yaml
@@ -31,7 +31,7 @@ tests:
   steps:
     cluster_profile: aws-quay-qe
     env:
-      OMR_IMAGE: quay.io/redhat-user-workloads/quay-eng-tenant/mirror-registry-v2-0@sha256:a6966203f3dc24888ec0a0434f843a6cced20befff474cd59aad0830d2eec1ef
+      MULTISTAGE_PARAM_OVERRIDE_OMR_IMAGE: quay.io/redhat-user-workloads/quay-eng-tenant/mirror-registry-v2-0@sha256:a6966203f3dc24888ec0a0434f843a6cced20befff474cd59aad0830d2eec1ef
       OMR_RELEASE: "false"
     post:
     - chain: quay-tests-aws-ipi-disconnected-private-deprovision

--- a/ci-operator/config/quay/quay-tests/quay-quay-tests-master__omr-ocp417.yaml
+++ b/ci-operator/config/quay/quay-tests/quay-quay-tests-master__omr-ocp417.yaml
@@ -32,6 +32,7 @@ tests:
     cluster_profile: aws-qe
     env:
       EXTRACT_MANIFEST_INCLUDED: "true"
+      OMR_RELEASE: "true"
     post:
     - chain: quay-tests-aws-ipi-disconnected-private-deprovision
     test:

--- a/ci-operator/config/quay/quay-tests/quay-quay-tests-master__omr-ocp418-unreleased.yaml
+++ b/ci-operator/config/quay/quay-tests/quay-quay-tests-master__omr-ocp418-unreleased.yaml
@@ -31,7 +31,7 @@ tests:
   steps:
     cluster_profile: aws-quay-qe
     env:
-      OMR_IMAGE: quay.io/redhat-user-workloads/quay-eng-tenant/mirror-registry-v2-0@sha256:a6966203f3dc24888ec0a0434f843a6cced20befff474cd59aad0830d2eec1ef
+      MULTISTAGE_PARAM_OVERRIDE_OMR_IMAGE: quay.io/redhat-user-workloads/quay-eng-tenant/mirror-registry-v2-0@sha256:a6966203f3dc24888ec0a0434f843a6cced20befff474cd59aad0830d2eec1ef
       OMR_RELEASE: "false"
     post:
     - chain: quay-tests-aws-ipi-disconnected-private-deprovision

--- a/ci-operator/config/quay/quay-tests/quay-quay-tests-master__omr-ocp418.yaml
+++ b/ci-operator/config/quay/quay-tests/quay-quay-tests-master__omr-ocp418.yaml
@@ -32,6 +32,7 @@ tests:
     cluster_profile: aws-qe
     env:
       EXTRACT_MANIFEST_INCLUDED: "true"
+      OMR_RELEASE: "true"
     post:
     - chain: quay-tests-aws-ipi-disconnected-private-deprovision
     test:

--- a/ci-operator/config/quay/quay-tests/quay-quay-tests-master__omr-ocp419-unreleased.yaml
+++ b/ci-operator/config/quay/quay-tests/quay-quay-tests-master__omr-ocp419-unreleased.yaml
@@ -32,8 +32,7 @@ tests:
     cluster_profile: aws-quay-qe
     env:
       BASE_DOMAIN: quayqe.devcluster.openshift.com
-      OMR_IMAGE: quay.io/redhat-user-workloads/quay-eng-tenant/mirror-registry-v2-0@sha256:a6966203f3dc24888ec0a0434f843a6cced20befff474cd59aad0830d2eec1ef
-      OMR_RELEASE: "false"
+      MULTISTAGE_PARAM_OVERRIDE_OMR_IMAGE: quay.io/redhat-user-workloads/quay-eng-tenant/mirror-registry-v2-0@sha256:818541781e701376b633ec03c1965a30bcbe2a2b8b6bd9309a5f8a7048a2eb97
     post:
     - chain: quay-tests-aws-ipi-disconnected-private-deprovision
     test:

--- a/ci-operator/config/quay/quay-tests/quay-quay-tests-master__omr-ocp420-unreleased.yaml
+++ b/ci-operator/config/quay/quay-tests/quay-quay-tests-master__omr-ocp420-unreleased.yaml
@@ -1,23 +1,20 @@
 base_images:
   upi-installer:
-    name: "4.16"
+    name: "4.20"
     namespace: ocp
     tag: upi-installer
 build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: rhel-8-release-golang-1.18-openshift-4.12
-prowgen:
-  expose: true
-  private: true
+    tag: rhel-9-release-golang-1.24-openshift-4.20
 releases:
   latest:
     candidate:
       architecture: amd64
       product: ocp
       stream: nightly
-      version: "4.16"
+      version: "4.20"
 resources:
   '*':
     limits:
@@ -26,13 +23,13 @@ resources:
       cpu: 100m
       memory: 200Mi
 tests:
-- as: quay-omr-tests-omr-ocp416-disconnected-unreleased
-  cron: 0 0 9 * *
+- as: quay-omr-tests-omr-ocp420-disconnected-unreleased
+  cron: 0 0 5 * *
   steps:
     cluster_profile: aws-quay-qe
     env:
-      MULTISTAGE_PARAM_OVERRIDE_OMR_IMAGE: quay.io/redhat-user-workloads/quay-eng-tenant/mirror-registry-v2-0@sha256:a6966203f3dc24888ec0a0434f843a6cced20befff474cd59aad0830d2eec1ef
-      OMR_RELEASE: "false"
+      BASE_DOMAIN: quayqe.devcluster.openshift.com
+      MULTISTAGE_PARAM_OVERRIDE_OMR_IMAGE: quay.io/redhat-user-workloads/quay-eng-tenant/mirror-registry-v2-0@sha256:818541781e701376b633ec03c1965a30bcbe2a2b8b6bd9309a5f8a7048a2eb97
     post:
     - chain: quay-tests-aws-ipi-disconnected-private-deprovision
     test:
@@ -41,4 +38,4 @@ zz_generated_metadata:
   branch: master
   org: quay
   repo: quay-tests
-  variant: omr-ocp416-unreleased
+  variant: omr-ocp420-unreleased

--- a/ci-operator/config/quay/quay-tests/quay-quay-tests-master__omr-ocp421-unreleased.yaml
+++ b/ci-operator/config/quay/quay-tests/quay-quay-tests-master__omr-ocp421-unreleased.yaml
@@ -32,8 +32,7 @@ tests:
     cluster_profile: aws-quay-qe
     env:
       BASE_DOMAIN: quayqe.devcluster.openshift.com
-      OMR_IMAGE: quay.io/redhat-user-workloads/quay-eng-tenant/mirror-registry-v2-0@sha256:818541781e701376b633ec03c1965a30bcbe2a2b8b6bd9309a5f8a7048a2eb97
-      OMR_RELEASE: "false"
+      MULTISTAGE_PARAM_OVERRIDE_OMR_IMAGE: quay.io/redhat-user-workloads/quay-eng-tenant/mirror-registry-v2-0@sha256:818541781e701376b633ec03c1965a30bcbe2a2b8b6bd9309a5f8a7048a2eb97
     post:
     - chain: quay-tests-aws-ipi-disconnected-private-deprovision
     test:

--- a/ci-operator/config/quay/quay-tests/quay-quay-tests-master__omr-ocp422-unreleased.yaml
+++ b/ci-operator/config/quay/quay-tests/quay-quay-tests-master__omr-ocp422-unreleased.yaml
@@ -1,23 +1,20 @@
 base_images:
   upi-installer:
-    name: "4.16"
+    name: "4.22"
     namespace: ocp
     tag: upi-installer
 build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: rhel-8-release-golang-1.18-openshift-4.12
-prowgen:
-  expose: true
-  private: true
+    tag: rhel-9-release-golang-1.24-openshift-4.22
 releases:
   latest:
     candidate:
       architecture: amd64
       product: ocp
       stream: nightly
-      version: "4.16"
+      version: "4.22"
 resources:
   '*':
     limits:
@@ -26,13 +23,13 @@ resources:
       cpu: 100m
       memory: 200Mi
 tests:
-- as: quay-omr-tests-omr-ocp416-disconnected-unreleased
-  cron: 0 0 9 * *
+- as: quay-omr-tests-omr-ocp422-disconnected-unreleased
+  cron: 0 0 5 * *
   steps:
     cluster_profile: aws-quay-qe
     env:
-      MULTISTAGE_PARAM_OVERRIDE_OMR_IMAGE: quay.io/redhat-user-workloads/quay-eng-tenant/mirror-registry-v2-0@sha256:a6966203f3dc24888ec0a0434f843a6cced20befff474cd59aad0830d2eec1ef
-      OMR_RELEASE: "false"
+      BASE_DOMAIN: quayqe.devcluster.openshift.com
+      MULTISTAGE_PARAM_OVERRIDE_OMR_IMAGE: quay.io/redhat-user-workloads/quay-eng-tenant/mirror-registry-v2-0@sha256:818541781e701376b633ec03c1965a30bcbe2a2b8b6bd9309a5f8a7048a2eb97
     post:
     - chain: quay-tests-aws-ipi-disconnected-private-deprovision
     test:
@@ -41,4 +38,4 @@ zz_generated_metadata:
   branch: master
   org: quay
   repo: quay-tests
-  variant: omr-ocp416-unreleased
+  variant: omr-ocp422-unreleased

--- a/ci-operator/config/quay/quay-tests/quay-quay-tests-master__quay-api.yaml
+++ b/ci-operator/config/quay/quay-tests/quay-quay-tests-master__quay-api.yaml
@@ -117,7 +117,7 @@ tests:
     env:
       BASE_DOMAIN: quayqe.devcluster.openshift.com
       COMPUTE_NODE_TYPE: m5.2xlarge
-      MULTISTAGE_PARAM_OVERRIDE_QUAY_INDEX_IMAGE: quay.io/redhat-user-workloads/quay-eng-tenant/stable-3-17-v4-21@sha256:be7ba8a18c423975e3c840984e9f89bdb6f988996ca8e0ad6287f92301ad45c7
+      MULTISTAGE_PARAM_OVERRIDE_QUAY_INDEX_IMAGE: quay.io/redhat-user-workloads/quay-eng-tenant/stable-3-17-v4-21@sha256:4a1bf7b5365b5d8a7a72e765940d63903cbf6cfd91846b8ff33fe2458015ba17
       QUAY_OPERATOR_CHANNEL: stable-3.17
       QUAY_OPERATOR_SOURCE: fbc-operator-catalog
       QUAY_VERSION: "3.17"

--- a/ci-operator/config/quay/quay-tests/quay-quay-tests-master__quay-api.yaml
+++ b/ci-operator/config/quay/quay-tests/quay-quay-tests-master__quay-api.yaml
@@ -126,6 +126,22 @@ tests:
     - ref: quay-tests-deploy-quay-aws-s3
     - ref: quay-tests-test-quay-api
     workflow: cucushift-installer-rehearse-aws-ipi
+- as: quay-e2e-tests-quay318-api-testing
+  cron: 0 0 6 * *
+  steps:
+    cluster_profile: aws-quay-qe
+    env:
+      BASE_DOMAIN: quayqe.devcluster.openshift.com
+      COMPUTE_NODE_TYPE: m5.2xlarge
+      MULTISTAGE_PARAM_OVERRIDE_QUAY_INDEX_IMAGE: quay.io/redhat-user-workloads/quay-eng-tenant/stable-3-18-v4-21@sha256:c69bc0168f3edb272e7e5f10f6e0e60b5b072982affac8813dfacdc3f5f5b64b
+      QUAY_OPERATOR_CHANNEL: stable-3.18
+      QUAY_OPERATOR_SOURCE: fbc-operator-catalog
+      QUAY_VERSION: "3.18"
+    test:
+    - ref: quay-tests-enable-quay-catalogsource
+    - ref: quay-tests-deploy-quay-aws-s3
+    - ref: quay-tests-test-quay-api
+    workflow: cucushift-installer-rehearse-aws-ipi
 zz_generated_metadata:
   branch: master
   org: quay

--- a/ci-operator/jobs/quay/quay-tests/quay-quay-tests-master-periodics.yaml
+++ b/ci-operator/jobs/quay/quay-tests/quay-quay-tests-master-periodics.yaml
@@ -6999,7 +6999,6 @@ periodics:
       - --gcs-upload-secret=/secrets/gcs/service-account.json
       - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
       - --lease-server-credentials-file=/etc/boskos/credentials
-      - --oauth-token-path=/usr/local/github-credentials/oauth
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
       - --target=quay-omr-tests-omr-ocp420-disconnected-unreleased
@@ -7030,9 +7029,6 @@ periodics:
       - mountPath: /secrets/gcs
         name: gcs-credentials
         readOnly: true
-      - mountPath: /usr/local/github-credentials
-        name: github-credentials-openshift-ci-robot-private-git-cloner
-        readOnly: true
       - mountPath: /secrets/manifest-tool
         name: manifest-tool-local-pusher
         readOnly: true
@@ -7053,9 +7049,6 @@ periodics:
     - name: ci-pull-credentials
       secret:
         secretName: ci-pull-credentials
-    - name: github-credentials-openshift-ci-robot-private-git-cloner
-      secret:
-        secretName: github-credentials-openshift-ci-robot-private-git-cloner
     - name: manifest-tool-local-pusher
       secret:
         secretName: manifest-tool-local-pusher
@@ -7179,7 +7172,6 @@ periodics:
       - --gcs-upload-secret=/secrets/gcs/service-account.json
       - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
       - --lease-server-credentials-file=/etc/boskos/credentials
-      - --oauth-token-path=/usr/local/github-credentials/oauth
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
       - --target=quay-omr-tests-omr-ocp422-disconnected-unreleased
@@ -7210,9 +7202,6 @@ periodics:
       - mountPath: /secrets/gcs
         name: gcs-credentials
         readOnly: true
-      - mountPath: /usr/local/github-credentials
-        name: github-credentials-openshift-ci-robot-private-git-cloner
-        readOnly: true
       - mountPath: /secrets/manifest-tool
         name: manifest-tool-local-pusher
         readOnly: true
@@ -7233,9 +7222,6 @@ periodics:
     - name: ci-pull-credentials
       secret:
         secretName: ci-pull-credentials
-    - name: github-credentials-openshift-ci-robot-private-git-cloner
-      secret:
-        secretName: github-credentials-openshift-ci-robot-private-git-cloner
     - name: manifest-tool-local-pusher
       secret:
         secretName: manifest-tool-local-pusher

--- a/ci-operator/jobs/quay/quay-tests/quay-quay-tests-master-periodics.yaml
+++ b/ci-operator/jobs/quay/quay-tests/quay-quay-tests-master-periodics.yaml
@@ -7798,6 +7798,96 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build09
+  cron: 0 0 6 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: master
+    org: quay
+    repo: quay-tests
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-quay-qe
+    ci-operator.openshift.io/variant: quay-api
+    ci.openshift.io/generator: prowgen
+    job-release: "4.21"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-quay-quay-tests-master-quay-api-quay-e2e-tests-quay318-api-testing
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --oauth-token-path=/usr/local/github-credentials/oauth
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=quay-e2e-tests-quay318-api-testing
+      - --variant=quay-api
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /usr/local/github-credentials
+        name: github-credentials-openshift-ci-robot-private-git-cloner
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: github-credentials-openshift-ci-robot-private-git-cloner
+      secret:
+        secretName: github-credentials-openshift-ci-robot-private-git-cloner
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build09
   cron: 0 12 * * 3
   decorate: true
   decoration_config:

--- a/ci-operator/jobs/quay/quay-tests/quay-quay-tests-master-periodics.yaml
+++ b/ci-operator/jobs/quay/quay-tests/quay-quay-tests-master-periodics.yaml
@@ -6977,6 +6977,96 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build09
+  cron: 0 0 5 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: master
+    org: quay
+    repo: quay-tests
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-quay-qe
+    ci-operator.openshift.io/variant: omr-ocp420-unreleased
+    ci.openshift.io/generator: prowgen
+    job-release: "4.20"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-quay-quay-tests-master-omr-ocp420-unreleased-quay-omr-tests-omr-ocp420-disconnected-unreleased
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --oauth-token-path=/usr/local/github-credentials/oauth
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=quay-omr-tests-omr-ocp420-disconnected-unreleased
+      - --variant=omr-ocp420-unreleased
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /usr/local/github-credentials
+        name: github-credentials-openshift-ci-robot-private-git-cloner
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: github-credentials-openshift-ci-robot-private-git-cloner
+      secret:
+        secretName: github-credentials-openshift-ci-robot-private-git-cloner
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build09
   cron: 0 0 4 * *
   decorate: true
   decoration_config:
@@ -7004,6 +7094,96 @@ periodics:
       - --secret-dir=/secrets/ci-pull-credentials
       - --target=quay-omr-tests-omr-ocp421-disconnected-unreleased
       - --variant=omr-ocp421-unreleased
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /usr/local/github-credentials
+        name: github-credentials-openshift-ci-robot-private-git-cloner
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: github-credentials-openshift-ci-robot-private-git-cloner
+      secret:
+        secretName: github-credentials-openshift-ci-robot-private-git-cloner
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build09
+  cron: 0 0 5 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: master
+    org: quay
+    repo: quay-tests
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-quay-qe
+    ci-operator.openshift.io/variant: omr-ocp422-unreleased
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-quay-quay-tests-master-omr-ocp422-unreleased-quay-omr-tests-omr-ocp422-disconnected-unreleased
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --oauth-token-path=/usr/local/github-credentials/oauth
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=quay-omr-tests-omr-ocp422-disconnected-unreleased
+      - --variant=omr-ocp422-unreleased
       command:
       - ci-operator
       env:

--- a/ci-operator/step-registry/quay-tests/aws-ipi-disconnected-private-provision/quay-tests-aws-ipi-disconnected-private-provision-chain.yaml
+++ b/ci-operator/step-registry/quay-tests/aws-ipi-disconnected-private-provision/quay-tests-aws-ipi-disconnected-private-provision-chain.yaml
@@ -35,7 +35,7 @@ chain:
     default: "Internal"
     documentation: "Cluster publish strategy."
   - name: MULTISTAGE_PARAM_OVERRIDE_OMR_IMAGE
-    default: "openshift-mirror-registry-rhel8:v2.0.1-5"
+    default: "brew.registry.redhat.io/rh-osbs/openshift-mirror-registry-rhel8:v2.0.1-5"
     documentation: "Unreleased OMR Image"
   documentation: |-
     Create an IPI cluster on AWS for QE e2e tests.

--- a/ci-operator/step-registry/quay-tests/aws-ipi-disconnected-private-provision/quay-tests-aws-ipi-disconnected-private-provision-chain.yaml
+++ b/ci-operator/step-registry/quay-tests/aws-ipi-disconnected-private-provision/quay-tests-aws-ipi-disconnected-private-provision-chain.yaml
@@ -34,5 +34,8 @@ chain:
   - name: PUBLISH
     default: "Internal"
     documentation: "Cluster publish strategy."
+  - name: MULTISTAGE_PARAM_OVERRIDE_OMR_IMAGE
+    default: "openshift-mirror-registry-rhel8:v2.0.1-5"
+    documentation: "Unreleased OMR Image"
   documentation: |-
     Create an IPI cluster on AWS for QE e2e tests.

--- a/ci-operator/step-registry/quay-tests/deploy-quay-aws-s3/quay-tests-deploy-quay-aws-s3-commands.sh
+++ b/ci-operator/step-registry/quay-tests/deploy-quay-aws-s3/quay-tests-deploy-quay-aws-s3-commands.sh
@@ -124,12 +124,6 @@ for _ in {1..30}; do
 done
 if ! oc get crd quayregistries.quay.redhat.com &>/dev/null; then
   echo "Timed out waiting for QuayRegistry CRD" >&2
-  echo "Sleeping 4 hours for debugging..." >&2
-  echo "Console: $(oc whoami --show-console 2>/dev/null || true)" >&2
-  oc get pods -n openshift-marketplace >&2 || true
-  oc get csv -n quay-enterprise >&2 || true
-  oc get catalogsource -n openshift-marketplace >&2 || true
-  sleep 14400
   exit 1
 fi
 

--- a/ci-operator/step-registry/quay-tests/deploy-quay-aws-s3/quay-tests-deploy-quay-aws-s3-commands.sh
+++ b/ci-operator/step-registry/quay-tests/deploy-quay-aws-s3/quay-tests-deploy-quay-aws-s3-commands.sh
@@ -124,13 +124,6 @@ for _ in {1..30}; do
 done
 if ! oc get crd quayregistries.quay.redhat.com &>/dev/null; then
   echo "Timed out waiting for QuayRegistry CRD" >&2
-  echo "Console: $(oc whoami --show-console 2>/dev/null || true)" >&2
-  oc get pods -n openshift-marketplace >&2 || true
-  oc get csv -n quay-enterprise >&2 || true
-  oc get catalogsource -n openshift-marketplace >&2 || true
-  oc get events -n quay-enterprise --sort-by='.lastTimestamp' 2>&1 | tail -20 >&2 || true
-  echo "Sleeping 4 hours for debugging..." >&2
-  sleep 14400
   exit 1
 fi
 

--- a/ci-operator/step-registry/quay-tests/deploy-quay-aws-s3/quay-tests-deploy-quay-aws-s3-commands.sh
+++ b/ci-operator/step-registry/quay-tests/deploy-quay-aws-s3/quay-tests-deploy-quay-aws-s3-commands.sh
@@ -124,6 +124,13 @@ for _ in {1..30}; do
 done
 if ! oc get crd quayregistries.quay.redhat.com &>/dev/null; then
   echo "Timed out waiting for QuayRegistry CRD" >&2
+  echo "Console: $(oc whoami --show-console 2>/dev/null || true)" >&2
+  oc get pods -n openshift-marketplace >&2 || true
+  oc get csv -n quay-enterprise >&2 || true
+  oc get catalogsource -n openshift-marketplace >&2 || true
+  oc get events -n quay-enterprise --sort-by='.lastTimestamp' 2>&1 | tail -20 >&2 || true
+  echo "Sleeping 4 hours for debugging..." >&2
+  sleep 14400
   exit 1
 fi
 

--- a/ci-operator/step-registry/quay-tests/deploy-quay-aws-s3/quay-tests-deploy-quay-aws-s3-commands.sh
+++ b/ci-operator/step-registry/quay-tests/deploy-quay-aws-s3/quay-tests-deploy-quay-aws-s3-commands.sh
@@ -124,6 +124,12 @@ for _ in {1..30}; do
 done
 if ! oc get crd quayregistries.quay.redhat.com &>/dev/null; then
   echo "Timed out waiting for QuayRegistry CRD" >&2
+  echo "Sleeping 4 hours for debugging..." >&2
+  echo "Console: $(oc whoami --show-console 2>/dev/null || true)" >&2
+  oc get pods -n openshift-marketplace >&2 || true
+  oc get csv -n quay-enterprise >&2 || true
+  oc get catalogsource -n openshift-marketplace >&2 || true
+  sleep 14400
   exit 1
 fi
 

--- a/ci-operator/step-registry/quay-tests/deploy-quay-aws-s3/quay-tests-deploy-quay-aws-s3-ref.yaml
+++ b/ci-operator/step-registry/quay-tests/deploy-quay-aws-s3/quay-tests-deploy-quay-aws-s3-ref.yaml
@@ -6,7 +6,6 @@ ref:
     namespace: ci
     tag: latest
   commands: quay-tests-deploy-quay-aws-s3-commands.sh
-  timeout: 5h0m0s
   resources:
     requests:
       cpu: 10m

--- a/ci-operator/step-registry/quay-tests/deploy-quay-aws-s3/quay-tests-deploy-quay-aws-s3-ref.yaml
+++ b/ci-operator/step-registry/quay-tests/deploy-quay-aws-s3/quay-tests-deploy-quay-aws-s3-ref.yaml
@@ -6,6 +6,7 @@ ref:
     namespace: ci
     tag: latest
   commands: quay-tests-deploy-quay-aws-s3-commands.sh
+  timeout: 5h0m0s
   resources:
     requests:
       cpu: 10m

--- a/ci-operator/step-registry/quay-tests/enable-quay-catalogsource/quay-tests-enable-quay-catalogsource-commands.sh
+++ b/ci-operator/step-registry/quay-tests/enable-quay-catalogsource/quay-tests-enable-quay-catalogsource-commands.sh
@@ -4,34 +4,25 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
+KONFLUX_REGISTRY="image-rbac-proxy.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com"
+
 # Merge the konflux prod auth into the current ocp global pull secret
 function update_pull_secret () {
     
     temp_dir=$(mktemp -d)
-    cat /var/run/quay-qe-konflux-auth/quay-v3-9-pull > "${temp_dir}"/quay-v3-9-pull.json
-    cat /var/run/quay-qe-konflux-auth/quay-v3-10-pull > "${temp_dir}"/quay-v3-10-pull.json
-    cat /var/run/quay-qe-konflux-auth/quay-v3-11-pull > "${temp_dir}"/quay-v3-11-pull.json
-    cat /var/run/quay-qe-konflux-auth/quay-v3-12-pull > "${temp_dir}"/quay-v3-12-pull.json
-    cat /var/run/quay-qe-konflux-auth/quay-v3-13-pull > "${temp_dir}"/quay-v3-13-pull.json
-    cat /var/run/quay-qe-konflux-auth/quay-v3-14-pull > "${temp_dir}"/quay-v3-14-pull.json
-    cat /var/run/quay-qe-konflux-auth/quay-v3-15-pull > "${temp_dir}"/quay-v3-15-pull.json
-    cat /var/run/quay-qe-konflux-auth/quay-v3-16-pull > "${temp_dir}"/quay-v3-16-pull.json
-    cat /var/run/quay-qe-konflux-auth/quay-v3-17-pull > "${temp_dir}"/quay-v3-17-pull.json
+
+    # Generate pull auth from konflux-quay-pull-auth credentials
+    KONFLUX_PULL_USER=$(cat /var/run/konflux-quay-pull-auth/username)
+    KONFLUX_PULL_PASS=$(cat /var/run/konflux-quay-pull-auth/password)
+    KONFLUX_PULL_AUTH=$(echo -n "${KONFLUX_PULL_USER}:${KONFLUX_PULL_PASS}" | base64 -w0)
+    echo '{"auths":{"'"${KONFLUX_REGISTRY}"'":{"auth":"'"${KONFLUX_PULL_AUTH}"'"}}}' > "${temp_dir}"/konflux-quay-pull.json
 
     oc get secret/pull-secret -n openshift-config \
       --template='{{index .data ".dockerconfigjson" | base64decode}}' > "${temp_dir}"/global_pull_secret.json
 
     jq -s 'map(.auths) | add | {auths: .}' \
       "${temp_dir}"/global_pull_secret.json \
-      "${temp_dir}"/quay-v3-9-pull.json \
-      "${temp_dir}"/quay-v3-10-pull.json \
-      "${temp_dir}"/quay-v3-11-pull.json \
-      "${temp_dir}"/quay-v3-12-pull.json \
-      "${temp_dir}"/quay-v3-13-pull.json \
-      "${temp_dir}"/quay-v3-14-pull.json \
-      "${temp_dir}"/quay-v3-15-pull.json \
-      "${temp_dir}"/quay-v3-16-pull.json \
-      "${temp_dir}"/quay-v3-17-pull.json \
+      "${temp_dir}"/konflux-quay-pull.json \
       > "${temp_dir}"/merged_pull_secret.json
 
     oc set data secret/pull-secret -n openshift-config --from-file=.dockerconfigjson="${temp_dir}"/merged_pull_secret.json
@@ -73,115 +64,124 @@ metadata:
 spec:
   repositoryDigestMirrors:
   - mirrors:
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-operator-v3-9
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-operator-v3-10
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-operator-v3-11
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-operator-v3-12
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-operator-v3-13
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-operator-v3-14
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-operator-v3-15
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-operator-v3-9
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-operator-v3-10
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-operator-v3-11
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-operator-v3-12
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-operator-v3-13
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-operator-v3-14
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-operator-v3-15
     source: registry.redhat.io/quay/quay-operator-rhel8
   - mirrors:
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-operator-v3-16
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-operator-v3-17
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-operator-v3-16
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-operator-v3-17
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-operator-v3-18
     source: registry.redhat.io/quay/quay-operator-rhel9
   - mirrors:
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-operator-bundle-v3-9
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-operator-bundle-v3-10
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-operator-bundle-v3-11
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-operator-bundle-v3-12
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-operator-bundle-v3-13
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-operator-bundle-v3-14
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-operator-bundle-v3-15
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-operator-bundle-v3-16
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-operator-bundle-v3-17
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-operator-bundle-v3-9
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-operator-bundle-v3-10
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-operator-bundle-v3-11
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-operator-bundle-v3-12
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-operator-bundle-v3-13
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-operator-bundle-v3-14
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-operator-bundle-v3-15
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-operator-bundle-v3-16
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-operator-bundle-v3-17
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-operator-bundle-v3-18
     source: registry.redhat.io/quay/quay-operator-bundle
   - mirrors:
-    - quay.io/redhat-user-workloads/quay-eng-tenant/container-security-operator-bundle-v3-9
-    - quay.io/redhat-user-workloads/quay-eng-tenant/container-security-operator-bundle-v3-10
-    - quay.io/redhat-user-workloads/quay-eng-tenant/container-security-operator-bundle-v3-11
-    - quay.io/redhat-user-workloads/quay-eng-tenant/container-security-operator-bundle-v3-12
-    - quay.io/redhat-user-workloads/quay-eng-tenant/container-security-operator-bundle-v3-13
-    - quay.io/redhat-user-workloads/quay-eng-tenant/container-security-operator-bundle-v3-14
-    - quay.io/redhat-user-workloads/quay-eng-tenant/container-security-operator-bundle-v3-15
-    - quay.io/redhat-user-workloads/quay-eng-tenant/container-security-operator-bundle-v3-16
-    - quay.io/redhat-user-workloads/quay-eng-tenant/container-security-operator-bundle-v3-17
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/container-security-operator-bundle-v3-9
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/container-security-operator-bundle-v3-10
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/container-security-operator-bundle-v3-11
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/container-security-operator-bundle-v3-12
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/container-security-operator-bundle-v3-13
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/container-security-operator-bundle-v3-14
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/container-security-operator-bundle-v3-15
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/container-security-operator-bundle-v3-16
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/container-security-operator-bundle-v3-17
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/container-security-operator-bundle-v3-18
     source: registry.redhat.io/quay/quay-container-security-operator-bundle
   - mirrors:
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-bridge-operator-bundle-v3-9
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-bridge-operator-bundle-v3-10
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-bridge-operator-bundle-v3-11
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-bridge-operator-bundle-v3-12
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-bridge-operator-bundle-v3-13
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-bridge-operator-bundle-v3-14
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-bridge-operator-bundle-v3-15
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-bridge-operator-bundle-v3-16
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-bridge-operator-bundle-v3-17
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-bridge-operator-bundle-v3-9
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-bridge-operator-bundle-v3-10
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-bridge-operator-bundle-v3-11
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-bridge-operator-bundle-v3-12
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-bridge-operator-bundle-v3-13
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-bridge-operator-bundle-v3-14
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-bridge-operator-bundle-v3-15
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-bridge-operator-bundle-v3-16
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-bridge-operator-bundle-v3-17
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-bridge-operator-bundle-v3-18
     source: registry.redhat.io/quay/quay-bridge-operator-bundle
   - mirrors:
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-quay-v3-9
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-quay-v3-10
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-quay-v3-11
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-quay-v3-12
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-quay-v3-13
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-quay-v3-14
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-quay-v3-15
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-quay-v3-9
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-quay-v3-10
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-quay-v3-11
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-quay-v3-12
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-quay-v3-13
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-quay-v3-14
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-quay-v3-15
     source: registry.redhat.io/quay/quay-rhel8
   - mirrors:
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-quay-v3-16
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-quay-v3-17
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-quay-v3-16
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-quay-v3-17
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-quay-v3-18
     source: registry.redhat.io/quay/quay-rhel9
   - mirrors:
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-bridge-operator-v3-9
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-bridge-operator-v3-10
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-bridge-operator-v3-11
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-bridge-operator-v3-12
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-bridge-operator-v3-13
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-bridge-operator-v3-14
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-bridge-operator-v3-15
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-bridge-operator-v3-9
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-bridge-operator-v3-10
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-bridge-operator-v3-11
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-bridge-operator-v3-12
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-bridge-operator-v3-13
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-bridge-operator-v3-14
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-bridge-operator-v3-15
     source: registry.redhat.io/quay/quay-bridge-operator-rhel8
   - mirrors:
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-bridge-operator-v3-16
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-bridge-operator-v3-17
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-bridge-operator-v3-16
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-bridge-operator-v3-17
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-bridge-operator-v3-18
     source: registry.redhat.io/quay/quay-bridge-operator-rhel9
   - mirrors:
-    - quay.io/redhat-user-workloads/quay-eng-tenant/container-security-operator-v3-9
-    - quay.io/redhat-user-workloads/quay-eng-tenant/container-security-operator-v3-10
-    - quay.io/redhat-user-workloads/quay-eng-tenant/container-security-operator-v3-11
-    - quay.io/redhat-user-workloads/quay-eng-tenant/container-security-operator-v3-12
-    - quay.io/redhat-user-workloads/quay-eng-tenant/container-security-operator-v3-13
-    - quay.io/redhat-user-workloads/quay-eng-tenant/container-security-operator-v3-14
-    - quay.io/redhat-user-workloads/quay-eng-tenant/container-security-operator-v3-15
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/container-security-operator-v3-9
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/container-security-operator-v3-10
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/container-security-operator-v3-11
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/container-security-operator-v3-12
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/container-security-operator-v3-13
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/container-security-operator-v3-14
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/container-security-operator-v3-15
     source: registry.redhat.io/quay/quay-container-security-operator-rhel8
   - mirrors:
-    - quay.io/redhat-user-workloads/quay-eng-tenant/container-security-operator-v3-16
-    - quay.io/redhat-user-workloads/quay-eng-tenant/container-security-operator-v3-17
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/container-security-operator-v3-16
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/container-security-operator-v3-17
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/container-security-operator-v3-18
     source: registry.redhat.io/quay/quay-container-security-operator-rhel9
   - mirrors:
-    - quay.io/redhat-user-workloads/quay-eng-tenant/container-security-operator-v3-9
-    - quay.io/redhat-user-workloads/quay-eng-tenant/container-security-operator-v3-10
-    - quay.io/redhat-user-workloads/quay-eng-tenant/container-security-operator-v3-11
-    - quay.io/redhat-user-workloads/quay-eng-tenant/container-security-operator-v3-12
-    - quay.io/redhat-user-workloads/quay-eng-tenant/container-security-operator-v3-13
-    - quay.io/redhat-user-workloads/quay-eng-tenant/container-security-operator-v3-14
-    - quay.io/redhat-user-workloads/quay-eng-tenant/container-security-operator-v3-15
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/container-security-operator-v3-9
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/container-security-operator-v3-10
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/container-security-operator-v3-11
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/container-security-operator-v3-12
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/container-security-operator-v3-13
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/container-security-operator-v3-14
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/container-security-operator-v3-15
     source: registry.redhat.io/quay/container-security-operator-rhel8
   - mirrors:
-    - quay.io/redhat-user-workloads/quay-eng-tenant/container-security-operator-v3-16
-    - quay.io/redhat-user-workloads/quay-eng-tenant/container-security-operator-v3-17
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/container-security-operator-v3-16
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/container-security-operator-v3-17
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/container-security-operator-v3-18
     source: registry.redhat.io/quay/container-security-operator-rhel9
   - mirrors:
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-clair-v3-9
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-clair-v3-10
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-clair-v3-11
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-clair-v3-12
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-clair-v3-13
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-clair-v3-14
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-clair-v3-15
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-clair-v3-9
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-clair-v3-10
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-clair-v3-11
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-clair-v3-12
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-clair-v3-13
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-clair-v3-14
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-clair-v3-15
     source: registry.redhat.io/quay/clair-rhel8
   - mirrors:
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-clair-v3-16
-    - quay.io/redhat-user-workloads/quay-eng-tenant/quay-clair-v3-17
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-clair-v3-16
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-clair-v3-17
+    - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-clair-v3-18
     source: registry.redhat.io/quay/clair-rhel9
   - mirrors:
     - brew.registry.redhat.io

--- a/ci-operator/step-registry/quay-tests/enable-quay-catalogsource/quay-tests-enable-quay-catalogsource-commands.sh
+++ b/ci-operator/step-registry/quay-tests/enable-quay-catalogsource/quay-tests-enable-quay-catalogsource-commands.sh
@@ -88,7 +88,7 @@ spec:
     - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-operator-bundle-v3-16
     - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-operator-bundle-v3-17
     - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-operator-bundle-v3-18
-    source: quay.io/redhat-user-workloads/quay-eng-tenant/quay-operator-bundle-v3-18
+    source: registry.redhat.io/quay/quay-operator-bundle
   - mirrors:
     - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/container-security-operator-bundle-v3-9
     - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/container-security-operator-bundle-v3-10

--- a/ci-operator/step-registry/quay-tests/enable-quay-catalogsource/quay-tests-enable-quay-catalogsource-commands.sh
+++ b/ci-operator/step-registry/quay-tests/enable-quay-catalogsource/quay-tests-enable-quay-catalogsource-commands.sh
@@ -88,7 +88,7 @@ spec:
     - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-operator-bundle-v3-16
     - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-operator-bundle-v3-17
     - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/quay-operator-bundle-v3-18
-    source: registry.redhat.io/quay/quay-operator-bundle
+    source: quay.io/redhat-user-workloads/quay-eng-tenant/quay-operator-bundle-v3-18
   - mirrors:
     - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/container-security-operator-bundle-v3-9
     - ${KONFLUX_REGISTRY}/redhat-user-workloads/quay-eng-tenant/container-security-operator-bundle-v3-10

--- a/ci-operator/step-registry/quay-tests/enable-quay-catalogsource/quay-tests-enable-quay-catalogsource-ref.yaml
+++ b/ci-operator/step-registry/quay-tests/enable-quay-catalogsource/quay-tests-enable-quay-catalogsource-ref.yaml
@@ -14,8 +14,8 @@ ref:
     Install Quay catalog source for Quay operator
   credentials:
   - namespace: test-credentials
-    name: quay-qe-konflux-auth
-    mount_path: /var/run/quay-qe-konflux-auth
+    name: konflux-quay-pull-auth
+    mount_path: /var/run/konflux-quay-pull-auth
   env:
   - name: MULTISTAGE_PARAM_OVERRIDE_QUAY_INDEX_IMAGE
     documentation: Quay KONFLUX FBC INDEX IMAGE

--- a/ci-operator/step-registry/quay-tests/mirror-images-oc-adm/quay-tests-mirror-images-oc-adm-commands.sh
+++ b/ci-operator/step-registry/quay-tests/mirror-images-oc-adm/quay-tests-mirror-images-oc-adm-commands.sh
@@ -48,7 +48,7 @@ oc registry login
 registry_cred="cXVheTpwYXNzd29yZA=="
 jq --argjson a "{\"${MIRROR_REGISTRY_HOST}\": {\"auth\": \"$registry_cred\"}}" '.auths |= . + $a' "${CLUSTER_PROFILE_DIR}/pull-secret" > "${new_pull_secret}"
 
-mirror_options="--insecure=true"
+mirror_options="--insecure=true --max-per-registry=2"
 # check whether the oc command supports the --keep-manifest-list and add it to the args array.
 if oc adm release mirror -h | grep -q -- --keep-manifest-list; then
     echo "Adding --keep-manifest-list to the mirror command."

--- a/ci-operator/step-registry/quay-tests/provisioning-omr-disconnected/quay-tests-provisioning-omr-disconnected-commands.sh
+++ b/ci-operator/step-registry/quay-tests/provisioning-omr-disconnected/quay-tests-provisioning-omr-disconnected-commands.sh
@@ -17,7 +17,7 @@ OMR_AWS_SECRET_KEY=$(cat /var/run/quay-qe-omr-secret/secret_key)
 OMR_BREW_USERNAME=$(cat /var/run/quay-qe-brew-secret/username)
 OMR_BREW_PASSWORD=$(cat /var/run/quay-qe-brew-secret/password)
 if [ -z "${OMR_IMAGE_ENV+x}" ]; then
-    OMR_IMAGE_TAG="${OMR_IMAGE}"
+    OMR_IMAGE_TAG="${MULTISTAGE_PARAM_OVERRIDE_OMR_IMAGE}"
 else
    OMR_IMAGE_TAG="brew.registry.redhat.io/rh-osbs/${OMR_IMAGE_ENV}"
 fi

--- a/ci-operator/step-registry/quay-tests/provisioning-omr-disconnected/quay-tests-provisioning-omr-disconnected-commands.sh
+++ b/ci-operator/step-registry/quay-tests/provisioning-omr-disconnected/quay-tests-provisioning-omr-disconnected-commands.sh
@@ -128,7 +128,7 @@ resource "aws_security_group" "quaybuilder" {
 resource "aws_instance" "quaybuilder" {
   key_name      = aws_key_pair.quaybuilder0710.key_name
   ami           = "${ami_id}"
-  instance_type = "m6i.xlarge"
+  instance_type = "m6i.2xlarge"
   associate_public_ip_address = true
   vpc_security_group_ids = [aws_security_group.quaybuilder.id]
   subnet_id = "${PublicSubnet}"

--- a/ci-operator/step-registry/quay-tests/provisioning-omr-disconnected/quay-tests-provisioning-omr-disconnected-ref.yaml
+++ b/ci-operator/step-registry/quay-tests/provisioning-omr-disconnected/quay-tests-provisioning-omr-disconnected-ref.yaml
@@ -22,7 +22,7 @@ ref:
   env:
   - name: OMR_RELEASE
     documentation: Test Released OMR or Unreleased OMR
-    default: "true"
-  - name: OMR_IMAGE
+    default: "false"
+  - name: MULTISTAGE_PARAM_OVERRIDE_OMR_IMAGE
     documentation: Unreleased OMR Image
     default: "openshift-mirror-registry-rhel8:v2.0.1-5"

--- a/ci-operator/step-registry/quay-tests/provisioning-omr-disconnected/quay-tests-provisioning-omr-disconnected-ref.yaml
+++ b/ci-operator/step-registry/quay-tests/provisioning-omr-disconnected/quay-tests-provisioning-omr-disconnected-ref.yaml
@@ -25,4 +25,4 @@ ref:
     default: "false"
   - name: MULTISTAGE_PARAM_OVERRIDE_OMR_IMAGE
     documentation: Unreleased OMR Image
-    default: "openshift-mirror-registry-rhel8:v2.0.1-5"
+    default: "brew.registry.redhat.io/rh-osbs/openshift-mirror-registry-rhel8:v2.0.1-5"

--- a/ci-operator/step-registry/quay-tests/test/quay-api/quay-tests-test-quay-api-commands.sh
+++ b/ci-operator/step-registry/quay-tests/test/quay-api/quay-tests-test-quay-api-commands.sh
@@ -34,7 +34,3 @@ mkdir -p $ARTIFACT_DIR/quay_api_testing_cypress_videos || true
 cp cypress/results/quay_api_testing_report.xml $ARTIFACT_DIR/quay_api_testing_report.xml || true
 cp quay_api_testing_report $ARTIFACT_DIR/quay_api_testing_report || true
 cp cypress/videos/* $ARTIFACT_DIR/quay_api_testing_cypress_videos/ || true
-
-echo "Sleeping 4 hours for debugging..." >&2
-echo "Console: $(oc whoami --show-console 2>/dev/null || true)" >&2
-sleep 14400

--- a/ci-operator/step-registry/quay-tests/test/quay-api/quay-tests-test-quay-api-commands.sh
+++ b/ci-operator/step-registry/quay-tests/test/quay-api/quay-tests-test-quay-api-commands.sh
@@ -34,3 +34,7 @@ mkdir -p $ARTIFACT_DIR/quay_api_testing_cypress_videos || true
 cp cypress/results/quay_api_testing_report.xml $ARTIFACT_DIR/quay_api_testing_report.xml || true
 cp quay_api_testing_report $ARTIFACT_DIR/quay_api_testing_report || true
 cp cypress/videos/* $ARTIFACT_DIR/quay_api_testing_cypress_videos/ || true
+
+echo "Sleeping 4 hours for debugging..." >&2
+echo "Console: $(oc whoami --show-console 2>/dev/null || true)" >&2
+sleep 14400

--- a/ci-operator/step-registry/quay-tests/test/quay-api/quay-tests-test-quay-api-ref.yaml
+++ b/ci-operator/step-registry/quay-tests/test/quay-api/quay-tests-test-quay-api-ref.yaml
@@ -10,7 +10,7 @@ ref:
     requests:
       cpu: 10m
       memory: 100Mi
-  timeout: 4h0m0s
+  timeout: 8h0m0s
   grace_period: 15m0s
   credentials:
   - namespace: test-credentials

--- a/ci-operator/step-registry/quay-tests/test/quay-api/quay-tests-test-quay-api-ref.yaml
+++ b/ci-operator/step-registry/quay-tests/test/quay-api/quay-tests-test-quay-api-ref.yaml
@@ -10,7 +10,7 @@ ref:
     requests:
       cpu: 10m
       memory: 100Mi
-  timeout: 8h0m0s
+  timeout: 4h0m0s
   grace_period: 15m0s
   credentials:
   - namespace: test-credentials


### PR DESCRIPTION
## Summary
- Rename `OMR_IMAGE` to `MULTISTAGE_PARAM_OVERRIDE_OMR_IMAGE` across all unreleased OMR configs, step registry ref, chain, and commands script to support Konflux ITS testing
- Set `OMR_RELEASE` default to `false` in the step registry ref
- Add `OMR_RELEASE: "true"` explicitly to all released OMR configs (ocp412, 414, 415, 416, 417, 418)
- Add OCP 4.20 and 4.22 unreleased configs
- Fix 4.22 build root tag from `openshift-4.21` to `openshift-4.22`
- Fix `MULTISTAGE_PARAM_OVERRIDE_OMR_IMAGE` default to fully qualified registry reference (`brew.registry.redhat.io/rh-osbs/...`)
- Upgrade EC2 instance type from `m6i.xlarge` to `m6i.2xlarge` for better network bandwidth during image mirroring
- Add `--max-per-registry=2` to `oc adm release mirror` to reduce parallel upload contention on large blob layers
- Add Quay 3.18 API testing job with Konflux FBC image
- Add 4-hour debug sleep to `quay-tests-deploy-quay-aws-s3` on QuayRegistry CRD timeout with debug output
- Switch `quay-tests-enable-quay-catalogsource` to use Konflux registry (`image-rbac-proxy.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com`) with `konflux-quay-pull-auth` credential
- Remove per-version `quay.io` pull secrets (`quay-qe-konflux-auth`) in favor of single `external-puller` credential
- Update ICSP mirrors to use Konflux registry for all Quay components
- Extract Konflux registry hostname into `KONFLUX_REGISTRY` variable

## Test plan
- [x] Verify `make update` passes locally
- [ ] Verify CI validation passes on the PR
- [ ] Confirm OMR disconnected tests trigger correctly with the new parameter name
- [ ] Verify released OMR jobs still use the download path with `OMR_RELEASE: "true"`
- [ ] Confirm image mirroring completes without `unexpected EOF` errors
- [ ] Verify Quay 3.18 API testing job runs successfully
- [ ] Confirm Quay operator images are pulled from Konflux registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)