### PR TITLE
DO NOT MERGE: Debug Cilium network policy dump

### DIFF
--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.22__periodics.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.22__periodics.yaml
@@ -189,7 +189,8 @@ tests:
         work with TCP (when fully idled)\| Unidling \[apigroup:apps.openshift.io\]\[apigroup:route.openshift.io\]
         should work with TCP (when fully idled)\| Unidling with Deployments \[apigroup:route.openshift.io\]
         should work with UDP\| DNS should answer queries using the local DNS endpoint\|
-        Ensure HTTPRoute object is created
+        Ensure HTTPRoute object is created\| Critical-CCO-based flow for olm managed
+        operators and AWS STS\| NonHyperShiftHOST-High-CCO metrics endpoint validation
     workflow: hypershift-aws-conformance-cilium
 - as: e2e-aws-external-oidc
   minimum_interval: 12h

--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.22__periodics.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.22__periodics.yaml
@@ -178,21 +178,18 @@ tests:
     cluster_profile: hypershift-aws
     env:
       TEST_SKIPS: Netpol NetworkPolicy between server and client should allow egress
-        access to server in CIDR block \[Feature:NetworkPolicy\] \[Suite:openshift/conformance/parallel\]
-        \[Suite:k8s\]\| Netpol NetworkPolicy between server and client should ensure
-        an IP overlapping both IPBlock.CIDR and IPBlock.Except is allowed \[Feature:NetworkPolicy\]
-        \[Suite:openshift/conformance/parallel\] \[Suite:k8s\]\| Services should serve
-        endpoints on same port and different protocols \[Conformance\] \[Suite:openshift/conformance/parallel/minimal\]
-        \[Suite:k8s\]\| Netpol NetworkPolicy between server and client should enforce
-        except clause while egress access to server in CIDR block \[Feature:NetworkPolicy\]
-        \[Suite:openshift/conformance/parallel\] \[Suite:k8s\]\| Unidling \[apigroup:apps.openshift.io\]\[apigroup:route.openshift.io\]
-        should work with UDP \[Suite:openshift/conformance/parallel\]\| Unidling with
-        Deployments \[apigroup:route.openshift.io\] should work with TCP (when fully
-        idled) \[Suite:openshift/conformance/parallel\]\| Unidling \[apigroup:apps.openshift.io\]\[apigroup:route.openshift.io\]
-        should work with TCP (when fully idled) \[Suite:openshift/conformance/parallel\]\|
-        Unidling with Deployments \[apigroup:route.openshift.io\] should work with
-        UDP \[Suite:openshift/conformance/parallel\]\| DNS should answer queries using
-        the local DNS endpoint \[Suite:openshift/conformance/parallel\]
+        access to server in CIDR block \[Feature:NetworkPolicy\]\| Netpol NetworkPolicy
+        between server and client should ensure an IP overlapping both IPBlock.CIDR
+        and IPBlock.Except is allowed \[Feature:NetworkPolicy\]\| Services should
+        serve endpoints on same port and different protocols \[Conformance\]\| Netpol
+        NetworkPolicy between server and client should enforce except clause while
+        egress access to server in CIDR block \[Feature:NetworkPolicy\]\| Unidling
+        \[apigroup:apps.openshift.io\]\[apigroup:route.openshift.io\] should work
+        with UDP\| Unidling with Deployments \[apigroup:route.openshift.io\] should
+        work with TCP (when fully idled)\| Unidling \[apigroup:apps.openshift.io\]\[apigroup:route.openshift.io\]
+        should work with TCP (when fully idled)\| Unidling with Deployments \[apigroup:route.openshift.io\]
+        should work with UDP\| DNS should answer queries using the local DNS endpoint\|
+        Ensure HTTPRoute object is created
     workflow: hypershift-aws-conformance-cilium
 - as: e2e-aws-external-oidc
   minimum_interval: 12h

