### PR TITLE
Add cyborg-python base image to cyborg CI pipeline

### DIFF
--- a/ci-operator/config/openshift-eng/cyborg/openshift-eng-cyborg-master.yaml
+++ b/ci-operator/config/openshift-eng/cyborg/openshift-eng-cyborg-master.yaml
@@ -5,6 +5,11 @@ images:
   items:
   - dockerfile_path: org_tools/images/Dockerfile
     to: cyborg-cli
+  - dockerfile_literal: |
+      FROM registry.ci.openshift.org/ocp/ubi-python-312:9
+      COPY --chown=1001:0 ./org_tools/orglib ./orglib
+      RUN pip install --no-cache-dir "./orglib[full]" && rm -rf ./orglib
+    to: cyborg-python
 promotion:
   to:
   - namespace: continuous-release-jobs


### PR DESCRIPTION
## Summary

- Add a new `cyborg-python` image to the cyborg CI pipeline — `ubi-python-312` with `orglib[full]` pre-installed, promoted to `continuous-release-jobs/cyborg-python:latest`.

## Details

Ship-help-bot depends on `orglib` from `openshift-eng/cyborg` (private). ci-operator's image builds have no GitHub credentials, so `pip install` can't clone the private repo during the build.

This PR creates a purpose-built base image (`cyborg-python`) that bakes in orglib and its dependencies. Once promoted, a follow-up PR will configure ship-help-bot to use it as its Dockerfile base image.

The `cyborg-python` image is minimal: just the Python 3.12 UBI base with orglib. It gets rebuilt automatically whenever the cyborg repo is updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added a new container image definition to the build configuration for enhanced image management capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->