### PR TITLE
WIP: INTEROP-8979: Wire Slack webhook into firewatch-report-issues step

### DIFF
--- a/ci-operator/config/RedHatQE/firewatch/RedHatQE-firewatch-main__slack-webhook-test.yaml
+++ b/ci-operator/config/RedHatQE/firewatch/RedHatQE-firewatch-main__slack-webhook-test.yaml
@@ -1,0 +1,63 @@
+base_images:
+  cli:
+    name: "4.21"
+    namespace: ocp
+    tag: cli
+  firewatch-base:
+    name: firewatch
+    namespace: firewatch
+    tag: main
+images:
+  items:
+  - dockerfile_literal: |
+      FROM firewatch-base
+      RUN pip install --no-cache-dir \
+          "firewatch @ git+https://github.com/RedHatQE/firewatch.git@slack-webhook-notifications" \
+          && echo "SUCCESS: firewatch PR branch (slack-webhook-notifications) injected at image build time"
+    from: firewatch-base
+    to: main
+releases:
+  latest:
+    candidate:
+      product: ocp
+      stream: nightly
+      version: "4.21"
+resources:
+  '*':
+    requests:
+      cpu: 200m
+      memory: 400Mi
+tests:
+- as: slack-webhook-test
+  cron: 0 23 31 2 *
+  steps:
+    cluster_profile: aws-cspi-qe
+    env:
+      BASE_DOMAIN: cspilp.interop.ccitredhat.com
+      FIREWATCH_CONFIG: |
+        {
+          "failure_rules": [
+            {"step": "*", "failure_type": "all", "classification": "Test", "jira_project": "INTEROP", "slack_user": "mpruitt@redhat.com"}
+          ]
+        }
+      FIREWATCH_DEFAULT_JIRA_ASSIGNEE: mpruitt@redhat.com
+      FIREWATCH_DEFAULT_JIRA_PROJECT: INTEROP
+    post:
+    - ref: firewatch-report-issues
+    pre:
+    - ref: ipi-conf
+    - ref: ipi-conf-aws
+    - chain: ipi-install
+    test:
+    - as: fail-to-trigger-webhook
+      commands: exit 1
+      from: cli
+      resources:
+        requests:
+          cpu: 100m
+          memory: 100Mi
+zz_generated_metadata:
+  branch: main
+  org: RedHatQE
+  repo: firewatch
+  variant: slack-webhook-test

--- a/ci-operator/config/RedHatQE/firewatch/RedHatQE-firewatch-main__slack-webhook-test.yaml
+++ b/ci-operator/config/RedHatQE/firewatch/RedHatQE-firewatch-main__slack-webhook-test.yaml
@@ -19,6 +19,7 @@ images:
       RUN pip install --no-cache-dir \
           "firewatch @ git+https://github.com/RedHatQE/firewatch.git@slack-webhook-notifications" \
           && echo "SUCCESS: firewatch PR branch (slack-webhook-notifications) injected at image build time"
+    from: firewatch-base
     to: main
 releases:
   latest:

--- a/ci-operator/config/RedHatQE/firewatch/RedHatQE-firewatch-main__slack-webhook-test.yaml
+++ b/ci-operator/config/RedHatQE/firewatch/RedHatQE-firewatch-main__slack-webhook-test.yaml
@@ -62,6 +62,46 @@ tests:
       - namespace: test-credentials
         name: firewatch-slack-notify-webhook-url
         mount_path: /tmp/secrets/slack
