### PR TITLE
MPIIT: Use ExitTrap--PostProcessPrep for updated test mapping

### DIFF
--- a/ci-operator/config/openshift-pipelines/release-tests/openshift-pipelines-release-tests-release-v1.21__ocp-4.22-lp-interop.yaml
+++ b/ci-operator/config/openshift-pipelines/release-tests/openshift-pipelines-release-tests-release-v1.21__ocp-4.22-lp-interop.yaml
@@ -48,7 +48,7 @@ tests:
       FIREWATCH_FAIL_WITH_TEST_FAILURES: "true"
       MAP_TESTS: "true"
       OCP_VERSION: "4.22"
-      REPORTPORTAL_CMP: lp-interop-OpenshiftPipelines
+      REPORTPORTAL_CMP: lp-ocp-compat--OpenshiftPipelines
       USER_TAGS: |
         scenario pipelines
     test:
@@ -77,7 +77,7 @@ tests:
       FIREWATCH_FAIL_WITH_TEST_FAILURES: "true"
       MAP_TESTS: "true"
       OCP_VERSION: "4.22"
-      REPORTPORTAL_CMP: lp-interop-OpenshiftPipelines
+      REPORTPORTAL_CMP: lp-ocp-compat--OpenshiftPipelines
       USER_TAGS: |
         scenario pipelines
     test:

--- a/ci-operator/config/openshift-pipelines/release-tests/openshift-pipelines-release-tests-release-v1.21__ocp-4.22-lp-interop.yaml
+++ b/ci-operator/config/openshift-pipelines/release-tests/openshift-pipelines-release-tests-release-v1.21__ocp-4.22-lp-interop.yaml
@@ -48,7 +48,7 @@ tests:
       FIREWATCH_FAIL_WITH_TEST_FAILURES: "true"
       MAP_TESTS: "true"
       OCP_VERSION: "4.22"
-      REPORTPORTAL_CMP: lp-ocp-compat--OpenshiftPipelines
+      DR__RP__CR_COMP_NAME: lp-ocp-compat--OpenshiftPipelines
       USER_TAGS: |
         scenario pipelines
     test:
@@ -77,7 +77,7 @@ tests:
       FIREWATCH_FAIL_WITH_TEST_FAILURES: "true"
       MAP_TESTS: "true"
       OCP_VERSION: "4.22"
-      REPORTPORTAL_CMP: lp-ocp-compat--OpenshiftPipelines
+      DR__RP__CR_COMP_NAME: lp-ocp-compat--OpenshiftPipelines
       USER_TAGS: |
         scenario pipelines
     test:

--- a/ci-operator/config/openshift-pipelines/release-tests/openshift-pipelines-release-tests-release-v1.21__ocp-4.22-lp-interop.yaml
+++ b/ci-operator/config/openshift-pipelines/release-tests/openshift-pipelines-release-tests-release-v1.21__ocp-4.22-lp-interop.yaml
@@ -33,6 +33,7 @@ tests:
     cluster_profile: aws-cspi-qe
     env:
       BASE_DOMAIN: cspilp.interop.ccitredhat.com
