### PR TITLE
prowgen: set max_concurrency in ci-operator config

### DIFF
--- a/ci-operator/config/openshift/aws-account-operator/openshift-aws-account-operator-master.yaml
+++ b/ci-operator/config/openshift/aws-account-operator/openshift-aws-account-operator-master.yaml
@@ -49,6 +49,7 @@ tests:
   skip_if_only_changed: ^(?:\.tekton|\.github)|\.md$|^(?:\.gitignore|OWNERS|LICENSE)$
 - always_run: false
   as: integration-test
+  max_concurrency: 1
   cluster_claim:
     architecture: amd64
     cloud: aws

--- a/ci-operator/config/openshift/aws-account-operator/openshift-aws-account-operator-master.yaml
+++ b/ci-operator/config/openshift/aws-account-operator/openshift-aws-account-operator-master.yaml
@@ -49,7 +49,6 @@ tests:
   skip_if_only_changed: ^(?:\.tekton|\.github)|\.md$|^(?:\.gitignore|OWNERS|LICENSE)$
 - always_run: false
   as: integration-test
-  max_concurrency: 1
   cluster_claim:
     architecture: amd64
     cloud: aws
@@ -57,6 +56,7 @@ tests:
     product: ocp
     timeout: 15m0s
     version: "4.16"
+  max_concurrency: 1
   optional: true
   steps:
     test:

--- a/ci-operator/config/redhat-developer/rhdh-plugin-export-overlays/redhat-developer-rhdh-plugin-export-overlays-main.yaml
+++ b/ci-operator/config/redhat-developer/rhdh-plugin-export-overlays/redhat-developer-rhdh-plugin-export-overlays-main.yaml
@@ -20,7 +20,6 @@ resources:
 tests:
 - always_run: false
   as: e2e-ocp-helm
-  max_concurrency: 2
   cluster_claim:
     architecture: amd64
     cloud: aws
@@ -30,6 +29,7 @@ tests:
     product: ocp
     timeout: 1h0m0s
     version: "4.18"
+  max_concurrency: 2
   optional: true
   steps:
     allow_skip_on_success: true
@@ -38,7 +38,6 @@ tests:
     workflow: generic-claim
 - always_run: false
   as: e2e-ocp-helm-nightly
-  max_concurrency: 1
   cluster_claim:
     architecture: amd64
     cloud: aws
@@ -49,6 +48,7 @@ tests:
     timeout: 1h0m0s
     version: "4.18"
   cron: 0 4 * * *
+  max_concurrency: 1
   optional: true
   presubmit: true
   steps:

--- a/ci-operator/config/redhat-developer/rhdh-plugin-export-overlays/redhat-developer-rhdh-plugin-export-overlays-main.yaml
+++ b/ci-operator/config/redhat-developer/rhdh-plugin-export-overlays/redhat-developer-rhdh-plugin-export-overlays-main.yaml
@@ -20,6 +20,7 @@ resources:
 tests:
 - always_run: false
   as: e2e-ocp-helm
+  max_concurrency: 2
   cluster_claim:
     architecture: amd64
     cloud: aws
@@ -37,6 +38,7 @@ tests:
     workflow: generic-claim
 - always_run: false
   as: e2e-ocp-helm-nightly
+  max_concurrency: 1
   cluster_claim:
     architecture: amd64
     cloud: aws

--- a/ci-operator/config/redhat-developer/rhdh-test-instance/redhat-developer-rhdh-test-instance-main.yaml
+++ b/ci-operator/config/redhat-developer/rhdh-test-instance/redhat-developer-rhdh-test-instance-main.yaml
@@ -20,6 +20,7 @@ resources:
 tests:
 - always_run: false
   as: deploy
+  max_concurrency: 3
   cluster_claim:
     architecture: amd64
     cloud: aws

--- a/ci-operator/config/redhat-developer/rhdh-test-instance/redhat-developer-rhdh-test-instance-main.yaml
+++ b/ci-operator/config/redhat-developer/rhdh-test-instance/redhat-developer-rhdh-test-instance-main.yaml
@@ -20,7 +20,6 @@ resources:
 tests:
 - always_run: false
   as: deploy
-  max_concurrency: 3
   cluster_claim:
     architecture: amd64
     cloud: aws
@@ -30,6 +29,7 @@ tests:
     product: ocp
     timeout: 1h0m0s
     version: "4.18"
+  max_concurrency: 3
   optional: true
   steps:
     test:

--- a/ci-operator/config/redhat-developer/rhdh/redhat-developer-rhdh-main.yaml
+++ b/ci-operator/config/redhat-developer/rhdh/redhat-developer-rhdh-main.yaml
@@ -242,6 +242,7 @@ tests:
     workflow: generic-claim
 - always_run: false
   as: cleanup-mapt-destroy-orphaned-aks-clusters
+  max_concurrency: 1
   cron: 0 2 * * SUN
   optional: true
   presubmit: true
@@ -254,6 +255,7 @@ tests:
     - ref: redhat-developer-rhdh-aks-mapt-orphaned-destroy
 - always_run: false
   as: cleanup-mapt-destroy-orphaned-eks-clusters
+  max_concurrency: 1
   cron: 0 2 * * SUN
   optional: true
   presubmit: true
