### PR TITLE
Add /test e2e-capi-sno Prow command for CAPI provider

### DIFF
--- a/ci-operator/config/openshift-assisted/cluster-api-provider-openshift-assisted/openshift-assisted-cluster-api-provider-openshift-assisted-master.yaml
+++ b/ci-operator/config/openshift-assisted/cluster-api-provider-openshift-assisted/openshift-assisted-cluster-api-provider-openshift-assisted-master.yaml
@@ -73,6 +73,14 @@ tests:
   steps:
     cluster_profile: packet-assisted
     workflow: assisted-ofcir-baremetal-capi
+- always_run: false
+  as: e2e-capi-sno
+  capabilities:
+  - intranet
+  optional: true
+  steps:
+    cluster_profile: packet-assisted
+    workflow: assisted-ofcir-baremetal-capi-sno
 - as: e2e-capi-multinode-postsubmit
   capabilities:
   - intranet

--- a/ci-operator/jobs/openshift-assisted/cluster-api-provider-openshift-assisted/openshift-assisted-cluster-api-provider-openshift-assisted-master-presubmits.yaml
+++ b/ci-operator/jobs/openshift-assisted/cluster-api-provider-openshift-assisted/openshift-assisted-cluster-api-provider-openshift-assisted-master-presubmits.yaml
@@ -215,6 +215,91 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-capi-multinode,?($|\s.*)
   - agent: kubernetes
+    always_run: false
+    branches:
+    - ^master$
+    - ^master-
+    cluster: build09
+    context: ci/prow/e2e-capi-sno
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      capability/intranet: intranet
+      ci-operator.openshift.io/cloud: packet-edge
+      ci-operator.openshift.io/cloud-cluster-profile: packet-assisted
+      ci.openshift.io/generator: prowgen
+      job-release: "4.18"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-assisted-cluster-api-provider-openshift-assisted-master-e2e-capi-sno
+    optional: true
+    rerun_command: /test e2e-capi-sno
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-capi-sno
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-capi-sno,?($|\s.*)
+  - agent: kubernetes
     always_run: true
     branches:
     - ^master$

--- a/ci-operator/step-registry/assisted/capi/test/assisted-capi-test-commands.sh
+++ b/ci-operator/step-registry/assisted/capi/test/assisted-capi-test-commands.sh
@@ -27,6 +27,8 @@ export GOCACHE
 export HOME
 export DIST_DIR
 export CONTAINER_TAG
+export CLUSTER_TOPOLOGY
+export NUMBER_OF_NODES
 
 make generate && make manifests && make build-installer
 

--- a/ci-operator/step-registry/assisted/capi/test/assisted-capi-test-ref.yaml
+++ b/ci-operator/step-registry/assisted/capi/test/assisted-capi-test-ref.yaml
@@ -19,5 +19,11 @@ ref:
     default: "false"
   - name: TEST_TARGET
     default: "e2e-test"
+  - name: CLUSTER_TOPOLOGY
+    default: "multinode"
+    documentation: Cluster topology to deploy. Valid values are "sno" or "multinode".
+  - name: NUMBER_OF_NODES
+    default: "7"
+    documentation: Number of nodes to provision. Use "1" for SNO, "7" for multinode.
   documentation: |-
     The Baremetal DS E2E assisted step executes the common end-to-end test suite.

--- a/ci-operator/step-registry/assisted/ofcir/baremetal/capi/sno/OWNERS
+++ b/ci-operator/step-registry/assisted/ofcir/baremetal/capi/sno/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+  - assisted-cicd

--- a/ci-operator/step-registry/assisted/ofcir/baremetal/capi/sno/assisted-ofcir-baremetal-capi-sno-workflow.metadata.json
+++ b/ci-operator/step-registry/assisted/ofcir/baremetal/capi/sno/assisted-ofcir-baremetal-capi-sno-workflow.metadata.json
@@ -1,0 +1,8 @@
+{
+	"path": "assisted/ofcir/baremetal/capi/sno/assisted-ofcir-baremetal-capi-sno-workflow.yaml",
+	"owners": {
+		"approvers": [
+			"assisted-cicd"
+		]
+	}
+}

--- a/ci-operator/step-registry/assisted/ofcir/baremetal/capi/sno/assisted-ofcir-baremetal-capi-sno-workflow.yaml
+++ b/ci-operator/step-registry/assisted/ofcir/baremetal/capi/sno/assisted-ofcir-baremetal-capi-sno-workflow.yaml
@@ -1,0 +1,20 @@
+workflow:
+  as: assisted-ofcir-baremetal-capi-sno
+  steps:
+    cluster_profile: packet-assisted
+    allow_best_effort_post_steps: true
+    allow_skip_on_success: true
+    pre:
+      - ref: ofcir-acquire
+      - ref: assisted-ofcir-setup
+    test:
+      - ref: assisted-capi-test
+    post:
+      - ref: ofcir-gather
+      - ref: ofcir-release
+    env:
+      CLUSTERTYPE: "assisted_medium_el9"
+      CLUSTER_TOPOLOGY: "sno"
+      NUMBER_OF_NODES: "1"
+  documentation: |-
+    This workflow executes e2e tests for CAPI OpenshiftAssisted bootstrap and controlplane providers in SNO (Single Node OpenShift) topology


### PR DESCRIPTION
Add SNO (Single Node OpenShift) e2e test variant for the cluster-api-provider-openshift-assisted repo, complementing the existing e2e-capi-multinode test.

Changes:
- Add CLUSTER_TOPOLOGY and NUMBER_OF_NODES env vars to assisted-capi-test ref
- Export topology env vars in assisted-capi-test-commands.sh
- Create assisted-ofcir-baremetal-capi-sno workflow (medium cluster type)
- Add e2e-capi-sno optional test in ci-operator config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional SNO (Single Node OpenShift) e2e test target for Cluster API Provider, gated to intranet and using a SNO-specific workflow and profile.
  * Introduced a dedicated baremetal SNO workflow with SNO defaults and new cluster topology/node-count parameters; these parameters are exported to downstream test/build steps.
  * Added an optional presubmit job to run the SNO e2e target.

* **Chores**
  * Added approval/ownership metadata for the new SNO workflow and job.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->