### PR TITLE
Add payload agent to 4.20 and 4.21 release controllers 

### DIFF
--- a/ci-operator/step-registry/openshift/claude/payload/agent/openshift-claude-payload-agent-commands.sh
+++ b/ci-operator/step-registry/openshift/claude/payload/agent/openshift-claude-payload-agent-commands.sh
@@ -16,9 +16,12 @@ else
     echo "Warning: GitHub token not found at ${GITHUB_TOKEN_PATH}. Revert operations will not be available."
 fi
 
-if [ -f "${SLACK_WEBHOOK_URL}" ]; then
+if [[ "${ENABLE_SLACK_NOTIFICATIONS}" == "true" ]] && [ -f "${SLACK_WEBHOOK_URL}" ]; then
     SLACK_WEBHOOK=$(cat "${SLACK_WEBHOOK_URL}")
     echo "Slack webhook loaded."
+elif [[ "${ENABLE_SLACK_NOTIFICATIONS}" != "true" ]]; then
+    SLACK_WEBHOOK=""
+    echo "Slack notifications disabled via ENABLE_SLACK_NOTIFICATIONS."
 else
     SLACK_WEBHOOK=""
     echo "Warning: Slack webhook not found at ${SLACK_WEBHOOK_URL}. Notifications will be skipped."

--- a/ci-operator/step-registry/openshift/claude/payload/agent/openshift-claude-payload-agent-ref.yaml
+++ b/ci-operator/step-registry/openshift/claude/payload/agent/openshift-claude-payload-agent-ref.yaml
@@ -42,6 +42,8 @@ ref:
     default: "https://redhat.atlassian.net"
   - name: ENABLE_PAYLOAD_REVERT
     default: "false"
+  - name: ENABLE_SLACK_NOTIFICATIONS
+    default: "true"
   resources:
     requests:
       cpu: 1000m

--- a/core-services/release-controller/_releases/priv/release-ocp-4.20.json
+++ b/core-services/release-controller/_releases/priv/release-ocp-4.20.json
@@ -177,6 +177,15 @@
             },
             "upgrade": true
         },
+        "claude-payload-agent": {
+            "async": true,
+            "disabled": true,
+            "multiJobAnalysis": true,
+            "optional": true,
+            "prowJob": {
+                "name": "periodic-ci-openshift-release-main-claude-payload-agent-no-slack-priv"
+            }
+        },
         "cnv": {
             "disabled": true,
             "optional": true,

--- a/core-services/release-controller/_releases/priv/release-ocp-4.21.json
+++ b/core-services/release-controller/_releases/priv/release-ocp-4.21.json
@@ -185,6 +185,15 @@
             },
             "upgrade": true
         },
+        "claude-payload-agent": {
+            "async": true,
+            "disabled": true,
+            "multiJobAnalysis": true,
+            "optional": true,
+            "prowJob": {
+                "name": "periodic-ci-openshift-release-main-claude-payload-agent-no-slack-priv"
+            }
+        },
         "cnv": {
             "disabled": true,
             "optional": true,

--- a/core-services/release-controller/_releases/release-ocp-4.20-ci.json
+++ b/core-services/release-controller/_releases/release-ocp-4.20-ci.json
@@ -18,6 +18,14 @@
     }
   },
   "verify": {
+    "claude-payload-agent": {
+      "async": true,
+      "optional": true,
+      "multiJobAnalysis": true,
+      "prowJob": {
+        "name": "periodic-ci-openshift-release-main-claude-payload-agent-no-slack"
+      }
+    },
     "aws-ovn-upgrade-4.20-minor": {
       "maxRetries": 1,
       "prowJob": {

--- a/core-services/release-controller/_releases/release-ocp-4.20.json
+++ b/core-services/release-controller/_releases/release-ocp-4.20.json
@@ -34,6 +34,14 @@
     }
   },
   "verify": {
+    "claude-payload-agent": {
+      "async": true,
+      "optional": true,
+      "multiJobAnalysis": true,
+      "prowJob": {
+        "name": "periodic-ci-openshift-release-main-claude-payload-agent-no-slack"
+      }
+    },
     "aws-ovn-upgrade-4.20-micro-fips": {
       "maxRetries": 1,
       "prowJob": {

--- a/core-services/release-controller/_releases/release-ocp-4.21-ci.json
+++ b/core-services/release-controller/_releases/release-ocp-4.21-ci.json
@@ -18,6 +18,14 @@
     }
   },
   "verify": {
+    "claude-payload-agent": {
+      "async": true,
+      "optional": true,
+      "multiJobAnalysis": true,
+      "prowJob": {
+        "name": "periodic-ci-openshift-release-main-claude-payload-agent-no-slack"
+      }
+    },
     "aws-ovn-upgrade-4.21-minor": {
       "maxRetries": 1,
       "prowJob": {

--- a/core-services/release-controller/_releases/release-ocp-4.21.json
+++ b/core-services/release-controller/_releases/release-ocp-4.21.json
@@ -34,6 +34,14 @@
     }
   },
   "verify": {
+    "claude-payload-agent": {
+      "async": true,
+      "optional": true,
+      "multiJobAnalysis": true,
+      "prowJob": {
+        "name": "periodic-ci-openshift-release-main-claude-payload-agent-no-slack"
+      }
+    },
     "aws-ovn-upgrade-4.21-micro-fips": {
       "maxRetries": 1,
       "prowJob": {


### PR DESCRIPTION
I want to shift all slack notifications out of the payload job, as we'll have more control and capability to ship-help.  For now, just disable it on ga-releases but turn on payload agent for patch managers.

Add ENABLE_SLACK_NOTIFICATIONS env var to the payload agent step ref and a no-slack prowjob variant that sets it to "false". Wire the no-slack variant into the 4.20 and 4.21 nightly and CI release controller configs as an async, optional verification step.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add runtime toggle (ENABLE_SLACK_NOTIFICATIONS, default "true") to enable/disable Slack notifications.
  * Add a new optional, asynchronous verification job for the claude-payload-agent across OpenShift 4.20 and 4.21 releases (integrated with existing periodic Prow jobs, participates in multi-job analysis).

* **Bug Fixes**
  * When notifications are disabled, webhook loading is suppressed and a disabled-notification message is shown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->