@@ -264,6 +266,7 @@ tests:
     - ref: redhat-developer-rhdh-eks-mapt-orphaned-destroy
 - always_run: false
   as: e2e-osd-gcp-helm-nightly
+  max_concurrency: 1
   cron: 30 7 * * TUE,THU,SAT,SUN
   optional: true
   presubmit: true
@@ -280,6 +283,7 @@ tests:
     workflow: redhat-developer-rhdh-osd-gcp-claim-cluster
 - always_run: false
   as: e2e-osd-gcp-operator-nightly
+  max_concurrency: 1
   cron: 30 5 * * TUE,THU,SAT,SUN
   optional: true
   presubmit: true
@@ -320,6 +324,7 @@ tests:
     workflow: generic-claim
 - always_run: false
   as: e2e-ocp-helm-upgrade-nightly
+  max_concurrency: 1
   cluster_claim:
     architecture: amd64
     cloud: aws

--- a/ci-operator/config/redhat-developer/rhdh/redhat-developer-rhdh-main.yaml
+++ b/ci-operator/config/redhat-developer/rhdh/redhat-developer-rhdh-main.yaml
@@ -242,8 +242,8 @@ tests:
     workflow: generic-claim
 - always_run: false
   as: cleanup-mapt-destroy-orphaned-aks-clusters
-  max_concurrency: 1
   cron: 0 2 * * SUN
+  max_concurrency: 1
   optional: true
   presubmit: true
   steps:
@@ -255,8 +255,8 @@ tests:
     - ref: redhat-developer-rhdh-aks-mapt-orphaned-destroy
 - always_run: false
   as: cleanup-mapt-destroy-orphaned-eks-clusters
-  max_concurrency: 1
   cron: 0 2 * * SUN
+  max_concurrency: 1
   optional: true
   presubmit: true
   steps:
@@ -266,8 +266,8 @@ tests:
     - ref: redhat-developer-rhdh-eks-mapt-orphaned-destroy
 - always_run: false
   as: e2e-osd-gcp-helm-nightly
-  max_concurrency: 1
   cron: 30 7 * * TUE,THU,SAT,SUN
+  max_concurrency: 1
   optional: true
   presubmit: true
   steps:
@@ -283,8 +283,8 @@ tests:
     workflow: redhat-developer-rhdh-osd-gcp-claim-cluster
 - always_run: false
   as: e2e-osd-gcp-operator-nightly
-  max_concurrency: 1
   cron: 30 5 * * TUE,THU,SAT,SUN
+  max_concurrency: 1
   optional: true
   presubmit: true
   steps:
@@ -324,7 +324,6 @@ tests:
     workflow: generic-claim
 - always_run: false
   as: e2e-ocp-helm-upgrade-nightly
-  max_concurrency: 1
   cluster_claim:
     architecture: amd64
     cloud: aws
@@ -335,6 +334,7 @@ tests:
     timeout: 1h0m0s
     version: "4.18"
   cron: 0 4 * * TUE,THU,SAT,SUN
+  max_concurrency: 1
   optional: true
   presubmit: true
   steps:

--- a/ci-operator/config/redhat-developer/rhdh/redhat-developer-rhdh-release-1.8.yaml
+++ b/ci-operator/config/redhat-developer/rhdh/redhat-developer-rhdh-release-1.8.yaml
@@ -138,6 +138,7 @@ tests:
     workflow: generic-claim
 - always_run: false
   as: e2e-aks-helm-nightly
+  max_concurrency: 4
   cron: 20 4 * * TUE,THU,SAT,SUN
   optional: true
   presubmit: true
@@ -152,6 +153,7 @@ tests:
     workflow: redhat-developer-rhdh-aks-mapt
 - always_run: false
   as: e2e-aks-operator-nightly
+  max_concurrency: 4
   cron: 40 4 * * TUE,THU,SAT,SUN
   optional: true
   presubmit: true
@@ -166,6 +168,7 @@ tests:
     workflow: redhat-developer-rhdh-aks-mapt
 - always_run: false
   as: e2e-eks-helm-nightly
+  max_concurrency: 4
   cron: 0 4 * * TUE,THU,SAT,SUN
   optional: true
   presubmit: true
@@ -180,6 +183,7 @@ tests:
     workflow: redhat-developer-rhdh-eks-mapt
 - always_run: false
   as: e2e-eks-operator-nightly
+  max_concurrency: 4
   cron: 0 4 * * TUE,THU,SAT,SUN
   optional: true
   presubmit: true
@@ -194,6 +198,7 @@ tests:
     workflow: redhat-developer-rhdh-eks-mapt
 - always_run: false
   as: e2e-gke-helm-nightly
+  max_concurrency: 1
   cron: 0 2 * * TUE,THU,SAT,SUN
   optional: true
   presubmit: true
@@ -206,6 +211,7 @@ tests:
     - ref: redhat-developer-rhdh-gke-helm-nightly
 - always_run: false
   as: e2e-gke-operator-nightly
+  max_concurrency: 1
   cron: 0 8 * * TUE,THU,SAT,SUN
   optional: true
   presubmit: true
@@ -273,6 +279,7 @@ tests:
     workflow: redhat-developer-rhdh-osd-gcp-claim-cluster
 - always_run: false
   as: e2e-ocp-operator-auth-providers-nightly
+  max_concurrency: 1
   cluster_claim:
     architecture: amd64
     cloud: aws

