### PR TITLE
Grant ship-help write access to payload resources on app.ci

### DIFF
--- a/clusters/app.ci/assets/ship-help_rbac.yaml
+++ b/clusters/app.ci/assets/ship-help_rbac.yaml
@@ -26,3 +26,90 @@ metadata:
   namespace: ci
   annotations:
     kubernetes.io/service-account.name: ship-help
+---
+# ClusterRole granting patch access to release payload resources.
+# Used by the ship-help-bot patch_manager coordinator to force-accept
+# rejected payloads via the force_accept_payload tool.
+# See: https://github.com/openshift-eng/ship-help-bot/pull/41
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ship-help-payload-manager
+rules:
+- apiGroups: ["image.openshift.io"]
+  resources: ["imagestreamtags"]
+  verbs: ["get", "patch"]
+- apiGroups: ["release.openshift.io"]
+  resources: ["releasepayloads"]
+  verbs: ["get", "patch"]
+---
+# RoleBindings scoped to the OCP release namespaces where payloads live.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ship-help-payload-manager
+  namespace: ocp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ship-help-payload-manager
+subjects:
+- kind: ServiceAccount
+  name: ship-help
+  namespace: ci
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ship-help-payload-manager
+  namespace: ocp-arm64
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ship-help-payload-manager
+subjects:
+- kind: ServiceAccount
+  name: ship-help
+  namespace: ci
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ship-help-payload-manager
+  namespace: ocp-s390x
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ship-help-payload-manager
+subjects:
+- kind: ServiceAccount
+  name: ship-help
+  namespace: ci
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ship-help-payload-manager
+  namespace: ocp-ppc64le
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ship-help-payload-manager
+subjects:
+- kind: ServiceAccount
+  name: ship-help
+  namespace: ci
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ship-help-payload-manager
+  namespace: ocp-multi
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ship-help-payload-manager
+subjects:
+- kind: ServiceAccount
+  name: ship-help
+  namespace: ci


### PR DESCRIPTION
## Summary

- Adds a `ship-help-payload-manager` ClusterRole with `get` + `patch` on `imagestreamtags` (image.openshift.io) and `releasepayloads` (release.openshift.io)
- Binds the ClusterRole to the existing `ship-help` ServiceAccount via namespace-scoped RoleBindings in the five OCP release namespaces: `ocp`, `ocp-arm64`, `ocp-s390x`, `ocp-ppc64le`, `ocp-multi`

## Motivation

[openshift-eng/ship-help-bot#41](https://github.com/openshift-eng/ship-help-bot/pull/41) adds a `force_accept_payload` tool to the patch_manager coordinator. This tool patches both the ImageStreamTag and ReleasePayload custom resource on app.ci to override a payload's phase to "Accepted". The existing `cluster-reader` binding ([#77639](https://github.com/openshift/release/pull/77639), [#77692](https://github.com/openshift/release/pull/77692)) only provides read access.

The permissions are scoped as narrowly as possible: only `get` and `patch` verbs, only on `imagestreamtags` and `releasepayloads`, and only in the specific namespaces where OCP release payloads are managed.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated access control permissions to enable the ship-help system to manage release payloads and associated resources across multiple OCP release environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->