### PR TITLE
NOJIRA: Migrate etcd to use release-* branch naming conventions instead of openshift-*

### DIFF
--- a/ci-operator/config/openshift/etcd/openshift-etcd-release-4.23.yaml
+++ b/ci-operator/config/openshift/etcd/openshift-etcd-release-4.23.yaml
@@ -19,18 +19,17 @@ images:
     to: installer-etcd-artifacts
 promotion:
   to:
-  - disabled: true
-    name: "5.0"
+  - name: "4.23"
     namespace: ocp
 releases:
   initial:
     integration:
-      name: "5.0"
+      name: "4.23"
       namespace: ocp
   latest:
     integration:
       include_built_images: true
-      name: "5.0"
+      name: "4.23"
       namespace: ocp
 resources:
   '*':
@@ -107,6 +106,6 @@ tests:
     - chain: openshift-qe-control-plane
     workflow: openshift-qe-installer-aws
 zz_generated_metadata:
-  branch: openshift-5.0
+  branch: release-4.23
   org: openshift
   repo: etcd

--- a/ci-operator/config/openshift/etcd/openshift-etcd-release-5.0.yaml
+++ b/ci-operator/config/openshift/etcd/openshift-etcd-release-5.0.yaml
@@ -19,17 +19,18 @@ images:
     to: installer-etcd-artifacts
 promotion:
   to:
-  - name: "5.1"
+  - disabled: true
+    name: "5.0"
     namespace: ocp
 releases:
   initial:
     integration:
-      name: "5.1"
+      name: "5.0"
       namespace: ocp
   latest:
     integration:
       include_built_images: true
-      name: "5.1"
+      name: "5.0"
       namespace: ocp
 resources:
   '*':
@@ -106,6 +107,6 @@ tests:
     - chain: openshift-qe-control-plane
     workflow: openshift-qe-installer-aws
 zz_generated_metadata:
-  branch: openshift-5.1
+  branch: release-5.0
   org: openshift
   repo: etcd

--- a/ci-operator/config/openshift/etcd/openshift-etcd-release-5.1.yaml
+++ b/ci-operator/config/openshift/etcd/openshift-etcd-release-5.1.yaml
@@ -19,17 +19,17 @@ images:
     to: installer-etcd-artifacts
 promotion:
   to:
-  - name: "4.23"
+  - name: "5.1"
     namespace: ocp
 releases:
   initial:
     integration:
-      name: "4.23"
+      name: "5.1"
       namespace: ocp
   latest:
     integration:
       include_built_images: true
-      name: "4.23"
+      name: "5.1"
       namespace: ocp
 resources:
   '*':
@@ -106,6 +106,6 @@ tests:
     - chain: openshift-qe-control-plane
     workflow: openshift-qe-installer-aws
 zz_generated_metadata:
-  branch: openshift-4.23
+  branch: release-5.1
   org: openshift
   repo: etcd

--- a/ci-operator/jobs/openshift/etcd/openshift-etcd-release-4.23-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/etcd/openshift-etcd-release-4.23-postsubmits.yaml
@@ -3,14 +3,14 @@ postsubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^openshift-5\.1$
-    cluster: build03
+    - ^release-4\.23$
+    cluster: build01
     decorate: true
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-openshift-etcd-openshift-5.1-images
+    name: branch-ci-openshift-etcd-release-4.23-images
     path_alias: go.etcd.io/etcd
     spec:
       containers:

--- a/ci-operator/jobs/openshift/etcd/openshift-etcd-release-4.23-presubmits.yaml
+++ b/ci-operator/jobs/openshift/etcd/openshift-etcd-release-4.23-presubmits.yaml
@@ -3,9 +3,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^openshift-5\.0$
-    - ^openshift-5\.0-
-    cluster: build07
+    - ^release-4\.23$
+    - ^release-4\.23-
+    cluster: build06
     context: ci/prow/configmap-scale
     decorate: true
     labels:
