### PR TITLE
Fix broken CDN URLs in release-controller repo files

### DIFF
--- a/core-services/release-controller/_repos/ocp-4.16-rhel8.repo
+++ b/core-services/release-controller/_repos/ocp-4.16-rhel8.repo
@@ -132,18 +132,6 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-8-nfv-ppc64le]
-name = rhel-8-nfv-ppc64le
-baseurl = https://cdn.redhat.com/content/tus/rhel8/8.6/x86_64-ppc64le/nfv/os/
-enabled = 1
-gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
-sslverify = false
-gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
-failovermethod = priority
-
 [rhel-8-server-ose-ppc64le]
 name = rhel-8-server-ose-ppc64le
 baseurl = https://mirror2.openshift.com/enterprise/reposync/4.16_ppc64le/rhel-8-server-ose-rpms
@@ -230,18 +218,6 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-8-nfv-s390x]
-name = rhel-8-nfv-s390x
-baseurl = https://cdn.redhat.com/content/tus/rhel8/8.6/x86_64-s390x/nfv/os/
-enabled = 1
-gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
-sslverify = false
-gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
-failovermethod = priority
-
 [rhel-8-server-ose-s390x]
 name = rhel-8-server-ose-s390x
 baseurl = https://mirror2.openshift.com/enterprise/reposync/4.16_s390x/rhel-8-server-ose-rpms
@@ -306,18 +282,6 @@ failovermethod = priority
 [rhel-8-fast-datapath-aarch64]
 name = rhel-8-fast-datapath-aarch64
 baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/aarch64/fast-datapath/os/
-enabled = 1
-gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
-sslverify = false
-gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
-failovermethod = priority
-
-[rhel-8-nfv-aarch64]
-name = rhel-8-nfv-aarch64
-baseurl = https://cdn.redhat.com/content/tus/rhel8/8.6/x86_64-aarch64/nfv/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false

--- a/core-services/release-controller/_repos/ocp-4.16-rhel810.repo
+++ b/core-services/release-controller/_repos/ocp-4.16-rhel810.repo
@@ -34,18 +34,6 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-8.10-nfv]
-name = rhel-8.10-nfv
-baseurl = https://cdn.redhat.com/content/tus/rhel8/8.10/x86_64/nfv/os/
-enabled = 1
-gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
-sslverify = false
-gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
-failovermethod = priority
-
 [rhel-8.10-server-ose-4.16]
 name = rhel-8.10-server-ose-4.16
 baseurl = https://mirror2.openshift.com/enterprise/reposync/4.16/rhel-8-server-ose-rpms

--- a/core-services/release-controller/_repos/ocp-4.17-rhel8.repo
+++ b/core-services/release-controller/_repos/ocp-4.17-rhel8.repo
@@ -130,18 +130,6 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-8-nfv-ppc64le]
-name = rhel-8-nfv-ppc64le
-baseurl = https://cdn.redhat.com/content/tus/rhel8/8.6/x86_64-ppc64le/nfv/os/
-enabled = 1
-gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
-sslverify = false
-gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
-failovermethod = priority
-
 [rhel-8-server-ose-ppc64le]
 name = rhel-8-server-ose-ppc64le
 baseurl = https://mirror2.openshift.com/enterprise/reposync/4.17_ppc64le/rhel-8-server-ose-rpms
@@ -226,18 +214,6 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-8-nfv-s390x]
-name = rhel-8-nfv-s390x
-baseurl = https://cdn.redhat.com/content/tus/rhel8/8.6/x86_64-s390x/nfv/os/
-enabled = 1
-gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
-sslverify = false
-gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
-failovermethod = priority
-
 [rhel-8-server-ose-s390x]
 name = rhel-8-server-ose-s390x
 baseurl = https://mirror2.openshift.com/enterprise/reposync/4.17_s390x/rhel-8-server-ose-rpms
@@ -301,18 +277,6 @@ failovermethod = priority
 [rhel-8-fast-datapath-aarch64]
 name = rhel-8-fast-datapath-aarch64
 baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/aarch64/fast-datapath/os/
-enabled = 1
-gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
-sslverify = false
-gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
-failovermethod = priority
-
-[rhel-8-nfv-aarch64]
-name = rhel-8-nfv-aarch64
-baseurl = https://cdn.redhat.com/content/tus/rhel8/8.6/x86_64-aarch64/nfv/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false

