### PR TITLE
test: rehearse LocalTagReferencePolicy fix for ci-tools images job

### DIFF
--- a/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-main-presubmits.yaml
@@ -411,7 +411,7 @@ presubmits:
         - --target=[images]
         command:
         - ci-operator
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        image: quay.io/prucek/ci-operator:latest
         imagePullPolicy: Always
         name: ""
         resources:


### PR DESCRIPTION
## Summary

- Uses a custom ci-operator image (`quay.io/prucek/ci-operator:latest`) for the `pull-ci-openshift-ci-tools-main-images` job to rehearse the `LocalTagReferencePolicy` fix from https://github.com/openshift/ci-tools/pull/5139
- The custom image switches input image tag reference policy from `Source` to `Local`, so builds pull base images from the internal registry instead of quay-proxy — avoiding "manifest unknown" failures when quay.io garbage-collects digests
- Also includes early-fail detection for "manifest unknown" errors to skip futile retries

This PR is temporary and will be closed after rehearsal validates the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI pipeline container image reference for presubmit job execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->