### PR TITLE
CAPK: use gp3-csi instead of ODF

### DIFF
--- a/ci-operator/config/openshift/cluster-api-provider-kubevirt/openshift-cluster-api-provider-kubevirt-main.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-kubevirt/openshift-cluster-api-provider-kubevirt-main.yaml
@@ -93,8 +93,17 @@ tests:
       CNV_SUBSCRIPTION_SOURCE: redhat-operators
       COMPUTE_NODE_REPLICAS: "1"
       COMPUTE_NODE_TYPE: c5n.metal
-      ODF_OPERATOR_CHANNEL: stable-4.19
+      E2E_TEST_REGEX: ^TestCreateCluster$|TestAutoscaling
+      ETCD_STORAGE_CLASS: gp3-csi
+      KUBEVIRT_CSI_INFRA: gp3-csi
+    pre:
+    - chain: ipi-aws-ovn-pre
+    - chain: ipi-install
+    - ref: hypershift-kubevirt-install
+    - ref: hypershift-install
+    - chain: hypershift-kubevirt-custom-capk
     workflow: hypershift-kubevirt-e2e-aws-capk
+  timeout: 5h0m0s
 zz_generated_metadata:
   branch: main
   org: openshift

--- a/ci-operator/config/openshift/cluster-api-provider-kubevirt/openshift-cluster-api-provider-kubevirt-release-4.20.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-kubevirt/openshift-cluster-api-provider-kubevirt-release-4.20.yaml
@@ -92,8 +92,17 @@ tests:
       BASE_DOMAIN: cnv-ci.syseng.devcluster.openshift.com
       COMPUTE_NODE_REPLICAS: "1"
       COMPUTE_NODE_TYPE: c5n.metal
-      ODF_OPERATOR_CHANNEL: stable-4.19
+      E2E_TEST_REGEX: ^TestCreateCluster$|TestAutoscaling
+      ETCD_STORAGE_CLASS: gp3-csi
+      KUBEVIRT_CSI_INFRA: gp3-csi
+    pre:
+    - chain: ipi-aws-ovn-pre
+    - chain: ipi-install
+    - ref: hypershift-kubevirt-install
+    - ref: hypershift-install
+    - chain: hypershift-kubevirt-custom-capk
     workflow: hypershift-kubevirt-e2e-aws-capk
+  timeout: 5h0m0s
 zz_generated_metadata:
   branch: release-4.20
   org: openshift

--- a/ci-operator/config/openshift/cluster-api-provider-kubevirt/openshift-cluster-api-provider-kubevirt-release-4.21.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-kubevirt/openshift-cluster-api-provider-kubevirt-release-4.21.yaml
@@ -93,8 +93,17 @@ tests:
       CNV_SUBSCRIPTION_SOURCE: redhat-operators
       COMPUTE_NODE_REPLICAS: "1"
       COMPUTE_NODE_TYPE: c5n.metal
-      ODF_OPERATOR_CHANNEL: stable-4.19
+      E2E_TEST_REGEX: ^TestCreateCluster$|TestAutoscaling
+      ETCD_STORAGE_CLASS: gp3-csi
+      KUBEVIRT_CSI_INFRA: gp3-csi
+    pre:
+    - chain: ipi-aws-ovn-pre
+    - chain: ipi-install
+    - ref: hypershift-kubevirt-install
+    - ref: hypershift-install
+    - chain: hypershift-kubevirt-custom-capk
     workflow: hypershift-kubevirt-e2e-aws-capk
+  timeout: 5h0m0s
 zz_generated_metadata:
   branch: release-4.21
   org: openshift

--- a/ci-operator/config/openshift/cluster-api-provider-kubevirt/openshift-cluster-api-provider-kubevirt-release-4.22.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-kubevirt/openshift-cluster-api-provider-kubevirt-release-4.22.yaml
@@ -93,8 +93,17 @@ tests:
       CNV_SUBSCRIPTION_SOURCE: redhat-operators
       COMPUTE_NODE_REPLICAS: "1"
       COMPUTE_NODE_TYPE: c5n.metal
-      ODF_OPERATOR_CHANNEL: stable-4.19
+      E2E_TEST_REGEX: ^TestCreateCluster$|TestAutoscaling
+      ETCD_STORAGE_CLASS: gp3-csi
+      KUBEVIRT_CSI_INFRA: gp3-csi
+    pre:
+    - chain: ipi-aws-ovn-pre
+    - chain: ipi-install
+    - ref: hypershift-kubevirt-install
+    - ref: hypershift-install
+    - chain: hypershift-kubevirt-custom-capk
     workflow: hypershift-kubevirt-e2e-aws-capk
+  timeout: 5h0m0s
 zz_generated_metadata:
   branch: release-4.22
   org: openshift

