### PR TITLE
Added secrets for build12 onboarding

### DIFF
--- a/core-services/ci-secret-bootstrap/_config.yaml
+++ b/core-services/ci-secret-bootstrap/_config.yaml
@@ -15,6 +15,7 @@ cluster_groups:
   - build09
   - build10
   - build11
+  - build12
   - core-ci
   - vsphere02
   managed_clusters:
@@ -30,6 +31,7 @@ cluster_groups:
   - build09
   - build10
   - build11
+  - build12
   - core-ci
   - hosted-mgmt
   non_app_ci:
@@ -44,6 +46,7 @@ cluster_groups:
   - build09
   - build10
   - build11
+  - build12
   - core-ci
   - vsphere02
   openshift_config_pull_secret:
@@ -58,6 +61,7 @@ cluster_groups:
   - build09
   - build10
   - build11
+  - build12
   - core-ci
   - hosted-mgmt
   - vsphere02
@@ -3181,6 +3185,9 @@ secret_configs:
     build11.config:
       field: sa.pod-scaler.build11.config
       item: pod-scaler
+    build12.config:
+      field: sa.pod-scaler.build12.config
+      item: pod-scaler
     core-ci.config:
       field: sa.pod-scaler.core-ci.config
       item: pod-scaler
@@ -3219,6 +3226,9 @@ secret_configs:
       item: pod-scaler
     sa.pod-scaler.build11.token.txt:
       field: sa.pod-scaler.build11.token.txt
+      item: pod-scaler
+    sa.pod-scaler.build12.token.txt:
+      field: sa.pod-scaler.build12.token.txt
       item: pod-scaler
     sa.pod-scaler.core-ci.token.txt:
       field: sa.pod-scaler.core-ci.token.txt
@@ -3600,6 +3610,12 @@ secret_configs:
     sa.crier.build11.token.txt:
       field: sa.crier.build11.token.txt
       item: build_farm
+    sa.crier.build12.config:
+      field: sa.crier.build12.config
+      item: build_farm
+    sa.crier.build12.token.txt:
+      field: sa.crier.build12.token.txt
+      item: build_farm
     sa.crier.core-ci.config:
       field: sa.crier.core-ci.config
       item: build_farm
@@ -3652,6 +3668,9 @@ secret_configs:
       item: config-updater
     sa.config-updater.build11.config:
       field: sa.config-updater.build11.config
+      item: config-updater
+    sa.config-updater.build12.config:
+      field: sa.config-updater.build12.config
       item: config-updater
     sa.config-updater.core-ci.config:
       field: sa.config-updater.core-ci.config
@@ -3745,6 +3764,12 @@ secret_configs:
     sa.deck.build11.token.txt:
       field: sa.deck.build11.token.txt
       item: build_farm
+    sa.deck.build12.config:
+      field: sa.deck.build12.config
+      item: build_farm
+    sa.deck.build12.token.txt:
+      field: sa.deck.build12.token.txt
+      item: build_farm
     sa.deck.core-ci.config:
       field: sa.deck.core-ci.config
       item: build_farm
@@ -3833,6 +3858,12 @@ secret_configs:
       item: build_farm
     sa.hook.build11.token.txt:
       field: sa.hook.build11.token.txt
+      item: build_farm
+    sa.hook.build12.config:
+      field: sa.hook.build12.config
+      item: build_farm
+    sa.hook.build12.token.txt:
+      field: sa.hook.build12.token.txt
       item: build_farm
     sa.hook.core-ci.config:
       field: sa.hook.core-ci.config
@@ -3925,6 +3956,12 @@ secret_configs:
       item: build_farm
     sa.prow-controller-manager.build11.token.txt:
       field: sa.prow-controller-manager.build11.token.txt
+      item: build_farm
+    sa.prow-controller-manager.build12.config:
+      field: sa.prow-controller-manager.build12.config
+      item: build_farm
+    sa.prow-controller-manager.build12.token.txt:
+      field: sa.prow-controller-manager.build12.token.txt
       item: build_farm
     sa.prow-controller-manager.core-ci.config:
       field: sa.prow-controller-manager.core-ci.config
