### PR TITLE
Add ODH Hive pool utilization dashboard and alerts

### DIFF
--- a/clusters/app.ci/openshift-user-workload-monitoring/mixins/Makefile
+++ b/clusters/app.ci/openshift-user-workload-monitoring/mixins/Makefile
@@ -1,7 +1,7 @@
 #
 SHELL=/usr/bin/env bash -o pipefail
 
-dashboards = build-cop boskos boskos-acquire boskos-http canary configresolver deck e2e-template-jobs dptp ghproxy hook osde2e plank prow sinker tide cluster-pool ci-chat-bot osp-hive-dashboard
+dashboards = build-cop boskos boskos-acquire boskos-http canary configresolver deck e2e-template-jobs dptp ghproxy hook osde2e plank prow sinker tide cluster-pool ci-chat-bot odh-hive-dashboard osp-hive-dashboard
 
 all: $(dashboards) ci-alerts_prometheusrule.yaml alertmanager-user-workload-secret_template.yaml
 

--- a/clusters/app.ci/openshift-user-workload-monitoring/mixins/_grafana_dashboards/odh-hive-dashboard.jsonnet
+++ b/clusters/app.ci/openshift-user-workload-monitoring/mixins/_grafana_dashboards/odh-hive-dashboard.jsonnet
@@ -1,0 +1,296 @@
+local config = import '../config.libsonnet';
+local grafana = import 'grafonnet/grafana.libsonnet';
+local dashboard = grafana.dashboard;
+local graphPanel = grafana.graphPanel;
+local prometheus = grafana.prometheus;
+local row = grafana.row;
+
+local legendConfig = {
+  interval: '1m',
+};
+
+local hiveDS = 'prometheus-k8s-on-hive';
+local prowDS = 'prometheus';
+local poolFilter = 'clusterpool_name=~"odh-.*|opendatahub-.*"';
+
+local dashboardConfig = {
+  uid: config._config.grafanaDashboardIDs['odh-hive-dashboard.json'],
+};
+
+local hiveQuery(metric) =
+  std.format('hive_clusterpool_clusterdeployments_%s{%s}', [metric, poolFilter]);
+
+local hiveQueryByPool(metric) =
+  std.format('sum(%s) by (clusterpool_name)', hiveQuery(metric));
+
+//-- Row 1: Pool Capacity Overview --
+
+local totalClustersPanel = (
+  graphPanel.new(
+    'ODH Total Clusters per Pool',
+    description='Total clusters (claimed + unclaimed) in each ODH Hive pool',
+    datasource=hiveDS,
+    legend_alignAsTable=true,
+    legend_values=true,
+    legend_max=true,
+    legend_min=true,
+    legend_current=true,
+    legend_sortDesc=true,
+    min='0',
+  ) + legendConfig
+).addTarget(
+  prometheus.target(
+    hiveQueryByPool('claimed') + '+' + hiveQueryByPool('unclaimed'),
+    legendFormat='{{clusterpool_name}}',
+  )
+);
+
+//-- Row 2: Claimed vs Available per Pool --
+
+local claimedUnclaimedPanel = (
+  graphPanel.new(
+    'ODH Claimed vs Unclaimed per Pool',
+    description='Claimed and unclaimed clusters per pool. Dashed lines show the configured target unclaimed count (spec.size) for each pool.',
+    datasource=hiveDS,
+    legend_alignAsTable=true,
+    legend_values=true,
+    legend_max=true,
+    legend_min=true,
+    legend_current=true,
+    legend_sortDesc=true,
+    min='0',
+  ) + legendConfig
+).addTarget(
+  prometheus.target(
+    hiveQueryByPool('claimed'),
+    legendFormat='claimed-{{clusterpool_name}}',
+  )
+).addTarget(
+  prometheus.target(
+    hiveQueryByPool('unclaimed'),
+    legendFormat='unclaimed-{{clusterpool_name}}',
+  )
+).addTarget(
+  prometheus.target(
+    'vector(12) and on() hive_clusterpool_clusterdeployments_unclaimed{clusterpool_name="odh-4-20-aws"}',
+    legendFormat='target-odh-4-20-aws (size=12)',
+  )
+).addTarget(
+  prometheus.target(
+    'vector(2) and on() hive_clusterpool_clusterdeployments_unclaimed{clusterpool_name="odh-4-19-aws"}',
+    legendFormat='target-odh-4-19-aws (size=2)',
+  )
+).addTarget(
+  prometheus.target(
+    'vector(1) and on() hive_clusterpool_clusterdeployments_unclaimed{clusterpool_name="opendatahub-ocp-4-18-amd64-aws"}',
+    legendFormat='target-4-18 (size=1)',
+  )
+) + {
+  targets: super.targets,
+  seriesOverrides+: [
+    { alias: '/target-.*/', dashes: true, fill: 0, linewidth: 2 },
+  ],
+};
+
+local assignablePanel = (
+  graphPanel.new(
+    'ODH Assignable Clusters per Pool',
+    description='Clusters ready to be claimed right now, per pool. Red zone = pool-exhausted alert (assignable == 0 for 10m).',
+    datasource=hiveDS,
+    legend_alignAsTable=true,
+    legend_values=true,
+    legend_max=true,
+    legend_min=true,
+    legend_current=true,
+    legend_sortDesc=true,
+    min='0',
+  ) + legendConfig
+).addTarget(
+  prometheus.target(
+    hiveQuery('assignable'),
+    legendFormat='{{clusterpool_name}}',
+  )
+) + {
+  thresholds: [
+    { value: 1, colorMode: 'critical', op: 'lt', fill: true, line: true, yaxis: 'left' },
+  ],
+};
+
+//-- Row 3: Unclaimed State Breakdown per Pool --
+
+local hivePanelForState(metric, displayName, desc) = (
+  graphPanel.new(
+    std.format('ODH %s Clusters per Pool', displayName),
+    description=desc,
+    datasource=hiveDS,
+    legend_alignAsTable=true,
+    legend_values=true,
+    legend_max=true,
+    legend_min=true,
+    legend_current=true,
+    legend_sortDesc=true,
+    min='0',
+  ) + legendConfig
+).addTarget(
+  prometheus.target(
+    hiveQuery(metric),
+    legendFormat='{{clusterpool_name}}',
+  )
+);
+
+local installingPanel = hivePanelForState(
+  'installing',
+  'Installing',
+  'Clusters being provisioned per pool. Dashed line = maxConcurrent (6). Orange zone = stuck-installing alert (> 5 for 30m).',
+).addTarget(
+  prometheus.target(
+    'vector(6) and on() hive_clusterpool_clusterdeployments_installing{clusterpool_name="odh-4-20-aws"}',
+    legendFormat='maxConcurrent (6)',
+  )
+) + {
+  targets: super.targets,
+  seriesOverrides+: [
+    { alias: 'maxConcurrent (6)', dashes: true, fill: 0, linewidth: 2 },
+  ],
+  thresholds: [
+    { value: 5, colorMode: 'warning', op: 'gt', fill: true, line: true, yaxis: 'left' },
+  ],
+};
+
+local standbyPanel = hivePanelForState(
+  'standby',
+  'Standby (Hibernated)',
+  'Clusters hibernated and waiting to resume per pool. These need ~20 min to wake up before they can be claimed.',
+);
+
+local brokenPanel = hivePanelForState(
+  'broken',
+  'Broken',
+  'Failed clusters per pool. Should be 0. If non-zero, check ClusterDeployment errors on hosted-mgmt in namespace opendatahub-cluster-pool.',
+);
+
+local claimActivityPanel = (
+  graphPanel.new(
+    'ODH Pool Activity (Claims + Releases)',
+    description='Number of times the claimed count changed per pool in a 30m window. Each claim and each release counts as one change, so the value is roughly 2x actual claims. Higher = busier pool.',
+    datasource=hiveDS,
+    legend_alignAsTable=true,
+    legend_values=true,
+    legend_max=true,
+    legend_min=true,
+    legend_current=true,
+    legend_sortDesc=true,
+    min='0',
+  ) + legendConfig
+).addTarget(
+  prometheus.target(
+    std.format('changes(%s[30m])', hiveQuery('claimed')),
+    legendFormat='{{clusterpool_name}}',
+  )
+);
+
+//-- Row 4: Prow Job Health --
+
+local e2eSuccessFailPanel = (
+  graphPanel.new(
+    'ODH E2E Job Success/Failure Count',
+    description='Number of successful, failed, and aborted ODH e2e Prow jobs in the last 1h window.',
+    datasource=prowDS,
+    legend_alignAsTable=true,
+    legend_values=true,
+    legend_max=true,
+    legend_min=true,
+    legend_current=true,
+    legend_sortDesc=true,
+    min='0',
+  ) + legendConfig
+).addTarget(
+  prometheus.target(
+    'sum(increase(prowjob_state_transitions{job_name=~".*opendatahub.*e2e.*",state="success"}[1h]))',
+    legendFormat='success',
+  )
+).addTarget(
+  prometheus.target(
+    'sum(increase(prowjob_state_transitions{job_name=~".*opendatahub.*e2e.*",state="failure"}[1h]))',
+    legendFormat='failure',
+  )
+).addTarget(
+  prometheus.target(
+    'sum(increase(prowjob_state_transitions{job_name=~".*opendatahub.*e2e.*",state="aborted"}[1h]))',
+    legendFormat='aborted',
+  )
+);
+
+local e2eFailureRatePanel = (
+  graphPanel.new(
+    'ODH E2E Failure Rate %',
+    description='Percentage of ODH e2e jobs that failed over a 2h window. Red zone = high-failure-rate alert (> 50% for 30m).',
+    datasource=prowDS,
+    legend_alignAsTable=true,
+    legend_values=true,
+    legend_max=true,
+    legend_min=true,
+    legend_current=true,
+    legend_sortDesc=true,
+    min='0',
+    max='100',
+    formatY1='percent',
+  ) + legendConfig
+).addTarget(
+  prometheus.target(
+    'sum(rate(prowjob_state_transitions{job_name=~".*opendatahub.*e2e.*",state="failure"}[2h])) / sum(rate(prowjob_state_transitions{job_name=~".*opendatahub.*e2e.*",state=~"success|failure"}[2h])) * 100',
+    legendFormat='failure rate %',
+  )
+) + {
+  thresholds: [
+    { value: 50, colorMode: 'critical', op: 'gt', fill: true, line: true, yaxis: 'left' },
+  ],
+};
+
+local allJobTransitionsPanel = (
+  graphPanel.new(
+    'ODH Job Outcome Count (All Jobs)',
+    description='Success, failure, and aborted counts for all ODH Prow jobs (not just e2e) in the last 1h window, stacked by state.',
+    datasource=prowDS,
+    legend_alignAsTable=true,
+    legend_values=true,
+    legend_max=true,
+    legend_min=true,
+    legend_current=true,
+    legend_sortDesc=true,
+    min='0',
+    stack=true,
+  ) + legendConfig
+).addTarget(
+  prometheus.target(
+    'sum(increase(prowjob_state_transitions{job_name=~".*opendatahub.*",state=~"success|failure|aborted"}[1h])) by (state)',
+    legendFormat='{{state}}',
+  )
+);
+
+//-- Assemble dashboard --
+
+dashboard.new(
+  'ODH Hive Pools & CI Health',
+  time_from='now-1d',
+  refresh='1m',
+  schemaVersion=18,
+)
+
+.addPanel(row.new(title='Pool Capacity Overview'), gridPos={ h: 1, w: 24, x: 0, y: 0 })
+.addPanel(totalClustersPanel, gridPos={ h: 9, w: 12, x: 0, y: 1 })
+.addPanel(claimedUnclaimedPanel, gridPos={ h: 9, w: 12, x: 12, y: 1 })
+
+.addPanel(row.new(title='Unclaimed State Breakdown (assignable + installing + standby + broken = unclaimed)'), gridPos={ h: 1, w: 24, x: 0, y: 10 })
+.addPanel(assignablePanel, gridPos={ h: 9, w: 12, x: 0, y: 11 })
+.addPanel(installingPanel, gridPos={ h: 9, w: 12, x: 12, y: 11 })
+.addPanel(standbyPanel, gridPos={ h: 9, w: 12, x: 0, y: 20 })
+.addPanel(brokenPanel, gridPos={ h: 9, w: 12, x: 12, y: 20 })
+
+.addPanel(row.new(title='Cluster Activity & Prow Job Health'), gridPos={ h: 1, w: 24, x: 0, y: 29 })
+.addPanel(claimActivityPanel, gridPos={ h: 9, w: 12, x: 0, y: 30 })
+.addPanel(e2eSuccessFailPanel, gridPos={ h: 9, w: 12, x: 12, y: 30 })
+.addPanel(allJobTransitionsPanel, gridPos={ h: 9, w: 12, x: 0, y: 39 })
+.addPanel(e2eFailureRatePanel, gridPos={ h: 9, w: 12, x: 12, y: 39 })
+
++ dashboardConfig