--- a/ci-operator/config/redhat-developer/rhdh/redhat-developer-rhdh-release-1.8.yaml
+++ b/ci-operator/config/redhat-developer/rhdh/redhat-developer-rhdh-release-1.8.yaml
@@ -138,8 +138,8 @@ tests:
     workflow: generic-claim
 - always_run: false
   as: e2e-aks-helm-nightly
-  max_concurrency: 4
   cron: 20 4 * * TUE,THU,SAT,SUN
+  max_concurrency: 4
   optional: true
   presubmit: true
   steps:
@@ -153,8 +153,8 @@ tests:
     workflow: redhat-developer-rhdh-aks-mapt
 - always_run: false
   as: e2e-aks-operator-nightly
-  max_concurrency: 4
   cron: 40 4 * * TUE,THU,SAT,SUN
+  max_concurrency: 4
   optional: true
   presubmit: true
   steps:
@@ -168,8 +168,8 @@ tests:
     workflow: redhat-developer-rhdh-aks-mapt
 - always_run: false
   as: e2e-eks-helm-nightly
-  max_concurrency: 4
   cron: 0 4 * * TUE,THU,SAT,SUN
+  max_concurrency: 4
   optional: true
   presubmit: true
   steps:
@@ -183,8 +183,8 @@ tests:
     workflow: redhat-developer-rhdh-eks-mapt
 - always_run: false
   as: e2e-eks-operator-nightly
-  max_concurrency: 4
   cron: 0 4 * * TUE,THU,SAT,SUN
+  max_concurrency: 4
   optional: true
   presubmit: true
   steps:
@@ -198,8 +198,8 @@ tests:
     workflow: redhat-developer-rhdh-eks-mapt
 - always_run: false
   as: e2e-gke-helm-nightly
-  max_concurrency: 1
   cron: 0 2 * * TUE,THU,SAT,SUN
+  max_concurrency: 1
   optional: true
   presubmit: true
   steps:
@@ -211,8 +211,8 @@ tests:
     - ref: redhat-developer-rhdh-gke-helm-nightly
 - always_run: false
   as: e2e-gke-operator-nightly
-  max_concurrency: 1
   cron: 0 8 * * TUE,THU,SAT,SUN
+  max_concurrency: 1
   optional: true
   presubmit: true
   steps:
@@ -279,7 +279,6 @@ tests:
     workflow: redhat-developer-rhdh-osd-gcp-claim-cluster
 - always_run: false
   as: e2e-ocp-operator-auth-providers-nightly
-  max_concurrency: 1
   cluster_claim:
     architecture: amd64
     cloud: aws
@@ -290,6 +289,7 @@ tests:
     timeout: 1h0m0s
     version: "4.18"
   cron: 0 2 * * TUE,THU,SAT,SUN
+  max_concurrency: 1
   optional: true
   presubmit: true
   steps:

--- a/ci-operator/config/redhat-developer/rhdh/redhat-developer-rhdh-release-1.9.yaml
+++ b/ci-operator/config/redhat-developer/rhdh/redhat-developer-rhdh-release-1.9.yaml
@@ -163,6 +163,7 @@ tests:
     workflow: generic-claim
 - always_run: false
   as: e2e-aks-helm-nightly
+  max_concurrency: 4
   cron: 40 3 * * MON,WED,FRI
   optional: true
   presubmit: true
@@ -177,6 +178,7 @@ tests:
     workflow: redhat-developer-rhdh-aks-mapt
 - always_run: false
   as: e2e-aks-operator-nightly
+  max_concurrency: 4
   cron: 50 3 * * MON,WED,FRI
   optional: true
   presubmit: true
@@ -191,6 +193,7 @@ tests:
     workflow: redhat-developer-rhdh-aks-mapt
 - always_run: false
   as: e2e-eks-helm-nightly
+  max_concurrency: 4
   cron: 30 3 * * MON,WED,FRI
   optional: true
   presubmit: true
@@ -205,6 +208,7 @@ tests:
     workflow: redhat-developer-rhdh-eks-mapt
 - always_run: false
   as: e2e-eks-operator-nightly
+  max_concurrency: 4
   cron: 30 3 * * MON,WED,FRI
   optional: true
   presubmit: true
@@ -219,6 +223,7 @@ tests:
     workflow: redhat-developer-rhdh-eks-mapt
 - always_run: false
   as: e2e-gke-helm-nightly
+  max_concurrency: 1
   cron: 0 5 * * MON,WED,FRI
   optional: true
   presubmit: true
@@ -231,6 +236,7 @@ tests:
     - ref: redhat-developer-rhdh-gke-helm-nightly
 - always_run: false
   as: e2e-gke-operator-nightly
+  max_concurrency: 1
   cron: 0 9 * * MON,WED,FRI
   optional: true
   presubmit: true
@@ -317,6 +323,7 @@ tests:
     workflow: generic-claim
 - always_run: false
   as: e2e-ocp-helm-upgrade-nightly
+  max_concurrency: 1
   cluster_claim:
     architecture: amd64
     cloud: aws

--- a/ci-operator/config/redhat-developer/rhdh/redhat-developer-rhdh-release-1.9.yaml
+++ b/ci-operator/config/redhat-developer/rhdh/redhat-developer-rhdh-release-1.9.yaml
@@ -163,8 +163,8 @@ tests:
     workflow: generic-claim
 - always_run: false
   as: e2e-aks-helm-nightly
