### PR TITLE
Enhance chart resolution state handling and ReportPortal publish

### DIFF
--- a/ci-operator/step-registry/insights-onprem/cost-onprem-chart/e2e/insights-onprem-cost-onprem-chart-e2e-commands.sh
+++ b/ci-operator/step-registry/insights-onprem/cost-onprem-chart/e2e/insights-onprem-cost-onprem-chart-e2e-commands.sh
@@ -274,6 +274,12 @@ echo "USE_LOCAL_CHART=${USE_LOCAL_CHART}"
 echo "USE_HELM_DEVEL=${USE_HELM_DEVEL}"
 echo "CHART_REF_RESOLVED=${CHART_REF_RESOLVED}"
 
+# Persist chart resolution state to SHARED_DIR for downstream steps (e.g., ReportPortal)
+# Environment variables don't persist across Prow steps, so we write to files
+echo "${CHART_REF_RESOLVED}" > "${SHARED_DIR}/chart_ref_resolved"
+echo "${USE_HELM_DEVEL}" > "${SHARED_DIR}/use_helm_devel"
+echo "${USE_LOCAL_CHART}" > "${SHARED_DIR}/use_local_chart"
+
 echo "========== Running E2E Tests =========="
 
 # Export environment variables for the deployment script
@@ -384,9 +390,18 @@ fi
 
 # Copy JUnit files to SHARED_DIR for ReportPortal post step
 # (ARTIFACT_DIR is step-specific; SHARED_DIR persists across steps)
+# NOTE: SHARED_DIR has a 1MB limit, so we compress the files
 echo "Copying JUnit files to SHARED_DIR for ReportPortal..."
-cp "${ARTIFACT_DIR}"/junit_*.xml "${SHARED_DIR}/" 2>/dev/null || true
-ls "${SHARED_DIR}"/junit_*.xml 2>/dev/null | sed 's/^/  - /' || echo "  (no junit files to copy)"
+if ls "${ARTIFACT_DIR}"/junit_*.xml &>/dev/null; then
+    # Compress to stay under 1MB SHARED_DIR limit
+    tar -czf "${SHARED_DIR}/junit_files.tar.gz" -C "${ARTIFACT_DIR}" junit_*.xml 2>/dev/null || true
+    if [[ -f "${SHARED_DIR}/junit_files.tar.gz" ]]; then
+        _compressed_size=$(stat -f%z "${SHARED_DIR}/junit_files.tar.gz" 2>/dev/null || stat -c%s "${SHARED_DIR}/junit_files.tar.gz" 2>/dev/null || echo "unknown")
+        echo "  - junit_files.tar.gz (compressed JUnit files, ${_compressed_size} bytes)"
+    fi
+else
+    echo "  (no junit files to copy)"
+fi
 
 # Copy version_info.json for ReportPortal metadata
 if [ -f "./version_info.json" ]; then

--- a/ci-operator/step-registry/insights-onprem/cost-onprem-chart/e2e/insights-onprem-cost-onprem-chart-e2e-commands.sh
+++ b/ci-operator/step-registry/insights-onprem/cost-onprem-chart/e2e/insights-onprem-cost-onprem-chart-e2e-commands.sh
@@ -394,7 +394,8 @@ fi
 echo "Copying JUnit files to SHARED_DIR for ReportPortal..."
 if ls "${ARTIFACT_DIR}"/junit_*.xml &>/dev/null; then
     # Compress to stay under 1MB SHARED_DIR limit
-    tar -czf "${SHARED_DIR}/junit_files.tar.gz" -C "${ARTIFACT_DIR}" junit_*.xml 2>/dev/null || true
+    # Use subshell to expand glob inside ARTIFACT_DIR
+    (cd "${ARTIFACT_DIR}" && tar -czf "${SHARED_DIR}/junit_files.tar.gz" junit_*.xml)
     if [[ -f "${SHARED_DIR}/junit_files.tar.gz" ]]; then
         _compressed_size=$(stat -f%z "${SHARED_DIR}/junit_files.tar.gz" 2>/dev/null || stat -c%s "${SHARED_DIR}/junit_files.tar.gz" 2>/dev/null || echo "unknown")
         echo "  - junit_files.tar.gz (compressed JUnit files, ${_compressed_size} bytes)"