--- a/clusters/app.ci/openshift-user-workload-monitoring/mixins/_prometheus/odh_alerts.libsonnet
+++ b/clusters/app.ci/openshift-user-workload-monitoring/mixins/_prometheus/odh_alerts.libsonnet
@@ -1,0 +1,58 @@
+{
+  prometheusAlerts+:: {
+    groups+: [
+      {
+        name: 'odh-hive-pool-health',
+        rules: [
+          {
+            alert: 'odh-pool-exhausted',
+            expr: |||
+              hive_clusterpool_clusterdeployments_assignable{clusterpool_name=~"odh-.*|opendatahub-.*"} == 0
+            |||,
+            'for': '10m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              message: 'ODH Hive pool {{ $labels.clusterpool_name }} has no assignable clusters. E2e jobs will queue. Check the <https://ci-route-ci-grafana.apps.ci.l2s4.p1.openshiftapps.com/d/%s/odh-hive-pools-ci-health|ODH CI dashboard>.' % $._config.grafanaDashboardIDs['odh-hive-dashboard.json'],
+            },
+          },
+          {
+            alert: 'odh-clusters-stuck-installing',
+            expr: |||
+              hive_clusterpool_clusterdeployments_installing{clusterpool_name=~"odh-.*|opendatahub-.*"} > 5
+            |||,
+            'for': '30m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              message: 'ODH Hive pool {{ $labels.clusterpool_name }} has {{ $value }} clusters stuck installing. Check Hive logs on hosted-mgmt in namespace opendatahub-cluster-pool.',
+            },
+          },
+        ],
+      },
+      {
+        name: 'odh-e2e-job-health',
+        rules: [
+          {
+            alert: 'odh-e2e-high-failure-rate',
+            expr: |||
+              sum(rate(prowjob_state_transitions{job_name=~".*opendatahub.*e2e.*",state="failure"}[2h]))
+              /
+              sum(rate(prowjob_state_transitions{job_name=~".*opendatahub.*e2e.*",state=~"success|failure"}[2h]))
+              > 0.5
+            |||,
+            'for': '30m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              message: 'More than 50% of ODH e2e jobs are failing. Check recent failures at <https://prow.ci.openshift.org/?job=*opendatahub*e2e*|Prow>.',
+            },
+          },
+        ],
+      },
+    ],
+  },
+}

