### PR TITLE
OCPNODE-4055: Add periodic CI jobs for additional-storage-support tests

### DIFF
--- a/ci-operator/config/openshift/origin/openshift-origin-release-4.22.yaml
+++ b/ci-operator/config/openshift/origin/openshift-origin-release-4.22.yaml
@@ -838,6 +838,14 @@ tests:
   steps:
     cluster_profile: hypershift-aws
     workflow: hypershift-aws-conformance
+- as: e2e-gcp-ovn-additional-storage-support
+  interval: 168h
+  steps:
+    cluster_profile: openshift-org-gcp
+    env:
+      FEATURE_SET: TechPreviewNoUpgrade
+      TEST_SUITE: openshift/additional-storage-support
+    workflow: openshift-e2e-gcp-serial
 zz_generated_metadata:
   branch: release-4.22
   org: openshift

--- a/ci-operator/jobs/openshift/origin/openshift-origin-release-4.22-periodics.yaml
+++ b/ci-operator/jobs/openshift/origin/openshift-origin-release-4.22-periodics.yaml
@@ -1,0 +1,79 @@
+periodics:
+- agent: kubernetes
+  cluster: build04
+  decorate: true
+  extra_refs:
+  - base_ref: release-4.22
+    org: openshift
+    repo: origin
+  interval: 168h
+  labels:
+    ci-operator.openshift.io/cloud: gcp
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-origin-release-4.22-e2e-gcp-ovn-additional-storage-support
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-gcp-ovn-additional-storage-support
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator


### PR DESCRIPTION
Summary
- Add weekly periodic CI jobs to run the `openshift/additional-storage-support` test suite
- Jobs test ContainerRuntimeConfig additional storage features with TechPreviewNoUpgrade feature set
- Test suite added in https://github.com/openshift/origin/pull/31083

Jobs Added
| Release | Job Name | Cluster | Interval |
|---------|----------|---------|----------|
| 4.22 | `periodic-ci-openshift-origin-release-4.22-e2e-gcp-ovn-additional-storage-support` | GCP | 168h |

Features Tested
These jobs validate the following ContainerRuntimeConfig features:
- `additionalImageStores` - Read-only shared image storage
- `additionalArtifactStores` - Read-only artifact storage  
- `additionalLayerStores` - Lazy-pull layer storage (stargz-store)

Configuration
- `FEATURE_SET: TechPreviewNoUpgrade` - Required to enable the additional storage features
- `TEST_SUITE: openshift/additional-storage-support` - Runs the dedicated test suite from origin repo