### PR TITLE
WINC-1708: Drop Windows Server 2019 from CI, update AWS default to 2022

### DIFF
--- a/ci-operator/step-registry/ipi/conf/aws/windows-machineset/ipi-conf-aws-windows-machineset-commands.sh
+++ b/ci-operator/step-registry/ipi/conf/aws/windows-machineset/ipi-conf-aws-windows-machineset-commands.sh
@@ -52,6 +52,7 @@ oc get machineset "${ref_machineset_name}" -n openshift-machine-api -o json |
       .spec.template.spec.providerSpec.value.ami.id = $ami_id |
       .spec.template.spec.providerSpec.value.instanceType = $instance_type |
       .spec.template.spec.providerSpec.value.userDataSecret.name = $user_data_secret |
+      .spec.template.spec.providerSpec.value.metadataServiceOptions.authentication = "Optional" |
       del(.status) |
       del(.metadata.selfLink) |
       del(.metadata.uid)

--- a/ci-operator/step-registry/ipi/conf/aws/windows-machineset/ipi-conf-aws-windows-machineset-ref.yaml
+++ b/ci-operator/step-registry/ipi/conf/aws/windows-machineset/ipi-conf-aws-windows-machineset-ref.yaml
@@ -17,7 +17,7 @@ ref:
     - name: WINDOWS_NODE_REPLICAS
       default: "1"
     - name: WINDOWS_OS_ID
-      default: "Windows_Server-2019-English-Core-Base"
+      default: "Windows_Server-2022-English-Core-Base"
   documentation: |-
     This IPI step adds a new machineSet to provision Windows instances in AWS and depends on a secret with name 
     `windows-user-data` in the `openshift-machine-api` namespace. The `windows-user-data` secret is created 


### PR DESCRIPTION
## Summary

- Drop Windows Server 2019 support from AWS step-registry default
- Update AWS `WINDOWS_OS_ID` default from `2019` to `2022`
- Add IMDSv2 `metadataServiceOptions.authentication = "Optional"` in AWS machineset commands (required for Server 2025)

## Changes (2 files)

### `ipi-conf-aws-windows-machineset-ref.yaml`
- `WINDOWS_OS_ID` default: `Windows_Server-2019-English-Core-Base` -> `Windows_Server-2022-English-Core-Base`

### `ipi-conf-aws-windows-machineset-commands.sh`
- Added `.spec.template.spec.providerSpec.value.metadataServiceOptions.authentication = "Optional"`
- Required for Server 2025 bootstrap ([WMCO commit b3e539ae0](https://github.com/openshift/windows-machine-config-operator/commit/b3e539ae0455ec673ddaf0b70cb05a05caf5294f))

## Follow-up

- [WINC-1926](https://redhat.atlassian.net/browse/WINC-1926): Dual-version CI test matrix (Server 2022 + 2025 across all platforms)
- [WINC-1927](https://redhat.atlassian.net/browse/WINC-1927): vSphere Server 2025 golden image template

/cc @mansikulkarni96

[WINC-1926]: https://redhat.atlassian.net/browse/WINC-1926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WINC-1927]: https://redhat.atlassian.net/browse/WINC-1927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