### PR TITLE
NTO: clearing servers for a new cluster

### DIFF
--- a/ci-operator/config/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main__compute-nto.yaml
+++ b/ci-operator/config/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main__compute-nto.yaml
@@ -71,11 +71,11 @@ tests:
 - as: e2e-telcov10n-nto-tests-upgrade-4-19
   capabilities:
   - intranet
-  cron: 59 23 * * 6
+  cron: 59 11 * * 6
   steps:
     env:
       CGROUP_VERSION: v2
-      CLUSTER_NAME: hlxcl52
+      CLUSTER_NAME: hlxcl15
       CONTAINER_RUNTIME: crun
       DAY0_INSTALLATION: "false"
       FEATURES: compute
@@ -163,7 +163,7 @@ tests:
 - as: e2e-telcov10n-nto-tests-v1-runc-bm-4-14
   capabilities:
   - intranet
-  cron: 59 11 * * 6
+  cron: 59 11 * * 2
   steps:
     env:
       CGROUP_VERSION: v1

--- a/ci-operator/jobs/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main-periodics.yaml
@@ -4876,7 +4876,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build05
-  cron: 59 23 * * 6
+  cron: 59 11 * * 6
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -5134,7 +5134,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build05
-  cron: 59 11 * * 6
+  cron: 59 11 * * 2
   decorate: true
   decoration_config:
     skip_cloning: true


### PR DESCRIPTION
- clear heilx51 and helix52 as part of migration for baremetal workers only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated compute-nto E2E test job execution schedules to optimize test timing.
  * Adjusted cluster resource assignments for test operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->