### PR TITLE
Add dptp_collection and remove collection from dockerconfigs

### DIFF
--- a/core-services/ci-secret-bootstrap/gsm-config.yaml
+++ b/core-services/ci-secret-bootstrap/gsm-config.yaml
@@ -64,6 +64,8 @@ cluster_groups:
     - build11
     - build12
 
+dptp_collection: test-platform-infra
+
 bundles:
   - name: gce-sa-credentials-gcs-publisher
     gsm_secrets:
@@ -152,40 +154,31 @@ bundles:
     dockerconfig:
       registries:
         - auth_field: token_image-puller_build01_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc.cluster.local:5000
         - auth_field: token_image-puller_build01_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc:5000
         - auth_field: token_image-puller_build01_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.build01.ci.openshift.org
         - auth_field: token_image-puller_app--dot--ci_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.ci.openshift.org
         - auth_field: auth
           email_field: email
-          collection: test-platform-infra
           group: quay--dot--io-pull-secret
           registry_url: quay.io
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay-proxy.ci.openshift.org
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay.io/openshift/ci
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay.io/openshift/network-edge-testing
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: qci-pull-through-cache-us-east-1-ci.apps.ci.l2s4.p1.openshiftapps.com
     sync_to_cluster: true
@@ -207,40 +200,31 @@ bundles:
     dockerconfig:
       registries:
         - auth_field: token_image-puller_build02_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc.cluster.local:5000
         - auth_field: token_image-puller_build02_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc:5000
         - auth_field: token_image-puller_build02_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.build02.ci.openshift.org
         - auth_field: token_image-puller_app--dot--ci_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.ci.openshift.org
         - auth_field: auth
           email_field: email
-          collection: test-platform-infra
           group: quay--dot--io-pull-secret
           registry_url: quay.io
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay-proxy.ci.openshift.org
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay.io/openshift/ci
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay.io/openshift/network-edge-testing
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: qci-pull-through-cache-us-east-1-ci.apps.ci.l2s4.p1.openshiftapps.com
     sync_to_cluster: true
@@ -262,40 +246,31 @@ bundles:
     dockerconfig:
       registries:
         - auth_field: token_image-puller_build03_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc.cluster.local:5000
         - auth_field: token_image-puller_build03_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc:5000
         - auth_field: token_image-puller_build03_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.build03.ci.openshift.org
         - auth_field: token_image-puller_app--dot--ci_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.ci.openshift.org
         - auth_field: auth
           email_field: email
-          collection: test-platform-infra
           group: quay--dot--io-pull-secret
           registry_url: quay.io
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay-proxy.ci.openshift.org
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay.io/openshift/ci
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay.io/openshift/network-edge-testing
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: qci-pull-through-cache-us-east-1-ci.apps.ci.l2s4.p1.openshiftapps.com
     sync_to_cluster: true
@@ -317,40 +292,31 @@ bundles:
     dockerconfig:
       registries:
         - auth_field: token_image-puller_build04_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc.cluster.local:5000
         - auth_field: token_image-puller_build04_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc:5000
         - auth_field: token_image-puller_build04_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.build04.ci.openshift.org
         - auth_field: token_image-puller_app--dot--ci_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.ci.openshift.org
         - auth_field: auth
           email_field: email
-          collection: test-platform-infra
           group: quay--dot--io-pull-secret
           registry_url: quay.io
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay-proxy.ci.openshift.org
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay.io/openshift/ci
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay.io/openshift/network-edge-testing
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: qci-pull-through-cache-us-east-1-ci.apps.ci.l2s4.p1.openshiftapps.com
     sync_to_cluster: true
@@ -372,40 +338,31 @@ bundles:
     dockerconfig:
       registries:
         - auth_field: token_image-puller_build05_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc.cluster.local:5000
         - auth_field: token_image-puller_build05_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc:5000
         - auth_field: token_image-puller_build05_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.build05.ci.openshift.org
         - auth_field: token_image-puller_app--dot--ci_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.ci.openshift.org
         - auth_field: auth
           email_field: email