+      env:
+      - name: FIREWATCH_JIRA_SERVER
+        default: https://redhat.atlassian.net
+      - name: FIREWATCH_JIRA_API_TOKEN_PATH
+        default: /tmp/secrets/jira/access_token
+      - name: FIREWATCH_JIRA_EMAIL_PATH
+        default: /tmp/secrets/jira/email
+      - name: FIREWATCH_FAIL_WITH_TEST_FAILURES
+        default: "false"
+      - name: FIREWATCH_FAIL_WITH_POD_FAILURES
+        default: "false"
+      - name: FIREWATCH_CONFIG
+        default: ""
+      - name: FIREWATCH_PRIVATE_DECK
+        default: "false"
+      - name: FIREWATCH_DEFAULT_JIRA_PROJECT
+      - name: FIREWATCH_DEFAULT_JIRA_EPIC
+        default: ""
+      - name: FIREWATCH_DEFAULT_JIRA_COMPONENT
+        default: ""
+      - name: FIREWATCH_DEFAULT_JIRA_AFFECTS_VERSION
+        default: ""
+      - name: FIREWATCH_DEFAULT_JIRA_ADDITIONAL_LABELS
+        default: ""
+      - name: FIREWATCH_JIRA_ADDITIONAL_LABELS_FILE
+        default: firewatch-additional-labels
+      - name: FIREWATCH_DEFAULT_JIRA_ASSIGNEE
+        default: ""
+      - name: FIREWATCH_DEFAULT_JIRA_PRIORITY
+        default: ""
+      - name: FIREWATCH_DEFAULT_JIRA_SECURITY_LEVEL
+        default: ""
+      - name: FIREWATCH_VERBOSE_TEST_FAILURE_REPORTING
+        default: "false"
+      - name: FIREWATCH_VERBOSE_TEST_FAILURE_REPORTING_LIMIT
+        default: "10"
+      - name: FIREWATCH_CONFIG_FILE_PATH
+        default: ""
+      - name: SLACK_WEBHOOK_URL
+        default: ""
       resources:
         requests:
           cpu: 10m

--- a/ci-operator/config/RedHatQE/firewatch/RedHatQE-firewatch-main__slack-webhook-test.yaml
+++ b/ci-operator/config/RedHatQE/firewatch/RedHatQE-firewatch-main__slack-webhook-test.yaml
@@ -7,6 +7,11 @@ base_images:
     name: firewatch
     namespace: firewatch
     tag: main
+build_root:
+  image_stream_tag:
+    name: release
+    namespace: openshift
+    tag: rhel-9-release-golang-1.19-openshift-4.15
 images:
   items:
   - dockerfile_literal: |
@@ -14,7 +19,6 @@ images:
       RUN pip install --no-cache-dir \
           "firewatch @ git+https://github.com/RedHatQE/firewatch.git@slack-webhook-notifications" \
           && echo "SUCCESS: firewatch PR branch (slack-webhook-notifications) injected at image build time"
-    from: firewatch-base
     to: main
 releases:
   latest:

--- a/ci-operator/config/RedHatQE/firewatch/RedHatQE-firewatch-main__slack-webhook-test.yaml
+++ b/ci-operator/config/RedHatQE/firewatch/RedHatQE-firewatch-main__slack-webhook-test.yaml
@@ -17,8 +17,8 @@ images:
   - dockerfile_literal: |
       FROM firewatch-base
       RUN pip install --no-cache-dir \
-          "firewatch @ git+https://github.com/RedHatQE/firewatch.git@slack-webhook-notifications" \
-          && echo "SUCCESS: firewatch PR branch (slack-webhook-notifications) injected at image build time"
+          "firewatch @ git+https://github.com/amp-rh/firewatch.git@interop-8976/token-rotation-alerts" \
+          && echo "SUCCESS: firewatch PR branch injected at image build time"
     from: firewatch-base
     to: main
 releases:

--- a/ci-operator/config/RedHatQE/firewatch/RedHatQE-firewatch-main__slack-webhook-test.yaml
+++ b/ci-operator/config/RedHatQE/firewatch/RedHatQE-firewatch-main__slack-webhook-test.yaml
@@ -19,7 +19,7 @@ images:
       RUN pip install --no-cache-dir \
           "firewatch @ git+https://github.com/amp-rh/firewatch.git@interop-8976/token-rotation-alerts" \
           && firewatch --help > /dev/null \
-          && echo "CACHE_BUST=2026-05-01a"
+          && echo "CACHE_BUST=2026-05-01b"
     from: firewatch-base
     to: main
 releases:
@@ -49,7 +49,23 @@ tests:
       FIREWATCH_DEFAULT_JIRA_ASSIGNEE: mpruitt@redhat.com
       FIREWATCH_DEFAULT_JIRA_PROJECT: INTEROP
     post:
