### PR TITLE
DNM: run verification tests against RC releases

### DIFF
--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22__multi-nightly.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22__multi-nightly.yaml
@@ -52,16 +52,14 @@ prowgen:
   private: true
 releases:
   arm64-latest:
-    candidate:
+    release:
       architecture: arm64
-      product: ocp
-      stream: nightly
+      channel: candidate
       version: "4.22"
   latest:
-    candidate:
+    release:
       architecture: multi
-      product: ocp
-      stream: nightly
+      channel: candidate
       version: "4.22"
 resources:
   '*':

--- a/ci-operator/config/openshift/verification-tests/openshift-verification-tests-main__installation-stable-4.22.yaml
+++ b/ci-operator/config/openshift/verification-tests/openshift-verification-tests-main__installation-stable-4.22.yaml
@@ -1,0 +1,474 @@
+base_images:
+  ansible:
+    name: "4.22"
+    namespace: ocp
+    tag: ansible
+  aws-efs-csi-operator-create-efs:
+    name: "4.22"
+    namespace: ocp
+    tag: aws-efs-csi-operator-create-efs
+  cli:
+    name: "4.22"
+    namespace: ocp
+    tag: cli
+  dev-scripts:
+    name: test
+    namespace: ocp-kni
+    tag: dev-scripts
+  tests-private:
+    name: tests-private
+    namespace: ci
+    tag: "4.22"
+  tools:
+    name: "4.22"
+    namespace: ocp
+    tag: tools
+  upi-installer:
+    name: "4.22"
+    namespace: ocp
+    tag: upi-installer
+  vsphere-ci-python:
+    name: vsphere-python
+    namespace: ci
+    tag: latest
+releases:
+  arm64-stable:
+    release:
+      architecture: arm64
+      channel: candidate
+      version: "4.22"
+  latest:
+    release:
+      architecture: amd64
+      channel: candidate
+      version: "4.22"
+  multi-stable:
+    release:
+      architecture: multi
+      channel: candidate
+      version: "4.22"
+  stable:
+    release:
+      architecture: amd64
+      channel: candidate
+      version: "4.22"
+  target:
+    release:
+      architecture: amd64
+      channel: candidate
+      version: "4.22"
+resources:
+  '*':
+    limits:
+      cpu: "1"
+      memory: 4Gi
+    requests:
+      cpu: 400m
+      memory: 800Mi
+tests:
+- as: aws-ipi-all-regions-f1
+  cron: 56 4 * * *
+  steps:
+    allow_skip_on_success: true
+    cluster_profile: aws-qe
+    dependencies:
+      OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: release:multi-stable
+    env:
+      BASE_DOMAIN: qe.devcluster.openshift.com
+      TEST_OBJECT: Regions
+    workflow: cucushift-installer-rehearse-aws-cases-clusters
+- as: aws-ipi-all-localzones-f1
+  cron: 34 18 * * *
+  steps:
+    allow_skip_on_success: true
+    cluster_profile: aws-qe
+    dependencies:
+      OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: release:multi-stable
+    env:
+      BASE_DOMAIN: qe.devcluster.openshift.com
+      TEST_OBJECT: LocalZones
+    workflow: cucushift-installer-rehearse-aws-cases-clusters-edge-zone
+- as: aws-ipi-all-wavelength-zones-f1
+  cron: 21 23 * * *
+  steps:
+    allow_skip_on_success: true
+    cluster_profile: aws-qe
+    dependencies:
+      OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: release:multi-stable
+    env:
+      BASE_DOMAIN: qe.devcluster.openshift.com
+      TEST_OBJECT: WavelengthZones
+    workflow: cucushift-installer-rehearse-aws-cases-clusters-edge-zone
+- as: aws-ipi-all-instance-types-f1
+  cron: 19 7 * * *
+  steps:
+    allow_skip_on_success: true
+    cluster_profile: aws-qe
+    dependencies:
+      OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: release:multi-stable
+    env:
+      BASE_DOMAIN: qe.devcluster.openshift.com
+      TEST_FILTERS: "57148"
+      TEST_OBJECT: InstanceTypes
+    test:
+    - ref: openshift-extended-test-longduration
+    - ref: openshift-e2e-test-qe-report
+    workflow: cucushift-installer-rehearse-aws-cases-clusters
+- as: aws-ipi-custom-proxy-creds-arm-f28
+  cron: 6 12 27 * *
+  steps:
+    allow_skip_on_success: true
+    cluster_profile: aws-qe
+    dependencies:
+      OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: release:arm64-stable
+    env:
+      BASE_DOMAIN: qe.devcluster.openshift.com
+      COMPUTE_NODE_TYPE: m6g.xlarge
+      CONTROL_PLANE_INSTANCE_TYPE: m6g.xlarge
+      CUSTOM_PROXY_CREDENTIAL: "true"
+      OCP_ARCH: arm64
+    workflow: cucushift-installer-rehearse-aws-ipi-proxy
+- as: aws-ipi-byo-iam-profile-master-arm-f28
+  cron: 13 12 17 * *
+  steps:
+    allow_skip_on_success: true
+    cluster_profile: aws-qe
+    dependencies:
+      OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: release:arm64-stable
+    env:
+      BASE_DOMAIN: qe.devcluster.openshift.com
+      COMPUTE_NODE_TYPE: m6g.xlarge
+      CONTROL_PLANE_INSTANCE_TYPE: m6g.xlarge
+      ENABLE_BYO_IAM_PROFILE_CONTROL_PLANE: "true"
+      ENABLE_BYO_IAM_PROFILE_CUMPUTE: "false"
+      ENABLE_BYO_IAM_PROFILE_DEFAULT_MACHINE: "false"
+      OCP_ARCH: arm64
+    workflow: cucushift-installer-rehearse-aws-ipi-byo-iam-profile
+- as: aws-ipi-byo-iam-profile-worker-arm-f28
+  cron: 55 9 9 * *
+  steps:
+    allow_skip_on_success: true
+    cluster_profile: aws-qe
+    dependencies:
+      OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: release:arm64-stable
+    env:
+      BASE_DOMAIN: qe.devcluster.openshift.com
+      COMPUTE_NODE_TYPE: m6g.xlarge
+      CONTROL_PLANE_INSTANCE_TYPE: m6g.xlarge
+      ENABLE_BYO_IAM_PROFILE_CONTROL_PLANE: "false"
+      ENABLE_BYO_IAM_PROFILE_CUMPUTE: "true"
+      ENABLE_BYO_IAM_PROFILE_DEFAULT_MACHINE: "false"
+      OCP_ARCH: arm64
+    workflow: cucushift-installer-rehearse-aws-ipi-byo-iam-profile
+- as: aws-ipi-byo-iam-role-master-arm-f28
+  cron: 56 18 29 * *
+  steps:
+    allow_skip_on_success: true
+    cluster_profile: aws-qe
+    dependencies:
+      OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: release:arm64-stable
+    env:
+      BASE_DOMAIN: qe.devcluster.openshift.com
+      COMPUTE_NODE_TYPE: m6g.xlarge
+      CONTROL_PLANE_INSTANCE_TYPE: m6g.xlarge
+      ENABLE_BYO_IAM_ROLE_CONTROL_PLANE: "true"
+      ENABLE_BYO_IAM_ROLE_CUMPUTE: "false"
+      ENABLE_BYO_IAM_ROLE_DEFAULT_MACHINE: "false"
+      OCP_ARCH: arm64
+    workflow: cucushift-installer-rehearse-aws-ipi-byo-iam-role
+- as: aws-ipi-byo-iam-role-worker-arm-f28
+  cron: 27 17 14 * *
+  steps:
+    allow_skip_on_success: true
+    cluster_profile: aws-qe
+    dependencies:
+      OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: release:arm64-stable
+    env:
+      BASE_DOMAIN: qe.devcluster.openshift.com
+      COMPUTE_NODE_TYPE: m6g.xlarge
+      CONTROL_PLANE_INSTANCE_TYPE: m6g.xlarge
+      ENABLE_BYO_IAM_ROLE_CONTROL_PLANE: "false"
+      ENABLE_BYO_IAM_ROLE_CUMPUTE: "true"
+      ENABLE_BYO_IAM_ROLE_DEFAULT_MACHINE: "false"
+      OCP_ARCH: arm64
+    workflow: cucushift-installer-rehearse-aws-ipi-byo-iam-role
+- as: aws-ipi-byo-subnets-role-only-public-mini-perm-arm-f14
+  cron: 36 1 1,15 * *
+  steps:
+    allow_skip_on_success: true
+    cluster_profile: aws-qe
+    dependencies:
+      OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: release:arm64-stable
+    env:
+      ADDITIONAL_SUBNETS_COUNT: "1"
+      ASSIGN_ROLES_TO_SUBNETS: "yes"
+      AWS_INSTALL_USE_MINIMAL_PERMISSIONS: "yes"
+      BASE_DOMAIN: qe.devcluster.openshift.com
+      COMPUTE_NODE_TYPE: m6g.xlarge
+      CONTROL_PLANE_INSTANCE_TYPE: m6g.xlarge
+      OCP_ARCH: arm64
+      OPENSHIFT_INSTALL_AWS_PUBLIC_ONLY: "true"
+      SUBNET_ROLES: |-
+        [
+          [
+            {
+              "private": "",
+              "public": "ControlPlaneInternalLB"
+            },
+            {
+              "private": "",
+              "public": "ControlPlaneExternalLB IngressControllerLB BootstrapNode ClusterNode"
+            }
+          ]
+        ]
+      ZONES_COUNT: "1"
+    test:
+    - ref: cucushift-installer-check-cluster-health
+    workflow: cucushift-installer-rehearse-aws-ipi-byo-subnets
+- as: aws-ipi-default-mini-perm-arm-f7
+  cron: 52 21 3,12,19,26 * *
+  steps:
+    allow_skip_on_success: true
+    cluster_profile: aws-qe
+    dependencies:
+      OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: release:arm64-stable
+    env:
+      AWS_INSTALL_USE_MINIMAL_PERMISSIONS: "yes"
+      BASE_DOMAIN: qe.devcluster.openshift.com
+      OCP_ARCH: arm64
+    workflow: cucushift-installer-rehearse-aws-ipi-default
+- as: aws-ipi-valid-lb-subnet-f14
+  cron: 22 14 2,16 * *
+  steps:
+    allow_skip_on_success: true
+    cluster_profile: aws-qe
+    env:
+      BASE_DOMAIN: qe.devcluster.openshift.com
+    workflow: cucushift-installer-rehearse-aws-cases-valid-lb-subnet
+- as: aws-ipi-multi-cidr-arm-f14
+  cron: 33 18 7,21 * *
+  steps:
+    allow_skip_on_success: true
+    cluster_profile: aws-qe
+    dependencies:
+      OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: release:arm64-stable
+    env:
+      BASE_DOMAIN: qe.devcluster.openshift.com
+      COMPUTE_NODE_TYPE: m6g.xlarge
+      CONTROL_PLANE_INSTANCE_TYPE: m6g.xlarge
+      OCP_ARCH: arm64
+    workflow: cucushift-installer-rehearse-aws-cases-multi-cidr
+- as: aws-ipi-multi-clusters-one-phz-arm-f14
+  cron: 19 12 4,18 * *
+  steps:
+    allow_skip_on_success: true
+    cluster_profile: aws-qe
+    dependencies:
+      OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: release:arm64-stable
+    env:
+      BASE_DOMAIN: qe.devcluster.openshift.com
+      COMPUTE_NODE_TYPE: m6g.xlarge
+      CONTROL_PLANE_INSTANCE_TYPE: m6g.xlarge
+      OCP_ARCH: arm64
+    workflow: cucushift-installer-rehearse-aws-cases-multi-clusters-one-phz
+- as: aws-ipi-valid-endpoints-f14
+  cron: 7 4 12,26 * *
+  steps:
+    allow_skip_on_success: true
+    cluster_profile: aws-qe
+    env:
+      BASE_DOMAIN: qe.devcluster.openshift.com
+    workflow: cucushift-installer-rehearse-aws-cases-valid-endpoints
+- as: aws-ipi-only-public-subnets-mini-perm-arm-f14
+  cron: 57 4 10,26 * *
+  steps:
+    allow_skip_on_success: true
+    cluster_profile: aws-qe
+    dependencies:
+      OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: release:arm64-stable
+    env:
+      AWS_INSTALL_USE_MINIMAL_PERMISSIONS: "yes"
+      BASE_DOMAIN: qe.devcluster.openshift.com
+      COMPUTE_NODE_TYPE: m6g.xlarge
+      CONTROL_PLANE_INSTANCE_TYPE: m6g.xlarge
+      OCP_ARCH: arm64
+      OPENSHIFT_INSTALL_AWS_PUBLIC_ONLY: "true"
+    test:
+    - ref: cucushift-installer-check-aws-only-public-subnets
+    - ref: cucushift-installer-check-cluster-health
+    workflow: cucushift-installer-rehearse-aws-ipi
+- as: aws-ipi-proxy-whitelist-arm-f14
+  cron: 26 4 2,18 * *
+  steps:
+    allow_skip_on_success: true
+    cluster_profile: aws-qe
+    dependencies:
+      OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: release:arm64-stable
+    env:
+      BASE_DOMAIN: qe.devcluster.openshift.com
+      COMPUTE_NODE_TYPE: m6g.xlarge
+      CONTROL_PLANE_INSTANCE_TYPE: m6g.xlarge
+      OCP_ARCH: arm64
+    test:
+    - ref: cucushift-installer-check-cluster-health
+    workflow: cucushift-installer-rehearse-aws-ipi-proxy-whitelist
+- as: aws-ipi-proxy-blocklist-arm-f28-ota
+  cron: 38 4 8 * *
+  steps:
+    allow_skip_on_success: true
+    cluster_profile: aws-qe
+    dependencies:
+      OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: release:arm64-stable
+    env:
+      BASE_DOMAIN: qe.devcluster.openshift.com
+      COMPUTE_NODE_TYPE: m6g.xlarge
+      CONTROL_PLANE_INSTANCE_TYPE: m6g.xlarge
+      OCP_ARCH: arm64
+      PROXY_BLOCKLIST: api.openshift.com
+    test:
+    - ref: cucushift-installer-check-cluster-health
+    workflow: cucushift-installer-rehearse-aws-ipi-proxy-blocklist
+- as: aws-ipi-proxy-reboot-nodes-arm-f28
+  cron: 56 23 7 * *
+  steps:
+    allow_skip_on_success: true
+    cluster_profile: aws-qe
+    dependencies:
+      OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: release:arm64-stable
+    env:
+      BASE_DOMAIN: qe.devcluster.openshift.com
+      COMPUTE_NODE_TYPE: m6g.xlarge
+      CONTROL_PLANE_INSTANCE_TYPE: m6g.xlarge
+      ENABLE_REBOOT_CHECK: "true"
+      OCP_ARCH: arm64
+      REBOOT_TYPE: HARD_REBOOT
+    test:
+    - ref: cucushift-installer-check-cluster-health
+    workflow: cucushift-installer-rehearse-aws-ipi-proxy
+- as: aws-ipi-shared-phz-f14
+  cron: 31 8 14,28 * *
+  steps:
+    allow_skip_on_success: true
+    cluster_profile: aws-qe
+    env:
+      BASE_DOMAIN: qe.devcluster.openshift.com
+    test:
+    - ref: cucushift-installer-check-cluster-health
+    workflow: cucushift-installer-rehearse-aws-ipi-shared-phz
+- as: aws-ipi-shared-phz-sts-f14
+  cron: 10 3 15,29 * *
+  steps:
+    allow_skip_on_success: true
+    cluster_profile: aws-qe
+    env:
+      BASE_DOMAIN: qe.devcluster.openshift.com
+    test:
+    - ref: cucushift-installer-check-cluster-health
+    workflow: cucushift-installer-rehearse-aws-ipi-shared-phz-sts
+- as: aws-ipi-custom-dns-mini-perm-arm-f7
+  cron: 11 3 1,8,15,22 * *
+  steps:
+    allow_skip_on_success: true
+    cluster_profile: aws-qe
+    dependencies:
+      OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: release:arm64-stable
+    env:
+      AWS_INSTALL_USE_MINIMAL_PERMISSIONS: "yes"
+      BASE_DOMAIN: qe.gcp.devcluster.openshift.com
+      COMPUTE_NODE_TYPE: m6g.xlarge
+      CONTROL_PLANE_INSTANCE_TYPE: m6g.xlarge
+      FEATURE_GATES: '["AWSClusterHostedDNSInstall=true"]'
+      FEATURE_SET: CustomNoUpgrade
+      OCP_ARCH: arm64
+    test:
+    - chain: cucushift-installer-check-cluster-health
+    workflow: cucushift-installer-rehearse-aws-ipi-custom-dns
+- as: aws-ipi-custom-dns-priv-mini-perm-arm-f7
+  cron: 19 11 1,8,15,22 * *
+  steps:
+    allow_skip_on_success: true
+    cluster_profile: aws-qe
+    dependencies:
+      OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: release:arm64-stable
+    env:
+      AWS_INSTALL_USE_MINIMAL_PERMISSIONS: "yes"
+      BASE_DOMAIN: custom-dns.com
+      COMPUTE_NODE_TYPE: m6g.xlarge
+      CONTROL_PLANE_INSTANCE_TYPE: m6g.xlarge
+      FEATURE_GATES: '["AWSClusterHostedDNSInstall=true"]'
+      FEATURE_SET: CustomNoUpgrade
+      OCP_ARCH: arm64
+    test:
+    - chain: cucushift-installer-check-cluster-health
+    workflow: cucushift-installer-rehearse-aws-ipi-custom-dns-private
+- as: aws-usgov-ipi-custom-dns-mini-perm-arm-f7
+  cron: 41 19 5,12,19,26 * *
+  steps:
+    allow_skip_on_success: true
+    cluster_profile: aws-usgov-qe
+    env:
+      AWS_INSTALL_USE_MINIMAL_PERMISSIONS: "yes"
+      BASE_DOMAIN: qe.gcp.devcluster.openshift.com
+      FEATURE_GATES: '["AWSClusterHostedDNSInstall=true"]'
+      FEATURE_SET: CustomNoUpgrade
+    test:
+    - chain: cucushift-installer-check-cluster-health
+    workflow: cucushift-installer-rehearse-aws-usgov-ipi-custom-dns
+- as: aws-ipi-additional-ca-always-arm-f14
+  cron: 45 1 13,27 * *
+  steps:
+    allow_skip_on_success: true
+    cluster_profile: aws-qe
+    dependencies:
+      OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: release:arm64-stable
+    env:
+      ADDITIONAL_TRUST_BUNDLE_POLICY: Always
+      BASE_DOMAIN: qe.devcluster.openshift.com
+      COMPUTE_NODE_TYPE: m6g.xlarge
+      CONTROL_PLANE_INSTANCE_TYPE: m6g.xlarge
+      OCP_ARCH: arm64
+    test:
+    - ref: cucushift-installer-check-cluster-health
+    workflow: cucushift-installer-rehearse-aws-ipi-additional-ca-policy
+- as: aws-ipi-arm-f28-ota
+  cron: 35 7 11 * *
+  steps:
+    allow_skip_on_success: true
+    cluster_profile: aws-qe
+    dependencies:
+      OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: release:arm64-stable
+    env:
+      BASE_DOMAIN: qe.devcluster.openshift.com
+      COMPUTE_NODE_TYPE: m6g.xlarge
+      CONTROL_PLANE_INSTANCE_TYPE: m6g.xlarge
+      ENABLE_OTA_TEST: OCP-47200
+      OCP_ARCH: arm64
+    test:
+    - ref: cucushift-ota-preupgrade
+    workflow: cucushift-installer-rehearse-aws-ipi
+- as: aws-ipi-zone-consistency-f14
+  cron: 16 22 10,26 * *
+  steps:
+    cluster_profile: aws-qe
+    env:
+      BASE_DOMAIN: qe.devcluster.openshift.com
+    workflow: cucushift-installer-rehearse-aws-cases-zone-consistency
+- as: aws-upi-reboot-nodes-f28
+  cron: 1 4 12 * *
+  steps:
+    allow_skip_on_success: true
+    cluster_profile: aws-qe
+    dependencies:
+      OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: release:stable
+    env:
+      BASE_DOMAIN: qe.devcluster.openshift.com
+      ENABLE_REBOOT_CHECK: "true"
+      REBOOT_TYPE: HARD_REBOOT
+    test:
+    - ref: cucushift-installer-check-cluster-health
+    workflow: cucushift-installer-rehearse-aws-upi
+zz_generated_metadata:
+  branch: main
+  org: openshift
+  repo: verification-tests
+  variant: installation-stable-4.22

