### PR TITLE
METAL-1549: Add multi-arch PXE job

### DIFF
--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22__multi-nightly.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22__multi-nightly.yaml
@@ -2475,15 +2475,15 @@ tests:
     test:
     - chain: openshift-e2e-test-qe
     workflow: baremetal-lab-ipi-virtual-media
-- as: metal-ipi-ovn-ipv4-vmedia-multi-arch-day2-amd-f14
+- as: metal-ipi-ovn-ipv4-pxe-multi-arch-day2-amd-f14
   capabilities:
   - intranet
-  cron: 8 17 1,17 * *
+  cron: 53 14 7,23 * *
   steps:
     cluster_profile: equinix-ocp-metal-qe
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: arm64
-      ADDITIONAL_WORKERS: "1"
+      ADDITIONAL_WORKERS: "2"
       ADDITIONAL_WORKERS_DAY2: "true"
       AUX_HOST: openshift-qe-metal-ci.arm.eng.rdu2.redhat.com
       DISCONNECTED: "false"
@@ -2493,7 +2493,7 @@ tests:
       workers: "1"
     test:
     - chain: openshift-e2e-test-qe
-    workflow: baremetal-lab-ipi-virtual-media
+    workflow: baremetal-lab-ipi
 - as: metal-ipi-ovn-ipv4-vmedia-multi-arch-amd-f14
   capabilities:
   - intranet

--- a/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22-periodics.yaml
+++ b/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22-periodics.yaml
@@ -106000,6 +106000,97 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build10
+  cron: 53 14 7,23 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: release-4.22
+    org: openshift
+    repo: openshift-tests-private
+  labels:
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: equinix-ocp-metal
+    ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal-qe
+    ci-operator.openshift.io/variant: multi-nightly
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-metal-ipi-ovn-ipv4-pxe-multi-arch-day2-amd-f14
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --oauth-token-path=/usr/local/github-credentials/oauth
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=metal-ipi-ovn-ipv4-pxe-multi-arch-day2-amd-f14
+      - --variant=multi-nightly
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /usr/local/github-credentials
+        name: github-credentials-openshift-ci-robot-private-git-cloner
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: github-credentials-openshift-ci-robot-private-git-cloner
+      secret:
+        secretName: github-credentials-openshift-ci-robot-private-git-cloner
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build10
   cron: 44 15 7,21 * *
   decorate: true
   decoration_config:
@@ -106300,97 +106391,6 @@ periodics:
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
       - --target=metal-ipi-ovn-ipv4-vmedia-multi-arch-amd-f28
-      - --variant=multi-nightly
-      command:
-      - ci-operator
-      env:
-      - name: HTTP_SERVER_IP
-        valueFrom:
-          fieldRef:
-            fieldPath: status.podIP
-      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-      imagePullPolicy: Always
-      name: ""
-      ports:
-      - containerPort: 8080
-        name: http
-      resources:
-        requests:
-          cpu: 10m
-      volumeMounts:
-      - mountPath: /etc/boskos
-        name: boskos
-        readOnly: true
-      - mountPath: /secrets/ci-pull-credentials
-        name: ci-pull-credentials
-        readOnly: true
-      - mountPath: /secrets/gcs
-        name: gcs-credentials
-        readOnly: true
-      - mountPath: /usr/local/github-credentials
-        name: github-credentials-openshift-ci-robot-private-git-cloner
-        readOnly: true
-      - mountPath: /secrets/manifest-tool
-        name: manifest-tool-local-pusher
-        readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
-      - mountPath: /etc/report
-        name: result-aggregator
-        readOnly: true
-    serviceAccountName: ci-operator
-    volumes:
-    - name: boskos
-      secret:
-        items:
-        - key: credentials
-          path: credentials
-        secretName: boskos-credentials
-    - name: ci-pull-credentials
-      secret:
-        secretName: ci-pull-credentials
-    - name: github-credentials-openshift-ci-robot-private-git-cloner
-      secret:
-        secretName: github-credentials-openshift-ci-robot-private-git-cloner
-    - name: manifest-tool-local-pusher
-      secret:
-        secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
-    - name: result-aggregator
-      secret:
-        secretName: result-aggregator
-- agent: kubernetes
-  cluster: build10
-  cron: 8 17 1,17 * *
-  decorate: true
-  decoration_config:
-    skip_cloning: true
-  extra_refs:
-  - base_ref: release-4.22
-    org: openshift
-    repo: openshift-tests-private
-  labels:
-    capability/intranet: intranet
-    ci-operator.openshift.io/cloud: equinix-ocp-metal
-    ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal-qe
-    ci-operator.openshift.io/variant: multi-nightly
-    ci.openshift.io/generator: prowgen
-    job-release: "4.22"
-    pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-metal-ipi-ovn-ipv4-vmedia-multi-arch-day2-amd-f14
-  spec:
-    containers:
-    - args:
-      - --gcs-upload-secret=/secrets/gcs/service-account.json
-      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-      - --lease-server-credentials-file=/etc/boskos/credentials
-      - --oauth-token-path=/usr/local/github-credentials/oauth
-      - --report-credentials-file=/etc/report/credentials
-      - --secret-dir=/secrets/ci-pull-credentials
-      - --target=metal-ipi-ovn-ipv4-vmedia-multi-arch-day2-amd-f14
       - --variant=multi-nightly
       command:
       - ci-operator

