### PR TITLE
specify local .snyk path

### DIFF
--- a/ci-operator/config/openshift-eng/aos-cd-jobs/openshift-eng-aos-cd-jobs-master.yaml
+++ b/ci-operator/config/openshift-eng/aos-cd-jobs/openshift-eng-aos-cd-jobs-master.yaml
@@ -21,7 +21,7 @@ tests:
   steps:
     env:
       PROJECT_NAME: openshift-eng/aos-cd-jobs
-      SNYK_CODE_ADDITIONAL_ARGS: "--policy-path .snyk"
+      SNYK_CODE_ADDITIONAL_ARGS: --policy-path .snyk
     workflow: openshift-ci-security
 zz_generated_metadata:
   branch: master

--- a/ci-operator/config/openshift-eng/aos-cd-jobs/openshift-eng-aos-cd-jobs-master.yaml
+++ b/ci-operator/config/openshift-eng/aos-cd-jobs/openshift-eng-aos-cd-jobs-master.yaml
@@ -21,6 +21,7 @@ tests:
   steps:
     env:
       PROJECT_NAME: openshift-eng/aos-cd-jobs
+      SNYK_CODE_ADDITIONAL_ARGS: "--policy-path .snyk"
     workflow: openshift-ci-security
 zz_generated_metadata:
   branch: master


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated security scanning configuration to ensure the Snyk scanner loads its policy from the repository’s .snyk policy path. This change only adjusts where the scanner reads its policy; no other workflow steps, wiring, or logic were modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->