### PR TITLE
NO-ISSUE: Use 4.20 for virt / AI bundle jobs as not all operators are available in 4.21

### DIFF
--- a/ci-operator/config/openshift/assisted-service/openshift-assisted-service-master__edge.yaml
+++ b/ci-operator/config/openshift/assisted-service/openshift-assisted-service-master__edge.yaml
@@ -1271,7 +1271,7 @@ tests:
         LOAD_BALANCER_TYPE=user-managed
       PLATFORM: vsphere
     workflow: assisted-vsphere-external-lb
-- as: e2e-metal-assisted-virtualization-4-21
+- as: e2e-metal-assisted-virtualization-4-20
   capabilities:
   - intranet
   run_if_changed: ^(internal/operators/.*\.go)$
@@ -1280,7 +1280,7 @@ tests:
     env:
       ASSISTED_CONFIG: |
         OLM_BUNDLES=virtualization
-        OPENSHIFT_VERSION=4.21
+        OPENSHIFT_VERSION=4.20
         MASTER_MEMORY=18700
         MASTER_CPU=10
         MASTER_DISK_COUNT=2

--- a/ci-operator/config/openshift/assisted-service/openshift-assisted-service-v2.52.yaml
+++ b/ci-operator/config/openshift/assisted-service/openshift-assisted-service-v2.52.yaml
@@ -269,7 +269,7 @@ tests:
       ASSISTED_CONFIG: |
         SERVICE_BASE_REF=v2.52
         OLM_BUNDLES=virtualization
-        OPENSHIFT_VERSION=4.22
+        OPENSHIFT_VERSION=4.20
         MASTER_MEMORY=18700
         MASTER_CPU=10
         MASTER_DISK_COUNT=2

--- a/ci-operator/config/openshift/assisted-test-infra/openshift-assisted-test-infra-master.yaml
+++ b/ci-operator/config/openshift/assisted-test-infra/openshift-assisted-test-infra-master.yaml
@@ -1015,7 +1015,7 @@ tests:
       PLATFORM: vsphere
     workflow: assisted-vsphere-external-lb
 - always_run: false
-  as: e2e-metal-assisted-virtualization-4-21
+  as: e2e-metal-assisted-virtualization-4-20
   capabilities:
   - intranet
   steps:
@@ -1023,7 +1023,7 @@ tests:
     env:
       ASSISTED_CONFIG: |
         OLM_BUNDLES=virtualization
-        OPENSHIFT_VERSION=4.21
+        OPENSHIFT_VERSION=4.20
         MASTER_MEMORY=18700
         MASTER_CPU=10
         MASTER_DISK_COUNT=2
@@ -1052,7 +1052,7 @@ tests:
       CLUSTERTYPE: assisted_large_el9
       REQUIRED_MEMORY_GIB: "400"
     workflow: assisted-ofcir-baremetal
-- as: e2e-metal-assisted-virtualization-4-21-periodic
+- as: e2e-metal-assisted-virtualization-4-20-periodic
   capabilities:
   - intranet
   cron: 30 11 * * 0,2,4
@@ -1061,7 +1061,7 @@ tests:
     env:
       ASSISTED_CONFIG: |
         OLM_BUNDLES=virtualization
-        OPENSHIFT_VERSION=4.21
+        OPENSHIFT_VERSION=4.20
         MASTER_MEMORY=18700
         MASTER_CPU=10
         MASTER_DISK_COUNT=2
@@ -1119,7 +1119,7 @@ tests:
         OPENSHIFT_VERSION=4.22
       CLUSTERTYPE: assisted_large_el9
     workflow: assisted-ofcir-baremetal
-- as: e2e-metal-assisted-openshift-ai-4-21-periodic
+- as: e2e-metal-assisted-openshift-ai-4-20-periodic
   capabilities:
   - intranet
   cron: 30 12 * * 0,2,4
@@ -1128,7 +1128,7 @@ tests:
     env:
       ASSISTED_CONFIG: |
         OLM_BUNDLES=openshift-ai
-        OPENSHIFT_VERSION=4.21
+        OPENSHIFT_VERSION=4.20
         NUM_WORKERS=3
         WORKER_MEMORY=65536
         WORKER_CPU=20

--- a/ci-operator/jobs/openshift/assisted-service/openshift-assisted-service-master-presubmits.yaml
+++ b/ci-operator/jobs/openshift/assisted-service/openshift-assisted-service-master-presubmits.yaml
@@ -5049,8 +5049,8 @@ presubmits:
     branches:
     - ^master$
     - ^master-
