### PR TITLE
NROP: updating gotest filters for prod

### DIFF
--- a/ci-operator/step-registry/telcov10n/functional/compute-nrop/e2e-testing-container/telcov10n-functional-compute-nrop-e2e-testing-container-commands.sh
+++ b/ci-operator/step-registry/telcov10n/functional/compute-nrop/e2e-testing-container/telcov10n-functional-compute-nrop-e2e-testing-container-commands.sh
@@ -50,6 +50,9 @@ else
     EXTRA_VARS="${EXTRA_VARS} topology_manager_scope=${SCOPE}"
 fi
 
+if [[ $TEST_ENV == "prod" ]]; then
+    EXTRA_VARS="${EXTRA_VARS} ginkgo_label='tier0 && tier1'"
+fi
 
 cd /eco-ci-cd/
 ansible-playbook -vv ./playbooks/compute/nrop_testing.yml -i ./inventories/ocp-deployment/build-inventory.py \

--- a/ci-operator/step-registry/telcov10n/functional/compute-nrop/e2e-testing-pod/telcov10n-functional-compute-nrop-e2e-testing-pod-commands.sh
+++ b/ci-operator/step-registry/telcov10n/functional/compute-nrop/e2e-testing-pod/telcov10n-functional-compute-nrop-e2e-testing-pod-commands.sh
@@ -50,6 +50,9 @@ else
     EXTRA_VARS="${EXTRA_VARS} topology_manager_scope=${SCOPE}"
 fi
 
+if [[ $TEST_ENV == "prod" ]]; then
+    EXTRA_VARS="${EXTRA_VARS} ginkgo_label='tier0 && tier1'"
+fi
 
 cd /eco-ci-cd/
 ansible-playbook -vv ./playbooks/compute/nrop_testing.yml -i ./inventories/ocp-deployment/build-inventory.py \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Test execution now conditionally applies a production-only filter so that only tier0 and tier1 tests are selected during production test runs, keeping non-production behavior unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->