-          collection: test-platform-infra
           group: quay--dot--io-pull-secret
           registry_url: quay.io
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay-proxy.ci.openshift.org
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay.io/openshift/ci
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay.io/openshift/network-edge-testing
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: qci-pull-through-cache-us-east-1-ci.apps.ci.l2s4.p1.openshiftapps.com
     sync_to_cluster: true
@@ -427,40 +384,31 @@ bundles:
     dockerconfig:
       registries:
         - auth_field: token_image-puller_build06_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc.cluster.local:5000
         - auth_field: token_image-puller_build06_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc:5000
         - auth_field: token_image-puller_build06_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.build06.ci.openshift.org
         - auth_field: token_image-puller_app--dot--ci_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.ci.openshift.org
         - auth_field: auth
           email_field: email
-          collection: test-platform-infra
           group: quay--dot--io-pull-secret
           registry_url: quay.io
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay-proxy.ci.openshift.org
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay.io/openshift/ci
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay.io/openshift/network-edge-testing
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: qci-pull-through-cache-us-east-1-ci.apps.ci.l2s4.p1.openshiftapps.com
     sync_to_cluster: true
@@ -482,40 +430,31 @@ bundles:
     dockerconfig:
       registries:
         - auth_field: token_image-puller_build07_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc.cluster.local:5000
         - auth_field: token_image-puller_build07_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc:5000
         - auth_field: token_image-puller_build07_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.build07.ci.openshift.org
         - auth_field: token_image-puller_app--dot--ci_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.ci.openshift.org
         - auth_field: auth
           email_field: email
-          collection: test-platform-infra
           group: quay--dot--io-pull-secret
           registry_url: quay.io
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay-proxy.ci.openshift.org
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay.io/openshift/ci
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay.io/openshift/network-edge-testing
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: qci-pull-through-cache-us-east-1-ci.apps.ci.l2s4.p1.openshiftapps.com
     sync_to_cluster: true
@@ -537,40 +476,31 @@ bundles:
     dockerconfig:
       registries:
         - auth_field: token_image-puller_build08_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc.cluster.local:5000
         - auth_field: token_image-puller_build08_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc:5000
         - auth_field: token_image-puller_build08_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.build08.ci.openshift.org
         - auth_field: token_image-puller_app--dot--ci_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.ci.openshift.org
         - auth_field: auth
           email_field: email
-          collection: test-platform-infra
           group: quay--dot--io-pull-secret
           registry_url: quay.io
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay-proxy.ci.openshift.org
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay.io/openshift/ci
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay.io/openshift/network-edge-testing
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: qci-pull-through-cache-us-east-1-ci.apps.ci.l2s4.p1.openshiftapps.com
     sync_to_cluster: true
@@ -592,40 +522,31 @@ bundles:
     dockerconfig:
       registries:
         - auth_field: token_image-puller_build09_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc.cluster.local:5000
         - auth_field: token_image-puller_build09_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc:5000
         - auth_field: token_image-puller_build09_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.build09.ci.openshift.org
         - auth_field: token_image-puller_app--dot--ci_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.ci.openshift.org
         - auth_field: auth
           email_field: email
-          collection: test-platform-infra
           group: quay--dot--io-pull-secret
           registry_url: quay.io
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay-proxy.ci.openshift.org
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay.io/openshift/ci
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay.io/openshift/network-edge-testing
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: qci-pull-through-cache-us-east-1-ci.apps.ci.l2s4.p1.openshiftapps.com
     sync_to_cluster: true
@@ -647,40 +568,31 @@ bundles:
     dockerconfig:
       registries:
         - auth_field: token_image-puller_build10_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc.cluster.local:5000
         - auth_field: token_image-puller_build10_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc:5000
         - auth_field: token_image-puller_build10_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.build10.ci.openshift.org
         - auth_field: token_image-puller_app--dot--ci_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.ci.openshift.org
         - auth_field: auth
           email_field: email