-  max_concurrency: 4
   cron: 40 3 * * MON,WED,FRI
+  max_concurrency: 4
   optional: true
   presubmit: true
   steps:
@@ -178,8 +178,8 @@ tests:
     workflow: redhat-developer-rhdh-aks-mapt
 - always_run: false
   as: e2e-aks-operator-nightly
-  max_concurrency: 4
   cron: 50 3 * * MON,WED,FRI
+  max_concurrency: 4
   optional: true
   presubmit: true
   steps:
@@ -193,8 +193,8 @@ tests:
     workflow: redhat-developer-rhdh-aks-mapt
 - always_run: false
   as: e2e-eks-helm-nightly
-  max_concurrency: 4
   cron: 30 3 * * MON,WED,FRI
+  max_concurrency: 4
   optional: true
   presubmit: true
   steps:
@@ -208,8 +208,8 @@ tests:
     workflow: redhat-developer-rhdh-eks-mapt
 - always_run: false
   as: e2e-eks-operator-nightly
-  max_concurrency: 4
   cron: 30 3 * * MON,WED,FRI
+  max_concurrency: 4
   optional: true
   presubmit: true
   steps:
@@ -223,8 +223,8 @@ tests:
     workflow: redhat-developer-rhdh-eks-mapt
 - always_run: false
   as: e2e-gke-helm-nightly
-  max_concurrency: 1
   cron: 0 5 * * MON,WED,FRI
+  max_concurrency: 1
   optional: true
   presubmit: true
   steps:
@@ -236,8 +236,8 @@ tests:
     - ref: redhat-developer-rhdh-gke-helm-nightly
 - always_run: false
   as: e2e-gke-operator-nightly
-  max_concurrency: 1
   cron: 0 9 * * MON,WED,FRI
+  max_concurrency: 1
   optional: true
   presubmit: true
   steps:
@@ -323,7 +323,6 @@ tests:
     workflow: generic-claim
 - always_run: false
   as: e2e-ocp-helm-upgrade-nightly
-  max_concurrency: 1
   cluster_claim:
     architecture: amd64
     cloud: aws
@@ -334,6 +333,7 @@ tests:
     timeout: 1h0m0s
     version: "4.18"
   cron: 30 4 * * MON,WED,FRI
+  max_concurrency: 1
   optional: true
   presubmit: true
   steps:

--- a/ci-operator/config/stackrox/scanner/stackrox-scanner-master.yaml
+++ b/ci-operator/config/stackrox/scanner/stackrox-scanner-master.yaml
@@ -47,6 +47,7 @@ tests:
           cpu: 2000m
           memory: 4000Mi
 - as: merge-e2e-tests
+  max_concurrency: 5
   postsubmit: true
   steps:
     test:
@@ -63,6 +64,7 @@ tests:
           memory: 4000Mi
       timeout: 4h0m0s
 - as: merge-slim-e2e-tests
+  max_concurrency: 5
   postsubmit: true
   steps:
     test:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master.yaml
@@ -248,28 +248,33 @@ tests:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-automation-flavors-aks-e2e
 - as: merge-gke-operator-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-ui-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-nongroovy-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-nongroovy-compatibility-tests
+  max_concurrency: 6
   postsubmit: true
   skip_if_only_changed: ^ui/
   steps:
@@ -277,22 +282,26 @@ tests:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-scanner-v4-install-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-sensor-integration-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-upgrade-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-version-compatibility-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     workflow: stackrox-stackrox-e2e-job

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4-12.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4-12.yaml
@@ -79,6 +79,7 @@ tests:
       TEST_SUITE: ocp-nongroovy-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -87,6 +88,7 @@ tests:
       TEST_SUITE: ocp-qa-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-operator-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -94,6 +96,7 @@ tests:
       TEST_SUITE: ocp-operator-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-scanner-v4-install-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -102,6 +105,7 @@ tests:
       TEST_SUITE: ocp-scanner-v4-install-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-ui-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -110,6 +114,7 @@ tests:
       TEST_SUITE: ocp-ui-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-nongroovy-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -118,6 +123,7 @@ tests:
       TEST_SUITE: ocp-nongroovy-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-compliance-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4-21.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4-21.yaml
@@ -112,6 +112,7 @@ tests:
     workflow: stackrox-automation-flavors-ocp-4-e2e
   timeout: 7h0m0s
 - as: merge-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -120,6 +121,7 @@ tests:
       TEST_SUITE: ocp-qa-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-operator-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -127,6 +129,7 @@ tests:
       TEST_SUITE: ocp-operator-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-scanner-v4-install-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -135,6 +138,7 @@ tests:
       TEST_SUITE: ocp-scanner-v4-install-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-ui-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -143,6 +147,7 @@ tests:
       TEST_SUITE: ocp-ui-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-nongroovy-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -151,6 +156,7 @@ tests:
       TEST_SUITE: ocp-nongroovy-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-compliance-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-4.10.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-4.10.yaml