--- a/ci-operator/step-registry/cucushift/hypershift-extended/cilium/network-policies/cucushift-hypershift-extended-cilium-network-policies-commands.sh
+++ b/ci-operator/step-registry/cucushift/hypershift-extended/cilium/network-policies/cucushift-hypershift-extended-cilium-network-policies-commands.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+if [ -f "${SHARED_DIR}/proxy-conf.sh" ] ; then
+  source "${SHARED_DIR}/proxy-conf.sh"
+fi
+
+if [[ -f "${SHARED_DIR}/nested_kubeconfig" ]]; then
+    export KUBECONFIG="${SHARED_DIR}/nested_kubeconfig"
+fi
+
+echo "Applying additional NetworkPolicies for Cilium compatibility"
+echo "OCP 4.22+ adds deny-all NetworkPolicies in openshift-monitoring and openshift-ingress."
+echo "OVN handles these via the network.openshift.io/policy-group label, but Cilium does not."
+echo "These policies restore the required traffic paths for conformance tests."
+
+# Allow all ingress to openshift-monitoring so test pods can access
+# Prometheus, Thanos Querier, and Alertmanager endpoints.
+# The OCP 4.22 deny-all policy blocks this traffic under Cilium.
+oc apply -f - <<'EOF'
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-ingress-cilium-workaround
+  namespace: openshift-monitoring
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  policyTypes:
+  - Ingress
+EOF
+
+# Allow all ingress to openshift-ingress so monitoring can scrape
+# router metrics and LB tests can reach ingress endpoints.
+oc apply -f - <<'EOF'
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-ingress-cilium-workaround
+  namespace: openshift-ingress
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  policyTypes:
+  - Ingress
+EOF
+
+echo "Cilium NetworkPolicy workarounds applied successfully"

--- a/ci-operator/step-registry/cucushift/hypershift-extended/cilium/network-policies/cucushift-hypershift-extended-cilium-network-policies-commands.sh
+++ b/ci-operator/step-registry/cucushift/hypershift-extended/cilium/network-policies/cucushift-hypershift-extended-cilium-network-policies-commands.sh
@@ -15,35 +15,88 @@ echo "OCP 4.22+ adds deny-all NetworkPolicies in openshift-monitoring and opensh
 echo "OVN handles these via the network.openshift.io/policy-group label, but Cilium does not."
 echo "These policies restore the required traffic paths for conformance tests."
 
-# Allow all ingress to openshift-monitoring so test pods can access
-# Prometheus, Thanos Querier, and Alertmanager endpoints.
-# The OCP 4.22 deny-all policy blocks this traffic under Cilium.
+# Allow test access to Prometheus web API (ports 9090, 9091)
 oc apply -f - <<'EOF'
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: allow-all-ingress-cilium-workaround
+  name: allow-test-access-prometheus-cilium
   namespace: openshift-monitoring
 spec:
-  podSelector: {}
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
   ingress:
-  - {}
+  - ports:
+    - port: 9090
+      protocol: TCP
+    - port: 9091
+      protocol: TCP
   policyTypes:
   - Ingress
 EOF
 
-# Allow all ingress to openshift-ingress so monitoring can scrape
-# router metrics and LB tests can reach ingress endpoints.
+# Allow test access to Thanos Querier (ports 9091, 9092)
 oc apply -f - <<'EOF'
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: allow-all-ingress-cilium-workaround
+  name: allow-test-access-thanos-cilium
+  namespace: openshift-monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: thanos-query
+  ingress:
+  - ports:
+    - port: 9091
+      protocol: TCP
+    - port: 9092
+      protocol: TCP
+  policyTypes:
+  - Ingress
+EOF
+
+# Allow test access to Alertmanager (ports 9093, 9094)
+oc apply -f - <<'EOF'
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-test-access-alertmanager-cilium
+  namespace: openshift-monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: alertmanager
+  ingress:
+  - ports:
+    - port: 9093
+      protocol: TCP
+    - port: 9094
+      protocol: TCP
+  policyTypes:
+  - Ingress
+EOF
+
+# Allow monitoring to scrape router metrics (port 1936)
+oc apply -f - <<'EOF'
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-monitoring-scrape-router-cilium
   namespace: openshift-ingress
 spec:
-  podSelector: {}
+  podSelector:
+    matchLabels:
+      ingresscontroller.operator.openshift.io/deployment-ingresscontroller: default
   ingress:
-  - {}
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-monitoring
+    ports:
+    - port: 1936
+      protocol: TCP
   policyTypes:
   - Ingress
 EOF

--- a/ci-operator/step-registry/cucushift/hypershift-extended/cilium/network-policies/cucushift-hypershift-extended-cilium-network-policies-ref.yaml
+++ b/ci-operator/step-registry/cucushift/hypershift-extended/cilium/network-policies/cucushift-hypershift-extended-cilium-network-policies-ref.yaml
@@ -1,0 +1,16 @@
+ref:
+  as: cucushift-hypershift-extended-cilium-network-policies
+  from: cli
+  commands: cucushift-hypershift-extended-cilium-network-policies-commands.sh
+  grace_period: 1m0s
+  resources:
+    requests:
+      cpu: 100m
+      memory: 100Mi
+  timeout: 5m0s
+  documentation: |-
+    Applies additional NetworkPolicies required for Cilium compatibility with OCP 4.22+.
+    OCP 4.22 introduced deny-all NetworkPolicies in openshift-monitoring and openshift-ingress.
+    OVN handles monitoring traffic via the network.openshift.io/policy-group label, but Cilium
+    does not support this extension. This step restores the required ingress paths for
+    conformance tests to pass under Cilium.