--- a/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22-periodics.yaml
+++ b/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22-periodics.yaml
@@ -84639,7 +84639,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-eusc
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-eusc-ipi-custom-dns-mini-perm-tp-amd-f28-destructive
   spec:
@@ -84729,7 +84728,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-eusc
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-eusc-ipi-custom-dns-mini-perm-tp-arm-f7
   spec:
@@ -84819,7 +84817,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-eusc
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-eusc-ipi-disc-priv-tp-amd-f28-destructive
   spec:
@@ -84909,7 +84906,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-eusc
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-eusc-ipi-disc-priv-tp-arm-f7
   spec:
@@ -84999,7 +84995,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-eusc
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-eusc-ipi-fips-tp-arm-f7
   spec:
@@ -85089,7 +85084,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-eusc
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-eusc-ipi-fips-tp-f28-destructive
   spec:
@@ -85179,7 +85173,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-eusc
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-eusc-ipi-private-tp-amd-f28-destructive
   spec:
@@ -85269,7 +85262,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-eusc
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-eusc-ipi-private-tp-arm-f7
   spec:
@@ -85359,7 +85351,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-amd-f7-netobserv
   reporter_config:
@@ -85460,7 +85451,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-arm-f28-netobserv
   reporter_config:
@@ -85561,7 +85551,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-arm-mixarch-f7-day2-64k-pagesize
   spec:
