### PR TITLE
SANDBOX-1630: enable periodic job for devsandbox e2e tests against prod

### DIFF
--- a/ci-operator/config/codeready-toolchain/toolchain-e2e/codeready-toolchain-toolchain-e2e-master.yaml
+++ b/ci-operator/config/codeready-toolchain/toolchain-e2e/codeready-toolchain-toolchain-e2e-master.yaml
@@ -56,6 +56,18 @@ tests:
           cpu: "3"
           memory: 250Mi
     workflow: codeready-toolchain-aws
+- as: ci-daily-prod
+  cron: 0 9 * * *
+  commands: |
+    export KUBECONF=/tmp/kubeconfig
+    printf '%s' "${KUBECONFIG}" | base64 -d > ${KUBECONF}
+    make test-devsandbox-dashboard-in-container-prod SSO_USERNAME=${SSO_USERNAME} SSO_PASSWORD=${SSO_PASSWORD} KUBECONFIG=${KUBECONF}
+  credentials:
+  - mount_path: /usr/local/sandbox-secrets
+    name: sandbox-test-kc
+    namespace: test-credentials
+  container:
+    from: src
 zz_generated_metadata:
   branch: master
   org: codeready-toolchain

--- a/ci-operator/config/codeready-toolchain/toolchain-e2e/codeready-toolchain-toolchain-e2e-master.yaml
+++ b/ci-operator/config/codeready-toolchain/toolchain-e2e/codeready-toolchain-toolchain-e2e-master.yaml
@@ -58,16 +58,8 @@ tests:
     workflow: codeready-toolchain-aws
 - as: ci-daily-prod
   cron: 0 9 * * *
-  commands: |
-    export KUBECONF=/tmp/kubeconfig
-    printf '%s' "${KUBECONFIG}" | base64 -d > ${KUBECONF}
-    make test-devsandbox-dashboard-in-container-prod SSO_USERNAME=${SSO_USERNAME} SSO_PASSWORD=${SSO_PASSWORD} KUBECONFIG=${KUBECONF}
-  credentials:
-  - mount_path: /usr/local/sandbox-secrets
-    name: sandbox-test-kc
-    namespace: test-credentials
-  container:
-    from: src
+  steps:
+    workflow: codeready-toolchain-devsandbox-dashboard-prod
 zz_generated_metadata:
   branch: master
   org: codeready-toolchain

--- a/ci-operator/config/openshift/ci-tools/openshift-ci-tools-main.yaml
+++ b/ci-operator/config/openshift/ci-tools/openshift-ci-tools-main.yaml
@@ -947,7 +947,6 @@ tests:
         field: gsm-e2e-test-sa-key
         group: test-credentials
         mount_path: /tmp/gcp-creds
-        namespace: ""
       - bundle: hive-hive-credentials
         mount_path: /tmp/hive
         namespace: test-credentials
@@ -1203,7 +1202,6 @@ tests:
         field: api-token
         group: snyk-credentials
         mount_path: /snyk-credentials
-        namespace: ""
       env:
       - default: ci-tools
         name: PROJECT_NAME

--- a/ci-operator/config/openshift/ci-tools/openshift-ci-tools-main.yaml
+++ b/ci-operator/config/openshift/ci-tools/openshift-ci-tools-main.yaml
@@ -947,6 +947,7 @@ tests:
         field: gsm-e2e-test-sa-key
         group: test-credentials
         mount_path: /tmp/gcp-creds
+        namespace: ""
       - bundle: hive-hive-credentials
         mount_path: /tmp/hive
         namespace: test-credentials
@@ -1202,6 +1203,7 @@ tests:
         field: api-token
         group: snyk-credentials
         mount_path: /snyk-credentials
+        namespace: ""
       env:
       - default: ci-tools
         name: PROJECT_NAME

