### PR TITLE
Add KMM sanity tests to AWS Neuron operator Prow jobs

### DIFF
--- a/ci-operator/config/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main__4.19-stable.yaml
+++ b/ci-operator/config/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main__4.19-stable.yaml
@@ -45,6 +45,8 @@ tests:
     allow_best_effort_post_steps: true
     cluster_profile: aws-edge-infra
     env:
+      ECO_HWACCEL_KMM_DEVICE_PLUGIN_IMAGE: quay.io/cvultur/device-plugin:latest-%s
+      ECO_HWACCEL_KMM_REGISTRY: quay.io/ocp-edge-qe
       ECO_HWACCEL_NEURON_DEVICE_PLUGIN_IMAGE: public.ecr.aws/neuron/neuron-device-plugin:2.29.94.0
       ECO_HWACCEL_NEURON_DRIVER_VERSION: 2.25.4.0
       ECO_HWACCEL_NEURON_DRIVERS_IMAGE: public.ecr.aws/os-partners/neuron-openshift/neuron-kernel-module:2.25.4.0
@@ -67,6 +69,8 @@ tests:
     allow_best_effort_post_steps: true
     cluster_profile: aws-edge-infra
     env:
+      ECO_HWACCEL_KMM_DEVICE_PLUGIN_IMAGE: quay.io/cvultur/device-plugin:latest-%s
+      ECO_HWACCEL_KMM_REGISTRY: quay.io/ocp-edge-qe
       ECO_HWACCEL_NEURON_DEVICE_PLUGIN_IMAGE: public.ecr.aws/neuron/neuron-device-plugin:2.29.94.0
       ECO_HWACCEL_NEURON_DRIVER_VERSION: 2.25.4.0
       ECO_HWACCEL_NEURON_DRIVERS_IMAGE: public.ecr.aws/os-partners/neuron-openshift/neuron-kernel-module:2.25.4.0

--- a/ci-operator/config/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main__4.20-stable.yaml
+++ b/ci-operator/config/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main__4.20-stable.yaml
@@ -46,6 +46,8 @@ tests:
     allow_best_effort_post_steps: true
     cluster_profile: aws-edge-infra
     env:
+      ECO_HWACCEL_KMM_DEVICE_PLUGIN_IMAGE: quay.io/cvultur/device-plugin:latest-%s
+      ECO_HWACCEL_KMM_REGISTRY: quay.io/ocp-edge-qe
       ECO_HWACCEL_NEURON_DEVICE_PLUGIN_IMAGE: public.ecr.aws/neuron/neuron-device-plugin:2.29.94.0
       ECO_HWACCEL_NEURON_DRIVER_VERSION: 2.25.4.0
       ECO_HWACCEL_NEURON_DRIVERS_IMAGE: public.ecr.aws/os-partners/neuron-openshift/neuron-kernel-module:2.25.4.0
@@ -68,6 +70,8 @@ tests:
     allow_best_effort_post_steps: true
     cluster_profile: aws-edge-infra
     env:
+      ECO_HWACCEL_KMM_DEVICE_PLUGIN_IMAGE: quay.io/cvultur/device-plugin:latest-%s
+      ECO_HWACCEL_KMM_REGISTRY: quay.io/ocp-edge-qe
       ECO_HWACCEL_NEURON_DEVICE_PLUGIN_IMAGE: public.ecr.aws/neuron/neuron-device-plugin:2.29.94.0
       ECO_HWACCEL_NEURON_DRIVER_VERSION: 2.25.4.0
       ECO_HWACCEL_NEURON_DRIVERS_IMAGE: public.ecr.aws/os-partners/neuron-openshift/neuron-kernel-module:2.25.4.0

--- a/ci-operator/config/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main__4.21-stable.yaml
+++ b/ci-operator/config/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main__4.21-stable.yaml
@@ -46,6 +46,8 @@ tests:
     allow_best_effort_post_steps: true
     cluster_profile: aws-edge-infra
     env:
+      ECO_HWACCEL_KMM_DEVICE_PLUGIN_IMAGE: quay.io/cvultur/device-plugin:latest-%s
+      ECO_HWACCEL_KMM_REGISTRY: quay.io/ocp-edge-qe
       ECO_HWACCEL_NEURON_DEVICE_PLUGIN_IMAGE: public.ecr.aws/neuron/neuron-device-plugin:2.29.94.0
       ECO_HWACCEL_NEURON_DRIVER_VERSION: 2.25.4.0
       ECO_HWACCEL_NEURON_DRIVERS_IMAGE: public.ecr.aws/os-partners/neuron-openshift/neuron-kernel-module:2.25.4.0
@@ -68,6 +70,8 @@ tests:
     allow_best_effort_post_steps: true
     cluster_profile: aws-edge-infra
     env:
+      ECO_HWACCEL_KMM_DEVICE_PLUGIN_IMAGE: quay.io/cvultur/device-plugin:latest-%s
+      ECO_HWACCEL_KMM_REGISTRY: quay.io/ocp-edge-qe
       ECO_HWACCEL_NEURON_DEVICE_PLUGIN_IMAGE: public.ecr.aws/neuron/neuron-device-plugin:2.29.94.0
       ECO_HWACCEL_NEURON_DRIVER_VERSION: 2.25.4.0
       ECO_HWACCEL_NEURON_DRIVERS_IMAGE: public.ecr.aws/os-partners/neuron-openshift/neuron-kernel-module:2.25.4.0

--- a/ci-operator/step-registry/aws-neuron-operator/conditional-e2e-rosa/aws-neuron-operator-conditional-e2e-rosa-workflow.yaml
+++ b/ci-operator/step-registry/aws-neuron-operator/conditional-e2e-rosa/aws-neuron-operator-conditional-e2e-rosa-workflow.yaml
@@ -30,6 +30,7 @@ workflow:
     - ref: aws-neuron-operator-install-operators
     test:
     - ref: aws-neuron-operator-test
+    - ref: aws-neuron-operator-kmm-test
     post:
     - ref: aws-neuron-operator-gather
     # Custom deprovision step with retry logic for STS resource deletion.

--- a/ci-operator/step-registry/aws-neuron-operator/e2e-rosa/aws-neuron-operator-e2e-rosa-workflow.yaml
+++ b/ci-operator/step-registry/aws-neuron-operator/e2e-rosa/aws-neuron-operator-e2e-rosa-workflow.yaml
@@ -30,6 +30,7 @@ workflow:
     - ref: aws-neuron-operator-install-operators
     test:
     - ref: aws-neuron-operator-test
+    - ref: aws-neuron-operator-kmm-test
     post:
     - ref: aws-neuron-operator-gather
     # Custom deprovision step with retry logic for STS resource deletion.

--- a/ci-operator/step-registry/aws-neuron-operator/kmm-test/OWNERS
+++ b/ci-operator/step-registry/aws-neuron-operator/kmm-test/OWNERS
@@ -1,0 +1,9 @@
+approvers:
+- ggordanired
+- ybrodsky-rh
+- yevgeny-shnaidman
+options: {}
+reviewers:
+- ggordanired
+- ybrodsky-rh
+- yevgeny-shnaidman

