### PR TITLE
Add pre-merge OTE job to NTO

### DIFF
--- a/ci-operator/config/openshift/cluster-node-tuning-operator/openshift-cluster-node-tuning-operator-main.yaml
+++ b/ci-operator/config/openshift/cluster-node-tuning-operator/openshift-cluster-node-tuning-operator-main.yaml
@@ -206,6 +206,16 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: e2e-aws-nto-ext
+  optional: true
+  steps:
+    cluster_profile: openshift-org-aws
+    env:
+      TEST_ARGS: --monitor=watch-namespaces
+      TEST_SUITE: openshift/cluster-node-tuning-operator/all
+    test:
+    - ref: openshift-e2e-test
+    workflow: openshift-e2e-aws
 zz_generated_metadata:
   branch: main
   org: openshift

--- a/ci-operator/jobs/openshift/cluster-node-tuning-operator/openshift-cluster-node-tuning-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-node-tuning-operator/openshift-cluster-node-tuning-operator-main-presubmits.yaml
@@ -6,6 +6,87 @@ presubmits:
     - ^main$
     - ^main-
     cluster: build06
+    context: ci/prow/e2e-aws-nto-ext
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-node-tuning-operator-main-e2e-aws-nto-ext
+    optional: true
+    rerun_command: /test e2e-aws-nto-ext
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-aws-nto-ext
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-aws-nto-ext,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build06
     context: ci/prow/e2e-aws-operator
     decorate: true
     labels:


### PR DESCRIPTION
This change adds an optional pre-merge OpenShift Test Extension (OTE) invoking job to the Cluster Node Tuning Operator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced AWS testing infrastructure with additional E2E execution path to improve quality assurance coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->