@@ -237,12 +237,14 @@ tests:
       TEST_SUITE: rosa-qa-e2e-tests
     workflow: stackrox-automation-flavors-rosa-hcp-e2e
 - as: merge-gke-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-oldest-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -251,6 +253,7 @@ tests:
       TEST_SUITE: gke-qa-e2e-tests
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-latest-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -259,12 +262,14 @@ tests:
       TEST_SUITE: gke-qa-e2e-tests
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-ui-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-oldest-ui-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -273,6 +278,7 @@ tests:
       TEST_SUITE: gke-ui-e2e-tests
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-latest-ui-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -281,12 +287,14 @@ tests:
       TEST_SUITE: gke-ui-e2e-tests
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-nongroovy-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-oldest-nongroovy-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -295,6 +303,7 @@ tests:
       TEST_SUITE: gke-nongroovy-e2e-tests
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-latest-nongroovy-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -303,28 +312,33 @@ tests:
       TEST_SUITE: gke-nongroovy-e2e-tests
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-nongroovy-compatibility-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-scanner-v4-install-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-sensor-integration-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-operator-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-oldest-operator-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -332,6 +346,7 @@ tests:
       TEST_SUITE: gke-operator-e2e-tests
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-latest-operator-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -339,54 +354,64 @@ tests:
       TEST_SUITE: gke-operator-e2e-tests
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-upgrade-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-version-compatibility-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-race-condition-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-scale-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     workflow: stackrox-stackrox-e2e-job
 - as: merge-eks-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-automation-flavors-eks-e2e
 - as: merge-osd-gcp-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-automation-flavors-osd-gcp-e2e
 - as: merge-aro-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-automation-flavors-aro-e2e
 - as: merge-aks-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-automation-flavors-aks-e2e
 - as: merge-rosa-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-automation-flavors-rosa-e2e
 - as: merge-rosa-hcp-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-4.10__ocp-4-12.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-4.10__ocp-4-12.yaml
@@ -79,6 +79,7 @@ tests:
       TEST_SUITE: ocp-compliance-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -87,6 +88,7 @@ tests:
       TEST_SUITE: ocp-qa-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-operator-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -94,6 +96,7 @@ tests:
       TEST_SUITE: ocp-operator-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-scanner-v4-install-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -102,6 +105,7 @@ tests:
       TEST_SUITE: ocp-scanner-v4-install-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-ui-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -110,6 +114,7 @@ tests:
       TEST_SUITE: ocp-ui-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-nongroovy-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -118,6 +123,7 @@ tests:
       TEST_SUITE: ocp-nongroovy-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-compliance-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-4.10__ocp-4-21.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-4.10__ocp-4-21.yaml
@@ -89,6 +89,7 @@ tests:
       TEST_SUITE: ocp-compliance-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -97,6 +98,7 @@ tests:
       TEST_SUITE: ocp-qa-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-fips-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -106,6 +108,7 @@ tests:
       TEST_SUITE: ocp-qa-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-operator-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -113,6 +116,7 @@ tests:
       TEST_SUITE: ocp-operator-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-scanner-v4-install-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -121,6 +125,7 @@ tests:
       TEST_SUITE: ocp-scanner-v4-install-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-ui-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -129,6 +134,7 @@ tests:
       TEST_SUITE: ocp-ui-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-nongroovy-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -137,6 +143,7 @@ tests:
       TEST_SUITE: ocp-nongroovy-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-compliance-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-4.10__ocp-dev-preview.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-4.10__ocp-dev-preview.yaml
@@ -89,6 +89,7 @@ tests:
       TEST_SUITE: ocp-compliance-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -97,6 +98,7 @@ tests:
       TEST_SUITE: ocp-qa-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-fips-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -106,6 +108,7 @@ tests:
       TEST_SUITE: ocp-qa-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-operator-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -113,6 +116,7 @@ tests:
       TEST_SUITE: ocp-operator-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-scanner-v4-install-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -121,6 +125,7 @@ tests:
       TEST_SUITE: ocp-scanner-v4-install-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-ui-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -129,6 +134,7 @@ tests:
       TEST_SUITE: ocp-ui-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-nongroovy-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -137,6 +143,7 @@ tests:
       TEST_SUITE: ocp-nongroovy-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-compliance-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-4.10__ocp-next-candidate.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-4.10__ocp-next-candidate.yaml
@@ -89,6 +89,7 @@ tests:
       TEST_SUITE: ocp-compliance-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -97,6 +98,7 @@ tests:
       TEST_SUITE: ocp-qa-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-fips-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -106,6 +108,7 @@ tests:
       TEST_SUITE: ocp-qa-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-operator-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -113,6 +116,7 @@ tests:
       TEST_SUITE: ocp-operator-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-scanner-v4-install-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -121,6 +125,7 @@ tests:
       TEST_SUITE: ocp-scanner-v4-install-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-ui-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -129,6 +134,7 @@ tests:
       TEST_SUITE: ocp-ui-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-nongroovy-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -137,6 +143,7 @@ tests:
       TEST_SUITE: ocp-nongroovy-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-compliance-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-4.8.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-4.8.yaml
