### PR TITLE
request a gangway api token for the quay team

### DIFF
--- a/clusters/app.ci/gangway-tokens/quay-ambient-ci/admin_rbac.yaml
+++ b/clusters/app.ci/gangway-tokens/quay-ambient-ci/admin_rbac.yaml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: quay-ambient-ci
+  annotations:
+    openshift.io/description: Service Accounts for quay-ambient-ci
+    openshift.io/display-name: quay-ambient-ci CI
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: periodic-job-bot
+  namespace: quay-ambient-ci
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: api-token-secret
+  namespace: quay-ambient-ci
+  annotations:
+    kubernetes.io/service-account.name: periodic-job-bot
+type: kubernetes.io/service-account-token
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: secret-owner
+  namespace: quay-ambient-ci
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["api-token-secret"]
+    verbs:
+      - get
+      - create
+      - update
+      - patch
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: secret-owner-quay-ambient-ci
+  namespace: quay-ambient-ci
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: quay-ambient-ci
+roleRef:
+  kind: Role
+  apiGroup: rbac.authorization.k8s.io
+  name: secret-owner

--- a/clusters/app.ci/prow/03_deployment/gangway.yaml
+++ b/clusters/app.ci/prow/03_deployment/gangway.yaml
@@ -317,3 +317,6 @@ objects:
   - kind: ServiceAccount
     namespace: quaykonflux
     name: periodic-job-bot
+  - kind: ServiceAccount
+    namespace: quay-ambient-ci
+    name: periodic-job-bot


### PR DESCRIPTION
Requesting a gangway api token for POC with ambient code platform. The purpose is to allow an agent to request a cluster for blackbox/e2e testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Established new CI environment infrastructure with secure authentication and role-based access controls for automated job submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->