### PR TITLE
ptp-operator: adding check for kubeconfig presence

### DIFF
--- a/ci-operator/step-registry/telco5g/ptp-cluster-setup/telco5g-ptp-cluster-setup-commands.sh
+++ b/ci-operator/step-registry/telco5g/ptp-cluster-setup/telco5g-ptp-cluster-setup-commands.sh
@@ -320,6 +320,14 @@ if [[ ! -f "$SHARED_DIR/kubeconfig" ]]; then
   status=1
 fi
 
+if [[ -f "$SHARED_DIR/kubeconfig" ]]; then
+  echo "************ Cluster version (oc get clusterversion) ************"
+  if ! KUBECONFIG="$SHARED_DIR/kubeconfig" oc get clusterversion; then
+    echo "WARNING: oc get clusterversion failed (API unreachable, auth, or oc missing in this ref)"
+  fi
+  echo "****************************************************************"
+fi
+
 if [[ "$SKIP_OCP_INSTALL" != "true" && "$status" -eq 0 ]]; then
   #installer has issues applying machine-configs with OCP 4.10, using manual way
   KUBECONFIG="$SHARED_DIR/kubeconfig" oc apply -f "$SHARED_DIR/disable_ntp.yml" || true

--- a/ci-operator/step-registry/telco5g/ptp-cluster-setup/telco5g-ptp-cluster-setup-commands.sh
+++ b/ci-operator/step-registry/telco5g/ptp-cluster-setup/telco5g-ptp-cluster-setup-commands.sh
@@ -306,9 +306,19 @@ if [[ "$SKIP_OCP_INSTALL" != "true" ]]; then
   ANSIBLE_STDOUT_CALLBACK=debug ansible-playbook -i $SHARED_DIR/inventory ~/ocp-install.yml -e job_type=$JOB_TYPE -vv || status=$?
 fi
 
-# Fetch kubeconfig and cluster information
-ansible-playbook -i $SHARED_DIR/inventory ~/fetch-kubeconfig.yml -e job_type=$JOB_TYPE -vv || true
+# Fetch kubeconfig and cluster information. Do not ignore failures: without kubeconfig the test
+# step has nothing to work with, and the job can spuriously pass the setup ref while the test
+# step then fails to upload artifacts (e.g. e2e-telco5g-ptp-upstream with SKIP_OCP_INSTALL=true).
+if ! ansible-playbook -i $SHARED_DIR/inventory ~/fetch-kubeconfig.yml -e job_type=$JOB_TYPE -vv; then
+  echo "ERROR: fetch-kubeconfig playbook failed; PTP e2e cannot run without a kubeconfig"
+  status=1
+fi
 ANSIBLE_STDOUT_CALLBACK=debug ansible-playbook -i $SHARED_DIR/inventory ~/fetch-information.yml -vv || true
+
+if [[ ! -f "$SHARED_DIR/kubeconfig" ]]; then
+  echo "ERROR: kubeconfig not found at $SHARED_DIR/kubeconfig after fetch-kubeconfig"
+  status=1
+fi
 
 if [[ "$SKIP_OCP_INSTALL" != "true" && "$status" -eq 0 ]]; then
   #installer has issues applying machine-configs with OCP 4.10, using manual way

--- a/ci-operator/step-registry/telco5g/ptp-cluster-setup/telco5g-ptp-cluster-setup-commands.sh
+++ b/ci-operator/step-registry/telco5g/ptp-cluster-setup/telco5g-ptp-cluster-setup-commands.sh
@@ -323,7 +323,8 @@ fi
 if [[ -f "$SHARED_DIR/kubeconfig" ]]; then
   echo "************ Cluster version (oc get clusterversion) ************"
   if ! KUBECONFIG="$SHARED_DIR/kubeconfig" oc get clusterversion; then
-    echo "WARNING: oc get clusterversion failed (API unreachable, auth, or oc missing in this ref)"
+    echo "ERROR: oc get clusterversion failed (API unreachable, auth, or oc missing in this ref)"
+    status=1
   fi
   echo "****************************************************************"
 fi

--- a/ci-operator/step-registry/telco5g/ptp/tests/telco5g-ptp-tests-ref.yaml
+++ b/ci-operator/step-registry/telco5g/ptp/tests/telco5g-ptp-tests-ref.yaml
@@ -8,8 +8,8 @@ ref:
   timeout: 3h45m
   resources:
     requests:
-      cpu: 100m
-      memory: 200Mi
+      cpu: 2000m
+      memory: 4Gi
   env:
   - name: E2E_TESTS_CONFIG
     default: ""


### PR DESCRIPTION
The fetch-kubeconfig ansible playbook was always followed by '|| true', so a successful kcli install could still report success for the ref even when copying kubeconfig from the lab hypervisor failed. The test step would then run (or no-op) without a valid KUBECONFIG, matching confusing failures and missing test artifacts in periodic e2e-telco5g-ptp / -upstream.

Require fetch-kubeconfig to succeed, and verify $SHARED_DIR/kubeconfig exists before completing the step.
Assisted-by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Setup now fails when kubeconfig retrieval, presence, or cluster-info verification are unsuccessful, preventing silent success.

* **Improvements**
  * Added a cluster diagnostic check during setup to verify cluster accessibility.
  * Increased test container CPU and memory requests for more reliable test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->