+      DR__RP__CR_COMP_NAME: lp-ocp-compat--OpenshiftPipelines
       FIREWATCH_CONFIG: |
         {
           "failure_rules":
@@ -48,7 +49,6 @@ tests:
       FIREWATCH_FAIL_WITH_TEST_FAILURES: "true"
       MAP_TESTS: "true"
       OCP_VERSION: "4.22"
-      DR__RP__CR_COMP_NAME: lp-ocp-compat--OpenshiftPipelines
       USER_TAGS: |
         scenario pipelines
     test:
@@ -62,6 +62,7 @@ tests:
     cluster_profile: aws-cspi-qe
     env:
       BASE_DOMAIN: cspilp.interop.ccitredhat.com
+      DR__RP__CR_COMP_NAME: lp-ocp-compat--OpenshiftPipelines
       FIREWATCH_CONFIG: |
         {
           "failure_rules":
@@ -77,7 +78,6 @@ tests:
       FIREWATCH_FAIL_WITH_TEST_FAILURES: "true"
       MAP_TESTS: "true"
       OCP_VERSION: "4.22"
-      DR__RP__CR_COMP_NAME: lp-ocp-compat--OpenshiftPipelines
       USER_TAGS: |
         scenario pipelines
     test:

--- a/ci-operator/step-registry/openshift-pipelines/install/openshift-pipelines-install-commands.sh
+++ b/ci-operator/step-registry/openshift-pipelines/install/openshift-pipelines-install-commands.sh
@@ -1,85 +1,36 @@
 #!/bin/bash
+set -euxo pipefail; shopt -s inherit_errexit
 
-set -o nounset
-set -o errexit
-set -o pipefail
-
-function install_yq_if_not_exists() {
-    # Install yq manually if not found in image
-    echo "Checking if yq exists"
-    cmd_yq="$(yq --version 2>/dev/null || true)"
-    if [ -n "$cmd_yq" ]; then
-        echo "yq version: $cmd_yq"
-    else
-        echo "Installing yq"
-        mkdir -p /tmp/bin
-        export PATH=$PATH:/tmp/bin/
-        curl -L "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_$(uname -m | sed 's/aarch64/arm64/;s/x86_64/amd64/')" \
-         -o /tmp/bin/yq && chmod +x /tmp/bin/yq
-    fi
-}
-
-function mapTestsForComponentReadiness() {
-    if [[ $MAP_TESTS == "true" ]]; then
-        results_file="${1}"
-        echo "Patching Tests Result File: ${results_file}"
-        if [ -f "${results_file}" ]; then
-            export cmp="${REPORTPORTAL_CMP}--"
-            
-            echo "Mapping Test Suite Name To: ${REPORTPORTAL_CMP}"
-            yq eval -px -ox -iI0 '.testsuites.testsuite.+@name |= sub("^(.*)$", env(cmp) + "${1}")' $results_file || echo "Warning: yq failed for ${results_file}, debug manually" >&2
-        fi
-    fi
-}
-
-# Archive results function
-function cleanup-collect() {
-    if [[ $MAP_TESTS == "true" ]]; then
-      install_yq_if_not_exists
-      original_results="${ARTIFACT_DIR}/original_results/"
-      mkdir "${original_results}" || true
-      echo "Collecting original results in ${original_results}"
-
-      # Keep a copy of all the original Junit files before modifying them
-      cp -r "${ARTIFACT_DIR}"/xml-report/ "${original_results}" || echo "Warning: couldn't copy original files" >&2
-
-      # Remove timestamped dir to avoid spacing in filename
-      mv "${ARTIFACT_DIR}"/xml-report/*/result.xml "${ARTIFACT_DIR}/xml-report/" || echo "Warning: couldn't move file to top level dir" >&2
-
-      result_file="${ARTIFACT_DIR}/xml-report/result.xml"
-      # Map tests if needed for related use cases
-      mapTestsForComponentReadiness $result_file
-
-      # Send modified file to shared dir for Data Router Reporter step
-      cp "${result_file}" "${SHARED_DIR}" || echo "Warning: couldn't copy files to SHARED_DIR" >&2
-    fi
-}
-
-CONSOLE_URL=$(cat $SHARED_DIR/console.url)
-API_URL="https://api.${CONSOLE_URL#"https://console-openshift-console.apps."}:6443"
-export CONSOLE_URL
-export API_URL
-export gauge_reports_dir=${ARTIFACT_DIR}
-export overwrite_reports=false
-export KUBECONFIG=$SHARED_DIR/kubeconfig
-export GOPROXY="https://proxy.golang.org/"
+# Map results by setting identifier prefix in tests suites names for reporting tools
+# Merge original results into a single file and compress
+# Send modified file to shared dir for Data Router Reporter step
+if [ "${MAP_TESTS}" = "true" ]; then
+    eval "$(
+        curl -fsSL \
+https://raw.githubusercontent.com/RedHatQE/OpenShift-LP-QE--Tools/refs/heads/main/libs/bash/ci-operator/interop/common/ExitTrap--PostProcessPrep.sh
+    )"; trap '
+        LP_IO__ET_PPP__NEW_TS_NAME="${REPORTPORTAL_CMP}--%s" \
+            ExitTrap--PostProcessPrep junit--openshift-pipelines__install__openshift-pipelines-install.xml
+    ' EXIT
+fi
 
 # Add timeout to ignore runner connection error
 gauge config runner_connection_timeout 600000 && gauge config runner_request_timeout 300000
 
 # login for interop
-if test -f ${SHARED_DIR}/kubeadmin-password
-then
-  OCP_CRED_USR="kubeadmin"
-  export OCP_CRED_USR
-  OCP_CRED_PSW="$(cat ${SHARED_DIR}/kubeadmin-password)"
-  export OCP_CRED_PSW
-  oc login -u kubeadmin -p "$(cat $SHARED_DIR/kubeadmin-password)" "${API_URL}" --insecure-skip-tls-verify=true
+if [ -s "${KUBECONFIG}" ]; then
+    oc whoami
 else #login for ROSA & Hypershift platforms
-  eval "$(cat "${SHARED_DIR}/api.login")"
+    (set +x; eval "$(cat "${SHARED_DIR}/api.login")")
 fi
 
-echo "Running olm.spec to install operator"
-CATALOG_SOURCE=redhat-operators CHANNEL=${OLM_CHANNEL} gauge run --log-level=debug --verbose --tags install specs/olm.spec || true
+# Install openshift-pipelines operator (olm.spec)
+CONSOLE_URL="$(oc whoami --show-console)" \
+    API_URL="$(oc whoami --show-server)" \
+    CATALOG_SOURCE=redhat-operators \
+    CHANNEL="${OLM_CHANNEL:-latest}" \
+    gauge_reports_dir="${ARTIFACT_DIR}" \
+    overwrite_reports=false \
+    gauge run --log-level=debug --verbose --tags install specs/olm.spec
 
-cleanup-collect
+true

--- a/ci-operator/step-registry/openshift-pipelines/install/openshift-pipelines-install-commands.sh
+++ b/ci-operator/step-registry/openshift-pipelines/install/openshift-pipelines-install-commands.sh
@@ -9,7 +9,7 @@ if [ "${MAP_TESTS}" = "true" ]; then
         curl -fsSL \
 https://raw.githubusercontent.com/RedHatQE/OpenShift-LP-QE--Tools/refs/heads/main/libs/bash/ci-operator/interop/common/ExitTrap--PostProcessPrep.sh
     )"; trap '
-        LP_IO__ET_PPP__NEW_TS_NAME="${REPORTPORTAL_CMP}--%s" \
+        LP_IO__ET_PPP__NEW_TS_NAME="${DR__RP__CR_COMP_NAME}--%s" \
             ExitTrap--PostProcessPrep junit--openshift-pipelines__install__openshift-pipelines-install.xml
     ' EXIT
 fi

--- a/ci-operator/step-registry/openshift-pipelines/install/openshift-pipelines-install-ref.yaml
+++ b/ci-operator/step-registry/openshift-pipelines/install/openshift-pipelines-install-ref.yaml
@@ -2,6 +2,7 @@ ref:
   as: openshift-pipelines-install
   from: openshift-pipelines-runner
   commands: openshift-pipelines-install-commands.sh
+  grace_period: 10m
   resources:
     requests:
       cpu: '1'
@@ -15,6 +16,6 @@ ref:
       default: "false"
       documentation: Specify whether to update the test suite name for reporting tools
     - name: REPORTPORTAL_CMP
-      default: "OpenshiftPipelines-lp-interop"
+      default: "lp-ocp-compat--OpenshiftPipelines"
   documentation: |-
     This step install openshift-pipelines operator.

--- a/ci-operator/step-registry/openshift-pipelines/install/openshift-pipelines-install-ref.yaml
+++ b/ci-operator/step-registry/openshift-pipelines/install/openshift-pipelines-install-ref.yaml
@@ -15,7 +15,7 @@ ref:
     - name: MAP_TESTS
       default: "false"
       documentation: Specify whether to update the test suite name for reporting tools
-    - name: REPORTPORTAL_CMP
+    - name: DR__RP__CR_COMP_NAME
       default: "lp-ocp-compat--OpenshiftPipelines"
   documentation: |-
     This step install openshift-pipelines operator.

--- a/ci-operator/step-registry/openshift-pipelines/tests/openshift-pipelines-tests-commands.sh
+++ b/ci-operator/step-registry/openshift-pipelines/tests/openshift-pipelines-tests-commands.sh
@@ -12,7 +12,7 @@ if [ "${MAP_TESTS}" = "true" ]; then
         curl -fsSL \
 https://raw.githubusercontent.com/RedHatQE/OpenShift-LP-QE--Tools/refs/heads/main/libs/bash/ci-operator/interop/common/ExitTrap--PostProcessPrep.sh
     )"; trap '
-        LP_IO__ET_PPP__NEW_TS_NAME="${REPORTPORTAL_CMP}--%s" \
+        LP_IO__ET_PPP__NEW_TS_NAME="${DR__RP__CR_COMP_NAME}--%s" \
             ExitTrap--PostProcessPrep junit--openshift-pipelines__tests__openshift-pipelines-tests.xml
     ' EXIT
 fi

--- a/ci-operator/step-registry/openshift-pipelines/tests/openshift-pipelines-tests-commands.sh
+++ b/ci-operator/step-registry/openshift-pipelines/tests/openshift-pipelines-tests-commands.sh
@@ -1,99 +1,46 @@
 #!/bin/bash
+set -euxo pipefail; shopt -s inherit_errexit
 
-set -o nounset
-set -o errexit
-set -o pipefail
+typeset -a specs=()
+typeset spec=''
 
-function install_yq_if_not_exists() {
-    # Install yq manually if not found in image
-    echo "Checking if yq exists"
-    cmd_yq="$(yq --version 2>/dev/null || true)"
-    if [ -n "$cmd_yq" ]; then
-        echo "yq version: $cmd_yq"
-    else
-        echo "Installing yq"
-        mkdir -p /tmp/bin
-        export PATH=$PATH:/tmp/bin/
-        curl -L "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_$(uname -m | sed 's/aarch64/arm64/;s/x86_64/amd64/')" \
-         -o /tmp/bin/yq && chmod +x /tmp/bin/yq
-    fi
-}
-
-function mapTestsForComponentReadiness() {
-    if [[ $MAP_TESTS == "true" ]]; then
-        results_file="${1}"
-        echo "Patching Tests Result File: ${results_file}"
-        if [ -f "${results_file}" ]; then
-            export cmp="${REPORTPORTAL_CMP}--"
-            
-            echo "Mapping Test Suite Name To: ${REPORTPORTAL_CMP}"
-            yq eval -px -ox -iI0 '.testsuites.testsuite.+@name |= sub("^(.*)$", env(cmp) + "${1}")' $results_file 2>/dev/null || yq eval -px -ox -iI0 '.testsuites.testsuite[].+@name |= sub("^(.*)$", env(cmp) + "${1}")' $results_file
-        fi
-    fi
-}
-
-# Archive results function
-function cleanup-collect() {
-    if [[ $MAP_TESTS == "true" ]]; then
-      install_yq_if_not_exists
-      original_results="${ARTIFACT_DIR}/original_results/"
-      mkdir "${original_results}" || true
-      echo "Collecting original results in ${original_results}"
-
-      find "${ARTIFACT_DIR}" -type f -iname "*.xml" | while IFS= read -r result_file; do
-        # Keep a copy of all the original Junit files before modifying them
-        cp "${result_file}" "${original_results}/" || echo "Warning: couldn't copy original file ${result_file}" >&2
-
-        # Map tests if needed for related use cases
-        mapTestsForComponentReadiness "${result_file}"
-
-        # Send junit file to shared dir for Data Router Reporter step
-        # Skip DR reporting for corrupted file #TODO remove
-        if [[ "${results_file}" != *"3.xml" ]]; then
-          cp "${result_file}" "${SHARED_DIR}/" || echo "Warning: couldn't copy ${result_file} to SHARED_DIR" >&2
-        fi
-      done
-    fi
-}
-
-CONSOLE_URL=$(cat $SHARED_DIR/console.url)
-API_URL="https://api.${CONSOLE_URL#"https://console-openshift-console.apps."}:6443"
-export CONSOLE_URL
-export API_URL
-export gauge_reports_dir=${ARTIFACT_DIR}
-export overwrite_reports=false
-export KUBECONFIG=$SHARED_DIR/kubeconfig
-export GOPROXY="https://proxy.golang.org/"
+# Map results by setting identifier prefix in tests suites names for reporting tools
+# Merge original results into a single file and compress
+# Send modified file to shared dir for Data Router Reporter step
+if [ "${MAP_TESTS}" = "true" ]; then
+    eval "$(
+        curl -fsSL \
+https://raw.githubusercontent.com/RedHatQE/OpenShift-LP-QE--Tools/refs/heads/main/libs/bash/ci-operator/interop/common/ExitTrap--PostProcessPrep.sh
+    )"; trap '
+        LP_IO__ET_PPP__NEW_TS_NAME="${REPORTPORTAL_CMP}--%s" \
+            ExitTrap--PostProcessPrep junit--openshift-pipelines__tests__openshift-pipelines-tests.xml
+    ' EXIT
+fi
 
 # Add timeout to ignore runner connection error
 gauge config runner_connection_timeout 600000 && gauge config runner_request_timeout 300000
 
 # login for interop
-if test -f ${SHARED_DIR}/kubeadmin-password
-then
-  OCP_CRED_USR="kubeadmin"
-  export OCP_CRED_USR
-  OCP_CRED_PSW="$(cat ${SHARED_DIR}/kubeadmin-password)"
-  export OCP_CRED_PSW
-  oc login -u kubeadmin -p "$(cat $SHARED_DIR/kubeadmin-password)" "${API_URL}" --insecure-skip-tls-verify=true
+if [ -s "${KUBECONFIG}" ]; then
+    oc whoami
 else #login for ROSA & Hypershift platforms
-  eval "$(cat "${SHARED_DIR}/api.login")"
+    (set +x; eval "$(cat "${SHARED_DIR}/api.login")")
 fi
 
 gauge uninstall xml-report
 gauge install xml-report --version 0.5.3
-echo "Running gauge specs"
-IFS=';' read -r -a specs <<< "$PIPELINES_TEST_SPECS"
+# Run gauge specs from PIPELINES_TEST_SPECS (semicolon-separated)
+IFS=';' read -r -a specs <<< "${PIPELINES_TEST_SPECS:-}"
 for spec in "${specs[@]}"; do
-  gauge run --log-level=debug --verbose --tags 'sanity & !tls' --max-retries-count=3 --retry-only 'sanity & !tls' ${spec} || true
+  [[ -n "${spec}" ]] || continue
+  gauge run --log-level=debug --verbose --tags 'sanity & !tls' --max-retries-count=3 --retry-only 'sanity & !tls' "${spec}"
 done
 
-gauge run --log-level=debug --verbose --tags sanity specs/operator/rbac.spec || true
+CONSOLE_URL="$(oc whoami --show-console)" \
+    API_URL="$(oc whoami --show-server)" \
+    GOPROXY="https://proxy.golang.org/" \
+    gauge_reports_dir="${ARTIFACT_DIR}" \
+    overwrite_reports=false \
+    gauge run --log-level=debug --verbose --tags sanity specs/operator/rbac.spec
 
-echo "Rename xml files to junit_test_*.xml"
-readarray -t path <<< "$(find ${ARTIFACT_DIR}/xml-report/ -name '*.xml')"
-for index in "${!path[@]}"; do
-  mv "${path[index]}" ${ARTIFACT_DIR}/junit_test_result$[index+1].xml
-done
-
-cleanup-collect
+true

--- a/ci-operator/step-registry/openshift-pipelines/tests/openshift-pipelines-tests-ref.yaml
+++ b/ci-operator/step-registry/openshift-pipelines/tests/openshift-pipelines-tests-ref.yaml
@@ -2,6 +2,7 @@ ref:
   as: openshift-pipelines-tests
   from: openshift-pipelines-runner
   commands: openshift-pipelines-tests-commands.sh
+  grace_period: 10m
   resources:
     requests:
       cpu: '1'
@@ -14,6 +15,6 @@ ref:
     default: "false"
     documentation: Specify whether to update the test suite name for reporting tools
   - name: REPORTPORTAL_CMP
-    default: "OpenshiftPipelines-lp-interop"
+    default: "lp-ocp-compat--OpenshiftPipelines"
   documentation: |-
     Runs OpenShift Pipelines interop tests

--- a/ci-operator/step-registry/openshift-pipelines/tests/openshift-pipelines-tests-ref.yaml
+++ b/ci-operator/step-registry/openshift-pipelines/tests/openshift-pipelines-tests-ref.yaml
@@ -14,7 +14,7 @@ ref:
   - name: MAP_TESTS
     default: "false"
     documentation: Specify whether to update the test suite name for reporting tools
-  - name: REPORTPORTAL_CMP
+  - name: DR__RP__CR_COMP_NAME
     default: "lp-ocp-compat--OpenshiftPipelines"
   documentation: |-
     Runs OpenShift Pipelines interop tests


### PR DESCRIPTION
Main changes:

- Instead of handling the installation of yq, TS mapping and original XML archive, use CleanupCollect as a trap function and import the [RedHatQE/OpenShift-LP-QE--Tools](https://github.com/RedHatQE/OpenShift-LP-QE--Tools) `ExitTrap--PostProcessPrep` mechanism
- Update file structure to use best practice principles
- Update CR and DR identifiers to `lp-ocp-compat--OpenshiftPipelines`. Following #78819, update env var to be `DR__RP__CR_COMP_NAME`.

Verified run: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/78416/rehearse-78416-periodic-ci-openshift-pipelines-release-tests-release-v1.21-ocp-4.22-lp-interop-cr-openshift-pipelines-aws/2052313354864693248

- [x] Mapped the XML with the desired prefix used in TS name
- [x] Original results are compressed
- [x] Successfully reporting results to DR

`
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Centralized test-result post-processing into an exit-triggered cleanup flow, standardizing artifact handling and strengthening script error controls while temporarily suppressing command tracing during credential/login steps.
  * Hardened runtime handling (safer quoting and options) and defaulted the operator install channel to "latest" for more robust installs.
  * Added a 10m grace period to the install and test step references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->