--- a/ci-operator/config/openshift/cluster-api-provider-kubevirt/openshift-cluster-api-provider-kubevirt-release-4.23.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-kubevirt/openshift-cluster-api-provider-kubevirt-release-4.23.yaml
@@ -93,8 +93,17 @@ tests:
       CNV_SUBSCRIPTION_SOURCE: redhat-operators
       COMPUTE_NODE_REPLICAS: "1"
       COMPUTE_NODE_TYPE: c5n.metal
-      ODF_OPERATOR_CHANNEL: stable-4.19
+      E2E_TEST_REGEX: ^TestCreateCluster$|TestAutoscaling
+      ETCD_STORAGE_CLASS: gp3-csi
+      KUBEVIRT_CSI_INFRA: gp3-csi
+    pre:
+    - chain: ipi-aws-ovn-pre
+    - chain: ipi-install
+    - ref: hypershift-kubevirt-install
+    - ref: hypershift-install
+    - chain: hypershift-kubevirt-custom-capk
     workflow: hypershift-kubevirt-e2e-aws-capk
+  timeout: 5h0m0s
 zz_generated_metadata:
   branch: release-4.23
   org: openshift

--- a/ci-operator/jobs/openshift/cluster-api-provider-kubevirt/openshift-cluster-api-provider-kubevirt-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-kubevirt/openshift-cluster-api-provider-kubevirt-main-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       skip_cloning: true
+      timeout: 5h0m0s
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: aws-virtualization

--- a/ci-operator/jobs/openshift/cluster-api-provider-kubevirt/openshift-cluster-api-provider-kubevirt-release-4.20-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-kubevirt/openshift-cluster-api-provider-kubevirt-release-4.20-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       skip_cloning: true
+      timeout: 5h0m0s
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: aws-virtualization

--- a/ci-operator/jobs/openshift/cluster-api-provider-kubevirt/openshift-cluster-api-provider-kubevirt-release-4.21-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-kubevirt/openshift-cluster-api-provider-kubevirt-release-4.21-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       skip_cloning: true
+      timeout: 5h0m0s
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: aws-virtualization

--- a/ci-operator/jobs/openshift/cluster-api-provider-kubevirt/openshift-cluster-api-provider-kubevirt-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-kubevirt/openshift-cluster-api-provider-kubevirt-release-4.22-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       skip_cloning: true
+      timeout: 5h0m0s
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: aws-virtualization

--- a/ci-operator/jobs/openshift/cluster-api-provider-kubevirt/openshift-cluster-api-provider-kubevirt-release-4.23-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-kubevirt/openshift-cluster-api-provider-kubevirt-release-4.23-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       skip_cloning: true
+      timeout: 5h0m0s
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: aws-virtualization

--- a/ci-operator/step-registry/hypershift/kubevirt/install/hypershift-kubevirt-install-commands.sh
+++ b/ci-operator/step-registry/hypershift/kubevirt/install/hypershift-kubevirt-install-commands.sh
@@ -202,6 +202,16 @@ EOF
 
 oc wait hyperconverged -n openshift-cnv kubevirt-hyperconverged --for=condition=Available --timeout=15m
 
+# CDI auto-detects only volumeMode=Block for gp3-csi in its StorageProfile.
+# KubeVirt DataVolumes created by HyperShift request volumeMode=Filesystem,
+# which CDI rejects because no matching claimPropertySet exists.
+# Patch the StorageProfile to also advertise Filesystem so DataVolumes can bind.
+if oc get storageprofile gp3-csi &>/dev/null; then
+  echo "Patching gp3-csi StorageProfile to include Filesystem volumeMode"
+  oc patch storageprofile gp3-csi --type=merge -p \
+    '{"spec":{"claimPropertySets":[{"accessModes":["ReadWriteOnce"],"volumeMode":"Filesystem"},{"accessModes":["ReadWriteOnce"],"volumeMode":"Block"}]}}'
+fi
+
 echo "Installing VM console logger in order to aid debugging potential VM boot issues"
 oc apply -f https://raw.githubusercontent.com/davidvossel/kubevirt-console-debugger/main/kubevirt-console-logger.yaml
 

--- a/ci-operator/step-registry/hypershift/kubevirt/run-e2e-external/hypershift-kubevirt-run-e2e-external-chain.yaml
+++ b/ci-operator/step-registry/hypershift/kubevirt/run-e2e-external/hypershift-kubevirt-run-e2e-external-chain.yaml
@@ -101,4 +101,4 @@ chain:
       requests:
         cpu: 100m
         memory: 100Mi
-    timeout: 1h0m0s
+    timeout: 2h0m0s


### PR DESCRIPTION
ODF can't be installed on OCP 5.0 due to maxOpenShiftVersion: 4.22 setting on ODF CSV. Since we don't need RWX storage in this job, we can use the built-in csi driver of AWS - gp3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added prerequisite install steps so required components run before KubeVirt e2e tests.
  * Parameterized e2e execution to target specific tests and increased overall test timeout to 5h for stability.
  * Set test environment storage settings to gp3-csi for more stable storage-dependent tests.
  * Installer now performs a best-effort adjustment of the gp3-csi storage profile (when present) and extended an intermediate step timeout to 2h.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->