--- a/core-services/release-controller/_repos/ocp-4.17-rhel810.repo
+++ b/core-services/release-controller/_repos/ocp-4.17-rhel810.repo
@@ -34,18 +34,6 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-8.10-nfv]
-name = rhel-8.10-nfv
-baseurl = https://cdn.redhat.com/content/tus/rhel8/8.10/x86_64/nfv/os/
-enabled = 1
-gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
-sslverify = false
-gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
-failovermethod = priority
-
 [rhel-8.10-server-ose-4.17]
 name = rhel-8.10-server-ose-4.17
 baseurl = https://mirror2.openshift.com/enterprise/reposync/4.17/rhel-8-server-ose-rpms

--- a/core-services/release-controller/_repos/ocp-4.18-rhel8.repo
+++ b/core-services/release-controller/_repos/ocp-4.18-rhel8.repo
@@ -130,18 +130,6 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-8-nfv-ppc64le]
-name = rhel-8-nfv-ppc64le
-baseurl = https://cdn.redhat.com/content/tus/rhel8/8.6/x86_64-ppc64le/nfv/os/
-enabled = 1
-gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
-sslverify = false
-gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
-failovermethod = priority
-
 [rhel-8-server-ose-ppc64le]
 name = rhel-8-server-ose-ppc64le
 baseurl = https://mirror2.openshift.com/enterprise/reposync/4.18_ppc64le/rhel-8-server-ose-rpms
@@ -226,18 +214,6 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-8-nfv-s390x]
-name = rhel-8-nfv-s390x
-baseurl = https://cdn.redhat.com/content/tus/rhel8/8.6/x86_64-s390x/nfv/os/
-enabled = 1
-gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
-sslverify = false
-gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
-failovermethod = priority
-
 [rhel-8-server-ose-s390x]
 name = rhel-8-server-ose-s390x
 baseurl = https://mirror2.openshift.com/enterprise/reposync/4.18_s390x/rhel-8-server-ose-rpms
@@ -301,18 +277,6 @@ failovermethod = priority
 [rhel-8-fast-datapath-aarch64]
 name = rhel-8-fast-datapath-aarch64
 baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/aarch64/fast-datapath/os/
-enabled = 1
-gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
-sslverify = false
-gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
-failovermethod = priority
-
-[rhel-8-nfv-aarch64]
-name = rhel-8-nfv-aarch64
-baseurl = https://cdn.redhat.com/content/tus/rhel8/8.6/x86_64-aarch64/nfv/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false

--- a/core-services/release-controller/_repos/ocp-4.19-rhel8.repo
+++ b/core-services/release-controller/_repos/ocp-4.19-rhel8.repo
@@ -130,18 +130,6 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-8-nfv-ppc64le]
-name = rhel-8-nfv-ppc64le
-baseurl = https://cdn.redhat.com/content/tus/rhel8/8.6/x86_64-ppc64le/nfv/os/
-enabled = 1
-gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
-sslverify = false
-gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
-failovermethod = priority
-
 [rhel-8-server-ose-ppc64le]
 name = rhel-8-server-ose-ppc64le
 baseurl = https://mirror2.openshift.com/enterprise/reposync/4.19_ppc64le/rhel-8-server-ose-rpms
@@ -226,18 +214,6 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-8-nfv-s390x]
-name = rhel-8-nfv-s390x
-baseurl = https://cdn.redhat.com/content/tus/rhel8/8.6/x86_64-s390x/nfv/os/
-enabled = 1
-gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
-sslverify = false
-gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
-failovermethod = priority
-
 [rhel-8-server-ose-s390x]
 name = rhel-8-server-ose-s390x
 baseurl = https://mirror2.openshift.com/enterprise/reposync/4.19_s390x/rhel-8-server-ose-rpms
@@ -301,18 +277,6 @@ failovermethod = priority
 [rhel-8-fast-datapath-aarch64]
 name = rhel-8-fast-datapath-aarch64
 baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/aarch64/fast-datapath/os/
-enabled = 1
-gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
-sslverify = false
-gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
-failovermethod = priority
-
-[rhel-8-nfv-aarch64]
-name = rhel-8-nfv-aarch64
-baseurl = https://cdn.redhat.com/content/tus/rhel8/8.6/x86_64-aarch64/nfv/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false

