### PR TITLE
Generate cyborg-python image

### DIFF
--- a/ci-operator/config/openshift-eng/cyborg/openshift-eng-cyborg-master.yaml
+++ b/ci-operator/config/openshift-eng/cyborg/openshift-eng-cyborg-master.yaml
@@ -1,3 +1,8 @@
+base_images:
+  ubi:
+    name: ubi-python-312
+    namespace: ocp
+    tag: "9"
 build_root:
   from_repository: true
   use_build_cache: true
@@ -5,6 +10,12 @@ images:
   items:
   - dockerfile_path: org_tools/images/Dockerfile
     to: cyborg-cli
+  - dockerfile_literal: |
+      FROM registry.ci.openshift.org/ocp/ubi-python-312:9
+      COPY --chown=1001:0 ./org_tools/orglib ./orglib
+      RUN pip install --no-cache-dir "./orglib[full]" && rm -rf ./orglib
+    from: ubi
+    to: cyborg-python
 promotion:
   to:
   - namespace: continuous-release-jobs


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced new `cyborg-python` container image powered by UBI Python 3.12.
  * Image now includes the complete `orglib[full]` package, expanding functionality beyond previous CLI-only build outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->