-          collection: test-platform-infra
           group: quay--dot--io-pull-secret
           registry_url: quay.io
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay-proxy.ci.openshift.org
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay.io/openshift/ci
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay.io/openshift/network-edge-testing
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: qci-pull-through-cache-us-east-1-ci.apps.ci.l2s4.p1.openshiftapps.com
     sync_to_cluster: true
@@ -702,40 +614,31 @@ bundles:
     dockerconfig:
       registries:
         - auth_field: token_image-puller_build11_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc.cluster.local:5000
         - auth_field: token_image-puller_build11_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc:5000
         - auth_field: token_image-puller_build11_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.build11.ci.openshift.org
         - auth_field: token_image-puller_app--dot--ci_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.ci.openshift.org
         - auth_field: auth
           email_field: email
-          collection: test-platform-infra
           group: quay--dot--io-pull-secret
           registry_url: quay.io
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay-proxy.ci.openshift.org
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay.io/openshift/ci
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay.io/openshift/network-edge-testing
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: qci-pull-through-cache-us-east-1-ci.apps.ci.l2s4.p1.openshiftapps.com
     sync_to_cluster: true
@@ -757,40 +660,31 @@ bundles:
     dockerconfig:
       registries:
         - auth_field: token_image-puller_build12_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc.cluster.local:5000
         - auth_field: token_image-puller_build12_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc:5000
         - auth_field: token_image-puller_build12_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.build12.ci.openshift.org
         - auth_field: token_image-puller_app--dot--ci_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.ci.openshift.org
         - auth_field: auth
           email_field: email
-          collection: test-platform-infra
           group: quay--dot--io-pull-secret
           registry_url: quay.io
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay-proxy.ci.openshift.org
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay.io/openshift/ci
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay.io/openshift/network-edge-testing
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: qci-pull-through-cache-us-east-1-ci.apps.ci.l2s4.p1.openshiftapps.com
     sync_to_cluster: true
@@ -812,40 +706,31 @@ bundles:
     dockerconfig:
       registries:
         - auth_field: token_image-puller_vsphere02_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc.cluster.local:5000
         - auth_field: token_image-puller_vsphere02_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc:5000
         - auth_field: token_image-puller_vsphere02_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.apps.build02.vmc.ci.openshift.org
         - auth_field: token_image-puller_app--dot--ci_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.ci.openshift.org
         - auth_field: auth
           email_field: email
-          collection: test-platform-infra
           group: quay--dot--io-pull-secret
           registry_url: quay.io
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay-proxy.ci.openshift.org
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay.io/openshift/ci
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay.io/openshift/network-edge-testing
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: qci-pull-through-cache-us-east-1-ci.apps.ci.l2s4.p1.openshiftapps.com
     sync_to_cluster: true
@@ -864,40 +749,31 @@ bundles:
     dockerconfig:
       registries:
         - auth_field: token_image-puller_core-ci_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc.cluster.local:5000
         - auth_field: token_image-puller_core-ci_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc:5000
         - auth_field: token_image-puller_core-ci_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.master.ci.openshift.org
         - auth_field: token_image-puller_app--dot--ci_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.ci.openshift.org
         - auth_field: auth
           email_field: email
-          collection: test-platform-infra
           group: quay--dot--io-pull-secret
           registry_url: quay.io
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay-proxy.ci.openshift.org
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay.io/openshift/ci
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay.io/openshift/network-edge-testing
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: qci-pull-through-cache-us-east-1-ci.apps.ci.l2s4.p1.openshiftapps.com
     sync_to_cluster: true
@@ -916,36 +792,28 @@ bundles:
     dockerconfig:
       registries:
         - auth_field: token_image-puller_app--dot--ci_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc.cluster.local:5000
         - auth_field: token_image-puller_app--dot--ci_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc:5000
         - auth_field: token_image-puller_app--dot--ci_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.ci.openshift.org
         - auth_field: auth
           email_field: email
