### PR TITLE
Restore hypershift-operator base_images for NTO Hypershift workflows

### DIFF
--- a/ci-operator/config/openshift-priv/cluster-node-tuning-operator/openshift-priv-cluster-node-tuning-operator-main.yaml
+++ b/ci-operator/config/openshift-priv/cluster-node-tuning-operator/openshift-priv-cluster-node-tuning-operator-main.yaml
@@ -1,4 +1,8 @@
 base_images:
+  hypershift-operator:
+    name: hypershift-operator
+    namespace: hypershift
+    tag: latest
   hypershift-tests:
     name: hypershift-tests
     namespace: hypershift

--- a/ci-operator/config/openshift-priv/cluster-node-tuning-operator/openshift-priv-cluster-node-tuning-operator-release-4.14.yaml
+++ b/ci-operator/config/openshift-priv/cluster-node-tuning-operator/openshift-priv-cluster-node-tuning-operator-release-4.14.yaml
@@ -3,6 +3,10 @@ base_images:
     name: 4.14-priv
     namespace: ocp-private
     tag: base-rhel9
+  hypershift-operator:
+    name: hypershift-operator
+    namespace: hypershift
+    tag: latest
   hypershift-tests:
     name: hypershift-tests
     namespace: hypershift

--- a/ci-operator/config/openshift-priv/cluster-node-tuning-operator/openshift-priv-cluster-node-tuning-operator-release-4.15.yaml
+++ b/ci-operator/config/openshift-priv/cluster-node-tuning-operator/openshift-priv-cluster-node-tuning-operator-release-4.15.yaml
@@ -1,4 +1,8 @@
 base_images:
+  hypershift-operator:
+    name: hypershift-operator
+    namespace: hypershift
+    tag: latest
   hypershift-tests:
     name: hypershift-tests
     namespace: hypershift

--- a/ci-operator/config/openshift-priv/cluster-node-tuning-operator/openshift-priv-cluster-node-tuning-operator-release-4.16.yaml
+++ b/ci-operator/config/openshift-priv/cluster-node-tuning-operator/openshift-priv-cluster-node-tuning-operator-release-4.16.yaml
@@ -1,4 +1,8 @@
 base_images:
+  hypershift-operator:
+    name: hypershift-operator
+    namespace: hypershift
+    tag: latest
   hypershift-tests:
     name: hypershift-tests
     namespace: hypershift

--- a/ci-operator/config/openshift-priv/cluster-node-tuning-operator/openshift-priv-cluster-node-tuning-operator-release-4.17.yaml
+++ b/ci-operator/config/openshift-priv/cluster-node-tuning-operator/openshift-priv-cluster-node-tuning-operator-release-4.17.yaml
@@ -1,4 +1,8 @@
 base_images:
+  hypershift-operator:
+    name: hypershift-operator
+    namespace: hypershift
+    tag: latest
   hypershift-tests:
     name: hypershift-tests
     namespace: hypershift

--- a/ci-operator/config/openshift-priv/cluster-node-tuning-operator/openshift-priv-cluster-node-tuning-operator-release-4.18.yaml
+++ b/ci-operator/config/openshift-priv/cluster-node-tuning-operator/openshift-priv-cluster-node-tuning-operator-release-4.18.yaml
@@ -1,4 +1,8 @@
 base_images:
+  hypershift-operator:
+    name: hypershift-operator
+    namespace: hypershift
+    tag: latest
   hypershift-tests:
     name: hypershift-tests
     namespace: hypershift

--- a/ci-operator/config/openshift-priv/cluster-node-tuning-operator/openshift-priv-cluster-node-tuning-operator-release-4.19.yaml
+++ b/ci-operator/config/openshift-priv/cluster-node-tuning-operator/openshift-priv-cluster-node-tuning-operator-release-4.19.yaml
@@ -1,4 +1,8 @@
 base_images:
+  hypershift-operator:
+    name: hypershift-operator
+    namespace: hypershift
+    tag: latest
   hypershift-tests:
     name: hypershift-tests
     namespace: hypershift

--- a/ci-operator/config/openshift-priv/cluster-node-tuning-operator/openshift-priv-cluster-node-tuning-operator-release-4.20.yaml
+++ b/ci-operator/config/openshift-priv/cluster-node-tuning-operator/openshift-priv-cluster-node-tuning-operator-release-4.20.yaml
@@ -1,4 +1,8 @@
 base_images:
+  hypershift-operator:
+    name: hypershift-operator
+    namespace: hypershift
+    tag: latest
   hypershift-tests:
     name: hypershift-tests
     namespace: hypershift

--- a/ci-operator/config/openshift-priv/cluster-node-tuning-operator/openshift-priv-cluster-node-tuning-operator-release-4.21.yaml
+++ b/ci-operator/config/openshift-priv/cluster-node-tuning-operator/openshift-priv-cluster-node-tuning-operator-release-4.21.yaml
@@ -1,4 +1,8 @@
 base_images:
+  hypershift-operator:
+    name: hypershift-operator
+    namespace: hypershift
+    tag: latest
   hypershift-tests:
     name: hypershift-tests
     namespace: hypershift

--- a/ci-operator/config/openshift-priv/cluster-node-tuning-operator/openshift-priv-cluster-node-tuning-operator-release-4.22.yaml
+++ b/ci-operator/config/openshift-priv/cluster-node-tuning-operator/openshift-priv-cluster-node-tuning-operator-release-4.22.yaml
@@ -1,4 +1,8 @@
 base_images:
+  hypershift-operator:
+    name: hypershift-operator
+    namespace: hypershift
+    tag: latest
   hypershift-tests:
     name: hypershift-tests
     namespace: hypershift

--- a/ci-operator/config/openshift-priv/cluster-node-tuning-operator/openshift-priv-cluster-node-tuning-operator-release-4.23.yaml
+++ b/ci-operator/config/openshift-priv/cluster-node-tuning-operator/openshift-priv-cluster-node-tuning-operator-release-4.23.yaml
@@ -1,4 +1,8 @@
 base_images:
+  hypershift-operator:
+    name: hypershift-operator
+    namespace: hypershift
+    tag: latest
   hypershift-tests:
     name: hypershift-tests
     namespace: hypershift

--- a/ci-operator/config/openshift-priv/cluster-node-tuning-operator/openshift-priv-cluster-node-tuning-operator-release-5.0.yaml
+++ b/ci-operator/config/openshift-priv/cluster-node-tuning-operator/openshift-priv-cluster-node-tuning-operator-release-5.0.yaml
@@ -1,4 +1,8 @@
 base_images:
+  hypershift-operator:
+    name: hypershift-operator
+    namespace: hypershift
+    tag: latest
   hypershift-tests:
     name: hypershift-tests
     namespace: hypershift

--- a/ci-operator/config/openshift-priv/cluster-node-tuning-operator/openshift-priv-cluster-node-tuning-operator-release-5.1.yaml
+++ b/ci-operator/config/openshift-priv/cluster-node-tuning-operator/openshift-priv-cluster-node-tuning-operator-release-5.1.yaml
@@ -1,4 +1,8 @@
 base_images:
+  hypershift-operator:
+    name: hypershift-operator
+    namespace: hypershift
+    tag: latest
   hypershift-tests:
     name: hypershift-tests
     namespace: hypershift

--- a/ci-operator/config/openshift/cluster-node-tuning-operator/openshift-cluster-node-tuning-operator-main.yaml
+++ b/ci-operator/config/openshift/cluster-node-tuning-operator/openshift-cluster-node-tuning-operator-main.yaml
@@ -1,4 +1,8 @@
 base_images:
+  hypershift-operator:
+    name: hypershift-operator
+    namespace: hypershift
+    tag: latest
   hypershift-tests:
     name: hypershift-tests
     namespace: hypershift

--- a/ci-operator/config/openshift/cluster-node-tuning-operator/openshift-cluster-node-tuning-operator-release-4.14.yaml
+++ b/ci-operator/config/openshift/cluster-node-tuning-operator/openshift-cluster-node-tuning-operator-release-4.14.yaml
@@ -3,6 +3,10 @@ base_images:
     name: "4.14"
     namespace: ocp
     tag: base-rhel9
+  hypershift-operator:
+    name: hypershift-operator
+    namespace: hypershift
+    tag: latest
   hypershift-tests:
     name: hypershift-tests
     namespace: hypershift

--- a/ci-operator/config/openshift/cluster-node-tuning-operator/openshift-cluster-node-tuning-operator-release-4.15.yaml
+++ b/ci-operator/config/openshift/cluster-node-tuning-operator/openshift-cluster-node-tuning-operator-release-4.15.yaml
@@ -1,4 +1,8 @@
 base_images:
+  hypershift-operator:
+    name: hypershift-operator
+    namespace: hypershift
+    tag: latest
   hypershift-tests:
     name: hypershift-tests
     namespace: hypershift

--- a/ci-operator/config/openshift/cluster-node-tuning-operator/openshift-cluster-node-tuning-operator-release-4.16.yaml
+++ b/ci-operator/config/openshift/cluster-node-tuning-operator/openshift-cluster-node-tuning-operator-release-4.16.yaml
@@ -1,4 +1,8 @@
 base_images:
+  hypershift-operator:
+    name: hypershift-operator
+    namespace: hypershift
+    tag: latest
   hypershift-tests:
     name: hypershift-tests
     namespace: hypershift

--- a/ci-operator/config/openshift/cluster-node-tuning-operator/openshift-cluster-node-tuning-operator-release-4.17.yaml
+++ b/ci-operator/config/openshift/cluster-node-tuning-operator/openshift-cluster-node-tuning-operator-release-4.17.yaml
@@ -1,4 +1,8 @@
 base_images:
