### PR TITLE
Skip InPlacePodVerticalScaling Beta test in HCP conformance

### DIFF
--- a/ci-operator/step-registry/rosa/aws/hcp/conformance/rosa-aws-hcp-conformance-workflow.yaml
+++ b/ci-operator/step-registry/rosa/aws/hcp/conformance/rosa-aws-hcp-conformance-workflow.yaml
@@ -28,6 +28,7 @@ workflow:
         NetworkPolicy between server and client should allow ingress access from updated pod\|
         In-tree Volumes.*local.*blockfs.*subPath should support file as subpath\|
         DRA.*kubelet.*DynamicResourceAllocation\|
+        InPlacePodVerticalScaling.*decrease memory limit below usage\|
         CSI Mock volume expansion Expansion with recovery recovery should not be possible\|
         cloud-provider-aws-e2e.*loadbalancer NLB internal should be reachable with hairpinning traffic\|
         cloud-provider-aws-e2e.*loadbalancer NLB should be reachable with target-node-labels

--- a/ci-operator/step-registry/rosa/aws/sts/conformance/rosa-aws-sts-conformance-workflow.yaml
+++ b/ci-operator/step-registry/rosa/aws/sts/conformance/rosa-aws-sts-conformance-workflow.yaml
@@ -20,7 +20,10 @@ workflow:
         NetworkPolicy between server and client should allow ingress access from updated pod\|
         CPU Partitioning cluster infrastructure should be configured correctly\|
         Managed cluster should set requests but not limits\|
-        Managed cluster should ensure platform components have system-\* priority class associated
+        Managed cluster should ensure platform components have system-\* priority class associated\|
+        cloud-provider-aws-e2e.*loadbalancer NLB internal should be reachable with hairpinning traffic\|
+        sig-network-edge.*GatewayAPIController\|
+        sig-olmv1.*NewOLM.*Catalog should serve FBC
     pre:
       - chain: rosa-aws-sts-provision
       - ref: osd-ccs-conf-idp-htpasswd-multi-users


### PR DESCRIPTION
## Summary

- Skip `InPlacePodVerticalScaling.*decrease memory limit below usage` in ROSA HCP conformance workflow
- Known upstream regression: kubernetes/kubernetes#135214 (runc 1.3.x incompatibility)
- Failing consistently on 4.21 nightlies

## Test plan

- [ ] Verify HCP conformance 4.21 nightly passes with this skip

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated conformance test configuration to skip InPlacePodVerticalScaling cases where memory limits are reduced below current usage.
  * Updated conformance test configuration to add skips for NLB hairpinning reachability, GatewayAPIController in edge networking, and a specific OLMv1 catalog-serving scenario; adjusted skip-list formatting to include the new entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->