### PR TITLE
Add CI for openshift/lightspeed-agentic-sandbox

### DIFF
--- a/ci-operator/config/openshift/ci-tools/openshift-ci-tools-main.yaml
+++ b/ci-operator/config/openshift/ci-tools/openshift-ci-tools-main.yaml
@@ -941,7 +941,6 @@ tests:
         field: gsm-e2e-test-sa-key
         group: test-credentials
         mount_path: /tmp/gcp-creds
-        namespace: ""
       - bundle: hive-hive-credentials
         mount_path: /tmp/hive
         namespace: test-credentials
@@ -1197,7 +1196,6 @@ tests:
         field: api-token
         group: snyk-credentials
         mount_path: /snyk-credentials
-        namespace: ""
       env:
       - default: ci-tools
         name: PROJECT_NAME

--- a/ci-operator/config/openshift/lightspeed-agentic-sandbox/OWNERS
+++ b/ci-operator/config/openshift/lightspeed-agentic-sandbox/OWNERS
@@ -1,0 +1,19 @@
+# DO NOT EDIT; this file is auto-generated using https://github.com/openshift/ci-tools.
+# Fetched from https://github.com/openshift/lightspeed-agentic-sandbox root OWNERS
+# If the repo had OWNERS_ALIASES then the aliases were expanded
+# Logins who are not members of 'openshift' organization were filtered out
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+- blublinsky
+- harche
+- joshuawilson
+- onmete
+- xrajesh
+options: {}
+reviewers:
+- blublinsky
+- harche
+- joshuawilson
+- onmete
+- xrajesh

--- a/ci-operator/config/openshift/lightspeed-agentic-sandbox/openshift-lightspeed-agentic-sandbox-main.yaml
+++ b/ci-operator/config/openshift/lightspeed-agentic-sandbox/openshift-lightspeed-agentic-sandbox-main.yaml
@@ -3,7 +3,7 @@ build_root:
     dockerfile_literal: |
       FROM registry.ci.openshift.org/ocp/ubi-python-312:9
       USER 0
-      RUN pip install uv
+      RUN pip install uv==0.9.24
 resources:
   '*':
     limits:

--- a/ci-operator/config/openshift/lightspeed-agentic-sandbox/openshift-lightspeed-agentic-sandbox-main.yaml
+++ b/ci-operator/config/openshift/lightspeed-agentic-sandbox/openshift-lightspeed-agentic-sandbox-main.yaml
@@ -1,0 +1,28 @@
+build_root:
+  project_image:
+    dockerfile_literal: |
+      FROM registry.ci.openshift.org/ocp/ubi-python-312:9
+      USER 0
+      RUN pip install uv
+resources:
+  '*':
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 100m
+      memory: 2Gi
+tests:
+- as: lint
+  commands: make install && make verify
+  container:
+    from: src
+  skip_if_only_changed: ^docs/|\.md$|^\.ols/|^evals/|^(?:.*/)?(?:\.gitignore|OWNERS|LICENSE)$
+- as: unit-test
+  commands: make install && make test
+  container:
+    from: src
+  skip_if_only_changed: ^docs/|\.md$|^\.ols/|^evals/|^(?:.*/)?(?:\.gitignore|OWNERS|LICENSE)$
+zz_generated_metadata:
+  branch: main
+  org: openshift
+  repo: lightspeed-agentic-sandbox

--- a/ci-operator/jobs/openshift/lightspeed-agentic-sandbox/OWNERS
+++ b/ci-operator/jobs/openshift/lightspeed-agentic-sandbox/OWNERS
@@ -1,0 +1,19 @@
+# DO NOT EDIT; this file is auto-generated using https://github.com/openshift/ci-tools.
+# Fetched from https://github.com/openshift/lightspeed-agentic-sandbox root OWNERS
+# If the repo had OWNERS_ALIASES then the aliases were expanded
+# Logins who are not members of 'openshift' organization were filtered out
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+- blublinsky
+- harche
+- joshuawilson
+- onmete
+- xrajesh
+options: {}
+reviewers:
+- blublinsky
+- harche
+- joshuawilson
+- onmete
+- xrajesh

--- a/ci-operator/jobs/openshift/lightspeed-agentic-sandbox/openshift-lightspeed-agentic-sandbox-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/lightspeed-agentic-sandbox/openshift-lightspeed-agentic-sandbox-main-presubmits.yaml
@@ -1,0 +1,130 @@
+presubmits:
+  openshift/lightspeed-agentic-sandbox:
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build01
+    context: ci/prow/lint
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-lightspeed-agentic-sandbox-main-lint
+    rerun_command: /test lint
+    skip_if_only_changed: ^docs/|\.md$|^\.ols/|^evals/|^(?:.*/)?(?:\.gitignore|OWNERS|LICENSE)$
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=lint
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )lint,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build01
+    context: ci/prow/unit-test
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-lightspeed-agentic-sandbox-main-unit-test
+    rerun_command: /test unit-test
+    skip_if_only_changed: ^docs/|\.md$|^\.ols/|^evals/|^(?:.*/)?(?:\.gitignore|OWNERS|LICENSE)$
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=unit-test
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )unit-test,?($|\s.*)


### PR DESCRIPTION
## Summary

- Add ci-operator configuration for `openshift/lightspeed-agentic-sandbox` with two presubmit jobs: **lint** and **unit-test**
- Build root uses Python 3.12 UBI image with `uv` installed to match the project's toolchain
- Both jobs are skipped for doc-only or metadata-only changes via `skip_if_only_changed`

### Jobs

| Job | Command | What it checks |
|-----|---------|----------------|
| `lint` | `make install && make verify` | ruff format, ruff lint, mypy strict type checking |
| `unit-test` | `make install && make test` | pytest unit tests (mocked, no API keys needed) |

### Not included (intentionally)

- **Container image build** — the `Containerfile` uses `registry.redhat.io` base image requiring auth; will be added separately once registry credentials are configured
- **Eval tests** — require live LLM API keys; stay as manual `make eval`
- **E2e tests** — require cluster provisioning; out of scope for initial CI


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed redundant namespace fields from credential mount configurations in CI pipeline.
  * Added new CI build configuration for repository with Python 3.12 environment, default resource allocation, and automated lint and unit-test commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->