### PR TITLE
cnf ran: added 4.16 trigger to 4.14 job

### DIFF
--- a/ci-operator/config/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main__cnf-ran-two-sno-4.14.yaml
+++ b/ci-operator/config/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main__cnf-ran-two-sno-4.14.yaml
@@ -32,6 +32,8 @@ tests:
           {"name":"multicluster-engine","catalog":"redhat-operators","nsname":"multicluster-engine","channel":"stable-2.6","default_channel":"stable-2.7","og_name":"multicluster-engine","subscription_name":"multicluster-engine","deploy_default_config":true,"og_spec":{}},
           {"name":"topology-aware-lifecycle-manager","catalog":"topology-aware-lifecycle-manager-fbc","og_name":"global-operators","nsname":"openshift-operators","fbc_iib_repo":"latest","channel":"stable","deploy_default_config":false,"ocp_operator_mirror_fbc_image_base":"quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-fbc-4-14"}
         ]
+      JOB_NAME: periodic-ci-openshift-kni-eco-ci-cd-main-cnf-ran-two-sno-4.16-cnf-ran-ztp-tests
+      JOB_TYPE: "1"
       RAN_METRICS_LIST: spoke_general_ocp,hub_general_ocp,sriov,sriov_fec,ptp,acm,talm,gitops,local_storage,logging
       REPORTER_TEMPLATE_NAME: Telco 5G RAN Regression 4_14 - Telco 5G RAN Regression
         - <build> - 4.14
@@ -48,14 +50,18 @@ tests:
         ]
       VERSION: "4.14"
       ZTP_GIT_BRANCH: two_sno
+    post:
+    - ref: telcov10n-functional-cnf-ran-report-compact
+    - ref: telcov10n-functional-cnf-ran-send-slack-notification
+    - ref: telcov10n-functional-cnf-network-trigger-job
+    - ref: telcov10n-verify-junit-reports
     pre:
     - ref: telcov10n-functional-cnf-ran-hub-deploy
     - ref: telcov10n-functional-cnf-ran-hub-config
     - ref: telcov10n-functional-cnf-ran-mirror-spoke-operators
     - ref: telcov10n-functional-cnf-ran-deploy-spoke-sno
+    test:
     - ref: telcov10n-functional-cnf-ran-eco-gotests-two-sno
-    - ref: telcov10n-functional-cnf-ran-report-compact
-    - ref: telcov10n-functional-cnf-ran-send-slack-notification
 zz_generated_metadata:
   branch: main
   org: openshift-kni

--- a/ci-operator/config/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main__cnf-ran-two-sno-4.16.yaml
+++ b/ci-operator/config/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main__cnf-ran-two-sno-4.16.yaml
@@ -32,6 +32,8 @@ tests:
           {"name":"multicluster-engine","catalog":"redhat-operators","nsname":"multicluster-engine","channel":"stable-2.8","default_channel":"stable-2.9","og_name":"multicluster-engine","subscription_name":"multicluster-engine","deploy_default_config":true,"og_spec":{}},
           {"name":"topology-aware-lifecycle-manager","catalog":"topology-aware-lifecycle-manager-fbc","og_name":"global-operators","nsname":"openshift-operators","fbc_iib_repo":"latest","channel":"stable","deploy_default_config":false,"ocp_operator_mirror_fbc_image_base":"quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-fbc-4-16"}
         ]
+      JOB_NAME: periodic-ci-openshift-kni-eco-ci-cd-main-cnf-ran-two-sno-4.18-cnf-ran-ztp-tests
+      JOB_TYPE: "1"
       RAN_METRICS_LIST: spoke_general_ocp,hub_general_ocp,sriov,sriov_fec,ptp,acm,talm,gitops,local_storage,logging
       REPORTER_TEMPLATE_NAME: Telco 5G RAN Regression 4_16 - Telco 5G RAN Regression
         - <build> - 4.16
@@ -48,14 +50,18 @@ tests:
         ]
       VERSION: "4.16"
       ZTP_GIT_BRANCH: two_sno
+    post:
+    - ref: telcov10n-functional-cnf-ran-report-compact
+    - ref: telcov10n-functional-cnf-ran-send-slack-notification
+    - ref: telcov10n-functional-cnf-network-trigger-job
+    - ref: telcov10n-verify-junit-reports
     pre:
     - ref: telcov10n-functional-cnf-ran-hub-deploy
     - ref: telcov10n-functional-cnf-ran-hub-config
     - ref: telcov10n-functional-cnf-ran-mirror-spoke-operators
     - ref: telcov10n-functional-cnf-ran-deploy-spoke-sno
