### PR TITLE
Move metallb-frr image build back to normal repos

### DIFF
--- a/ci-operator/config/openshift/frr/openshift-frr-main.yaml
+++ b/ci-operator/config/openshift/frr/openshift-frr-main.yaml
@@ -3,16 +3,11 @@ base_images:
     name: test
     namespace: ocp-kni
     tag: dev-scripts
-  ocp_4.22_base-rhel9:
-    name: builder
-    namespace: ocp
-    tag: rhel-9-golang-1.24-openshift-4.22
 build_root:
   from_repository: true
 images:
   items:
   - dockerfile_path: Dockerfile.openshift
-    from: ocp_builder_rhel-9-base-openshift-4.22
     to: metallb-frr
 promotion:
   to:
@@ -20,12 +15,6 @@ promotion:
     namespace: origin
   - name: "5.0"
     namespace: ocp
-raw_steps:
-- pipeline_image_cache_step:
-    commands: |
-      curl http://base-4-22-rhel98.ocp.svc > /etc/yum.repos.art/ci/base-4-22-rhel-98-appstream.repo
-    from: ocp_4.22_base-rhel9
-    to: ocp_builder_rhel-9-base-openshift-4.22
 releases:
   initial:
     integration:

--- a/ci-operator/config/openshift/frr/openshift-frr-release-4.22.yaml
+++ b/ci-operator/config/openshift/frr/openshift-frr-release-4.22.yaml
@@ -3,16 +3,11 @@ base_images:
     name: test
     namespace: ocp-kni
     tag: dev-scripts
-  ocp_4.22_base-rhel9:
-    name: builder
-    namespace: ocp
-    tag: rhel-9-golang-1.24-openshift-4.22
 build_root:
   from_repository: true
 images:
   items:
   - dockerfile_path: Dockerfile.openshift
-    from: ocp_builder_rhel-9-base-openshift-4.22
     to: metallb-frr
 promotion:
   to:
@@ -20,12 +15,6 @@ promotion:
     namespace: origin
   - name: "4.22"
     namespace: ocp
-raw_steps:
-- pipeline_image_cache_step:
-    commands: |
-      curl http://base-4-22-rhel98.ocp.svc > /etc/yum.repos.art/ci/base-4-22-rhel-98-appstream.repo
-    from: ocp_4.22_base-rhel9
-    to: ocp_builder_rhel-9-base-openshift-4.22
 releases:
   initial:
     integration:

--- a/ci-operator/config/openshift/frr/openshift-frr-release-4.23.yaml
+++ b/ci-operator/config/openshift/frr/openshift-frr-release-4.23.yaml
@@ -3,16 +3,11 @@ base_images:
     name: test
     namespace: ocp-kni
     tag: dev-scripts
-  ocp_4.22_base-rhel9:
-    name: builder
-    namespace: ocp
-    tag: rhel-9-golang-1.24-openshift-4.22
 build_root:
   from_repository: true
 images:
   items:
   - dockerfile_path: Dockerfile.openshift
-    from: ocp_builder_rhel-9-base-openshift-4.22
     to: metallb-frr
 promotion:
   to:
@@ -20,12 +15,6 @@ promotion:
     namespace: origin
   - name: "4.23"
     namespace: ocp
-raw_steps:
-- pipeline_image_cache_step:
-    commands: |
-      curl http://base-4-22-rhel98.ocp.svc > /etc/yum.repos.art/ci/base-4-22-rhel-98-appstream.repo
-    from: ocp_4.22_base-rhel9
-    to: ocp_builder_rhel-9-base-openshift-4.22
 releases:
   initial:
     integration:

--- a/ci-operator/config/openshift/frr/openshift-frr-release-5.0.yaml
+++ b/ci-operator/config/openshift/frr/openshift-frr-release-5.0.yaml
@@ -3,16 +3,11 @@ base_images:
     name: test
     namespace: ocp-kni
     tag: dev-scripts
-  ocp_4.22_base-rhel9:
-    name: builder
-    namespace: ocp
-    tag: rhel-9-golang-1.24-openshift-4.22
 build_root:
   from_repository: true
 images:
   items:
   - dockerfile_path: Dockerfile.openshift
-    from: ocp_builder_rhel-9-base-openshift-4.22
     to: metallb-frr
 promotion:
   to:
@@ -22,12 +17,6 @@ promotion:
   - disabled: true
     name: "5.0"
     namespace: ocp
-raw_steps:
-- pipeline_image_cache_step:
-    commands: |
-      curl http://base-4-22-rhel98.ocp.svc > /etc/yum.repos.art/ci/base-4-22-rhel-98-appstream.repo
-    from: ocp_4.22_base-rhel9
-    to: ocp_builder_rhel-9-base-openshift-4.22
 releases:
   initial:
     integration:

--- a/ci-operator/config/openshift/frr/openshift-frr-release-5.1.yaml
+++ b/ci-operator/config/openshift/frr/openshift-frr-release-5.1.yaml
@@ -3,16 +3,11 @@ base_images:
     name: test
     namespace: ocp-kni
     tag: dev-scripts
-  ocp_4.22_base-rhel9:
-    name: builder
-    namespace: ocp
-    tag: rhel-9-golang-1.24-openshift-4.22
 build_root:
   from_repository: true
 images:
   items:
   - dockerfile_path: Dockerfile.openshift
-    from: ocp_builder_rhel-9-base-openshift-4.22
     to: metallb-frr
 promotion:
   to:
@@ -20,12 +15,6 @@ promotion:
     namespace: origin
   - name: "5.1"
     namespace: ocp
-raw_steps:
-- pipeline_image_cache_step:
-    commands: |
-      curl http://base-4-22-rhel98.ocp.svc > /etc/yum.repos.art/ci/base-4-22-rhel-98-appstream.repo
-    from: ocp_4.22_base-rhel9
-    to: ocp_builder_rhel-9-base-openshift-4.22
 releases:
   initial:
     integration:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/build configuration across branches to change and consolidate base image sourcing.
  * Removed several explicit base-image references and replaced/standardized cache source mappings.
  * Simplified pipelines by removing redundant image-cache steps and adjusting cache discovery commands.
  * Cleared explicit empty namespace fields from test credential mounts in CI configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->