--- a/core-services/release-controller/_repos/ocp-4.20-rhel8.repo
+++ b/core-services/release-controller/_repos/ocp-4.20-rhel8.repo
@@ -130,18 +130,6 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-8-nfv-ppc64le]
-name = rhel-8-nfv-ppc64le
-baseurl = https://cdn.redhat.com/content/tus/rhel8/8.6/x86_64-ppc64le/nfv/os/
-enabled = 1
-gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
-sslverify = false
-gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
-failovermethod = priority
-
 [rhel-8-server-ose-ppc64le]
 name = rhel-8-server-ose-ppc64le
 baseurl = https://mirror2.openshift.com/enterprise/reposync/4.20_ppc64le/rhel-8-server-ose-rpms
@@ -226,18 +214,6 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-8-nfv-s390x]
-name = rhel-8-nfv-s390x
-baseurl = https://cdn.redhat.com/content/tus/rhel8/8.6/x86_64-s390x/nfv/os/
-enabled = 1
-gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
-sslverify = false
-gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
-failovermethod = priority
-
 [rhel-8-server-ose-s390x]
 name = rhel-8-server-ose-s390x
 baseurl = https://mirror2.openshift.com/enterprise/reposync/4.20_s390x/rhel-8-server-ose-rpms
@@ -301,18 +277,6 @@ failovermethod = priority
 [rhel-8-fast-datapath-aarch64]
 name = rhel-8-fast-datapath-aarch64
 baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/aarch64/fast-datapath/os/
-enabled = 1
-gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
-sslverify = false
-gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
-failovermethod = priority
-
-[rhel-8-nfv-aarch64]
-name = rhel-8-nfv-aarch64
-baseurl = https://cdn.redhat.com/content/tus/rhel8/8.6/x86_64-aarch64/nfv/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false

--- a/core-services/release-controller/_repos/ocp-4.21-rhel101.repo
+++ b/core-services/release-controller/_repos/ocp-4.21-rhel101.repo
@@ -1,6 +1,6 @@
 [rhel-10.1-baseos]
 name = rhel-10.1-baseos
-baseurl = https://cdn.redhat.com/content/eus/rhel10/10.1/x86_64/baseos/os/
+baseurl = https://cdn.redhat.com/content/dist/rhel10/10.1/x86_64/baseos/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -11,7 +11,7 @@ failovermethod = priority
 
 [rhel-10.1-appstream]
 name = rhel-10.1-appstream
-baseurl = https://cdn.redhat.com/content/eus/rhel10/10.1/x86_64/appstream/os/
+baseurl = https://cdn.redhat.com/content/dist/rhel10/10.1/x86_64/appstream/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -22,7 +22,7 @@ failovermethod = priority
 
 [rhel-10.1-nfv]
 name = rhel-10.1-nfv
-baseurl = https://cdn.redhat.com/content/e4s/rhel10/10.1/x86_64/nfv/os/
+baseurl = https://cdn.redhat.com/content/dist/rhel10/10.1/x86_64/nfv/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -33,7 +33,7 @@ failovermethod = priority
 
 [rhel-10.1-highavailability]
 name = rhel-10.1-highavailability
-baseurl = https://cdn.redhat.com/content/e4s/rhel10/10.1/x86_64/highavailability/os/
+baseurl = https://cdn.redhat.com/content/dist/rhel10/10.1/x86_64/highavailability/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false

--- a/core-services/release-controller/_repos/ocp-4.21-rhel8.repo
+++ b/core-services/release-controller/_repos/ocp-4.21-rhel8.repo
@@ -130,18 +130,6 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-8-nfv-ppc64le]
-name = rhel-8-nfv-ppc64le
-baseurl = https://cdn.redhat.com/content/tus/rhel8/8.6/x86_64-ppc64le/nfv/os/
-enabled = 1
-gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
-sslverify = false
-gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
-failovermethod = priority
-
 [rhel-8-server-ose-ppc64le]
 name = rhel-8-server-ose-ppc64le
 baseurl = https://mirror2.openshift.com/enterprise/reposync/4.21_ppc64le/rhel-8-server-ose-rpms
@@ -226,18 +214,6 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-8-nfv-s390x]
-name = rhel-8-nfv-s390x
-baseurl = https://cdn.redhat.com/content/tus/rhel8/8.6/x86_64-s390x/nfv/os/
-enabled = 1
-gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
-sslverify = false
-gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
-failovermethod = priority
-
 [rhel-8-server-ose-s390x]
 name = rhel-8-server-ose-s390x
 baseurl = https://mirror2.openshift.com/enterprise/reposync/4.21_s390x/rhel-8-server-ose-rpms
