### PR TITLE
NO-JIRA: bump out cron time

### DIFF
--- a/ci-operator/jobs/infra-periodics.yaml
+++ b/ci-operator/jobs/infra-periodics.yaml
@@ -2688,7 +2688,7 @@ periodics:
         secretName: github-credentials-openshift-bot
 - agent: kubernetes
   cluster: app.ci
-  cron: 0 1 * * 5
+  cron: 0 3 * * 5
   decorate: true
   extra_refs:
   - base_ref: main


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted the weekly execution time of the origin disruption alert data update job from 1 AM to 3 AM UTC on Fridays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->