### PR TITLE
Disable blunderbuss plugin for ROSA regional platform repos

### DIFF
--- a/core-services/prow/02_config/openshift-online/aws-nuke-cf/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-online/aws-nuke-cf/_pluginconfig.yaml
@@ -50,7 +50,6 @@ plugins:
   openshift-online/aws-nuke-cf:
     plugins:
     - assign
-    - blunderbuss
     - cat
     - dog
     - heart

--- a/core-services/prow/02_config/openshift-online/rosa-regional-platform-api/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-online/rosa-regional-platform-api/_pluginconfig.yaml
@@ -50,7 +50,6 @@ plugins:
   openshift-online/rosa-regional-platform-api:
     plugins:
     - assign
-    - blunderbuss
     - cat
     - dog
     - heart

--- a/core-services/prow/02_config/openshift-online/rosa-regional-platform-cli/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-online/rosa-regional-platform-cli/_pluginconfig.yaml
@@ -49,7 +49,6 @@ plugins:
   openshift-online/rosa-regional-platform-cli:
     plugins:
     - assign
-    - blunderbuss
     - cat
     - dog
     - heart

--- a/core-services/prow/02_config/openshift-online/rosa-regional-platform-internal/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-online/rosa-regional-platform-internal/_pluginconfig.yaml
@@ -50,7 +50,6 @@ plugins:
   openshift-online/rosa-regional-platform-internal:
     plugins:
     - assign
-    - blunderbuss
     - cat
     - dog
     - heart

--- a/core-services/prow/02_config/openshift-online/rosa-regional-platform/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-online/rosa-regional-platform/_pluginconfig.yaml
@@ -50,7 +50,6 @@ plugins:
   openshift-online/rosa-regional-platform:
     plugins:
     - assign
-    - blunderbuss
     - cat
     - dog
     - heart


### PR DESCRIPTION

## Summary

- Remove the `blunderbuss` plugin from 5 openshift-online repos:
  - `rosa-regional-platform`
  - `rosa-regional-platform-api`
  - `rosa-regional-platform-cli`
  - `rosa-regional-platform-internal`
  - `aws-nuke-cf`

## Motivation

The blunderbuss plugin automatically assigns reviewers on new PRs by
pulling from OWNERS approvers when no explicit reviewers are listed.
Our team prefers to manually select reviewers for each PR rather than
having them auto-assigned.

All other plugins (approve, lgtm, trigger, assign, etc.) remain
unchanged. Manual reviewer assignment via `/cc` or the GitHub UI
continues to work as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled the blunderbuss automation plugin across Prow configurations for multiple OpenShift Online infrastructure projects. This plugin is no longer active and will not execute automated actions on pull requests for affected repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->