### PR TITLE
telco: support scheduler-plugins release-4.22 branch

### DIFF
--- a/ci-operator/config/openshift-kni/scheduler-plugins/openshift-kni-scheduler-plugins-release-4.22.yaml
+++ b/ci-operator/config/openshift-kni/scheduler-plugins/openshift-kni-scheduler-plugins-release-4.22.yaml
@@ -19,17 +19,17 @@ images:
     to: scheduler-plugins
 promotion:
   to:
-  - name: scheduler-plugins
+  - name: scheduler-plugins-4.22
     namespace: ocp-kni
 releases:
   initial:
     integration:
-      name: "5.0"
+      name: "4.22"
       namespace: ocp
   latest:
     integration:
       include_built_images: true
-      name: "5.0"
+      name: "4.22"
       namespace: ocp
 resources:
   '*':
@@ -48,6 +48,6 @@ tests:
       PROJECT_NAME: noderesourcetopology-scheduler
     workflow: openshift-ci-security
 zz_generated_metadata:
-  branch: master
+  branch: release-4.22
   org: openshift-kni
   repo: scheduler-plugins

--- a/ci-operator/jobs/openshift-kni/scheduler-plugins/openshift-kni-scheduler-plugins-release-4.22-postsubmits.yaml
+++ b/ci-operator/jobs/openshift-kni/scheduler-plugins/openshift-kni-scheduler-plugins-release-4.22-postsubmits.yaml
@@ -1,0 +1,62 @@
+postsubmits:
+  openshift-kni/scheduler-plugins:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.22$
+    cluster: build01
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/is-promotion: "true"
+      ci.openshift.io/generator: prowgen
+    max_concurrency: 1
+    name: branch-ci-openshift-kni-scheduler-plugins-release-4.22-images
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --image-mirror-push-secret=/etc/push-secret/.dockerconfigjson
+        - --promote
+        - --report-credentials-file=/etc/report/credentials
+        - --target=[images]
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/push-secret
+          name: push-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: push-secret
+        secret:
+          secretName: registry-push-credentials-ci-central
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator

--- a/ci-operator/jobs/openshift-kni/scheduler-plugins/openshift-kni-scheduler-plugins-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift-kni/scheduler-plugins/openshift-kni-scheduler-plugins-release-4.22-presubmits.yaml
@@ -1,0 +1,201 @@
+presubmits:
+  openshift-kni/scheduler-plugins:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.22$
+    - ^release-4\.22-
+    cluster: build01
+    context: ci/prow/ci-unit
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-kni-scheduler-plugins-release-4.22-ci-unit
+    rerun_command: /test ci-unit
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=ci-unit
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )ci-unit,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.22$
+    - ^release-4\.22-
+    cluster: build01
+    context: ci/prow/images
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-kni-scheduler-plugins-release-4.22-images
+    rerun_command: /test images
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=[images]
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )images,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.22$
+    - ^release-4\.22-
+    cluster: build01
+    context: ci/prow/security
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-kni-scheduler-plugins-release-4.22-security
+    optional: true
+    rerun_command: /test security
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=security
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )security,?($|\s.*)

--- a/core-services/image-mirroring/openshift-kni/mapping_openshift-kni_quay
+++ b/core-services/image-mirroring/openshift-kni/mapping_openshift-kni_quay
@@ -26,7 +26,8 @@ registry.ci.openshift.org/ocp-kni/telco-ran-tools:telco-ran-tools quay.io/opensh
 registry.ci.openshift.org/ocp-kni/telco-ran-tools-1.0:telco-ran-tools quay.io/openshift-kni/telco-ran-tools:1.0
 # scheduler-plugins
 registry.ci.openshift.org/ocp-kni/scheduler-plugins:scheduler-plugins quay.io/openshift-kni/scheduler-plugins:test-ci
-registry.ci.openshift.org/ocp-kni/scheduler-plugins:scheduler-plugins quay.io/openshift-kni/scheduler-plugins:4.22-snapshot
+registry.ci.openshift.org/ocp-kni/scheduler-plugins:scheduler-plugins quay.io/openshift-kni/scheduler-plugins:5.0-snapshot
+registry.ci.openshift.org/ocp-kni/scheduler-plugins-4.22:scheduler-plugins quay.io/openshift-kni/scheduler-plugins:4.22-snapshot
 registry.ci.openshift.org/ocp-kni/scheduler-plugins-4.21:scheduler-plugins quay.io/openshift-kni/scheduler-plugins:4.21-snapshot
 registry.ci.openshift.org/ocp-kni/scheduler-plugins-4.20:scheduler-plugins quay.io/openshift-kni/scheduler-plugins:4.20-snapshot
 registry.ci.openshift.org/ocp-kni/scheduler-plugins-4.19:scheduler-plugins quay.io/openshift-kni/scheduler-plugins:4.19-snapshot


### PR DESCRIPTION
A new release-4.22 branch was created, enable prow CI for it and point master jobs to test 5.0.

Assisted-by: Cursor v2.3.37
AIA Attribution: AIA EAI Hin R Cursor 2.3.37 v1.0