### PR TITLE
Fix KMM test step env var collision with Neuron job config

### DIFF
--- a/ci-operator/step-registry/aws-neuron-operator/conditional-e2e-rosa/aws-neuron-operator-conditional-e2e-rosa-workflow.yaml
+++ b/ci-operator/step-registry/aws-neuron-operator/conditional-e2e-rosa/aws-neuron-operator-conditional-e2e-rosa-workflow.yaml
@@ -43,6 +43,7 @@ workflow:
       best_effort: true
     - ref: aws-deprovision-stacks
       best_effort: true
+      timeout: 30m
   documentation: |-
     This workflow provisions a ROSA HCP cluster with 2x AWS Inferentia (inf2.8xlarge)
     compute nodes, then runs the AWS Neuron operator E2E tests conditionally

--- a/ci-operator/step-registry/aws-neuron-operator/e2e-rosa/aws-neuron-operator-e2e-rosa-workflow.yaml
+++ b/ci-operator/step-registry/aws-neuron-operator/e2e-rosa/aws-neuron-operator-e2e-rosa-workflow.yaml
@@ -43,6 +43,7 @@ workflow:
       best_effort: true
     - ref: aws-deprovision-stacks
       best_effort: true
+      timeout: 30m
   documentation: |-
     This workflow provisions a ROSA HCP cluster with 2x AWS Inferentia (inf2.8xlarge)
     compute nodes, then runs the AWS Neuron operator E2E tests using eco-gotests framework.

--- a/ci-operator/step-registry/aws-neuron-operator/kmm-test/aws-neuron-operator-kmm-test-commands.sh
+++ b/ci-operator/step-registry/aws-neuron-operator/kmm-test/aws-neuron-operator-kmm-test-commands.sh
@@ -38,10 +38,10 @@ fi
 
 cd /home/testuser || exit 1
 
-export ECO_TEST_FEATURES="${ECO_TEST_FEATURES:-modules}"
-export ECO_TEST_LABELS="${ECO_TEST_LABELS:-kmm-sanity}"
-export ECO_TEST_VERBOSE="${ECO_TEST_VERBOSE:-true}"
-export ECO_VERBOSE_LEVEL="${ECO_VERBOSE_LEVEL:-100}"
+export ECO_TEST_FEATURES="${KMM_TEST_FEATURES:-modules}"
+export ECO_TEST_LABELS="${KMM_TEST_LABELS:-kmm-sanity}"
+export ECO_TEST_VERBOSE="true"
+export ECO_VERBOSE_LEVEL="100"
 export ECO_DUMP_FAILED_TESTS="${ECO_DUMP_FAILED_TESTS:-true}"
 export ECO_REPORTS_DUMP_DIR="${ARTIFACT_DIR}"
 

--- a/ci-operator/step-registry/aws-neuron-operator/kmm-test/aws-neuron-operator-kmm-test-ref.yaml
+++ b/ci-operator/step-registry/aws-neuron-operator/kmm-test/aws-neuron-operator-kmm-test-ref.yaml
@@ -9,24 +9,18 @@ ref:
       memory: 256Mi
   timeout: 90m
   env:
-  - name: ECO_TEST_FEATURES
+  - name: KMM_TEST_FEATURES
     default: "modules"
-    documentation: The eco-gotests feature directories to run (space-separated).
-  - name: ECO_TEST_LABELS
+    documentation: The eco-gotests feature directories to run for KMM tests (space-separated).
+  - name: KMM_TEST_LABELS
     default: "kmm-sanity"
-    documentation: Ginkgo label filter expression for test selection.
+    documentation: Ginkgo label filter expression for KMM test selection.
   - name: ECO_HWACCEL_KMM_REGISTRY
     default: "quay.io/ocp-edge-qe"
     documentation: External registry used by KMM tests for pushing built module images.
   - name: ECO_HWACCEL_KMM_DEVICE_PLUGIN_IMAGE
     default: "quay.io/cvultur/device-plugin:latest-%s"
     documentation: Device plugin image template. The %s is replaced with the node architecture (amd64/arm64).
-  - name: ECO_TEST_VERBOSE
-    default: "true"
-    documentation: Enable verbose test output.
-  - name: ECO_VERBOSE_LEVEL
-    default: "100"
-    documentation: Verbosity level for klog output in tests.
   documentation: |-
     Runs KMM (Kernel Module Management) sanity tests using eco-gotests on a
     ROSA cluster where KMM is already installed. Validates basic KMM


### PR DESCRIPTION
## Summary
- Fixes the `aws-neuron-operator-kmm-test` step running 0 tests because `ECO_TEST_FEATURES` and `ECO_TEST_LABELS` were set to `neuron` by the job config, overriding the step defaults of `modules` and `kmm-sanity`
- Renames the step env vars to `KMM_TEST_FEATURES` and `KMM_TEST_LABELS` to avoid collision with the job-level Neuron vars
- The script now unconditionally sets `ECO_TEST_FEATURES` and `ECO_TEST_LABELS` from the KMM-specific vars

Fixes issue found in: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_neuron-ci/19/pull-ci-rh-ecosystem-edge-neuron-ci-main-4.20-stable-aws-neuron-operator-e2e/2049035222443364352

## Test plan
- [ ] `/test aws-neuron-operator-e2e` on neuron-ci PR to verify KMM tests now run with correct labels
- [ ] Verify log shows `Running KMM tests with features: modules` and `labels: kmm-sanity`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test configuration parameters for AWS Neuron Operator KMM testing
  * Simplified test output verbosity settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->