@@ -4041,6 +4078,12 @@ secret_configs:
     sa.sinker.build11.token.txt:
       field: sa.sinker.build11.token.txt
       item: build_farm
+    sa.sinker.build12.config:
+      field: sa.sinker.build12.config
+      item: build_farm
+    sa.sinker.build12.token.txt:
+      field: sa.sinker.build12.token.txt
+      item: build_farm
     sa.sinker.core-ci.config:
       field: sa.sinker.core-ci.config
       item: build_farm
@@ -4124,6 +4167,12 @@ secret_configs:
     sa.dptp-controller-manager.build11.token.txt:
       field: sa.dptp-controller-manager.build11.token.txt
       item: build_farm
+    sa.dptp-controller-manager.build12.config:
+      field: sa.dptp-controller-manager.build12.config
+      item: build_farm
+    sa.dptp-controller-manager.build12.token.txt:
+      field: sa.dptp-controller-manager.build12.token.txt
+      item: build_farm
     sa.dptp-controller-manager.core-ci.config:
       field: sa.dptp-controller-manager.core-ci.config
       item: build_farm
@@ -4206,6 +4255,12 @@ secret_configs:
       item: build_farm
     sa.promoted-image-governor.build11.token.txt:
       field: sa.promoted-image-governor.build11.token.txt
+      item: build_farm
+    sa.promoted-image-governor.build12.config:
+      field: sa.promoted-image-governor.build12.config
+      item: build_farm
+    sa.promoted-image-governor.build12.token.txt:
+      field: sa.promoted-image-governor.build12.token.txt
       item: build_farm
     sa.promoted-image-governor.core-ci.config:
       field: sa.promoted-image-governor.core-ci.config
@@ -4327,6 +4382,12 @@ secret_configs:
     sa.ci-chat-bot.build11.token.txt:
       field: sa.ci-chat-bot.build11.token.txt
       item: ci-chat-bot
+    sa.ci-chat-bot.build12.config:
+      field: sa.ci-chat-bot.build12.config
+      item: ci-chat-bot
+    sa.ci-chat-bot.build12.token.txt:
+      field: sa.ci-chat-bot.build12.token.txt
+      item: ci-chat-bot
     sa.ci-chat-bot.core-ci.config:
       field: sa.ci-chat-bot.core-ci.config
       item: ci-chat-bot
@@ -4415,6 +4476,12 @@ secret_configs:
       item: build_farm
     sa.github-ldap-user-group-creator.build11.token.txt:
       field: sa.github-ldap-user-group-creator.build11.token.txt
+      item: build_farm
+    sa.github-ldap-user-group-creator.build12.config:
+      field: sa.github-ldap-user-group-creator.build12.config
+      item: build_farm
+    sa.github-ldap-user-group-creator.build12.token.txt:
+      field: sa.github-ldap-user-group-creator.build12.token.txt
       item: build_farm
     sa.github-ldap-user-group-creator.core-ci.config:
       field: sa.github-ldap-user-group-creator.core-ci.config
@@ -5403,6 +5470,12 @@ secret_configs:
       item: build_farm
     sa.cluster-display.build11.token.txt:
       field: sa.cluster-display.build11.token.txt
+      item: build_farm
+    sa.cluster-display.build12.config:
+      field: sa.cluster-display.build12.config
+      item: build_farm
+    sa.cluster-display.build12.token.txt:
+      field: sa.cluster-display.build12.token.txt
       item: build_farm
     sa.cluster-display.core-ci.config:
       field: sa.cluster-display.core-ci.config
@@ -7430,6 +7503,48 @@ secret_configs:
     name: multi-arch-builder-controller-build11-registry-credentials
     namespace: ci
     type: kubernetes.io/dockerconfigjson
