### PR TITLE
CNV-85530: HCO: add bundle image for v1.19

### DIFF
--- a/core-services/image-mirroring/_config.yaml
+++ b/core-services/image-mirroring/_config.yaml
@@ -271,6 +271,8 @@ supplementalCIImages:
     image: quay.io/kubevirt/hyperconverged-cluster-bundle:1.17.0-unstable
   ci/hyperconverged-cluster-bundle:1.18.0-unstable:
     image: quay.io/kubevirt/hyperconverged-cluster-bundle:1.18.0-unstable
+  ci/hyperconverged-cluster-bundle:1.19.0-unstable:
+    image: quay.io/kubevirt/hyperconverged-cluster-bundle:1.19.0-unstable
   ci/hyperconverged-cluster-bundle:1.9.0-unstable:
     image: quay.io/kubevirt/hyperconverged-cluster-bundle:1.9.0-unstable
   ci/hyperconverged-cluster-index:1.10.0-fbc-unstable:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration to support the hyperconverged-cluster-bundle version 1.19.0-unstable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->