### PR TITLE
 Mirror the pause image to additional locations

### DIFF
--- a/ci-operator/step-registry/hypershift/conformance/hypershift-conformance-chain.yaml
+++ b/ci-operator/step-registry/hypershift/conformance/hypershift-conformance-chain.yaml
@@ -50,6 +50,7 @@ chain:
       oc image mirror --registry-config ${DS_WORKING_DIR}/pull_secret.json --filter-by-os="linux/${ARCHITECTURE}.*" registry.k8s.io/pause:3.9  $DEVSCRIPTS_TEST_IMAGE_REPO:e2e-28-registry-k8s-io-pause-3-9-p9APyPDU5GsW02Rk
       oc image mirror --registry-config ${DS_WORKING_DIR}/pull_secret.json --filter-by-os="linux/${ARCHITECTURE}.*" registry.k8s.io/pause:3.10 $DEVSCRIPTS_TEST_IMAGE_REPO:e2e-25-registry-k8s-io-pause-3-10-b3MYAwZ_MelO9baY
       oc image mirror --registry-config ${DS_WORKING_DIR}/pull_secret.json --filter-by-os="linux/${ARCHITECTURE}.*" registry.k8s.io/pause:3.10 $DEVSCRIPTS_TEST_IMAGE_REPO:e2e-27-registry-k8s-io-pause-3-10-b3MYAwZ_MelO9baY
+      oc image mirror --registry-config ${DS_WORKING_DIR}/pull_secret.json --filter-by-os="linux/${ARCHITECTURE}.*" registry.k8s.io/pause:3.10.1 $DEVSCRIPTS_TEST_IMAGE_REPO:e2e-22-registry-k8s-io-pause-3-10-1-a6__nK-VRxiifU0Z
       oc image mirror --registry-config ${DS_WORKING_DIR}/pull_secret.json --filter-by-os="linux/${ARCHITECTURE}.*" registry.k8s.io/pause:3.10.1 $DEVSCRIPTS_TEST_IMAGE_REPO:e2e-25-registry-k8s-io-pause-3-10-1-a6__nK-VRxiifU0Z
       oc image mirror --registry-config ${DS_WORKING_DIR}/pull_secret.json --filter-by-os="linux/${ARCHITECTURE}.*" registry.k8s.io/etcd:3.5.15-0 $DEVSCRIPTS_TEST_IMAGE_REPO:e2e-11-registry-k8s-io-etcd-3-5-15-0-W7c5qq4cz4EE20EQ
       EOF

--- a/ci-operator/step-registry/hypershift/mce/agent/manual/conformance/hypershift-mce-agent-manual-conformance-workflow.yaml
+++ b/ci-operator/step-registry/hypershift/mce/agent/manual/conformance/hypershift-mce-agent-manual-conformance-workflow.yaml
@@ -8,7 +8,6 @@ workflow:
     allow_best_effort_post_steps: true
     allow_skip_on_success: true
     post:
-    - ref: wait
     - ref: hypershift-mce-dump
     - chain: hypershift-mce-agent-destroy
     - chain: baremetalds-ofcir-post

--- a/ci-operator/step-registry/hypershift/mce/kubevirt/baremetalds/conformance/hypershift-mce-kubevirt-baremetalds-conformance-workflow.yaml
+++ b/ci-operator/step-registry/hypershift/mce/kubevirt/baremetalds/conformance/hypershift-mce-kubevirt-baremetalds-conformance-workflow.yaml
@@ -19,7 +19,6 @@ workflow:
     Track HyperShift's development here: https://issues.redhat.com/projects/HOSTEDCP
   steps:
     post:
-    - ref: wait
     - ref: hypershift-mce-dump
     - chain: gather-core-dump
     - chain: hypershift-mce-kubevirt-destroy


### PR DESCRIPTION
Fixes the issue from https://github.com/openshift/release/pull/78238#issuecomment-4312712184

The image index is now different:
https://github.com/openshift/origin/blob/main/vendor/k8s.io/kubernetes/test/utils/image/manifest.go
Some time ago, some images were removed from the list so the resulting
index is 22, not 25. We now mirror the image to both 22 and 25 to preserve backwards
compatibility.

This is a temporary solution. It needs some re-work to prevent the issue in the future as it already happens 3 times:
e.g. https://github.com/openshift/release/commit/e4b31396ff89730037588df4b754b69886b46600

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced conformance testing setup with support for additional container images in the mirroring pipeline.

* **Chores**
  * Optimized test cleanup workflows by streamlining post-execution step sequences across multiple conformance test configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->