### PR TITLE
periodic-prow-auto-sippy-config-generator should alert in #trt-alert only

### DIFF
--- a/ci-operator/jobs/infra-periodics.yaml
+++ b/ci-operator/jobs/infra-periodics.yaml
@@ -2818,6 +2818,13 @@ periodics:
   labels:
     ci.openshift.io/role: infra
   name: periodic-prow-auto-sippy-config-generator
+  reporter_config:
+    slack:
+      channel: '#trt-alert'
+      job_states_to_report:
+      - failure
+      report_template: Job {{.Spec.Job}} failed. See https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-prow-auto-sippy-config-generator/{{.Status.BuildID}}
+        for details.
   spec:
     containers:
     - args:

--- a/clusters/app.ci/openshift-user-workload-monitoring/mixins/_prometheus/dptp_alerts.libsonnet
+++ b/clusters/app.ci/openshift-user-workload-monitoring/mixins/_prometheus/dptp_alerts.libsonnet
@@ -27,7 +27,7 @@
             expr: |||
               sum by (job_name) (
                 rate(
-                  prowjob_state_transitions{job="prow-controller-manager",job_name!~"rehearse.*",state="failure"}[5m]
+                  prowjob_state_transitions{job="prow-controller-manager",job_name!~"rehearse.*|periodic-prow-auto-sippy-config-generator",state="failure"}[5m]
                 )
               )
               * on (job_name) group_left max by (job_name) (prow_job_labels{job_agent="kubernetes",label_ci_openshift_io_role="infra"}) > 0

--- a/clusters/app.ci/openshift-user-workload-monitoring/mixins/prometheus_out/ci-alerts_prometheusrule.yaml
+++ b/clusters/app.ci/openshift-user-workload-monitoring/mixins/prometheus_out/ci-alerts_prometheusrule.yaml
@@ -163,7 +163,7 @@ spec:
       expr: |
         sum by (job_name) (
           rate(
-            prowjob_state_transitions{job="prow-controller-manager",job_name!~"rehearse.*",state="failure"}[5m]
+            prowjob_state_transitions{job="prow-controller-manager",job_name!~"rehearse.*|periodic-prow-auto-sippy-config-generator",state="failure"}[5m]
           )
         )
         * on (job_name) group_left max by (job_name) (prow_job_labels{job_agent="kubernetes",label_ci_openshift_io_role="infra"}) > 0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure monitoring alerts to exclude additional internal jobs from failure-rate calculations, improving alert accuracy and reducing false positives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->