### PR TITLE
ci(hypershift): add calico conformance periodic tests for 4.22

### DIFF
--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.22__periodics.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.22__periodics.yaml
@@ -265,6 +265,52 @@ tests:
   steps:
     cluster_profile: openshift-org-aws
     workflow: hypershift-kubevirt-csi-e2e
+- as: e2e-aws-conformance-calico
+  minimum_interval: 168h
+  steps:
+    cluster_profile: hypershift-aws
+    workflow: hypershift-aws-conformance-calico
+- as: e2e-aws-conformance-calico-private
+  minimum_interval: 168h
+  steps:
+    cluster_profile: aws-qe
+    env:
+      BASE_DOMAIN: qe.devcluster.openshift.com
+      HYPERSHIFT_GUEST_INFRA_OCP_ACCOUNT: "true"
+      TEST_ARGS: --disable-monitor=apiserver-incluster-availability,service-type-load-balancer-availability
+      TEST_SKIPS: The default cluster RBAC policy should have correct RBAC rules\|
+        Cluster scoped load balancer healthcheck port and path should be 10256/healthz\|
+        Prometheus \[apigroup:image.openshift.io\] when installed on the cluster should
+        provide named network metrics\| Unidling \[apigroup:apps.openshift.io\]\[apigroup:route.openshift.io\]
+        should work with UDP\| Unidling with Deployments \[apigroup:route.openshift.io\]
+        should work with TCP (when fully idled)\| Unidling \[apigroup:apps.openshift.io\]\[apigroup:route.openshift.io\]
+        should work with TCP (when fully idled)\| Unidling with Deployments \[apigroup:route.openshift.io\]
+        should work with UDP\|pod should not start for sysctls not on whitelist \[apigroup:k8s.cni.cncf.io\]
+        net.ipv4.conf.IFNAME.arp_filter\| pod should not start for sysctls not on
+        whitelist \[apigroup:k8s.cni.cncf.io\] net.ipv4.conf.all.send_redirects\|
+        sysctl allowlist update should start a pod with custom sysctl only when the
+        sysctl is added to whitelist\|Ensure HTTPRoute object is created
+    test:
+    - chain: hypershift-conformance
+    workflow: cucushift-installer-rehearse-aws-ipi-ovn-hypershift-private-guest-calico
+- as: e2e-kubevirt-metal-conformance-calico
+  capabilities:
+  - intranet
+  minimum_interval: 168h
+  steps:
+    cluster_profile: equinix-ocp-hcp
+    env:
+      KONFLUX_DEPLOY_CATALOG_SOURCE: "true"
+      KONFLUX_DEPLOY_OPERATORS: "true"
+      KONFLUX_DEPLOY_SUBSCRIPTION: "false"
+      LOCAL_STORAGE_OPERATOR_SUB_SOURCE: local-storage-konflux
+      LVM_OPERATOR_SUB_CHANNEL: stable-4.22
+      LVM_OPERATOR_SUB_SOURCE: lvm-catalogsource
+      METALLB_OPERATOR_SUB_SOURCE: metallb-konflux
+      ODF_OPERATOR_SUB_CHANNEL: stable-4.21
+      ODF_OPERATOR_SUB_SOURCE: redhat-operators-v4-21
+      REDHAT_OPERATORS_INDEX_TAG: v4.21
+    workflow: hypershift-kubevirt-baremetalds-conformance-calico
 - as: e2e-azure-aks-ovn-conformance
   cron: 0 */2 * * *
   steps:

--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.22__periodics.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.22__periodics.yaml
@@ -277,7 +277,7 @@ tests:
         NLB internal should be reachable with hairpinning traffic\| loadbalancer NLB
         should be reachable with target-node-labels\| Critical-CCO-based flow for
         olm managed operators and AWS STS\|The HAProxy router should pass the http2
-        tests
+        tests\|\[ovn-kubernetes-ote\]
     test:
     - chain: hypershift-conformance
     workflow: cucushift-installer-rehearse-aws-ipi-ovn-hypershift-private-guest-calico

--- a/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.22-periodics.yaml
+++ b/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.22-periodics.yaml
@@ -410,6 +410,172 @@ periodics:
     job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   minimum_interval: 168h
