### PR TITLE
CNV-85530: bump HCO version to v1.19

### DIFF
--- a/ci-operator/config/kubevirt/hyperconverged-cluster-operator/kubevirt-hyperconverged-cluster-operator-main.yaml
+++ b/ci-operator/config/kubevirt/hyperconverged-cluster-operator/kubevirt-hyperconverged-cluster-operator-main.yaml
@@ -14,11 +14,11 @@ base_images:
   hco-bundle-reg:
     name: hyperconverged-cluster-bundle
     namespace: ci
-    tag: 1.18.0-unstable
+    tag: 1.19.0-unstable
   hco-bundle-reg-prev:
     name: hyperconverged-cluster-bundle
     namespace: ci
-    tag: 1.17.0-unstable
+    tag: 1.18.0-unstable
 binary_build_commands: make install
 build_root:
   image_stream_tag:
@@ -194,7 +194,7 @@ tests:
       OO_BUNDLE: hco-bundle-reg
     env:
       BASE_DOMAIN: cnv-devel.azure.devcluster.openshift.com
-      INITIAL_VERSION: 1.18.0
+      INITIAL_VERSION: 1.19.0
       OO_INSTALL_NAMESPACE: kubevirt-hyperconverged
       OO_INSTALL_TIMEOUT_MINUTES: "15"
     test:
@@ -249,7 +249,7 @@ tests:
       OO_BUNDLE: hco-bundle-reg-prev
     env:
       BASE_DOMAIN: cnv-devel.azure.devcluster.openshift.com
-      INITIAL_VERSION: 1.17.0
+      INITIAL_VERSION: 1.18.0
       OO_INSTALL_NAMESPACE: kubevirt-hyperconverged
       OO_INSTALL_TIMEOUT_MINUTES: "15"
     test:
@@ -336,7 +336,7 @@ tests:
       OO_BUNDLE: hco-bundle-reg
     env:
       BASE_DOMAIN: cnv-ci.syseng.devcluster.openshift.com
-      INITIAL_VERSION: 1.18.0
+      INITIAL_VERSION: 1.19.0
       OO_INSTALL_NAMESPACE: kubevirt-hyperconverged
       OO_INSTALL_TIMEOUT_MINUTES: "15"
     test:
@@ -391,7 +391,7 @@ tests:
       OO_BUNDLE: hco-bundle-reg-prev
     env:
       BASE_DOMAIN: cnv-ci.syseng.devcluster.openshift.com
-      INITIAL_VERSION: 1.17.0
+      INITIAL_VERSION: 1.18.0
       OO_INSTALL_NAMESPACE: kubevirt-hyperconverged
       OO_INSTALL_TIMEOUT_MINUTES: "15"
     test:
@@ -552,7 +552,7 @@ tests:
       OO_BUNDLE: hco-bundle-reg
     env:
       BASE_DOMAIN: cnv-ci.syseng.devcluster.openshift.com
-      INITIAL_VERSION: 1.18.0
+      INITIAL_VERSION: 1.19.0
       OO_INSTALL_NAMESPACE: kubevirt-hyperconverged
       OO_INSTALL_TIMEOUT_MINUTES: "15"
       SPOT_INSTANCES: "true"
@@ -607,7 +607,7 @@ tests:
       OO_BUNDLE: hco-bundle-reg
     env:
       BASE_DOMAIN: cnv-devel.azure.devcluster.openshift.com
-      INITIAL_VERSION: 1.18.0
+      INITIAL_VERSION: 1.19.0
       OO_INSTALL_NAMESPACE: kubevirt-hyperconverged
       OO_INSTALL_TIMEOUT_MINUTES: "15"
     test:
@@ -661,7 +661,7 @@ tests:
       OO_BUNDLE: hco-bundle-reg-prev
     env:
       BASE_DOMAIN: cnv-ci.syseng.devcluster.openshift.com
-      INITIAL_VERSION: 1.17.0
+      INITIAL_VERSION: 1.18.0
       OO_INSTALL_NAMESPACE: kubevirt-hyperconverged
       OO_INSTALL_TIMEOUT_MINUTES: "15"
       SPOT_INSTANCES: "true"
@@ -716,7 +716,7 @@ tests:
       OO_BUNDLE: hco-bundle-reg-prev
     env:
       BASE_DOMAIN: cnv-devel.azure.devcluster.openshift.com
-      INITIAL_VERSION: 1.17.0
+      INITIAL_VERSION: 1.18.0
       OO_INSTALL_NAMESPACE: kubevirt-hyperconverged
       OO_INSTALL_TIMEOUT_MINUTES: "15"
     test:
@@ -770,7 +770,7 @@ tests:
       OO_BUNDLE: hco-bundle-reg-prev
     env:
       BASE_DOMAIN: cnv-ci.syseng.devcluster.openshift.com
-      INITIAL_VERSION: 1.17.0
+      INITIAL_VERSION: 1.18.0
       OO_INSTALL_NAMESPACE: kubevirt-hyperconverged
     test:
     - as: deploy-cr
@@ -825,7 +825,7 @@ tests:
       OO_BUNDLE: hco-bundle-reg-prev
     env:
       BASE_DOMAIN: cnv-devel.azure.devcluster.openshift.com
-      INITIAL_VERSION: 1.17.0
+      INITIAL_VERSION: 1.18.0
       OO_INSTALL_NAMESPACE: kubevirt-hyperconverged
       OO_INSTALL_TIMEOUT_MINUTES: "15"
     test:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated hyperconverged cluster operator bundle versions: primary advanced to 1.19.0-unstable (from 1.18.0-unstable) and previous to 1.18.0-unstable (from 1.17.0-unstable). Test job environments and upgrade scenarios updated to align initial version settings with the new bundle tags across cloud providers and upgrade paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->