### PR TITLE
require staff-eng-approved for openshift-tests-private

### DIFF
--- a/core-services/prow/02_config/openshift/openshift-tests-private/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/openshift-tests-private/_prowconfig.yaml
@@ -5,6 +5,7 @@ tide:
   - labels:
     - approved
     - lgtm
+    - staff-eng-approved
     missingLabels:
     - backports/unvalidated-commits
     - do-not-merge/hold


### PR DESCRIPTION
We want to stop new tests from going into openshift-tests-private to motivate the migration of tests to openshift/origin or some other repo closed to the code. To this end, the staff-eng-approved label will need to added by a QSE for any PR.  This will start after 4.22 RC.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request merge requirements to include additional approval criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->