@@ -237,12 +237,14 @@ tests:
       TEST_SUITE: rosa-qa-e2e-tests
     workflow: stackrox-automation-flavors-rosa-hcp-e2e
 - as: merge-gke-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-oldest-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -251,6 +253,7 @@ tests:
       TEST_SUITE: gke-qa-e2e-tests
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-latest-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -259,12 +262,14 @@ tests:
       TEST_SUITE: gke-qa-e2e-tests
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-ui-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-oldest-ui-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -273,6 +278,7 @@ tests:
       TEST_SUITE: gke-ui-e2e-tests
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-latest-ui-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -281,12 +287,14 @@ tests:
       TEST_SUITE: gke-ui-e2e-tests
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-nongroovy-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-oldest-nongroovy-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -295,6 +303,7 @@ tests:
       TEST_SUITE: gke-nongroovy-e2e-tests
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-latest-nongroovy-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -303,28 +312,33 @@ tests:
       TEST_SUITE: gke-nongroovy-e2e-tests
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-nongroovy-compatibility-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-scanner-v4-install-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-sensor-integration-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-operator-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-oldest-operator-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -332,6 +346,7 @@ tests:
       TEST_SUITE: gke-operator-e2e-tests
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-latest-operator-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -339,54 +354,64 @@ tests:
       TEST_SUITE: gke-operator-e2e-tests
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-upgrade-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-version-compatibility-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-race-condition-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-scale-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     workflow: stackrox-stackrox-e2e-job
 - as: merge-eks-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-automation-flavors-eks-e2e
 - as: merge-osd-gcp-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-automation-flavors-osd-gcp-e2e
 - as: merge-aro-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-automation-flavors-aro-e2e
 - as: merge-aks-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-automation-flavors-aks-e2e
 - as: merge-rosa-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-automation-flavors-rosa-e2e
 - as: merge-rosa-hcp-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-4.8__ocp-4-12.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-4.8__ocp-4-12.yaml
@@ -79,6 +79,7 @@ tests:
       TEST_SUITE: ocp-compliance-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -87,6 +88,7 @@ tests:
       TEST_SUITE: ocp-qa-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-operator-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -94,6 +96,7 @@ tests:
       TEST_SUITE: ocp-operator-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-scanner-v4-install-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -102,6 +105,7 @@ tests:
       TEST_SUITE: ocp-scanner-v4-install-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-ui-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -110,6 +114,7 @@ tests:
       TEST_SUITE: ocp-ui-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-nongroovy-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -118,6 +123,7 @@ tests:
       TEST_SUITE: ocp-nongroovy-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-compliance-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-4.8__ocp-4-20.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-4.8__ocp-4-20.yaml
@@ -89,6 +89,7 @@ tests:
       TEST_SUITE: ocp-compliance-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -97,6 +98,7 @@ tests:
       TEST_SUITE: ocp-qa-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-fips-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -106,6 +108,7 @@ tests:
       TEST_SUITE: ocp-qa-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-operator-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -113,6 +116,7 @@ tests:
       TEST_SUITE: ocp-operator-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-scanner-v4-install-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -121,6 +125,7 @@ tests:
       TEST_SUITE: ocp-scanner-v4-install-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-ui-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -129,6 +134,7 @@ tests:
       TEST_SUITE: ocp-ui-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-nongroovy-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -137,6 +143,7 @@ tests:
       TEST_SUITE: ocp-nongroovy-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-compliance-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-4.8__ocp-dev-preview.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-4.8__ocp-dev-preview.yaml
@@ -89,6 +89,7 @@ tests:
       TEST_SUITE: ocp-compliance-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -97,6 +98,7 @@ tests:
       TEST_SUITE: ocp-qa-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-fips-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -106,6 +108,7 @@ tests:
       TEST_SUITE: ocp-qa-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-operator-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -113,6 +116,7 @@ tests:
       TEST_SUITE: ocp-operator-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-scanner-v4-install-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -121,6 +125,7 @@ tests:
       TEST_SUITE: ocp-scanner-v4-install-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-ui-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -129,6 +134,7 @@ tests:
       TEST_SUITE: ocp-ui-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-nongroovy-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -137,6 +143,7 @@ tests:
       TEST_SUITE: ocp-nongroovy-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-compliance-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-4.8__ocp-next-candidate.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-4.8__ocp-next-candidate.yaml
@@ -89,6 +89,7 @@ tests:
       TEST_SUITE: ocp-compliance-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -97,6 +98,7 @@ tests:
       TEST_SUITE: ocp-qa-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-fips-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -106,6 +108,7 @@ tests:
       TEST_SUITE: ocp-qa-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-operator-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -113,6 +116,7 @@ tests:
       TEST_SUITE: ocp-operator-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-scanner-v4-install-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -121,6 +125,7 @@ tests:
       TEST_SUITE: ocp-scanner-v4-install-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-ui-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -129,6 +134,7 @@ tests:
       TEST_SUITE: ocp-ui-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-nongroovy-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -137,6 +143,7 @@ tests:
       TEST_SUITE: ocp-nongroovy-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-compliance-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-4.9.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-4.9.yaml