+    test:
     - ref: telcov10n-functional-cnf-ran-eco-gotests-two-sno
-    - ref: telcov10n-functional-cnf-ran-report-compact
-    - ref: telcov10n-functional-cnf-ran-send-slack-notification
 zz_generated_metadata:
   branch: main
   org: openshift-kni

--- a/ci-operator/config/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main__cnf-ran-two-sno-4.18.yaml
+++ b/ci-operator/config/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main__cnf-ran-two-sno-4.18.yaml
@@ -32,6 +32,8 @@ tests:
           {"name":"multicluster-engine","catalog":"redhat-operators","nsname":"multicluster-engine","channel":"stable-2.8","default_channel":"stable-2.11","og_name":"multicluster-engine","subscription_name":"multicluster-engine","deploy_default_config":true,"og_spec":{}},
           {"name":"topology-aware-lifecycle-manager","catalog":"topology-aware-lifecycle-manager-fbc","og_name":"global-operators","nsname":"openshift-operators","fbc_iib_repo":"latest","channel":"stable","deploy_default_config":false,"ocp_operator_mirror_fbc_image_base":"quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-fbc-4-18"}
         ]
+      JOB_NAME: periodic-ci-openshift-kni-eco-ci-cd-main-cnf-ran-two-sno-4.20-cnf-ran-ztp-tests
+      JOB_TYPE: "1"
       RAN_METRICS_LIST: spoke_general_ocp,hub_general_ocp,sriov,sriov_fec,ptp,acm,talm,gitops,local_storage,logging
       REPORTER_TEMPLATE_NAME: Telco 5G RAN Regression 4_18 - Telco 5G RAN Regression
         - <build> - 4.18
@@ -48,14 +50,18 @@ tests:
         ]
       VERSION: "4.18"
       ZTP_GIT_BRANCH: two_sno
+    post:
+    - ref: telcov10n-functional-cnf-ran-report-compact
+    - ref: telcov10n-functional-cnf-ran-send-slack-notification
+    - ref: telcov10n-functional-cnf-network-trigger-job
+    - ref: telcov10n-verify-junit-reports
     pre:
     - ref: telcov10n-functional-cnf-ran-hub-deploy
     - ref: telcov10n-functional-cnf-ran-hub-config
     - ref: telcov10n-functional-cnf-ran-mirror-spoke-operators
     - ref: telcov10n-functional-cnf-ran-deploy-spoke-sno
+    test:
     - ref: telcov10n-functional-cnf-ran-eco-gotests-two-sno
-    - ref: telcov10n-functional-cnf-ran-report-compact
-    - ref: telcov10n-functional-cnf-ran-send-slack-notification
 zz_generated_metadata:
   branch: main
   org: openshift-kni

--- a/ci-operator/config/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main__cnf-ran-two-sno-4.20.yaml
+++ b/ci-operator/config/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main__cnf-ran-two-sno-4.20.yaml
@@ -32,6 +32,8 @@ tests:
           {"name":"multicluster-engine","catalog":"redhat-operators","nsname":"multicluster-engine","channel":"stable-2.10","default_channel":"stable-2.11","og_name":"multicluster-engine","subscription_name":"multicluster-engine","deploy_default_config":true,"og_spec":{}},
           {"name":"topology-aware-lifecycle-manager","catalog":"topology-aware-lifecycle-manager-fbc","og_name":"global-operators","nsname":"openshift-operators","fbc_iib_repo":"latest","channel":"stable","deploy_default_config":false,"ocp_operator_mirror_fbc_image_base":"quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-fbc-${VERSION_TAG}"}
         ]
+      JOB_NAME: periodic-ci-openshift-kni-eco-ci-cd-main-cnf-ran-two-sno-4.21-cnf-ran-ztp-tests
+      JOB_TYPE: "1"
       RAN_METRICS_LIST: spoke_general_ocp,hub_general_ocp,sriov,sriov_fec,ptp,acm,talm,gitops,local_storage,logging
       REPORTER_TEMPLATE_NAME: Telco 5G RAN Regression 4_20 - Telco 5G RAN Regression
         - <build> - 4.20
@@ -48,14 +50,18 @@ tests:
         ]
       VERSION: "4.20"
       ZTP_GIT_BRANCH: two_sno
