### PR TITLE
OCM-23800 | feat: cs-rosa-hcp-zero-egress-staging-main FVT migration

### DIFF
--- a/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__ocm-fvt-rosa-hcp-staging.yaml
+++ b/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__ocm-fvt-rosa-hcp-staging.yaml
@@ -364,6 +364,44 @@ tests:
   secrets:
   - mount_path: /usr/local/cs-qe-credentials
     name: cs-qe-credentials
+- as: ocm-fvt-periodic-cs-rosa-hcp-zero-egress-staging-main
+  capabilities:
+  - nested-podman
+  commands: |
+    JOB_LINK="https://prow.ci.openshift.org/view/gs/test-platform-results/"
+    if [ -n "${PULL_NUMBER:-}" ]; then
+      JOB_LINK="${JOB_LINK}pr-logs/pull/openshift_release/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
+    else
+      JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
+    fi
+    env -i bash --norc --noprofile <<'EOF' > /tmp/podman.env
+    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
+    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
+    export ENABLE_JIRA_REPORTING=true
+    source /usr/local/cs-qe-credentials/ocm-tokens
+    source /usr/local/cs-qe-credentials/jira-cred
+    env | grep -v '^_='
+    EOFExpand commentComment on lines R213 to R227Resolved
+
+    podman run \
+      --authfile /usr/local/cs-qe-credentials/.dockerconfigjson \
+      --env-file /tmp/podman.env \
+      -v /usr/local/cs-qe-credentials:/credentials:ro,z \
+      --rm \
+      quay.io/redhat-services-prod/ocmci/ocmci:latest \
+      ocmtest test \
+        --service cms \
+        --job cs-rosa-hcp-zero-egress-staging-main \
+        --reportJiraTicket
+  container:
+    from: nested-podman
+    memory_backed_volume:
+      size: 1Gi
+  cron: 0 8 * * *
+  nested_podman: true
+  secrets:
+  - mount_path: /usr/local/cs-qe-credentials
+    name: cs-qe-credentials
 zz_generated_metadata:
   branch: main
   org: openshift-online

--- a/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-periodics.yaml
@@ -1455,6 +1455,78 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-online-rosa-e2e-main-ocm-fvt-rosa-hcp-staging-ocm-fvt-periodic-cs-rosa-hcp-zero-egress-staging-main
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/cs-qe-credentials
+      - --target=ocm-fvt-periodic-cs-rosa-hcp-zero-egress-staging-main
+      - --variant=ocm-fvt-rosa-hcp-staging
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /secrets/cs-qe-credentials
+        name: cs-qe-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: cs-qe-credentials
+      secret:
+        secretName: cs-qe-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build06
+  cron: 0 8 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-online
+    repo: rosa-e2e
+  labels:
+    capability/nested-podman: nested-podman
+    ci-operator.openshift.io/variant: ocm-fvt-rosa-hcp-staging
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-online-rosa-e2e-main-ocm-fvt-rosa-hcp-staging-ocm-fvt-periodic-cs-rosa-hcp-zero-egress-upgrade-staging-main
   spec:
     containers:


### PR DESCRIPTION
This PR is for migrating cs-rosa-hcp-zero-egress-staging-main FVT to Prow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds a new periodic Functional Verification Test (FVT) job to the OpenShift Online ROSA E2E CI configuration in the openshift/release repository. It migrates the cs-rosa-hcp-zero-egress-staging FVT into Prow by adding the ocm-fvt-periodic-cs-rosa-hcp-zero-egress-staging-main test to ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__ocm-fvt-rosa-hcp-staging.yaml.

Practical impact
- A new Prow-managed periodic test will run against the openshift-online/rosa-e2e pipeline to validate ROSA HCP clusters with zero-egress networking in staging.
- The job is scheduled daily at 08:00 UTC (cron: 0 8 * * *).

What the job does / key configuration
- Runs inside a nested-podman container (container from: nested-podman) and uses nested_podman: true.
- Prepares an env file that sets AWS credential paths (AWS_SHARED_CREDENTIALS_FILE, AWS_SHARED_VPC_CREDENTIALS_FILE), enables Jira reporting, sets JOB_LINK, and sources ocm tokens and Jira credentials from the cs-qe-credentials secret.
- Invokes the ocmci container (quay.io/redhat-services-prod/ocmci/ocmci:latest) via podman to run ocmtest test --service cms --job cs-rosa-hcp-zero-egress-staging-main --reportJiraTicket.
- Mounts the cs-qe-credentials secret read-only at /usr/local/cs-qe-credentials and uses an authfile for container image auth.
- Allocates a 1Gi memory-backed volume for the container run.

Consistency
- The new test mirrors the structure, scheduling, credential handling, and reporting used by the other ROSA HCP staging FVT entries in the same file (AD, upgrade, shared VPC, PL, etc.), ensuring consistent CI behavior and Jira reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->