### PR TITLE
Prepare CI jobs for ROSACLI 1.2.62-rc2

### DIFF
--- a/ci-operator/config/openshift/rosa/openshift-rosa-master__e2e.yaml
+++ b/ci-operator/config/openshift/rosa/openshift-rosa-master__e2e.yaml
@@ -30,6 +30,7 @@ tests:
       CLUSTER_TIMEOUT: "120"
       IMPORTANCE: (Critical,High)
       NAME_PREFIX: rosa-sts-f3
+      ROSACLI_BUILD: v1.2.62-rc2
       TEST_PROFILE: rosa-advanced
     test:
     - chain: rosa-tests-e2e-fullcycle
@@ -42,6 +43,7 @@ tests:
       CLUSTER_TIMEOUT: "120"
       IMPORTANCE: (Critical,High)
       NAME_PREFIX: rosa-sv-f3
+      ROSACLI_BUILD: v1.2.62-rc2
       TEST_PROFILE: rosa-shared-vpc
     test:
     - chain: rosa-tests-e2e-fullcycle
@@ -54,6 +56,7 @@ tests:
       CLUSTER_TIMEOUT: "120"
       IMPORTANCE: (Medium,Low)
       NAME_PREFIX: rosa-sv-f7
+      ROSACLI_BUILD: v1.2.62-rc2
       TEST_PROFILE: rosa-shared-vpc
     test:
     - chain: rosa-tests-e2e-fullcycle
@@ -67,6 +70,7 @@ tests:
       IMPORTANCE: (Critical,High)
       NAME_PREFIX: rosa-sts-f3
       OCM_LOGIN_ENV: production
+      ROSACLI_BUILD: v1.2.62-rc2
       TEST_PROFILE: rosa-advanced
     test:
     - chain: rosa-tests-e2e-fullcycle
@@ -79,6 +83,7 @@ tests:
       CLUSTER_TIMEOUT: "120"
       IMPORTANCE: (Medium,Low)
       NAME_PREFIX: rosa-sts-f7
+      ROSACLI_BUILD: v1.2.62-rc2
       TEST_PROFILE: rosa-advanced
     test:
     - chain: rosa-tests-e2e-fullcycle
@@ -90,6 +95,7 @@ tests:
     env:
       IMPORTANCE: (Critical,High)
       NAME_PREFIX: hcp-sv-f3
+      ROSACLI_BUILD: v1.2.62-rc2
       TEST_PROFILE: rosa-hcp-shared-vpc-advanced
     test:
     - chain: rosa-tests-e2e-fullcycle
@@ -101,6 +107,7 @@ tests:
     env:
       IMPORTANCE: (Medium,Low)
       NAME_PREFIX: hcp-sv-f7
+      ROSACLI_BUILD: v1.2.62-rc2
       TEST_PROFILE: rosa-hcp-shared-vpc-advanced
     test:
     - chain: rosa-tests-e2e-fullcycle
@@ -113,6 +120,7 @@ tests:
       CLUSTER_TIMEOUT: "120"
       IMPORTANCE: (Critical,High)
       NAME_PREFIX: rosa-pl-f3
+      ROSACLI_BUILD: v1.2.62-rc2
       TEST_PROFILE: rosa-private-link
     test:
     - chain: rosa-tests-e2e-fullcycle
@@ -125,6 +133,7 @@ tests:
       CLUSTER_TIMEOUT: "120"
       IMPORTANCE: (Medium,Low)
       NAME_PREFIX: rosa-pl-f7
+      ROSACLI_BUILD: v1.2.62-rc2
       TEST_PROFILE: rosa-private-link
     test:
     - chain: rosa-tests-e2e-fullcycle
@@ -137,6 +146,7 @@ tests:
       CLUSTER_TIMEOUT: "100"
       IMPORTANCE: (Critical,High)
       NAME_PREFIX: rosa-nsts-f3
+      ROSACLI_BUILD: v1.2.62-rc2
       TEST_PROFILE: rosa-non-sts-advanced
     test:
     - chain: rosa-tests-e2e-fullcycle
@@ -148,6 +158,7 @@ tests:
     env:
       IMPORTANCE: (Medium,Low)
       NAME_PREFIX: rosa-auth-f7
+      ROSACLI_BUILD: v1.2.62-rc2
       TEST_PROFILE: rosa-hcp-external-auth
     test:
     - chain: rosa-tests-e2e-fullcycle
@@ -159,6 +170,7 @@ tests:
     env:
       IMPORTANCE: (Critical,High)
       NAME_PREFIX: rosa-auth-f3
+      ROSACLI_BUILD: v1.2.62-rc2
       TEST_PROFILE: rosa-hcp-external-auth
     test:
     - chain: rosa-tests-e2e-fullcycle
@@ -170,6 +182,7 @@ tests:
     env:
       IMPORTANCE: (Critical,High)
       NAME_PREFIX: rosa-hcp-f3
+      ROSACLI_BUILD: v1.2.62-rc2
       TEST_PROFILE: rosa-hcp-advanced
     test:
     - chain: rosa-tests-e2e-fullcycle
@@ -182,6 +195,7 @@ tests:
       IMPORTANCE: (Critical,High)
       NAME_PREFIX: rosa-hcp-f3
       OCM_LOGIN_ENV: production
+      ROSACLI_BUILD: v1.2.62-rc2
       TEST_PROFILE: rosa-hcp-advanced
     test:
     - chain: rosa-tests-e2e-fullcycle
@@ -193,6 +207,7 @@ tests:
     env:
       IMPORTANCE: (Medium,Low)
       NAME_PREFIX: rosa-hcp-f7