-          collection: test-platform-infra
           group: quay--dot--io-pull-secret
           registry_url: quay.io
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay-proxy.ci.openshift.org
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay.io/openshift/ci
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay.io/openshift/network-edge-testing
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: qci-pull-through-cache-us-east-1-ci.apps.ci.l2s4.p1.openshiftapps.com
     sync_to_cluster: true
@@ -970,15 +838,12 @@ bundles:
     dockerconfig:
       registries:
         - auth_field: token_image-pusher_app--dot--ci_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc.cluster.local:5000
         - auth_field: token_image-pusher_app--dot--ci_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc:5000
         - auth_field: token_image-pusher_app--dot--ci_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.ci.openshift.org
     sync_to_cluster: true
@@ -994,27 +859,21 @@ bundles:
     dockerconfig:
       registries:
         - auth_field: token_image-puller_build01_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc.cluster.local:5000
         - auth_field: token_image-puller_build01_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc:5000
         - auth_field: token_image-puller_build01_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.build01.ci.openshift.org
         - auth_field: token_image-pusher_app--dot--ci_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.ci.openshift.org
         - auth_field: auth
-          collection: test-platform-infra
           group: quay-io-push-credentials
           registry_url: quay.io/openshift/ci
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay-proxy.ci.openshift.org
     sync_to_cluster: true
@@ -1030,27 +889,21 @@ bundles:
     dockerconfig:
       registries:
         - auth_field: token_image-puller_build02_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc.cluster.local:5000
         - auth_field: token_image-puller_build02_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc:5000
         - auth_field: token_image-puller_build02_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.build02.ci.openshift.org
         - auth_field: token_image-pusher_app--dot--ci_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.ci.openshift.org
         - auth_field: auth
-          collection: test-platform-infra
           group: quay-io-push-credentials
           registry_url: quay.io/openshift/ci
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay-proxy.ci.openshift.org
     sync_to_cluster: true
@@ -1066,27 +919,21 @@ bundles:
     dockerconfig:
       registries:
         - auth_field: token_image-puller_build03_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc.cluster.local:5000
         - auth_field: token_image-puller_build03_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc:5000
         - auth_field: token_image-puller_build03_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.build03.ci.openshift.org
         - auth_field: token_image-pusher_app--dot--ci_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.ci.openshift.org
         - auth_field: auth
-          collection: test-platform-infra
           group: quay-io-push-credentials
           registry_url: quay.io/openshift/ci
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay-proxy.ci.openshift.org
     sync_to_cluster: true
@@ -1102,27 +949,21 @@ bundles:
     dockerconfig:
       registries:
         - auth_field: token_image-puller_build04_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc.cluster.local:5000
         - auth_field: token_image-puller_build04_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc:5000
         - auth_field: token_image-puller_build04_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.build04.ci.openshift.org
         - auth_field: token_image-pusher_app--dot--ci_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.ci.openshift.org
         - auth_field: auth
-          collection: test-platform-infra
           group: quay-io-push-credentials
           registry_url: quay.io/openshift/ci
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay-proxy.ci.openshift.org
     sync_to_cluster: true
@@ -1138,27 +979,21 @@ bundles:
     dockerconfig:
       registries:
         - auth_field: token_image-puller_build05_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc.cluster.local:5000
         - auth_field: token_image-puller_build05_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc:5000
         - auth_field: token_image-puller_build05_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.build05.ci.openshift.org
         - auth_field: token_image-pusher_app--dot--ci_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.ci.openshift.org
         - auth_field: auth
-          collection: test-platform-infra
           group: quay-io-push-credentials
           registry_url: quay.io/openshift/ci
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay-proxy.ci.openshift.org
     sync_to_cluster: true
@@ -1174,27 +1009,21 @@ bundles:
     dockerconfig:
       registries:
         - auth_field: token_image-puller_build06_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc.cluster.local:5000
         - auth_field: token_image-puller_build06_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc:5000
         - auth_field: token_image-puller_build06_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.build06.ci.openshift.org
         - auth_field: token_image-pusher_app--dot--ci_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.ci.openshift.org
         - auth_field: auth
