### PR TITLE
Use cyborg-python base image for ship-help-bot CI

### DIFF
--- a/ci-operator/config/openshift-eng/ship-help-bot/openshift-eng-ship-help-bot-main.yaml
+++ b/ci-operator/config/openshift-eng/ship-help-bot/openshift-eng-ship-help-bot-main.yaml
@@ -1,3 +1,8 @@
+base_images:
+  cyborg-python:
+    name: cyborg-python
+    namespace: continuous-release-jobs
+    tag: latest
 build_root:
   project_image:
     dockerfile_literal: |-
@@ -8,6 +13,10 @@ images:
   items:
   - dockerfile_path: Dockerfile
     from: src
+    inputs:
+      cyborg-python:
+        as:
+        - registry.access.redhat.com/ubi9/python-312
     to: ship-help-bot
 promotion:
   to:


### PR DESCRIPTION
## Summary

- Configure ship-help-bot CI to use `cyborg-python` as the Dockerfile base image via `inputs`, replacing `registry.access.redhat.com/ubi9/python-312`.

## Details

Ship-help-bot depends on `orglib` from `openshift-eng/cyborg` (private). ci-operator image builds have no GitHub credentials, so `pip install` can't clone the private repo during the build.

This PR swaps the base image to `cyborg-python` (from `continuous-release-jobs`), which has orglib pre-installed. The `cyborg-python` image is created in #78427.

**Depends on #78427** — the `cyborg-python` image must be promoted before this PR can merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ship-help-bot build configuration to use Python 3.12 as the base image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->