### PR TITLE
Narrow KMM test scope to modules-only for ROSA HCP

### DIFF
--- a/ci-operator/step-registry/aws-neuron-operator/kmm-test/aws-neuron-operator-kmm-test-commands.sh
+++ b/ci-operator/step-registry/aws-neuron-operator/kmm-test/aws-neuron-operator-kmm-test-commands.sh
@@ -39,7 +39,7 @@ fi
 cd /home/testuser || exit 1
 
 export ECO_TEST_FEATURES="${KMM_TEST_FEATURES:-modules}"
-export ECO_TEST_LABELS="${KMM_TEST_LABELS:-kmm-sanity}"
+export ECO_TEST_LABELS="${KMM_TEST_LABELS:-kmm-sanity && !bmc}"
 export ECO_TEST_VERBOSE="true"
 export ECO_VERBOSE_LEVEL="100"
 export ECO_DUMP_FAILED_TESTS="${ECO_DUMP_FAILED_TESTS:-true}"
@@ -56,7 +56,7 @@ ginkgo --label-filter="${ECO_TEST_LABELS}" \
     --keep-going \
     --junit-report=junit_kmm_modules.xml \
     --output-dir="${ARTIFACT_DIR}" \
-    ./tests/hw-accel/kmm/... || TEST_EXIT_CODE=$?
+    ./tests/hw-accel/kmm/modules/... || TEST_EXIT_CODE=$?
 
 if [[ ${TEST_EXIT_CODE} -eq 0 ]]; then
     echo "SUCCESS" > "${ARTIFACT_DIR}/kmm_sanity.status"

--- a/ci-operator/step-registry/aws-neuron-operator/kmm-test/aws-neuron-operator-kmm-test-ref.yaml
+++ b/ci-operator/step-registry/aws-neuron-operator/kmm-test/aws-neuron-operator-kmm-test-ref.yaml
@@ -13,7 +13,7 @@ ref:
     default: "modules"
     documentation: The eco-gotests feature directories to run for KMM tests (space-separated).
   - name: KMM_TEST_LABELS
-    default: "kmm-sanity"
+    default: "kmm-sanity && !bmc"
     documentation: Ginkgo label filter expression for KMM test selection.
   - name: ECO_HWACCEL_KMM_REGISTRY
     default: "quay.io/ocp-edge-qe"


### PR DESCRIPTION
## Summary
- Restrict KMM ginkgo test path from `./tests/hw-accel/kmm/...` to `./tests/hw-accel/kmm/modules/...` to avoid running BMC, MCM, and upgrade suites that require master nodes or hub-spoke topology
- Update label filter default to `kmm-sanity && !bmc` as additional safety against BMC-labeled tests within modules
- ROSA HCP clusters have no master nodes, so MachineConfig-dependent tests always fail

## Test plan
- [ ] CI rehearsal validates step registry syntax
- [ ] Retrigger KMM test on neuron-ci PR to confirm only modules tests run
- [ ] Verify JUnit report shows reduced test count (no BMC/MCM/upgrade tests)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test selection filtering to exclude specific test categories while maintaining focus on core validation tests.
  * Refined test execution scope to target module-specific testing, improving testing efficiency and focus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->