### PR TITLE
STOR-2131: Promote vSphere host groups CSI jobs from tech preview to GA

### DIFF
--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22.yaml
@@ -1057,12 +1057,10 @@ tests:
         PV (block volmode).*multiVolume.*should concurrently access the single volume
         from pods on different node'
     workflow: openshift-e2e-vsphere-csi
-- as: e2e-vsphere-ovn-host-groups-csi-techpreview
+- as: e2e-vsphere-ovn-host-groups-csi
   cron: 36 3 * * 0
   steps:
     cluster_profile: vsphere-elastic
-    env:
-      FEATURE_SET: TechPreviewNoUpgrade
     workflow: openshift-e2e-vsphere-host-groups-csi
 - as: e2e-vsphere-ovn-zones
   cron: 16 0 * * 5

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.23.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.23.yaml
@@ -1020,12 +1020,10 @@ tests:
         PV (block volmode).*multiVolume.*should concurrently access the single volume
         from pods on different node'
     workflow: openshift-e2e-vsphere-csi
-- as: e2e-vsphere-ovn-host-groups-csi-techpreview
+- as: e2e-vsphere-ovn-host-groups-csi
   cron: 36 3 * * 0
   steps:
     cluster_profile: vsphere-elastic
-    env:
-      FEATURE_SET: TechPreviewNoUpgrade
     workflow: openshift-e2e-vsphere-host-groups-csi
 - as: e2e-vsphere-ovn-zones
   cron: 16 0 * * 5

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
@@ -1020,12 +1020,10 @@ tests:
         PV (block volmode).*multiVolume.*should concurrently access the single volume
         from pods on different node'
     workflow: openshift-e2e-vsphere-csi
-- as: e2e-vsphere-ovn-host-groups-csi-techpreview
+- as: e2e-vsphere-ovn-host-groups-csi
   cron: 42 0 * * 5
   steps:
     cluster_profile: vsphere-elastic
-    env:
-      FEATURE_SET: TechPreviewNoUpgrade
     workflow: openshift-e2e-vsphere-host-groups-csi
 - as: e2e-vsphere-ovn-zones
   cron: 44 16 * * 5


### PR DESCRIPTION
Promote vSphere host groups CSI jobs from tech preview to GA make it consistent.
Adapted from Penghao <pewang@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated vSphere host-groups CSI test job configurations across nightly releases for versions 4.22, 4.23, and 5.0. Test identifiers have been renamed and technical preview settings have been removed, reflecting the graduation of the vSphere host-groups CSI feature from technical preview to general availability status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->