@@ -13,7 +13,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-5.0-configmap-scale
+    name: pull-ci-openshift-etcd-release-4.23-configmap-scale
     path_alias: go.etcd.io/etcd
     rerun_command: /test configmap-scale
     spec:
@@ -84,9 +84,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^openshift-5\.0$
-    - ^openshift-5\.0-
-    cluster: build07
+    - ^release-4\.23$
+    - ^release-4\.23-
+    cluster: build06
     context: ci/prow/e2e-aws-etcd-recovery
     decorate: true
     labels:
@@ -94,7 +94,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-5.0-e2e-aws-etcd-recovery
+    name: pull-ci-openshift-etcd-release-4.23-e2e-aws-etcd-recovery
     optional: true
     path_alias: go.etcd.io/etcd
     rerun_command: /test e2e-aws-etcd-recovery
@@ -166,9 +166,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^openshift-5\.0$
-    - ^openshift-5\.0-
-    cluster: build07
+    - ^release-4\.23$
+    - ^release-4\.23-
+    cluster: build06
     context: ci/prow/e2e-aws-ovn
     decorate: true
     labels:
@@ -176,7 +176,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-5.0-e2e-aws-ovn
+    name: pull-ci-openshift-etcd-release-4.23-e2e-aws-ovn
     path_alias: go.etcd.io/etcd
     rerun_command: /test e2e-aws-ovn
     spec:
@@ -247,9 +247,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^openshift-5\.0$
-    - ^openshift-5\.0-
-    cluster: build07
+    - ^release-4\.23$
+    - ^release-4\.23-
+    cluster: build06
     context: ci/prow/e2e-aws-ovn-serial
     decorate: true
     labels:
@@ -257,7 +257,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-5.0-e2e-aws-ovn-serial
+    name: pull-ci-openshift-etcd-release-4.23-e2e-aws-ovn-serial
     path_alias: go.etcd.io/etcd
     rerun_command: /test e2e-aws-ovn-serial
     spec:
@@ -328,9 +328,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^openshift-5\.0$
-    - ^openshift-5\.0-
-    cluster: build07
+    - ^release-4\.23$
+    - ^release-4\.23-
+    cluster: build06
     context: ci/prow/e2e-aws-ovn-upgrade
     decorate: true
     labels:
@@ -338,7 +338,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-5.0-e2e-aws-ovn-upgrade
+    name: pull-ci-openshift-etcd-release-4.23-e2e-aws-ovn-upgrade
     path_alias: go.etcd.io/etcd
     rerun_command: /test e2e-aws-ovn-upgrade
     spec:
@@ -409,9 +409,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^openshift-5\.0$
-    - ^openshift-5\.0-
-    cluster: build06
+    - ^release-4\.23$
+    - ^release-4\.23-
+    cluster: build01
     context: ci/prow/e2e-hypershift
     decorate: true
     labels:
@@ -419,7 +419,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: hypershift-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-5.0-e2e-hypershift
+    name: pull-ci-openshift-etcd-release-4.23-e2e-hypershift
     optional: true
     path_alias: go.etcd.io/etcd
     rerun_command: /test e2e-hypershift
@@ -491,9 +491,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^openshift-5\.0$
-    - ^openshift-5\.0-
-    cluster: build06
+    - ^release-4\.23$
+    - ^release-4\.23-
+    cluster: build01
     context: ci/prow/e2e-hypershift-conformance
     decorate: true
     labels:
@@ -501,7 +501,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: hypershift-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-5.0-e2e-hypershift-conformance
+    name: pull-ci-openshift-etcd-release-4.23-e2e-hypershift-conformance
     optional: true
     path_alias: go.etcd.io/etcd
     rerun_command: /test e2e-hypershift-conformance
@@ -573,15 +573,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^openshift-5\.0$
-    - ^openshift-5\.0-
-    cluster: build06
+    - ^release-4\.23$
+    - ^release-4\.23-
+    cluster: build01
     context: ci/prow/images
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-5.0-images
+    name: pull-ci-openshift-etcd-release-4.23-images
     path_alias: go.etcd.io/etcd
     rerun_command: /test images
     spec:
