### PR TITLE
Use specific pip installer for RHEL9 SNO AWS conf

### DIFF
--- a/ci-operator/step-registry/single-node/conf/aws/single-node-conf-aws-commands.sh
+++ b/ci-operator/step-registry/single-node/conf/aws/single-node-conf-aws-commands.sh
@@ -20,7 +20,7 @@ echo "Updating install-config.yaml to a single ${SINGLE_NODE_AWS_INSTANCE_TYPE} 
 OS_VER=$(awk -F= '/^VERSION_ID=/ { print $2 }' /etc/os-release | tr -d '"' | cut -f1 -d'.')
 if [[ ${OS_VER} == "9" ]]; then
     echo "Detected RHEL9, installing pip"
-    curl -L -o /tmp/get-pip.py -w "\nStatus Code: %{http_code}\n" https://bootstrap.pypa.io/get-pip.py
+    curl -L -o /tmp/get-pip.py -w "\nStatus Code: %{http_code}\n" "https://bootstrap.pypa.io/pip/$(python --version | cut -d' ' -f2 | cut -d'.' -f1-2)/get-pip.py"
     python /tmp/get-pip.py
     export PATH=$PATH:$HOME/.local/bin
 fi


### PR DESCRIPTION
We've seen the following error in the rehearsals for this [1] PR:

```
ERROR: This script does not work on Python 3.9. The minimum supported Python version is 3.10. Please use https://bootstrap.pypa.io/pip/3.9/get-pip.py instead.
```

I'm not sure what about the PR is causing this, but looks like it can be solved by adding the version number to the pip installer download URL.

[1] https://github.com/openshift/release/pull/78300

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pip bootstrapper configuration for RHEL9 systems by using Python-version-specific endpoints, ensuring better compatibility with the target runtime environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->