-          collection: test-platform-infra
           group: quay-io-push-credentials
           registry_url: quay.io/openshift/ci
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay-proxy.ci.openshift.org
     sync_to_cluster: true
@@ -1210,27 +1039,21 @@ bundles:
     dockerconfig:
       registries:
         - auth_field: token_image-puller_build07_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc.cluster.local:5000
         - auth_field: token_image-puller_build07_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc:5000
         - auth_field: token_image-puller_build07_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.build07.ci.openshift.org
         - auth_field: token_image-pusher_app--dot--ci_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.ci.openshift.org
         - auth_field: auth
-          collection: test-platform-infra
           group: quay-io-push-credentials
           registry_url: quay.io/openshift/ci
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay-proxy.ci.openshift.org
     sync_to_cluster: true
@@ -1246,27 +1069,21 @@ bundles:
     dockerconfig:
       registries:
         - auth_field: token_image-puller_build08_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc.cluster.local:5000
         - auth_field: token_image-puller_build08_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc:5000
         - auth_field: token_image-puller_build08_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.build08.ci.openshift.org
         - auth_field: token_image-pusher_app--dot--ci_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.ci.openshift.org
         - auth_field: auth
-          collection: test-platform-infra
           group: quay-io-push-credentials
           registry_url: quay.io/openshift/ci
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay-proxy.ci.openshift.org
     sync_to_cluster: true
@@ -1282,27 +1099,21 @@ bundles:
     dockerconfig:
       registries:
         - auth_field: token_image-puller_build09_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc.cluster.local:5000
         - auth_field: token_image-puller_build09_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc:5000
         - auth_field: token_image-puller_build09_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.build09.ci.openshift.org
         - auth_field: token_image-pusher_app--dot--ci_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.ci.openshift.org
         - auth_field: auth
-          collection: test-platform-infra
           group: quay-io-push-credentials
           registry_url: quay.io/openshift/ci
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay-proxy.ci.openshift.org
     sync_to_cluster: true
@@ -1318,27 +1129,21 @@ bundles:
     dockerconfig:
       registries:
         - auth_field: token_image-puller_build10_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc.cluster.local:5000
         - auth_field: token_image-puller_build10_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc:5000
         - auth_field: token_image-puller_build10_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.build10.ci.openshift.org
         - auth_field: token_image-pusher_app--dot--ci_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.ci.openshift.org
         - auth_field: auth
-          collection: test-platform-infra
           group: quay-io-push-credentials
           registry_url: quay.io/openshift/ci
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay-proxy.ci.openshift.org
     sync_to_cluster: true
@@ -1354,27 +1159,21 @@ bundles:
     dockerconfig:
       registries:
         - auth_field: token_image-puller_build11_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc.cluster.local:5000
         - auth_field: token_image-puller_build11_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc:5000
         - auth_field: token_image-puller_build11_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.build11.ci.openshift.org
         - auth_field: token_image-pusher_app--dot--ci_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.ci.openshift.org
         - auth_field: auth
-          collection: test-platform-infra
           group: quay-io-push-credentials
           registry_url: quay.io/openshift/ci
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay-proxy.ci.openshift.org
     sync_to_cluster: true
@@ -1390,27 +1189,21 @@ bundles:
     dockerconfig:
       registries:
         - auth_field: token_image-puller_build12_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc.cluster.local:5000
         - auth_field: token_image-puller_build12_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc:5000
         - auth_field: token_image-puller_build12_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.build12.ci.openshift.org
         - auth_field: token_image-pusher_app--dot--ci_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.ci.openshift.org
         - auth_field: auth
-          collection: test-platform-infra
           group: quay-io-push-credentials
           registry_url: quay.io/openshift/ci
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay-proxy.ci.openshift.org
     sync_to_cluster: true