--- a/ci-operator/jobs/codeready-toolchain/toolchain-e2e/codeready-toolchain-toolchain-e2e-master-periodics.yaml
+++ b/ci-operator/jobs/codeready-toolchain/toolchain-e2e/codeready-toolchain-toolchain-e2e-master-periodics.yaml
@@ -89,3 +89,64 @@ periodics:
     - name: result-aggregator
       secret:
         secretName: result-aggregator
+- agent: kubernetes
+  cluster: build01
+  cron: 0 9 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: master
+    org: codeready-toolchain
+    repo: toolchain-e2e
+  labels:
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-codeready-toolchain-toolchain-e2e-master-ci-daily-prod
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --report-credentials-file=/etc/report/credentials
+      - --target=ci-daily-prod
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator

--- a/ci-operator/jobs/codeready-toolchain/toolchain-e2e/codeready-toolchain-toolchain-e2e-master-periodics.yaml
+++ b/ci-operator/jobs/codeready-toolchain/toolchain-e2e/codeready-toolchain-toolchain-e2e-master-periodics.yaml
@@ -103,6 +103,16 @@ periodics:
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-codeready-toolchain-toolchain-e2e-master-ci-daily-prod
+  reporter_config:
+    slack:
+      channel: '#sandbox-ci-reports'
+      job_states_to_report:
+      - success
+      - failure
+      - error
+      report_template: '{{ if eq .Status.State "success" }} :succeeded: {{ else }}
+        :failed: {{ end }} Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+        logs>'
   spec:
     containers:
     - args:

--- a/ci-operator/jobs/codeready-toolchain/toolchain-e2e/codeready-toolchain-toolchain-e2e-master-periodics.yaml
+++ b/ci-operator/jobs/codeready-toolchain/toolchain-e2e/codeready-toolchain-toolchain-e2e-master-periodics.yaml
@@ -103,22 +103,14 @@ periodics:
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-codeready-toolchain-toolchain-e2e-master-ci-daily-prod
-  reporter_config:
-    slack:
-      channel: '#sandbox-ci-reports'
-      job_states_to_report:
-      - success
-      - failure
-      - error
-      report_template: '{{ if eq .Status.State "success" }} :succeeded: {{ else }}
-        :failed: {{ end }} Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
-        logs>'
   spec:
     containers:
     - args:
       - --gcs-upload-secret=/secrets/gcs/service-account.json
       - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
       - --target=ci-daily-prod
       command:
       - ci-operator
@@ -137,6 +129,12 @@ periodics:
         requests:
           cpu: 10m
       volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
       - mountPath: /secrets/gcs
         name: gcs-credentials
         readOnly: true
@@ -151,6 +149,15 @@ periodics:
         readOnly: true
     serviceAccountName: ci-operator
     volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
     - name: manifest-tool-local-pusher
       secret:
         secretName: manifest-tool-local-pusher

--- a/ci-operator/step-registry/codeready-toolchain/devsandbox-dashboard-prod/OWNERS
+++ b/ci-operator/step-registry/codeready-toolchain/devsandbox-dashboard-prod/OWNERS
@@ -1,0 +1,23 @@
+approvers:
+- alexeykazakov
+- fbm3307
+- matousjobanek
+- metlos
+- mfrancisc
+- rajivnathan
+- ranakan19
+- rsoaresd
+- xcoulon
+- jrosental
+options: {}
+reviewers:
+- alexeykazakov
+- fbm3307
+- matousjobanek
+- metlos
+- mfrancisc
+- rajivnathan
+- ranakan19
+- rsoaresd
+- xcoulon
+- jrosental

--- a/ci-operator/step-registry/codeready-toolchain/devsandbox-dashboard-prod/codeready-toolchain-devsandbox-dashboard-prod-commands.sh
+++ b/ci-operator/step-registry/codeready-toolchain/devsandbox-dashboard-prod/codeready-toolchain-devsandbox-dashboard-prod-commands.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+
+export KUBECONF=/tmp/kubeconfig
+printf '%s' "${KUBECONFIG}" | base64 -d > "${KUBECONF}"
+make test-devsandbox-dashboard-in-container-prod \
+  SSO_USERNAME="${SSO_USERNAME}" \
+  SSO_PASSWORD="${SSO_PASSWORD}" \
+  KUBECONFIG="${KUBECONF}"