--- a/clusters/app.ci/openshift-user-workload-monitoring/mixins/_prometheus/prometheus.libsonnet
+++ b/clusters/app.ci/openshift-user-workload-monitoring/mixins/_prometheus/prometheus.libsonnet
@@ -10,4 +10,5 @@
 (import 'prow_alerts.libsonnet') +
 (import 'ci_chat_bot_alerts.libsonnet') +
 (import 'release_controller_alerts.libsonnet') +
-(import 'tide_alerts.libsonnet')
+(import 'tide_alerts.libsonnet') +
+(import 'odh_alerts.libsonnet')

--- a/clusters/app.ci/openshift-user-workload-monitoring/mixins/config.libsonnet
+++ b/clusters/app.ci/openshift-user-workload-monitoring/mixins/config.libsonnet
@@ -14,6 +14,7 @@
       'configresolver.json': '703f0ccf02cc4339a374b52eb10f653b',
       'clusterpool.json': '22491886c1e19dde8d2984bca82154c1',
       'ci-chat-bot.json': '63182a3ee8939d9b5c54b5c5ce97134c',
+      'odh-hive-dashboard.json': '066cdc06b370b6ac50dbfdec774bb8fe',
       'osp-hive-dashboard.json': '114c4a96cb93b35ef74ccf94c23b63f4',
     },
     alertManagerReceivers: {

--- a/clusters/app.ci/openshift-user-workload-monitoring/mixins/grafana_dashboards_out/odh-hive-dashboard.json
+++ b/clusters/app.ci/openshift-user-workload-monitoring/mixins/grafana_dashboards_out/odh-hive-dashboard.json
@@ -1,0 +1,1083 @@
+{
+   "__inputs": [ ],
+   "__requires": [ ],
+   "annotations": {
+      "list": [ ]
+   },
+   "editable": false,
+   "gnetId": null,
+   "graphTooltip": 0,
+   "hideControls": false,
+   "id": null,
+   "links": [ ],
+   "panels": [
+      {
+         "collapse": false,
+         "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+         },
+         "id": 2,
+         "panels": [ ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "Pool Capacity Overview",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "prometheus-k8s-on-hive",
+         "description": "Total clusters (claimed + unclaimed) in each ODH Hive pool",
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 1
+         },
+         "id": 3,
+         "interval": "1m",
+         "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "sum(hive_clusterpool_clusterdeployments_claimed{clusterpool_name=~\"odh-.*|opendatahub-.*\"}) by (clusterpool_name)+sum(hive_clusterpool_clusterdeployments_unclaimed{clusterpool_name=~\"odh-.*|opendatahub-.*\"}) by (clusterpool_name)",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{clusterpool_name}}",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "ODH Total Clusters per Pool",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": "0",
+               "show": true
+            },
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": "0",
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "prometheus-k8s-on-hive",
+         "description": "Claimed and unclaimed clusters per pool. Dashed lines show the configured target unclaimed count (spec.size) for each pool.",
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 1
+         },
+         "id": 4,
+         "interval": "1m",
+         "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [
+            {
+               "alias": "/target-.*/",
+               "dashes": true,
+               "fill": 0,
+               "linewidth": 2
+            }
+         ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "sum(hive_clusterpool_clusterdeployments_claimed{clusterpool_name=~\"odh-.*|opendatahub-.*\"}) by (clusterpool_name)",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "claimed-{{clusterpool_name}}",
+               "refId": "A"
+            },
+            {
+               "expr": "sum(hive_clusterpool_clusterdeployments_unclaimed{clusterpool_name=~\"odh-.*|opendatahub-.*\"}) by (clusterpool_name)",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "unclaimed-{{clusterpool_name}}",
+               "refId": "B"
+            },
+            {
+               "expr": "vector(12) and on() hive_clusterpool_clusterdeployments_unclaimed{clusterpool_name=\"odh-4-20-aws\"}",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "target-odh-4-20-aws (size=12)",
+               "refId": "C"
+            },
+            {
+               "expr": "vector(2) and on() hive_clusterpool_clusterdeployments_unclaimed{clusterpool_name=\"odh-4-19-aws\"}",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "target-odh-4-19-aws (size=2)",
+               "refId": "D"
+            },
+            {
+               "expr": "vector(1) and on() hive_clusterpool_clusterdeployments_unclaimed{clusterpool_name=\"opendatahub-ocp-4-18-amd64-aws\"}",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "target-4-18 (size=1)",
+               "refId": "E"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "ODH Claimed vs Unclaimed per Pool",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": "0",
+               "show": true
+            },
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": "0",
+               "show": true
+            }
+         ]
+      },
+      {
+         "collapse": false,
+         "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 10
+         },
+         "id": 5,
+         "panels": [ ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "Unclaimed State Breakdown (assignable + installing + standby + broken = unclaimed)",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "prometheus-k8s-on-hive",
+         "description": "Clusters ready to be claimed right now, per pool. Red zone = pool-exhausted alert (assignable == 0 for 10m).",
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 11
+         },
+         "id": 6,
+         "interval": "1m",
+         "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "hive_clusterpool_clusterdeployments_assignable{clusterpool_name=~\"odh-.*|opendatahub-.*\"}",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{clusterpool_name}}",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [
+            {
+               "colorMode": "critical",
+               "fill": true,
+               "line": true,
+               "op": "lt",
+               "value": 1,
+               "yaxis": "left"
+            }
+         ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "ODH Assignable Clusters per Pool",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": "0",
+               "show": true
+            },
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": "0",
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "prometheus-k8s-on-hive",
+         "description": "Clusters being provisioned per pool. Dashed line = maxConcurrent (6). Orange zone = stuck-installing alert (> 5 for 30m).",
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 11
+         },
+         "id": 7,
+         "interval": "1m",
+         "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [
+            {
+               "alias": "maxConcurrent (6)",
+               "dashes": true,
+               "fill": 0,
+               "linewidth": 2
+            }
+         ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "hive_clusterpool_clusterdeployments_installing{clusterpool_name=~\"odh-.*|opendatahub-.*\"}",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{clusterpool_name}}",
+               "refId": "A"
+            },
+            {
+               "expr": "vector(6) and on() hive_clusterpool_clusterdeployments_installing{clusterpool_name=\"odh-4-20-aws\"}",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "maxConcurrent (6)",
+               "refId": "B"
+            }
+         ],
+         "thresholds": [
+            {
+               "colorMode": "warning",
+               "fill": true,
+               "line": true,
+               "op": "gt",
+               "value": 5,
+               "yaxis": "left"
+            }
+         ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "ODH Installing Clusters per Pool",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": "0",
+               "show": true
+            },
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": "0",
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "prometheus-k8s-on-hive",
+         "description": "Clusters hibernated and waiting to resume per pool. These need ~20 min to wake up before they can be claimed.",
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 20
+         },
+         "id": 8,
+         "interval": "1m",
+         "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "hive_clusterpool_clusterdeployments_standby{clusterpool_name=~\"odh-.*|opendatahub-.*\"}",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{clusterpool_name}}",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "ODH Standby (Hibernated) Clusters per Pool",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": "0",
+               "show": true
+            },
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": "0",
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "prometheus-k8s-on-hive",
+         "description": "Failed clusters per pool. Should be 0. If non-zero, check ClusterDeployment errors on hosted-mgmt in namespace opendatahub-cluster-pool.",
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 20
+         },
+         "id": 9,
+         "interval": "1m",
+         "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "hive_clusterpool_clusterdeployments_broken{clusterpool_name=~\"odh-.*|opendatahub-.*\"}",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{clusterpool_name}}",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "ODH Broken Clusters per Pool",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": "0",
+               "show": true
+            },
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": "0",
+               "show": true
+            }
+         ]
+      },
+      {
+         "collapse": false,
+         "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 29
+         },
+         "id": 10,
+         "panels": [ ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "Cluster Activity & Prow Job Health",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "prometheus-k8s-on-hive",
+         "description": "Number of times the claimed count changed per pool in a 30m window. Each claim and each release counts as one change, so the value is roughly 2x actual claims. Higher = busier pool.",
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 30
+         },
+         "id": 11,
+         "interval": "1m",
+         "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "changes(hive_clusterpool_clusterdeployments_claimed{clusterpool_name=~\"odh-.*|opendatahub-.*\"}[30m])",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{clusterpool_name}}",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "ODH Pool Activity (Claims + Releases)",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": "0",
+               "show": true
+            },
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": "0",
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "prometheus",
+         "description": "Number of successful, failed, and aborted ODH e2e Prow jobs in the last 1h window.",
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 30
+         },
+         "id": 12,
+         "interval": "1m",
+         "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "sum(increase(prowjob_state_transitions{job_name=~\".*opendatahub.*e2e.*\",state=\"success\"}[1h]))",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "success",
+               "refId": "A"
+            },
+            {
+               "expr": "sum(increase(prowjob_state_transitions{job_name=~\".*opendatahub.*e2e.*\",state=\"failure\"}[1h]))",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "failure",
+               "refId": "B"
+            },
+            {
+               "expr": "sum(increase(prowjob_state_transitions{job_name=~\".*opendatahub.*e2e.*\",state=\"aborted\"}[1h]))",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "aborted",
+               "refId": "C"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "ODH E2E Job Success/Failure Count",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": "0",
+               "show": true
+            },
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": "0",
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "prometheus",
+         "description": "Success, failure, and aborted counts for all ODH Prow jobs (not just e2e) in the last 1h window, stacked by state.",
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 39
+         },
+         "id": 13,
+         "interval": "1m",
+         "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": true,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "sum(increase(prowjob_state_transitions{job_name=~\".*opendatahub.*\",state=~\"success|failure|aborted\"}[1h])) by (state)",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{state}}",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "ODH Job Outcome Count (All Jobs)",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": "0",
+               "show": true
+            },
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": "0",
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "prometheus",
+         "description": "Percentage of ODH e2e jobs that failed over a 2h window. Red zone = high-failure-rate alert (> 50% for 30m).",
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 39
+         },
+         "id": 14,
+         "interval": "1m",
+         "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "sum(rate(prowjob_state_transitions{job_name=~\".*opendatahub.*e2e.*\",state=\"failure\"}[2h])) / sum(rate(prowjob_state_transitions{job_name=~\".*opendatahub.*e2e.*\",state=~\"success|failure\"}[2h])) * 100",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "failure rate %",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [
+            {
+               "colorMode": "critical",
+               "fill": true,
+               "line": true,
+               "op": "gt",
+               "value": 50,
+               "yaxis": "left"
+            }
+         ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "ODH E2E Failure Rate %",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "percent",
+               "label": null,
+               "logBase": 1,
+               "max": "100",
+               "min": "0",
+               "show": true
+            },
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": "100",
+               "min": "0",
+               "show": true
+            }
+         ]
+      }
+   ],
+   "refresh": "1m",
+   "rows": [ ],
+   "schemaVersion": 18,
+   "style": "dark",
+   "tags": [ ],
+   "templating": {
+      "list": [ ]
+   },
+   "time": {
+      "from": "now-1d",
+      "to": "now"
+   },
+   "timepicker": {
+      "refresh_intervals": [
+         "5s",
+         "10s",
+         "30s",
+         "1m",
+         "5m",
+         "15m",
+         "30m",
+         "1h",
+         "2h",
+         "1d"
+      ],
+      "time_options": [
+         "5m",
+         "15m",
+         "1h",
+         "6h",
+         "12h",
+         "24h",
+         "2d",
+         "7d",
+         "30d"
+      ]
+   },
+   "timezone": "browser",
+   "title": "ODH Hive Pools & CI Health",
+   "uid": "066cdc06b370b6ac50dbfdec774bb8fe",
+   "version": 0
+}