@@ -1426,27 +1219,21 @@ bundles:
     dockerconfig:
       registries:
         - auth_field: token_image-puller_vsphere02_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc.cluster.local:5000
         - auth_field: token_image-puller_vsphere02_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc:5000
         - auth_field: token_image-puller_vsphere02_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.apps.build02.vmc.ci.openshift.org
         - auth_field: token_image-pusher_app--dot--ci_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.ci.openshift.org
         - auth_field: auth
-          collection: test-platform-infra
           group: quay-io-push-credentials
           registry_url: quay.io/openshift/ci
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay-proxy.ci.openshift.org
     sync_to_cluster: true
@@ -1462,27 +1249,21 @@ bundles:
     dockerconfig:
       registries:
         - auth_field: token_image-puller_core-ci_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc.cluster.local:5000
         - auth_field: token_image-puller_core-ci_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc:5000
         - auth_field: token_image-puller_core-ci_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.master.ci.openshift.org
         - auth_field: token_image-pusher_app--dot--ci_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.ci.openshift.org
         - auth_field: auth
-          collection: test-platform-infra
           group: quay-io-push-credentials
           registry_url: quay.io/openshift/ci
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay-proxy.ci.openshift.org
     sync_to_cluster: true
@@ -1498,55 +1279,43 @@ bundles:
     dockerconfig:
       registries:
         - auth_field: token_image-puller_app--dot--ci_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.ci.openshift.org
         - auth_field: auth
-          collection: test-platform-infra
           email_field: email
           group: cloud--dot--openshift--dot--com-pull-secret
           registry_url: cloud.openshift.com
         - auth_field: auth
-          collection: test-platform-infra
           email_field: email
           group: quay--dot--io-pull-secret
           registry_url: quay.io
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay-proxy.ci.openshift.org
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay.io/openshift/ci
         - auth_field: auth
-          collection: test-platform-infra
           email_field: email
           group: registry--dot--connect--dot--redhat--dot--com-pull-secret
           registry_url: registry.connect.redhat.com
         - auth_field: auth
-          collection: test-platform-infra
           email_field: email
           group: registry--dot--redhat--dot--io-pull-secret
           registry_url: registry.redhat.io
         - auth_field: auth
-          collection: test-platform-infra
           group: registry--dot--stage--dot--redhat--dot--io
           registry_url: registry.stage.redhat.io
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay-proxy.ci.openshift.org
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay.io/openshift/ci
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay.io/openshift/network-edge-testing
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: qci-pull-through-cache-us-east-1-ci.apps.ci.l2s4.p1.openshiftapps.com
     sync_to_cluster: true
@@ -1586,11 +1355,9 @@ bundles:
     dockerconfig:
       registries:
         - auth_field: token_image-pusher_app--dot--ci_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc:5000
         - auth_field: token_image-pusher_app--dot--ci_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.ci.openshift.org
     sync_to_cluster: true
@@ -1606,11 +1373,9 @@ bundles:
     dockerconfig:
       registries:
         - auth_field: token_image-pusher_core-ci_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc:5000
         - auth_field: token_image-pusher_core-ci_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.master.ci.openshift.org
     sync_to_cluster: true
@@ -1626,11 +1391,9 @@ bundles:
     dockerconfig:
       registries:
         - auth_field: token_image-pusher_build01_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc:5000
         - auth_field: token_image-pusher_build01_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.build01.ci.openshift.org
     sync_to_cluster: true
@@ -1646,11 +1409,9 @@ bundles:
     dockerconfig:
       registries:
         - auth_field: token_image-pusher_build02_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc:5000
         - auth_field: token_image-pusher_build02_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.build02.ci.openshift.org
     sync_to_cluster: true
@@ -1666,11 +1427,9 @@ bundles:
     dockerconfig:
       registries:
         - auth_field: token_image-pusher_build03_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc:5000
         - auth_field: token_image-pusher_build03_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.build03.ci.openshift.org
     sync_to_cluster: true
@@ -1686,11 +1445,9 @@ bundles:
     dockerconfig:
       registries:
         - auth_field: token_image-pusher_build04_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc:5000
         - auth_field: token_image-pusher_build04_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.build04.ci.openshift.org
     sync_to_cluster: true
