### PR TITLE
HYPERFLEET-975 - ci: add verify-migrations presubmit job for hyperfleet-api

### DIFF
--- a/ci-operator/config/openshift-hyperfleet/hyperfleet-api/openshift-hyperfleet-hyperfleet-api-main.yaml
+++ b/ci-operator/config/openshift-hyperfleet/hyperfleet-api/openshift-hyperfleet-hyperfleet-api-main.yaml
@@ -57,6 +57,12 @@ tests:
   container:
     from: podman-test
   nested_podman: true
+- as: verify-migrations
+  commands: |
+    make verify-migrations
+  container:
+    from: src
+  run_if_changed: ^pkg/db/migrations/
 - as: helm-test
   commands: |
     curl -fsSL https://get.helm.sh/helm-v3.17.2-linux-amd64.tar.gz | tar xz

--- a/ci-operator/jobs/openshift-hyperfleet/hyperfleet-api/openshift-hyperfleet-hyperfleet-api-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-hyperfleet/hyperfleet-api/openshift-hyperfleet-hyperfleet-api-main-presubmits.yaml
@@ -556,3 +556,74 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )validate-commits,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build11
+    context: ci/prow/verify-migrations
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-hyperfleet-hyperfleet-api-main-verify-migrations
+    rerun_command: /test verify-migrations
+    run_if_changed: ^pkg/db/migrations/
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --target=verify-migrations
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: github-credentials-openshift-ci-robot-private-git-cloner
+        secret:
+          secretName: github-credentials-openshift-ci-robot-private-git-cloner
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-migrations,?($|\s.*)


### PR DESCRIPTION
Add a required presubmit CI job that runs hack/verify-migrations.sh to prevent accidental modifications to existing database migration files.

- Add verify-migrations test to ci-operator config for hyperfleet-api main branch
- Regenerate Prow job definitions with always_run: true and optional: false

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a CI verification step that runs when database migration files change to validate migrations before merge, improving reliability of DB-related updates.
* **Chores**
  * Introduced CI configuration to wire the migration verification into the project’s automated pipeline and set default pod resource requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->