+- from:
+    .dockerconfigjson:
+      dockerconfigJSON:
+      - auth_field: token_image-pusher_build12_reg_auth_value.txt
+        item: build_farm
+        registry_url: image-registry.openshift-image-registry.svc:5000
+      - auth_field: token_multi-arch-builder-controller_build12_reg_auth_value.txt
+        item: build_farm
+        registry_url: registry.multi-build01.arm-build.devcluster.openshift.com
+      - auth_field: token_image-pusher_app.ci_reg_auth_value.txt
+        item: build_farm
+        registry_url: registry.ci.openshift.org
+  to:
+  - cluster: build12
+    name: multi-arch-builder-controller-build12-registry-credentials
+    namespace: ci
+    type: kubernetes.io/dockerconfigjson
+- from:
+    build12-id:
+      field: build12-id
+      item: dex
+    build12-secret:
+      field: build12-secret
+      item: dex
+  to:
+  - cluster: app.ci
+    name: build12-secret
+    namespace: dex
+  - cluster: app.ci
+    name: build12-dex-oidc
+    namespace: ci
+  - cluster: core-ci
+    name: build12-dex-oidc
+    namespace: ci
+- from:
+    clientSecret:
+      field: build12-secret
+      item: dex
+  to:
+  - cluster: build12
+    name: dex-rh-sso
+    namespace: openshift-config
 user_secrets_target_clusters:
 - app.ci
 - build01
@@ -7443,6 +7558,7 @@ user_secrets_target_clusters:
 - build09
 - build10
 - build11
+- build12
 - core-ci
 - hosted-mgmt
 - vsphere02

--- a/core-services/ci-secret-bootstrap/gsm-config.yaml
+++ b/core-services/ci-secret-bootstrap/gsm-config.yaml
@@ -16,6 +16,7 @@ cluster_groups:
     - build09
     - build10
     - build11
+    - build12
     - core-ci
     - vsphere02
   managed_clusters:
@@ -31,6 +32,7 @@ cluster_groups:
     - build09
     - build10
     - build11
+    - build12
     - core-ci
     - hosted-mgmt
   non_app_ci:
@@ -45,6 +47,7 @@ cluster_groups:
     - build09
     - build10
     - build11
+    - build12
     - core-ci
     - vsphere02
   standard_build_clusters:
@@ -59,6 +62,7 @@ cluster_groups:
     - build09
     - build10
     - build11
+    - build12
 
 bundles:
   - name: gce-sa-credentials-gcs-publisher
@@ -119,6 +123,8 @@ bundles:
           - sa--dot--cluster-init--dot--build10--dot--token--dot--txt
           - sa--dot--cluster-init--dot--build11--dot--config
           - sa--dot--cluster-init--dot--build11--dot--token--dot--txt
+          - sa--dot--cluster-init--dot--build12--dot--config
+          - sa--dot--cluster-init--dot--build12--dot--token--dot--txt
           - sa--dot--cluster-init--dot--core-ci--dot--config
           - sa--dot--cluster-init--dot--core-ci--dot--token--dot--txt
           - sa--dot--cluster-init--dot--vsphere02--dot--config
@@ -750,6 +756,61 @@ bundles:
   - name: registry-pull-credentials
     dockerconfig:
       registries:
+        - auth_field: token_image-puller_build12_reg_auth_value--dot--txt
+          collection: test-platform-infra
+          group: build_farm
+          registry_url: image-registry.openshift-image-registry.svc.cluster.local:5000
+        - auth_field: token_image-puller_build12_reg_auth_value--dot--txt
+          collection: test-platform-infra
+          group: build_farm
+          registry_url: image-registry.openshift-image-registry.svc:5000
+        - auth_field: token_image-puller_build12_reg_auth_value--dot--txt
+          collection: test-platform-infra
+          group: build_farm
+          registry_url: registry.build12.ci.openshift.org
+        - auth_field: token_image-puller_app--dot--ci_reg_auth_value--dot--txt
+          collection: test-platform-infra
+          group: build_farm
+          registry_url: registry.ci.openshift.org
+        - auth_field: auth
+          email_field: email
+          collection: test-platform-infra
+          group: quay--dot--io-pull-secret
+          registry_url: quay.io
+        - auth_field: auth
+          collection: test-platform-infra
+          group: quayio-ci-read-only-robot
+          registry_url: quay-proxy.ci.openshift.org
+        - auth_field: auth
+          collection: test-platform-infra
+          group: quayio-ci-read-only-robot
+          registry_url: quay.io/openshift/ci
+        - auth_field: auth
+          collection: test-platform-infra
+          group: quayio-ci-read-only-robot
+          registry_url: quay.io/openshift/network-edge-testing
+        - auth_field: auth
+          collection: test-platform-infra
+          group: quayio-ci-read-only-robot
+          registry_url: qci-pull-through-cache-us-east-1-ci.apps.ci.l2s4.p1.openshiftapps.com
+    sync_to_cluster: true
+    targets:
+      - cluster: build12
+        namespace: ci
+        type: kubernetes.io/dockerconfigjson
+      - cluster: build12
+        namespace: test-credentials
+        type: kubernetes.io/dockerconfigjson
+      - cluster: build12
+        namespace: keel
+        type: kubernetes.io/dockerconfigjson
+      - cluster: build12
+        namespace: ocp
+        type: kubernetes.io/dockerconfigjson
+
+  - name: registry-pull-credentials
+    dockerconfig:
+      registries:
         - auth_field: token_image-puller_vsphere02_reg_auth_value--dot--txt
           collection: test-platform-infra
           group: build_farm
