### PR TITLE
DNM: Test openshift/cluster-capi-operator#527 with aws-disconnected

### DIFF
--- a/ci-operator/config/openshift/cluster-capi-operator/openshift-cluster-capi-operator-main.yaml
+++ b/ci-operator/config/openshift/cluster-capi-operator/openshift-cluster-capi-operator-main.yaml
@@ -117,6 +117,31 @@ tests:
       timeout: 3h0m0s
     workflow: openshift-e2e-aws
 - always_run: false
+  as: e2e-aws-capi-disconnected-techpreview
+  optional: true
+  pipeline_skip_if_only_changed: \.md$|(^|/)docs/|(^|/)LICENSE$|(^|/)manifests-gen/|(^|/)OWNERS$
+  steps:
+    cluster_profile: openshift-org-aws
+    env:
+      ENABLE_IDMS: "yes"
+      FEATURE_SET: TechPreviewNoUpgrade
+    observers:
+      enable:
+      - observers-resource-watch
+    test:
+    - as: test
+      commands: |-
+        if test -f "${SHARED_DIR}/proxy-conf.sh"; then
+          source "${SHARED_DIR}/proxy-conf.sh"
+        fi
+        make e2e
+      from: src
+      resources:
+        requests:
+          cpu: 100m
+      timeout: 3h0m0s
+    workflow: openshift-e2e-aws-disconnected
+- always_run: false
   as: e2e-gcp-ovn-techpreview
   pipeline_skip_if_only_changed: \.md$|(^|/)docs/|(^|/)LICENSE$|(^|/)manifests-gen/|(^|/)OWNERS$
   steps:

--- a/ci-operator/config/openshift/cluster-capi-operator/openshift-cluster-capi-operator-main.yaml
+++ b/ci-operator/config/openshift/cluster-capi-operator/openshift-cluster-capi-operator-main.yaml
@@ -123,6 +123,7 @@ tests:
   steps:
     cluster_profile: openshift-org-aws
     env:
+      CUSTOM_OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: registry.build10.ci.openshift.org/ci-ln-d906xw2/release:latest
       ENABLE_IDMS: "yes"
       FEATURE_SET: TechPreviewNoUpgrade
     observers:

--- a/ci-operator/config/openshift/cluster-capi-operator/openshift-cluster-capi-operator-main.yaml
+++ b/ci-operator/config/openshift/cluster-capi-operator/openshift-cluster-capi-operator-main.yaml
@@ -123,7 +123,7 @@ tests:
   steps:
     cluster_profile: openshift-org-aws
     env:
-      CUSTOM_OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: registry.build10.ci.openshift.org/ci-ln-jj7k7db/release:latest
+      CUSTOM_OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: registry.build10.ci.openshift.org/ci-ln-q5f6pbt/release:latest
       ENABLE_IDMS: "yes"
       FEATURE_SET: TechPreviewNoUpgrade
     observers:

--- a/ci-operator/config/openshift/cluster-capi-operator/openshift-cluster-capi-operator-main.yaml
+++ b/ci-operator/config/openshift/cluster-capi-operator/openshift-cluster-capi-operator-main.yaml
@@ -123,7 +123,7 @@ tests:
   steps:
     cluster_profile: openshift-org-aws
     env:
-      CUSTOM_OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: registry.build10.ci.openshift.org/ci-ln-d906xw2/release:latest
+      CUSTOM_OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: registry.build10.ci.openshift.org/ci-ln-3k5z2y2/release:latest
       ENABLE_IDMS: "yes"
       FEATURE_SET: TechPreviewNoUpgrade
     observers:

--- a/ci-operator/config/openshift/cluster-capi-operator/openshift-cluster-capi-operator-main.yaml
+++ b/ci-operator/config/openshift/cluster-capi-operator/openshift-cluster-capi-operator-main.yaml
@@ -123,7 +123,7 @@ tests:
   steps:
     cluster_profile: openshift-org-aws
     env:
-      CUSTOM_OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: registry.build10.ci.openshift.org/ci-ln-q5f6pbt/release:latest
+      CUSTOM_OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: registry.build10.ci.openshift.org/ci-ln-frlwnqk/release:latest
       ENABLE_IDMS: "yes"
       FEATURE_SET: TechPreviewNoUpgrade
     observers:

--- a/ci-operator/config/openshift/cluster-capi-operator/openshift-cluster-capi-operator-main.yaml
+++ b/ci-operator/config/openshift/cluster-capi-operator/openshift-cluster-capi-operator-main.yaml
@@ -123,7 +123,7 @@ tests:
   steps:
     cluster_profile: openshift-org-aws
     env:
-      CUSTOM_OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: registry.build10.ci.openshift.org/ci-ln-3k5z2y2/release:latest
+      CUSTOM_OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: registry.build10.ci.openshift.org/ci-ln-jj7k7db/release:latest
       ENABLE_IDMS: "yes"
       FEATURE_SET: TechPreviewNoUpgrade
     observers:

--- a/ci-operator/jobs/openshift/cluster-capi-operator/openshift-cluster-capi-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-capi-operator/openshift-cluster-capi-operator-main-presubmits.yaml
@@ -69,6 +69,89 @@ presubmits:
     - ^main$
     - ^main-
     cluster: build07
+    context: ci/prow/e2e-aws-capi-disconnected-techpreview
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-capi-operator-main-e2e-aws-capi-disconnected-techpreview
+    optional: true
+    rerun_command: /test e2e-aws-capi-disconnected-techpreview
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-aws-capi-disconnected-techpreview
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-aws-capi-disconnected-techpreview,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    annotations:
+      pipeline_skip_if_only_changed: \.md$|(^|/)docs/|(^|/)LICENSE$|(^|/)manifests-gen/|(^|/)OWNERS$
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build07
     context: ci/prow/e2e-aws-capi-techpreview
     decorate: true
     labels:

--- a/ci-operator/step-registry/aws/provision/cco-manual-users/static/aws-provision-cco-manual-users-static-commands.sh
+++ b/ci-operator/step-registry/aws/provision/cco-manual-users/static/aws-provision-cco-manual-users-static-commands.sh
@@ -64,7 +64,7 @@ function create_secret_file_for_aws()
     local key_id=$3
     local key_sec=$4
     local output_file=$5
-    cat <<EOF >${output_file}
+    cat <<EOF >"${output_file}"
 apiVersion: v1
 kind: Secret
 metadata:

--- a/ci-operator/step-registry/aws/provision/cco-manual-users/static/aws-provision-cco-manual-users-static-commands.sh
+++ b/ci-operator/step-registry/aws/provision/cco-manual-users/static/aws-provision-cco-manual-users-static-commands.sh
@@ -57,14 +57,12 @@ function aws_create_user()
     return 0
 }
 
-function b64() { echo -n "${1}" | base64 ; }
-
 function create_secret_file_for_aws()
 {
     local ns=$1
     local name=$2
-    local b64_key_id=$3
-    local b64_key_sec=$4
+    local key_id=$3
+    local key_sec=$4
     local output_file=$5
     cat <<EOF >${output_file}
 apiVersion: v1
@@ -72,9 +70,13 @@ kind: Secret
 metadata:
   name: ${name}
   namespace: ${ns}
-data:
-  aws_access_key_id: ${b64_key_id}
-  aws_secret_access_key: ${b64_key_sec}
+stringData:
+  aws_access_key_id: ${key_id}
+  aws_secret_access_key: ${key_sec}
+  credentials: |
+    [default]
+    aws_access_key_id = ${key_id}
+    aws_secret_access_key = ${key_sec}
 EOF
 }
 
@@ -212,7 +214,7 @@ do
     # Generate users manifests
     user_manifest="${SHARED_DIR}/manifest_user-${ns}-${name}-secret.yaml"
     echo "Generate users manifest file ${user_manifest}"
-    create_secret_file_for_aws "$ns" "$name" "$(b64 ${key_id})" "$(b64 ${key_sec})" "${user_manifest}"
+    create_secret_file_for_aws "$ns" "$name" "${key_id}" "${key_sec}" "${user_manifest}"
 done < "${credentials_requests_files}"
 
 exit 0