--- a/ci-operator/step-registry/aws-neuron-operator/kmm-test/aws-neuron-operator-kmm-test-commands.sh
+++ b/ci-operator/step-registry/aws-neuron-operator/kmm-test/aws-neuron-operator-kmm-test-commands.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+set -o nounset
+set -o pipefail
+
+echo "Starting KMM sanity tests"
+
+TOOLS_DIR="/tmp/tools"
+mkdir -p "${TOOLS_DIR}"
+export PATH="${TOOLS_DIR}:${PATH}"
+
+if ! command -v oc &>/dev/null; then
+    echo "oc not found, downloading OpenShift client..."
+    curl -sL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz \
+        | tar xzf - -C "${TOOLS_DIR}" oc kubectl 2>/dev/null || true
+    if command -v oc &>/dev/null; then
+        echo "oc installed: $(oc version --client 2>/dev/null || echo 'ok')"
+    else
+        echo "WARNING: failed to install oc"
+    fi
+fi
+
+export KUBECONFIG="${SHARED_DIR}/kubeconfig"
+mkdir -p "${ARTIFACT_DIR}"
+
+# Load KMM pull secret from cluster profile if available
+if [[ -f "${CLUSTER_PROFILE_DIR}/kmm-pull-secret" ]]; then
+    export ECO_HWACCEL_KMM_PULL_SECRET
+    ECO_HWACCEL_KMM_PULL_SECRET=$(cat "${CLUSTER_PROFILE_DIR}/kmm-pull-secret")
+    echo "KMM pull secret loaded from cluster profile"
+elif [[ -f "/var/run/vault/kmm-pull-secret/pull-secret" ]]; then
+    export ECO_HWACCEL_KMM_PULL_SECRET
+    ECO_HWACCEL_KMM_PULL_SECRET=$(cat "/var/run/vault/kmm-pull-secret/pull-secret")
+    echo "KMM pull secret loaded from vault credentials"
+else
+    echo "WARNING: No KMM pull secret found, tests requiring external registry may be skipped"
+fi
+
+cd /home/testuser || exit 1
+
+export ECO_TEST_FEATURES="${ECO_TEST_FEATURES:-modules}"
+export ECO_TEST_LABELS="${ECO_TEST_LABELS:-kmm-sanity}"
+export ECO_TEST_VERBOSE="${ECO_TEST_VERBOSE:-true}"
+export ECO_VERBOSE_LEVEL="${ECO_VERBOSE_LEVEL:-100}"
+export ECO_DUMP_FAILED_TESTS="${ECO_DUMP_FAILED_TESTS:-true}"
+export ECO_REPORTS_DUMP_DIR="${ARTIFACT_DIR}"
+
+echo "Running KMM tests with features: ${ECO_TEST_FEATURES}"
+echo "Running KMM tests with labels: ${ECO_TEST_LABELS}"
+
+TEST_EXIT_CODE=0
+
+ginkgo --label-filter="${ECO_TEST_LABELS}" \
+    --timeout=1h \
+    --v \
+    --keep-going \
+    --junit-report=junit_kmm_modules.xml \
+    --output-dir="${ARTIFACT_DIR}" \
+    ./tests/hw-accel/kmm/... || TEST_EXIT_CODE=$?
+
+if [[ ${TEST_EXIT_CODE} -eq 0 ]]; then
+    echo "SUCCESS" > "${ARTIFACT_DIR}/kmm_sanity.status"
+    echo "KMM sanity tests passed"
+else
+    echo "FAILURE" > "${ARTIFACT_DIR}/kmm_sanity.status"
+    echo "KMM sanity tests failed with exit code ${TEST_EXIT_CODE}"
+fi
+
+echo "=== Collecting KMM debug info ==="
+debug_dir="${ARTIFACT_DIR}/debug-kmm"
+mkdir -p "${debug_dir}"
+oc get modules.kmm.sigs.x-k8s.io -A -o yaml > "${debug_dir}/kmm-modules.yaml" 2>&1 || true
+oc get pods -n openshift-kmm -o wide > "${debug_dir}/kmm-pods.txt" 2>&1 || true
+oc logs -n openshift-kmm -l app.kubernetes.io/component=kmm --tail=500 > "${debug_dir}/kmm-operator-logs.txt" 2>&1 || true
+oc get events -n openshift-kmm --sort-by='.lastTimestamp' > "${debug_dir}/kmm-events.txt" 2>&1 || true
+oc get csv -n openshift-kmm -o yaml > "${debug_dir}/kmm-csvs.yaml" 2>&1 || true
+oc get daemonsets -n openshift-kmm -o wide > "${debug_dir}/kmm-daemonsets.txt" 2>&1 || true
+echo "=== KMM debug info collected ==="
+
+echo "KMM sanity tests completed"
+exit ${TEST_EXIT_CODE}

