### PR TITLE
fix(e2e): add GitHub comment for pre-submit nightly jobs and Logs link

### DIFF
--- a/ci-operator/step-registry/redhat-developer/rhdh-plugin-export-overlays/ocp/helm/redhat-developer-rhdh-plugin-export-overlays-ocp-helm-commands.sh
+++ b/ci-operator/step-registry/redhat-developer/rhdh-plugin-export-overlays/ocp/helm/redhat-developer-rhdh-plugin-export-overlays-ocp-helm-commands.sh
@@ -147,9 +147,38 @@ echo "RHDH_VERSION: ${RHDH_VERSION}, INSTALLATION_METHOD: ${INSTALLATION_METHOD}
 collect_artifacts() {
     if [[ -n "${ARTIFACT_DIR:-}" ]]; then
         echo "[INFO] Copying artifacts to ${ARTIFACT_DIR}"
-        cp -a playwright-report "${ARTIFACT_DIR}/" 2>/dev/null || true
-        cp -a node_modules/.cache/e2e-test-results "${ARTIFACT_DIR}/" 2>/dev/null || true
+        cp -a playwright-report "${ARTIFACT_DIR}/" 2>&1 || echo "[WARNING] playwright-report not found"
+        cp -a node_modules/.cache/e2e-test-results "${ARTIFACT_DIR}/" 2>&1 || echo "[WARNING] e2e-test-results not found"
     fi
+}
+
+# ── Post GitHub comment ──────────────────────────────────────────────────────
+
+post_github_comment() {
+    set +ex
+    local heading="$1"
+
+    [[ -z "${GIT_PR_NUMBER:-}" ]] && return 0
+    [[ -z "${VAULT_GITHUB_TEST_REPORTER_TOKEN:-}" ]] && { echo "WARNING: VAULT_GITHUB_TEST_REPORTER_TOKEN not set"; return 1; }
+
+    local gcs_base="https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull"
+    local test_name="${JOB_NAME##*-"${RELEASE_BRANCH_NAME}"-}"
+    local step_path="${gcs_base}/${GITHUB_ORG_NAME}_${GITHUB_REPOSITORY_NAME}/${GIT_PR_NUMBER}/${JOB_NAME}/${BUILD_ID}/artifacts/${test_name}/redhat-developer-rhdh-plugin-export-overlays-ocp-helm"
+
+    local stats counts status comment
+    stats=$(jq -r '(.stats.duration // 0) / 1000 | floor | "\(. / 60 | floor)m \(. % 60)s"' playwright-report/results.json 2>/dev/null || echo "N/A")
+    counts=$(jq -r '"Passed: \(.stats.expected // 0) | Failed: \(.stats.unexpected // 0) | Flaky: \(.stats.flaky // 0) | Skipped: \(.stats.skipped // 0)"' playwright-report/results.json 2>/dev/null || echo "N/A")
+    [[ "$TEST_EXIT_CODE" -eq 0 ]] && status="✅ Passed" || status="❌ Failed"
+
+    comment="### ${status} ${heading}
+**Platform:** ${CONTAINER_PLATFORM} ${CONTAINER_PLATFORM_VERSION} | **RHDH Version:** ${RHDH_VERSION} | **Duration:** ${stats}
+${counts}
+[Playwright Report](${step_path}/artifacts/playwright-report/index.html) | [Build Log](${step_path}/build-log.txt) | [Logs](${step_path}/artifacts/e2e-test-results/logs/) | [Artifacts](${step_path}/artifacts)"
+
+    curl -sS -X POST -H "Authorization: Bearer ${VAULT_GITHUB_TEST_REPORTER_TOKEN}" \
+        -H "Accept: application/vnd.github+json" \
+        "https://api.github.com/repos/${GITHUB_ORG_NAME}/${GITHUB_REPOSITORY_NAME}/issues/${GIT_PR_NUMBER}/comments" \
+        -d "$(jq -n --arg body "$comment" '{body: $body}')" > /dev/null && echo "Posted GitHub comment"
 }
 
 # ── Run tests ────────────────────────────────────────────────────────────────
