### PR TITLE
[DO NOT MERGE] 4.15.63 rerun s390x

### DIFF
--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.15-upgrade-from-nightly-4.14.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.15-upgrade-from-nightly-4.14.yaml
@@ -188,7 +188,7 @@ tests:
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance
     workflow: openshift-upgrade-gcp-heterogeneous
-- as: ocp-ovn-remote-libvirt-s390x
+- as: ocp-ovn-remote-libvirt-s390x-test
   capabilities:
   - sshd-bastion
   cron: 0 2 * * 5

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.15.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.15.yaml
@@ -380,7 +380,7 @@ tests:
       OCP_ARCH: arm64
       TEST_SUITE: upgrade-conformance
     workflow: openshift-upgrade-azure
-- as: ocp-e2e-ovn-remote-libvirt-s390x
+- as: ocp-e2e-ovn-remote-libvirt-s390x-test
   capabilities:
   - sshd-bastion
   cron: 0 0 * * 5
@@ -462,7 +462,7 @@ tests:
       BRANCH: "4.15"
       TEST_TYPE: conformance-serial
     workflow: openshift-e2e-libvirt
-- as: ocp-fips-ovn-remote-libvirt-s390x
+- as: ocp-fips-ovn-remote-libvirt-s390x-test
   capabilities:
   - sshd-bastion
   cron: 0 10 * * 5

--- a/ci-operator/jobs/openshift/multiarch/openshift-multiarch-main-periodics.yaml
+++ b/ci-operator/jobs/openshift/multiarch/openshift-multiarch-main-periodics.yaml
@@ -14418,7 +14418,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build01
-  cron: 0 0 * * 5
+  cron: 0 0 9 1 *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -14428,13 +14428,13 @@ periodics:
     repo: multiarch
   labels:
     capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-2
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
+    ci-operator.openshift.io/cloud: libvirt-s390x-amd64
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-amd64
     ci-operator.openshift.io/variant: nightly-4.15
     ci.openshift.io/generator: prowgen
     job-release: "4.15"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-multiarch-main-nightly-4.15-ocp-e2e-ovn-remote-libvirt-s390x-test
+  name: periodic-ci-openshift-multiarch-main-nightly-4.15-ocp-e2e-ovn-remote-libvirt-s390x-heterogeneous
   spec:
     containers:
     - args:
@@ -14443,7 +14443,7 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=ocp-e2e-ovn-remote-libvirt-s390x-test
+      - --target=ocp-e2e-ovn-remote-libvirt-s390x-heterogeneous
       - --variant=nightly-4.15
       command:
       - ci-operator
@@ -14502,7 +14502,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build01
-  cron: 0 0 9 1 *
+  cron: 0 0 * * 5
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -14512,13 +14512,13 @@ periodics:
     repo: multiarch
   labels:
     capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-amd64
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-amd64
+    ci-operator.openshift.io/cloud: libvirt-s390x-2
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
     ci-operator.openshift.io/variant: nightly-4.15
     ci.openshift.io/generator: prowgen
     job-release: "4.15"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-multiarch-main-nightly-4.15-ocp-e2e-ovn-remote-libvirt-s390x-heterogeneous
+  name: periodic-ci-openshift-multiarch-main-nightly-4.15-ocp-e2e-ovn-remote-libvirt-s390x-test
   spec:
     containers:
     - args:
@@ -14527,7 +14527,7 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=ocp-e2e-ovn-remote-libvirt-s390x-heterogeneous
+      - --target=ocp-e2e-ovn-remote-libvirt-s390x-test
       - --variant=nightly-4.15
       command:
       - ci-operator

--- a/ci-operator/jobs/openshift/multiarch/openshift-multiarch-main-periodics.yaml
+++ b/ci-operator/jobs/openshift/multiarch/openshift-multiarch-main-periodics.yaml
@@ -14434,7 +14434,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.15"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-multiarch-main-nightly-4.15-ocp-e2e-ovn-remote-libvirt-s390x
+  name: periodic-ci-openshift-multiarch-main-nightly-4.15-ocp-e2e-ovn-remote-libvirt-s390x-test
   spec:
     containers:
     - args:
@@ -14443,7 +14443,7 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=ocp-e2e-ovn-remote-libvirt-s390x
+      - --target=ocp-e2e-ovn-remote-libvirt-s390x-test
       - --variant=nightly-4.15
       command:
       - ci-operator
@@ -15601,7 +15601,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.15"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-multiarch-main-nightly-4.15-ocp-fips-ovn-remote-libvirt-s390x
+  name: periodic-ci-openshift-multiarch-main-nightly-4.15-ocp-fips-ovn-remote-libvirt-s390x-test
   spec:
     containers:
     - args:
@@ -15610,7 +15610,7 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=ocp-fips-ovn-remote-libvirt-s390x
+      - --target=ocp-fips-ovn-remote-libvirt-s390x-test
       - --variant=nightly-4.15
       command:
       - ci-operator
@@ -16852,7 +16852,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.15"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-multiarch-main-nightly-4.15-upgrade-from-nightly-4.14-ocp-ovn-remote-libvirt-s390x
+  name: periodic-ci-openshift-multiarch-main-nightly-4.15-upgrade-from-nightly-4.14-ocp-ovn-remote-libvirt-s390x-test
   spec:
     containers:
     - args:
@@ -16861,7 +16861,7 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=ocp-ovn-remote-libvirt-s390x
+      - --target=ocp-ovn-remote-libvirt-s390x-test
       - --variant=nightly-4.15-upgrade-from-nightly-4.14
       command:
       - ci-operator


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test job identifiers in multiarch nightly configurations for `s390x` libvirt environments to include consistent naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->