### PR TITLE
NO-JIRA: chore: onboarding the openshift-eng/openshift-ci-mcp to prow

### DIFF
--- a/core-services/prow/02_config/openshift-eng/openshift-ci-mcp/OWNERS
+++ b/core-services/prow/02_config/openshift-eng/openshift-ci-mcp/OWNERS
@@ -1,0 +1,49 @@
+# DO NOT EDIT; this file is auto-generated using https://github.com/openshift/ci-tools.
+# Fetched from https://github.com/openshift-eng/openshift-ci-mcp root OWNERS
+# If the repo had OWNERS_ALIASES then the aliases were expanded
+# Logins who are not members of 'openshift' organization were filtered out
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+- agullon
+- brandisher
+- copejon
+- dhensel-rh
+- eggfoobar
+- eslutsky
+- fonta-rh
+- fracappa
+- ggiguash
+- jaypoulz
+- jeff-roche
+- jerpeter1
+- kasturinarra
+- lucaconsalvi
+- mmakwana30
+- pacevedom
+- pmtk
+- qjkee
+- suleymanakbas91
+- vimauro
+options: {}
+reviewers:
+- agullon
+- brandisher
+- copejon
+- dhensel-rh
+- eggfoobar
+- eslutsky
+- fonta-rh
+- fracappa
+- ggiguash
+- jaypoulz
+- jeff-roche
+- jerpeter1
+- kasturinarra
+- lucaconsalvi
+- mmakwana30
+- pacevedom
+- pmtk
+- qjkee
+- suleymanakbas91
+- vimauro

--- a/core-services/prow/02_config/openshift-eng/openshift-ci-mcp/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-eng/openshift-ci-mcp/_pluginconfig.yaml
@@ -1,0 +1,26 @@
+approve:
+- repos:
+  - openshift-eng/openshift-ci-mcp
+  require_self_approval: false
+lgtm:
+- repos:
+  - openshift-eng/openshift-ci-mcp
+  review_acts_as_lgtm: true
+plugins:
+  openshift-eng/openshift-ci-mcp:
+    plugins:
+    - approve
+    - hold
+    - label
+    - lgtm
+    - trigger
+    - verify-owners
+    - wip
+    - jira
+triggers:
+- org_invite:
+    prominent: {}
+  repos:
+  - openshift-eng/openshift-ci-mcp
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-eng/openshift-ci-mcp/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift-eng/openshift-ci-mcp/_prowconfig.yaml
@@ -1,0 +1,13 @@
+tide:
+  queries:
+  - labels:
+    - approved
+    - lgtm
+    missingLabels:
+    - backports/unvalidated-commits
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - jira/invalid-bug
+    repos:
+    - openshift-eng/openshift-ci-mcp


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Onboards the openshift-eng/openshift-ci-mcp repository to Prow by adding repository-specific Prow configuration and an autogenerated OWNERS file under core-services/prow/02_config/openshift-eng/openshift-ci-mcp.

- OWNERS: adds an autogenerated OWNERS file listing explicit approvers and reviewers (same GitHub usernames) and empty options. This establishes who can approve and review PRs for that repo when verify-owners/approve plugins run.

- Plugin configuration (_pluginconfig.yaml): enables Prow plugins for the repo: approve, hold, label, lgtm, trigger, verify-owners, wip, and jira. Key behavioral settings:
  - require_self_approval: false (authors cannot self-approve).
  - review_acts_as_lgtm: true (a review counts as LGTM).
  - triggers are restricted to the trusted app openshift-merge-bot.

- Tide configuration (_prowconfig.yaml): adds a Tide query for the repo that only matches PRs labeled with both approved and lgtm, and treats several “do-not-merge/*” and other operational labels (e.g., backports/unvalidated-commits, jira/invalid-bug) as missingLabels that prevent Tide from considering PRs for automatic merging.

Practical effect: this PR wires the repository into OpenShift’s automated review and merge workflows — establishing who can review/approve, which Prow plugins will run, how approvals/LGTM behave, which bot can trigger jobs, and the Tide criteria that gate automated merges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->