--- a/ci-operator/step-registry/ipi/aws/post/disconnected/OWNERS
+++ b/ci-operator/step-registry/ipi/aws/post/disconnected/OWNERS
@@ -1,0 +1,3 @@
+approvers:
+- mdbooth
+- theobarberbany

--- a/ci-operator/step-registry/ipi/aws/post/disconnected/ipi-aws-post-disconnected-chain.metadata.json
+++ b/ci-operator/step-registry/ipi/aws/post/disconnected/ipi-aws-post-disconnected-chain.metadata.json
@@ -1,0 +1,9 @@
+{
+	"path": "ipi/aws/post/disconnected/ipi-aws-post-disconnected-chain.yaml",
+	"owners": {
+		"approvers": [
+			"mdbooth",
+			"theobarberbany"
+		]
+	}
+}

--- a/ci-operator/step-registry/ipi/aws/post/disconnected/ipi-aws-post-disconnected-chain.yaml
+++ b/ci-operator/step-registry/ipi/aws/post/disconnected/ipi-aws-post-disconnected-chain.yaml
@@ -1,0 +1,15 @@
+chain:
+  as: ipi-aws-post-disconnected
+  steps:
+  - ref: gather-aws-console
+  - ref: gather-installer-boostrap-logs-in-bastion
+  - ref: gather-mirror-registry
+  - chain: ipi-deprovision
+  - ref: aws-deprovision-security-group
+  - ref: aws-deprovision-stacks
+  - ref: aws-deprovision-users-and-policies
+  - ref: aws-deprovision-verification
+  documentation: |-
+    The ipi-aws-post-disconnected chain gathers artifacts and deprovisions
+    a disconnected OpenShift cluster on AWS, including the bastion host,
+    CloudFormation VPC stack, and static IAM users created during installation.

--- a/ci-operator/step-registry/ipi/aws/pre/disconnected/OWNERS
+++ b/ci-operator/step-registry/ipi/aws/pre/disconnected/OWNERS
@@ -1,0 +1,3 @@
+approvers:
+- mdbooth
+- theobarberbany

--- a/ci-operator/step-registry/ipi/aws/pre/disconnected/ipi-aws-pre-disconnected-chain.metadata.json
+++ b/ci-operator/step-registry/ipi/aws/pre/disconnected/ipi-aws-pre-disconnected-chain.metadata.json
@@ -1,0 +1,9 @@
+{
+	"path": "ipi/aws/pre/disconnected/ipi-aws-pre-disconnected-chain.yaml",
+	"owners": {
+		"approvers": [
+			"mdbooth",
+			"theobarberbany"
+		]
+	}
+}