-    - ref: firewatch-report-issues
+    - as: firewatch-report-issues
+      from: main
+      commands: firewatch-report-issues-commands.sh
+      credentials:
+      - namespace: test-credentials
+        name: firewatch-tool-jira-credentials
+        mount_path: /tmp/secrets/jira
+      - namespace: test-credentials
+        name: firewatch-tool-private-deck-credentials
+        mount_path: /tmp/secrets/private-deck
+      - namespace: test-credentials
+        name: firewatch-slack-notify-webhook-url
+        mount_path: /tmp/secrets/slack
+      resources:
+        requests:
+          cpu: 10m
+          memory: 100Mi
     pre:
     - ref: ipi-conf
     - ref: ipi-conf-aws

--- a/ci-operator/config/RedHatQE/firewatch/RedHatQE-firewatch-main__slack-webhook-test.yaml
+++ b/ci-operator/config/RedHatQE/firewatch/RedHatQE-firewatch-main__slack-webhook-test.yaml
@@ -18,7 +18,8 @@ images:
       FROM firewatch-base
       RUN pip install --no-cache-dir \
           "firewatch @ git+https://github.com/amp-rh/firewatch.git@interop-8976/token-rotation-alerts" \
-          && echo "SUCCESS: firewatch PR branch injected at image build time"
+          && firewatch --help > /dev/null \
+          && echo "CACHE_BUST=2026-05-01a"
     from: firewatch-base
     to: main
 releases:

--- a/ci-operator/config/RedHatQE/firewatch/RedHatQE-firewatch-main__slack-webhook-test.yaml
+++ b/ci-operator/config/RedHatQE/firewatch/RedHatQE-firewatch-main__slack-webhook-test.yaml
@@ -49,7 +49,7 @@ tests:
       FIREWATCH_DEFAULT_JIRA_ASSIGNEE: mpruitt@redhat.com
       FIREWATCH_DEFAULT_JIRA_PROJECT: INTEROP
     post:
-    - as: firewatch-report-issues
+    - as: firewatch-report-issues-fork
       from: main
       commands: |
         #!/bin/bash

--- a/ci-operator/config/RedHatQE/firewatch/RedHatQE-firewatch-main__slack-webhook-test.yaml
+++ b/ci-operator/config/RedHatQE/firewatch/RedHatQE-firewatch-main__slack-webhook-test.yaml
@@ -51,7 +51,67 @@ tests:
     post:
     - as: firewatch-report-issues
       from: main
