### PR TITLE
Add must-gather step to Cilium/AWS workflow

### DIFF
--- a/ci-operator/step-registry/hypershift/aws/conformance-cilium/hypershift-aws-conformance-cilium-workflow.yaml
+++ b/ci-operator/step-registry/hypershift/aws/conformance-cilium/hypershift-aws-conformance-cilium-workflow.yaml
@@ -44,6 +44,7 @@ workflow:
         Ensure HTTPRoute object is created
     post:
     - chain: hypershift-dump
+    - chain: gather
     - chain: hypershift-aws-destroy
     - chain: hypershift-destroy-nested-management-cluster
     test:


### PR DESCRIPTION
Related to https://redhat.atlassian.net/browse/OCPBUGS-84104

* Add must-gather step that should collect events related to memory/CPU resources if there are any.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated HyperShift AWS conformance workflow configuration to establish a fixed node count of 4 for test executions.
  * Added a data gathering step to the post-test execution sequence to occur between dump and teardown phases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->