@@ -1328,6 +1389,42 @@ bundles:
   - name: registry-push-credentials-ci-central
     dockerconfig:
       registries:
+        - auth_field: token_image-puller_build12_reg_auth_value--dot--txt
+          collection: test-platform-infra
+          group: build_farm
+          registry_url: image-registry.openshift-image-registry.svc.cluster.local:5000
+        - auth_field: token_image-puller_build12_reg_auth_value--dot--txt
+          collection: test-platform-infra
+          group: build_farm
+          registry_url: image-registry.openshift-image-registry.svc:5000
+        - auth_field: token_image-puller_build12_reg_auth_value--dot--txt
+          collection: test-platform-infra
+          group: build_farm
+          registry_url: registry.build12.ci.openshift.org
+        - auth_field: token_image-pusher_app--dot--ci_reg_auth_value--dot--txt
+          collection: test-platform-infra
+          group: build_farm
+          registry_url: registry.ci.openshift.org
+        - auth_field: auth
+          collection: test-platform-infra
+          group: quay-io-push-credentials
+          registry_url: quay.io/openshift/ci
+        - auth_field: auth
+          collection: test-platform-infra
+          group: quayio-ci-read-only-robot
+          registry_url: quay-proxy.ci.openshift.org
+    sync_to_cluster: true
+    targets:
+      - cluster: build12
+        namespace: ci
+        type: kubernetes.io/dockerconfigjson
+      - cluster: build12
+        namespace: test-credentials
+        type: kubernetes.io/dockerconfigjson
+
+  - name: registry-push-credentials-ci-central
+    dockerconfig:
+      registries:
         - auth_field: token_image-puller_vsphere02_reg_auth_value--dot--txt
           collection: test-platform-infra
           group: build_farm
@@ -1742,6 +1839,26 @@ bundles:
         namespace: ci
         type: kubernetes.io/dockerconfigjson
       - cluster: build11
+        namespace: test-credentials
+        type: kubernetes.io/dockerconfigjson
+
+  - name: manifest-tool-local-pusher
+    dockerconfig:
+      registries:
+        - auth_field: token_image-pusher_build12_reg_auth_value--dot--txt
+          collection: test-platform-infra
+          group: build_farm
+          registry_url: image-registry.openshift-image-registry.svc:5000
+        - auth_field: token_image-pusher_build12_reg_auth_value--dot--txt
+          collection: test-platform-infra
+          group: build_farm
+          registry_url: registry.build12.ci.openshift.org
+    sync_to_cluster: true
+    targets:
+      - cluster: build12
+        namespace: ci
+        type: kubernetes.io/dockerconfigjson
+      - cluster: build12
         namespace: test-credentials
         type: kubernetes.io/dockerconfigjson
 


### PR DESCRIPTION
This will be used to unblock https://github.com/openshift/release/pull/78358 a broader PR about onboarding build12.

@coderabbitai ignore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new `build12` cluster to the CI/CD infrastructure with configuration for cluster targeting, service account credentials, and registry authentication across multiple namespaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->