### PR TITLE
NO-JIRA: feat: avoid running slack notify on rehersals

### DIFF
--- a/ci-operator/config/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main.yaml
+++ b/ci-operator/config/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main.yaml
@@ -52,7 +52,7 @@ tests:
   steps:
     workflow: openshift-edge-tooling-ci-monitor
 - as: pr-notifier
-  cron: 0 3 * * 0-5
+  cron: 0 7 * * 0-5
   restrict_network_access: false
   steps:
     env:

--- a/ci-operator/jobs/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main-periodics.yaml
@@ -79,7 +79,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build05
-  cron: 0 3 * * 0-5
+  cron: 0 7 * * 0-5
   decorate: true
   decoration_config:
     skip_cloning: true

--- a/ci-operator/step-registry/openshift/edge-tooling/gh-notifier/openshift-edge-tooling-gh-notifier-commands.sh
+++ b/ci-operator/step-registry/openshift/edge-tooling/gh-notifier/openshift-edge-tooling-gh-notifier-commands.sh
@@ -45,13 +45,12 @@ fi
 
 echo "Working directory: ${PWD}"
 
+# Presubmit/rehearse jobs set PULL_NUMBER; omit PROW_JOB_URL so the notifier does not
+# surface a deck link (noise). Periodics and other non-PR jobs get a logs URL.
 job_base="https://prow.ci.openshift.org/view/gs/test-platform-results"
-if [[ -n "${PULL_NUMBER:-}" ]]; then
-  PROW_JOB_URL="${job_base}/pr-logs/pull/${REPO_OWNER}_${REPO_NAME}/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
-else
-  PROW_JOB_URL="${job_base}/logs/${JOB_NAME}/${BUILD_ID}"
+if [[ -z "${PULL_NUMBER:-}" ]]; then
+  export PROW_JOB_URL="${job_base}/logs/${JOB_NAME}/${BUILD_ID}"
 fi
-export PROW_JOB_URL
 
 GH_NOTIFIER_INVOKE="${GH_NOTIFIER_INVOKE:-python3 gh-notifier/gh-notifier.py}"
 bash -c "set -euo pipefail; ${GH_NOTIFIER_INVOKE}"


### PR DESCRIPTION
update cron timer to run 7utc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the schedule for GitHub notifier workflow to run at 7 AM (previously 3 AM) on weekdays.
  * Modified how pull request job notifications handle workflow links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->