-      commands: firewatch-report-issues-commands.sh
+      commands: |
+        #!/bin/bash
+        set -o nounset
+        set -o errexit
+        set -o pipefail
+
+        echo "=== Firewatch Debug Info ==="
+        firewatch --version 2>&1 || echo "WARNING: firewatch --version not supported"
+        pip show firewatch 2>/dev/null | grep -E '^(Name|Version|Location)' || true
+        python3 -c "import firewatch; print('firewatch package path:', firewatch.__file__)" 2>/dev/null || true
+        echo "=== End Debug Info ==="
+
+        jira_config_cmd="firewatch jira-config-gen --token-path ${FIREWATCH_JIRA_API_TOKEN_PATH} --server-url ${FIREWATCH_JIRA_SERVER}"
+        if [ -f "${FIREWATCH_JIRA_EMAIL_PATH}" ]; then
+            jira_config_cmd+=" --email $(cat "${FIREWATCH_JIRA_EMAIL_PATH}")"
+        fi
+        eval "${jira_config_cmd}"
+
+        report_command="firewatch report"
+        if [ "${FIREWATCH_PRIVATE_DECK,,}" = "true" ]; then
+            report_command+=" --gcs-bucket qe-private-deck --gcs-creds-file /tmp/secrets/private-deck/creds.json"
+        fi
+        if [ "${FIREWATCH_FAIL_WITH_TEST_FAILURES,,}" = "true" ]; then
+            report_command+=" --fail-with-test-failures"
+        fi
+        if [ "${FIREWATCH_FAIL_WITH_POD_FAILURES,,}" = "true" ]; then
+            report_command+=" --fail-with-pod-failures"
+        fi
+        if [ "${FIREWATCH_VERBOSE_TEST_FAILURE_REPORTING,,}" = "true" ]; then
+            report_command+=" --verbose-test-failure-reporting"
+            report_command+=" --verbose-test-failure-reporting-ticket-limit ${FIREWATCH_VERBOSE_TEST_FAILURE_REPORTING_LIMIT}"
+        fi
+        if [ -n "${FIREWATCH_CONFIG_FILE_PATH}" ]; then
+            report_command+=" --firewatch-config-path=${FIREWATCH_CONFIG_FILE_PATH}"
+        fi
+        if [ -f "${SHARED_DIR}/${FIREWATCH_JIRA_ADDITIONAL_LABELS_FILE}" ]; then
+            report_command+=" --additional-labels-file=${SHARED_DIR}/${FIREWATCH_JIRA_ADDITIONAL_LABELS_FILE}"
+        fi
+
+        if [ -f /tmp/secrets/slack/slack_rule_notification_webhook_url ]; then
+            SLACK_WEBHOOK_URL=$(cat /tmp/secrets/slack/slack_rule_notification_webhook_url)
+            SLACK_WEBHOOK_URL="${SLACK_WEBHOOK_URL%"${SLACK_WEBHOOK_URL##*[![:space:]]}"}"
+            if [ -z "${SLACK_WEBHOOK_URL}" ]; then
+                echo "ERROR: slack_rule_notification_webhook_url secret is present but empty" >&2
+                exit 1
+            fi
+            export SLACK_WEBHOOK_URL
+            echo "=== Slack Webhook ==="
+            echo "SLACK_WEBHOOK_URL is set (${#SLACK_WEBHOOK_URL} chars, starts with: ${SLACK_WEBHOOK_URL:0:30}...)"
+            echo "=== End Slack Webhook ==="
+        else
+            echo "=== Slack Webhook ==="
+            echo "WARNING: /tmp/secrets/slack/slack_rule_notification_webhook_url not found"
+            ls -la /tmp/secrets/slack/ 2>/dev/null || echo "WARNING: /tmp/secrets/slack/ directory does not exist"
+            echo "=== End Slack Webhook ==="
+        fi
+
+        echo "=== Report Command ==="
+        echo $report_command
+        echo "=== End Report Command ==="
+        eval "$report_command"
       credentials:
       - namespace: test-credentials
         name: firewatch-tool-jira-credentials

--- a/ci-operator/config/RedHatQE/firewatch/RedHatQE-firewatch-main__slack-webhook-test.yaml
+++ b/ci-operator/config/RedHatQE/firewatch/RedHatQE-firewatch-main__slack-webhook-test.yaml
@@ -19,7 +19,8 @@ images:
       RUN pip install --no-cache-dir \
           "firewatch @ git+https://github.com/amp-rh/firewatch.git@interop-8976/token-rotation-alerts" \
           && firewatch --help > /dev/null \
-          && echo "CACHE_BUST=2026-05-01b"
+          && echo "PIPELINE_IMAGE_MARKER=2026-05-04" > /tmp/.pipeline-image-marker \
+          && python3 -c "from src.report.report import Report; print('IMPORT CHECK: Report has _notify_failure_webhooks:', hasattr(Report, '_notify_failure_webhooks'))"
     from: firewatch-base
     to: main
 releases:
@@ -59,8 +60,15 @@ tests:
 
         echo "=== Firewatch Debug Info ==="
         firewatch --version 2>&1 || echo "WARNING: firewatch --version not supported"
-        pip show firewatch 2>/dev/null | grep -E '^(Name|Version|Location)' || true
+        pip show firewatch 2>/dev/null | grep -E '^(Name|Version|Location|Requires)' || true
         python3 -c "import firewatch; print('firewatch package path:', firewatch.__file__)" 2>/dev/null || true
+        echo "=== Pipeline Image Check ==="
+        if [ -f /tmp/.pipeline-image-marker ]; then
+            echo "PIPELINE IMAGE CONFIRMED: $(cat /tmp/.pipeline-image-marker)"
+        else
+            echo "WARNING: NOT running pipeline image (marker file missing)"
+        fi
+        python3 -c "from src.report.report import Report; print('has _notify_failure_webhooks:', hasattr(Report, '_notify_failure_webhooks'))" 2>/dev/null || echo "WARNING: could not import Report"
         echo "=== End Debug Info ==="
 
         jira_config_cmd="firewatch jira-config-gen --token-path ${FIREWATCH_JIRA_API_TOKEN_PATH} --server-url ${FIREWATCH_JIRA_SERVER}"

--- a/ci-operator/jobs/RedHatQE/firewatch/RedHatQE-firewatch-main-periodics.yaml
+++ b/ci-operator/jobs/RedHatQE/firewatch/RedHatQE-firewatch-main-periodics.yaml
@@ -1,0 +1,84 @@
+periodics:
+- agent: kubernetes
+  cluster: build10
+  cron: 0 23 31 2 *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: RedHatQE
+    repo: firewatch
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-cspi-qe
+    ci-operator.openshift.io/variant: slack-webhook-test
+    ci.openshift.io/generator: prowgen
+    job-release: "4.21"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-RedHatQE-firewatch-main-slack-webhook-test-slack-webhook-test
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=slack-webhook-test
+      - --variant=slack-webhook-test
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator

--- a/ci-operator/jobs/RedHatQE/firewatch/RedHatQE-firewatch-main-presubmits.yaml
+++ b/ci-operator/jobs/RedHatQE/firewatch/RedHatQE-firewatch-main-presubmits.yaml
@@ -57,3 +57,61 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )image-images,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build11
+    context: ci/prow/slack-webhook-test-images
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/variant: slack-webhook-test
+      ci.openshift.io/generator: prowgen
+      job-release: "4.21"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-RedHatQE-firewatch-main-slack-webhook-test-images
+    rerun_command: /test slack-webhook-test-images
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=[images]
+        - --variant=slack-webhook-test
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )slack-webhook-test-images,?($|\s.*)