@@ -1706,11 +1463,9 @@ bundles:
     dockerconfig:
       registries:
         - auth_field: token_image-pusher_build05_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc:5000
         - auth_field: token_image-pusher_build05_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.build05.ci.openshift.org
     sync_to_cluster: true
@@ -1726,11 +1481,9 @@ bundles:
     dockerconfig:
       registries:
         - auth_field: token_image-pusher_build06_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc:5000
         - auth_field: token_image-pusher_build06_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.build06.ci.openshift.org
     sync_to_cluster: true
@@ -1746,11 +1499,9 @@ bundles:
     dockerconfig:
       registries:
         - auth_field: token_image-pusher_build07_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc:5000
         - auth_field: token_image-pusher_build07_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.build07.ci.openshift.org
     sync_to_cluster: true
@@ -1766,11 +1517,9 @@ bundles:
     dockerconfig:
       registries:
         - auth_field: token_image-pusher_build08_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc:5000
         - auth_field: token_image-pusher_build08_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.build08.ci.openshift.org
     sync_to_cluster: true
@@ -1786,11 +1535,9 @@ bundles:
     dockerconfig:
       registries:
         - auth_field: token_image-pusher_build09_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc:5000
         - auth_field: token_image-pusher_build09_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.build09.ci.openshift.org
     sync_to_cluster: true
@@ -1806,11 +1553,9 @@ bundles:
     dockerconfig:
       registries:
         - auth_field: token_image-pusher_build10_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc:5000
         - auth_field: token_image-pusher_build10_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.build10.ci.openshift.org
     sync_to_cluster: true
@@ -1826,11 +1571,9 @@ bundles:
     dockerconfig:
       registries:
         - auth_field: token_image-pusher_build11_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc:5000
         - auth_field: token_image-pusher_build11_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.build11.ci.openshift.org
     sync_to_cluster: true
@@ -1846,11 +1589,9 @@ bundles:
     dockerconfig:
       registries:
         - auth_field: token_image-pusher_build12_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc:5000
         - auth_field: token_image-pusher_build12_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.build12.ci.openshift.org
     sync_to_cluster: true
@@ -1866,7 +1607,6 @@ bundles:
     dockerconfig:
       registries:
         - auth_field: token_image-pusher_vsphere02_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: image-registry.openshift-image-registry.svc:5000
     sync_to_cluster: true
@@ -1883,35 +1623,28 @@ bundles:
       as: pull-secret
       registries:
         - auth_field: token_image-puller_app--dot--ci_reg_auth_value--dot--txt
-          collection: test-platform-infra
           group: build_farm
           registry_url: registry.ci.openshift.org
         - auth_field: auth
           email_field: email
-          collection: test-platform-infra
           group: cloud--dot--openshift--dot--com-pull-secret
           registry_url: cloud.openshift.com
         - auth_field: auth
           email_field: email
-          collection: test-platform-infra
           group: quay--dot--io-pull-secret
           registry_url: quay.io
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay-proxy.ci.openshift.org
         - auth_field: auth
-          collection: test-platform-infra
           group: quayio-ci-read-only-robot
           registry_url: quay.io/openshift/ci
         - auth_field: auth
           email_field: email
-          collection: test-platform-infra
           group: registry--dot--connect--dot--redhat--dot--com-pull-secret
           registry_url: registry.connect.redhat.com
         - auth_field: auth
           email_field: email
-          collection: test-platform-infra
           group: registry--dot--redhat--dot--io-pull-secret
           registry_url: registry.redhat.io
     gsm_secrets:


### PR DESCRIPTION
Needs to be merged after https://github.com/openshift/ci-tools/pull/5136 is merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Centralized Docker registry configuration by introducing a new top-level collection setting.
  * Removed explicit per-registry collection entries across deployment bundles.
  * Preserved individual registry fields (auth, optional email, group, registry URL) while reducing repetition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->