### PR TITLE
OCM-23822 | feat: rosa-sts-upgrade-sdn-staging-main FVT migration

### DIFF
--- a/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main.yaml
+++ b/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main.yaml
@@ -307,6 +307,40 @@ tests:
   secrets:
   - mount_path: /usr/local/cs-qe-credentials
     name: cs-qe-credentials
+- as: ocm-fvt-periodic-cs-rosa-sts-upgrade-sdn-staging-main
+  capabilities:
+  - nested-podman
+  commands: |
+    env -i bash --norc --noprofile <<'EOF' > /tmp/podman.env
+    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
+    export AWS_SHARED_VPC_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
+    export ENABLE_JIRA_REPORTING=true
+
+    source /usr/local/cs-qe-credentials/ocm-tokens
+    source /usr/local/cs-qe-credentials/jira-cred
+
+    env | grep -v '^_='
+    EOF
+
+    podman run \
+      --authfile /usr/local/cs-qe-credentials/.dockerconfigjson \
+      --env-file /tmp/podman.env \
+      -v /usr/local/cs-qe-credentials:/credentials:ro,z \
+      --rm \
+      quay.io/redhat-services-prod/ocmci/ocmci:latest \
+      ocmtest test \
+        --service cms \
+        --job cs-rosa-sts-upgrade-sdn-staging-main \
+        --reportJiraTicket
+  container:
+    from: nested-podman
+    memory_backed_volume:
+      size: 1Gi
+  cron: 0 8 * * *
+  nested_podman: true
+  secrets:
+  - mount_path: /usr/local/cs-qe-credentials
+    name: cs-qe-credentials
 zz_generated_metadata:
   branch: main
   org: openshift-online

--- a/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-periodics.yaml
@@ -434,6 +434,76 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-online-rosa-e2e-main-ocm-fvt-periodic-cs-rosa-sts-upgrade-sdn-staging-main
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/cs-qe-credentials
+      - --target=ocm-fvt-periodic-cs-rosa-sts-upgrade-sdn-staging-main
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /secrets/cs-qe-credentials
+        name: cs-qe-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: cs-qe-credentials
+      secret:
+        secretName: cs-qe-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build06
+  cron: 0 8 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-online
+    repo: rosa-e2e
+  labels:
+    capability/nested-podman: nested-podman
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-online-rosa-e2e-main-ocm-fvt-periodic-cs-rosa-sts-upgrade-staging-main
   spec:
     containers:
@@ -1010,9 +1080,9 @@ periodics:
       - failure
       - error
       report_template: |-
-        {{if eq .Status.State "success"}}:large_green_circle: *ROSA CI Daily Status:* all jobs passing{{else}}:red_circle: *ROSA CI Daily Status:* failures detected{{end}} (<{{.Status.URL}}|Full report>)
-        <https://prow.ci.openshift.org/?type=periodic&job=*rosa-hcp-e2e-nightly*|ROSA E2E> | <https://prow.ci.openshift.org/?type=periodic&job=*ocm-fvt*rosa*|OCM FVT> | <https://prow.ci.openshift.org/?type=periodic&job=*main-nightly-*e2e-rosa-hcp-ovn|HCP Conformance> | <https://prow.ci.openshift.org/?type=periodic&job=*main-nightly-*e2e-rosa-sts-ovn|Classic STS Conformance>
-        :bar_chart: <https://sippy.dptools.openshift.org/sippy-ng/release/rosa-stage|Sippy>
+        {{if eq .Status.State "success"}} :white_check_mark: ROSA CI Daily Status: all tracked jobs healthy. <{{.Status.URL}}|Full report> | <https://sippy.dptools.openshift.org/sippy-ng/release/rosa-stage|Sippy>
+        <https://prow.ci.openshift.org/?type=periodic&job=*rosa-hcp-e2e-nightly*|ROSA E2E> | <https://prow.ci.openshift.org/?type=periodic&job=*ocm-fvt*rosa*|OCM FVT> | <https://prow.ci.openshift.org/?type=periodic&job=*main-nightly-*e2e-rosa-*-ovn|Conformance> {{else}} :x: ROSA CI Daily Status: some jobs failing. <{{.Status.URL}}|Full report> | <https://sippy.dptools.openshift.org/sippy-ng/release/rosa-stage|Sippy>
+        <https://prow.ci.openshift.org/?type=periodic&job=*rosa-hcp-e2e-nightly*|ROSA E2E> | <https://prow.ci.openshift.org/?type=periodic&job=*ocm-fvt*rosa*|OCM FVT> | <https://prow.ci.openshift.org/?type=periodic&job=*main-nightly-*e2e-rosa-*-ovn|Conformance> {{end}}
   spec:
     containers:
     - args:


### PR DESCRIPTION
This PR is for migrating rosa-sts-upgrade-sdn FVT to Prow.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new daily periodic end-to-end test job for STS upgrade scenarios with integrated JIRA reporting to improve QA and issue tracking.
  * Cleaned up credential configuration entries to remove redundant fields and improve configuration consistency for test credential mounts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->