@@ -237,12 +237,14 @@ tests:
       TEST_SUITE: rosa-qa-e2e-tests
     workflow: stackrox-automation-flavors-rosa-hcp-e2e
 - as: merge-gke-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-oldest-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -251,6 +253,7 @@ tests:
       TEST_SUITE: gke-qa-e2e-tests
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-latest-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -259,12 +262,14 @@ tests:
       TEST_SUITE: gke-qa-e2e-tests
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-ui-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-oldest-ui-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -273,6 +278,7 @@ tests:
       TEST_SUITE: gke-ui-e2e-tests
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-latest-ui-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -281,12 +287,14 @@ tests:
       TEST_SUITE: gke-ui-e2e-tests
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-nongroovy-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-oldest-nongroovy-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -295,6 +303,7 @@ tests:
       TEST_SUITE: gke-nongroovy-e2e-tests
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-latest-nongroovy-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -303,28 +312,33 @@ tests:
       TEST_SUITE: gke-nongroovy-e2e-tests
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-nongroovy-compatibility-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-scanner-v4-install-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-sensor-integration-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-operator-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-oldest-operator-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -332,6 +346,7 @@ tests:
       TEST_SUITE: gke-operator-e2e-tests
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-latest-operator-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -339,54 +354,64 @@ tests:
       TEST_SUITE: gke-operator-e2e-tests
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-upgrade-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-version-compatibility-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-race-condition-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-scale-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     workflow: stackrox-stackrox-e2e-job
 - as: merge-eks-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-automation-flavors-eks-e2e
 - as: merge-osd-gcp-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-automation-flavors-osd-gcp-e2e
 - as: merge-aro-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-automation-flavors-aro-e2e
 - as: merge-aks-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-automation-flavors-aks-e2e
 - as: merge-rosa-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-automation-flavors-rosa-e2e
 - as: merge-rosa-hcp-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-4.9__ocp-4-12.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-4.9__ocp-4-12.yaml
@@ -79,6 +79,7 @@ tests:
       TEST_SUITE: ocp-compliance-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -87,6 +88,7 @@ tests:
       TEST_SUITE: ocp-qa-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-operator-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -94,6 +96,7 @@ tests:
       TEST_SUITE: ocp-operator-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-scanner-v4-install-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -102,6 +105,7 @@ tests:
       TEST_SUITE: ocp-scanner-v4-install-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-ui-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -110,6 +114,7 @@ tests:
       TEST_SUITE: ocp-ui-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-nongroovy-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -118,6 +123,7 @@ tests:
       TEST_SUITE: ocp-nongroovy-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-compliance-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-4.9__ocp-4-21.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-4.9__ocp-4-21.yaml
@@ -89,6 +89,7 @@ tests:
       TEST_SUITE: ocp-compliance-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -97,6 +98,7 @@ tests:
       TEST_SUITE: ocp-qa-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-fips-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -106,6 +108,7 @@ tests:
       TEST_SUITE: ocp-qa-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-operator-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -113,6 +116,7 @@ tests:
       TEST_SUITE: ocp-operator-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-scanner-v4-install-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -121,6 +125,7 @@ tests:
       TEST_SUITE: ocp-scanner-v4-install-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-ui-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -129,6 +134,7 @@ tests:
       TEST_SUITE: ocp-ui-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-nongroovy-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -137,6 +143,7 @@ tests:
       TEST_SUITE: ocp-nongroovy-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-compliance-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-4.9__ocp-dev-preview.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-4.9__ocp-dev-preview.yaml
@@ -89,6 +89,7 @@ tests:
       TEST_SUITE: ocp-compliance-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -97,6 +98,7 @@ tests:
       TEST_SUITE: ocp-qa-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-fips-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -106,6 +108,7 @@ tests:
       TEST_SUITE: ocp-qa-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-operator-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -113,6 +116,7 @@ tests:
       TEST_SUITE: ocp-operator-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-scanner-v4-install-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -121,6 +125,7 @@ tests:
       TEST_SUITE: ocp-scanner-v4-install-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-ui-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -129,6 +134,7 @@ tests:
       TEST_SUITE: ocp-ui-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-nongroovy-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -137,6 +143,7 @@ tests:
       TEST_SUITE: ocp-nongroovy-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-compliance-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-4.9__ocp-next-candidate.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-4.9__ocp-next-candidate.yaml
@@ -89,6 +89,7 @@ tests:
       TEST_SUITE: ocp-compliance-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -97,6 +98,7 @@ tests:
       TEST_SUITE: ocp-qa-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-fips-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -106,6 +108,7 @@ tests:
       TEST_SUITE: ocp-qa-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-operator-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -113,6 +116,7 @@ tests:
       TEST_SUITE: ocp-operator-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-scanner-v4-install-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -121,6 +125,7 @@ tests:
       TEST_SUITE: ocp-scanner-v4-install-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-ui-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -129,6 +134,7 @@ tests:
       TEST_SUITE: ocp-ui-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-nongroovy-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -137,6 +143,7 @@ tests:
       TEST_SUITE: ocp-nongroovy-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-compliance-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-x.y.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-x.y.yaml