--- a/ci-operator/step-registry/codeready-toolchain/devsandbox-dashboard-prod/codeready-toolchain-devsandbox-dashboard-prod-commands.sh
+++ b/ci-operator/step-registry/codeready-toolchain/devsandbox-dashboard-prod/codeready-toolchain-devsandbox-dashboard-prod-commands.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 export KUBECONF=/tmp/kubeconfig
-printf '%s' "${KUBECONFIG}" | base64 -d > "${KUBECONF}"
+printf '%s' "${KUBECONFIG_E2E_TESTS}" | base64 -d > "${KUBECONF}"
 make test-devsandbox-dashboard-in-container-prod \
   SSO_USERNAME="${SSO_USERNAME}" \
   SSO_PASSWORD="${SSO_PASSWORD}" \

--- a/ci-operator/step-registry/codeready-toolchain/devsandbox-dashboard-prod/codeready-toolchain-devsandbox-dashboard-prod-commands.sh
+++ b/ci-operator/step-registry/codeready-toolchain/devsandbox-dashboard-prod/codeready-toolchain-devsandbox-dashboard-prod-commands.sh
@@ -2,6 +2,6 @@
 set -euo pipefail
 
 export KUBECONF=/tmp/kubeconfig
-cat /usr/local/sandbox-secrets/KUBECONFIG_E2E_TESTS 2>/dev/null | base64 -d > "${KUBECONF}"
+cat /usr/local/sandbox-secrets-test-kc/KUBECONFIG_E2E_TESTS 2>/dev/null | base64 -d > "${KUBECONF}"
 make test-devsandbox-dashboard-e2e-prod \
   KUBECONFIG="${KUBECONF}"

--- a/ci-operator/step-registry/codeready-toolchain/devsandbox-dashboard-prod/codeready-toolchain-devsandbox-dashboard-prod-commands.sh
+++ b/ci-operator/step-registry/codeready-toolchain/devsandbox-dashboard-prod/codeready-toolchain-devsandbox-dashboard-prod-commands.sh
@@ -2,8 +2,6 @@
 set -euo pipefail
 
 export KUBECONF=/tmp/kubeconfig
-printf '%s' "${KUBECONFIG_E2E_TESTS}" | base64 -d > "${KUBECONF}"
+cat /usr/local/sandbox-secrets/KUBECONFIG_E2E_TESTS 2>/dev/null | base64 -d > "${KUBECONF}"
 make test-devsandbox-dashboard-in-container-prod \
-  SSO_USERNAME="${SSO_USERNAME}" \
-  SSO_PASSWORD="${SSO_PASSWORD}" \
   KUBECONFIG="${KUBECONF}"

--- a/ci-operator/step-registry/codeready-toolchain/devsandbox-dashboard-prod/codeready-toolchain-devsandbox-dashboard-prod-commands.sh
+++ b/ci-operator/step-registry/codeready-toolchain/devsandbox-dashboard-prod/codeready-toolchain-devsandbox-dashboard-prod-commands.sh
@@ -3,5 +3,5 @@ set -euo pipefail
 
 export KUBECONF=/tmp/kubeconfig
 cat /usr/local/sandbox-secrets/KUBECONFIG_E2E_TESTS 2>/dev/null | base64 -d > "${KUBECONF}"
-make test-devsandbox-dashboard-in-container-prod \
+make test-devsandbox-dashboard-e2e-prod \
   KUBECONFIG="${KUBECONF}"

