### PR TITLE
OCM-23799 | feat: rosa-hcp-pl (Private Link) FVT migration

### DIFF
--- a/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main.yaml
+++ b/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main.yaml
@@ -51,7 +51,7 @@ tests:
   commands: |
     env -i bash --norc --noprofile << 'EOF' > /tmp/podman.env
     export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
-    export AWS_SHARED_VPC_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
+    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
     export ENABLE_JIRA_REPORTING=true
     JOB_LINK="https://prow.ci.openshift.org/view/gs/test-platform-results/"
     if [ -n "${PULL_NUMBER:-}" ]; then
@@ -184,6 +184,43 @@ tests:
     --rm \
     quay.io/redhat-services-prod/ocmci/ocmci:latest \
     ocmtest test --service cms --job cs-rosa-ad-staging-main --reportJiraTicket
+  container:
+    from: nested-podman
+    memory_backed_volume:
+      size: 1Gi
+  cron: 0 8 * * *
+  nested_podman: true
+  secrets:
+  - mount_path: /usr/local/cs-qe-credentials
+    name: cs-qe-credentials
+- as: ocm-fvt-periodic-cs-rosa-hcp-pl-staging-main
+  capabilities:
+  - nested-podman
+  commands: |
+    env -i bash --norc --noprofile << 'EOF' > /tmp/podman.env
+    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
+    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
+    export ENABLE_JIRA_REPORTING=true
+    JOB_LINK="https://prow.ci.openshift.org/view/gs/test-platform-results/"
+    if [ -n "${PULL_NUMBER:-}" ]; then
+      JOB_LINK="${JOB_LINK}/pr-logs/pull/openshift-online_rosa-e2e/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
+    else
+      JOB_LINK="${JOB_LINK}/logs/${JOB_NAME}/${BUILD_ID}"
+    fi
+    echo "JOB_LINK=${JOB_LINK}"
+    export JOB_LINK=${JOB_LINK}
+    source /usr/local/cs-qe-credentials/ocm-tokens
+    source /usr/local/cs-qe-credentials/jira-cred
+    env | grep -v '^_='
+    EOF
+
+    podman run \
+    --authfile /usr/local/cs-qe-credentials/.dockerconfigjson \
+    --env-file /tmp/podman.env \
+    -v /usr/local/cs-qe-credentials:/credentials:ro,z \
+    --rm \
+    quay.io/redhat-services-prod/ocmci/ocmci:latest \
+    ocmtest test --service cms --job cs-rosa-hcp-pl-staging-main --reportJiraTicket
   container:
     from: nested-podman
     memory_backed_volume:

--- a/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-periodics.yaml
@@ -224,6 +224,76 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-online-rosa-e2e-main-ocm-fvt-periodic-cs-rosa-hcp-pl-staging-main
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/cs-qe-credentials
+      - --target=ocm-fvt-periodic-cs-rosa-hcp-pl-staging-main
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /secrets/cs-qe-credentials
+        name: cs-qe-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: cs-qe-credentials
+      secret:
+        secretName: cs-qe-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build06
+  cron: 0 8 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-online
+    repo: rosa-e2e
+  labels:
+    capability/nested-podman: nested-podman
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-online-rosa-e2e-main-ocm-fvt-periodic-cs-rosa-hcp-zero-egress-upgrade-staging-main
   spec:
     containers:


### PR DESCRIPTION
As part of the **ROSA CI E2E Reliability**, this PR is proposing the migration of rosa-hcp-pl (Private Link) FVT.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Renamed an internal CI environment variable for shared-VPC credentials to SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE to align periodic test environments.

* **Tests**
  * Added a new daily scheduled periodic test for ROSA HCP (nested test runner) that mounts required credentials, improves job-link selection for PR vs build runs, and enables Jira reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->