@@ -85651,7 +85640,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-byo-iam-profile-fips-mini-perm-amd-f28-destructive
   spec:
@@ -85741,7 +85729,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-byo-iam-profile-mini-perm-arm-f7
   spec:
@@ -85831,7 +85818,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-byo-iam-role-efs-arm-regen-cert-f14
   spec:
@@ -85921,7 +85907,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-byo-iam-role-efs-fips-mini-perm-amd-f28-destructive
   spec:
@@ -86011,7 +85996,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-byo-iam-role-efs-fips-rhcos10-tp-amd-f28-destructive
   spec:
@@ -86101,7 +86085,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-byo-iam-role-efs-mini-perm-arm-f7-custom-cert
   spec:
@@ -86191,7 +86174,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-byo-iam-role-efs-rhcos10-tp-arm-f7-custom-cert
   spec:
@@ -86281,7 +86263,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-byo-iam-role-efs-rhcos10-tp-arm-regen-cert-f14
   spec:
@@ -86371,7 +86352,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-byo-kms-etcd-encryption-fips-amd-f28-destructive
   spec:
@@ -86461,7 +86441,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-byo-kms-etcd-encryption-mini-perm-arm-f7
   spec:
@@ -86551,7 +86530,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-byo-route53-compact-cloudfront-amd-f28-destructive
   spec:
@@ -86641,7 +86619,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-byo-route53-compact-cloudfront-mini-perm-arm-f7
   spec:
@@ -86731,7 +86708,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-byo-subnet-role-isolate-lb-arm-f28-destructive
   spec:
@@ -86821,7 +86797,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-byo-subnet-role-isolate-lb-mini-perm-arm-f14
   spec:
@@ -86911,7 +86886,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-byo-subnet-role-share-lb-tags-sg-arm-f28-destructive
   spec:
@@ -87001,7 +86975,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-byo-subnet-role-share-lb-tags-sg-mini-perm-arm-f14
   spec:
@@ -87091,7 +87064,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-custom-dns-mini-perm-tp-arm-f28-destructive
   spec:
@@ -87181,7 +87153,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-custom-dns-mini-perm-tp-arm-f7
   spec:
@@ -87271,7 +87242,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-custom-dns-priv-mini-perm-tp-arm-f28-destructive
   spec:
@@ -87361,7 +87331,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-custom-dns-priv-mini-perm-tp-arm-f7
   spec:
@@ -87451,7 +87420,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-custom-masternameprefix-tp-amd-f28
   spec:
@@ -87541,7 +87509,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-custom-masternameprefix-tp-arm-f28-destructive
   spec:
@@ -87631,7 +87598,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-disc-priv-amd-mixarch-f28-destructive
   spec:
@@ -87721,7 +87687,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-disc-priv-arm-mixarch-f7
   spec:
@@ -87811,7 +87776,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-https-proxy-sts-mini-perm-amd-f28-destructive
   spec:
@@ -87901,7 +87865,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-https-proxy-sts-mini-perm-arm-f7
   spec:
@@ -87991,7 +87954,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-https-proxy-sts-mini-perm-rhcos10-tp-arm-f7
   spec:
@@ -88081,7 +88043,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-https-proxy-sts-rhcos10-tp-amd-f28-destructive
   spec:
@@ -88171,7 +88132,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-imdsv2-arm-f7
   spec:
@@ -88261,7 +88221,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-imdsv2-fips-amd-f28-destructive
   spec:
@@ -88351,7 +88310,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-ingress-lbtype-classic-subnets-amd-f28-destructive
   spec:
@@ -88441,7 +88399,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-ingress-lbtype-classic-subnets-mini-perm-arm-f7
   spec:
@@ -88531,7 +88488,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-ingress-lbtype-nlb-amd-f14
   spec:
@@ -88621,7 +88577,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-ingress-lbtype-nlb-arm-f28-destructive
   spec:
@@ -88711,7 +88666,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-ingress-lbtype-nlb-subnets-amd-f28-destructive
   spec:
@@ -88801,7 +88755,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-ingress-lbtype-nlb-subnets-mini-perm-arm-amd-day0-f7
   spec:
@@ -88891,7 +88844,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-kms-etcd-encrypt-fips-rhcos10-tp-amd-f28-destructive
   spec:
@@ -88981,7 +88933,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-kms-etcd-encrypt-rhcos10-tp-arm-f7
   spec:
@@ -89071,7 +89022,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-1-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-localzone-rootvolume-f28-destructive
   spec:
@@ -89161,7 +89111,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-1-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-localzone-rootvolume-f7
   spec:
@@ -89251,7 +89200,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-ovn-amd-cp-infra-to-arm-cp-infra-f7
   spec:
@@ -89341,7 +89289,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-ovn-arm-mixarch-mto-hypershift-arm-guest-f14
   reporter_config:
@@ -89442,7 +89389,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-ovn-arm-mixarch-mto-hypershift-arm-mgmt-f14
   reporter_config:
@@ -89543,7 +89489,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-ovn-compact-arm-cp-infra-to-amd-cp-infra-f7
   spec:
@@ -89633,7 +89578,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-ovn-efs-fips-amd-f28-destructive-ui
   spec:
@@ -89723,7 +89667,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-ovn-ipsec-mini-perm-amd-arm-day0-f28-destructive
   spec:
@@ -89813,7 +89756,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-ovn-ipsec-mini-perm-arm-mixarch-f7
   spec:
@@ -89903,7 +89845,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-ovn-ipsec-mini-perm-rhcos10-tp-arm-mixarch-f7
   spec:
@@ -89993,7 +89934,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-ovn-ipsec-rhcos10-tp-amd-arm-day0-f28-destructive
   spec:
@@ -90083,7 +90023,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-ovn-ipv4-subnet-arm-f14
   spec:
@@ -90173,7 +90112,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-ovn-ipv4-subnet-arm-f28-destructive
   spec:
@@ -90263,7 +90201,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-priv-sts-basecap-none-mini-perm-amd-f28-destructive
   spec:
@@ -90353,7 +90290,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-priv-sts-basecap-none-mini-perm-arm-f14
   spec:
@@ -90443,7 +90379,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-private-byo-subnet-role-mini-perm-arm-f14
   spec:
@@ -90533,7 +90468,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-private-byo-subnet-role-mini-perm-arm-f28-destructive
   spec:
@@ -90623,7 +90557,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-private-ingress-lbtype-nlb-amd-f28-destructive
   spec:
@@ -90713,7 +90646,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-private-ingress-lbtype-nlb-arm-f14
   spec:
@@ -90803,7 +90735,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-public-ipv4-pool-byo-subnet-amd-f28-destructive
   spec:
@@ -90893,7 +90824,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-public-ipv4-pool-byo-subnet-mini-perm-arm-f14
   spec:
@@ -90983,7 +90913,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-public-ipv4-pool-mini-perm-amd-f28-destructive
   spec:
@@ -91073,7 +91002,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-public-ipv4-pool-mini-perm-arm-f14
   spec:
@@ -91163,7 +91091,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-public-to-private-arm-f28
   spec:
@@ -91253,7 +91180,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-public-to-private-f28-destructive
   spec:
@@ -91343,7 +91269,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-sno-etcd-encryption-basecap-none-amd-f28-destructive
   spec:
@@ -91433,7 +91358,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-sno-etcd-encryption-basecap-none-arm-f7
   spec:
@@ -91523,7 +91447,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-ipi-sno-lvms-rhcos10-tp-arm-f7
   reporter_config:
@@ -91624,7 +91547,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-short-cert-rotation-arm-f7
   spec:
@@ -91714,7 +91636,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-upi-basecap-none-amd-f28-destructive
   spec:
@@ -91804,7 +91725,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: aws-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-aws-upi-basecap-none-arm-f7
   spec:
@@ -91894,7 +91814,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-aks-hypershift-guest-f14
   reporter_config:
@@ -91995,7 +91914,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-aks-hypershift-guest-reversed-f14
   reporter_config:
@@ -92096,7 +92014,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-amd-f7-netobserv
   reporter_config:
@@ -92197,7 +92114,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-arm-mixarch-disc-fullypriv-f7-day2-64k-pagesize
   spec:
@@ -92287,7 +92203,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-arm-mixarch-f14-ui
   spec:
@@ -92377,7 +92292,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-basecap-vset-additionalcap-amd-f28-destructive
   spec:
@@ -92467,7 +92381,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-basecap-vset-additionalcap-mini-perm-arm-f7
   spec:
@@ -92557,7 +92470,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-basecap-vset-mini-perm-amd-f28-destructive
   spec:
@@ -92647,7 +92559,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-basecap-vset-mini-perm-arm-f7
   spec:
@@ -92737,7 +92648,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-custom-dns-mini-perm-tp-amd-f28-destructive
   spec:
@@ -92827,7 +92737,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-custom-dns-mini-perm-tp-arm-f7
   spec:
@@ -92917,7 +92826,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-custom-masternameprefix-tp-amd-f28
   spec:
@@ -93007,7 +92915,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-custom-masternameprefix-tp-arm-f28-destructive
   spec:
@@ -93097,7 +93004,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-des-arm-regen-cert-f14
   spec:
@@ -93187,7 +93093,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-des-day2-arm-f28
   spec:
@@ -93277,7 +93182,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-des-day2-fips-amd-f28-destructive
   spec:
@@ -93367,7 +93271,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-des-mini-perm-fips-amd-f28-destructive
   spec:
@@ -93457,7 +93360,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-des-mini-perm-fips-rhcos10-tp-amd-f28-destructive
   spec:
@@ -93547,7 +93449,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-des-mini-perm-rhcos10-tp-arm-f14
   spec:
@@ -93637,7 +93538,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-des-sharedkeyaccess-mini-perm-arm-f14
   spec:
@@ -93727,7 +93627,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-disc-fullypriv-amd-mixarch-f28-destructive
   spec:
@@ -93817,7 +93716,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-disc-fullypriv-arm-mixarch-f7
   spec:
@@ -93907,7 +93805,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-etcd-encrypt-compact-mini-perm-rhcos10-tp-arm-f7
   spec:
@@ -93997,7 +93894,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-etcd-encrypt-compact-rhcos10-tp-amd-f28-destructive
   spec:
@@ -94087,7 +93983,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-fullyprivate-internal-registry-amd-f28-destructive
   spec:
@@ -94177,7 +94072,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-fullyprivate-internal-registry-mini-perm-arm-f7
   spec:
@@ -94267,7 +94161,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-fullyprivate-proxy-arm-f28-longduration-cloud
   reporter_config:
@@ -94367,7 +94260,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-fullyprivate-proxy-mini-perm-amd-f28-destructive
   spec:
@@ -94457,7 +94349,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-fullyprivate-proxy-mini-perm-arm-f7
   spec:
@@ -94547,7 +94438,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-identity-none-amd-f28-destructive
   spec:
@@ -94637,7 +94527,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-identity-none-mini-perm-arm-f14
   spec:
@@ -94727,7 +94616,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-mixed-apiserver-internal-amd-f28-destructive
   spec:
@@ -94817,7 +94705,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-mixed-apiserver-internal-mini-perm-arm-f7
   spec:
@@ -94907,7 +94794,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-mixed-ingress-internal-amd-f28-destructive
   spec:
@@ -94997,7 +94883,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-mixed-ingress-internal-mini-perm-arm-f7
   spec:
@@ -95087,7 +94972,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-mto-amd-mixarch-f28-destructive
   spec:
@@ -95177,7 +95061,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-mto-arm-mixarch-f7
   spec:
@@ -95267,7 +95150,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-multi-disk-etcd-mini-perm-rhcos10-tp-arm-f14
   spec:
@@ -95357,7 +95239,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-multi-disk-etcd-mini-perm-tp-amd-f28-destructive
   spec:
@@ -95447,7 +95328,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-multi-disk-etcd-mini-perm-tp-arm-f14
   spec:
@@ -95537,7 +95417,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-multi-disk-etcd-rhcos10-tp-amd-f28-destructive
   spec:
@@ -95627,7 +95506,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-multi-disk-swap-mini-perm-rhcos10-tp-arm-f14
   spec:
@@ -95717,7 +95595,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-multi-disk-swap-mini-perm-tp-amd-f28-destructive
   spec:
@@ -95807,7 +95684,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-multi-disk-swap-mini-perm-tp-arm-f14
   spec:
@@ -95897,7 +95773,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-multi-disk-swap-rhcos10-tp-amd-f28-destructive
   spec:
@@ -95987,7 +95862,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-multi-disk-user-defined-mini-perm-tp-arm-f14
   spec:
@@ -96077,7 +95951,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-multi-disk-user-defined-tp-amd-f28-destructive
   spec:
@@ -96167,7 +96040,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-multi-disk-usrdef-mini-perm-rhcos10-tp-arm-f14
   spec:
@@ -96257,7 +96129,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-multi-disk-usrdef-rhcos10-tp-amd-f28-destructive
   spec:
@@ -96347,7 +96218,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-nat-gateway-mzone-byo-subnets-amd-f28-destructive
   spec:
@@ -96437,7 +96307,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-nat-gateway-mzone-byo-subnets-mini-perm-arm-f7
   spec:
@@ -96527,7 +96396,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-nat-gateway-mzone-mini-perm-amd-f28-destructive
   spec:
@@ -96617,7 +96485,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-nat-gateway-mzone-mini-perm-arm-f7
   spec:
@@ -96707,7 +96574,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-nat-gateway-szone-byo-subnets-amd-f28-destructive
   spec:
@@ -96797,7 +96663,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-nat-gateway-szone-byo-subnets-mini-perm-arm-f7
   spec:
@@ -96887,7 +96752,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-nat-gateway-szone-mini-perm-amd-f28-destructive
   spec:
@@ -96977,7 +96841,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-nat-gateway-szone-mini-perm-arm-f7
   spec:
@@ -97067,7 +96930,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-oidc-mini-perm-amd-f28-destructive
   spec:
@@ -97157,7 +97019,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-oidc-mini-perm-arm-f7
   spec:
@@ -97247,7 +97108,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-ovn-etcd-encryption-compact-amd-f28-destructive
   spec:
@@ -97337,7 +97197,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-ovn-etcd-encryption-compact-mini-perm-arm-f7
   spec:
@@ -97427,7 +97286,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-ovn-ipsec-azurefile-csi-amd-f28-destructive
   spec:
@@ -97517,7 +97375,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-ovn-ipsec-azurefile-csi-mini-perm-arm-f7
   spec:
@@ -97607,7 +97464,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-ovn-ipsec-file-csi-rhcos10-tp-amd-f28-destructive
   spec:
@@ -97697,7 +97553,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-ovn-ipsec-file-csi-rhcos10-tp-mini-perm-arm-f7
   spec:
@@ -97787,7 +97642,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-private-custom-dns-mini-perm-tp-amd-f28-destructive
   spec:
@@ -97877,7 +97731,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-private-custom-dns-mini-perm-tp-arm-f7
   spec:
@@ -97967,7 +97820,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-private-spec-net-type-spec-perm-amd-f28-destructive
   spec:
@@ -98057,7 +97909,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-private-spec-net-type-spec-perm-arm-f7
   spec:
@@ -98147,7 +97998,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-proxy-amd-f28-destructive
   spec:
@@ -98237,7 +98087,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-proxy-arm-f14
   spec:
@@ -98327,7 +98176,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-proxy-tp-amd-f28-destructive
   spec:
@@ -98417,7 +98265,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-proxy-tp-arm-f7
   spec:
@@ -98507,7 +98354,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-public-to-private-amd-f28-destructive
   spec:
@@ -98597,7 +98443,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-public-to-private-arm-f28
   spec:
@@ -98687,7 +98532,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-sharednetwork-public-to-private-amd-f28-destructive
   spec:
@@ -98777,7 +98621,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-sharednetwork-public-to-private-arm-f28
   spec:
@@ -98867,7 +98710,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-sno-etcd-encryption-amd-f28-destructive
   spec:
@@ -98957,7 +98799,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-sno-etcd-encryption-arm-f7
   spec:
@@ -99047,7 +98888,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-tp-day2-amd-f28-destructive
   spec:
@@ -99137,7 +98977,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-tp-day2-arm-f28
   spec:
@@ -99227,7 +99066,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-ultrassd-disks-fips-mini-perm-amd-f28-destructive
   spec:
@@ -99317,7 +99155,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-ultrassd-disks-mini-perm-arm-f14
   spec:
@@ -99407,7 +99244,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-usertags-sa-encryption-amd-f28-destructive
   spec:
@@ -99497,7 +99333,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-usertags-sa-encryption-mini-perm-arm-f7
   spec:
@@ -99587,7 +99422,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-vnet-encrypted-ovn-ipv4-subnet-mini-perm-amd-f14
   spec:
@@ -99677,7 +99511,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-ipi-vnet-ovn-ipv4-subnet-arm-f28-destructive
   spec:
@@ -99767,7 +99600,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-short-cert-rotation-arm-f7
   spec:
@@ -99857,7 +99689,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-upi-amd-f28-destructive
   spec:
@@ -99947,7 +99778,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: azure-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-azure-upi-mini-perm-arm-f7
   spec:
@@ -100037,7 +99867,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-amd-f7-netobserv
   reporter_config:
@@ -100138,7 +99967,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-basecap-none-additionalcaps-amd-f28-destructive
   spec:
@@ -100228,7 +100056,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-basecap-none-additionalcaps-mini-perm-arm-f7
   spec:
@@ -100318,7 +100145,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe-c3-metal
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-c3-metal-private-amd-f999
   spec:
@@ -100408,7 +100234,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe-c3-metal
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-c3-metal-private-amd-f999-destructive
   spec:
@@ -100498,7 +100323,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-compact-filestore-csi-mini-perm-amd-f28-destructive
   spec:
@@ -100588,7 +100412,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-compact-filestore-csi-mini-perm-arm-f14
   spec:
@@ -100678,7 +100501,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-compact-filestore-csi-mini-perm-rhcos10-tp-arm-f14
   spec:
@@ -100768,7 +100590,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-compact-filestore-csi-rhcos10-tp-amd-f28-destructive
   spec:
@@ -100858,7 +100679,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-custom-dns-mini-perm-amd-f28-destructive
   spec:
@@ -100948,7 +100768,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-custom-dns-mini-perm-arm-f14
   spec:
@@ -101038,7 +100857,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-custom-dns-priv-mini-perm-amd-f28-destructive
   spec:
@@ -101128,7 +100946,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-custom-dns-priv-mini-perm-arm-f14
   spec:
@@ -101218,7 +101035,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-custom-endpoint-mini-perm-amd-f28-destructive
   spec:
@@ -101308,7 +101124,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-custom-endpoint-mini-perm-arm-f14
   spec:
@@ -101398,7 +101213,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-custom-masternameprefix-tp-amd-f28-destructive
   spec:
@@ -101488,7 +101302,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-custom-masternameprefix-tp-arm-f28
   spec:
@@ -101578,7 +101391,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-disc-priv-mini-perm-amd-arm-day0-f28-destructive
   spec:
@@ -101668,7 +101480,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-disc-priv-mini-perm-arm-amd-day0-f28
   spec:
@@ -101758,7 +101569,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-disk-encrypt-mini-perm-rhcos10-tp-amd-f28-destructive
   spec:
@@ -101848,7 +101658,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-disk-encrypt-rhcos10-tp-arm-f14-custom-cert
   spec:
@@ -101938,7 +101747,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-disk-encryption-arm-f14-cert-manager-custom-cert
   spec:
@@ -102028,7 +101836,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-disk-encryption-mini-perm-amd-f28-destructive
   spec:
@@ -102118,7 +101925,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-labels-tags-filestore-csi-arm-f14
   spec:
@@ -102208,7 +102014,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-labels-tags-filestore-csi-fips-amd-f28-destructive
   spec:
@@ -102298,7 +102103,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-oidc-mini-perm-arm-f28-destructive
   spec:
@@ -102388,7 +102192,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-oidc-mini-perm-rt-fips-amd-regen-cert-f14
   spec:
@@ -102478,7 +102281,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-ovn-ipsec-amd-mixarch-f28-destructive
   spec:
@@ -102568,7 +102370,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-ovn-ipsec-arm-mixarch-external-oidc-keycloak-f14
   spec:
@@ -102658,7 +102459,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-ovn-ipsec-arm-mixarch-f14
   spec:
@@ -102748,7 +102548,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-ovn-mtu-migrate-amd-f28
   spec:
@@ -102838,7 +102637,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-ovn-mtu-migrate-arm-f28
   spec:
@@ -102928,7 +102726,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-proxy-etcd-encryption-mini-perm-amd-f28-destructive
   spec:
@@ -103018,7 +102815,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-proxy-etcd-encryption-mini-perm-arm-f14
   spec:
@@ -103108,7 +102904,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-proxy-etcd-encryption-rhcos10-tp-amd-f28-destructive
   spec:
@@ -103198,7 +102993,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-proxy-etcd-encryption-rhcos10-tp-mini-perm-arm-f14
   spec:
@@ -103288,7 +103082,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-proxy-oidc-mini-perm-amd-f28-destructive
   spec:
@@ -103378,7 +103171,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-proxy-oidc-mini-perm-filestore-csi-arm-f28
   spec:
@@ -103468,7 +103260,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-proxy-private-arm-f28-tp-longduration-cloud
   reporter_config:
@@ -103568,7 +103359,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-proxy-private-mini-perm-amd-f28-destructive
   spec:
@@ -103658,7 +103448,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-proxy-private-mini-perm-arm-f14
   spec:
@@ -103748,7 +103537,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-sno-etcd-encryption-mini-perm-amd-f28-destructive
   spec:
@@ -103838,7 +103626,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-sno-etcd-encryption-mini-perm-arm-f14
   spec:
@@ -103928,7 +103715,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-sno-fips-tp-mini-perm-amd-f28-destructive
   spec:
@@ -104018,7 +103804,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-sno-tp-mini-perm-arm-f28
   spec:
@@ -104108,7 +103893,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-xpn-min-byo-zone-f28-longduration-cloud
   reporter_config:
@@ -104208,7 +103992,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-xpn-mini-perm-arm-f28
   spec:
@@ -104298,7 +104081,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-xpn-mini-perm-byo-hosted-zone-amd-f28-destructive
   spec:
@@ -104388,7 +104170,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-xpn-mini-perm-byo-hosted-zone-arm-f28
   spec:
@@ -104478,7 +104259,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-xpn-mini-perm-dns-project-amd-f28-destructive
   spec:
@@ -104568,7 +104348,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-xpn-mini-perm-dns-project-arm-f14
   spec:
@@ -104658,7 +104437,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-xpn-mini-perm-dns-project-priv-amd-f28-destructive
   spec:
@@ -104748,7 +104526,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-xpn-mini-perm-dns-project-priv-arm-f14
   spec:
@@ -104838,7 +104615,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-xpn-mini-perm-fips-amd-f28-destructive
   spec:
@@ -104928,7 +104704,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-xpn-oidc-mini-perm-amd-f28-destructive
   spec:
@@ -105018,7 +104793,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-xpn-oidc-mini-perm-arm-f28
   spec:
@@ -105108,7 +104882,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-xpn-private-amd-f28-destructive
   spec:
@@ -105198,7 +104971,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-ipi-xpn-private-arm-f14
   spec:
@@ -105288,7 +105060,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-short-cert-rotation-arm-f7
   spec:
@@ -105378,7 +105149,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-upi-private-xpn-ingress-glb-amd-f28-destructive
   spec:
@@ -105468,7 +105238,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: gcp-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-gcp-upi-private-xpn-ingress-glb-arm-f14
   spec:
@@ -105558,7 +105327,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: ibmcloud-multi-ppc64le
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-ibmcloud-ovn-multi-ppc64le-f999
   spec:
@@ -105649,7 +105417,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-metal-ipi-ovn-dualstack-arm-vmedia-f7
   spec:
@@ -105740,7 +105507,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-metal-ipi-ovn-ipv4-amd-f7
   spec:
@@ -105831,7 +105597,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-metal-ipi-ovn-ipv4-arm-f7
   spec:
@@ -105922,7 +105687,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-metal-ipi-ovn-ipv4-basecap-none-arm-f28
   spec:
@@ -106013,7 +105777,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-metal-ipi-ovn-ipv4-external-lb-arm-f7
   spec:
@@ -106104,7 +105867,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-metal-ipi-ovn-ipv4-vmedia-capi-tp-amd-f14
   spec:
@@ -106195,7 +105957,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-metal-ipi-ovn-ipv4-vmedia-disruptive-arm-f7
   spec:
@@ -106286,7 +106047,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-metal-ipi-ovn-ipv4-vmedia-multi-arch-amd-f14
   spec:
@@ -106377,7 +106137,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-metal-ipi-ovn-ipv4-vmedia-multi-arch-amd-f28
   spec:
@@ -106468,7 +106227,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-metal-ipi-ovn-ipv4-vmedia-multi-arch-day2-amd-f14
   spec:
@@ -106559,7 +106317,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-metal-ipi-ovn-ipv4-vmedia-multi-arch-day2-amd-f28
   spec:
@@ -106650,7 +106407,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-metal-ipi-ovn-ipv4-vmedia-multi-arch-day2-rhcos10-tp-amd-f28
   spec:
@@ -106741,7 +106497,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-metal-ipi-ovn-ipv4-vmedia-multi-arch-rhcos10-tp-amd-f28
   spec:
@@ -106832,7 +106587,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-metal-short-cert-rotation-arm-f7
   spec:
@@ -106923,7 +106677,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-metal-upi-ovn-ipv4-arm-mixarch-f14-day2-64k-pagesize
   spec:
@@ -107014,7 +106767,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-metal-upi-ovn-ipv4-day2-scale-amd-f14
   spec:
@@ -107105,7 +106857,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal-qe
     ci-operator.openshift.io/variant: multi-nightly
     ci.openshift.io/generator: prowgen
-    job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.22-multi-nightly-metal-upi-ovn-ipv4-disconnected-arm-f14
   spec:

--- a/ci-operator/jobs/openshift/verification-tests/openshift-verification-tests-main-periodics.yaml
+++ b/ci-operator/jobs/openshift/verification-tests/openshift-verification-tests-main-periodics.yaml
@@ -60705,6 +60705,2302 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
+  cluster: build01
+  cron: 45 1 13,27 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: verification-tests
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-qe
+    ci-operator.openshift.io/variant: installation-stable-4.22
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-verification-tests-main-installation-stable-4.22-aws-ipi-additional-ca-always-arm-f14
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=aws-ipi-additional-ca-always-arm-f14
+      - --variant=installation-stable-4.22
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build01
+  cron: 19 7 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: verification-tests
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-qe
+    ci-operator.openshift.io/variant: installation-stable-4.22
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-verification-tests-main-installation-stable-4.22-aws-ipi-all-instance-types-f1
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=aws-ipi-all-instance-types-f1
+      - --variant=installation-stable-4.22
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build01
+  cron: 34 18 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: verification-tests
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-qe
+    ci-operator.openshift.io/variant: installation-stable-4.22
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-verification-tests-main-installation-stable-4.22-aws-ipi-all-localzones-f1
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=aws-ipi-all-localzones-f1
+      - --variant=installation-stable-4.22
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build01
+  cron: 56 4 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: verification-tests
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-qe
+    ci-operator.openshift.io/variant: installation-stable-4.22
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-verification-tests-main-installation-stable-4.22-aws-ipi-all-regions-f1
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=aws-ipi-all-regions-f1
+      - --variant=installation-stable-4.22
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build01
+  cron: 21 23 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: verification-tests
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-qe
+    ci-operator.openshift.io/variant: installation-stable-4.22
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-verification-tests-main-installation-stable-4.22-aws-ipi-all-wavelength-zones-f1
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=aws-ipi-all-wavelength-zones-f1
+      - --variant=installation-stable-4.22
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build01
+  cron: 35 7 11 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: verification-tests
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-qe
+    ci-operator.openshift.io/variant: installation-stable-4.22
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-verification-tests-main-installation-stable-4.22-aws-ipi-arm-f28-ota
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=aws-ipi-arm-f28-ota
+      - --variant=installation-stable-4.22
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build01
+  cron: 13 12 17 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: verification-tests
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-qe
+    ci-operator.openshift.io/variant: installation-stable-4.22
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-verification-tests-main-installation-stable-4.22-aws-ipi-byo-iam-profile-master-arm-f28
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=aws-ipi-byo-iam-profile-master-arm-f28
+      - --variant=installation-stable-4.22
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build01
+  cron: 55 9 9 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: verification-tests
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-qe
+    ci-operator.openshift.io/variant: installation-stable-4.22
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-verification-tests-main-installation-stable-4.22-aws-ipi-byo-iam-profile-worker-arm-f28
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=aws-ipi-byo-iam-profile-worker-arm-f28
+      - --variant=installation-stable-4.22
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build01
+  cron: 56 18 29 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: verification-tests
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-qe
+    ci-operator.openshift.io/variant: installation-stable-4.22
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-verification-tests-main-installation-stable-4.22-aws-ipi-byo-iam-role-master-arm-f28
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=aws-ipi-byo-iam-role-master-arm-f28
+      - --variant=installation-stable-4.22
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build01
+  cron: 27 17 14 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: verification-tests
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-qe
+    ci-operator.openshift.io/variant: installation-stable-4.22
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-verification-tests-main-installation-stable-4.22-aws-ipi-byo-iam-role-worker-arm-f28
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=aws-ipi-byo-iam-role-worker-arm-f28
+      - --variant=installation-stable-4.22
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build01
+  cron: 36 1 1,15 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: verification-tests
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-qe
+    ci-operator.openshift.io/variant: installation-stable-4.22
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-verification-tests-main-installation-stable-4.22-aws-ipi-byo-subnets-role-only-public-mini-perm-arm-f14
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=aws-ipi-byo-subnets-role-only-public-mini-perm-arm-f14
+      - --variant=installation-stable-4.22
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build01
+  cron: 11 3 1,8,15,22 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: verification-tests
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-qe
+    ci-operator.openshift.io/variant: installation-stable-4.22
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-verification-tests-main-installation-stable-4.22-aws-ipi-custom-dns-mini-perm-arm-f7
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=aws-ipi-custom-dns-mini-perm-arm-f7
+      - --variant=installation-stable-4.22
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build01
+  cron: 19 11 1,8,15,22 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: verification-tests
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-qe
+    ci-operator.openshift.io/variant: installation-stable-4.22
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-verification-tests-main-installation-stable-4.22-aws-ipi-custom-dns-priv-mini-perm-arm-f7
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=aws-ipi-custom-dns-priv-mini-perm-arm-f7
+      - --variant=installation-stable-4.22
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build01
+  cron: 6 12 27 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: verification-tests
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-qe
+    ci-operator.openshift.io/variant: installation-stable-4.22
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-verification-tests-main-installation-stable-4.22-aws-ipi-custom-proxy-creds-arm-f28
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=aws-ipi-custom-proxy-creds-arm-f28
+      - --variant=installation-stable-4.22
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build01
+  cron: 52 21 3,12,19,26 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: verification-tests
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-qe
+    ci-operator.openshift.io/variant: installation-stable-4.22
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-verification-tests-main-installation-stable-4.22-aws-ipi-default-mini-perm-arm-f7
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=aws-ipi-default-mini-perm-arm-f7
+      - --variant=installation-stable-4.22
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build01
+  cron: 33 18 7,21 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: verification-tests
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-qe
+    ci-operator.openshift.io/variant: installation-stable-4.22
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-verification-tests-main-installation-stable-4.22-aws-ipi-multi-cidr-arm-f14
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=aws-ipi-multi-cidr-arm-f14
+      - --variant=installation-stable-4.22
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build01
+  cron: 19 12 4,18 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: verification-tests
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-qe
+    ci-operator.openshift.io/variant: installation-stable-4.22
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-verification-tests-main-installation-stable-4.22-aws-ipi-multi-clusters-one-phz-arm-f14
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=aws-ipi-multi-clusters-one-phz-arm-f14
+      - --variant=installation-stable-4.22
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build01
+  cron: 57 4 10,26 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: verification-tests
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-qe
+    ci-operator.openshift.io/variant: installation-stable-4.22
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-verification-tests-main-installation-stable-4.22-aws-ipi-only-public-subnets-mini-perm-arm-f14
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=aws-ipi-only-public-subnets-mini-perm-arm-f14
+      - --variant=installation-stable-4.22
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build01
+  cron: 38 4 8 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: verification-tests
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-qe
+    ci-operator.openshift.io/variant: installation-stable-4.22
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-verification-tests-main-installation-stable-4.22-aws-ipi-proxy-blocklist-arm-f28-ota
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=aws-ipi-proxy-blocklist-arm-f28-ota
+      - --variant=installation-stable-4.22
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build01
+  cron: 56 23 7 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: verification-tests
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-qe
+    ci-operator.openshift.io/variant: installation-stable-4.22
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-verification-tests-main-installation-stable-4.22-aws-ipi-proxy-reboot-nodes-arm-f28
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=aws-ipi-proxy-reboot-nodes-arm-f28
+      - --variant=installation-stable-4.22
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build01
+  cron: 26 4 2,18 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: verification-tests
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-qe
+    ci-operator.openshift.io/variant: installation-stable-4.22
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-verification-tests-main-installation-stable-4.22-aws-ipi-proxy-whitelist-arm-f14
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=aws-ipi-proxy-whitelist-arm-f14
+      - --variant=installation-stable-4.22
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build01
+  cron: 31 8 14,28 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: verification-tests
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-qe
+    ci-operator.openshift.io/variant: installation-stable-4.22
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-verification-tests-main-installation-stable-4.22-aws-ipi-shared-phz-f14
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=aws-ipi-shared-phz-f14
+      - --variant=installation-stable-4.22
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build01
+  cron: 10 3 15,29 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: verification-tests
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-qe
+    ci-operator.openshift.io/variant: installation-stable-4.22
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-verification-tests-main-installation-stable-4.22-aws-ipi-shared-phz-sts-f14
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=aws-ipi-shared-phz-sts-f14
+      - --variant=installation-stable-4.22
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build01
+  cron: 7 4 12,26 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: verification-tests
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-qe
+    ci-operator.openshift.io/variant: installation-stable-4.22
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-verification-tests-main-installation-stable-4.22-aws-ipi-valid-endpoints-f14
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=aws-ipi-valid-endpoints-f14
+      - --variant=installation-stable-4.22
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build01
+  cron: 22 14 2,16 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: verification-tests
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-qe
+    ci-operator.openshift.io/variant: installation-stable-4.22
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-verification-tests-main-installation-stable-4.22-aws-ipi-valid-lb-subnet-f14
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=aws-ipi-valid-lb-subnet-f14
+      - --variant=installation-stable-4.22
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build01
+  cron: 16 22 10,26 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: verification-tests
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-qe
+    ci-operator.openshift.io/variant: installation-stable-4.22
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-verification-tests-main-installation-stable-4.22-aws-ipi-zone-consistency-f14
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=aws-ipi-zone-consistency-f14
+      - --variant=installation-stable-4.22
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build01
+  cron: 1 4 12 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: verification-tests
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-qe
+    ci-operator.openshift.io/variant: installation-stable-4.22
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-verification-tests-main-installation-stable-4.22-aws-upi-reboot-nodes-f28
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=aws-upi-reboot-nodes-f28
+      - --variant=installation-stable-4.22
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build08
+  cron: 41 19 5,12,19,26 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: verification-tests
+  labels:
+    ci-operator.openshift.io/cloud: aws-usgov
+    ci-operator.openshift.io/cloud-cluster-profile: aws-usgov-qe
+    ci-operator.openshift.io/variant: installation-stable-4.22
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-verification-tests-main-installation-stable-4.22-aws-usgov-ipi-custom-dns-mini-perm-arm-f7
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=aws-usgov-ipi-custom-dns-mini-perm-arm-f7
+      - --variant=installation-stable-4.22
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
   cluster: build08
   cron: '@yearly'
   decorate: true


### PR DESCRIPTION
This PR is meant for experimenting with job configurations in order to run verification tests against RC releases.

/hold

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added extensive verification-tests CI configuration for OpenShift stable 4.22 covering multiple architectures, cloud regions/zones, instance types, proxy/credential scenarios, BYO IAM modes, DNS/CA/OTA variations, and rehearsal workflows for broader installer case coverage.
  * Updated validation and health/proxy check workflows to expand cluster and release scenario coverage.
* **Chores**
  * Normalized release descriptor format for 4.22 CI entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->