### PR TITLE
Add deprovisioner periodic for hypershift-ci-3

### DIFF
--- a/ci-operator/jobs/openshift/hypershift/openshift-hypershift-infra-periodics.yaml
+++ b/ci-operator/jobs/openshift/hypershift/openshift-hypershift-infra-periodics.yaml
@@ -59,3 +59,65 @@ periodics:
     - name: kubeconfig
       secret:
         secretName: hypershift-ci-2
+- agent: kubernetes
+  cluster: build11
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: release
+    workdir: true
+  interval: 15m
+  labels:
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  max_concurrency: 1
+  name: periodic-ipi-deprovision-aws-osd-hypershift-3
+  reporter_config:
+    slack:
+      channel: '#team-ocp-hypershift-alerts'
+      job_states_to_report:
+      - failure
+      - error
+      report_template: Job {{.Spec.Job}} failed. <{{.Status.URL}}|View logs>
+  spec:
+    containers:
+    - command:
+      - ./core-services/ipi-deprovision/aws.sh
+      env:
+      - name: HOME
+        value: /tmp
+      - name: AWS_SHARED_CREDENTIALS_FILE
+        value: /aws/credentials
+      - name: CLUSTER_TTL
+        value: 30 minutes ago
+      - name: HYPERSHIFT_BASE_DOMAIN
+        value: ci.hypershift.devcluster.openshift.com
+      - name: HYPERSHIFT_PRUNER
+        value: "true"
+      - name: HYPERSHIFT_PRUNER_ALL_NAMESPACES
+        value: "true"
+      - name: KUBECONFIG
+        value: /kubeconfig/hypershift-ops-admin.kubeconfig
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ipi-deprovision_latest
+      imagePullPolicy: Always
+      name: ipi-deprovision
+      resources:
+        requests:
+          cpu: "1"
+          memory: 300Mi
+      volumeMounts:
+      - mountPath: /aws
+        name: cluster-secrets-aws
+      - mountPath: /kubeconfig
+        name: kubeconfig
+    serviceAccountName: ipi-deprovisioner
+    volumes:
+    - name: cluster-secrets-aws
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: hypershift-pool-aws-credentials
+    - name: kubeconfig
+      secret:
+        secretName: hypershift-ci-3

--- a/core-services/ipi-deprovision/aws.sh
+++ b/core-services/ipi-deprovision/aws.sh
@@ -38,10 +38,19 @@ function deprovision() {
 
 if [[ -n ${HYPERSHIFT_PRUNER:-} ]]; then
 	had_failure=0
-	hostedclusters="$(oc get hostedcluster -n clusters -o json | jq -r --argjson timestamp 14400 '.items[] | select (.metadata.creationTimestamp | sub("\\..*";"Z") | sub("\\s";"T") | fromdate < now - $timestamp).metadata.name')"
-	for hostedcluster in $hostedclusters; do
-		hypershift destroy cluster aws --aws-creds "${AWS_SHARED_CREDENTIALS_FILE}" --namespace clusters --name "${hostedcluster}" || had_failure=$((had_failure+1))
-	done
+	if [[ -n ${HYPERSHIFT_PRUNER_ALL_NAMESPACES:-} ]]; then
+		hostedclusters="$(oc get hostedcluster -A -o json | jq -r --argjson timestamp 14400 '.items[] | select (.metadata.creationTimestamp | sub("\\..*";"Z") | sub("\\s";"T") | fromdate < now - $timestamp) | .metadata.namespace + "/" + .metadata.name')"
+		for entry in $hostedclusters; do
+			ns="${entry%%/*}"
+			name="${entry##*/}"
+			hypershift destroy cluster aws --aws-creds "${AWS_SHARED_CREDENTIALS_FILE}" --namespace "${ns}" --name "${name}" || had_failure=$((had_failure+1))
+		done
+	else
+		hostedclusters="$(oc get hostedcluster -n clusters -o json | jq -r --argjson timestamp 14400 '.items[] | select (.metadata.creationTimestamp | sub("\\..*";"Z") | sub("\\s";"T") | fromdate < now - $timestamp).metadata.name')"
+		for hostedcluster in $hostedclusters; do
+			hypershift destroy cluster aws --aws-creds "${AWS_SHARED_CREDENTIALS_FILE}" --namespace clusters --name "${hostedcluster}" || had_failure=$((had_failure+1))
+		done
+	fi
 	# Exit here if we had errors, otherwise we destroy the OIDC providers for the hostedclusters and deadlock deletion as cluster api creds stop working so it will never be able to remove machine finalizers
 	if [[ $had_failure -ne 0 ]]; then exit $had_failure; fi
 fi

--- a/core-services/ipi-deprovision/aws.sh
+++ b/core-services/ipi-deprovision/aws.sh
@@ -40,9 +40,9 @@ if [[ -n ${HYPERSHIFT_PRUNER:-} ]]; then
 	had_failure=0
 	if [[ -n ${HYPERSHIFT_PRUNER_ALL_NAMESPACES:-} ]]; then
 		hostedclusters="$(oc get hostedcluster -A -o json | jq -r --argjson timestamp 14400 '.items[] | select (.metadata.creationTimestamp | sub("\\..*";"Z") | sub("\\s";"T") | fromdate < now - $timestamp) | .metadata.namespace + "/" + .metadata.name')"
-		for entry in $hostedclusters; do
-			ns="${entry%%/*}"
-			name="${entry##*/}"
+		for hostedcluster in $hostedclusters; do
+			ns="${hostedcluster%%/*}"
+			name="${hostedcluster##*/}"
 			hypershift destroy cluster aws --aws-creds "${AWS_SHARED_CREDENTIALS_FILE}" --namespace "${ns}" --name "${name}" || had_failure=$((had_failure+1))
 		done
 	else


### PR DESCRIPTION
The existing `periodic-ipi-deprovision-aws-osd-hypershift` job only targets
`hypershift-ci-2`. Orphaned HostedClusters on `hypershift-ci-3` are never
cleaned up, contributing to resource exhaustion and CI test failures
(OCPBUGS-82112).

On `ci-3`, jobs run directly on the root management cluster (no nested
management cluster), so HostedClusters exist in both the `clusters` namespace
(conformance path) and `e2e-clusters-*` namespaces (e2e test path). The
existing pruner only looks at `-n clusters`.

### Changes

**`core-services/ipi-deprovision/aws.sh`** — add `HYPERSHIFT_PRUNER_ALL_NAMESPACES` support:
- When unset (default): existing behavior — `oc get hostedcluster -n clusters`, deletes with `--namespace clusters`. No change for the ci-2 job.
- When set: uses `oc get hostedcluster -A` to discover HCs across all namespaces, then passes the actual `--namespace` per HC to `hypershift destroy`.

**`openshift-hypershift-infra-periodics.yaml`** — add `periodic-ipi-deprovision-aws-osd-hypershift-3`:
- Targets `hypershift-ci-3` kubeconfig secret
- Sets `HYPERSHIFT_PRUNER_ALL_NAMESPACES=true`
- Same 15m interval, same AWS credentials, same base domain as the ci-2 job

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional cross-namespace hosted cluster cleanup: enable cluster-wide discovery and destruction of hosted clusters via a configuration flag.

* **Improvements**
  * Preserves existing namespace-scoped behavior by default and retains failure counting/early-exit behavior for reliable cleanup operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->