+  hypershift-operator:
+    name: hypershift-operator
+    namespace: hypershift
+    tag: latest
   hypershift-tests:
     name: hypershift-tests
     namespace: hypershift

--- a/ci-operator/config/openshift/cluster-node-tuning-operator/openshift-cluster-node-tuning-operator-release-4.18.yaml
+++ b/ci-operator/config/openshift/cluster-node-tuning-operator/openshift-cluster-node-tuning-operator-release-4.18.yaml
@@ -1,4 +1,8 @@
 base_images:
+  hypershift-operator:
+    name: hypershift-operator
+    namespace: hypershift
+    tag: latest
   hypershift-tests:
     name: hypershift-tests
     namespace: hypershift

--- a/ci-operator/config/openshift/cluster-node-tuning-operator/openshift-cluster-node-tuning-operator-release-4.19.yaml
+++ b/ci-operator/config/openshift/cluster-node-tuning-operator/openshift-cluster-node-tuning-operator-release-4.19.yaml
@@ -1,4 +1,8 @@
 base_images:
+  hypershift-operator:
+    name: hypershift-operator
+    namespace: hypershift
+    tag: latest
   hypershift-tests:
     name: hypershift-tests
     namespace: hypershift

--- a/ci-operator/config/openshift/cluster-node-tuning-operator/openshift-cluster-node-tuning-operator-release-4.20.yaml
+++ b/ci-operator/config/openshift/cluster-node-tuning-operator/openshift-cluster-node-tuning-operator-release-4.20.yaml
@@ -1,4 +1,8 @@
 base_images:
+  hypershift-operator:
+    name: hypershift-operator
+    namespace: hypershift
+    tag: latest
   hypershift-tests:
     name: hypershift-tests
     namespace: hypershift

--- a/ci-operator/config/openshift/cluster-node-tuning-operator/openshift-cluster-node-tuning-operator-release-4.21.yaml
+++ b/ci-operator/config/openshift/cluster-node-tuning-operator/openshift-cluster-node-tuning-operator-release-4.21.yaml
@@ -1,4 +1,8 @@
 base_images:
+  hypershift-operator:
+    name: hypershift-operator
+    namespace: hypershift
+    tag: latest
   hypershift-tests:
     name: hypershift-tests
     namespace: hypershift

--- a/ci-operator/config/openshift/cluster-node-tuning-operator/openshift-cluster-node-tuning-operator-release-4.22.yaml
+++ b/ci-operator/config/openshift/cluster-node-tuning-operator/openshift-cluster-node-tuning-operator-release-4.22.yaml
@@ -1,4 +1,8 @@
 base_images:
+  hypershift-operator:
+    name: hypershift-operator
+    namespace: hypershift
+    tag: latest
   hypershift-tests:
     name: hypershift-tests
     namespace: hypershift

--- a/ci-operator/config/openshift/cluster-node-tuning-operator/openshift-cluster-node-tuning-operator-release-4.23.yaml
+++ b/ci-operator/config/openshift/cluster-node-tuning-operator/openshift-cluster-node-tuning-operator-release-4.23.yaml
@@ -1,4 +1,8 @@
 base_images:
+  hypershift-operator:
+    name: hypershift-operator
+    namespace: hypershift
+    tag: latest
   hypershift-tests:
     name: hypershift-tests
     namespace: hypershift

--- a/ci-operator/config/openshift/cluster-node-tuning-operator/openshift-cluster-node-tuning-operator-release-5.0.yaml
+++ b/ci-operator/config/openshift/cluster-node-tuning-operator/openshift-cluster-node-tuning-operator-release-5.0.yaml
@@ -1,4 +1,8 @@
 base_images:
+  hypershift-operator:
+    name: hypershift-operator
+    namespace: hypershift
+    tag: latest
   hypershift-tests:
     name: hypershift-tests
     namespace: hypershift

--- a/ci-operator/config/openshift/cluster-node-tuning-operator/openshift-cluster-node-tuning-operator-release-5.1.yaml
+++ b/ci-operator/config/openshift/cluster-node-tuning-operator/openshift-cluster-node-tuning-operator-release-5.1.yaml
@@ -1,4 +1,8 @@
 base_images:
+  hypershift-operator:
+    name: hypershift-operator
+    namespace: hypershift
+    tag: latest
   hypershift-tests:
     name: hypershift-tests
     namespace: hypershift


### PR DESCRIPTION
- PR #77260 incorrectly removed the hypershift-operator base_image from configs that still need it for step-registry steps.

- The hypershift-install step (ref: hypershift-install) has `from: hypershift-operator` and requires the image to be imported into the pipeline. 

- Without it, jobs using hypershift workflows like hypershift-aws-e2e-cluster fail because ci-operator cannot resolve the hypershift-operator dependency.

- Restored the entry for `openshift/*` and `openshift-priv/*` cluster-node-tuning-operator configs that declare hypershift-tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated CI/CD infrastructure configurations across release branches to include additional operational tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->