+  name: periodic-ci-openshift-hypershift-release-4.22-periodics-e2e-aws-conformance-calico
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-aws-conformance-calico
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build01
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: release-4.22
+    org: openshift
+    repo: hypershift
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-qe
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  minimum_interval: 168h
+  name: periodic-ci-openshift-hypershift-release-4.22-periodics-e2e-aws-conformance-calico-private
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-aws-conformance-calico-private
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build01
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: release-4.22
+    org: openshift
+    repo: hypershift
+  labels:
+    ci-operator.openshift.io/cloud: hypershift-aws
+    ci-operator.openshift.io/cloud-cluster-profile: hypershift-aws
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  minimum_interval: 168h
   name: periodic-ci-openshift-hypershift-release-4.22-periodics-e2e-aws-conformance-cilium
   spec:
     containers:
@@ -1662,6 +1828,90 @@ periodics:
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
       - --target=e2e-kubevirt-azure
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build11
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: release-4.22
+    org: openshift
+    repo: hypershift
+  labels:
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: equinix-ocp-metal
+    ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-hcp
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  minimum_interval: 168h
+  name: periodic-ci-openshift-hypershift-release-4.22-periodics-e2e-kubevirt-metal-conformance-calico
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-kubevirt-metal-conformance-calico
       - --variant=periodics
       command:
       - ci-operator

--- a/ci-operator/step-registry/hypershift/aws/conformance-calico/hypershift-aws-conformance-calico-workflow.yaml
+++ b/ci-operator/step-registry/hypershift/aws/conformance-calico/hypershift-aws-conformance-calico-workflow.yaml
@@ -24,7 +24,8 @@ workflow:
         sysctl is added to whitelist\|Ensure HTTPRoute object is created\|
         loadbalancer NLB internal should be reachable with hairpinning traffic\|
         loadbalancer NLB should be reachable with target-node-labels\|
-        Critical-CCO-based flow for olm managed operators and AWS STS
+        Critical-CCO-based flow for olm managed operators and AWS STS\|
+        \[ovn-kubernetes-ote\]
     post:
     - chain: hypershift-dump
     - chain: hypershift-aws-destroy

--- a/ci-operator/step-registry/hypershift/kubevirt/baremetalds/conformance-calico/hypershift-kubevirt-baremetalds-conformance-calico-workflow.yaml
+++ b/ci-operator/step-registry/hypershift/kubevirt/baremetalds/conformance-calico/hypershift-kubevirt-baremetalds-conformance-calico-workflow.yaml
@@ -47,7 +47,8 @@ workflow:
         should work with TCP (when fully idled)\| Unidling with Deployments \[apigroup:route.openshift.io\]
         should work with UDP\|\[Feature:tuning\]\|\[Feature:bond\]\|\[Feature:vlan\]\|StatefulSet Basic\|
         StatefulSet Non-retain\|\[OCPFeatureGate:RouteExternalCertificate\]\|
-        migration when running openshift cluster on KubeVirt virtual machines and live migrate hosted control plane
+        migration when running openshift cluster on KubeVirt virtual machines and live migrate hosted control plane\|
+        \[ovn-kubernetes-ote\]
       DEVSCRIPTS_CONFIG: |
         IP_STACK=v4
         NETWORK_TYPE=OVNKubernetes

--- a/ci-operator/step-registry/hypershift/mce/agent/metal3/conformance/calico/hypershift-mce-agent-metal3-conformance-calico-workflow.yaml
+++ b/ci-operator/step-registry/hypershift/mce/agent/metal3/conformance/calico/hypershift-mce-agent-metal3-conformance-calico-workflow.yaml
@@ -32,7 +32,7 @@ workflow:
         should work with TCP (when fully idled)\|Unidling with Deployments \[apigroup:route.openshift.io\]
         should work with UDP\|\[Feature:tuning\]\|\[Feature:bond\]\|\[Feature:vlan\]\|
         etcd leader changes are not excessive\|check registry.redhat.io is available
-        and samples operator can import sample imagestreams
+        and samples operator can import sample imagestreams\|\[ovn-kubernetes-ote\]
       HYPERSHIFT_NETWORK_TYPE: "Other"
       CALICO_VERSION: "3.29.3"
       AGENT_NAMESPACE: hypershift-agents


### PR DESCRIPTION
Port three calico conformance tests from 4.21 to the 4.22 periodics config: e2e-aws-conformance-calico, e2e-aws-conformance-calico-private, and e2e-kubevirt-metal-conformance-calico. LVM operator bumped to stable-4.22; ODF kept at stable-4.21.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added three new periodic test configurations to expand validation coverage across AWS Calico deployments in standard and private modes, plus bare metal Kubernetes virtualization infrastructure testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->