+    post:
+    - ref: telcov10n-functional-cnf-ran-report-compact
+    - ref: telcov10n-functional-cnf-ran-send-slack-notification
+    - ref: telcov10n-functional-cnf-network-trigger-job
+    - ref: telcov10n-verify-junit-reports
     pre:
     - ref: telcov10n-functional-cnf-ran-hub-deploy
     - ref: telcov10n-functional-cnf-ran-hub-config
     - ref: telcov10n-functional-cnf-ran-mirror-spoke-operators
     - ref: telcov10n-functional-cnf-ran-deploy-spoke-sno
+    test:
     - ref: telcov10n-functional-cnf-ran-eco-gotests-two-sno
-    - ref: telcov10n-functional-cnf-ran-report-compact
-    - ref: telcov10n-functional-cnf-ran-send-slack-notification
 zz_generated_metadata:
   branch: main
   org: openshift-kni

--- a/ci-operator/config/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main__cnf-ran-two-sno-4.21.yaml
+++ b/ci-operator/config/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main__cnf-ran-two-sno-4.21.yaml
@@ -32,6 +32,8 @@ tests:
           {"name":"multicluster-engine","catalog":"redhat-operators","nsname":"multicluster-engine","channel":"stable-2.11","og_name":"multicluster-engine","subscription_name":"multicluster-engine","deploy_default_config":true,"og_spec":{}},
           {"name":"topology-aware-lifecycle-manager","catalog":"topology-aware-lifecycle-manager-fbc","og_name":"global-operators","nsname":"openshift-operators","fbc_iib_repo":"latest","channel":"stable","deploy_default_config":false,"ocp_operator_mirror_fbc_image_base":"quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-fbc-${VERSION_TAG}"}
         ]
+      JOB_NAME: periodic-ci-openshift-kni-eco-ci-cd-main-cnf-ran-two-sno-4.22-cnf-ran-ztp-tests
+      JOB_TYPE: "1"
       RAN_METRICS_LIST: spoke_general_ocp,hub_general_ocp,sriov,sriov_fec,ptp,acm,talm,gitops,local_storage,logging
       REPORTER_TEMPLATE_NAME: Telco 5G RAN Regression 4_21 - Telco 5G RAN Regression
         - <build> - 4.21
@@ -48,14 +50,18 @@ tests:
         ]
       VERSION: "4.21"
       ZTP_GIT_BRANCH: two_sno
+    post:
+    - ref: telcov10n-functional-cnf-ran-report-compact
+    - ref: telcov10n-functional-cnf-ran-send-slack-notification
+    - ref: telcov10n-functional-cnf-network-trigger-job
+    - ref: telcov10n-verify-junit-reports
     pre:
     - ref: telcov10n-functional-cnf-ran-hub-deploy
     - ref: telcov10n-functional-cnf-ran-hub-config
     - ref: telcov10n-functional-cnf-ran-mirror-spoke-operators
     - ref: telcov10n-functional-cnf-ran-deploy-spoke-sno
+    test:
     - ref: telcov10n-functional-cnf-ran-eco-gotests-two-sno
-    - ref: telcov10n-functional-cnf-ran-report-compact
-    - ref: telcov10n-functional-cnf-ran-send-slack-notification
 zz_generated_metadata:
   branch: main
   org: openshift-kni

--- a/ci-operator/config/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main__cnf-ran-two-sno-4.22.yaml
+++ b/ci-operator/config/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main__cnf-ran-two-sno-4.22.yaml
@@ -48,14 +48,18 @@ tests:
         ]
       VERSION: "4.22"
       ZTP_GIT_BRANCH: two_sno
+    post:
+    - ref: telcov10n-functional-cnf-ran-report-compact
+    - ref: telcov10n-functional-cnf-ran-send-slack-notification
+    - ref: telcov10n-functional-cnf-network-trigger-job
+    - ref: telcov10n-verify-junit-reports
     pre:
     - ref: telcov10n-functional-cnf-ran-hub-deploy
     - ref: telcov10n-functional-cnf-ran-hub-config
     - ref: telcov10n-functional-cnf-ran-mirror-spoke-operators
     - ref: telcov10n-functional-cnf-ran-deploy-spoke-sno
+    test:
     - ref: telcov10n-functional-cnf-ran-eco-gotests-two-sno
-    - ref: telcov10n-functional-cnf-ran-report-compact
-    - ref: telcov10n-functional-cnf-ran-send-slack-notification
 zz_generated_metadata:
   branch: main
   org: openshift-kni


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow phases reorganized: reporting, notifications, network-trigger and JUnit verification moved into a dedicated post phase; main tests explicitly grouped under a test phase.
  * Test job environment updated to set a periodic job identifier and a fixed job type value across relevant job variants.

* **Tests**
  * Clarified test ordering and added explicit post-run verification steps to improve reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->