### PR TITLE
Add loading of local context for prom-label-proxy

### DIFF
--- a/ci-operator/config/openshift/prom-label-proxy/openshift-prom-label-proxy-main.yaml
+++ b/ci-operator/config/openshift/prom-label-proxy/openshift-prom-label-proxy-main.yaml
@@ -25,11 +25,15 @@ resources:
       memory: 200Mi
 tests:
 - as: vendor
-  commands: make unused && git diff --exit-code
+  commands: |
+    [ -f .ci-operator.rc ] && . .ci-operator.rc
+    make unused && git diff --exit-code
   container:
     from: src
 - as: test-unit
-  commands: make test
+  commands: |
+    [ -f .ci-operator.rc ] && . .ci-operator.rc
+    make test
   container:
     from: src
 - as: e2e-aws


### PR DESCRIPTION
The goal is to pass environment variables to the CI job at the same time we update the downstream fork.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal CI/CD configuration updates to improve test execution workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->