--- a/ci-operator/step-registry/hypershift/aws/conformance-cilium/hypershift-aws-conformance-cilium-workflow.yaml
+++ b/ci-operator/step-registry/hypershift/aws/conformance-cilium/hypershift-aws-conformance-cilium-workflow.yaml
@@ -41,7 +41,9 @@ workflow:
         should work with TCP (when fully idled)\|
         Unidling with Deployments \[apigroup:route.openshift.io\] should work with UDP\|
         DNS should answer queries using the local DNS endpoint\|
-        Ensure HTTPRoute object is created
+        Ensure HTTPRoute object is created\|
+        Critical-CCO-based flow for olm managed operators and AWS STS\|
+        NonHyperShiftHOST-High-CCO metrics endpoint validation
     post:
     - chain: hypershift-dump
     - as: dump-cilium-debug

--- a/ci-operator/step-registry/hypershift/aws/conformance-cilium/hypershift-aws-conformance-cilium-workflow.yaml
+++ b/ci-operator/step-registry/hypershift/aws/conformance-cilium/hypershift-aws-conformance-cilium-workflow.yaml
@@ -76,3 +76,4 @@ workflow:
     - chain: hypershift-aws-create
     - ref: cucushift-hypershift-extended-cilium
     - ref: cucushift-hypershift-extended-cilium-health-check
+    - ref: cucushift-hypershift-extended-cilium-network-policies

--- a/ci-operator/step-registry/hypershift/aws/conformance-cilium/hypershift-aws-conformance-cilium-workflow.yaml
+++ b/ci-operator/step-registry/hypershift/aws/conformance-cilium/hypershift-aws-conformance-cilium-workflow.yaml
@@ -58,7 +58,24 @@ workflow:
         oc version > ${ARTIFACT_DIR}/cilium-debug/oc-version.txt 2>&1 || true
         oc get ns openshift-monitoring -o yaml > ${ARTIFACT_DIR}/cilium-debug/ns-openshift-monitoring.yaml 2>&1 || true
         oc get pods -n cilium -o wide > ${ARTIFACT_DIR}/cilium-debug/cilium-pods.txt 2>&1 || true
-        oc logs -n cilium -l k8s-app=cilium --tail=200 > ${ARTIFACT_DIR}/cilium-debug/cilium-agent-logs.txt 2>&1 || true
+        oc logs -n cilium -l k8s-app=cilium --tail=500 > ${ARTIFACT_DIR}/cilium-debug/cilium-agent-logs.txt 2>&1 || true
+
+        # CLB/LoadBalancer debug
+        oc get svc -A -o wide > ${ARTIFACT_DIR}/cilium-debug/services.txt 2>&1 || true
+        oc get svc -A -o yaml | grep -A 20 "type: LoadBalancer" > ${ARTIFACT_DIR}/cilium-debug/loadbalancer-svcs.txt 2>&1 || true
+        oc get endpoints -A > ${ARTIFACT_DIR}/cilium-debug/endpoints.txt 2>&1 || true
+
+        # Cilium service handling
+        CILIUM_POD=$(oc get pods -n cilium -l k8s-app=cilium -o jsonpath='{.items[0].metadata.name}' 2>/dev/null) || true
+        if [[ -n "${CILIUM_POD}" ]]; then
+          oc exec -n cilium ${CILIUM_POD} -- cilium status > ${ARTIFACT_DIR}/cilium-debug/cilium-status.txt 2>&1 || true
+          oc exec -n cilium ${CILIUM_POD} -- cilium service list > ${ARTIFACT_DIR}/cilium-debug/cilium-service-list.txt 2>&1 || true
+          oc exec -n cilium ${CILIUM_POD} -- cilium bpf lb list > ${ARTIFACT_DIR}/cilium-debug/cilium-bpf-lb-list.txt 2>&1 || true
+          oc exec -n cilium ${CILIUM_POD} -- cilium config | grep -i -E "kube-proxy|nodeport|lb|loadbalancer|masquerade|snat" > ${ARTIFACT_DIR}/cilium-debug/cilium-lb-config.txt 2>&1 || true
+        fi
+
+        # CiliumConfig
+        oc get ciliumconfig -n cilium -o yaml > ${ARTIFACT_DIR}/cilium-debug/ciliumconfig.yaml 2>&1 || true
       from: cli
       resources:
         requests:

