### PR TITLE
Updated slack reporter to include successful job

### DIFF
--- a/ci-operator/config/openshift/ci-tools/openshift-ci-tools-main.yaml
+++ b/ci-operator/config/openshift/ci-tools/openshift-ci-tools-main.yaml
@@ -941,7 +941,6 @@ tests:
         field: gsm-e2e-test-sa-key
         group: test-credentials
         mount_path: /tmp/gcp-creds
-        namespace: ""
       - bundle: hive-hive-credentials
         mount_path: /tmp/hive
         namespace: test-credentials
@@ -1197,7 +1196,6 @@ tests:
         field: api-token
         group: snyk-credentials
         mount_path: /snyk-credentials
-        namespace: ""
       env:
       - default: ci-tools
         name: PROJECT_NAME

--- a/ci-operator/config/rh-ecosystem-edge/openshift-dpf/.config.prowgen
+++ b/ci-operator/config/rh-ecosystem-edge/openshift-dpf/.config.prowgen
@@ -1,6 +1,7 @@
 slack_reporter:
 - channel: "#wg-nvidia-dpf-ci"
   job_states_to_report:
+  - success
   - failure
   - error
   - aborted
@@ -17,3 +18,6 @@ slack_reporter:
   - sanity
   - deploy-cluster
   - network-tests
+  - pull-ci-rh-ecosystem-edge-openshift-dpf-main-sanity
+  - pull-ci-rh-ecosystem-edge-openshift-dpf-main-deploy-cluster
+  - pull-ci-rh-ecosystem-edge-openshift-dpf-main-network-tests

--- a/ci-operator/jobs/rh-ecosystem-edge/openshift-dpf/rh-ecosystem-edge-openshift-dpf-main-presubmits.yaml
+++ b/ci-operator/jobs/rh-ecosystem-edge/openshift-dpf/rh-ecosystem-edge-openshift-dpf-main-presubmits.yaml
@@ -21,6 +21,7 @@ presubmits:
       slack:
         channel: '#wg-nvidia-dpf-ci'
         job_states_to_report:
+        - success
         - failure
         - error
         - aborted
@@ -168,6 +169,7 @@ presubmits:
       slack:
         channel: '#wg-nvidia-dpf-ci'
         job_states_to_report:
+        - success
         - failure
         - error
         - aborted
@@ -260,6 +262,7 @@ presubmits:
       slack:
         channel: '#wg-nvidia-dpf-ci'
         job_states_to_report:
+        - success
         - failure
         - error
         - aborted


### PR DESCRIPTION
Updated files:
- ci-operator/config/rh-ecosystem-edge/openshift-dpf/.config.prowgen
- ci-operator/jobs/rh-ecosystem-edge/openshift-dpf/rh-ecosystem-edge-openshift-dpf-main-presubmits.yaml

Addelack reporter tmore error checking for deplou-cluster

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Slack notifications now include successful job completions for clearer CI status.
  * Added three pull-based validation jobs on main: sanity, deploy-cluster, and network-tests to broaden automated checks.
  * Cleaned up credential configuration entries by removing redundant empty namespace values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->