### PR TITLE
update the skip list for rosa conformance tests

### DIFF
--- a/ci-operator/step-registry/rosa/aws/sts/conformance/rosa-aws-sts-conformance-workflow.yaml
+++ b/ci-operator/step-registry/rosa/aws/sts/conformance/rosa-aws-sts-conformance-workflow.yaml
@@ -21,9 +21,9 @@ workflow:
         CPU Partitioning cluster infrastructure should be configured correctly\|
         Managed cluster should set requests but not limits\|
         Managed cluster should ensure platform components have system-\* priority class associated\|
-        cloud-provider-aws-e2e.*loadbalancer NLB internal should be reachable with hairpinning traffic\|
-        sig-network-edge.*GatewayAPIController\|
-        sig-olmv1.*NewOLM.*Catalog should serve FBC
+        \[cloud-provider-aws-e2e\] loadbalancer NLB internal should be reachable with hairpinning traffic\|
+        \[sig-network-edge\]\[OCPFeatureGate:GatewayAPIController\]\[Feature:Router\]\[apigroup:gateway.networking.k8s.io\]\|
+        \[sig-olmv1\]\[OCPFeatureGate:NewOLM\]\[Skipped:Disconnected\] OLMv1
     pre:
       - chain: rosa-aws-sts-provision
       - ref: osd-ccs-conf-idp-htpasswd-multi-users


### PR DESCRIPTION
The current test runs cannot skip the specified tests as expected.

Change the order to see if it is the expression issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Adjusted skip patterns in the ROSA AWS STS conformance workflow: three exclusion rules were updated to use more structured selectors (including bracketed prefixes, feature/feature-gate selectors, and status qualifiers) so test exclusions are more specific and reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->