-    cluster: build05
-    context: ci/prow/edge-e2e-metal-assisted-virtualization-4-21
+    cluster: build03
+    context: ci/prow/edge-e2e-metal-assisted-virtualization-4-20
     decorate: true
     labels:
       capability/intranet: intranet
@@ -5060,8 +5060,8 @@ presubmits:
       ci.openshift.io/generator: prowgen
       job-release: "4.22"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-assisted-service-master-edge-e2e-metal-assisted-virtualization-4-21
-    rerun_command: /test edge-e2e-metal-assisted-virtualization-4-21
+    name: pull-ci-openshift-assisted-service-master-edge-e2e-metal-assisted-virtualization-4-20
+    rerun_command: /test edge-e2e-metal-assisted-virtualization-4-20
     run_if_changed: ^(internal/operators/.*\.go)$
     spec:
       containers:
@@ -5071,7 +5071,7 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-metal-assisted-virtualization-4-21
+        - --target=e2e-metal-assisted-virtualization-4-20
         - --variant=edge
         command:
         - ci-operator
@@ -5128,7 +5128,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )edge-e2e-metal-assisted-virtualization-4-21,?($|\s.*)
+    trigger: (?m)^/test( | .* )edge-e2e-metal-assisted-virtualization-4-20,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:

--- a/ci-operator/jobs/openshift/assisted-test-infra/openshift-assisted-test-infra-master-periodics.yaml
+++ b/ci-operator/jobs/openshift/assisted-test-infra/openshift-assisted-test-infra-master-periodics.yaml
@@ -2096,7 +2096,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-assisted-test-infra-master-e2e-metal-assisted-openshift-ai-4-21-periodic
+  name: periodic-ci-openshift-assisted-test-infra-master-e2e-metal-assisted-openshift-ai-4-20-periodic
   spec:
     containers:
     - args:
@@ -2105,7 +2105,7 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=e2e-metal-assisted-openshift-ai-4-21-periodic
+      - --target=e2e-metal-assisted-openshift-ai-4-20-periodic
       command:
       - ci-operator
       env:
@@ -2575,7 +2575,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-assisted-test-infra-master-e2e-metal-assisted-virtualization-4-21-periodic
+  name: periodic-ci-openshift-assisted-test-infra-master-e2e-metal-assisted-virtualization-4-20-periodic
   spec:
     containers:
     - args:
@@ -2584,7 +2584,7 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=e2e-metal-assisted-virtualization-4-21-periodic
+      - --target=e2e-metal-assisted-virtualization-4-20-periodic
       command:
       - ci-operator
       env:

--- a/ci-operator/jobs/openshift/assisted-test-infra/openshift-assisted-test-infra-master-presubmits.yaml
+++ b/ci-operator/jobs/openshift/assisted-test-infra/openshift-assisted-test-infra-master-presubmits.yaml
@@ -3053,8 +3053,8 @@ presubmits:
     branches:
     - ^master$
     - ^master-
-    cluster: build09
-    context: ci/prow/e2e-metal-assisted-virtualization-4-21
+    cluster: build07
+    context: ci/prow/e2e-metal-assisted-virtualization-4-20
     decorate: true
     labels:
       capability/intranet: intranet
@@ -3063,8 +3063,8 @@ presubmits:
       ci.openshift.io/generator: prowgen
       job-release: "4.22"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-assisted-test-infra-master-e2e-metal-assisted-virtualization-4-21
-    rerun_command: /test e2e-metal-assisted-virtualization-4-21
+    name: pull-ci-openshift-assisted-test-infra-master-e2e-metal-assisted-virtualization-4-20
+    rerun_command: /test e2e-metal-assisted-virtualization-4-20
     spec:
       containers:
       - args:
@@ -3073,7 +3073,7 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-metal-assisted-virtualization-4-21
+        - --target=e2e-metal-assisted-virtualization-4-20
         command:
         - ci-operator
         env:
@@ -3129,7 +3129,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )(e2e-metal-assisted-virtualization-4-21|remaining-required),?($|\s.*)
+    trigger: (?m)^/test( | .* )(e2e-metal-assisted-virtualization-4-20|remaining-required),?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI test configurations to use OpenShift version 4.20 (replacing prior 4.21/4.22 values).
  * Renamed assisted virtualization test entries from "-4-21" to "-4-20" (including periodic variants).
  * Renamed assisted OpenShift AI periodic test entry from "-4-21-periodic" to "-4-20-periodic".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->