### PR TITLE
USHIFT-6863: Remove approved label requirement for microshift-rebase-script

### DIFF
--- a/core-services/prow/02_config/openshift/microshift/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/microshift/_prowconfig.yaml
@@ -10,7 +10,7 @@ tide:
   queries:
   - author: microshift-rebase-script[bot]
     labels:
-    - approved
+    - backport-risk-assessed
     missingLabels:
     - do-not-merge/hold
     - do-not-merge/invalid-owners-file


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the GitHub approval label requirement from pull request processing configuration, simplifying the validation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->