### PR TITLE
INTEROP-8979: Wire Slack webhook into firewatch step

### DIFF
--- a/ci-operator/config/RedHatQE/firewatch/RedHatQE-firewatch-main__slack-webhook-test.yaml
+++ b/ci-operator/config/RedHatQE/firewatch/RedHatQE-firewatch-main__slack-webhook-test.yaml
@@ -1,0 +1,55 @@
+base_images:
+  cli:
+    name: "4.21"
+    namespace: ocp
+    tag: cli
+build_root:
+  image_stream_tag:
+    name: release
+    namespace: openshift
+    tag: rhel-9-release-golang-1.23-openshift-4.20
+images:
+- context_dir: .
+  dockerfile_path: Dockerfile
+  to: firewatch-pr
+resources:
+  '*':
+    requests:
+      cpu: 200m
+      memory: 400Mi
+tests:
+- as: slack-webhook-test
+  cron: 0 23 31 2 *
+  steps:
+    cluster_profile: aws-cspi-qe
+    dependencies:
+      firewatch-report-issues: pipeline:firewatch-pr
+    env:
+      BASE_DOMAIN: cspilp.interop.ccitredhat.com
+      FIREWATCH_CONFIG: |
+        {
+          "failure_rules": [
+            {"step": "*", "failure_type": "all", "classification": "Test", "jira_project": "INTEROP"}
+          ]
+        }
+      FIREWATCH_DEFAULT_JIRA_PROJECT: INTEROP
+      FIREWATCH_DEFAULT_JIRA_ASSIGNEE: mpruitt@redhat.com
+    post:
+    - ref: firewatch-report-issues
+    pre:
+    - ref: ipi-conf
+    - ref: ipi-conf-aws
+    - chain: ipi-install
+    test:
+    - as: noop
+      commands: echo "Slack webhook test - this step intentionally passes"
+      from: cli
+      resources:
+        requests:
+          cpu: 100m
+          memory: 100Mi
+zz_generated_metadata:
+  branch: main
+  org: RedHatQE
+  repo: firewatch
+  variant: slack-webhook-test

--- a/ci-operator/config/RedHatQE/firewatch/RedHatQE-firewatch-main__slack-webhook-test.yaml
+++ b/ci-operator/config/RedHatQE/firewatch/RedHatQE-firewatch-main__slack-webhook-test.yaml
@@ -29,7 +29,7 @@ tests:
       FIREWATCH_CONFIG: |
         {
           "failure_rules": [
-            {"step": "*", "failure_type": "all", "classification": "Test", "jira_project": "INTEROP"}
+            {"step": "*", "failure_type": "all", "classification": "Test", "jira_project": "INTEROP", "slack_user": "mpruitt@redhat.com"}
           ]
         }
       FIREWATCH_DEFAULT_JIRA_PROJECT: INTEROP

--- a/ci-operator/step-registry/firewatch/report-issues/firewatch-report-issues-commands.sh
+++ b/ci-operator/step-registry/firewatch/report-issues/firewatch-report-issues-commands.sh
@@ -42,6 +42,10 @@ if [ -f "${SHARED_DIR}/${FIREWATCH_JIRA_ADDITIONAL_LABELS_FILE}" ]; then
     report_command+=" --additional-labels-file=${SHARED_DIR}/${FIREWATCH_JIRA_ADDITIONAL_LABELS_FILE}"
 fi
 
+if [ -f /tmp/secrets/slack/url ]; then
+    export SLACK_WEBHOOK_URL=$(cat /tmp/secrets/slack/url)
+fi
+
 echo $report_command
 
 eval "$report_command"

--- a/ci-operator/step-registry/firewatch/report-issues/firewatch-report-issues-ref.yaml
+++ b/ci-operator/step-registry/firewatch/report-issues/firewatch-report-issues-ref.yaml
@@ -12,6 +12,9 @@ ref:
     - namespace: test-credentials
       name: firewatch-tool-private-deck-credentials
       mount_path: /tmp/secrets/private-deck
+    - namespace: test-credentials
+      name: firewatch-slack-notify-webhook-url
+      mount_path: /tmp/secrets/slack
   resources:
     requests:
       cpu: 10m
@@ -74,6 +77,9 @@ ref:
   - name: FIREWATCH_CONFIG_FILE_PATH
     default: ""
     documentation: The URL/file path of the Firewatch configuration (json file).
+  - name: SLACK_WEBHOOK_URL
+    default: ""
+    documentation: Slack incoming webhook URL. When set, firewatch posts notifications on issue creation and duplicate detection.
   
   documentation: |-
     Please see the CSPI-QE repository for more documentation on this tool: https://github.com/CSPI-QE/firewatch


### PR DESCRIPTION
## Summary

- Mount `firewatch-slack-notify-webhook-url` secret at `/tmp/secrets/slack` in the `firewatch-report-issues` step
- Read `/tmp/secrets/slack/url` and export as `$SLACK_WEBHOOK_URL` before running firewatch report
- Add `SLACK_WEBHOOK_URL` env var declaration to the step ref
- Add minimal test config (`RedHatQE-firewatch-main__slack-webhook-test.yaml`) with `slack_user` routing to verify end-to-end webhook delivery

## Dependencies

Requires firewatch PR: https://github.com/RedHatQE/firewatch/pull/274
- Adds `slack_user` and `slack_channel` per-rule fields to the webhook payload
- Adds `post_webhook()` static method to `SlackClient`
- Posts structured JSON to `$SLACK_WEBHOOK_URL` on issue creation, duplicate detection, and success

## Prerequisites

- [x] Create `firewatch-slack-notify-webhook-url` secret in `test-credentials` namespace with key `url`

## Test plan

- [ ] Rehearse `slack-webhook-test` job from this PR
- [ ] Verify firewatch posts a Slack notification to the configured webhook with `slack_user` field
- [ ] Confirm no impact to existing firewatch-report-issues consumers (webhook is opt-in via secret)

Relates: https://issues.redhat.com/browse/INTEROP-8979