### PR TITLE
infra-periodics: enable PR lifecycle management for Azure/ARO-HCP

### DIFF
--- a/ci-operator/jobs/infra-periodics.yaml
+++ b/ci-operator/jobs/infra-periodics.yaml
@@ -365,6 +365,7 @@ periodics:
         comments:<2500
         repo:operator-framework/operator-sdk
         repo:openshift-eng/ai-helpers
+        repo:Azure/ARO-HCP
         -label:lifecycle/frozen
         -label:tide/merge-blocker
         label:lifecycle/rotten
@@ -457,6 +458,7 @@ periodics:
         comments:<2500
         repo:operator-framework/operator-sdk
         repo:openshift-eng/ai-helpers
+        repo:Azure/ARO-HCP
         -label:tide/merge-blocker
         -label:lifecycle/frozen
         label:lifecycle/stale
@@ -558,6 +560,7 @@ periodics:
         comments:<2500
         repo:operator-framework/operator-sdk
         repo:openshift-eng/ai-helpers
+        repo:Azure/ARO-HCP
         -label:lifecycle/frozen
         -label:lifecycle/stale
         -label:lifecycle/rotten


### PR DESCRIPTION
### What

Add `repo:Azure/ARO-HCP` to the three PR lifecycle periodic jobs:
- `periodic-issue-stale` — marks issues/PRs as stale after 90 days of inactivity
- `periodic-issue-rotten` — marks stale issues/PRs as rotten after 30 more days
- `periodic-issue-close` — closes rotten issues/PRs after 30 more days

### Why

Azure/ARO-HCP currently has no automated PR lifecycle management. Stale and forgotten PRs accumulate without being flagged or cleaned up.

Confirmed with DPTP helpdesk (@jguzik) that this is the correct mechanism for enabling fejta-bot-style lifecycle management for repos outside the openshift org.

### References

- DPTP Helpdesk thread (Slack, 2026-04-27)
- JIRA: [AROSLSRE-722](https://redhat.atlassian.net/browse/AROSLSRE-722)

[AROSLSRE-722]: https://redhat.atlassian.net/browse/AROSLSRE-722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