### PR TITLE
SPLAT-2651: Changed e2e-vsphere-operator-test to leverage OTE

### DIFF
--- a/ci-operator/config/openshift/vmware-vsphere-csi-driver-operator/openshift-vmware-vsphere-csi-driver-operator-main.yaml
+++ b/ci-operator/config/openshift/vmware-vsphere-csi-driver-operator/openshift-vmware-vsphere-csi-driver-operator-main.yaml
@@ -53,16 +53,9 @@ tests:
 - as: e2e-vsphere-operator-test
   steps:
     cluster_profile: vsphere-elastic
-    test:
-    - as: test
-      cli: latest
-      commands: |
-        make operator-e2e-test
-      from: src
-      resources:
-        requests:
-          cpu: 100m
-    workflow: ipi-vsphere
+    env:
+      TEST_SUITE: vvcdo/conformance/serial
+    workflow: openshift-e2e-vsphere-ovn
 - as: e2e-vsphere-csi
   steps:
     cluster_profile: vsphere-elastic


### PR DESCRIPTION
[SPLAT-2651](https://redhat.atlassian.net/browse/SPLAT-2651)

### Changes
- Changed e2e-vsphere-operator-test to leverage OTE

[SPLAT-2651]: https://redhat.atlassian.net/browse/SPLAT-2651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched vSphere operator conformance testing to a workflow-driven execution for improved consistency and orchestration.
  * Configured the CI to run the serial conformance suite, streamlining test selection and reducing per-step resource overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->