@@ -237,12 +237,14 @@ tests:
       TEST_SUITE: rosa-qa-e2e-tests
     workflow: stackrox-automation-flavors-rosa-hcp-e2e
 - as: merge-gke-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-oldest-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -251,6 +253,7 @@ tests:
       TEST_SUITE: gke-qa-e2e-tests
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-latest-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -259,12 +262,14 @@ tests:
       TEST_SUITE: gke-qa-e2e-tests
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-ui-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-oldest-ui-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -273,6 +278,7 @@ tests:
       TEST_SUITE: gke-ui-e2e-tests
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-latest-ui-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -281,12 +287,14 @@ tests:
       TEST_SUITE: gke-ui-e2e-tests
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-nongroovy-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-oldest-nongroovy-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -295,6 +303,7 @@ tests:
       TEST_SUITE: gke-nongroovy-e2e-tests
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-latest-nongroovy-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -303,28 +312,33 @@ tests:
       TEST_SUITE: gke-nongroovy-e2e-tests
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-nongroovy-compatibility-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-scanner-v4-install-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-sensor-integration-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-operator-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-oldest-operator-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -332,6 +346,7 @@ tests:
       TEST_SUITE: gke-operator-e2e-tests
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-latest-operator-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -339,54 +354,64 @@ tests:
       TEST_SUITE: gke-operator-e2e-tests
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-upgrade-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-version-compatibility-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-race-condition-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-stackrox-e2e-job
 - as: merge-gke-scale-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     workflow: stackrox-stackrox-e2e-job
 - as: merge-eks-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-automation-flavors-eks-e2e
 - as: merge-osd-gcp-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-automation-flavors-osd-gcp-e2e
 - as: merge-aro-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-automation-flavors-aro-e2e
 - as: merge-aks-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-automation-flavors-aks-e2e
 - as: merge-rosa-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
       COLLECTION_METHOD: core_bpf
     workflow: stackrox-automation-flavors-rosa-e2e
 - as: merge-rosa-hcp-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-x.y__ocp-4-12.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-x.y__ocp-4-12.yaml
@@ -79,6 +79,7 @@ tests:
       TEST_SUITE: ocp-compliance-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -87,6 +88,7 @@ tests:
       TEST_SUITE: ocp-qa-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-operator-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -94,6 +96,7 @@ tests:
       TEST_SUITE: ocp-operator-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-scanner-v4-install-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -102,6 +105,7 @@ tests:
       TEST_SUITE: ocp-scanner-v4-install-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-ui-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -110,6 +114,7 @@ tests:
       TEST_SUITE: ocp-ui-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-nongroovy-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -118,6 +123,7 @@ tests:
       TEST_SUITE: ocp-nongroovy-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-compliance-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-x.y__ocp-4-21.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-x.y__ocp-4-21.yaml
@@ -89,6 +89,7 @@ tests:
       TEST_SUITE: ocp-compliance-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -97,6 +98,7 @@ tests:
       TEST_SUITE: ocp-qa-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-fips-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -106,6 +108,7 @@ tests:
       TEST_SUITE: ocp-qa-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-operator-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -113,6 +116,7 @@ tests:
       TEST_SUITE: ocp-operator-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-scanner-v4-install-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -121,6 +125,7 @@ tests:
       TEST_SUITE: ocp-scanner-v4-install-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-ui-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -129,6 +134,7 @@ tests:
       TEST_SUITE: ocp-ui-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-nongroovy-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -137,6 +143,7 @@ tests:
       TEST_SUITE: ocp-nongroovy-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-compliance-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-x.y__ocp-dev-preview.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-x.y__ocp-dev-preview.yaml
@@ -89,6 +89,7 @@ tests:
       TEST_SUITE: ocp-compliance-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -97,6 +98,7 @@ tests:
       TEST_SUITE: ocp-qa-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-fips-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -106,6 +108,7 @@ tests:
       TEST_SUITE: ocp-qa-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-operator-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -113,6 +116,7 @@ tests:
       TEST_SUITE: ocp-operator-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-scanner-v4-install-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -121,6 +125,7 @@ tests:
       TEST_SUITE: ocp-scanner-v4-install-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-ui-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -129,6 +134,7 @@ tests:
       TEST_SUITE: ocp-ui-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-nongroovy-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -137,6 +143,7 @@ tests:
       TEST_SUITE: ocp-nongroovy-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-compliance-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-x.y__ocp-next-candidate.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-x.y__ocp-next-candidate.yaml
@@ -89,6 +89,7 @@ tests:
       TEST_SUITE: ocp-compliance-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -97,6 +98,7 @@ tests:
       TEST_SUITE: ocp-qa-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-fips-qa-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -106,6 +108,7 @@ tests:
       TEST_SUITE: ocp-qa-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-operator-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -113,6 +116,7 @@ tests:
       TEST_SUITE: ocp-operator-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-scanner-v4-install-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -121,6 +125,7 @@ tests:
       TEST_SUITE: ocp-scanner-v4-install-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-ui-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -129,6 +134,7 @@ tests:
       TEST_SUITE: ocp-ui-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-nongroovy-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:
@@ -137,6 +143,7 @@ tests:
       TEST_SUITE: ocp-nongroovy-e2e-tests
     workflow: stackrox-automation-flavors-ocp-4-e2e
 - as: merge-compliance-e2e-tests
+  max_concurrency: 6
   postsubmit: true
   steps:
     env:


### PR DESCRIPTION
## Summary
- Adds `max_concurrency` to ci-operator test config for 254 tests across 30 config files
- Migrates manually-set values from Prow job YAMLs into the source of truth (ci-operator config)
- Repos affected: stackrox/stackrox (6), stackrox/scanner (5), redhat-developer/rhdh (1-4), redhat-developer/rhdh-plugin-export-overlays (2), redhat-developer/rhdh-test-instance (3), openshift/aws-account-operator (1)
- No behavioral change — merge logic preserves existing job YAML values until manual overrides are removed
- Depends on openshift/ci-tools#5140

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added concurrency limits to CI test jobs across multiple project configurations to cap parallel test runs (values vary by job, commonly between 1 and 6). This reduces resource contention and improves test scheduling and stability across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->