### PR TITLE
fix rhel9 repo names for 4.22, 4.23, 5.0 and 5.1

### DIFF
--- a/.claude/SLASH_COMMANDS.md
+++ b/.claude/SLASH_COMMANDS.md
@@ -375,6 +375,56 @@ tests:
 # - Real examples to copy from
 ```
 
+---
+
+### `/test-repo-files` - Validate Repo File URLs
+
+**Purpose**: Validate that `core-services/release-controller/_repos/ocp-*.repo` files have correct mirror2 and CDN URLs after editing.
+
+**Why it exists**: Repo files define RPM sources for CI builds. Incorrect baseurls (e.g., wrong S3 paths or missing arch-prefixed paths) cause build failures that are hard to debug. This command catches broken URLs before merging.
+
+#### Basic Usage
+
+```bash
+/test-repo-files [file-pattern]
+```
+
+#### Parameters
+
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| `file-pattern` | No | modified files | Version or filename pattern (e.g., `4.22`, `ocp-4.22-rhel9`) |
+
+#### Examples
+
+```bash
+# Test all repo files modified vs main branch
+/test-repo-files
+
+# Test all 4.22 repo files
+/test-repo-files 4.22
+
+# Test a specific repo file
+/test-repo-files ocp-4.22-rhel98
+```
+
+#### Validation Steps
+
+1. **mirror2 paths**: Checks `mirror2.openshift.com` baseurls return 401 (auth required = exists), not 404
+2. **CDN paths**: Checks `cdn.redhat.com` baseurls via `rhsm-pulp.corp.redhat.com` return 200 (requires VPN)
+3. **dnf wrapper test** (optional): Runs `dnf-wrapper-test` container against the repo file to verify no 404 errors
+
+#### Sample Output
+
+```
+=== ocp-4.22-rhel9.repo ===
+mirror2 paths: 15/15 OK (all 401)
+CDN paths:      8/8 OK (all 200)
+dnf wrapper:   PASS (0 paths returned 404)
+```
+
+---
+
 ## Integration with Development Workflow
 
 1. **Discover** components: `/step-finder <query>`

--- a/.claude/commands/README.md
+++ b/.claude/commands/README.md
@@ -623,6 +623,45 @@ When creating new step-registry components:
 4. **Make it reusable** - Use environment variables for configuration
 5. **Test thoroughly** - Validate before submitting
 
+### `/test-repo-files` - Validate Repo File URLs
+
+**Purpose**: Validate that `core-services/release-controller/_repos/ocp-*.repo` files have correct mirror2 and CDN URLs after editing.
+
+**Usage**:
+```bash
+/test-repo-files [file-pattern]
+```
+
+**Parameters**:
+- `file-pattern` (optional): Version or filename pattern to match repo files. If omitted, tests all `.repo` files modified vs `main` branch.
+
+**Examples**:
+```bash
+# Test all modified repo files
+/test-repo-files
+
+# Test all 4.22 repo files
+/test-repo-files 4.22
+
+# Test a specific repo file
+/test-repo-files ocp-4.22-rhel9
+```
+
+**What it does**:
+1. **mirror2 path validation**: Checks that all `mirror2.openshift.com` baseurls return 401 (auth required = path exists), not 404 (missing)
+2. **CDN path validation**: Checks that all `cdn.redhat.com` baseurls resolve via `rhsm-pulp.corp.redhat.com` (requires Red Hat VPN)
+3. **dnf wrapper container test** (optional): Serves the repo file locally and runs a `dnf-wrapper-test` container to verify no 404 errors occur. Requires podman and a pre-built `dnf-wrapper-test` image (from `ocp-build-data` repo, branch `openshift-<version>`, at `ci_images/dnf_wrapper_test.Dockerfile`)
+
+**Output**:
+```
+=== ocp-4.22-rhel9.repo ===
+mirror2 paths: 15/15 OK (all 401)
+CDN paths:      8/8 OK (all 200)
+dnf wrapper:   PASS (0 paths returned 404)
+```
+
+---
+
 ## Additional Resources
 
 - [CI Operator Documentation](https://docs.ci.openshift.org/docs/architecture/ci-operator/)

--- a/.claude/commands/test-repo-files.md
+++ b/.claude/commands/test-repo-files.md
@@ -1,0 +1,101 @@
+---
+description: Validate that repo file URLs (mirror2 and CDN) resolve correctly after editing ocp-*.repo files
+args: "[file-pattern]"
+allowed-tools: Read, Bash, AskUserQuestion
+---
+
+# Test Repo Files
+
+You are helping the user validate that `core-services/release-controller/_repos/ocp-*.repo` files have correct URLs after editing.
+
+## Command Arguments
+
+This command accepts an optional argument: `/test-repo-files [file-pattern]`
+- If a pattern is provided (e.g., `4.22`, `ocp-4.22-rhel98`, `5.0`), find matching `.repo` files in `core-services/release-controller/_repos/`
+  - A version like `4.22` matches all `ocp-4.22-*.repo` files
+  - A more specific pattern like `ocp-4.22-rhel9` matches that specific file
+- If no argument is provided, detect which `ocp-*.repo` files have been modified vs `main` branch using `git diff --name-only main -- core-services/release-controller/_repos/*.repo`
+- If no files found either way, ask the user which files to test
+
+## Steps to follow
+
+For each repo file found, run these validation steps:
+
+### Step 1: Validate mirror2 paths
+
+Extract all `baseurl` lines pointing to `mirror2.openshift.com` from the repo file. For each URL:
+
+```bash
+curl -sk -o /dev/null -w "%{http_code}" "${url}/repodata/repomd.xml"
+```
+
+- **401** = PASS (auth required means the path exists on the server)
+- **404** = FAIL (path does not exist)
+- Any other code = WARN (unexpected, report to user)
+
+### Step 2: Validate CDN paths
+
+Extract all `baseurl` lines pointing to `cdn.redhat.com` from the repo file. For each URL, replace `cdn.redhat.com` with `rhsm-pulp.corp.redhat.com` and test:
+
+```bash
+url_to_test=$(echo "$url" | sed 's/cdn.redhat.com/rhsm-pulp.corp.redhat.com/')
+curl -sk -o /dev/null -w "%{http_code}" "${url_to_test}/repodata/repomd.xml"
+```
+
+- **200** = PASS
+- **404** = FAIL (path does not exist)
+- Any other code = WARN (could mean VPN is not connected; tell the user that CDN validation requires Red Hat VPN)
+
+### Step 3: dnf wrapper container test (optional)
+
+This step requires:
+- `podman` available and working
+- A pre-built `dnf-wrapper-test` container image (built from the `ocp-build-data` repo, branch `openshift-<version>`, file `ci_images/dnf_wrapper_test.Dockerfile`)
+
+Check if podman is available and if the `dnf-wrapper-test` image exists:
+```bash
+podman image exists dnf-wrapper-test
+```
+
+If either is unavailable, ask the user if they want to skip this step. If skipping, report "dnf wrapper: SKIPPED".
+
+If running:
+1. Pick a random available port (e.g., between 18080-18099)
+2. Copy the repo file to a temp directory as `index.html`
+3. Start a local HTTP server: `cd /tmp/repo-test-dir && python3 -m http.server <port> &>/dev/null &`
+4. Wait 1 second for the server to start
+5. Run the container:
+   ```bash
+   podman run --network=host -e CI_RPM_SVC=http://localhost:<port>/ --rm dnf-wrapper-test dnf search vim 2>&1
+   ```
+6. Check output for `Status code: 404` lines — any 404 means FAIL
+7. Kill the HTTP server and clean up temp directory
+8. Report results
+
+### Output format
+
+Present results in a clear summary per file:
+
+```
+=== ocp-4.22-rhel9.repo ===
+mirror2 paths: 10/10 OK (all 401)
+CDN paths:      8/8 OK (all 200)
+dnf wrapper:   PASS (0 paths returned 404)
+```
+
+If any step has failures, list the failing URLs:
+```
+=== ocp-4.22-rhel9.repo ===
+mirror2 paths: 8/10 FAIL
+  FAIL (404): https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-baseos-aarch64
+  FAIL (404): https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-baseos-ppc64le
+CDN paths:      8/8 OK (all 200)
+dnf wrapper:   FAIL (2 paths returned 404)
+```
+
+## Important notes
+
+- CDN path validation requires being connected to the Red Hat VPN. If CDN checks fail with non-200/non-404 codes, remind the user to check their VPN connection.
+- The dnf wrapper test runs the container with `--network=host` so it can reach the local HTTP server.
+- Always clean up HTTP servers and temp directories after testing, even if errors occur.
+- Run all mirror2 URL checks in a single loop for efficiency rather than one curl per tool call.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,15 @@ Search the step-registry (4,400+ reusable CI components) to find existing steps,
 
 **Always use `/step-finder` before creating new step-registry components to avoid duplication.**
 
+### `/test-repo-files` - Repo File URL Validation
+Validate that `core-services/release-controller/_repos/ocp-*.repo` files have correct mirror2 and CDN URLs after editing:
+
+```bash
+/test-repo-files 4.22              # Test all 4.22 repo files
+/test-repo-files ocp-4.22-rhel9    # Test a specific repo file
+/test-repo-files                   # Test all modified repo files vs main
+```
+
 See `.claude/SLASH_COMMANDS.md` for detailed documentation.
 
 ## Common Development Commands

--- a/core-services/release-controller/_repos/ocp-4.22-rhel9.repo
+++ b/core-services/release-controller/_repos/ocp-4.22-rhel9.repo
@@ -1,6 +1,6 @@
 [rhel-9-baseos]
 name = rhel-9-baseos
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-baseos
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-9-baseos-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -12,7 +12,7 @@ skip_if_unavailable = true
 
 [rhel-9-appstream]
 name = rhel-9-appstream
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-appstream
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-9-appstream-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -25,7 +25,7 @@ excludepkgs=toolbox*
 
 [rhel-9-nfv]
 name = rhel-9-nfv
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-nfv
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-9-nfv
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -37,7 +37,7 @@ skip_if_unavailable = true
 
 [rhel-9-highavailability]
 name = rhel-9-highavailability
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-highavailability
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-9-highavailability
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -108,7 +108,7 @@ includepkgs=kernel,kernel-*,toolbox*,
 
 [rhel-9-baseos-ppc64le]
 name = rhel-9-baseos-ppc64le
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-baseos-ppc64le
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22_ppc64le/rhel-9-baseos-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -120,7 +120,7 @@ skip_if_unavailable = true
 
 [rhel-9-appstream-ppc64le]
 name = rhel-9-appstream-ppc64le
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-appstream-ppc64le
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22_ppc64le/rhel-9-appstream-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -168,7 +168,7 @@ failovermethod = priority
 
 [rhel-9-baseos-s390x]
 name = rhel-9-baseos-s390x
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-baseos-s390x
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22_s390x/rhel-9-baseos-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -180,7 +180,7 @@ skip_if_unavailable = true
 
 [rhel-9-appstream-s390x]
 name = rhel-9-appstream-s390x
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-appstream-s390x
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22_s390x/rhel-9-appstream-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -228,7 +228,7 @@ failovermethod = priority
 
 [rhel-9-baseos-aarch64]
 name = rhel-9-baseos-aarch64
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-baseos-aarch64
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22_aarch64/rhel-9-baseos-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -240,7 +240,7 @@ skip_if_unavailable = true
 
 [rhel-9-appstream-aarch64]
 name = rhel-9-appstream-aarch64
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-98-appstream-aarch64
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22_aarch64/rhel-9-appstream-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false

--- a/core-services/release-controller/_repos/ocp-4.23-rhel9.repo
+++ b/core-services/release-controller/_repos/ocp-4.23-rhel9.repo
@@ -1,26 +1,51 @@
 [rhel-9-baseos]
 name = rhel-9-baseos
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.23/rhel-9-baseos-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
 [rhel-9-appstream]
 name = rhel-9-appstream
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.23/rhel-9-appstream-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
+excludepkgs=toolbox*
+
+[rhel-9-nfv]
+name = rhel-9-nfv
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.23/rhel-9-nfv
+enabled = 1
+gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
+sslverify = false
+gpgcheck = 0
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
+failovermethod = priority
+skip_if_unavailable = true
+
+[rhel-9-highavailability]
+name = rhel-9-highavailability
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.23/rhel-9-highavailability
+enabled = 1
+gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
+sslverify = false
+gpgcheck = 0
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
+failovermethod = priority
+skip_if_unavailable = true
 
 [rhel-9-fast-datapath]
 name = rhel-9-fast-datapath
@@ -34,9 +59,9 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-9-nfv]
-name = rhel-9-nfv
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/x86_64/nfv/os/
+[rhel-9-codeready-builder-rpms]
+name = rhel-9-codeready-builder-rpms
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/codeready-builder/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -58,41 +83,52 @@ password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
 skip_if_unavailable = true
 
-[rhel-9-codeready-builder-rpms]
-name = rhel-9-codeready-builder-rpms
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/x86_64/codeready-builder/os/
+# In the el-only variants, we still want the early kernels. Currently
+# those are just part of the plashets, which are OCP-versioned. In
+# https://issues.redhat.com/browse/ART-11248, we've agreed for now that
+# instead of having a separate RHEL-only repo, we'll just reuse a plashet repo
+# and filter out everything *but* the kernel. We just need to make sure to
+# use a plashet of an OCP version we know is based on the RHEL version we're
+# interested in.
+[rhel-9.8-early-kernel]
+name = rhel-9.8-early-kernel
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.23/rhel-9-server-ose-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
+# - Also include the legacy toolbox package until we move to the new containers one
+#   https://docs.google.com/document/d/137krt0IRctfwf2e7k1r7tKYPysWrDlTxqdFhFA9XKbw/edit?tab=t.0#heading=h.slko10np055j
+#   https://issues.redhat.com/browse/OCPBUGS-56600
+includepkgs=kernel,kernel-*,toolbox*,
 
 [rhel-9-baseos-ppc64le]
 name = rhel-9-baseos-ppc64le
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.23_ppc64le/rhel-9-baseos-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
 [rhel-9-appstream-ppc64le]
 name = rhel-9-appstream-ppc64le
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.23_ppc64le/rhel-9-appstream-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
 [rhel-9-fast-datapath-ppc64le]
 name = rhel-9-fast-datapath-ppc64le
@@ -120,7 +156,7 @@ skip_if_unavailable = true
 
 [rhel-9-codeready-builder-rpms-ppc64le]
 name = rhel-9-codeready-builder-rpms-ppc64le
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/codeready-builder/os/
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/codeready-builder/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -132,27 +168,27 @@ failovermethod = priority
 
 [rhel-9-baseos-s390x]
 name = rhel-9-baseos-s390x
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/os/
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.23_s390x/rhel-9-baseos-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
 [rhel-9-appstream-s390x]
 name = rhel-9-appstream-s390x
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.23_s390x/rhel-9-appstream-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
 [rhel-9-fast-datapath-s390x]
 name = rhel-9-fast-datapath-s390x
@@ -180,7 +216,7 @@ skip_if_unavailable = true
 
 [rhel-9-codeready-builder-rpms-s390x]
 name = rhel-9-codeready-builder-rpms-s390x
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/s390x/codeready-builder/os/
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/codeready-builder/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -192,27 +228,27 @@ failovermethod = priority
 
 [rhel-9-baseos-aarch64]
 name = rhel-9-baseos-aarch64
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.23_aarch64/rhel-9-baseos-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
 [rhel-9-appstream-aarch64]
 name = rhel-9-appstream-aarch64
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.23_aarch64/rhel-9-appstream-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
 [rhel-9-fast-datapath-aarch64]
 name = rhel-9-fast-datapath-aarch64
@@ -240,7 +276,7 @@ skip_if_unavailable = true
 
 [rhel-9-codeready-builder-rpms-aarch64]
 name = rhel-9-codeready-builder-rpms-aarch64
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/aarch64/codeready-builder/os/
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/codeready-builder/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false

--- a/core-services/release-controller/_repos/ocp-5.0-rhel9.repo
+++ b/core-services/release-controller/_repos/ocp-5.0-rhel9.repo
@@ -1,6 +1,6 @@
 [rhel-9-baseos]
 name = rhel-9-baseos
-baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0/rhel-9-baseos
+baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0/rhel-9-baseos-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -12,7 +12,7 @@ skip_if_unavailable = true
 
 [rhel-9-appstream]
 name = rhel-9-appstream
-baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0/rhel-9-appstream
+baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0/rhel-9-appstream-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -109,7 +109,7 @@ includepkgs = kernel,kernel-*,toolbox*,
 
 [rhel-9-baseos-ppc64le]
 name = rhel-9-baseos-ppc64le
-baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0/rhel-9-baseos-ppc64le
+baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0_ppc64le/rhel-9-baseos-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -121,7 +121,7 @@ skip_if_unavailable = true
 
 [rhel-9-appstream-ppc64le]
 name = rhel-9-appstream-ppc64le
-baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0/rhel-9-appstream-ppc64le
+baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0_ppc64le/rhel-9-appstream-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -169,7 +169,7 @@ failovermethod = priority
 
 [rhel-9-baseos-s390x]
 name = rhel-9-baseos-s390x
-baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0/rhel-9-baseos-s390x
+baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0_s390x/rhel-9-baseos-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -181,7 +181,7 @@ skip_if_unavailable = true
 
 [rhel-9-appstream-s390x]
 name = rhel-9-appstream-s390x
-baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0/rhel-9-appstream-s390x
+baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0_s390x/rhel-9-appstream-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -229,7 +229,7 @@ failovermethod = priority
 
 [rhel-9-baseos-aarch64]
 name = rhel-9-baseos-aarch64
-baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0/rhel-9-baseos-aarch64
+baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0_aarch64/rhel-9-baseos-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -241,7 +241,7 @@ skip_if_unavailable = true
 
 [rhel-9-appstream-aarch64]
 name = rhel-9-appstream-aarch64
-baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0/rhel-9-appstream-aarch64
+baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0_aarch64/rhel-9-appstream-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false

--- a/core-services/release-controller/_repos/ocp-5.1-rhel9.repo
+++ b/core-services/release-controller/_repos/ocp-5.1-rhel9.repo
@@ -1,26 +1,51 @@
 [rhel-9-baseos]
 name = rhel-9-baseos
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/
+baseurl = https://mirror2.openshift.com/enterprise/reposync/5.1/rhel-9-baseos-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
 [rhel-9-appstream]
 name = rhel-9-appstream
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/
+baseurl = https://mirror2.openshift.com/enterprise/reposync/5.1/rhel-9-appstream-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
+excludepkgs=toolbox*
+
+[rhel-9-nfv]
+name = rhel-9-nfv
+baseurl = https://mirror2.openshift.com/enterprise/reposync/5.1/rhel-9-nfv
+enabled = 1
+gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
+sslverify = false
+gpgcheck = 0
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
+failovermethod = priority
+skip_if_unavailable = true
+
+[rhel-9-highavailability]
+name = rhel-9-highavailability
+baseurl = https://mirror2.openshift.com/enterprise/reposync/5.1/rhel-9-highavailability
+enabled = 1
+gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
+sslverify = false
+gpgcheck = 0
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
+failovermethod = priority
+skip_if_unavailable = true
 
 [rhel-9-fast-datapath]
 name = rhel-9-fast-datapath
@@ -34,9 +59,9 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-9-nfv]
-name = rhel-9-nfv
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/x86_64/nfv/os/
+[rhel-9-codeready-builder-rpms]
+name = rhel-9-codeready-builder-rpms
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/codeready-builder/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -58,41 +83,52 @@ password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
 skip_if_unavailable = true
 
-[rhel-9-codeready-builder-rpms]
-name = rhel-9-codeready-builder-rpms
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/x86_64/codeready-builder/os/
+# In the el-only variants, we still want the early kernels. Currently
+# those are just part of the plashets, which are OCP-versioned. In
+# https://issues.redhat.com/browse/ART-11248, we've agreed for now that
+# instead of having a separate RHEL-only repo, we'll just reuse a plashet repo
+# and filter out everything *but* the kernel. We just need to make sure to
+# use a plashet of an OCP version we know is based on the RHEL version we're
+# interested in.
+[rhel-9.8-early-kernel]
+name = rhel-9.8-early-kernel
+baseurl = https://mirror2.openshift.com/enterprise/reposync/5.1/rhel-9-server-ose-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
+# - Also include the legacy toolbox package until we move to the new containers one
+#   https://docs.google.com/document/d/137krt0IRctfwf2e7k1r7tKYPysWrDlTxqdFhFA9XKbw/edit?tab=t.0#heading=h.slko10np055j
+#   https://issues.redhat.com/browse/OCPBUGS-56600
+includepkgs=kernel,kernel-*,toolbox*,
 
 [rhel-9-baseos-ppc64le]
 name = rhel-9-baseos-ppc64le
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/
+baseurl = https://mirror2.openshift.com/enterprise/reposync/5.1_ppc64le/rhel-9-baseos-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
 [rhel-9-appstream-ppc64le]
 name = rhel-9-appstream-ppc64le
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/
+baseurl = https://mirror2.openshift.com/enterprise/reposync/5.1_ppc64le/rhel-9-appstream-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
 [rhel-9-fast-datapath-ppc64le]
 name = rhel-9-fast-datapath-ppc64le
@@ -120,7 +156,7 @@ skip_if_unavailable = true
 
 [rhel-9-codeready-builder-rpms-ppc64le]
 name = rhel-9-codeready-builder-rpms-ppc64le
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/codeready-builder/os/
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/codeready-builder/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -132,27 +168,27 @@ failovermethod = priority
 
 [rhel-9-baseos-s390x]
 name = rhel-9-baseos-s390x
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/os/
+baseurl = https://mirror2.openshift.com/enterprise/reposync/5.1_s390x/rhel-9-baseos-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
 [rhel-9-appstream-s390x]
 name = rhel-9-appstream-s390x
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/
+baseurl = https://mirror2.openshift.com/enterprise/reposync/5.1_s390x/rhel-9-appstream-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
 [rhel-9-fast-datapath-s390x]
 name = rhel-9-fast-datapath-s390x
@@ -180,7 +216,7 @@ skip_if_unavailable = true
 
 [rhel-9-codeready-builder-rpms-s390x]
 name = rhel-9-codeready-builder-rpms-s390x
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/s390x/codeready-builder/os/
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/codeready-builder/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -192,27 +228,27 @@ failovermethod = priority
 
 [rhel-9-baseos-aarch64]
 name = rhel-9-baseos-aarch64
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/
+baseurl = https://mirror2.openshift.com/enterprise/reposync/5.1_aarch64/rhel-9-baseos-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
 [rhel-9-appstream-aarch64]
 name = rhel-9-appstream-aarch64
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/
+baseurl = https://mirror2.openshift.com/enterprise/reposync/5.1_aarch64/rhel-9-appstream-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
 [rhel-9-fast-datapath-aarch64]
 name = rhel-9-fast-datapath-aarch64
@@ -240,7 +276,7 @@ skip_if_unavailable = true
 
 [rhel-9-codeready-builder-rpms-aarch64]
 name = rhel-9-codeready-builder-rpms-aarch64
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9/aarch64/codeready-builder/os/
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/codeready-builder/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configurations for OpenShift Container Platform versions 4.22, 4.23, 5.0, and 5.1 to point to updated package sources across multiple architectures (x86_64, ppc64le, s390x, aarch64).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->