### PR TITLE
HYPERFLEET-1013: Add retry logic to API accessibility checks in E2E setup

### DIFF
--- a/ci-operator/step-registry/openshift-hyperfleet/e2e/setup/openshift-hyperfleet-e2e-setup-commands.sh
+++ b/ci-operator/step-registry/openshift-hyperfleet/e2e/setup/openshift-hyperfleet-e2e-setup-commands.sh
@@ -84,14 +84,36 @@ export MAESTRO_URL=http://${MAESTRO_EXTERNAL_IP}:8000
 echo "${MAESTRO_URL}" > "${SHARED_DIR}/maestro_url"
 
 
-log "=== Checking Hyperfleet API accessibility ==="
-if ! curl -f -X GET ${HYPERFLEET_API_URL}/api/hyperfleet/v1/clusters/; then
-  log "ERROR: Hyperfleet API is not accessible at ${HYPERFLEET_API_URL}"
+wait_for_api() {
+  local url="$1"
+  local name="$2"
+  local max_attempts="${API_RETRY_ATTEMPTS:-30}"
+  local wait_seconds="${API_RETRY_INTERVAL:-10}"
+
+  log "=== Waiting for ${name} to become accessible at ${url} ==="
+  for attempt in $(seq 1 "$max_attempts"); do
+    if curl -sf --connect-timeout 5 --max-time 10 -X GET "${url}" > /dev/null 2>&1; then
+      log "SUCCESS: ${name} is accessible (attempt ${attempt}/${max_attempts})"
+      return 0
+    fi
+    if [ "$attempt" -lt "$max_attempts" ]; then
+      log "Attempt ${attempt}/${max_attempts}: ${name} not yet accessible, retrying in ${wait_seconds}s..."
+      sleep "$wait_seconds"
+    else
+      log "Attempt ${attempt}/${max_attempts}: ${name} not yet accessible, no retries remaining"
+    fi
+  done
+
+  log "ERROR: ${name} is not accessible at ${url} after ${max_attempts} attempts"
+  log "Final attempt output for diagnostics:"
+  curl --connect-timeout 5 --max-time 10 -X GET "${url}" 2>&1 || true
+  return 1
+}
+
+if ! wait_for_api "${HYPERFLEET_API_URL}/api/hyperfleet/v1/clusters/" "Hyperfleet API"; then
   exit 1
 fi
 
-log "=== Checking Maestro API accessibility ==="
-if ! curl -f -X GET ${MAESTRO_URL}/api/maestro/v1/consumers; then
-  log "ERROR: Maestro API is not accessible at ${MAESTRO_URL}"
+if ! wait_for_api "${MAESTRO_URL}/api/maestro/v1/consumers" "Maestro API"; then
   exit 1
 fi

--- a/ci-operator/step-registry/openshift-hyperfleet/e2e/setup/openshift-hyperfleet-e2e-setup-ref.yaml
+++ b/ci-operator/step-registry/openshift-hyperfleet/e2e/setup/openshift-hyperfleet-e2e-setup-ref.yaml
@@ -45,6 +45,12 @@ ref:
   - name: SENTINEL_CHART_PATH
     default: "charts"
     documentation: The path to the charts directory within the Sentinel chart repository.
+  - name: API_RETRY_ATTEMPTS
+    default: "30"
+    documentation: Maximum number of retry attempts for API accessibility checks.
+  - name: API_RETRY_INTERVAL
+    default: "10"
+    documentation: Seconds to wait between API accessibility retry attempts.
   - name: IMAGE_REGISTRY
     default: "registry.ci.openshift.org"
     documentation: The container image registry to pull images from.


### PR DESCRIPTION
## Summary
- Replace single bare `curl` with a `wait_for_api` retry function (30 attempts, 10s interval, 5s connect timeout)
- Applies to both Hyperfleet API and Maestro API accessibility checks in the E2E setup step
- Fixes false-negative pipeline failures caused by GKE LoadBalancer propagation delays

## Context
The `release-0.2` tier0-candidate periodic job ([build 2049036212114558976](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-hyperfleet-hyperfleet-e2e-release-0.2-e2e-tier0-candidate/2049036212114558976)) failed because the setup step's single `curl` timed out waiting for the LoadBalancer IP to become routable — despite all 9 pods being healthy.

JIRA: [HYPERFLEET-1013](https://redhat.atlassian.net/browse/HYPERFLEET-1013)

## Test plan
- [ ] Verify the setup step retries and succeeds when LB takes a few seconds to propagate
- [ ] Verify the setup step still fails with a clear error when the API is genuinely unreachable
- [ ] Confirm retry progress is logged (attempt N/M) for debuggability

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[HYPERFLEET-1013]: https://redhat.atlassian.net/browse/HYPERFLEET-1013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved endpoint connectivity checks with configurable retry attempts and interval to make setup waits more resilient.
  * Enhanced logging during waits: shows ongoing polling, reports success with attempt counts, and provides a final diagnostic output on failure to aid troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->