### PR TITLE
NO-ISSUE: start fast-forward for backplane-5.0 instead of ocm-2.17

### DIFF
--- a/ci-operator/jobs/infra-periodics.yaml
+++ b/ci-operator/jobs/infra-periodics.yaml
@@ -2161,8 +2161,8 @@ periodics:
     - args:
       - --config-dir=./ci-operator/config/openshift/assisted-image-service
       - --current-promotion-namespace=edge-infrastructure
-      - --current-release=ocm-2.17
-      - --future-release=ocm-2.17
+      - --current-release=backplane-5.0
+      - --future-release=backplane-5.0
       - --confirm
       - --username=openshift-merge-robot
       - --token-path=/etc/github/oauth
@@ -2205,8 +2205,8 @@ periodics:
     - args:
       - --config-dir=./ci-operator/config/openshift/cluster-api-provider-agent
       - --current-promotion-namespace=edge-infrastructure
-      - --current-release=ocm-2.17
-      - --future-release=ocm-2.17
+      - --current-release=backplane-5.0
+      - --future-release=backplane-5.0
       - --confirm
       - --username=openshift-merge-robot
       - --token-path=/etc/github/oauth
@@ -2249,8 +2249,8 @@ periodics:
     - args:
       - --config-dir=./ci-operator/config/openshift/assisted-installer
       - --current-promotion-namespace=edge-infrastructure
-      - --current-release=ocm-2.17
-      - --future-release=ocm-2.17
+      - --current-release=backplane-5.0
+      - --future-release=backplane-5.0
       - --confirm
       - --username=openshift-merge-robot
       - --token-path=/etc/github/oauth
@@ -2293,8 +2293,8 @@ periodics:
     - args:
       - --config-dir=./ci-operator/config/openshift/assisted-installer-agent
       - --current-promotion-namespace=edge-infrastructure
-      - --current-release=ocm-2.17
-      - --future-release=ocm-2.17
+      - --current-release=backplane-5.0
+      - --future-release=backplane-5.0
       - --confirm
       - --username=openshift-merge-robot
       - --token-path=/etc/github/oauth
@@ -2337,8 +2337,8 @@ periodics:
     - args:
       - --config-dir=./ci-operator/config/openshift/assisted-service
       - --current-promotion-namespace=edge-infrastructure
-      - --current-release=ocm-2.17
-      - --future-release=ocm-2.17
+      - --current-release=backplane-5.0
+      - --future-release=backplane-5.0
       - --confirm
       - --username=openshift-merge-robot
       - --token-path=/etc/github/oauth
@@ -2381,8 +2381,8 @@ periodics:
     - args:
       - --config-dir=./ci-operator/config/openshift/assisted-test-infra
       - --current-promotion-namespace=edge-infrastructure
-      - --current-release=ocm-2.17
-      - --future-release=ocm-2.17
+      - --current-release=backplane-5.0
+      - --future-release=backplane-5.0
       - --confirm
       - --username=openshift-merge-robot
       - --token-path=/etc/github/oauth


### PR DESCRIPTION
As part of the creating of backplane-5.0 branch, we want to switch between 2.17 and 5.0, so 5.0 will follow master now.
/cc @danmanor @gamli75