--- a/clusters/app.ci/openshift-user-workload-monitoring/mixins/grafana_dashboards_out/odh-hive-dashboard_grafanadashboard.yaml
+++ b/clusters/app.ci/openshift-user-workload-monitoring/mixins/grafana_dashboards_out/odh-hive-dashboard_grafanadashboard.yaml
@@ -1,0 +1,1095 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  labels:
+    app: grafana
+  name: odh-hive-dashboard
+  namespace: ci-grafana
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  json: |
+    {
+       "__inputs": [ ],
+       "__requires": [ ],
+       "annotations": {
+          "list": [ ]
+       },
+       "editable": false,
+       "gnetId": null,
+       "graphTooltip": 0,
+       "hideControls": false,
+       "id": null,
+       "links": [ ],
+       "panels": [
+          {
+             "collapse": false,
+             "collapsed": false,
+             "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 0
+             },
+             "id": 2,
+             "panels": [ ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Pool Capacity Overview",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "aliasColors": { },
+             "bars": false,
+             "dashLength": 10,
+             "dashes": false,
+             "datasource": "prometheus-k8s-on-hive",
+             "description": "Total clusters (claimed + unclaimed) in each ODH Hive pool",
+             "fill": 1,
+             "fillGradient": 0,
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 0,
+                "y": 1
+             },
+             "id": 3,
+             "interval": "1m",
+             "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": true,
+                "max": true,
+                "min": true,
+                "rightSide": false,
+                "show": true,
+                "sideWidth": null,
+                "sortDesc": true,
+                "total": false,
+                "values": true
+             },
+             "lines": true,
+             "linewidth": 1,
+             "links": [ ],
+             "nullPointMode": "null",
+             "percentage": false,
+             "pointradius": 5,
+             "points": false,
+             "renderer": "flot",
+             "repeat": null,
+             "seriesOverrides": [ ],
+             "spaceLength": 10,
+             "stack": false,
+             "steppedLine": false,
+             "targets": [
+                {
+                   "expr": "sum(hive_clusterpool_clusterdeployments_claimed{clusterpool_name=~\"odh-.*|opendatahub-.*\"}) by (clusterpool_name)+sum(hive_clusterpool_clusterdeployments_unclaimed{clusterpool_name=~\"odh-.*|opendatahub-.*\"}) by (clusterpool_name)",
+                   "format": "time_series",
+                   "intervalFactor": 2,
+                   "legendFormat": "{{clusterpool_name}}",
+                   "refId": "A"
+                }
+             ],
+             "thresholds": [ ],
+             "timeFrom": null,
+             "timeShift": null,
+             "title": "ODH Total Clusters per Pool",
+             "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+             },
+             "type": "graph",
+             "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": [ ]
+             },
+             "yaxes": [
+                {
+                   "format": "short",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": "0",
+                   "show": true
+                },
+                {
+                   "format": "short",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": "0",
+                   "show": true
+                }
+             ]
+          },
+          {
+             "aliasColors": { },
+             "bars": false,
+             "dashLength": 10,
+             "dashes": false,
+             "datasource": "prometheus-k8s-on-hive",
+             "description": "Claimed and unclaimed clusters per pool. Dashed lines show the configured target unclaimed count (spec.size) for each pool.",
+             "fill": 1,
+             "fillGradient": 0,
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 12,
+                "y": 1
+             },
+             "id": 4,
+             "interval": "1m",
+             "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": true,
+                "max": true,
+                "min": true,
+                "rightSide": false,
+                "show": true,
+                "sideWidth": null,
+                "sortDesc": true,
+                "total": false,
+                "values": true
+             },
+             "lines": true,
+             "linewidth": 1,
+             "links": [ ],
+             "nullPointMode": "null",
+             "percentage": false,
+             "pointradius": 5,
+             "points": false,
+             "renderer": "flot",
+             "repeat": null,
+             "seriesOverrides": [
+                {
+                   "alias": "/target-.*/",
+                   "dashes": true,
+                   "fill": 0,
+                   "linewidth": 2
+                }
+             ],
+             "spaceLength": 10,
+             "stack": false,
+             "steppedLine": false,
+             "targets": [
+                {
+                   "expr": "sum(hive_clusterpool_clusterdeployments_claimed{clusterpool_name=~\"odh-.*|opendatahub-.*\"}) by (clusterpool_name)",
+                   "format": "time_series",
+                   "intervalFactor": 2,
+                   "legendFormat": "claimed-{{clusterpool_name}}",
+                   "refId": "A"
+                },
+                {
+                   "expr": "sum(hive_clusterpool_clusterdeployments_unclaimed{clusterpool_name=~\"odh-.*|opendatahub-.*\"}) by (clusterpool_name)",
+                   "format": "time_series",
+                   "intervalFactor": 2,
+                   "legendFormat": "unclaimed-{{clusterpool_name}}",
+                   "refId": "B"
+                },
+                {
+                   "expr": "vector(12) and on() hive_clusterpool_clusterdeployments_unclaimed{clusterpool_name=\"odh-4-20-aws\"}",
+                   "format": "time_series",
+                   "intervalFactor": 2,
+                   "legendFormat": "target-odh-4-20-aws (size=12)",
+                   "refId": "C"
+                },
+                {
+                   "expr": "vector(2) and on() hive_clusterpool_clusterdeployments_unclaimed{clusterpool_name=\"odh-4-19-aws\"}",
+                   "format": "time_series",
+                   "intervalFactor": 2,
+                   "legendFormat": "target-odh-4-19-aws (size=2)",
+                   "refId": "D"
+                },
+                {
+                   "expr": "vector(1) and on() hive_clusterpool_clusterdeployments_unclaimed{clusterpool_name=\"opendatahub-ocp-4-18-amd64-aws\"}",
+                   "format": "time_series",
+                   "intervalFactor": 2,
+                   "legendFormat": "target-4-18 (size=1)",
+                   "refId": "E"
+                }
+             ],
+             "thresholds": [ ],
+             "timeFrom": null,
+             "timeShift": null,
+             "title": "ODH Claimed vs Unclaimed per Pool",
+             "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+             },
+             "type": "graph",
+             "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": [ ]
+             },
+             "yaxes": [
+                {
+                   "format": "short",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": "0",
+                   "show": true
+                },
+                {
+                   "format": "short",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": "0",
+                   "show": true
+                }
+             ]
+          },
+          {
+             "collapse": false,
+             "collapsed": false,
+             "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 10
+             },
+             "id": 5,
+             "panels": [ ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Unclaimed State Breakdown (assignable + installing + standby + broken = unclaimed)",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "aliasColors": { },
+             "bars": false,
+             "dashLength": 10,
+             "dashes": false,
+             "datasource": "prometheus-k8s-on-hive",
+             "description": "Clusters ready to be claimed right now, per pool. Red zone = pool-exhausted alert (assignable == 0 for 10m).",
+             "fill": 1,
+             "fillGradient": 0,
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 0,
+                "y": 11
+             },
+             "id": 6,
+             "interval": "1m",
+             "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": true,
+                "max": true,
+                "min": true,
+                "rightSide": false,
+                "show": true,
+                "sideWidth": null,
+                "sortDesc": true,
+                "total": false,
+                "values": true
+             },
+             "lines": true,
+             "linewidth": 1,
+             "links": [ ],
+             "nullPointMode": "null",
+             "percentage": false,
+             "pointradius": 5,
+             "points": false,
+             "renderer": "flot",
+             "repeat": null,
+             "seriesOverrides": [ ],
+             "spaceLength": 10,
+             "stack": false,
+             "steppedLine": false,
+             "targets": [
+                {
+                   "expr": "hive_clusterpool_clusterdeployments_assignable{clusterpool_name=~\"odh-.*|opendatahub-.*\"}",
+                   "format": "time_series",
+                   "intervalFactor": 2,
+                   "legendFormat": "{{clusterpool_name}}",
+                   "refId": "A"
+                }
+             ],
+             "thresholds": [
+                {
+                   "colorMode": "critical",
+                   "fill": true,
+                   "line": true,
+                   "op": "lt",
+                   "value": 1,
+                   "yaxis": "left"
+                }
+             ],
+             "timeFrom": null,
+             "timeShift": null,
+             "title": "ODH Assignable Clusters per Pool",
+             "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+             },
+             "type": "graph",
+             "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": [ ]
+             },
+             "yaxes": [
+                {
+                   "format": "short",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": "0",
+                   "show": true
+                },
+                {
+                   "format": "short",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": "0",
+                   "show": true
+                }
+             ]
+          },
+          {
+             "aliasColors": { },
+             "bars": false,
+             "dashLength": 10,
+             "dashes": false,
+             "datasource": "prometheus-k8s-on-hive",
+             "description": "Clusters being provisioned per pool. Dashed line = maxConcurrent (6). Orange zone = stuck-installing alert (> 5 for 30m).",
+             "fill": 1,
+             "fillGradient": 0,
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 12,
+                "y": 11
+             },
+             "id": 7,
+             "interval": "1m",
+             "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": true,
+                "max": true,
+                "min": true,
+                "rightSide": false,
+                "show": true,
+                "sideWidth": null,
+                "sortDesc": true,
+                "total": false,
+                "values": true
+             },
+             "lines": true,
+             "linewidth": 1,
+             "links": [ ],
+             "nullPointMode": "null",
+             "percentage": false,
+             "pointradius": 5,
+             "points": false,
+             "renderer": "flot",
+             "repeat": null,
+             "seriesOverrides": [
+                {
+                   "alias": "maxConcurrent (6)",
+                   "dashes": true,
+                   "fill": 0,
+                   "linewidth": 2
+                }
+             ],
+             "spaceLength": 10,
+             "stack": false,
+             "steppedLine": false,
+             "targets": [
+                {
+                   "expr": "hive_clusterpool_clusterdeployments_installing{clusterpool_name=~\"odh-.*|opendatahub-.*\"}",
+                   "format": "time_series",
+                   "intervalFactor": 2,
+                   "legendFormat": "{{clusterpool_name}}",
+                   "refId": "A"
+                },
+                {
+                   "expr": "vector(6) and on() hive_clusterpool_clusterdeployments_installing{clusterpool_name=\"odh-4-20-aws\"}",
+                   "format": "time_series",
+                   "intervalFactor": 2,
+                   "legendFormat": "maxConcurrent (6)",
+                   "refId": "B"
+                }
+             ],
+             "thresholds": [
+                {
+                   "colorMode": "warning",
+                   "fill": true,
+                   "line": true,
+                   "op": "gt",
+                   "value": 5,
+                   "yaxis": "left"
+                }
+             ],
+             "timeFrom": null,
+             "timeShift": null,
+             "title": "ODH Installing Clusters per Pool",
+             "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+             },
+             "type": "graph",
+             "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": [ ]
+             },
+             "yaxes": [
+                {
+                   "format": "short",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": "0",
+                   "show": true
+                },
+                {
+                   "format": "short",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": "0",
+                   "show": true
+                }
+             ]
+          },
+          {
+             "aliasColors": { },
+             "bars": false,
+             "dashLength": 10,
+             "dashes": false,
+             "datasource": "prometheus-k8s-on-hive",
+             "description": "Clusters hibernated and waiting to resume per pool. These need ~20 min to wake up before they can be claimed.",
+             "fill": 1,
+             "fillGradient": 0,
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 0,
+                "y": 20
+             },
+             "id": 8,
+             "interval": "1m",
+             "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": true,
+                "max": true,
+                "min": true,
+                "rightSide": false,
+                "show": true,
+                "sideWidth": null,
+                "sortDesc": true,
+                "total": false,
+                "values": true
+             },
+             "lines": true,
+             "linewidth": 1,
+             "links": [ ],
+             "nullPointMode": "null",
+             "percentage": false,
+             "pointradius": 5,
+             "points": false,
+             "renderer": "flot",
+             "repeat": null,
+             "seriesOverrides": [ ],
+             "spaceLength": 10,
+             "stack": false,
+             "steppedLine": false,
+             "targets": [
+                {
+                   "expr": "hive_clusterpool_clusterdeployments_standby{clusterpool_name=~\"odh-.*|opendatahub-.*\"}",
+                   "format": "time_series",
+                   "intervalFactor": 2,
+                   "legendFormat": "{{clusterpool_name}}",
+                   "refId": "A"
+                }
+             ],
+             "thresholds": [ ],
+             "timeFrom": null,
+             "timeShift": null,
+             "title": "ODH Standby (Hibernated) Clusters per Pool",
+             "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+             },
+             "type": "graph",
+             "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": [ ]
+             },
+             "yaxes": [
+                {
+                   "format": "short",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": "0",
+                   "show": true
+                },
+                {
+                   "format": "short",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": "0",
+                   "show": true
+                }
+             ]
+          },
+          {
+             "aliasColors": { },
+             "bars": false,
+             "dashLength": 10,
+             "dashes": false,
+             "datasource": "prometheus-k8s-on-hive",
+             "description": "Failed clusters per pool. Should be 0. If non-zero, check ClusterDeployment errors on hosted-mgmt in namespace opendatahub-cluster-pool.",
+             "fill": 1,
+             "fillGradient": 0,
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 12,
+                "y": 20
+             },
+             "id": 9,
+             "interval": "1m",
+             "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": true,
+                "max": true,
+                "min": true,
+                "rightSide": false,
+                "show": true,
+                "sideWidth": null,
+                "sortDesc": true,
+                "total": false,
+                "values": true
+             },
+             "lines": true,
+             "linewidth": 1,
+             "links": [ ],
+             "nullPointMode": "null",
+             "percentage": false,
+             "pointradius": 5,
+             "points": false,
+             "renderer": "flot",
+             "repeat": null,
+             "seriesOverrides": [ ],
+             "spaceLength": 10,
+             "stack": false,
+             "steppedLine": false,
+             "targets": [
+                {
+                   "expr": "hive_clusterpool_clusterdeployments_broken{clusterpool_name=~\"odh-.*|opendatahub-.*\"}",
+                   "format": "time_series",
+                   "intervalFactor": 2,
+                   "legendFormat": "{{clusterpool_name}}",
+                   "refId": "A"
+                }
+             ],
+             "thresholds": [ ],
+             "timeFrom": null,
+             "timeShift": null,
+             "title": "ODH Broken Clusters per Pool",
+             "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+             },
+             "type": "graph",
+             "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": [ ]
+             },
+             "yaxes": [
+                {
+                   "format": "short",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": "0",
+                   "show": true
+                },
+                {
+                   "format": "short",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": "0",
+                   "show": true
+                }
+             ]
+          },
+          {
+             "collapse": false,
+             "collapsed": false,
+             "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 29
+             },
+             "id": 10,
+             "panels": [ ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Cluster Activity & Prow Job Health",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "aliasColors": { },
+             "bars": false,
+             "dashLength": 10,
+             "dashes": false,
+             "datasource": "prometheus-k8s-on-hive",
+             "description": "Number of times the claimed count changed per pool in a 30m window. Each claim and each release counts as one change, so the value is roughly 2x actual claims. Higher = busier pool.",
+             "fill": 1,
+             "fillGradient": 0,
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 0,
+                "y": 30
+             },
+             "id": 11,
+             "interval": "1m",
+             "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": true,
+                "max": true,
+                "min": true,
+                "rightSide": false,
+                "show": true,
+                "sideWidth": null,
+                "sortDesc": true,
+                "total": false,
+                "values": true
+             },
+             "lines": true,
+             "linewidth": 1,
+             "links": [ ],
+             "nullPointMode": "null",
+             "percentage": false,
+             "pointradius": 5,
+             "points": false,
+             "renderer": "flot",
+             "repeat": null,
+             "seriesOverrides": [ ],
+             "spaceLength": 10,
+             "stack": false,
+             "steppedLine": false,
+             "targets": [
+                {
+                   "expr": "changes(hive_clusterpool_clusterdeployments_claimed{clusterpool_name=~\"odh-.*|opendatahub-.*\"}[30m])",
+                   "format": "time_series",
+                   "intervalFactor": 2,
+                   "legendFormat": "{{clusterpool_name}}",
+                   "refId": "A"
+                }
+             ],
+             "thresholds": [ ],
+             "timeFrom": null,
+             "timeShift": null,
+             "title": "ODH Pool Activity (Claims + Releases)",
+             "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+             },
+             "type": "graph",
+             "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": [ ]
+             },
+             "yaxes": [
+                {
+                   "format": "short",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": "0",
+                   "show": true
+                },
+                {
+                   "format": "short",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": "0",
+                   "show": true
+                }
+             ]
+          },
+          {
+             "aliasColors": { },
+             "bars": false,
+             "dashLength": 10,
+             "dashes": false,
+             "datasource": "prometheus",
+             "description": "Number of successful, failed, and aborted ODH e2e Prow jobs in the last 1h window.",
+             "fill": 1,
+             "fillGradient": 0,
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 12,
+                "y": 30
+             },
+             "id": 12,
+             "interval": "1m",
+             "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": true,
+                "max": true,
+                "min": true,
+                "rightSide": false,
+                "show": true,
+                "sideWidth": null,
+                "sortDesc": true,
+                "total": false,
+                "values": true
+             },
+             "lines": true,
+             "linewidth": 1,
+             "links": [ ],
+             "nullPointMode": "null",
+             "percentage": false,
+             "pointradius": 5,
+             "points": false,
+             "renderer": "flot",
+             "repeat": null,
+             "seriesOverrides": [ ],
+             "spaceLength": 10,
+             "stack": false,
+             "steppedLine": false,
+             "targets": [
+                {
+                   "expr": "sum(increase(prowjob_state_transitions{job_name=~\".*opendatahub.*e2e.*\",state=\"success\"}[1h]))",
+                   "format": "time_series",
+                   "intervalFactor": 2,
+                   "legendFormat": "success",
+                   "refId": "A"
+                },
+                {
+                   "expr": "sum(increase(prowjob_state_transitions{job_name=~\".*opendatahub.*e2e.*\",state=\"failure\"}[1h]))",
+                   "format": "time_series",
+                   "intervalFactor": 2,
+                   "legendFormat": "failure",
+                   "refId": "B"
+                },
+                {
+                   "expr": "sum(increase(prowjob_state_transitions{job_name=~\".*opendatahub.*e2e.*\",state=\"aborted\"}[1h]))",
+                   "format": "time_series",
+                   "intervalFactor": 2,
+                   "legendFormat": "aborted",
+                   "refId": "C"
+                }
+             ],
+             "thresholds": [ ],
+             "timeFrom": null,
+             "timeShift": null,
+             "title": "ODH E2E Job Success/Failure Count",
+             "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+             },
+             "type": "graph",
+             "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": [ ]
+             },
+             "yaxes": [
+                {
+                   "format": "short",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": "0",
+                   "show": true
+                },
+                {
+                   "format": "short",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": "0",
+                   "show": true
+                }
+             ]
+          },
+          {
+             "aliasColors": { },
+             "bars": false,
+             "dashLength": 10,
+             "dashes": false,
+             "datasource": "prometheus",
+             "description": "Success, failure, and aborted counts for all ODH Prow jobs (not just e2e) in the last 1h window, stacked by state.",
+             "fill": 1,
+             "fillGradient": 0,
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 0,
+                "y": 39
+             },
+             "id": 13,
+             "interval": "1m",
+             "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": true,
+                "max": true,
+                "min": true,
+                "rightSide": false,
+                "show": true,
+                "sideWidth": null,
+                "sortDesc": true,
+                "total": false,
+                "values": true
+             },
+             "lines": true,
+             "linewidth": 1,
+             "links": [ ],
+             "nullPointMode": "null",
+             "percentage": false,
+             "pointradius": 5,
+             "points": false,
+             "renderer": "flot",
+             "repeat": null,
+             "seriesOverrides": [ ],
+             "spaceLength": 10,
+             "stack": true,
+             "steppedLine": false,
+             "targets": [
+                {
+                   "expr": "sum(increase(prowjob_state_transitions{job_name=~\".*opendatahub.*\",state=~\"success|failure|aborted\"}[1h])) by (state)",
+                   "format": "time_series",
+                   "intervalFactor": 2,
+                   "legendFormat": "{{state}}",
+                   "refId": "A"
+                }
+             ],
+             "thresholds": [ ],
+             "timeFrom": null,
+             "timeShift": null,
+             "title": "ODH Job Outcome Count (All Jobs)",
+             "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+             },
+             "type": "graph",
+             "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": [ ]
+             },
+             "yaxes": [
+                {
+                   "format": "short",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": "0",
+                   "show": true
+                },
+                {
+                   "format": "short",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": "0",
+                   "show": true
+                }
+             ]
+          },
+          {
+             "aliasColors": { },
+             "bars": false,
+             "dashLength": 10,
+             "dashes": false,
+             "datasource": "prometheus",
+             "description": "Percentage of ODH e2e jobs that failed over a 2h window. Red zone = high-failure-rate alert (> 50% for 30m).",
+             "fill": 1,
+             "fillGradient": 0,
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 12,
+                "y": 39
+             },
+             "id": 14,
+             "interval": "1m",
+             "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": true,
+                "max": true,
+                "min": true,
+                "rightSide": false,
+                "show": true,
+                "sideWidth": null,
+                "sortDesc": true,
+                "total": false,
+                "values": true
+             },
+             "lines": true,
+             "linewidth": 1,
+             "links": [ ],
+             "nullPointMode": "null",
+             "percentage": false,
+             "pointradius": 5,
+             "points": false,
+             "renderer": "flot",
+             "repeat": null,
+             "seriesOverrides": [ ],
+             "spaceLength": 10,
+             "stack": false,
+             "steppedLine": false,
+             "targets": [
+                {
+                   "expr": "sum(rate(prowjob_state_transitions{job_name=~\".*opendatahub.*e2e.*\",state=\"failure\"}[2h])) / sum(rate(prowjob_state_transitions{job_name=~\".*opendatahub.*e2e.*\",state=~\"success|failure\"}[2h])) * 100",
+                   "format": "time_series",
+                   "intervalFactor": 2,
+                   "legendFormat": "failure rate %",
+                   "refId": "A"
+                }
+             ],
+             "thresholds": [
+                {
+                   "colorMode": "critical",
+                   "fill": true,
+                   "line": true,
+                   "op": "gt",
+                   "value": 50,
+                   "yaxis": "left"
+                }
+             ],
+             "timeFrom": null,
+             "timeShift": null,
+             "title": "ODH E2E Failure Rate %",
+             "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+             },
+             "type": "graph",
+             "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": [ ]
+             },
+             "yaxes": [
+                {
+                   "format": "percent",
+                   "label": null,
+                   "logBase": 1,
+                   "max": "100",
+                   "min": "0",
+                   "show": true
+                },
+                {
+                   "format": "short",
+                   "label": null,
+                   "logBase": 1,
+                   "max": "100",
+                   "min": "0",
+                   "show": true
+                }
+             ]
+          }
+       ],
+       "refresh": "1m",
+       "rows": [ ],
+       "schemaVersion": 18,
+       "style": "dark",
+       "tags": [ ],
+       "templating": {
+          "list": [ ]
+       },
+       "time": {
+          "from": "now-1d",
+          "to": "now"
+       },
+       "timepicker": {
+          "refresh_intervals": [
+             "5s",
+             "10s",
+             "30s",
+             "1m",
+             "5m",
+             "15m",
+             "30m",
+             "1h",
+             "2h",
+             "1d"
+          ],
+          "time_options": [
+             "5m",
+             "15m",
+             "1h",
+             "6h",
+             "12h",
+             "24h",
+             "2d",
+             "7d",
+             "30d"
+          ]
+       },
+       "timezone": "browser",
+       "title": "ODH Hive Pools & CI Health",
+       "uid": "066cdc06b370b6ac50dbfdec774bb8fe",
+       "version": 0
+    }

