### PR TITLE
test: 1.21 and 1.22 Results CI testing

### DIFF
--- a/ci-operator/config/openshift-pipelines/performance/openshift-pipelines-performance-main.yaml
+++ b/ci-operator/config/openshift-pipelines/performance/openshift-pipelines-performance-main.yaml
@@ -2300,6 +2300,37 @@ tests:
       TOTAL_TIMEOUT: "2700"
     workflow: openshift-pipelines-scaling-pipelines
   timeout: 8h0m0s
+- always_run: false
+  as: tkn-res-downstream-1-22-s3-locust-2-lsr
+  optional: true
+  steps:
+    cluster_profile: aws-pipelines-performance
+    env:
+      CHAINS_WAIT_TIME: "0"
+      DEPLOYMENT_RESULTS_WATCHER_DISABLE_STORING_INCOMPLETE_RUNS: "true"
+      DEPLOYMENT_RESULTS_WATCHER_KUBE_API_BURST: "100"
+      DEPLOYMENT_RESULTS_WATCHER_KUBE_API_QPS: "50.0"
+      DEPLOYMENT_RESULTS_WATCHER_THREADINESS: "16"
+      DEPLOYMENT_VERSION: "1.22"
+      INSTALL_RESULTS: "true"
+      LOCUST_DURATION: 8m
+      LOCUST_SPAWN_RATE: "2"
+      LOCUST_USERS: "500"
+      LOCUST_WAIT_TIME: "1800"
+      LOCUST_WORKERS: "30"
+      MUST_GATHER_TIMEOUT: 35m
+      PRUNER_WAIT_TIME: "0"
+      RUN_LOCUST: "true"
+      STORE_LOGS_IN_S3: "true"
+      TEST_BIGBANG_MULTI_STEP__LINE_COUNT: "10"
+      TEST_BIGBANG_MULTI_STEP__STEP_COUNT: "1"
+      TEST_BIGBANG_MULTI_STEP__TASK_COUNT: "1"
+      TEST_CONCURRENT: "30"
+      TEST_NAMESPACE: "5"
+      TEST_SCENARIO: timebased-sign-pruner
+      TOTAL_TIMEOUT: "2700"
+    workflow: openshift-pipelines-scaling-pipelines
+  timeout: 8h0m0s
 zz_generated_metadata:
   branch: main
   org: openshift-pipelines

--- a/ci-operator/jobs/openshift-pipelines/performance/openshift-pipelines-performance-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-pipelines/performance/openshift-pipelines-performance-main-presubmits.yaml
@@ -12687,3 +12687,87 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )tkn-res-downstream-1-21-s3-locust-2-lsr,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build07
+    context: ci/prow/tkn-res-downstream-1-22-s3-locust-2-lsr
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+      timeout: 8h0m0s
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: aws-pipelines-performance
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-pipelines-performance-main-tkn-res-downstream-1-22-s3-locust-2-lsr
+    optional: true
+    rerun_command: /test tkn-res-downstream-1-22-s3-locust-2-lsr
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=tkn-res-downstream-1-22-s3-locust-2-lsr
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )tkn-res-downstream-1-22-s3-locust-2-lsr,?($|\s.*)

--- a/ci-operator/step-registry/openshift-pipelines/scaling-pipelines/openshift-pipelines-scaling-pipelines-ref.yaml
+++ b/ci-operator/step-registry/openshift-pipelines/scaling-pipelines/openshift-pipelines-scaling-pipelines-ref.yaml
@@ -129,6 +129,9 @@ ref:
     - name: LOCUST_WAIT_TIME
       default: "600"
       documentation: Wait time before starting locust test.
+    - name: CI_TEST_DUMMY_VARIABLE
+      default: "false"
+      documentation: Dummy variable for CI testing purposes - DO NOT USE IN PRODUCTION
   credentials:
     - mount_path: /usr/local/ci-secrets/openshift-pipelines-scaling-pipelines
       name: openshift-pipelines-perfscale


### PR DESCRIPTION
This is a test PR to trigger CI jobs for 1.21 Results testing. DO NOT MERGE - For CI validation purposes only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new CI/testing environment variable to internal test configuration.
  * Added a new scheduled performance test entry (optional, not always run) that exercises the scaling pipelines for the 1.22 deployment version using existing test settings and an 8-hour timeout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->