@@ -591,6 +591,7 @@ presubmits:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --report-credentials-file=/etc/report/credentials
         - --target=[images]
+        - --target=[release:latest]
         command:
         - ci-operator
         image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
@@ -627,9 +628,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^openshift-5\.0$
-    - ^openshift-5\.0-
-    cluster: build07
+    - ^release-4\.23$
+    - ^release-4\.23-
+    cluster: build06
     context: ci/prow/perfscale-payload-control-plane-6nodes
     decorate: true
     labels:
@@ -637,7 +638,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-5.0-perfscale-payload-control-plane-6nodes
+    name: pull-ci-openshift-etcd-release-4.23-perfscale-payload-control-plane-6nodes
     optional: true
     path_alias: go.etcd.io/etcd
     rerun_command: /test perfscale-payload-control-plane-6nodes
@@ -709,15 +710,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^openshift-5\.0$
-    - ^openshift-5\.0-
-    cluster: build06
+    - ^release-4\.23$
+    - ^release-4\.23-
+    cluster: build01
     context: ci/prow/upstream-e2e
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-5.0-upstream-e2e
+    name: pull-ci-openshift-etcd-release-4.23-upstream-e2e
     optional: true
     path_alias: go.etcd.io/etcd
     rerun_command: /test upstream-e2e
@@ -772,15 +773,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^openshift-5\.0$
-    - ^openshift-5\.0-
-    cluster: build06
+    - ^release-4\.23$
+    - ^release-4\.23-
+    cluster: build01
     context: ci/prow/upstream-integration
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-5.0-upstream-integration
+    name: pull-ci-openshift-etcd-release-4.23-upstream-integration
     optional: true
     path_alias: go.etcd.io/etcd
     rerun_command: /test upstream-integration
@@ -835,15 +836,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^openshift-5\.0$
-    - ^openshift-5\.0-
-    cluster: build06
+    - ^release-4\.23$
+    - ^release-4\.23-
+    cluster: build01
     context: ci/prow/upstream-release
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-5.0-upstream-release
+    name: pull-ci-openshift-etcd-release-4.23-upstream-release
     optional: true
     path_alias: go.etcd.io/etcd
     rerun_command: /test upstream-release
@@ -898,15 +899,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^openshift-5\.0$
-    - ^openshift-5\.0-
-    cluster: build06
+    - ^release-4\.23$
+    - ^release-4\.23-
+    cluster: build01
     context: ci/prow/upstream-unit
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-5.0-upstream-unit
+    name: pull-ci-openshift-etcd-release-4.23-upstream-unit
     path_alias: go.etcd.io/etcd
     rerun_command: /test upstream-unit
     spec:

--- a/ci-operator/jobs/openshift/etcd/openshift-etcd-release-5.0-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/etcd/openshift-etcd-release-5.0-postsubmits.yaml
@@ -3,14 +3,14 @@ postsubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^openshift-5\.0$
-    cluster: build03
+    - ^release-5\.0$
+    cluster: build01
     decorate: true
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-openshift-etcd-openshift-5.0-images
+    name: branch-ci-openshift-etcd-release-5.0-images
     path_alias: go.etcd.io/etcd
     spec:
       containers:

--- a/ci-operator/jobs/openshift/etcd/openshift-etcd-release-5.0-presubmits.yaml
+++ b/ci-operator/jobs/openshift/etcd/openshift-etcd-release-5.0-presubmits.yaml
@@ -3,9 +3,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^openshift-4\.23$
-    - ^openshift-4\.23-
-    cluster: build09
+    - ^release-5\.0$
+    - ^release-5\.0-
+    cluster: build05
     context: ci/prow/configmap-scale
     decorate: true
     labels:
@@ -13,7 +13,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-4.23-configmap-scale
+    name: pull-ci-openshift-etcd-release-5.0-configmap-scale
     path_alias: go.etcd.io/etcd
     rerun_command: /test configmap-scale
     spec:
@@ -84,9 +84,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^openshift-4\.23$
-    - ^openshift-4\.23-
-    cluster: build09
+    - ^release-5\.0$
+    - ^release-5\.0-
+    cluster: build05
     context: ci/prow/e2e-aws-etcd-recovery
     decorate: true
     labels:
@@ -94,7 +94,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-4.23-e2e-aws-etcd-recovery
+    name: pull-ci-openshift-etcd-release-5.0-e2e-aws-etcd-recovery
     optional: true
     path_alias: go.etcd.io/etcd
     rerun_command: /test e2e-aws-etcd-recovery
@@ -166,9 +166,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^openshift-4\.23$
-    - ^openshift-4\.23-
-    cluster: build09
+    - ^release-5\.0$
+    - ^release-5\.0-
+    cluster: build05
     context: ci/prow/e2e-aws-ovn
     decorate: true
     labels:
@@ -176,7 +176,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-4.23-e2e-aws-ovn
+    name: pull-ci-openshift-etcd-release-5.0-e2e-aws-ovn
     path_alias: go.etcd.io/etcd
     rerun_command: /test e2e-aws-ovn
     spec:
@@ -247,9 +247,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^openshift-4\.23$
-    - ^openshift-4\.23-
-    cluster: build09
+    - ^release-5\.0$
+    - ^release-5\.0-
+    cluster: build05
     context: ci/prow/e2e-aws-ovn-serial
     decorate: true
     labels:
@@ -257,7 +257,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-4.23-e2e-aws-ovn-serial
+    name: pull-ci-openshift-etcd-release-5.0-e2e-aws-ovn-serial
     path_alias: go.etcd.io/etcd
     rerun_command: /test e2e-aws-ovn-serial
     spec:
@@ -328,9 +328,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^openshift-4\.23$
-    - ^openshift-4\.23-
-    cluster: build09
+    - ^release-5\.0$
+    - ^release-5\.0-
+    cluster: build05
     context: ci/prow/e2e-aws-ovn-upgrade
     decorate: true
     labels:
@@ -338,7 +338,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-4.23-e2e-aws-ovn-upgrade
+    name: pull-ci-openshift-etcd-release-5.0-e2e-aws-ovn-upgrade
     path_alias: go.etcd.io/etcd
     rerun_command: /test e2e-aws-ovn-upgrade
     spec:
@@ -409,9 +409,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^openshift-4\.23$
-    - ^openshift-4\.23-
-    cluster: build06
+    - ^release-5\.0$
+    - ^release-5\.0-
+    cluster: build01
     context: ci/prow/e2e-hypershift
     decorate: true
     labels:
@@ -419,7 +419,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: hypershift-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-4.23-e2e-hypershift
+    name: pull-ci-openshift-etcd-release-5.0-e2e-hypershift
     optional: true
     path_alias: go.etcd.io/etcd
     rerun_command: /test e2e-hypershift
@@ -491,9 +491,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^openshift-4\.23$
-    - ^openshift-4\.23-
-    cluster: build06
+    - ^release-5\.0$
+    - ^release-5\.0-
+    cluster: build01
     context: ci/prow/e2e-hypershift-conformance
     decorate: true
     labels:
@@ -501,7 +501,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: hypershift-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-4.23-e2e-hypershift-conformance
+    name: pull-ci-openshift-etcd-release-5.0-e2e-hypershift-conformance
     optional: true
     path_alias: go.etcd.io/etcd
     rerun_command: /test e2e-hypershift-conformance
@@ -573,15 +573,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^openshift-4\.23$
-    - ^openshift-4\.23-
-    cluster: build06
+    - ^release-5\.0$
+    - ^release-5\.0-
+    cluster: build01
     context: ci/prow/images
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-4.23-images
+    name: pull-ci-openshift-etcd-release-5.0-images
     path_alias: go.etcd.io/etcd
     rerun_command: /test images
     spec:
@@ -591,7 +591,6 @@ presubmits:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --report-credentials-file=/etc/report/credentials
         - --target=[images]
-        - --target=[release:latest]
         command:
         - ci-operator
         image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