--- a/clusters/app.ci/openshift-user-workload-monitoring/mixins/prometheus_out/ci-alerts_prometheusrule.yaml
+++ b/clusters/app.ci/openshift-user-workload-monitoring/mixins/prometheus_out/ci-alerts_prometheusrule.yaml
@@ -603,3 +603,34 @@ spec:
       for: 60m
       labels:
         severity: critical
+  - name: odh-hive-pool-health
+    rules:
+    - alert: odh-pool-exhausted
+      annotations:
+        message: ODH Hive pool {{ $labels.clusterpool_name }} has no assignable clusters. E2e jobs will queue. Check the <https://ci-route-ci-grafana.apps.ci.l2s4.p1.openshiftapps.com/d/066cdc06b370b6ac50dbfdec774bb8fe/odh-hive-pools-ci-health|ODH CI dashboard>.
+      expr: |
+        hive_clusterpool_clusterdeployments_assignable{clusterpool_name=~"odh-.*|opendatahub-.*"} == 0
+      for: 10m
+      labels:
+        severity: critical
+    - alert: odh-clusters-stuck-installing
+      annotations:
+        message: ODH Hive pool {{ $labels.clusterpool_name }} has {{ $value }} clusters stuck installing. Check Hive logs on hosted-mgmt in namespace opendatahub-cluster-pool.
+      expr: |
+        hive_clusterpool_clusterdeployments_installing{clusterpool_name=~"odh-.*|opendatahub-.*"} > 5
+      for: 30m
+      labels:
+        severity: warning
+  - name: odh-e2e-job-health
+    rules:
+    - alert: odh-e2e-high-failure-rate
+      annotations:
+        message: More than 50% of ODH e2e jobs are failing. Check recent failures at <https://prow.ci.openshift.org/?job=*opendatahub*e2e*|Prow>.
+      expr: |
+        sum(rate(prowjob_state_transitions{job_name=~".*opendatahub.*e2e.*",state="failure"}[2h]))
+        /
+        sum(rate(prowjob_state_transitions{job_name=~".*opendatahub.*e2e.*",state=~"success|failure"}[2h]))
+        > 0.5
+      for: 30m
+      labels:
+        severity: warning


### PR DESCRIPTION
Adds a Grafana dashboard for monitoring OpenDataHub Hive cluster pool health and Prow e2e job metrics, with per-pool breakdown across odh-4-20-aws, odh-4-19-aws, and opendatahub-ocp-4-18-amd64-aws.

Includes 3 Prometheus alert rules: pool exhaustion, clusters stuck installing, and high e2e failure rate.

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "ODH Hive Pools & CI Health" Grafana dashboard (1m refresh, last 24h default) showing pool capacity, unclaimed state breakdown, per-pool activity, and ODH e2e job health.
  * Added Prometheus alerts for exhausted assignable pools, clusters stuck installing, and high ODH e2e failure rates (with warning/critical severities).
* **Chores**
  * Dashboard registration and generation updated to include the new dashboard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->