@@ -301,18 +277,6 @@ failovermethod = priority
 [rhel-8-fast-datapath-aarch64]
 name = rhel-8-fast-datapath-aarch64
 baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/aarch64/fast-datapath/os/
-enabled = 1
-gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
-sslverify = false
-gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
-failovermethod = priority
-
-[rhel-8-nfv-aarch64]
-name = rhel-8-nfv-aarch64
-baseurl = https://cdn.redhat.com/content/tus/rhel8/8.6/x86_64-aarch64/nfv/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false

--- a/core-services/release-controller/_repos/ocp-4.22-rhel8.repo
+++ b/core-services/release-controller/_repos/ocp-4.22-rhel8.repo
@@ -130,18 +130,6 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-8-nfv-ppc64le]
-name = rhel-8-nfv-ppc64le
-baseurl = https://cdn.redhat.com/content/tus/rhel8/8.6/x86_64-ppc64le/nfv/os/
-enabled = 1
-gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
-sslverify = false
-gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
-failovermethod = priority
-
 [rhel-8-server-ose-ppc64le]
 name = rhel-8-server-ose-ppc64le
 baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22_ppc64le/rhel-8-server-ose-rpms
@@ -226,18 +214,6 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-8-nfv-s390x]
-name = rhel-8-nfv-s390x
-baseurl = https://cdn.redhat.com/content/tus/rhel8/8.6/x86_64-s390x/nfv/os/
-enabled = 1
-gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
-sslverify = false
-gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
-failovermethod = priority
-
 [rhel-8-server-ose-s390x]
 name = rhel-8-server-ose-s390x
 baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22_s390x/rhel-8-server-ose-rpms
@@ -301,18 +277,6 @@ failovermethod = priority
 [rhel-8-fast-datapath-aarch64]
 name = rhel-8-fast-datapath-aarch64
 baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/aarch64/fast-datapath/os/
-enabled = 1
-gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
-sslverify = false
-gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
-failovermethod = priority
-
-[rhel-8-nfv-aarch64]
-name = rhel-8-nfv-aarch64
-baseurl = https://cdn.redhat.com/content/tus/rhel8/8.6/x86_64-aarch64/nfv/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false

--- a/core-services/release-controller/_repos/ocp-4.23-rhel8.repo
+++ b/core-services/release-controller/_repos/ocp-4.23-rhel8.repo
@@ -130,18 +130,6 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-8-nfv-ppc64le]
-name = rhel-8-nfv-ppc64le
-baseurl = https://cdn.redhat.com/content/tus/rhel8/8.6/x86_64-ppc64le/nfv/os/
-enabled = 1
-gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
-sslverify = false
-gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
-failovermethod = priority
-
 [rhel-8-server-ose-ppc64le]
 name = rhel-8-server-ose-ppc64le
 baseurl = https://mirror2.openshift.com/enterprise/reposync/4.23_ppc64le/rhel-8-server-ose-rpms
@@ -226,18 +214,6 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-8-nfv-s390x]
-name = rhel-8-nfv-s390x
-baseurl = https://cdn.redhat.com/content/tus/rhel8/8.6/x86_64-s390x/nfv/os/
-enabled = 1
-gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
-sslverify = false
-gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
-failovermethod = priority
-
 [rhel-8-server-ose-s390x]
 name = rhel-8-server-ose-s390x
 baseurl = https://mirror2.openshift.com/enterprise/reposync/4.23_s390x/rhel-8-server-ose-rpms
@@ -301,18 +277,6 @@ failovermethod = priority
 [rhel-8-fast-datapath-aarch64]
 name = rhel-8-fast-datapath-aarch64
 baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/aarch64/fast-datapath/os/
-enabled = 1
-gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
-sslverify = false
-gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
-failovermethod = priority
-
-[rhel-8-nfv-aarch64]
-name = rhel-8-nfv-aarch64
-baseurl = https://cdn.redhat.com/content/tus/rhel8/8.6/x86_64-aarch64/nfv/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false

--- a/core-services/release-controller/_repos/ocp-5.0-rhel8.repo
+++ b/core-services/release-controller/_repos/ocp-5.0-rhel8.repo
@@ -130,18 +130,6 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-8-nfv-ppc64le]
-name = rhel-8-nfv-ppc64le
-baseurl = https://cdn.redhat.com/content/tus/rhel8/8.6/x86_64-ppc64le/nfv/os/
-enabled = 1
-gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
-sslverify = false
-gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
-failovermethod = priority
-
 [rhel-8-server-ose-ppc64le]
 name = rhel-8-server-ose-ppc64le
 baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0_ppc64le/rhel-8-server-ose-rpms
