### PR TITLE
No-Jira: Updated workflow to only include clusterinfra cases

### DIFF
--- a/ci-operator/config/openshift/cloud-provider-azure/openshift-cloud-provider-azure-main.yaml
+++ b/ci-operator/config/openshift/cloud-provider-azure/openshift-cloud-provider-azure-main.yaml
@@ -102,12 +102,12 @@ tests:
   steps:
     cluster_profile: openshift-org-azure
     workflow: openshift-e2e-azure
-- as: e2e-azurestack-ipi
+- as: openshift-e2e-azurestack-clusterinfra
   cluster: build01
   skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
   steps:
     cluster_profile: azurestack-dev
-    workflow: openshift-e2e-azurestack
+    workflow: openshift-e2e-azurestack-clusterinfra
 - as: e2e-azure-ovn-upgrade
   skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
   steps:

--- a/ci-operator/jobs/openshift/cloud-provider-azure/openshift-cloud-provider-azure-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-azure/openshift-cloud-provider-azure-main-presubmits.yaml
@@ -165,89 +165,6 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-azure-ovn-upgrade,?($|\s.*)
   - agent: kubernetes
-    always_run: false
-    branches:
-    - ^main$
-    - ^main-
-    cluster: build01
-    context: ci/prow/e2e-azurestack-ipi
-    decorate: true
-    labels:
-      ci-operator.openshift.io/cloud: azurestack
-      ci-operator.openshift.io/cloud-cluster-profile: azurestack-dev
-      ci-operator.openshift.io/cluster: build01
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cloud-provider-azure-main-e2e-azurestack-ipi
-    path_alias: github.com/kubernetes-sigs/cloud-provider-azure
-    rerun_command: /test e2e-azurestack-ipi
-    skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-azurestack-ipi
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-azurestack-ipi,?($|\s.*)
-  - agent: kubernetes
     always_run: true
     branches:
     - ^main$
@@ -446,6 +363,89 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )okd-scos-images,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build01
+    context: ci/prow/openshift-e2e-azurestack-clusterinfra
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: azurestack
+      ci-operator.openshift.io/cloud-cluster-profile: azurestack-dev
+      ci-operator.openshift.io/cluster: build01
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cloud-provider-azure-main-openshift-e2e-azurestack-clusterinfra
+    path_alias: github.com/kubernetes-sigs/cloud-provider-azure
+    rerun_command: /test openshift-e2e-azurestack-clusterinfra
+    skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=openshift-e2e-azurestack-clusterinfra
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )openshift-e2e-azurestack-clusterinfra,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:

--- a/ci-operator/jobs/openshift/cloud-provider-azure/openshift-cloud-provider-azure-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-azure/openshift-cloud-provider-azure-main-presubmits.yaml
@@ -175,94 +175,6 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-azure-ovn-upgrade,?($|\s.*)
   - agent: kubernetes
-    always_run: false
-    branches:
-    - ^main$
-    - ^main-
-    cluster: build01
-    context: ci/prow/e2e-azurestack-ipi
-    decorate: true
-    decoration_config:
-      sparse_checkout_files:
-      - .ci-operator.yaml
-      - openshift-hack/images/cloud-controller-manager-openshift.Dockerfile
-      - openshift-hack/images/cloud-node-manager-openshift.Dockerfile
-    labels:
-      ci-operator.openshift.io/cloud: azurestack
-      ci-operator.openshift.io/cloud-cluster-profile: azurestack-dev
-      ci-operator.openshift.io/cluster: build01
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cloud-provider-azure-main-e2e-azurestack-ipi
-    path_alias: github.com/kubernetes-sigs/cloud-provider-azure
-    rerun_command: /test e2e-azurestack-ipi
-    skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-azurestack-ipi
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-azurestack-ipi,?($|\s.*)
-  - agent: kubernetes
     always_run: true
     branches:
     - ^main$
@@ -478,6 +390,11 @@ presubmits:
     cluster: build01
     context: ci/prow/openshift-e2e-azurestack-clusterinfra
     decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - .ci-operator.yaml
+      - openshift-hack/images/cloud-controller-manager-openshift.Dockerfile
+      - openshift-hack/images/cloud-node-manager-openshift.Dockerfile
     labels:
       ci-operator.openshift.io/cloud: azurestack
       ci-operator.openshift.io/cloud-cluster-profile: azurestack-dev

--- a/ci-operator/step-registry/openshift/e2e/azurestack/clusterinfra/OWNERS
+++ b/ci-operator/step-registry/openshift/e2e/azurestack/clusterinfra/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+- damdo
+- mdbooth
+- nrb
+- racheljpg
+- radekmanak
+- stephenfin
+- theobarberbany

--- a/ci-operator/step-registry/openshift/e2e/azurestack/clusterinfra/openshift-e2e-azurestack-clusterinfra-workflow.metadata.json
+++ b/ci-operator/step-registry/openshift/e2e/azurestack/clusterinfra/openshift-e2e-azurestack-clusterinfra-workflow.metadata.json
@@ -1,0 +1,14 @@
+{
+	"path": "openshift/e2e/azurestack/clusterinfra/openshift-e2e-azurestack-clusterinfra-workflow.yaml",
+	"owners": {
+		"approvers": [
+			"damdo",
+			"mdbooth",
+			"nrb",
+			"racheljpg",
+			"radekmanak",
+			"stephenfin",
+			"theobarberbany"
+		]
+	}
+}

--- a/ci-operator/step-registry/openshift/e2e/azurestack/clusterinfra/openshift-e2e-azurestack-clusterinfra-workflow.yaml
+++ b/ci-operator/step-registry/openshift/e2e/azurestack/clusterinfra/openshift-e2e-azurestack-clusterinfra-workflow.yaml
@@ -1,0 +1,12 @@
+workflow:
+  as: openshift-e2e-azurestack-clusterinfra
+  steps:
+    pre:
+    - chain: ipi-azurestack-pre
+    test:
+    - chain: openshift-e2e-test-clusterinfra-qe-regression
+    post:
+    - chain: gather-core-dump
+    - chain: ipi-azurestack-post
+  documentation: |-
+    The Openshift E2E AzureStack Cluster Infrastructure workflow executes the cluster infrastructure QE regression test suite on AzureStack.


### PR DESCRIPTION
@damdo PTAL when time permits , this is related to ash pre-submit job running all tests instead of just clusterinfra Azure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Azure Stack IPI E2E test step alias in CI configuration.
  * Added a new Azure Stack cluster-infrastructure E2E workflow (pre/test/post phases) and accompanying metadata.
  * Added approvers to the workflow's ownership configuration to authorize reviews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->