### PR TITLE
NO-JIRA: refactor(owners): consolidate edge team aliases

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -93,15 +93,22 @@ aliases:
   - danmanor
   - rccrdpccl
   - gamli75
-  single-node:
-  - romfreiman
-  - eranco74
-  - tsorya
-  - omertuc
-  - adriengentil
-  - danmanor
-  - eggfoobar
-  - jeff-roche
+  ecosystem-edge-single-node:
+  - Neilhamza
+  - brandisher
+  - copejon
+  - eslutsky
+  - fonta-rh
+  - fracappa
+  - ggiguash
+  - jaypoulz
+  - jerpeter1
+  - lucaconsalvi
+  - pacevedom
+  - pmtk
+  - qJkee
+  - suleymanakbas91
+  - vimauro
   edge-eco:
   - romfreiman
   - tsorya
@@ -414,41 +421,52 @@ aliases:
   - smongiar
   - mcarlett
   - croway
-  microshift-reviewers:
+  openshift-edge-reviewers:
+  - Neilhamza
   - agullon
   - copejon
   - dhensel-rh
+  - eggfoobar
   - eslutsky
+  - fonta-rh
+  - fracappa
   - ggiguash
+  - jaypoulz
+  - jeff-roche
   - jerpeter1
   - jogeo
+  - kasturinarra
+  - lucaconsalvi
+  - mmakwana30
   - pacevedom
   - pmtk
+  - qJkee
   - vanhalenar
-  microshift-approvers:
+  - vimauro
+  openshift-edge-approvers:
+  - Neilhamza
+  - agullon
+  - brandisher
   - copejon
+  - dhensel-rh
+  - eggfoobar
   - eslutsky
+  - fonta-rh
+  - fracappa
   - ggiguash
+  - jaypoulz
+  - jeff-roche
   - jerpeter1
+  - jogeo
+  - kasturinarra
+  - lucaconsalvi
+  - mmakwana30
   - pacevedom
   - pmtk
-  edge-enablement-reviewers:
-  - jerpeter1
-  - eggfoobar
-  - jeff-roche
-  - suleymanakbas91
   - qJkee
-  - jaypoulz
-  - pacevedom
-  edge-enablement-approvers:
-  - jerpeter1
-  - eggfoobar
-  - jeff-roche
   - suleymanakbas91
-  - brandisher
-  - qJkee
-  - jaypoulz
-  - pacevedom
+  - vanhalenar
+  - vimauro
   vsphere-reviewers:
   - jcpowermac
   - patrickdillon

--- a/ci-operator/step-registry/agent/e2e/two-node/OWNERS
+++ b/ci-operator/step-registry/agent/e2e/two-node/OWNERS
@@ -1,2 +1,2 @@
 approvers:
-  - edge-enablement-approvers
+  - openshift-edge-approvers

--- a/ci-operator/step-registry/agent/e2e/two-node/arbiter/ipv4/agent-e2e-two-node-arbiter-ipv4-workflow.metadata.json
+++ b/ci-operator/step-registry/agent/e2e/two-node/arbiter/ipv4/agent-e2e-two-node-arbiter-ipv4-workflow.metadata.json
@@ -2,7 +2,7 @@
 	"path": "agent/e2e/two-node/arbiter/ipv4/agent-e2e-two-node-arbiter-ipv4-workflow.yaml",
 	"owners": {
 		"approvers": [
-			"edge-enablement-approvers"
+			"openshift-edge-approvers"
 		]
 	}
 }

--- a/ci-operator/step-registry/agent/e2e/two-node/fencing/ipv4/agent-e2e-two-node-fencing-ipv4-workflow.metadata.json
+++ b/ci-operator/step-registry/agent/e2e/two-node/fencing/ipv4/agent-e2e-two-node-fencing-ipv4-workflow.metadata.json
@@ -2,7 +2,7 @@
 	"path": "agent/e2e/two-node/fencing/ipv4/agent-e2e-two-node-fencing-ipv4-workflow.yaml",
 	"owners": {
 		"approvers": [
-			"edge-enablement-approvers"
+			"openshift-edge-approvers"
 		]
 	}
 }

--- a/ci-operator/step-registry/baremetalds/sno/OWNERS
+++ b/ci-operator/step-registry/baremetalds/sno/OWNERS
@@ -1,2 +1,5 @@
 approvers:
-- single-node
+- ecosystem-edge-single-node
+- openshift-edge-approvers
+reviewers:
+- openshift-edge-reviewers