@@ -628,9 +627,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^openshift-4\.23$
-    - ^openshift-4\.23-
-    cluster: build09
+    - ^release-5\.0$
+    - ^release-5\.0-
+    cluster: build05
     context: ci/prow/perfscale-payload-control-plane-6nodes
     decorate: true
     labels:
@@ -638,7 +637,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-4.23-perfscale-payload-control-plane-6nodes
+    name: pull-ci-openshift-etcd-release-5.0-perfscale-payload-control-plane-6nodes
     optional: true
     path_alias: go.etcd.io/etcd
     rerun_command: /test perfscale-payload-control-plane-6nodes
@@ -710,15 +709,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^openshift-4\.23$
-    - ^openshift-4\.23-
-    cluster: build06
+    - ^release-5\.0$
+    - ^release-5\.0-
+    cluster: build01
     context: ci/prow/upstream-e2e
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-4.23-upstream-e2e
+    name: pull-ci-openshift-etcd-release-5.0-upstream-e2e
     optional: true
     path_alias: go.etcd.io/etcd
     rerun_command: /test upstream-e2e
@@ -773,15 +772,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^openshift-4\.23$
-    - ^openshift-4\.23-
-    cluster: build06
+    - ^release-5\.0$
+    - ^release-5\.0-
+    cluster: build01
     context: ci/prow/upstream-integration
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-4.23-upstream-integration
+    name: pull-ci-openshift-etcd-release-5.0-upstream-integration
     optional: true
     path_alias: go.etcd.io/etcd
     rerun_command: /test upstream-integration
@@ -836,15 +835,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^openshift-4\.23$
-    - ^openshift-4\.23-
-    cluster: build06
+    - ^release-5\.0$
+    - ^release-5\.0-
+    cluster: build01
     context: ci/prow/upstream-release
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-4.23-upstream-release
+    name: pull-ci-openshift-etcd-release-5.0-upstream-release
     optional: true
     path_alias: go.etcd.io/etcd
     rerun_command: /test upstream-release
@@ -899,15 +898,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^openshift-4\.23$
-    - ^openshift-4\.23-
-    cluster: build06
+    - ^release-5\.0$
+    - ^release-5\.0-
+    cluster: build01
     context: ci/prow/upstream-unit
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-4.23-upstream-unit
+    name: pull-ci-openshift-etcd-release-5.0-upstream-unit
     path_alias: go.etcd.io/etcd
     rerun_command: /test upstream-unit
     spec:

--- a/ci-operator/jobs/openshift/etcd/openshift-etcd-release-5.1-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/etcd/openshift-etcd-release-5.1-postsubmits.yaml
@@ -3,14 +3,14 @@ postsubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^openshift-4\.23$
-    cluster: build05
+    - ^release-5\.1$
+    cluster: build01
     decorate: true
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-openshift-etcd-openshift-4.23-images
+    name: branch-ci-openshift-etcd-release-5.1-images
     path_alias: go.etcd.io/etcd
     spec:
       containers:

--- a/ci-operator/jobs/openshift/etcd/openshift-etcd-release-5.1-presubmits.yaml
+++ b/ci-operator/jobs/openshift/etcd/openshift-etcd-release-5.1-presubmits.yaml
@@ -3,9 +3,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^openshift-5\.1$
-    - ^openshift-5\.1-
-    cluster: build07
+    - ^release-5\.1$
+    - ^release-5\.1-
+    cluster: build05
     context: ci/prow/configmap-scale
     decorate: true
     labels:
@@ -13,7 +13,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-5.1-configmap-scale
+    name: pull-ci-openshift-etcd-release-5.1-configmap-scale
     path_alias: go.etcd.io/etcd
     rerun_command: /test configmap-scale
     spec:
@@ -84,9 +84,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^openshift-5\.1$
-    - ^openshift-5\.1-
-    cluster: build07
+    - ^release-5\.1$
+    - ^release-5\.1-
+    cluster: build05
     context: ci/prow/e2e-aws-etcd-recovery
     decorate: true
     labels:
@@ -94,7 +94,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-5.1-e2e-aws-etcd-recovery
+    name: pull-ci-openshift-etcd-release-5.1-e2e-aws-etcd-recovery
     optional: true
     path_alias: go.etcd.io/etcd
     rerun_command: /test e2e-aws-etcd-recovery
@@ -166,9 +166,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^openshift-5\.1$
-    - ^openshift-5\.1-
-    cluster: build07
+    - ^release-5\.1$
+    - ^release-5\.1-
+    cluster: build05
     context: ci/prow/e2e-aws-ovn
     decorate: true
     labels:
@@ -176,7 +176,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-5.1-e2e-aws-ovn
+    name: pull-ci-openshift-etcd-release-5.1-e2e-aws-ovn
     path_alias: go.etcd.io/etcd
     rerun_command: /test e2e-aws-ovn
     spec:
@@ -247,9 +247,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^openshift-5\.1$
-    - ^openshift-5\.1-
-    cluster: build07
+    - ^release-5\.1$
+    - ^release-5\.1-
+    cluster: build05
     context: ci/prow/e2e-aws-ovn-serial
     decorate: true
     labels:
@@ -257,7 +257,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-5.1-e2e-aws-ovn-serial
+    name: pull-ci-openshift-etcd-release-5.1-e2e-aws-ovn-serial
     path_alias: go.etcd.io/etcd
     rerun_command: /test e2e-aws-ovn-serial
     spec:
@@ -328,9 +328,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^openshift-5\.1$
-    - ^openshift-5\.1-
-    cluster: build07
+    - ^release-5\.1$
+    - ^release-5\.1-
+    cluster: build05
     context: ci/prow/e2e-aws-ovn-upgrade
     decorate: true
     labels:
@@ -338,7 +338,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-5.1-e2e-aws-ovn-upgrade
+    name: pull-ci-openshift-etcd-release-5.1-e2e-aws-ovn-upgrade
     path_alias: go.etcd.io/etcd
     rerun_command: /test e2e-aws-ovn-upgrade
     spec:
@@ -409,9 +409,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^openshift-5\.1$
-    - ^openshift-5\.1-
-    cluster: build06
+    - ^release-5\.1$
+    - ^release-5\.1-
+    cluster: build01
     context: ci/prow/e2e-hypershift
     decorate: true
     labels:
@@ -419,7 +419,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: hypershift-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-5.1-e2e-hypershift
+    name: pull-ci-openshift-etcd-release-5.1-e2e-hypershift
     optional: true
     path_alias: go.etcd.io/etcd
     rerun_command: /test e2e-hypershift
@@ -491,9 +491,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^openshift-5\.1$
-    - ^openshift-5\.1-
-    cluster: build06
+    - ^release-5\.1$
+    - ^release-5\.1-
+    cluster: build01
     context: ci/prow/e2e-hypershift-conformance
     decorate: true
     labels:
@@ -501,7 +501,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: hypershift-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-5.1-e2e-hypershift-conformance
+    name: pull-ci-openshift-etcd-release-5.1-e2e-hypershift-conformance
     optional: true
     path_alias: go.etcd.io/etcd
     rerun_command: /test e2e-hypershift-conformance
@@ -573,15 +573,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^openshift-5\.1$
-    - ^openshift-5\.1-
-    cluster: build06
+    - ^release-5\.1$
+    - ^release-5\.1-
+    cluster: build01
     context: ci/prow/images
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-5.1-images
+    name: pull-ci-openshift-etcd-release-5.1-images
     path_alias: go.etcd.io/etcd
     rerun_command: /test images
     spec:
@@ -628,9 +628,9 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^openshift-5\.1$
-    - ^openshift-5\.1-
-    cluster: build07
+    - ^release-5\.1$
+    - ^release-5\.1-
+    cluster: build05
     context: ci/prow/perfscale-payload-control-plane-6nodes
     decorate: true
     labels:
@@ -638,7 +638,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale-qe
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-5.1-perfscale-payload-control-plane-6nodes
+    name: pull-ci-openshift-etcd-release-5.1-perfscale-payload-control-plane-6nodes
     optional: true
     path_alias: go.etcd.io/etcd
     rerun_command: /test perfscale-payload-control-plane-6nodes
@@ -710,15 +710,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^openshift-5\.1$
-    - ^openshift-5\.1-
-    cluster: build06
+    - ^release-5\.1$
+    - ^release-5\.1-
+    cluster: build01
     context: ci/prow/upstream-e2e
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-5.1-upstream-e2e
+    name: pull-ci-openshift-etcd-release-5.1-upstream-e2e
     optional: true
     path_alias: go.etcd.io/etcd
     rerun_command: /test upstream-e2e
@@ -773,15 +773,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^openshift-5\.1$
-    - ^openshift-5\.1-
-    cluster: build06
+    - ^release-5\.1$
+    - ^release-5\.1-
+    cluster: build01
     context: ci/prow/upstream-integration
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-5.1-upstream-integration
+    name: pull-ci-openshift-etcd-release-5.1-upstream-integration
     optional: true
     path_alias: go.etcd.io/etcd
     rerun_command: /test upstream-integration
@@ -836,15 +836,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^openshift-5\.1$
-    - ^openshift-5\.1-
-    cluster: build06
+    - ^release-5\.1$
+    - ^release-5\.1-
+    cluster: build01
     context: ci/prow/upstream-release
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-5.1-upstream-release
+    name: pull-ci-openshift-etcd-release-5.1-upstream-release
     optional: true
     path_alias: go.etcd.io/etcd
     rerun_command: /test upstream-release
@@ -899,15 +899,15 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^openshift-5\.1$
-    - ^openshift-5\.1-
-    cluster: build06
+    - ^release-5\.1$
+    - ^release-5\.1-
+    cluster: build01
     context: ci/prow/upstream-unit
     decorate: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-etcd-openshift-5.1-upstream-unit
+    name: pull-ci-openshift-etcd-release-5.1-upstream-unit
     path_alias: go.etcd.io/etcd
     rerun_command: /test upstream-unit
     spec:

--- a/core-services/prow/02_config/openshift/etcd/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/etcd/_prowconfig.yaml
@@ -32,6 +32,7 @@ tide:
     - openshift-4.9
     - release-4.21
     - release-4.22
+    - release-4.23
     labels:
     - approved
     - backport-risk-assessed
@@ -50,8 +51,8 @@ tide:
     repos:
     - openshift/etcd
   - includedBranches:
-    - openshift-5.0
     - release-5.0
+    - release-5.1
     labels:
     - approved
     - backport-risk-assessed
@@ -103,6 +104,7 @@ tide:
     - openshift-4.20
     - openshift-4.21
     - openshift-4.22
+    - openshift-4.23
     - openshift-4.3
     - openshift-4.4
     - openshift-4.5
@@ -111,6 +113,10 @@ tide:
     - openshift-4.8
     - openshift-4.9
     - openshift-5.0
+    - openshift-5.1
+    - release-4.23
+    - release-5.0
+    - release-5.1
     labels:
     - approved
     - jira/valid-reference


### PR DESCRIPTION
In https://github.com/openshift/release/pull/77725, I added a main branch config for the openshift/etcd repository; however, etcd currently uses the "openshift-*" branch naming scheme and the branch promotion uses the "release-*" naming scheme when promoting from main/master (https://github.com/openshift/ci-tools/blob/5ad440bf41f7aa71149a86c3295536375286ca43/pkg/promotion/promotion.go#L68). 

This PR begins the migration of the etcd repository to use the release-* naming conventions from 5.0/4.23 onwards: this does not change any previously shipped (or about to ship) branches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release configuration metadata branch references across all versions 4.23, 5.0, and 5.1 with standardized naming conventions for improved consistency and better operational clarity.
  * Enhanced CI/CD pipeline branch handling and automation configuration to properly support and manage the updated branch naming conventions and associated branch exclusion rules across the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->