### PR TITLE
MGMT-24018: Add backplane to the protection rules (assisted components) + update capi-agent to use a regex format consistent with the others

### DIFF
--- a/core-services/prow/02_config/openshift/assisted-image-service/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/assisted-image-service/_prowconfig.yaml
@@ -4,6 +4,7 @@ branch-protection:
       repos:
         assisted-image-service:
           include:
+          - ^backplane-[0-9.]+$
           - ^main$
           - ^master$
           - ^release-ocm-[0-9.]+$

--- a/core-services/prow/02_config/openshift/assisted-installer-agent/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/assisted-installer-agent/_prowconfig.yaml
@@ -4,6 +4,7 @@ branch-protection:
       repos:
         assisted-installer-agent:
           include:
+          - ^backplane-[0-9.]+$
           - ^master$
           - ^release-[0-9.]+$
           - ^release-ocm-[0-9.]+$

--- a/core-services/prow/02_config/openshift/assisted-installer/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/assisted-installer/_prowconfig.yaml
@@ -4,6 +4,7 @@ branch-protection:
       repos:
         assisted-installer:
           include:
+          - ^backplane-[0-9.]+$
           - ^master$
           - ^release-[0-9.]+$
           - ^release-ocm-[0-9.]+$

--- a/core-services/prow/02_config/openshift/assisted-service/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/assisted-service/_prowconfig.yaml
@@ -4,6 +4,7 @@ branch-protection:
       repos:
         assisted-service:
           include:
+          - ^backplane-[0-9.]+$
           - ^master$
           - ^release-[0-9.]+$
           - ^release-ocm-[0-9.]+$

--- a/core-services/prow/02_config/openshift/assisted-test-infra/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/assisted-test-infra/_prowconfig.yaml
@@ -4,6 +4,7 @@ branch-protection:
       repos:
         assisted-test-infra:
           include:
+          - ^backplane-[0-9.]+$
           - ^master$
           - ^release-ocm-[0-9.]+$
 slack_reporter_configs:

--- a/core-services/prow/02_config/openshift/cluster-api-provider-agent/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/cluster-api-provider-agent/_prowconfig.yaml
@@ -3,30 +3,10 @@ branch-protection:
     openshift:
       repos:
         cluster-api-provider-agent:
-          branches:
-            master:
-              protect: true
-            release-ocm-2.7:
-              protect: true
-            release-ocm-2.8:
-              protect: true
-            release-ocm-2.9:
-              protect: true
-            release-ocm-2.10:
-              protect: true
-            release-ocm-2.11:
-              protect: true
-            release-ocm-2.12:
-              protect: true
-            release-ocm-2.13:
-              protect: true
-            release-ocm-2.14:
-              protect: true
-            release-ocm-2.15:
-              protect: true
-            release-ocm-2.16:
-              protect: true
-          protect: false
+          include:
+          - ^backplane-[0-9.]+$
+          - ^master$
+          - ^release-ocm-[0-9.]+$
 slack_reporter_configs:
   openshift/cluster-api-provider-agent:
     channel: '#capi-agent-infrastructure-provider-ci'


### PR DESCRIPTION
Add backplane to the protection rules (assisted components) and update capi-agent protection rules to use a regex format consistent with the others.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended branch protection configuration across multiple repositories to automatically include backplane release branches alongside existing protected branch patterns, ensuring consistent security and stability policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->