--- a/ci-operator/step-registry/codeready-toolchain/devsandbox-dashboard-prod/codeready-toolchain-devsandbox-dashboard-prod-commands.sh
+++ b/ci-operator/step-registry/codeready-toolchain/devsandbox-dashboard-prod/codeready-toolchain-devsandbox-dashboard-prod-commands.sh
@@ -2,6 +2,6 @@
 set -euo pipefail
 
 export KUBECONF=/tmp/kubeconfig
-cat /usr/local/sandbox-secrets-test-kc/KUBECONFIG_E2E_TESTS 2>/dev/null | base64 -d > "${KUBECONF}"
+cat /usr/local/sandbox-secrets/KUBECONFIG_E2E_TESTS 2>/dev/null | base64 -d > "${KUBECONF}"
 make test-devsandbox-dashboard-e2e-prod \
   KUBECONFIG="${KUBECONF}"

--- a/ci-operator/step-registry/codeready-toolchain/devsandbox-dashboard-prod/codeready-toolchain-devsandbox-dashboard-prod-commands.sh
+++ b/ci-operator/step-registry/codeready-toolchain/devsandbox-dashboard-prod/codeready-toolchain-devsandbox-dashboard-prod-commands.sh
@@ -3,5 +3,6 @@ set -euo pipefail
 
 export KUBECONF=/tmp/kubeconfig
 cat /usr/local/sandbox-secrets/KUBECONFIG_E2E_TESTS 2>/dev/null | base64 -d > "${KUBECONF}"
+echo "username: $(cat /usr/local/sandbox-secrets/SSO_USERNAME 2>/dev/null)"
 make test-devsandbox-dashboard-e2e-prod \
   KUBECONFIG="${KUBECONF}"

--- a/ci-operator/step-registry/codeready-toolchain/devsandbox-dashboard-prod/codeready-toolchain-devsandbox-dashboard-prod-commands.sh
+++ b/ci-operator/step-registry/codeready-toolchain/devsandbox-dashboard-prod/codeready-toolchain-devsandbox-dashboard-prod-commands.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 export KUBECONF=/tmp/kubeconfig
 cat /usr/local/sandbox-secrets/KUBECONFIG_E2E_TESTS 2>/dev/null | base64 -d > "${KUBECONF}"
-echo "username: $(cat /usr/local/sandbox-secrets/SSO_USERNAME 2>/dev/null)"
+SSO_USER=$(cat /usr/local/sandbox-secrets/SSO_USERNAME 2>/dev/null)
+echo "username: ${SSO_USER} (length: ${#SSO_USER})"
 make test-devsandbox-dashboard-e2e-prod \
   KUBECONFIG="${KUBECONF}"

--- a/ci-operator/step-registry/codeready-toolchain/devsandbox-dashboard-prod/codeready-toolchain-devsandbox-dashboard-prod-commands.sh
+++ b/ci-operator/step-registry/codeready-toolchain/devsandbox-dashboard-prod/codeready-toolchain-devsandbox-dashboard-prod-commands.sh
@@ -3,7 +3,5 @@ set -euo pipefail
 
 export KUBECONF=/tmp/kubeconfig
 cat /usr/local/sandbox-secrets/KUBECONFIG_E2E_TESTS 2>/dev/null | base64 -d > "${KUBECONF}"
-SSO_USER=$(cat /usr/local/sandbox-secrets/SSO_USERNAME 2>/dev/null)
-echo "username: ${SSO_USER} (length: ${#SSO_USER})"
 make test-devsandbox-dashboard-e2e-prod \
   KUBECONFIG="${KUBECONF}"