--- a/ci-operator/step-registry/insights-onprem/cost-onprem-chart/send-reportportal/insights-onprem-cost-onprem-chart-send-reportportal-commands.sh
+++ b/ci-operator/step-registry/insights-onprem/cost-onprem-chart/send-reportportal/insights-onprem-cost-onprem-chart-send-reportportal-commands.sh
@@ -24,6 +24,24 @@ fi
 DYNAMIC_LAUNCH_NAME=""
 RUN_TYPE=""
 RELEASE_TYPE=""
+CHART_REF_RESOLVED=""
+USE_HELM_DEVEL=""
+USE_LOCAL_CHART=""
+
+load_chart_resolution_state() {
+    # Load chart resolution state from SHARED_DIR (persisted by e2e step)
+    # Environment variables don't persist across Prow steps
+    if [[ -f "${SHARED_DIR}/chart_ref_resolved" ]]; then
+        CHART_REF_RESOLVED=$(cat "${SHARED_DIR}/chart_ref_resolved")
+    fi
+    if [[ -f "${SHARED_DIR}/use_helm_devel" ]]; then
+        USE_HELM_DEVEL=$(cat "${SHARED_DIR}/use_helm_devel")
+    fi
+    if [[ -f "${SHARED_DIR}/use_local_chart" ]]; then
+        USE_LOCAL_CHART=$(cat "${SHARED_DIR}/use_local_chart")
+    fi
+    echo "Loaded chart resolution state: CHART_REF_RESOLVED=${CHART_REF_RESOLVED:-}, USE_HELM_DEVEL=${USE_HELM_DEVEL:-}, USE_LOCAL_CHART=${USE_LOCAL_CHART:-}"
+}
 
 get_chart_version() {
     # Returns chart version from env var or version_info.json
@@ -65,6 +83,9 @@ determine_release_type() {
     elif [[ -n "${CHART_REF_RESOLVED:-}" ]] && [[ "${CHART_REF_RESOLVED}" == *"-rc"* ]]; then
         # Resolved ref contains RC indicator (explicit version like 0.2.20-rc1)
         RELEASE_TYPE="rc"
+    elif [[ -n "${CHART_REF_RESOLVED:-}" ]]; then
+        # Any other non-empty resolved ref is a concrete release tag (e.g., cost-onprem-0.2.19)
+        RELEASE_TYPE="release"
     else
         # Fall back to inferring from chart version (for PRs using local chart)
         local chart_version
@@ -125,7 +146,14 @@ validate_prerequisites() {
 
     local errors=0
 
-    # JUnit files are passed via SHARED_DIR (not ARTIFACT_DIR which is step-specific)
+    # JUnit files are passed via SHARED_DIR as a compressed tarball
+    # (SHARED_DIR has 1MB limit, JUnit files can exceed this)
+    if [[ -f "${SHARED_DIR}/junit_files.tar.gz" ]]; then
+        echo "Found compressed JUnit archive, extracting..."
+        tar -xzf "${SHARED_DIR}/junit_files.tar.gz" -C "${SHARED_DIR}/" 2>/dev/null || true
+        rm -f "${SHARED_DIR}/junit_files.tar.gz"
+    fi
+    
     if ! ls "${SHARED_DIR}"/junit_*.xml &>/dev/null; then
         echo "ERROR: No junit_*.xml files found in ${SHARED_DIR}"
         echo "  Tests may not have run or artifact collection failed"
@@ -263,6 +291,9 @@ generate_datarouter_metadata() {
 
     local metadata_file="${ARTIFACT_DIR}/datarouter_metadata.json"
 
+    # Load chart resolution state from e2e step (env vars don't persist across steps)
+    load_chart_resolution_state
+    
     # Determine run type, release type, and launch name (sets global variables)
     determine_run_type
     determine_release_type


### PR DESCRIPTION
Fix ReportPortal upload failures caused by JUnit files exceeding the 1MB SHARED_DIR limit.

### Changes
- Compress JUnit files into junit_files.tar.gz before copying to SHARED_DIR
- Extract compressed archive in ReportPortal step before processing
- Persist chart resolution state (CHART_REF_RESOLVED, USE_HELM_DEVEL, USE_LOCAL_CHART) to files in SHARED_DIR since environment variables don't persist across Prow steps
- Add load_chart_resolution_state() function to read persisted state
- Fix determine_release_type() to correctly classify explicit non-RC release tags

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed test artifact persistence across CI/CD pipeline steps to ensure reliable test report handling.
  * Improved storage efficiency by compressing test report files to stay within size limits.
  * Enhanced handling of test artifacts when exceeding storage constraints.

* **Improvements**
  * Refined release-type classification logic for chart resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->