--- a/ci-operator/step-registry/baremetalds/sno/baremetalds-sno-workflow.metadata.json
+++ b/ci-operator/step-registry/baremetalds/sno/baremetalds-sno-workflow.metadata.json
@@ -2,7 +2,11 @@
 	"path": "baremetalds/sno/baremetalds-sno-workflow.yaml",
 	"owners": {
 		"approvers": [
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-approvers"
+		],
+		"reviewers": [
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/baremetalds/sno/conf/baremetalds-sno-conf-ref.metadata.json
+++ b/ci-operator/step-registry/baremetalds/sno/conf/baremetalds-sno-conf-ref.metadata.json
@@ -2,7 +2,11 @@
 	"path": "baremetalds/sno/conf/baremetalds-sno-conf-ref.yaml",
 	"owners": {
 		"approvers": [
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-approvers"
+		],
+		"reviewers": [
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/baremetalds/sno/gather/baremetalds-sno-gather-ref.metadata.json
+++ b/ci-operator/step-registry/baremetalds/sno/gather/baremetalds-sno-gather-ref.metadata.json
@@ -2,7 +2,11 @@
 	"path": "baremetalds/sno/gather/baremetalds-sno-gather-ref.yaml",
 	"owners": {
 		"approvers": [
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-approvers"
+		],
+		"reviewers": [
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/baremetalds/sno/rename/baremetalds-sno-rename-ref.metadata.json
+++ b/ci-operator/step-registry/baremetalds/sno/rename/baremetalds-sno-rename-ref.metadata.json
@@ -2,7 +2,11 @@
 	"path": "baremetalds/sno/rename/baremetalds-sno-rename-ref.yaml",
 	"owners": {
 		"approvers": [
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-approvers"
+		],
+		"reviewers": [
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/baremetalds/sno/setup/baremetalds-sno-setup-ref.metadata.json
+++ b/ci-operator/step-registry/baremetalds/sno/setup/baremetalds-sno-setup-ref.metadata.json
@@ -2,7 +2,11 @@
 	"path": "baremetalds/sno/setup/baremetalds-sno-setup-ref.yaml",
 	"owners": {
 		"approvers": [
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-approvers"
+		],
+		"reviewers": [
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/baremetalds/sno/test/baremetalds-sno-test-ref.metadata.json
+++ b/ci-operator/step-registry/baremetalds/sno/test/baremetalds-sno-test-ref.metadata.json
@@ -2,7 +2,11 @@
 	"path": "baremetalds/sno/test/baremetalds-sno-test-ref.yaml",
 	"owners": {
 		"approvers": [
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-approvers"
+		],
+		"reviewers": [
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/baremetalds/two-node/OWNERS
+++ b/ci-operator/step-registry/baremetalds/two-node/OWNERS
@@ -1,2 +1,2 @@
 approvers:
-  - edge-enablement-approvers
+  - openshift-edge-approvers

--- a/ci-operator/step-registry/baremetalds/two-node/arbiter/OWNERS
+++ b/ci-operator/step-registry/baremetalds/two-node/arbiter/OWNERS
@@ -1,2 +1,2 @@
 approvers:
-  - edge-enablement-approvers
+  - openshift-edge-approvers

--- a/ci-operator/step-registry/baremetalds/two-node/arbiter/add-workers/baremetalds-two-node-arbiter-add-workers-ref.metadata.json
+++ b/ci-operator/step-registry/baremetalds/two-node/arbiter/add-workers/baremetalds-two-node-arbiter-add-workers-ref.metadata.json
@@ -2,7 +2,7 @@
 	"path": "baremetalds/two-node/arbiter/add-workers/baremetalds-two-node-arbiter-add-workers-ref.yaml",
 	"owners": {
 		"approvers": [
-			"edge-enablement-approvers"
+			"openshift-edge-approvers"
 		]
 	}
 }

--- a/ci-operator/step-registry/baremetalds/two-node/arbiter/baremetalds-two-node-arbiter-workflow.metadata.json
+++ b/ci-operator/step-registry/baremetalds/two-node/arbiter/baremetalds-two-node-arbiter-workflow.metadata.json
@@ -2,7 +2,7 @@
 	"path": "baremetalds/two-node/arbiter/baremetalds-two-node-arbiter-workflow.yaml",
 	"owners": {
 		"approvers": [
-			"edge-enablement-approvers"
+			"openshift-edge-approvers"
 		]
 	}
 }

--- a/ci-operator/step-registry/baremetalds/two-node/arbiter/e2e-openshift-test-private-tests/OWNERS
+++ b/ci-operator/step-registry/baremetalds/two-node/arbiter/e2e-openshift-test-private-tests/OWNERS
@@ -1,12 +1,4 @@
 approvers:
-  - edge-enablement-approvers
-  - jogeo
-  - kasturinarra
-  - Neilhamza
-  - dhensel-rh
-
+  - openshift-edge-approvers
 reviewers:
- - jogeo
- - kasturinarra
- - Neilhamza
- - dhensel-rh
+  - openshift-edge-reviewers

--- a/ci-operator/step-registry/baremetalds/two-node/arbiter/e2e-openshift-test-private-tests/baremetalds-two-node-arbiter-e2e-openshift-test-private-tests-workflow.metadata.json
+++ b/ci-operator/step-registry/baremetalds/two-node/arbiter/e2e-openshift-test-private-tests/baremetalds-two-node-arbiter-e2e-openshift-test-private-tests-workflow.metadata.json
@@ -2,17 +2,10 @@
 	"path": "baremetalds/two-node/arbiter/e2e-openshift-test-private-tests/baremetalds-two-node-arbiter-e2e-openshift-test-private-tests-workflow.yaml",
 	"owners": {
 		"approvers": [
-			"edge-enablement-approvers",
-			"jogeo",
-			"kasturinarra",
-			"Neilhamza",
-			"dhensel-rh"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"jogeo",
-			"kasturinarra",
-			"Neilhamza",
-			"dhensel-rh"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/baremetalds/two-node/arbiter/techpreview/baremetalds-two-node-arbiter-techpreview-workflow.metadata.json
+++ b/ci-operator/step-registry/baremetalds/two-node/arbiter/techpreview/baremetalds-two-node-arbiter-techpreview-workflow.metadata.json
@@ -2,7 +2,7 @@
 	"path": "baremetalds/two-node/arbiter/techpreview/baremetalds-two-node-arbiter-techpreview-workflow.yaml",
 	"owners": {
 		"approvers": [
-			"edge-enablement-approvers"
+			"openshift-edge-approvers"
 		]
 	}
 }

--- a/ci-operator/step-registry/baremetalds/two-node/arbiter/upgrade/baremetalds-two-node-arbiter-upgrade-workflow.metadata.json
+++ b/ci-operator/step-registry/baremetalds/two-node/arbiter/upgrade/baremetalds-two-node-arbiter-upgrade-workflow.metadata.json
@@ -2,7 +2,7 @@
 	"path": "baremetalds/two-node/arbiter/upgrade/baremetalds-two-node-arbiter-upgrade-workflow.yaml",
 	"owners": {
 		"approvers": [
-			"edge-enablement-approvers"
+			"openshift-edge-approvers"
 		]
 	}
 }

--- a/ci-operator/step-registry/baremetalds/two-node/arbiter/upgrade/day-2-workers/baremetalds-two-node-arbiter-upgrade-day-2-workers-workflow.metadata.json
+++ b/ci-operator/step-registry/baremetalds/two-node/arbiter/upgrade/day-2-workers/baremetalds-two-node-arbiter-upgrade-day-2-workers-workflow.metadata.json
@@ -2,7 +2,7 @@
 	"path": "baremetalds/two-node/arbiter/upgrade/day-2-workers/baremetalds-two-node-arbiter-upgrade-day-2-workers-workflow.yaml",
 	"owners": {
 		"approvers": [
-			"edge-enablement-approvers"
+			"openshift-edge-approvers"
 		]
 	}
 }

--- a/ci-operator/step-registry/baremetalds/two-node/arbiter/upgrade/workers/baremetalds-two-node-arbiter-upgrade-workers-workflow.metadata.json
+++ b/ci-operator/step-registry/baremetalds/two-node/arbiter/upgrade/workers/baremetalds-two-node-arbiter-upgrade-workers-workflow.metadata.json
@@ -2,7 +2,7 @@
 	"path": "baremetalds/two-node/arbiter/upgrade/workers/baremetalds-two-node-arbiter-upgrade-workers-workflow.yaml",
 	"owners": {
 		"approvers": [
-			"edge-enablement-approvers"
+			"openshift-edge-approvers"
 		]
 	}
 }

--- a/ci-operator/step-registry/baremetalds/two-node/arbiter/workload-partitioning/baremetalds-two-node-arbiter-workload-partitioning-workflow.metadata.json
+++ b/ci-operator/step-registry/baremetalds/two-node/arbiter/workload-partitioning/baremetalds-two-node-arbiter-workload-partitioning-workflow.metadata.json
@@ -2,7 +2,7 @@
 	"path": "baremetalds/two-node/arbiter/workload-partitioning/baremetalds-two-node-arbiter-workload-partitioning-workflow.yaml",
 	"owners": {
 		"approvers": [
-			"edge-enablement-approvers"
+			"openshift-edge-approvers"
 		]
 	}
 }

--- a/ci-operator/step-registry/baremetalds/two-node/fencing/OWNERS
+++ b/ci-operator/step-registry/baremetalds/two-node/fencing/OWNERS
@@ -1,2 +1,2 @@
 approvers:
-  - edge-enablement-approvers
+  - openshift-edge-approvers

--- a/ci-operator/step-registry/baremetalds/two-node/fencing/baremetalds-two-node-fencing-workflow.metadata.json
+++ b/ci-operator/step-registry/baremetalds/two-node/fencing/baremetalds-two-node-fencing-workflow.metadata.json
@@ -2,7 +2,7 @@
 	"path": "baremetalds/two-node/fencing/baremetalds-two-node-fencing-workflow.yaml",
 	"owners": {
 		"approvers": [
-			"edge-enablement-approvers"
+			"openshift-edge-approvers"
 		]
 	}
 }

--- a/ci-operator/step-registry/baremetalds/two-node/fencing/degraded/baremetalds-two-node-fencing-degraded-workflow.metadata.json
+++ b/ci-operator/step-registry/baremetalds/two-node/fencing/degraded/baremetalds-two-node-fencing-degraded-workflow.metadata.json
@@ -2,7 +2,7 @@
 	"path": "baremetalds/two-node/fencing/degraded/baremetalds-two-node-fencing-degraded-workflow.yaml",
 	"owners": {
 		"approvers": [
-			"edge-enablement-approvers"
+			"openshift-edge-approvers"
 		]
 	}
 }

--- a/ci-operator/step-registry/baremetalds/two-node/fencing/extended/OWNERS
+++ b/ci-operator/step-registry/baremetalds/two-node/fencing/extended/OWNERS
@@ -1,12 +1,4 @@
 approvers:
-  - edge-enablement-approvers
-  - dhensel-rh
-  - jogeo
-  - kasturinarra
-  - Neilhamza
-
+  - openshift-edge-approvers
 reviewers:
- - jogeo
- - dhensel-rh
- - kasturinarra
- - Neilhamza
+  - openshift-edge-reviewers

--- a/ci-operator/step-registry/baremetalds/two-node/fencing/extended/baremetalds-two-node-fencing-extended-workflow.metadata.json
+++ b/ci-operator/step-registry/baremetalds/two-node/fencing/extended/baremetalds-two-node-fencing-extended-workflow.metadata.json
@@ -2,17 +2,10 @@
 	"path": "baremetalds/two-node/fencing/extended/baremetalds-two-node-fencing-extended-workflow.yaml",
 	"owners": {
 		"approvers": [
-			"edge-enablement-approvers",
-			"dhensel-rh",
-			"jogeo",
-			"kasturinarra",
-			"Neilhamza"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"jogeo",
-			"dhensel-rh",
-			"kasturinarra",
-			"Neilhamza"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/baremetalds/two-node/fencing/post-install/baremetalds-two-node-fencing-post-install-chain.metadata.json
+++ b/ci-operator/step-registry/baremetalds/two-node/fencing/post-install/baremetalds-two-node-fencing-post-install-chain.metadata.json
@@ -2,7 +2,7 @@
 	"path": "baremetalds/two-node/fencing/post-install/baremetalds-two-node-fencing-post-install-chain.yaml",
 	"owners": {
 		"approvers": [
-			"edge-enablement-approvers"
+			"openshift-edge-approvers"
 		]
 	}
 }

--- a/ci-operator/step-registry/baremetalds/two-node/fencing/post-install/node-degredation/OWNERS
+++ b/ci-operator/step-registry/baremetalds/two-node/fencing/post-install/node-degredation/OWNERS
@@ -1,2 +1,2 @@
 approvers:
-  - edge-enablement-approvers
+  - openshift-edge-approvers

--- a/ci-operator/step-registry/baremetalds/two-node/fencing/post-install/node-degredation/baremetalds-two-node-fencing-post-install-node-degredation-ref.metadata.json
+++ b/ci-operator/step-registry/baremetalds/two-node/fencing/post-install/node-degredation/baremetalds-two-node-fencing-post-install-node-degredation-ref.metadata.json
@@ -2,7 +2,7 @@
 	"path": "baremetalds/two-node/fencing/post-install/node-degredation/baremetalds-two-node-fencing-post-install-node-degredation-ref.yaml",
 	"owners": {
 		"approvers": [
-			"edge-enablement-approvers"
+			"openshift-edge-approvers"
 		]
 	}
 }

--- a/ci-operator/step-registry/baremetalds/two-node/fencing/post-install/validation/baremetalds-two-node-fencing-post-install-validation-ref.metadata.json
+++ b/ci-operator/step-registry/baremetalds/two-node/fencing/post-install/validation/baremetalds-two-node-fencing-post-install-validation-ref.metadata.json
@@ -2,7 +2,7 @@
 	"path": "baremetalds/two-node/fencing/post-install/validation/baremetalds-two-node-fencing-post-install-validation-ref.yaml",
 	"owners": {
 		"approvers": [
-			"edge-enablement-approvers"
+			"openshift-edge-approvers"
 		]
 	}
 }

--- a/ci-operator/step-registry/baremetalds/two-node/fencing/post-install/validation/baremetalds-two-node-fencing-post-install-validation-workflow.metadata.json
+++ b/ci-operator/step-registry/baremetalds/two-node/fencing/post-install/validation/baremetalds-two-node-fencing-post-install-validation-workflow.metadata.json
@@ -2,7 +2,7 @@
 	"path": "baremetalds/two-node/fencing/post-install/validation/baremetalds-two-node-fencing-post-install-validation-workflow.yaml",
 	"owners": {
 		"approvers": [
-			"edge-enablement-approvers"
+			"openshift-edge-approvers"
 		]
 	}
 }

--- a/ci-operator/step-registry/baremetalds/two-node/fencing/recovery/baremetalds-two-node-fencing-recovery-workflow.metadata.json
+++ b/ci-operator/step-registry/baremetalds/two-node/fencing/recovery/baremetalds-two-node-fencing-recovery-workflow.metadata.json
@@ -2,7 +2,7 @@
 	"path": "baremetalds/two-node/fencing/recovery/baremetalds-two-node-fencing-recovery-workflow.yaml",
 	"owners": {
 		"approvers": [
-			"edge-enablement-approvers"
+			"openshift-edge-approvers"
 		]
 	}
 }

--- a/ci-operator/step-registry/baremetalds/two-node/fencing/resource-agents/OWNERS
+++ b/ci-operator/step-registry/baremetalds/two-node/fencing/resource-agents/OWNERS
@@ -1,4 +1,4 @@
 approvers:
-  - edge-enablement-approvers
+  - openshift-edge-approvers
 reviewers:
-  - edge-enablement-reviewers
+  - openshift-edge-reviewers

--- a/ci-operator/step-registry/baremetalds/two-node/fencing/resource-agents/update-rhcos/OWNERS
+++ b/ci-operator/step-registry/baremetalds/two-node/fencing/resource-agents/update-rhcos/OWNERS
@@ -1,4 +1,4 @@
 approvers:
-  - edge-enablement-approvers
+  - openshift-edge-approvers
 reviewers:
-  - edge-enablement-reviewers
+  - openshift-edge-reviewers

--- a/ci-operator/step-registry/baremetalds/two-node/fencing/resource-agents/update-rhcos/baremetalds-two-node-fencing-resource-agents-update-rhcos-ref.metadata.json
+++ b/ci-operator/step-registry/baremetalds/two-node/fencing/resource-agents/update-rhcos/baremetalds-two-node-fencing-resource-agents-update-rhcos-ref.metadata.json
@@ -2,10 +2,10 @@
 	"path": "baremetalds/two-node/fencing/resource-agents/update-rhcos/baremetalds-two-node-fencing-resource-agents-update-rhcos-ref.yaml",
 	"owners": {
 		"approvers": [
-			"edge-enablement-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"edge-enablement-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/baremetalds/two-node/fencing/techpreview/baremetalds-two-node-fencing-techpreview-workflow.metadata.json
+++ b/ci-operator/step-registry/baremetalds/two-node/fencing/techpreview/baremetalds-two-node-fencing-techpreview-workflow.metadata.json
@@ -2,7 +2,7 @@
 	"path": "baremetalds/two-node/fencing/techpreview/baremetalds-two-node-fencing-techpreview-workflow.yaml",
 	"owners": {
 		"approvers": [
-			"edge-enablement-approvers"
+			"openshift-edge-approvers"
 		]
 	}
 }

--- a/ci-operator/step-registry/baremetalds/two-node/fencing/upgrade/OWNERS
+++ b/ci-operator/step-registry/baremetalds/two-node/fencing/upgrade/OWNERS
@@ -1,2 +1,2 @@
 approvers:
-  - edge-enablement-approvers
+  - openshift-edge-approvers

--- a/ci-operator/step-registry/baremetalds/two-node/fencing/upgrade/baremetalds-two-node-fencing-upgrade-workflow.metadata.json
+++ b/ci-operator/step-registry/baremetalds/two-node/fencing/upgrade/baremetalds-two-node-fencing-upgrade-workflow.metadata.json
@@ -2,7 +2,7 @@
 	"path": "baremetalds/two-node/fencing/upgrade/baremetalds-two-node-fencing-upgrade-workflow.yaml",
 	"owners": {
 		"approvers": [
-			"edge-enablement-approvers"
+			"openshift-edge-approvers"
 		]
 	}
 }

--- a/ci-operator/step-registry/cucushift/installer/rehearse/aws/ipi/mno/OWNERS
+++ b/ci-operator/step-registry/cucushift/installer/rehearse/aws/ipi/mno/OWNERS
@@ -1,9 +1,5 @@
 approvers:
-- edge-enablement-approvers
-- mmakwana30
-- kasturinarra
+- openshift-edge-approvers
 reviewers:
-- edge-enablement-reviewers
-- mmakwana30
+- openshift-edge-reviewers
 - Phaow
-- kasturinarra

--- a/ci-operator/step-registry/cucushift/installer/rehearse/aws/ipi/mno/lvms/OWNERS
+++ b/ci-operator/step-registry/cucushift/installer/rehearse/aws/ipi/mno/lvms/OWNERS
@@ -1,9 +1,5 @@
 approvers:
-- edge-enablement-approvers
-- mmakwana30
-- kasturinarra
+- openshift-edge-approvers
 reviewers:
-- edge-enablement-reviewers
-- mmakwana30
+- openshift-edge-reviewers
 - Phaow
-- kasturinarra

--- a/ci-operator/step-registry/cucushift/installer/rehearse/aws/ipi/mno/lvms/cucushift-installer-rehearse-aws-ipi-mno-lvms-workflow.metadata.json
+++ b/ci-operator/step-registry/cucushift/installer/rehearse/aws/ipi/mno/lvms/cucushift-installer-rehearse-aws-ipi-mno-lvms-workflow.metadata.json
@@ -2,15 +2,11 @@
 	"path": "cucushift/installer/rehearse/aws/ipi/mno/lvms/cucushift-installer-rehearse-aws-ipi-mno-lvms-workflow.yaml",
 	"owners": {
 		"approvers": [
-			"edge-enablement-approvers",
-			"mmakwana30",
-			"kasturinarra"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"edge-enablement-reviewers",
-			"mmakwana30",
-			"Phaow",
-			"kasturinarra"
+			"openshift-edge-reviewers",
+			"Phaow"
 		]
 	}
 }

--- a/ci-operator/step-registry/lvms/OWNERS
+++ b/ci-operator/step-registry/lvms/OWNERS
@@ -1,5 +1,5 @@
 approvers:
-- edge-enablement-approvers
+- openshift-edge-approvers
 options: {}
 reviewers:
-- edge-enablement-reviewers
+- openshift-edge-reviewers

--- a/ci-operator/step-registry/lvms/catalogsource/lvms-catalogsource-ref.metadata.json
+++ b/ci-operator/step-registry/lvms/catalogsource/lvms-catalogsource-ref.metadata.json
@@ -2,10 +2,10 @@
 	"path": "lvms/catalogsource/lvms-catalogsource-ref.yaml",
 	"owners": {
 		"approvers": [
-			"edge-enablement-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"edge-enablement-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/lvms/topolvm/OWNERS
+++ b/ci-operator/step-registry/lvms/topolvm/OWNERS
@@ -1,5 +1,5 @@
 approvers:
-- edge-enablement-approvers
+- openshift-edge-approvers
 options: {}
 reviewers:
-- edge-enablement-reviewers
+- openshift-edge-reviewers

--- a/ci-operator/step-registry/lvms/topolvm/conformance/OWNERS
+++ b/ci-operator/step-registry/lvms/topolvm/conformance/OWNERS
@@ -1,5 +1,5 @@
 approvers:
-- edge-enablement-approvers
+- openshift-edge-approvers
 options: {}
 reviewers:
-- edge-enablement-reviewers
+- openshift-edge-reviewers

--- a/ci-operator/step-registry/lvms/topolvm/conformance/e2e/OWNERS
+++ b/ci-operator/step-registry/lvms/topolvm/conformance/e2e/OWNERS
@@ -1,5 +1,5 @@
 approvers:
-- edge-enablement-approvers
+- openshift-edge-approvers
 options: {}
 reviewers:
-- edge-enablement-reviewers
+- openshift-edge-reviewers

--- a/ci-operator/step-registry/lvms/topolvm/conformance/e2e/lvms-topolvm-conformance-e2e-ref.metadata.json
+++ b/ci-operator/step-registry/lvms/topolvm/conformance/e2e/lvms-topolvm-conformance-e2e-ref.metadata.json
@@ -2,10 +2,10 @@
 	"path": "lvms/topolvm/conformance/e2e/lvms-topolvm-conformance-e2e-ref.yaml",
 	"owners": {
 		"approvers": [
-			"edge-enablement-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"edge-enablement-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/lvms/topolvm/conformance/lvms-topolvm-conformance-workflow.metadata.json
+++ b/ci-operator/step-registry/lvms/topolvm/conformance/lvms-topolvm-conformance-workflow.metadata.json
@@ -2,10 +2,10 @@
 	"path": "lvms/topolvm/conformance/lvms-topolvm-conformance-workflow.yaml",
 	"owners": {
 		"approvers": [
-			"edge-enablement-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"edge-enablement-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/lvms/topolvm/infra/OWNERS
+++ b/ci-operator/step-registry/lvms/topolvm/infra/OWNERS
@@ -1,5 +1,5 @@
 approvers:
-- edge-enablement-approvers
+- openshift-edge-approvers
 options: {}
 reviewers:
-- edge-enablement-reviewers
+- openshift-edge-reviewers

--- a/ci-operator/step-registry/lvms/topolvm/infra/aws/OWNERS
+++ b/ci-operator/step-registry/lvms/topolvm/infra/aws/OWNERS
@@ -1,5 +1,5 @@
 approvers:
-- edge-enablement-approvers
+- openshift-edge-approvers
 options: {}
 reviewers:
-- edge-enablement-reviewers
+- openshift-edge-reviewers

--- a/ci-operator/step-registry/lvms/topolvm/infra/aws/ec2/OWNERS
+++ b/ci-operator/step-registry/lvms/topolvm/infra/aws/ec2/OWNERS
@@ -1,5 +1,5 @@
 approvers:
-- edge-enablement-approvers
+- openshift-edge-approvers
 options: {}
 reviewers:
-- edge-enablement-reviewers
+- openshift-edge-reviewers

--- a/ci-operator/step-registry/lvms/topolvm/infra/aws/ec2/logs/OWNERS
+++ b/ci-operator/step-registry/lvms/topolvm/infra/aws/ec2/logs/OWNERS
@@ -1,5 +1,5 @@
 approvers:
-- edge-enablement-approvers
+- openshift-edge-approvers
 options: {}
 reviewers:
-- edge-enablement-reviewers
+- openshift-edge-reviewers

--- a/ci-operator/step-registry/lvms/topolvm/infra/aws/ec2/logs/lvms-topolvm-infra-aws-ec2-logs-ref.metadata.json
+++ b/ci-operator/step-registry/lvms/topolvm/infra/aws/ec2/logs/lvms-topolvm-infra-aws-ec2-logs-ref.metadata.json
@@ -2,10 +2,10 @@
 	"path": "lvms/topolvm/infra/aws/ec2/logs/lvms-topolvm-infra-aws-ec2-logs-ref.yaml",
 	"owners": {
 		"approvers": [
-			"edge-enablement-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"edge-enablement-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/lvms/topolvm/infra/aws/ec2/lvms-topolvm-infra-aws-ec2-chain.metadata.json
+++ b/ci-operator/step-registry/lvms/topolvm/infra/aws/ec2/lvms-topolvm-infra-aws-ec2-chain.metadata.json
@@ -2,10 +2,10 @@
 	"path": "lvms/topolvm/infra/aws/ec2/lvms-topolvm-infra-aws-ec2-chain.yaml",
 	"owners": {
 		"approvers": [
-			"edge-enablement-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"edge-enablement-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/lvms/topolvm/infra/aws/ec2/lvms-topolvm-infra-aws-ec2-ref.metadata.json
+++ b/ci-operator/step-registry/lvms/topolvm/infra/aws/ec2/lvms-topolvm-infra-aws-ec2-ref.metadata.json
@@ -2,10 +2,10 @@
 	"path": "lvms/topolvm/infra/aws/ec2/lvms-topolvm-infra-aws-ec2-ref.yaml",
 	"owners": {
 		"approvers": [
-			"edge-enablement-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"edge-enablement-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/lvms/topolvm/metal/OWNERS
+++ b/ci-operator/step-registry/lvms/topolvm/metal/OWNERS
@@ -1,5 +1,5 @@
 approvers:
-- edge-enablement-approvers
+- openshift-edge-approvers
 options: {}
 reviewers:
-- edge-enablement-reviewers
+- openshift-edge-reviewers

--- a/ci-operator/step-registry/lvms/topolvm/metal/config/OWNERS
+++ b/ci-operator/step-registry/lvms/topolvm/metal/config/OWNERS
@@ -1,5 +1,5 @@
 approvers:
-- edge-enablement-approvers
+- openshift-edge-approvers
 options: {}
 reviewers:
-- edge-enablement-reviewers
+- openshift-edge-reviewers

--- a/ci-operator/step-registry/lvms/topolvm/metal/config/lvms-topolvm-metal-config-ref.metadata.json
+++ b/ci-operator/step-registry/lvms/topolvm/metal/config/lvms-topolvm-metal-config-ref.metadata.json
@@ -2,10 +2,10 @@
 	"path": "lvms/topolvm/metal/config/lvms-topolvm-metal-config-ref.yaml",
 	"owners": {
 		"approvers": [
-			"edge-enablement-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"edge-enablement-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/e2e/aws/single-node/OWNERS
+++ b/ci-operator/step-registry/openshift/e2e/aws/single-node/OWNERS
@@ -1,2 +1,5 @@
 approvers:
-- single-node
+- ecosystem-edge-single-node
+- openshift-edge-approvers
+reviewers:
+- openshift-edge-reviewers

--- a/ci-operator/step-registry/openshift/e2e/aws/single-node/csi/openshift-e2e-aws-single-node-csi-workflow.metadata.json
+++ b/ci-operator/step-registry/openshift/e2e/aws/single-node/csi/openshift-e2e-aws-single-node-csi-workflow.metadata.json
@@ -2,7 +2,11 @@
 	"path": "openshift/e2e/aws/single-node/csi/openshift-e2e-aws-single-node-csi-workflow.yaml",
 	"owners": {
 		"approvers": [
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-approvers"
+		],
+		"reviewers": [
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/e2e/aws/single-node/graceful-shutdown/OWNERS
+++ b/ci-operator/step-registry/openshift/e2e/aws/single-node/graceful-shutdown/OWNERS
@@ -1,5 +1,8 @@
 approvers:
-- single-node
+- ecosystem-edge-single-node
+- openshift-edge-approvers
 - wgahnagl
-- rphillips 
+- rphillips
 - mrunalp
+reviewers:
+- openshift-edge-reviewers

--- a/ci-operator/step-registry/openshift/e2e/aws/single-node/install/OWNERS
+++ b/ci-operator/step-registry/openshift/e2e/aws/single-node/install/OWNERS
@@ -1,2 +1,5 @@
 approvers:
-- single-node
+- ecosystem-edge-single-node
+- openshift-edge-approvers
+reviewers:
+- openshift-edge-reviewers

--- a/ci-operator/step-registry/openshift/e2e/aws/single-node/install/openshift-e2e-aws-single-node-install-workflow.metadata.json
+++ b/ci-operator/step-registry/openshift/e2e/aws/single-node/install/openshift-e2e-aws-single-node-install-workflow.metadata.json
@@ -2,7 +2,11 @@
 	"path": "openshift/e2e/aws/single-node/install/openshift-e2e-aws-single-node-install-workflow.yaml",
 	"owners": {
 		"approvers": [
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-approvers"
+		],
+		"reviewers": [
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/e2e/aws/single-node/one-core/OWNERS
+++ b/ci-operator/step-registry/openshift/e2e/aws/single-node/one-core/OWNERS
@@ -1,2 +1,5 @@
 approvers:
-- single-node
+- ecosystem-edge-single-node
+- openshift-edge-approvers
+reviewers:
+- openshift-edge-reviewers

--- a/ci-operator/step-registry/openshift/e2e/aws/single-node/one-core/openshift-e2e-aws-single-node-one-core-workflow.metadata.json
+++ b/ci-operator/step-registry/openshift/e2e/aws/single-node/one-core/openshift-e2e-aws-single-node-one-core-workflow.metadata.json
@@ -2,7 +2,11 @@
 	"path": "openshift/e2e/aws/single-node/one-core/openshift-e2e-aws-single-node-one-core-workflow.yaml",
 	"owners": {
 		"approvers": [
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-approvers"
+		],
+		"reviewers": [
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/e2e/aws/single-node/openshift-e2e-aws-single-node-workflow.metadata.json
+++ b/ci-operator/step-registry/openshift/e2e/aws/single-node/openshift-e2e-aws-single-node-workflow.metadata.json
@@ -2,7 +2,11 @@
 	"path": "openshift/e2e/aws/single-node/openshift-e2e-aws-single-node-workflow.yaml",
 	"owners": {
 		"approvers": [
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-approvers"
+		],
+		"reviewers": [
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/e2e/aws/single-node/recert/OWNERS
+++ b/ci-operator/step-registry/openshift/e2e/aws/single-node/recert/OWNERS
@@ -1,2 +1,5 @@
 approvers:
-- single-node
+- ecosystem-edge-single-node
+- openshift-edge-approvers
+reviewers:
+- openshift-edge-reviewers

--- a/ci-operator/step-registry/openshift/e2e/aws/single-node/recert/openshift-e2e-aws-single-node-recert-workflow.metadata.json
+++ b/ci-operator/step-registry/openshift/e2e/aws/single-node/recert/openshift-e2e-aws-single-node-recert-workflow.metadata.json
@@ -2,7 +2,11 @@
 	"path": "openshift/e2e/aws/single-node/recert/openshift-e2e-aws-single-node-recert-workflow.yaml",
 	"owners": {
 		"approvers": [
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-approvers"
+		],
+		"reviewers": [
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/e2e/aws/single-node/workers/openshift-e2e-aws-single-node-workers-workflow.metadata.json
+++ b/ci-operator/step-registry/openshift/e2e/aws/single-node/workers/openshift-e2e-aws-single-node-workers-workflow.metadata.json
@@ -2,7 +2,11 @@
 	"path": "openshift/e2e/aws/single-node/workers/openshift-e2e-aws-single-node-workers-workflow.yaml",
 	"owners": {
 		"approvers": [
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-approvers"
+		],
+		"reviewers": [
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/e2e/gcp/single-node/OWNERS
+++ b/ci-operator/step-registry/openshift/e2e/gcp/single-node/OWNERS
@@ -1,2 +1,5 @@
 approvers:
-- single-node
+- ecosystem-edge-single-node
+- openshift-edge-approvers
+reviewers:
+- openshift-edge-reviewers

--- a/ci-operator/step-registry/openshift/e2e/gcp/single-node/openshift-e2e-gcp-single-node-workflow.metadata.json
+++ b/ci-operator/step-registry/openshift/e2e/gcp/single-node/openshift-e2e-gcp-single-node-workflow.metadata.json
@@ -2,7 +2,11 @@
 	"path": "openshift/e2e/gcp/single-node/openshift-e2e-gcp-single-node-workflow.yaml",
 	"owners": {
 		"approvers": [
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-approvers"
+		],
+		"reviewers": [
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/edge-tooling/OWNERS
+++ b/ci-operator/step-registry/openshift/edge-tooling/OWNERS
@@ -1,5 +1,4 @@
 approvers:
-  - edge-enablement-approvers
+  - openshift-edge-approvers
 reviewers:
-  - edge-enablement-reviewers
-  - microshift-reviewers
+  - openshift-edge-reviewers

--- a/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/OWNERS
+++ b/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/OWNERS
@@ -1,5 +1,4 @@
 approvers:
-  - edge-enablement-approvers
+  - openshift-edge-approvers
 reviewers:
-  - edge-enablement-reviewers
-  - microshift-reviewers
+  - openshift-edge-reviewers

--- a/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-ref.metadata.json
@@ -2,11 +2,10 @@
 	"path": "openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-ref.yaml",
 	"owners": {
 		"approvers": [
-			"edge-enablement-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"edge-enablement-reviewers",
-			"microshift-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-workflow.metadata.json
+++ b/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-workflow.metadata.json
@@ -2,11 +2,10 @@
 	"path": "openshift/edge-tooling/ci-monitor/openshift-edge-tooling-ci-monitor-workflow.yaml",
 	"owners": {
 		"approvers": [
-			"edge-enablement-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"edge-enablement-reviewers",
-			"microshift-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/send-slack/OWNERS
+++ b/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/send-slack/OWNERS
@@ -1,5 +1,4 @@
 approvers:
-  - edge-enablement-approvers
+  - openshift-edge-approvers
 reviewers:
-  - edge-enablement-reviewers
-  - microshift-reviewers
+  - openshift-edge-reviewers

--- a/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/send-slack/openshift-edge-tooling-ci-monitor-send-slack-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/edge-tooling/ci-monitor/send-slack/openshift-edge-tooling-ci-monitor-send-slack-ref.metadata.json
@@ -2,11 +2,10 @@
 	"path": "openshift/edge-tooling/ci-monitor/send-slack/openshift-edge-tooling-ci-monitor-send-slack-ref.yaml",
 	"owners": {
 		"approvers": [
-			"edge-enablement-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"edge-enablement-reviewers",
-			"microshift-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/edge-tooling/gh-notifier/OWNERS
+++ b/ci-operator/step-registry/openshift/edge-tooling/gh-notifier/OWNERS
@@ -1,5 +1,4 @@
 approvers:
-  - edge-enablement-approvers
+  - openshift-edge-approvers
 reviewers:
-  - edge-enablement-reviewers
-  - microshift-reviewers
+  - openshift-edge-reviewers

--- a/ci-operator/step-registry/openshift/edge-tooling/gh-notifier/openshift-edge-tooling-gh-notifier-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/edge-tooling/gh-notifier/openshift-edge-tooling-gh-notifier-ref.metadata.json
@@ -2,11 +2,10 @@
 	"path": "openshift/edge-tooling/gh-notifier/openshift-edge-tooling-gh-notifier-ref.yaml",
 	"owners": {
 		"approvers": [
-			"edge-enablement-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"edge-enablement-reviewers",
-			"microshift-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/edge-tooling/gh-notifier/openshift-edge-tooling-gh-notifier-workflow.metadata.json
+++ b/ci-operator/step-registry/openshift/edge-tooling/gh-notifier/openshift-edge-tooling-gh-notifier-workflow.metadata.json
@@ -2,11 +2,10 @@
 	"path": "openshift/edge-tooling/gh-notifier/openshift-edge-tooling-gh-notifier-workflow.yaml",
 	"owners": {
 		"approvers": [
-			"edge-enablement-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"edge-enablement-reviewers",
-			"microshift-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/image-based/OWNERS
+++ b/ci-operator/step-registry/openshift/image-based/OWNERS
@@ -1,7 +1,9 @@
 approvers:
 - image-based
-- single-node
+- ecosystem-edge-single-node
+- openshift-edge-approvers
 options: {}
 reviewers:
 - image-based
-- single-node
+- ecosystem-edge-single-node
+- openshift-edge-reviewers

--- a/ci-operator/step-registry/openshift/image-based/infra/aws/deprovision/OWNERS
+++ b/ci-operator/step-registry/openshift/image-based/infra/aws/deprovision/OWNERS
@@ -1,7 +1,9 @@
 approvers:
 - image-based
-- single-node
+- ecosystem-edge-single-node
+- openshift-edge-approvers
 options: {}
 reviewers:
 - image-based
-- single-node
+- ecosystem-edge-single-node
+- openshift-edge-reviewers

--- a/ci-operator/step-registry/openshift/image-based/infra/aws/deprovision/openshift-image-based-infra-aws-deprovision-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/image-based/infra/aws/deprovision/openshift-image-based-infra-aws-deprovision-ref.metadata.json
@@ -3,11 +3,13 @@
 	"owners": {
 		"approvers": [
 			"image-based",
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
 			"image-based",
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/image-based/infra/aws/ec2/logs/openshift-image-based-infra-aws-ec2-logs-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/image-based/infra/aws/ec2/logs/openshift-image-based-infra-aws-ec2-logs-ref.metadata.json
@@ -3,11 +3,13 @@
 	"owners": {
 		"approvers": [
 			"image-based",
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
 			"image-based",
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/image-based/infra/aws/ec2/openshift-image-based-infra-aws-ec2-chain.metadata.json
+++ b/ci-operator/step-registry/openshift/image-based/infra/aws/ec2/openshift-image-based-infra-aws-ec2-chain.metadata.json
@@ -3,11 +3,13 @@
 	"owners": {
 		"approvers": [
 			"image-based",
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
 			"image-based",
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/image-based/infra/aws/ec2/openshift-image-based-infra-aws-ec2-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/image-based/infra/aws/ec2/openshift-image-based-infra-aws-ec2-ref.metadata.json
@@ -3,11 +3,13 @@
 	"owners": {
 		"approvers": [
 			"image-based",
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
 			"image-based",
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/image-based/infra/sos/openshift-image-based-infra-sos-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/image-based/infra/sos/openshift-image-based-infra-sos-ref.metadata.json
@@ -3,11 +3,13 @@
 	"owners": {
 		"approvers": [
 			"image-based",
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
 			"image-based",
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/image-based/install/openshift-image-based-install-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/image-based/install/openshift-image-based-install-ref.metadata.json
@@ -3,11 +3,13 @@
 	"owners": {
 		"approvers": [
 			"image-based",
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
 			"image-based",
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/image-based/install/openshift-image-based-install-workflow.metadata.json
+++ b/ci-operator/step-registry/openshift/image-based/install/openshift-image-based-install-workflow.metadata.json
@@ -3,11 +3,13 @@
 	"owners": {
 		"approvers": [
 			"image-based",
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
 			"image-based",
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/image-based/network-configuration/configure/openshift-image-based-network-configuration-configure-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/image-based/network-configuration/configure/openshift-image-based-network-configuration-configure-ref.metadata.json
@@ -3,11 +3,13 @@
 	"owners": {
 		"approvers": [
 			"image-based",
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
 			"image-based",
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/image-based/network-configuration/gather/openshift-image-based-network-configuration-gather-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/image-based/network-configuration/gather/openshift-image-based-network-configuration-gather-ref.metadata.json
@@ -3,11 +3,13 @@
 	"owners": {
 		"approvers": [
 			"image-based",
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
 			"image-based",
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/image-based/network-configuration/openshift-image-based-network-configuration-workflow.metadata.json
+++ b/ci-operator/step-registry/openshift/image-based/network-configuration/openshift-image-based-network-configuration-workflow.metadata.json
@@ -3,11 +3,13 @@
 	"owners": {
 		"approvers": [
 			"image-based",
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
 			"image-based",
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/image-based/upgrade/e2e/baseline/openshift-image-based-upgrade-e2e-baseline-workflow.metadata.json
+++ b/ci-operator/step-registry/openshift/image-based/upgrade/e2e/baseline/openshift-image-based-upgrade-e2e-baseline-workflow.metadata.json
@@ -3,11 +3,13 @@
 	"owners": {
 		"approvers": [
 			"image-based",
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
 			"image-based",
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/image-based/upgrade/e2e/conf/OWNERS
+++ b/ci-operator/step-registry/openshift/image-based/upgrade/e2e/conf/OWNERS
@@ -1,5 +1,5 @@
 approvers:
-- edge-enablement-approvers
+- openshift-edge-approvers
 options: {}
 reviewers:
-- edge-enablement-reviewers
+- openshift-edge-reviewers

--- a/ci-operator/step-registry/openshift/image-based/upgrade/e2e/conf/openshift-image-based-upgrade-e2e-conf-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/image-based/upgrade/e2e/conf/openshift-image-based-upgrade-e2e-conf-ref.metadata.json
@@ -2,10 +2,10 @@
 	"path": "openshift/image-based/upgrade/e2e/conf/openshift-image-based-upgrade-e2e-conf-ref.yaml",
 	"owners": {
 		"approvers": [
-			"edge-enablement-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"edge-enablement-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/image-based/upgrade/e2e/gather/openshift-image-based-upgrade-e2e-gather-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/image-based/upgrade/e2e/gather/openshift-image-based-upgrade-e2e-gather-ref.metadata.json
@@ -3,11 +3,13 @@
 	"owners": {
 		"approvers": [
 			"image-based",
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
 			"image-based",
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/image-based/upgrade/e2e/openshift-image-based-upgrade-e2e-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/image-based/upgrade/e2e/openshift-image-based-upgrade-e2e-ref.metadata.json
@@ -3,11 +3,13 @@
 	"owners": {
 		"approvers": [
 			"image-based",
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
 			"image-based",
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/image-based/upgrade/e2e/openshift-image-based-upgrade-e2e-workflow.metadata.json
+++ b/ci-operator/step-registry/openshift/image-based/upgrade/e2e/openshift-image-based-upgrade-e2e-workflow.metadata.json
@@ -3,11 +3,13 @@
 	"owners": {
 		"approvers": [
 			"image-based",
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
 			"image-based",
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/image-based/upgrade/metal/config/openshift-image-based-upgrade-metal-config-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/image-based/upgrade/metal/config/openshift-image-based-upgrade-metal-config-ref.metadata.json
@@ -3,11 +3,13 @@
 	"owners": {
 		"approvers": [
 			"image-based",
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
 			"image-based",
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/image-based/upgrade/presubmit/openshift-image-based-upgrade-presubmit-workflow.metadata.json
+++ b/ci-operator/step-registry/openshift/image-based/upgrade/presubmit/openshift-image-based-upgrade-presubmit-workflow.metadata.json
@@ -3,11 +3,13 @@
 	"owners": {
 		"approvers": [
 			"image-based",
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
 			"image-based",
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/image-based/upgrade/seed/create/openshift-image-based-upgrade-seed-create-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/image-based/upgrade/seed/create/openshift-image-based-upgrade-seed-create-ref.metadata.json
@@ -3,11 +3,13 @@
 	"owners": {
 		"approvers": [
 			"image-based",
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
 			"image-based",
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/image-based/upgrade/seed/create/openshift-image-based-upgrade-seed-create-workflow.metadata.json
+++ b/ci-operator/step-registry/openshift/image-based/upgrade/seed/create/openshift-image-based-upgrade-seed-create-workflow.metadata.json
@@ -3,11 +3,13 @@
 	"owners": {
 		"approvers": [
 			"image-based",
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
 			"image-based",
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/image-based/upgrade/seed/gather/cluster/openshift-image-based-upgrade-seed-gather-cluster-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/image-based/upgrade/seed/gather/cluster/openshift-image-based-upgrade-seed-gather-cluster-ref.metadata.json
@@ -3,11 +3,13 @@
 	"owners": {
 		"approvers": [
 			"image-based",
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
 			"image-based",
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/image-based/upgrade/seed/gather/lca/openshift-image-based-upgrade-seed-gather-lca-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/image-based/upgrade/seed/gather/lca/openshift-image-based-upgrade-seed-gather-lca-ref.metadata.json
@@ -3,11 +3,13 @@
 	"owners": {
 		"approvers": [
 			"image-based",
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
 			"image-based",
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/image-based/upgrade/target/gather/cluster/openshift-image-based-upgrade-target-gather-cluster-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/image-based/upgrade/target/gather/cluster/openshift-image-based-upgrade-target-gather-cluster-ref.metadata.json
@@ -3,11 +3,13 @@
 	"owners": {
 		"approvers": [
 			"image-based",
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
 			"image-based",
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/image-based/upgrade/target/gather/lca/openshift-image-based-upgrade-target-gather-lca-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/image-based/upgrade/target/gather/lca/openshift-image-based-upgrade-target-gather-lca-ref.metadata.json
@@ -3,11 +3,13 @@
 	"owners": {
 		"approvers": [
 			"image-based",
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
 			"image-based",
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/image-based/upgrade/target/openshift-image-based-upgrade-target-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/image-based/upgrade/target/openshift-image-based-upgrade-target-ref.metadata.json
@@ -3,11 +3,13 @@
 	"owners": {
 		"approvers": [
 			"image-based",
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
 			"image-based",
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/microshift/OWNERS
+++ b/ci-operator/step-registry/openshift/microshift/OWNERS
@@ -1,5 +1,5 @@
 approvers:
-- microshift-approvers
+- openshift-edge-approvers
 options: {}
 reviewers:
-- microshift-reviewers
+- openshift-edge-reviewers

--- a/ci-operator/step-registry/openshift/microshift/claude/OWNERS
+++ b/ci-operator/step-registry/openshift/microshift/claude/OWNERS
@@ -1,5 +1,5 @@
 approvers:
-- microshift-approvers
+- openshift-edge-approvers
 options: {}
 reviewers:
-- microshift-reviewers
+- openshift-edge-reviewers

--- a/ci-operator/step-registry/openshift/microshift/claude/ci-doctor/OWNERS
+++ b/ci-operator/step-registry/openshift/microshift/claude/ci-doctor/OWNERS
@@ -1,5 +1,5 @@
 approvers:
-- microshift-approvers
+- openshift-edge-approvers
 options: {}
 reviewers:
-- microshift-reviewers
+- openshift-edge-reviewers

--- a/ci-operator/step-registry/openshift/microshift/claude/ci-doctor/openshift-microshift-claude-ci-doctor-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/microshift/claude/ci-doctor/openshift-microshift-claude-ci-doctor-ref.metadata.json
@@ -2,10 +2,10 @@
 	"path": "openshift/microshift/claude/ci-doctor/openshift-microshift-claude-ci-doctor-ref.yaml",
 	"owners": {
 		"approvers": [
-			"microshift-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"microshift-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/microshift/claude/ci-doctor/openshift-microshift-claude-ci-doctor-workflow.metadata.json
+++ b/ci-operator/step-registry/openshift/microshift/claude/ci-doctor/openshift-microshift-claude-ci-doctor-workflow.metadata.json
@@ -2,10 +2,10 @@
 	"path": "openshift/microshift/claude/ci-doctor/openshift-microshift-claude-ci-doctor-workflow.yaml",
 	"owners": {
 		"approvers": [
-			"microshift-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"microshift-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/microshift/claude/post/OWNERS
+++ b/ci-operator/step-registry/openshift/microshift/claude/post/OWNERS
@@ -1,5 +1,5 @@
 approvers:
-- microshift-approvers
+- openshift-edge-approvers
 options: {}
 reviewers:
-- microshift-reviewers
+- openshift-edge-reviewers

--- a/ci-operator/step-registry/openshift/microshift/claude/post/openshift-microshift-claude-post-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/microshift/claude/post/openshift-microshift-claude-post-ref.metadata.json
@@ -2,10 +2,10 @@
 	"path": "openshift/microshift/claude/post/openshift-microshift-claude-post-ref.yaml",
 	"owners": {
 		"approvers": [
-			"microshift-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"microshift-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/microshift/clusterbot/openshift-microshift-clusterbot-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/microshift/clusterbot/openshift-microshift-clusterbot-ref.metadata.json
@@ -2,10 +2,10 @@
 	"path": "openshift/microshift/clusterbot/openshift-microshift-clusterbot-ref.yaml",
 	"owners": {
 		"approvers": [
-			"microshift-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"microshift-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/microshift/clusterbot/openshift-microshift-clusterbot-workflow.metadata.json
+++ b/ci-operator/step-registry/openshift/microshift/clusterbot/openshift-microshift-clusterbot-workflow.metadata.json
@@ -2,10 +2,10 @@
 	"path": "openshift/microshift/clusterbot/openshift-microshift-clusterbot-workflow.yaml",
 	"owners": {
 		"approvers": [
-			"microshift-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"microshift-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/microshift/clusterbot/prepare-host/openshift-microshift-clusterbot-prepare-host-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/microshift/clusterbot/prepare-host/openshift-microshift-clusterbot-prepare-host-ref.metadata.json
@@ -2,10 +2,10 @@
 	"path": "openshift/microshift/clusterbot/prepare-host/openshift-microshift-clusterbot-prepare-host-ref.yaml",
 	"owners": {
 		"approvers": [
-			"microshift-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"microshift-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/microshift/e2e/bare-metal-tests/openshift-microshift-e2e-bare-metal-tests-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/microshift/e2e/bare-metal-tests/openshift-microshift-e2e-bare-metal-tests-ref.metadata.json
@@ -2,10 +2,10 @@
 	"path": "openshift/microshift/e2e/bare-metal-tests/openshift-microshift-e2e-bare-metal-tests-ref.yaml",
 	"owners": {
 		"approvers": [
-			"microshift-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"microshift-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/microshift/e2e/bare-metal-tests/openshift-microshift-e2e-bare-metal-tests-workflow.metadata.json
+++ b/ci-operator/step-registry/openshift/microshift/e2e/bare-metal-tests/openshift-microshift-e2e-bare-metal-tests-workflow.metadata.json
@@ -2,10 +2,10 @@
 	"path": "openshift/microshift/e2e/bare-metal-tests/openshift-microshift-e2e-bare-metal-tests-workflow.yaml",
 	"owners": {
 		"approvers": [
-			"microshift-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"microshift-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/microshift/e2e/conformance-from-source/openshift-microshift-e2e-conformance-from-source-workflow.metadata.json
+++ b/ci-operator/step-registry/openshift/microshift/e2e/conformance-from-source/openshift-microshift-e2e-conformance-from-source-workflow.metadata.json
@@ -2,10 +2,10 @@
 	"path": "openshift/microshift/e2e/conformance-from-source/openshift-microshift-e2e-conformance-from-source-workflow.yaml",
 	"owners": {
 		"approvers": [
-			"microshift-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"microshift-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/microshift/e2e/metal-cache/openshift-microshift-e2e-metal-cache-workflow.metadata.json
+++ b/ci-operator/step-registry/openshift/microshift/e2e/metal-cache/openshift-microshift-e2e-metal-cache-workflow.metadata.json
@@ -2,10 +2,10 @@
 	"path": "openshift/microshift/e2e/metal-cache/openshift-microshift-e2e-metal-cache-workflow.yaml",
 	"owners": {
 		"approvers": [
-			"microshift-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"microshift-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/microshift/e2e/metal-tests/openshift-microshift-e2e-metal-tests-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/microshift/e2e/metal-tests/openshift-microshift-e2e-metal-tests-ref.metadata.json
@@ -2,10 +2,10 @@
 	"path": "openshift/microshift/e2e/metal-tests/openshift-microshift-e2e-metal-tests-ref.yaml",
 	"owners": {
 		"approvers": [
-			"microshift-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"microshift-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/microshift/e2e/metal-tests/openshift-microshift-e2e-metal-tests-workflow.metadata.json
+++ b/ci-operator/step-registry/openshift/microshift/e2e/metal-tests/openshift-microshift-e2e-metal-tests-workflow.metadata.json
@@ -2,10 +2,10 @@
 	"path": "openshift/microshift/e2e/metal-tests/openshift-microshift-e2e-metal-tests-workflow.yaml",
 	"owners": {
 		"approvers": [
-			"microshift-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"microshift-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/microshift/e2e/openshift-conformance-build-and-run/openshift-microshift-e2e-openshift-conformance-build-and-run-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/microshift/e2e/openshift-conformance-build-and-run/openshift-microshift-e2e-openshift-conformance-build-and-run-ref.metadata.json
@@ -2,10 +2,10 @@
 	"path": "openshift/microshift/e2e/openshift-conformance-build-and-run/openshift-microshift-e2e-openshift-conformance-build-and-run-ref.yaml",
 	"owners": {
 		"approvers": [
-			"microshift-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"microshift-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/microshift/e2e/openshift-conformance-build-and-run/openshift-microshift-e2e-openshift-conformance-build-and-run-workflow.metadata.json
+++ b/ci-operator/step-registry/openshift/microshift/e2e/openshift-conformance-build-and-run/openshift-microshift-e2e-openshift-conformance-build-and-run-workflow.metadata.json
@@ -2,10 +2,10 @@
 	"path": "openshift/microshift/e2e/openshift-conformance-build-and-run/openshift-microshift-e2e-openshift-conformance-build-and-run-workflow.yaml",
 	"owners": {
 		"approvers": [
-			"microshift-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"microshift-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/microshift/e2e/openshift-conformance-reduced-aws/openshift-microshift-e2e-openshift-conformance-reduced-aws-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/microshift/e2e/openshift-conformance-reduced-aws/openshift-microshift-e2e-openshift-conformance-reduced-aws-ref.metadata.json
@@ -2,10 +2,10 @@
 	"path": "openshift/microshift/e2e/openshift-conformance-reduced-aws/openshift-microshift-e2e-openshift-conformance-reduced-aws-ref.yaml",
 	"owners": {
 		"approvers": [
-			"microshift-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"microshift-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/microshift/e2e/openshift-conformance-reduced-aws/openshift-microshift-e2e-openshift-conformance-reduced-aws-workflow.metadata.json
+++ b/ci-operator/step-registry/openshift/microshift/e2e/openshift-conformance-reduced-aws/openshift-microshift-e2e-openshift-conformance-reduced-aws-workflow.metadata.json
@@ -2,10 +2,10 @@
 	"path": "openshift/microshift/e2e/openshift-conformance-reduced-aws/openshift-microshift-e2e-openshift-conformance-reduced-aws-workflow.yaml",
 	"owners": {
 		"approvers": [
-			"microshift-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"microshift-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/microshift/e2e/origin-conformance/openshift-microshift-e2e-origin-conformance-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/microshift/e2e/origin-conformance/openshift-microshift-e2e-origin-conformance-ref.metadata.json
@@ -2,10 +2,10 @@
 	"path": "openshift/microshift/e2e/origin-conformance/openshift-microshift-e2e-origin-conformance-ref.yaml",
 	"owners": {
 		"approvers": [
-			"microshift-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"microshift-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/microshift/e2e/origin-conformance/openshift-microshift-e2e-origin-conformance-workflow.metadata.json
+++ b/ci-operator/step-registry/openshift/microshift/e2e/origin-conformance/openshift-microshift-e2e-origin-conformance-workflow.metadata.json
@@ -2,10 +2,10 @@
 	"path": "openshift/microshift/e2e/origin-conformance/openshift-microshift-e2e-origin-conformance-workflow.yaml",
 	"owners": {
 		"approvers": [
-			"microshift-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"microshift-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/microshift/includes/openshift-microshift-includes-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/microshift/includes/openshift-microshift-includes-ref.metadata.json
@@ -2,10 +2,10 @@
 	"path": "openshift/microshift/includes/openshift-microshift-includes-ref.yaml",
 	"owners": {
 		"approvers": [
-			"microshift-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"microshift-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/microshift/infra/aws/deprovision/openshift-microshift-infra-aws-deprovision-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/microshift/infra/aws/deprovision/openshift-microshift-infra-aws-deprovision-ref.metadata.json
@@ -2,10 +2,10 @@
 	"path": "openshift/microshift/infra/aws/deprovision/openshift-microshift-infra-aws-deprovision-ref.yaml",
 	"owners": {
 		"approvers": [
-			"microshift-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"microshift-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/microshift/infra/aws/ec2/openshift-microshift-infra-aws-ec2-chain.metadata.json
+++ b/ci-operator/step-registry/openshift/microshift/infra/aws/ec2/openshift-microshift-infra-aws-ec2-chain.metadata.json
@@ -2,10 +2,10 @@
 	"path": "openshift/microshift/infra/aws/ec2/openshift-microshift-infra-aws-ec2-chain.yaml",
 	"owners": {
 		"approvers": [
-			"microshift-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"microshift-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/microshift/infra/aws/ec2/openshift-microshift-infra-aws-ec2-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/microshift/infra/aws/ec2/openshift-microshift-infra-aws-ec2-ref.metadata.json
@@ -2,10 +2,10 @@
 	"path": "openshift/microshift/infra/aws/ec2/openshift-microshift-infra-aws-ec2-ref.yaml",
 	"owners": {
 		"approvers": [
-			"microshift-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"microshift-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/microshift/infra/aws/post/openshift-microshift-infra-aws-post-chain.metadata.json
+++ b/ci-operator/step-registry/openshift/microshift/infra/aws/post/openshift-microshift-infra-aws-post-chain.metadata.json
@@ -2,10 +2,10 @@
 	"path": "openshift/microshift/infra/aws/post/openshift-microshift-infra-aws-post-chain.yaml",
 	"owners": {
 		"approvers": [
-			"microshift-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"microshift-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/microshift/infra/aws/pre/openshift-microshift-infra-aws-pre-chain.metadata.json
+++ b/ci-operator/step-registry/openshift/microshift/infra/aws/pre/openshift-microshift-infra-aws-pre-chain.metadata.json
@@ -2,10 +2,10 @@
 	"path": "openshift/microshift/infra/aws/pre/openshift-microshift-infra-aws-pre-chain.yaml",
 	"owners": {
 		"approvers": [
-			"microshift-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"microshift-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/microshift/infra/conformance-setup/openshift-microshift-infra-conformance-setup-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/microshift/infra/conformance-setup/openshift-microshift-infra-conformance-setup-ref.metadata.json
@@ -2,10 +2,10 @@
 	"path": "openshift/microshift/infra/conformance-setup/openshift-microshift-infra-conformance-setup-ref.yaml",
 	"owners": {
 		"approvers": [
-			"microshift-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"microshift-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/microshift/infra/install-from-source/openshift-microshift-infra-install-from-source-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/microshift/infra/install-from-source/openshift-microshift-infra-install-from-source-ref.metadata.json
@@ -2,10 +2,10 @@
 	"path": "openshift/microshift/infra/install-from-source/openshift-microshift-infra-install-from-source-ref.yaml",
 	"owners": {
 		"approvers": [
-			"microshift-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"microshift-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/microshift/infra/iso-boot/openshift-microshift-infra-iso-boot-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/microshift/infra/iso-boot/openshift-microshift-infra-iso-boot-ref.metadata.json
@@ -2,10 +2,10 @@
 	"path": "openshift/microshift/infra/iso-boot/openshift-microshift-infra-iso-boot-ref.yaml",
 	"owners": {
 		"approvers": [
-			"microshift-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"microshift-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/microshift/infra/iso-build/openshift-microshift-infra-iso-build-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/microshift/infra/iso-build/openshift-microshift-infra-iso-build-ref.metadata.json
@@ -2,10 +2,10 @@
 	"path": "openshift/microshift/infra/iso-build/openshift-microshift-infra-iso-build-ref.yaml",
 	"owners": {
 		"approvers": [
-			"microshift-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"microshift-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/microshift/infra/lvm-install/openshift-microshift-infra-lvm-install-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/microshift/infra/lvm-install/openshift-microshift-infra-lvm-install-ref.metadata.json
@@ -2,10 +2,10 @@
 	"path": "openshift/microshift/infra/lvm-install/openshift-microshift-infra-lvm-install-ref.yaml",
 	"owners": {
 		"approvers": [
-			"microshift-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"microshift-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/microshift/infra/pcp/openshift-microshift-infra-pcp-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/microshift/infra/pcp/openshift-microshift-infra-pcp-ref.metadata.json
@@ -2,10 +2,10 @@
 	"path": "openshift/microshift/infra/pcp/openshift-microshift-infra-pcp-ref.yaml",
 	"owners": {
 		"approvers": [
-			"microshift-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"microshift-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/microshift/infra/pmlogs/openshift-microshift-infra-pmlogs-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/microshift/infra/pmlogs/openshift-microshift-infra-pmlogs-ref.metadata.json
@@ -2,10 +2,10 @@
 	"path": "openshift/microshift/infra/pmlogs/openshift-microshift-infra-pmlogs-ref.yaml",
 	"owners": {
 		"approvers": [
-			"microshift-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"microshift-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/microshift/infra/rpm-install-aws/openshift-microshift-infra-rpm-install-aws-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/microshift/infra/rpm-install-aws/openshift-microshift-infra-rpm-install-aws-ref.metadata.json
@@ -2,10 +2,10 @@
 	"path": "openshift/microshift/infra/rpm-install-aws/openshift-microshift-infra-rpm-install-aws-ref.yaml",
 	"owners": {
 		"approvers": [
-			"microshift-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"microshift-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/microshift/infra/sos-aws/openshift-microshift-infra-sos-aws-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/microshift/infra/sos-aws/openshift-microshift-infra-sos-aws-ref.metadata.json
@@ -2,10 +2,10 @@
 	"path": "openshift/microshift/infra/sos-aws/openshift-microshift-infra-sos-aws-ref.yaml",
 	"owners": {
 		"approvers": [
-			"microshift-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"microshift-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/microshift/infra/wait-for-cluster-up-aws/openshift-microshift-infra-wait-for-cluster-up-aws-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/microshift/infra/wait-for-cluster-up-aws/openshift-microshift-infra-wait-for-cluster-up-aws-ref.metadata.json
@@ -2,10 +2,10 @@
 	"path": "openshift/microshift/infra/wait-for-cluster-up-aws/openshift-microshift-infra-wait-for-cluster-up-aws-ref.yaml",
 	"owners": {
 		"approvers": [
-			"microshift-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"microshift-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/microshift/manage-versions-releases/OWNERS
+++ b/ci-operator/step-registry/openshift/microshift/manage-versions-releases/OWNERS
@@ -1,5 +1,5 @@
 approvers:
-- microshift-approvers
+- openshift-edge-approvers
 options: {}
 reviewers:
-- microshift-reviewers
+- openshift-edge-reviewers

--- a/ci-operator/step-registry/openshift/microshift/manage-versions-releases/openshift-microshift-manage-versions-releases-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/microshift/manage-versions-releases/openshift-microshift-manage-versions-releases-ref.metadata.json
@@ -2,10 +2,10 @@
 	"path": "openshift/microshift/manage-versions-releases/openshift-microshift-manage-versions-releases-ref.yaml",
 	"owners": {
 		"approvers": [
-			"microshift-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"microshift-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/microshift/manage-versions-releases/openshift-microshift-manage-versions-releases-workflow.metadata.json
+++ b/ci-operator/step-registry/openshift/microshift/manage-versions-releases/openshift-microshift-manage-versions-releases-workflow.metadata.json
@@ -2,10 +2,10 @@
 	"path": "openshift/microshift/manage-versions-releases/openshift-microshift-manage-versions-releases-workflow.yaml",
 	"owners": {
 		"approvers": [
-			"microshift-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"microshift-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/microshift/publish-release-notes/openshift-microshift-publish-release-notes-chain.metadata.json
+++ b/ci-operator/step-registry/openshift/microshift/publish-release-notes/openshift-microshift-publish-release-notes-chain.metadata.json
@@ -2,10 +2,10 @@
 	"path": "openshift/microshift/publish-release-notes/openshift-microshift-publish-release-notes-chain.yaml",
 	"owners": {
 		"approvers": [
-			"microshift-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"microshift-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/microshift/publish-release-notes/openshift-microshift-publish-release-notes-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/microshift/publish-release-notes/openshift-microshift-publish-release-notes-ref.metadata.json
@@ -2,10 +2,10 @@
 	"path": "openshift/microshift/publish-release-notes/openshift-microshift-publish-release-notes-ref.yaml",
 	"owners": {
 		"approvers": [
-			"microshift-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"microshift-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/microshift/publish-release-notes/openshift-microshift-publish-release-notes-workflow.metadata.json
+++ b/ci-operator/step-registry/openshift/microshift/publish-release-notes/openshift-microshift-publish-release-notes-workflow.metadata.json
@@ -2,10 +2,10 @@
 	"path": "openshift/microshift/publish-release-notes/openshift-microshift-publish-release-notes-workflow.yaml",
 	"owners": {
 		"approvers": [
-			"microshift-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"microshift-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/microshift/rebase/openshift-microshift-rebase-chain.metadata.json
+++ b/ci-operator/step-registry/openshift/microshift/rebase/openshift-microshift-rebase-chain.metadata.json
@@ -2,10 +2,10 @@
 	"path": "openshift/microshift/rebase/openshift-microshift-rebase-chain.yaml",
 	"owners": {
 		"approvers": [
-			"microshift-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"microshift-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/microshift/rebase/openshift-microshift-rebase-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/microshift/rebase/openshift-microshift-rebase-ref.metadata.json
@@ -2,10 +2,10 @@
 	"path": "openshift/microshift/rebase/openshift-microshift-rebase-ref.yaml",
 	"owners": {
 		"approvers": [
-			"microshift-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"microshift-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/microshift/rebase/openshift-microshift-rebase-workflow.metadata.json
+++ b/ci-operator/step-registry/openshift/microshift/rebase/openshift-microshift-rebase-workflow.metadata.json
@@ -2,10 +2,10 @@
 	"path": "openshift/microshift/rebase/openshift-microshift-rebase-workflow.yaml",
 	"owners": {
 		"approvers": [
-			"microshift-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"microshift-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/upgrade/aws/single-node/OWNERS
+++ b/ci-operator/step-registry/openshift/upgrade/aws/single-node/OWNERS
@@ -1,3 +1,6 @@
 approvers:
-- single-node
+- ecosystem-edge-single-node
+- openshift-edge-approvers
 - vrutkovs
+reviewers:
+- openshift-edge-reviewers

--- a/ci-operator/step-registry/openshift/upgrade/aws/single-node/openshift-upgrade-aws-single-node-workflow.metadata.json
+++ b/ci-operator/step-registry/openshift/upgrade/aws/single-node/openshift-upgrade-aws-single-node-workflow.metadata.json
@@ -2,8 +2,12 @@
 	"path": "openshift/upgrade/aws/single-node/openshift-upgrade-aws-single-node-workflow.yaml",
 	"owners": {
 		"approvers": [
-			"single-node",
+			"ecosystem-edge-single-node",
+			"openshift-edge-approvers",
 			"vrutkovs"
+		],
+		"reviewers": [
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/openshift/upgrade/aws/single-node/realtime/openshift-upgrade-aws-single-node-realtime-workflow.metadata.json
+++ b/ci-operator/step-registry/openshift/upgrade/aws/single-node/realtime/openshift-upgrade-aws-single-node-realtime-workflow.metadata.json
@@ -2,8 +2,12 @@
 	"path": "openshift/upgrade/aws/single-node/realtime/openshift-upgrade-aws-single-node-realtime-workflow.yaml",
 	"owners": {
 		"approvers": [
-			"single-node",
+			"ecosystem-edge-single-node",
+			"openshift-edge-approvers",
 			"vrutkovs"
+		],
+		"reviewers": [
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/optional-operators/ci/operator-sdk/hypershift/OWNERS
+++ b/ci-operator/step-registry/optional-operators/ci/operator-sdk/hypershift/OWNERS
@@ -1,4 +1,4 @@
 approvers:
-  - edge-enablement-approvers
+  - openshift-edge-approvers
 reviewers:
-  - edge-enablement-reviewers
+  - openshift-edge-reviewers

--- a/ci-operator/step-registry/optional-operators/ci/operator-sdk/hypershift/optional-operators-ci-operator-sdk-hypershift-workflow.metadata.json
+++ b/ci-operator/step-registry/optional-operators/ci/operator-sdk/hypershift/optional-operators-ci-operator-sdk-hypershift-workflow.metadata.json
@@ -2,10 +2,10 @@
 	"path": "optional-operators/ci/operator-sdk/hypershift/optional-operators-ci-operator-sdk-hypershift-workflow.yaml",
 	"owners": {
 		"approvers": [
-			"edge-enablement-approvers"
+			"openshift-edge-approvers"
 		],
 		"reviewers": [
-			"edge-enablement-reviewers"
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/single-node/OWNERS
+++ b/ci-operator/step-registry/single-node/OWNERS
@@ -1,2 +1,5 @@
 approvers:
-- single-node
+- ecosystem-edge-single-node
+- openshift-edge-approvers
+reviewers:
+- openshift-edge-reviewers

--- a/ci-operator/step-registry/single-node/add-workers/single-node-add-workers-ref.metadata.json
+++ b/ci-operator/step-registry/single-node/add-workers/single-node-add-workers-ref.metadata.json
@@ -2,7 +2,11 @@
 	"path": "single-node/add-workers/single-node-add-workers-ref.yaml",
 	"owners": {
 		"approvers": [
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-approvers"
+		],
+		"reviewers": [
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/single-node/conf/aws/single-node-conf-aws-ref.metadata.json
+++ b/ci-operator/step-registry/single-node/conf/aws/single-node-conf-aws-ref.metadata.json
@@ -2,7 +2,11 @@
 	"path": "single-node/conf/aws/single-node-conf-aws-ref.yaml",
 	"owners": {
 		"approvers": [
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-approvers"
+		],
+		"reviewers": [
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/single-node/conf/azure/single-node-conf-azure-ref.metadata.json
+++ b/ci-operator/step-registry/single-node/conf/azure/single-node-conf-azure-ref.metadata.json
@@ -2,7 +2,11 @@
 	"path": "single-node/conf/azure/single-node-conf-azure-ref.yaml",
 	"owners": {
 		"approvers": [
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-approvers"
+		],
+		"reviewers": [
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/single-node/conf/e2e/graceful-shutdown/OWNERS
+++ b/ci-operator/step-registry/single-node/conf/e2e/graceful-shutdown/OWNERS
@@ -1,5 +1,8 @@
 approvers:
-- single-node
+- ecosystem-edge-single-node
+- openshift-edge-approvers
 - wgahnagl
 - rphillips
 - mrunalp
+reviewers:
+- openshift-edge-reviewers

--- a/ci-operator/step-registry/single-node/conf/e2e/graceful-shutdown/single-node-conf-e2e-graceful-shutdown-ref.metadata.json
+++ b/ci-operator/step-registry/single-node/conf/e2e/graceful-shutdown/single-node-conf-e2e-graceful-shutdown-ref.metadata.json
@@ -2,10 +2,14 @@
 	"path": "single-node/conf/e2e/graceful-shutdown/single-node-conf-e2e-graceful-shutdown-ref.yaml",
 	"owners": {
 		"approvers": [
-			"single-node",
+			"ecosystem-edge-single-node",
+			"openshift-edge-approvers",
 			"wgahnagl",
 			"rphillips",
 			"mrunalp"
+		],
+		"reviewers": [
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/single-node/conf/e2e/single-node-conf-e2e-ref.metadata.json
+++ b/ci-operator/step-registry/single-node/conf/e2e/single-node-conf-e2e-ref.metadata.json
@@ -2,7 +2,11 @@
 	"path": "single-node/conf/e2e/single-node-conf-e2e-ref.yaml",
 	"owners": {
 		"approvers": [
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-approvers"
+		],
+		"reviewers": [
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/single-node/conf/gcp/single-node-conf-gcp-ref.metadata.json
+++ b/ci-operator/step-registry/single-node/conf/gcp/single-node-conf-gcp-ref.metadata.json
@@ -2,7 +2,11 @@
 	"path": "single-node/conf/gcp/single-node-conf-gcp-ref.yaml",
 	"owners": {
 		"approvers": [
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-approvers"
+		],
+		"reviewers": [
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/single-node/conf/realtime/single-node-conf-realtime-ref.metadata.json
+++ b/ci-operator/step-registry/single-node/conf/realtime/single-node-conf-realtime-ref.metadata.json
@@ -2,7 +2,11 @@
 	"path": "single-node/conf/realtime/single-node-conf-realtime-ref.yaml",
 	"owners": {
 		"approvers": [
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-approvers"
+		],
+		"reviewers": [
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/single-node/e2e/test/single-node-e2e-test-ref.metadata.json
+++ b/ci-operator/step-registry/single-node/e2e/test/single-node-e2e-test-ref.metadata.json
@@ -2,7 +2,11 @@
 	"path": "single-node/e2e/test/single-node-e2e-test-ref.yaml",
 	"owners": {
 		"approvers": [
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-approvers"
+		],
+		"reviewers": [
+			"openshift-edge-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/single-node/recert/OWNERS
+++ b/ci-operator/step-registry/single-node/recert/OWNERS
@@ -1,2 +1,5 @@
 approvers:
-- single-node
+- ecosystem-edge-single-node
+- openshift-edge-approvers
+reviewers:
+- openshift-edge-reviewers

--- a/ci-operator/step-registry/single-node/recert/single-node-recert-ref.metadata.json
+++ b/ci-operator/step-registry/single-node/recert/single-node-recert-ref.metadata.json
@@ -2,7 +2,11 @@
 	"path": "single-node/recert/single-node-recert-ref.yaml",
 	"owners": {
 		"approvers": [
-			"single-node"
+			"ecosystem-edge-single-node",
+			"openshift-edge-approvers"
+		],
+		"reviewers": [
+			"openshift-edge-reviewers"
 		]
 	}
 }


### PR DESCRIPTION
- Consolidated edge-enablement aliases into openshift-edge-{reviewers,approvers}
- Removed redundant microshift-specific aliases (now covered by openshift-edge)
- Renamed single-node to ecosystem-edge-single-node (excluding jeff/egli, now in openshift-edge)
- Updated OWNERS files across single-node and microshift components
- Removed managers from reviewer lists (retained as approvers only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Replaced legacy approval and reviewer aliases with new edge-focused approver/reviewer groups and added an ecosystem-edge single-node approver alias.
  * Consolidated and reorganized membership rosters for the new aliases.
  * Applied these governance updates across CI/workflow and step metadata to standardize approval and review routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->