--- a/ci-operator/step-registry/ipi/aws/pre/disconnected/ipi-aws-pre-disconnected-chain.yaml
+++ b/ci-operator/step-registry/ipi/aws/pre/disconnected/ipi-aws-pre-disconnected-chain.yaml
@@ -1,0 +1,58 @@
+chain:
+  as: ipi-aws-pre-disconnected
+  steps:
+  - ref: aws-provision-vpc-disconnected
+  - chain: aws-provision-bastionhost
+  - chain: mirror-images-payload
+  - ref: ipi-conf
+  - ref: ipi-conf-telemetry
+  - ref: ipi-conf-aws-custom-vpc
+  - ref: ipi-conf-manual-creds
+  - ref: ipi-conf-aws
+  - ref: ipi-conf-mirror
+  - ref: ipi-install-monitoringpvc
+  - ref: proxy-config-generate
+  - ref: aws-provision-cco-manual-users-static
+  - ref: ipi-conf-manual-creds-remove-unnecessary-creds
+  - chain: aws-provision-iam-user-minimal-permission
+  - ref: openshift-cluster-bot-rbac
+  - ref: ipi-install-hosted-loki
+  - ref: ipi-install-install-aws
+  - ref: ipi-install-times-collection
+  - ref: nodes-readiness
+  - ref: multiarch-validate-nodes
+  - as: disable-default-sources
+    from: cli
+    commands: |-
+      set -euo pipefail
+      if test -f "${SHARED_DIR}/proxy-conf.sh"; then
+        source "${SHARED_DIR}/proxy-conf.sh"
+      fi
+      oc patch OperatorHub cluster --type json \
+        -p '[{"op": "add", "path": "/spec/disableAllDefaultSources", "value": true}]'
+    resources:
+      requests:
+        cpu: 100m
+        memory: 100Mi
+    timeout: 5m0s
+    grace_period: 5m0s
+  env:
+  - name: MIRROR_IN_BASTION
+    default: "yes"
+    documentation: "Mirror images from the bastion host rather than the build farm."
+  - name: PUBLISH
+    default: "Internal"
+    documentation: "Cluster publish strategy for disconnected install."
+  - name: ADD_INGRESS_RECORDS_MANUALLY
+    default: "yes"
+    documentation: "Manually create ingress DNS records for private clusters."
+  - name: ZONES_COUNT
+    default: "2"
+    documentation: "Number of availability zones. Default 2 to avoid regions with fewer than 3 AZs."
+  documentation: |-
+    The ipi-aws-pre-disconnected chain provisions a fully disconnected
+    OpenShift cluster on AWS. It creates an isolated VPC with private subnets
+    and no direct internet access, a bastion host on the public subnet
+    providing a mirror registry, egress proxy, and SSH jump host, then
+    mirrors the release payload and installs the cluster using manual CCO
+    credentials.

--- a/ci-operator/step-registry/openshift/e2e/aws/disconnected/OWNERS
+++ b/ci-operator/step-registry/openshift/e2e/aws/disconnected/OWNERS
@@ -1,0 +1,3 @@
+approvers:
+- mdbooth
+- theobarberbany

--- a/ci-operator/step-registry/openshift/e2e/aws/disconnected/openshift-e2e-aws-disconnected-workflow.metadata.json
+++ b/ci-operator/step-registry/openshift/e2e/aws/disconnected/openshift-e2e-aws-disconnected-workflow.metadata.json
@@ -1,0 +1,9 @@
+{
+	"path": "openshift/e2e/aws/disconnected/openshift-e2e-aws-disconnected-workflow.yaml",
+	"owners": {
+		"approvers": [
+			"mdbooth",
+			"theobarberbany"
+		]
+	}
+}

--- a/ci-operator/step-registry/openshift/e2e/aws/disconnected/openshift-e2e-aws-disconnected-workflow.yaml
+++ b/ci-operator/step-registry/openshift/e2e/aws/disconnected/openshift-e2e-aws-disconnected-workflow.yaml
@@ -1,0 +1,16 @@
+workflow:
+  as: openshift-e2e-aws-disconnected
+  steps:
+    allow_best_effort_post_steps: true
+    pre:
+    - chain: ipi-aws-pre-disconnected
+    test:
+    - ref: openshift-e2e-test
+    post:
+    - chain: gather-core-dump
+    - chain: ipi-aws-post-disconnected
+  documentation: |-
+    The openshift-e2e-aws-disconnected workflow executes the common end-to-end
+    test suite on a disconnected AWS cluster. The cluster is installed in a
+    private VPC with no direct internet access. A bastion host on the public
+    subnet provides a mirror registry, egress proxy, and SSH jump host.


### PR DESCRIPTION
- **Add openshift-e2e-aws-disconnected workflow**
- **DNM: test disconnected job with openshift/cluster-capi-operator#527**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional TechPreview disconnected AWS Cluster API E2E pipeline, plus a CI presubmit to run it.
  * Added a disconnected AWS workflow with pre-install provisioning (bastion/mirroring), E2E tests, artifact gathering, and automated deprovisioning.

* **Refactor**
  * Improved credential handling for AWS provisioning to use raw credential fields.

* **Chores**
  * Added ownership/metadata entries for new steps and workflows; pipeline skips runs for docs/license/manifest/OWNERS-only changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->