--- a/ci-operator/step-registry/aws-neuron-operator/kmm-test/aws-neuron-operator-kmm-test-ref.metadata.json
+++ b/ci-operator/step-registry/aws-neuron-operator/kmm-test/aws-neuron-operator-kmm-test-ref.metadata.json
@@ -1,0 +1,15 @@
+{
+	"path": "aws-neuron-operator/kmm-test/aws-neuron-operator-kmm-test-ref.yaml",
+	"owners": {
+		"approvers": [
+			"ggordanired",
+			"ybrodsky-rh",
+			"yevgeny-shnaidman"
+		],
+		"reviewers": [
+			"ggordanired",
+			"ybrodsky-rh",
+			"yevgeny-shnaidman"
+		]
+	}
+}

--- a/ci-operator/step-registry/aws-neuron-operator/kmm-test/aws-neuron-operator-kmm-test-ref.yaml
+++ b/ci-operator/step-registry/aws-neuron-operator/kmm-test/aws-neuron-operator-kmm-test-ref.yaml
@@ -1,0 +1,34 @@
+ref:
+  as: aws-neuron-operator-kmm-test
+  from: eco-gotests
+  grace_period: 10m
+  commands: aws-neuron-operator-kmm-test-commands.sh
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+  timeout: 90m
+  env:
+  - name: ECO_TEST_FEATURES
+    default: "modules"
+    documentation: The eco-gotests feature directories to run (space-separated).
+  - name: ECO_TEST_LABELS
+    default: "kmm-sanity"
+    documentation: Ginkgo label filter expression for test selection.
+  - name: ECO_HWACCEL_KMM_REGISTRY
+    default: "quay.io/ocp-edge-qe"
+    documentation: External registry used by KMM tests for pushing built module images.
+  - name: ECO_HWACCEL_KMM_DEVICE_PLUGIN_IMAGE
+    default: "quay.io/cvultur/device-plugin:latest-%s"
+    documentation: Device plugin image template. The %s is replaced with the node architecture (amd64/arm64).
+  - name: ECO_TEST_VERBOSE
+    default: "true"
+    documentation: Enable verbose test output.
+  - name: ECO_VERBOSE_LEVEL
+    default: "100"
+    documentation: Verbosity level for klog output in tests.
+  documentation: |-
+    Runs KMM (Kernel Module Management) sanity tests using eco-gotests on a
+    ROSA cluster where KMM is already installed. Validates basic KMM
+    functionality including module build/sign/load, device plugin, webhooks,
+    in-tree replacement, firmware loading, and DTK auto-selection.


### PR DESCRIPTION
## Summary
- Adds a new `aws-neuron-operator-kmm-test` step that runs KMM (Kernel Module Management) sanity tests using eco-gotests after the Neuron operator tests complete on the same ROSA cluster
- KMM is already installed as a dependency, so we leverage the existing cluster to validate ~15 KMM sanity tests (device-plugin, webhooks, signing, firmware, DTK, in-tree replacement)
- Updated both `e2e-rosa` and `conditional-e2e-rosa` workflows, and all config variants (4.19, 4.20, 4.21)

## Test plan
- [ ] CI rehearsal validates step registry syntax
- [ ] `/test aws-neuron-operator-e2e` to verify KMM tests execute on ROSA
- [ ] Confirm JUnit XML and `finished.json` appear in artifacts at `artifacts/<test>/aws-neuron-operator-kmm-test/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new KMM (Kernel Module Management) sanity tests to AWS Neuron Operator CI/CD workflows for multiple release versions.
  
* **Chores**
  * Updated test step configurations with new environment variables for KMM device plugin image and registry references.
  * Extended ROSA workflow test suites to execute additional KMM-related test steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->