--- a/ci-operator/step-registry/cluster-profiles/cluster-profiles-config.yaml
+++ b/ci-operator/step-registry/cluster-profiles/cluster-profiles-config.yaml
@@ -1073,6 +1073,7 @@
         - web-terminal-operator
     - org: RedHatQE
       repos:
+        - firewatch
         - interop-testing
     - org: rh-messaging-qe
       repos:

--- a/ci-operator/step-registry/firewatch/report-issues/firewatch-report-issues-commands.sh
+++ b/ci-operator/step-registry/firewatch/report-issues/firewatch-report-issues-commands.sh
@@ -42,6 +42,16 @@ if [ -f "${SHARED_DIR}/${FIREWATCH_JIRA_ADDITIONAL_LABELS_FILE}" ]; then
     report_command+=" --additional-labels-file=${SHARED_DIR}/${FIREWATCH_JIRA_ADDITIONAL_LABELS_FILE}"
 fi
 
+if [ -f /tmp/secrets/slack/slack_rule_notification_webhook_url ]; then
+    SLACK_WEBHOOK_URL=$(cat /tmp/secrets/slack/slack_rule_notification_webhook_url)
+    SLACK_WEBHOOK_URL="${SLACK_WEBHOOK_URL%"${SLACK_WEBHOOK_URL##*[![:space:]]}"}"
+    if [ -z "${SLACK_WEBHOOK_URL}" ]; then
+        echo "ERROR: slack_rule_notification_webhook_url secret is present but empty" >&2
+        exit 1
+    fi
+    export SLACK_WEBHOOK_URL
+fi
+
 echo $report_command
 
 eval "$report_command"

--- a/ci-operator/step-registry/firewatch/report-issues/firewatch-report-issues-commands.sh
+++ b/ci-operator/step-registry/firewatch/report-issues/firewatch-report-issues-commands.sh
@@ -4,6 +4,12 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
+echo "=== Firewatch Debug Info ==="
+firewatch --version 2>&1 || echo "WARNING: firewatch --version not supported"
+pip show firewatch 2>/dev/null | grep -E '^(Name|Version|Location)' || true
+python3 -c "import firewatch; print('firewatch package path:', firewatch.__file__)" 2>/dev/null || true
+echo "=== End Debug Info ==="
+
 jira_config_cmd="firewatch jira-config-gen --token-path ${FIREWATCH_JIRA_API_TOKEN_PATH} --server-url ${FIREWATCH_JIRA_SERVER}"
 
 if [ -f "${FIREWATCH_JIRA_EMAIL_PATH}" ]; then
@@ -50,8 +56,18 @@ if [ -f /tmp/secrets/slack/slack_rule_notification_webhook_url ]; then
         exit 1
     fi
     export SLACK_WEBHOOK_URL
+    echo "=== Slack Webhook ==="
+    echo "SLACK_WEBHOOK_URL is set (${#SLACK_WEBHOOK_URL} chars, starts with: ${SLACK_WEBHOOK_URL:0:30}...)"
+    echo "=== End Slack Webhook ==="
+else
+    echo "=== Slack Webhook ==="
+    echo "WARNING: /tmp/secrets/slack/slack_rule_notification_webhook_url not found"
+    ls -la /tmp/secrets/slack/ 2>/dev/null || echo "WARNING: /tmp/secrets/slack/ directory does not exist"
+    echo "=== End Slack Webhook ==="
 fi
 
+echo "=== Report Command ==="
 echo $report_command
+echo "=== End Report Command ==="
 
 eval "$report_command"

--- a/ci-operator/step-registry/firewatch/report-issues/firewatch-report-issues-ref.yaml
+++ b/ci-operator/step-registry/firewatch/report-issues/firewatch-report-issues-ref.yaml
@@ -12,6 +12,9 @@ ref:
     - namespace: test-credentials
       name: firewatch-tool-private-deck-credentials
       mount_path: /tmp/secrets/private-deck
+    - namespace: test-credentials
+      name: firewatch-slack-notify-webhook-url
+      mount_path: /tmp/secrets/slack
   resources:
     requests:
       cpu: 10m
@@ -74,6 +77,9 @@ ref:
   - name: FIREWATCH_CONFIG_FILE_PATH
     default: ""
     documentation: The URL/file path of the Firewatch configuration (json file).
+  - name: SLACK_WEBHOOK_URL
+    default: ""
+    documentation: Slack incoming webhook URL. When set, firewatch posts notifications on issue creation and duplicate detection.
   
   documentation: |-
     Please see the CSPI-QE repository for more documentation on this tool: https://github.com/CSPI-QE/firewatch


### PR DESCRIPTION
## Summary

- Mount `firewatch-slack-notify-webhook-url` secret at `/tmp/secrets/slack` in the `firewatch-report-issues` step
- Read `/tmp/secrets/slack/slack_rule_notification_webhook_url` and export as `$SLACK_WEBHOOK_URL` before running firewatch report
- Add `SLACK_WEBHOOK_URL` env var declaration to the step ref
- Add minimal test config (`RedHatQE-firewatch-main__slack-webhook-test.yaml`) to verify end-to-end webhook delivery

## Dependencies

Requires firewatch PR: https://github.com/RedHatQE/firewatch/pull/274

## Prerequisites

- [ ] Create `firewatch-slack-notify-webhook-url` secret in `test-credentials` namespace with key `slack_rule_notification_webhook_url`

## Test plan

- [ ] Rehearse `slack-webhook-test` job from this PR
- [ ] Verify firewatch posts a Slack notification to the configured webhook
- [ ] Confirm no impact to existing firewatch-report-issues consumers (webhook is opt-in via secret)

Supersedes: https://github.com/openshift/release/pull/78342
Relates: https://issues.redhat.com/browse/INTEROP-8979

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Integrated Slack webhook notifications into the Firewatch issue reporting system, enabling automatic posting of test failures and duplicate detection alerts to Slack channels.
  * Extended CI infrastructure configuration to support Slack notification delivery for improved test result tracking and visibility.
  * Configured secure credential management for webhook authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->