--- a/ci-operator/step-registry/hypershift/aws/conformance-cilium/hypershift-aws-conformance-cilium-workflow.yaml
+++ b/ci-operator/step-registry/hypershift/aws/conformance-cilium/hypershift-aws-conformance-cilium-workflow.yaml
@@ -44,6 +44,27 @@ workflow:
         Ensure HTTPRoute object is created
     post:
     - chain: hypershift-dump
+    - as: dump-cilium-debug
+      cli: latest
+      commands: |-
+        set -xuo pipefail
+        export KUBECONFIG=${SHARED_DIR}/nested_kubeconfig
+        mkdir -p ${ARTIFACT_DIR}/cilium-debug
+
+        oc get networkpolicy -A -o yaml > ${ARTIFACT_DIR}/cilium-debug/networkpolicies.yaml 2>&1 || true
+        oc get ciliumnetworkpolicy -A -o yaml > ${ARTIFACT_DIR}/cilium-debug/ciliumnetworkpolicies.yaml 2>&1 || true
+        oc get ciliumclusterwidenetworkpolicy -A -o yaml > ${ARTIFACT_DIR}/cilium-debug/ciliumclusterwidenetworkpolicies.yaml 2>&1 || true
+        oc get ciliumendpoint -A > ${ARTIFACT_DIR}/cilium-debug/ciliumendpoints.txt 2>&1 || true
+        oc version > ${ARTIFACT_DIR}/cilium-debug/oc-version.txt 2>&1 || true
+        oc get ns openshift-monitoring -o yaml > ${ARTIFACT_DIR}/cilium-debug/ns-openshift-monitoring.yaml 2>&1 || true
+        oc get pods -n cilium -o wide > ${ARTIFACT_DIR}/cilium-debug/cilium-pods.txt 2>&1 || true
+        oc logs -n cilium -l app.kubernetes.io/name=cilium --tail=200 > ${ARTIFACT_DIR}/cilium-debug/cilium-agent-logs.txt 2>&1 || true
+      from: cli
+      resources:
+        requests:
+          cpu: 100m
+          memory: 100Mi
+      timeout: 5m0s
     - chain: hypershift-aws-destroy
     - chain: hypershift-destroy-nested-management-cluster
     test:

--- a/ci-operator/step-registry/hypershift/aws/conformance-cilium/hypershift-aws-conformance-cilium-workflow.yaml
+++ b/ci-operator/step-registry/hypershift/aws/conformance-cilium/hypershift-aws-conformance-cilium-workflow.yaml
@@ -58,7 +58,7 @@ workflow:
         oc version > ${ARTIFACT_DIR}/cilium-debug/oc-version.txt 2>&1 || true
         oc get ns openshift-monitoring -o yaml > ${ARTIFACT_DIR}/cilium-debug/ns-openshift-monitoring.yaml 2>&1 || true
         oc get pods -n cilium -o wide > ${ARTIFACT_DIR}/cilium-debug/cilium-pods.txt 2>&1 || true
-        oc logs -n cilium -l app.kubernetes.io/name=cilium --tail=200 > ${ARTIFACT_DIR}/cilium-debug/cilium-agent-logs.txt 2>&1 || true
+        oc logs -n cilium -l k8s-app=cilium --tail=200 > ${ARTIFACT_DIR}/cilium-debug/cilium-agent-logs.txt 2>&1 || true
       from: cli
       resources:
         requests:


### PR DESCRIPTION
## Summary
- Temporary debug PR to collect Cilium/NetworkPolicy artifacts from the 4.22 Cilium conformance job
- Investigating why Prometheus/monitoring tests pass on 4.21 but fail on 4.22 with identical Cilium v1.15.1
- Adds inline dump step to collect: NetworkPolicies, CiliumNetworkPolicies, CiliumEndpoints, Cilium agent logs

## Action
- Will trigger rehearsal of `periodic-ci-openshift-hypershift-release-4.22-periodics-e2e-aws-conformance-cilium`
- Will close this PR after collecting artifacts — **do not merge**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a post-execution diagnostic step that exports nested-cluster kubeconfig and collects Cilium/OpenShift networking diagnostics into artifacts (per-command failures tolerated); step runs with modest resource requests and a 5-minute timeout.
  * Added a pre-test step that applies NetworkPolicies to restore ingress paths for openshift-monitoring and openshift-ingress required for Cilium-enabled conformance runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->