### PR TITLE
Update odf-release for 4.20.11, 4.19.16

### DIFF
--- a/core-services/jira-lifecycle-plugin/config.yaml
+++ b/core-services/jira-lifecycle-plugin/config.yaml
@@ -1109,16 +1109,16 @@ orgs:
         target_version: odf-4.18.20
         validate_by_default: true
       release-4.19:
-        target_version: odf-4.19.15
+        target_version: odf-4.19.16
         validate_by_default: true
       release-4.19-compatibility:
-        target_version: odf-4.19.15
+        target_version: odf-4.19.16
         validate_by_default: true
       release-4.20:
-        target_version: odf-4.20.10
+        target_version: odf-4.20.11
         validate_by_default: true
       release-4.20-compatibility:
-        target_version: odf-4.20.10
+        target_version: odf-4.20.11
         validate_by_default: true
       release-4.21:
         target_version: odf-4.21.3


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped ODF target versions for four release branches: release-4.19 and release-4.19-compatibility from odf-4.19.15 to odf-4.19.16, and release-4.20 and release-4.20-compatibility from odf-4.20.10 to odf-4.20.11. These are configuration-only updates to align branch targets to the next patch versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->