### PR TITLE
DNM: Use candidate release for aws-upi-reboot-nodes-f28 job

### DIFF
--- a/ci-operator/config/openshift/ci-tools/openshift-ci-tools-main.yaml
+++ b/ci-operator/config/openshift/ci-tools/openshift-ci-tools-main.yaml
@@ -941,7 +941,6 @@ tests:
         field: gsm-e2e-test-sa-key
         group: test-credentials
         mount_path: /tmp/gcp-creds
-        namespace: ""
       - bundle: hive-hive-credentials
         mount_path: /tmp/hive
         namespace: test-credentials
@@ -1197,7 +1196,6 @@ tests:
         field: api-token
         group: snyk-credentials
         mount_path: /snyk-credentials
-        namespace: ""
       env:
       - default: ci-tools
         name: PROJECT_NAME

--- a/ci-operator/config/openshift/verification-tests/openshift-verification-tests-main__installation-nightly-4.22.yaml
+++ b/ci-operator/config/openshift/verification-tests/openshift-verification-tests-main__installation-nightly-4.22.yaml
@@ -38,6 +38,11 @@ releases:
       product: ocp
       stream: nightly
       version: "4.22"
+  candidate:
+    release:
+      architecture: amd64
+      channel: candidate
+      version: "4.22"
   latest:
     candidate:
       architecture: amd64
@@ -457,6 +462,8 @@ tests:
   steps:
     allow_skip_on_success: true
     cluster_profile: aws-qe
+    dependencies:
+      OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: release:candidate
     env:
       BASE_DOMAIN: qe.devcluster.openshift.com
       ENABLE_REBOOT_CHECK: "true"


### PR DESCRIPTION
Configure the aws-upi-reboot-nodes-f28 periodic job to use the OCP 4.22 candidate channel instead of nightly builds by adding a candidate release definition and updating the job to use it via OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE.

/hold



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified credential configuration by removing redundant namespace settings from test pipeline configurations.
  * Added testing support for OpenShift Container Platform 4.22 with candidate release images, enabling validation of the 4.22 release on amd64 architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->