--- a/ci-operator/step-registry/baremetal/lab/ipi/multi-arch/baremetal-lab-ipi-multi-arch-commands.sh
+++ b/ci-operator/step-registry/baremetal/lab/ipi/multi-arch/baremetal-lab-ipi-multi-arch-commands.sh
@@ -43,6 +43,7 @@ check_prov_vmedia() {
 }
 
 echo "[INFO] Preparing the baremetalhost resource file to add multi-arch worker node..."
+check_prov_vmedia && vmedia_cluster="true" || vmedia_cluster="false"
 # shellcheck disable=SC2154
 for bmhost in $(yq e -o=j -I=0 '.[]' "${SHARED_DIR}/hosts.yaml"); do
   # shellcheck disable=SC1090
@@ -50,11 +51,20 @@ for bmhost in $(yq e -o=j -I=0 '.[]' "${SHARED_DIR}/hosts.yaml"); do
   if [[ "${name}" == *-a-* ]]; then
     echo "Prepare yaml files for ${name}"
     bmhlist+=("${name}")
-    if check_prov_vmedia; then
+    if ${vmedia_cluster}; then
       prov_address="${redfish_scheme}://${bmc_address}${redfish_base_uri}"
-    else
+      username=$(echo -n "${redfish_user}" | base64)
+      password=$(echo -n "${redfish_password}" | base64)
+    elif [[ "${name}" == *-a-01* ]]; then
       prov_address="${bmc_scheme}://${bmc_address}${bmc_base_uri}"
+      username=$(echo -n "${bmc_user}" | base64)
+      password=$(echo -n "${bmc_pass}" | base64)
+    else
+      prov_address="redfish+https://${bmc_address}${redfish_base_uri}"
+      username=$(echo -n "${redfish_user}" | base64)
+      password=$(echo -n "${redfish_password}" | base64)
     fi
+
     cat > "${DIR}/${name}.yaml" <<EOF
 ---
 apiVersion: v1
@@ -64,8 +74,8 @@ metadata:
   namespace: "${bm_namespace}"
 type: Opaque
 data:
-  username: $(echo -n "${bmc_user}" | base64)
-  password: $(echo -n "${bmc_pass}" | base64)
+  username: ${username}
+  password: ${password}
 ---
 apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost


### PR DESCRIPTION
Added a day 2 pxe job with 2 additional workers with 1 added via ipmi and the other with redfish+https
Removed day 2 job for vmedia multi-arch in 4.22 as it is being tested with day 1 already

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenShift periodic test schedules and baremetal workflow configurations for multi-arch testing
  * Reassigned test execution targets with adjusted cron schedules for improved scheduling
  * Enhanced credential handling mechanisms for baremetal provisioning in multi-arch environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->