+      ROSACLI_BUILD: v1.2.62-rc2
       TEST_PROFILE: rosa-hcp-advanced
     test:
     - chain: rosa-tests-e2e-fullcycle
@@ -206,6 +221,7 @@ tests:
       NAME_PREFIX: rosa-reghcp-f3
       OCM_LOGIN_ENV: https://api.aws.ap-southeast-1.stage.openshift.com
       REGION: ap-southeast-1
+      ROSACLI_BUILD: v1.2.62-rc2
       TEST_PROFILE: rosa-hcp-advanced
       VERSION: "4.14"
     test:
@@ -218,6 +234,7 @@ tests:
     env:
       IMPORTANCE: (Critical,High)
       NAME_PREFIX: rosa-hcppl-f3
+      ROSACLI_BUILD: v1.2.62-rc2
       TEST_PROFILE: rosa-hcp-pl
     test:
     - chain: rosa-tests-e2e-fullcycle
@@ -229,6 +246,7 @@ tests:
     env:
       COMPUTE_MACHINE_TYPE: m6g.xlarge
       NAME_PREFIX: rosa-hcparm-f3
+      ROSACLI_BUILD: v1.2.62-rc2
       TEST_PROFILE: rosa-hcp-advanced
     test:
     - chain: rosa-tests-e2e-fullcycle
@@ -238,6 +256,7 @@ tests:
   steps:
     cluster_profile: oex-aws-qe
     env:
+      ROSACLI_BUILD: v1.2.62-rc2
       TEST_LABEL_FILTERS: (ocm-resources)&&!Exclude
       TEST_PROFILE: "null"
     test:
@@ -248,6 +267,7 @@ tests:
   steps:
     cluster_profile: oex-aws-qe
     env:
+      ROSACLI_BUILD: v1.2.62-rc2
       TEST_LABEL_FILTERS: (day1-negative)&&!Exclude
       TEST_PROFILE: "null"
     test:
@@ -258,6 +278,7 @@ tests:
   steps:
     cluster_profile: oex-aws-qe
     env:
+      ROSACLI_BUILD: v1.2.62-rc2
       TEST_LABEL_FILTERS: (day1-supplemental)&&!Exclude
       TEST_PROFILE: "null"
     test:
@@ -270,6 +291,7 @@ tests:
     env:
       CLUSTER_TIMEOUT: "120"
       NAME_PREFIX: rosa-upgz-f3
+      ROSACLI_BUILD: v1.2.62-rc2
       TEST_LABEL_FILTERS: (upgrade)&&!Exclude
       TEST_PROFILE: rosa-upgrade-z-stream
     test:
@@ -283,6 +305,7 @@ tests:
     env:
       CLUSTER_TIMEOUT: "100"
       NAME_PREFIX: rosa-upgy-f3
+      ROSACLI_BUILD: v1.2.62-rc2
       TEST_LABEL_FILTERS: (upgrade)&&!Exclude
       TEST_PROFILE: rosa-non-sts-upgrade-y-stream
     test:
@@ -296,6 +319,7 @@ tests:
     env:
       CLUSTER_TIMEOUT: "120"
       NAME_PREFIX: rosa-upgy-f3
+      ROSACLI_BUILD: v1.2.62-rc2
       TEST_LABEL_FILTERS: (upgrade)&&!Exclude
       TEST_PROFILE: rosa-shared-vpc
       VERSION: y-1
@@ -310,6 +334,7 @@ tests:
     env:
       CLUSTER_TIMEOUT: "120"
       NAME_PREFIX: rosa-upgy-f3
+      ROSACLI_BUILD: v1.2.62-rc2
       TEST_LABEL_FILTERS: (upgrade)&&!Exclude
       TEST_PROFILE: rosa-upgrade-y-stream
     test:
@@ -324,6 +349,7 @@ tests:
       CLUSTER_TIMEOUT: "120"
       NAME_PREFIX: rosa-upgy-f3
       OCM_LOGIN_ENV: production
+      ROSACLI_BUILD: v1.2.62-rc2
       TEST_LABEL_FILTERS: (upgrade)&&!Exclude
       TEST_PROFILE: rosa-upgrade-y-stream
     test:
@@ -336,6 +362,7 @@ tests:
     cluster_profile: oex-aws-qe
     env:
       NAME_PREFIX: rosa-hcpz-f3
+      ROSACLI_BUILD: v1.2.62-rc2
       TEST_LABEL_FILTERS: (upgrade)&&!Exclude
       TEST_PROFILE: rosa-hcp-upgrade-z-stream
     test:
@@ -348,6 +375,7 @@ tests:
     cluster_profile: oex-aws-qe
     env:
       NAME_PREFIX: rosa-hcpy-f3
+      ROSACLI_BUILD: v1.2.62-rc2
       TEST_LABEL_FILTERS: (upgrade)&&!Exclude
       TEST_PROFILE: rosa-hcp-upgrade-y-stream
     test:
@@ -361,6 +389,7 @@ tests:
     env:
       CLUSTER_TIMEOUT: "120"
       NAME_PREFIX: rosa-hib-f14
+      ROSACLI_BUILD: v1.2.62-rc2
       TEST_LABEL_FILTERS: (hibernate)&&!Exclude
       TEST_PROFILE: rosa-advanced
     test:


### PR DESCRIPTION
DO NOT MERGE, this is just for triggering our automated tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated e2e test job configurations with ROSACLI build v1.2.62-rc2 across multiple test suites including STS, HCP, upgrades, and hibernation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->