### PR TITLE
[WIP] DEBUG: Add monitoring for pod-network-availability test failures on PowerVS

### DIFF
--- a/ci-operator/step-registry/ipi/conf/powervs/ipi-conf-powervs-commands.sh
+++ b/ci-operator/step-registry/ipi/conf/powervs/ipi-conf-powervs-commands.sh
@@ -316,6 +316,8 @@ echo "PERSISTENT_TG=${PERSISTENT_TG}"
 echo "PERSISTENT_VPC=${PERSISTENT_VPC}"
 
 echo "CONTROL_PLANE_REPLICAS=${CONTROL_PLANE_REPLICAS}"
+# Hardcoded for testing - change worker replicas to 3
+WORKER_REPLICAS=3
 echo "WORKER_REPLICAS=${WORKER_REPLICAS}"
 # Are we performing a Single Node OpenShift cluster deploy?
 if [[ "${CONTROL_PLANE_REPLICAS}" == "1" && "${WORKER_REPLICAS}" == "0" ]]; then

--- a/ci-operator/step-registry/openshift/e2e/libvirt/test/openshift-e2e-libvirt-test-commands.sh
+++ b/ci-operator/step-registry/openshift/e2e/libvirt/test/openshift-e2e-libvirt-test-commands.sh
@@ -284,6 +284,42 @@ function oc_adm_top_nodes_loop() {
 	done
 }
 
+function oc_describe_nodes_loop() {
+	log_to_file "${ARTIFACT_DIR}/oc-describe-nodes.log"
+
+	while true
+	do
+		echo "8<----------8<---------- $(date +%s) 8<----------8<----------"
+
+		oc describe nodes
+
+		sleep 2m
+	done
+}
+
+function monitor_test_pods_loop() {
+	log_to_file "${ARTIFACT_DIR}/monitor-test-pods.log"
+
+	while true
+	do
+		echo "8<----------8<---------- $(date +%s) 8<----------8<----------"
+
+		# Get all disruption-poller pods
+		echo "=== Disruption Poller Pods ==="
+		oc get pods -A | grep -E "disruption-poller|disruption-target" || echo "No disruption pods found"
+
+		echo ""
+		echo "=== Describe Disruption Pods ==="
+		for pod in $(oc get pods -A -o json | jq -r '.items[] | select(.metadata.name | contains("disruption")) | "\(.metadata.namespace)/\(.metadata.name)"'); do
+			echo "--- Pod: $pod ---"
+			oc describe pod -n ${pod%/*} ${pod##*/} 2>&1 | grep -A 30 "Events:" || echo "No events"
+			echo ""
+		done
+
+		sleep 1m
+	done
+}
+
 function suite() {
     if [ -f "${SHARED_DIR}/excluded_tests" ]; then
         cat > ${SHARED_DIR}/invert_excluded.py <<EOSCRIPT
@@ -383,6 +419,12 @@ else
 fi
 
 oc_adm_top_nodes_loop &
+WATCHERS+=( "$!" )
+
+oc_describe_nodes_loop &
+WATCHERS+=( "$!" )
+
+monitor_test_pods_loop &
 WATCHERS+=( "$!" )
 
 case "${TEST_TYPE}" in


### PR DESCRIPTION
Monitor tests failing with pods stuck in ContainerCreating on PowerVS. Need data to diagnose if it's resource exhaustion.

Changes
Add two background monitoring loops:

oc_describe_nodes_loop - Captures node resource allocation every 2 minutes
monitor_test_pods_loop - Tracks disruption-poller pod status every 1 minute
Output
New artifacts:

oc-describe-nodes.log - Node limits, usage, and pressure conditions
monitor-test-pods.log - Pod events and state transitions

Testing with 3 worker replicas too

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced test monitoring with additional background diagnostics that periodically capture node status and pod disruption event information during e2e test execution, providing more detailed troubleshooting information in test logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->