@@ -162,6 +191,7 @@ if [[ "$JOB_MODE" == "nightly" ]]; then
 
     bash ./run-e2e.sh --workers=4 || TEST_EXIT_CODE=$?
     collect_artifacts
+    post_github_comment "Nightly E2E Tests" || echo "WARNING: Failed to post GitHub comment"
     exit $TEST_EXIT_CODE
 fi
 
@@ -194,32 +224,6 @@ fi
 echo "Running tests for workspace: ${CHANGED_WORKSPACES}"
 bash ./run-e2e.sh -w "${CHANGED_WORKSPACES}" || TEST_EXIT_CODE=$?
 collect_artifacts
-
-# ── Post GitHub comment ──────────────────────────────────────────────────────
-
-post_github_comment() {
-    set +ex
-    [[ -z "${GIT_PR_NUMBER:-}" ]] && return 0
-    [[ -z "${VAULT_GITHUB_TEST_REPORTER_TOKEN:-}" ]] && { echo "WARNING: VAULT_GITHUB_TEST_REPORTER_TOKEN not set"; return 1; }
-
-    local gcs_base="https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull"
-    local step_path="${gcs_base}/${GITHUB_ORG_NAME}_${GITHUB_REPOSITORY_NAME}/${GIT_PR_NUMBER}/${JOB_NAME}/${BUILD_ID}/artifacts/e2e-ocp-helm/redhat-developer-rhdh-plugin-export-overlays-ocp-helm"
-
-    local stats counts status comment
-    stats=$(jq -r '(.stats.duration // 0) / 1000 | floor | "\(. / 60 | floor)m \(. % 60)s"' playwright-report/results.json 2>/dev/null || echo "N/A")
-    counts=$(jq -r '"Passed: \(.stats.expected // 0) | Failed: \(.stats.unexpected // 0) | Flaky: \(.stats.flaky // 0) | Skipped: \(.stats.skipped // 0)"' playwright-report/results.json 2>/dev/null || echo "N/A")
-    [[ "$TEST_EXIT_CODE" -eq 0 ]] && status="✅ Passed" || status="❌ Failed"
-
-    comment="### ${status} E2E Tests - \`${CHANGED_WORKSPACES}\`
-**Platform:** ${CONTAINER_PLATFORM} ${CONTAINER_PLATFORM_VERSION} | **RHDH Version:** ${RHDH_VERSION} | **Duration:** ${stats}
-${counts}
-[Playwright Report](${step_path}/artifacts/playwright-report/index.html) | [Build Log](${step_path}/build-log.txt) | [Artifacts](${step_path}/artifacts)"
-
-    curl -sS -X POST -H "Authorization: Bearer ${VAULT_GITHUB_TEST_REPORTER_TOKEN}" \
-        -H "Accept: application/vnd.github+json" \
-        "https://api.github.com/repos/${GITHUB_ORG_NAME}/${GITHUB_REPOSITORY_NAME}/issues/${GIT_PR_NUMBER}/comments" \
-        -d "$(jq -n --arg body "$comment" '{body: $body}')" > /dev/null && echo "Posted GitHub comment"
-}
-post_github_comment || echo "WARNING: Failed to post GitHub comment"
+post_github_comment "E2E Tests - \`${CHANGED_WORKSPACES}\`" || echo "WARNING: Failed to post GitHub comment"
 
 exit $TEST_EXIT_CODE


### PR DESCRIPTION
## Summary

- Post GitHub PR comment for presubmit nightly E2E jobs (`/test e2e-ocp-helm-nightly`) with explicit "Nightly E2E Tests" heading to distinguish from pr-check comments
- Add `[Logs]` link in PR comments pointing to collected diagnostic logs artifact (`e2e-test-results/logs/`)
- Surface `cp` errors in `collect_artifacts()` instead of silently swallowing stderr (`2>/dev/null` → `2>&1`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved artifact handling with explicit warnings for missing test result directories instead of job failures
  * Enhanced GitHub PR comments with clearer, distinct labels for different test run types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->