@@ -226,18 +214,6 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-8-nfv-s390x]
-name = rhel-8-nfv-s390x
-baseurl = https://cdn.redhat.com/content/tus/rhel8/8.6/x86_64-s390x/nfv/os/
-enabled = 1
-gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
-sslverify = false
-gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
-failovermethod = priority
-
 [rhel-8-server-ose-s390x]
 name = rhel-8-server-ose-s390x
 baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0_s390x/rhel-8-server-ose-rpms
@@ -301,18 +277,6 @@ failovermethod = priority
 [rhel-8-fast-datapath-aarch64]
 name = rhel-8-fast-datapath-aarch64
 baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/aarch64/fast-datapath/os/
-enabled = 1
-gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
-sslverify = false
-gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
-failovermethod = priority
-
-[rhel-8-nfv-aarch64]
-name = rhel-8-nfv-aarch64
-baseurl = https://cdn.redhat.com/content/tus/rhel8/8.6/x86_64-aarch64/nfv/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false

--- a/core-services/release-controller/_repos/ocp-5.1-rhel8.repo
+++ b/core-services/release-controller/_repos/ocp-5.1-rhel8.repo
@@ -130,18 +130,6 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-8-nfv-ppc64le]
-name = rhel-8-nfv-ppc64le
-baseurl = https://cdn.redhat.com/content/tus/rhel8/8.6/x86_64-ppc64le/nfv/os/
-enabled = 1
-gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
-sslverify = false
-gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
-failovermethod = priority
-
 [rhel-8-server-ose-ppc64le]
 name = rhel-8-server-ose-ppc64le
 baseurl = https://mirror2.openshift.com/enterprise/reposync/5.1_ppc64le/rhel-8-server-ose-rpms
@@ -226,18 +214,6 @@ sslclientkey = /tmp/key/rh-cdn.pem
 sslclientcert = /tmp/key/rh-cdn.pem
 failovermethod = priority
 
-[rhel-8-nfv-s390x]
-name = rhel-8-nfv-s390x
-baseurl = https://cdn.redhat.com/content/tus/rhel8/8.6/x86_64-s390x/nfv/os/
-enabled = 1
-gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
-sslverify = false
-gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
-failovermethod = priority
-
 [rhel-8-server-ose-s390x]
 name = rhel-8-server-ose-s390x
 baseurl = https://mirror2.openshift.com/enterprise/reposync/5.1_s390x/rhel-8-server-ose-rpms
@@ -301,18 +277,6 @@ failovermethod = priority
 [rhel-8-fast-datapath-aarch64]
 name = rhel-8-fast-datapath-aarch64
 baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/aarch64/fast-datapath/os/
-enabled = 1
-gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
-sslverify = false
-gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
-failovermethod = priority
-
-[rhel-8-nfv-aarch64]
-name = rhel-8-nfv-aarch64
-baseurl = https://cdn.redhat.com/content/tus/rhel8/8.6/x86_64-aarch64/nfv/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false


### PR DESCRIPTION
## Summary
- Remove non-existent NFV repo sections for ppc64le, s390x, aarch64 from `*-rhel8.repo` files (4.16-5.1) — these architectures have no NFV repo on RHEL 8.6 TUS
- Remove non-existent NFV repo section from `*-rhel810.repo` files (4.16, 4.17) — no NFV repo exists for RHEL 8.10 TUS
- Fix RHEL 10.1 CDN paths in `ocp-4.21-rhel101.repo` — change `content/eus` and `content/e4s` to `content/dist`, matching the working pattern in `ocp-4.22-rhel101.repo`

All URLs validated against mirror2 (401 = path exists) and CDN via rhsm-pulp (200 = valid).

## Test plan
- [ ] Verify no 404s remain in modified repo files by running `/test-repo-files` or manually curling the URLs
- [ ] Confirm removed NFV sections were not referenced by any CI jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed architecture-specific NFV repository configurations for ppc64le, s390x, and aarch64 across multiple OpenShift release versions (4.16–5.1).
  * Removed NFV repository entries from RHEL 8.10 configurations.
  * Updated repository endpoint URLs for OpenShift 4.21 on RHEL 10.1 to use distribution content paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->