--- a/ci-operator/step-registry/codeready-toolchain/devsandbox-dashboard-prod/codeready-toolchain-devsandbox-dashboard-prod-ref.metadata.json
+++ b/ci-operator/step-registry/codeready-toolchain/devsandbox-dashboard-prod/codeready-toolchain-devsandbox-dashboard-prod-ref.metadata.json
@@ -1,0 +1,29 @@
+{
+	"path": "codeready-toolchain/devsandbox-dashboard-prod/codeready-toolchain-devsandbox-dashboard-prod-ref.yaml",
+	"owners": {
+		"approvers": [
+			"alexeykazakov",
+			"fbm3307",
+			"matousjobanek",
+			"metlos",
+			"mfrancisc",
+			"rajivnathan",
+			"ranakan19",
+			"rsoaresd",
+			"xcoulon",
+			"jrosental"
+		],
+		"reviewers": [
+			"alexeykazakov",
+			"fbm3307",
+			"matousjobanek",
+			"metlos",
+			"mfrancisc",
+			"rajivnathan",
+			"ranakan19",
+			"rsoaresd",
+			"xcoulon",
+			"jrosental"
+		]
+	}
+}

--- a/ci-operator/step-registry/codeready-toolchain/devsandbox-dashboard-prod/codeready-toolchain-devsandbox-dashboard-prod-ref.yaml
+++ b/ci-operator/step-registry/codeready-toolchain/devsandbox-dashboard-prod/codeready-toolchain-devsandbox-dashboard-prod-ref.yaml
@@ -11,6 +11,6 @@ ref:
       cpu: "3"
       memory: 250Mi
   documentation: |-
-    Runs Developer Sandbox Dashboard E2E tests against production environment. Expects
-    base64-encoded kubeconfig in KUBECONFIG (from CI credentials) and SSO env
-    from the mounted sandbox-test-kc secret. Does not provision a test cluster.
+    Runs Developer Sandbox Dashboard E2E tests against production environment. Kubeconfig
+    is read as base64 from file KUBECONFIG_E2E_TESTS under the mounted sandbox-test-kc secret
+    at /usr/local/sandbox-secrets. Does not provision a test cluster.

--- a/ci-operator/step-registry/codeready-toolchain/devsandbox-dashboard-prod/codeready-toolchain-devsandbox-dashboard-prod-ref.yaml
+++ b/ci-operator/step-registry/codeready-toolchain/devsandbox-dashboard-prod/codeready-toolchain-devsandbox-dashboard-prod-ref.yaml
@@ -3,7 +3,7 @@ ref:
   from: src
   commands: codeready-toolchain-devsandbox-dashboard-prod-commands.sh
   credentials:
-  - mount_path: /usr/local/sandbox-secrets
+  - mount_path: /usr/local/sandbox-secrets-test-kc
     name: sandbox-test-kc
     namespace: test-credentials
   - mount_path: /usr/local/sandbox-secrets

--- a/ci-operator/step-registry/codeready-toolchain/devsandbox-dashboard-prod/codeready-toolchain-devsandbox-dashboard-prod-ref.yaml
+++ b/ci-operator/step-registry/codeready-toolchain/devsandbox-dashboard-prod/codeready-toolchain-devsandbox-dashboard-prod-ref.yaml
@@ -6,6 +6,9 @@ ref:
   - mount_path: /usr/local/sandbox-secrets
     name: sandbox-test-kc
     namespace: test-credentials
+  - mount_path: /usr/local/sandbox-secrets
+    name: sandbox-devsso
+    namespace: test-credentials
   resources:
     requests:
       cpu: "3"

--- a/ci-operator/step-registry/codeready-toolchain/devsandbox-dashboard-prod/codeready-toolchain-devsandbox-dashboard-prod-ref.yaml
+++ b/ci-operator/step-registry/codeready-toolchain/devsandbox-dashboard-prod/codeready-toolchain-devsandbox-dashboard-prod-ref.yaml
@@ -1,0 +1,16 @@
+ref:
+  as: codeready-toolchain-devsandbox-dashboard-prod
+  from: src
+  commands: codeready-toolchain-devsandbox-dashboard-prod-commands.sh
+  credentials:
+  - mount_path: /usr/local/sandbox-secrets
+    name: sandbox-test-kc
+    namespace: test-credentials
+  resources:
+    requests:
+      cpu: "3"
+      memory: 250Mi
+  documentation: |-
+    Runs Developer Sandbox Dashboard E2E tests against production environment. Expects
+    base64-encoded kubeconfig in KUBECONFIG (from CI credentials) and SSO env
+    from the mounted sandbox-test-kc secret. Does not provision a test cluster.

