### PR TITLE
CNTRLPLANE-3258: Add --effort max to jira-agent and review-agent

### DIFF
--- a/ci-operator/step-registry/hypershift/jira-agent/process/hypershift-jira-agent-process-commands.sh
+++ b/ci-operator/step-registry/hypershift/jira-agent/process/hypershift-jira-agent-process-commands.sh
@@ -401,6 +401,7 @@ while IFS= read -r line; do
     --system-prompt "$SKILL_CONTENT" \
     --allowedTools "Bash Read Write Edit Grep Glob WebFetch" \
     --max-turns 100 \
+    --effort max \
     --model "$CLAUDE_MODEL" \
     --verbose \
     --output-format stream-json \
@@ -467,6 +468,7 @@ while IFS= read -r line; do
         --append-system-prompt "SECURITY: Do NOT run commands that reveal git credentials like 'git remote -v' or 'git remote get-url origin'. ${SUBAGENT_PROMPT}" \
         --allowedTools "Bash Read Grep Glob Task" \
         --max-turns 75 \
+        --effort max \
         --model "$CLAUDE_MODEL" \
         --verbose \
         --output-format stream-json \
@@ -540,6 +542,7 @@ IMPORTANT:
         claude -p "$FIX_PROMPT" \
           --allowedTools "Bash Read Write Edit Grep Glob" \
           --max-turns 75 \
+          --effort max \
           --model "$CLAUDE_MODEL" \
           --verbose \
           --output-format stream-json \
@@ -631,6 +634,7 @@ IMPORTANT:
       claude -p "$PR_PROMPT" \
         --allowedTools "Bash Read Grep Glob" \
         --max-turns 15 \
+        --effort max \
         --model "$CLAUDE_MODEL" \
         --verbose \
         --output-format stream-json \

--- a/ci-operator/step-registry/hypershift/review-agent/process/hypershift-review-agent-process-commands.sh
+++ b/ci-operator/step-registry/hypershift/review-agent/process/hypershift-review-agent-process-commands.sh
@@ -737,6 +737,7 @@ INSTRUCTIONS:
   claude -p "$resolve_prompt" \
     --allowedTools "Bash Read Write Edit Grep Glob" \
     --max-turns 30 \
+    --effort max \
     --model "$CLAUDE_MODEL" \
     --verbose \
     --output-format stream-json \
@@ -1127,6 +1128,7 @@ ${SUBAGENT_PROMPT}"
       --system-prompt "$SKILL_CONTENT" \
       --allowedTools "Bash Read Write Edit Grep Glob WebFetch" \
       --max-turns 150 \
+      --effort max \
       --model "$CLAUDE_MODEL" \
       --verbose \
       --output-format stream-json \
@@ -1212,6 +1214,7 @@ Reproduce each failure, fix the code, and verify the fix passes."
       --system-prompt "$CI_FIX_SYSTEM" \
       --allowedTools "Bash Read Write Edit Grep Glob" \
       --max-turns 150 \
+      --effort max \
       --model "$CLAUDE_MODEL" \
       --verbose \
       --output-format stream-json \


### PR DESCRIPTION
## Summary

- Adds `--effort max` flag to all Claude CLI invocations in jira-agent (4 phases: solve, review, fix, PR) and review-agent (1 phase)
- Enables extended thinking for deeper reasoning and better solution quality

## Test plan

- [ ] Verify jira-agent periodic job runs successfully with --effort max
- [ ] Verify review-agent periodic job runs successfully with --effort max

/cc @bryan-cox

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automation agent execution parameters across continuous integration workflows to enhance performance and efficiency in internal review and processing pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->