--- a/ci-operator/step-registry/codeready-toolchain/devsandbox-dashboard-prod/codeready-toolchain-devsandbox-dashboard-prod-ref.yaml
+++ b/ci-operator/step-registry/codeready-toolchain/devsandbox-dashboard-prod/codeready-toolchain-devsandbox-dashboard-prod-ref.yaml
@@ -3,11 +3,8 @@ ref:
   from: src
   commands: codeready-toolchain-devsandbox-dashboard-prod-commands.sh
   credentials:
-  - mount_path: /usr/local/sandbox-secrets-test-kc
-    name: sandbox-test-kc
-    namespace: test-credentials
   - mount_path: /usr/local/sandbox-secrets
-    name: sandbox-devsso
+    name: sandbox-test-kc
     namespace: test-credentials
   resources:
     requests:

--- a/ci-operator/step-registry/codeready-toolchain/devsandbox-dashboard-prod/codeready-toolchain-devsandbox-dashboard-prod-workflow.metadata.json
+++ b/ci-operator/step-registry/codeready-toolchain/devsandbox-dashboard-prod/codeready-toolchain-devsandbox-dashboard-prod-workflow.metadata.json
@@ -1,0 +1,29 @@
+{
+	"path": "codeready-toolchain/devsandbox-dashboard-prod/codeready-toolchain-devsandbox-dashboard-prod-workflow.yaml",
+	"owners": {
+		"approvers": [
+			"alexeykazakov",
+			"fbm3307",
+			"matousjobanek",
+			"metlos",
+			"mfrancisc",
+			"rajivnathan",
+			"ranakan19",
+			"rsoaresd",
+			"xcoulon",
+			"jrosental"
+		],
+		"reviewers": [
+			"alexeykazakov",
+			"fbm3307",
+			"matousjobanek",
+			"metlos",
+			"mfrancisc",
+			"rajivnathan",
+			"ranakan19",
+			"rsoaresd",
+			"xcoulon",
+			"jrosental"
+		]
+	}
+}

--- a/ci-operator/step-registry/codeready-toolchain/devsandbox-dashboard-prod/codeready-toolchain-devsandbox-dashboard-prod-workflow.yaml
+++ b/ci-operator/step-registry/codeready-toolchain/devsandbox-dashboard-prod/codeready-toolchain-devsandbox-dashboard-prod-workflow.yaml
@@ -1,0 +1,8 @@
+workflow:
+  as: codeready-toolchain-devsandbox-dashboard-prod
+  steps:
+    test:
+    - ref: codeready-toolchain-devsandbox-dashboard-prod
+  documentation: |-
+    Minimal workflow for in-container Developer Sandbox Dashboard E2E tests against production environment: no cluster
+    profile, no IPI/AWS. Credentials and test logic live in the ref.


### PR DESCRIPTION
# Description
Enable periodic job for devsandbox e2e tests against prod

## Issue ticket number and link
[SANDBOX-1630](https://issues.redhat.com/browse/SANDBOX-1630)

Assisted-by:  Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new daily automated job to run production-targeted Developer Sandbox Dashboard end-to-end tests each morning.
  * Added a minimal workflow and test step that executes those E2E checks using provided credentials and kubeconfig, with resource requests configured.
  * Added ownership metadata to assign approvers and reviewers for the new CI workflow and step.
  * Cleaned up two credential entries by removing empty namespace fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[SANDBOX-1630]: https://redhat.atlassian.net/browse/SANDBOX-1630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