### PR TITLE
Enable RHCOS 10 for perfscale AWS 5.0 nightly workloads

### DIFF
--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-5.0-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-5.0-nightly-x86.yaml
@@ -23,6 +23,8 @@ tests:
     env:
       ADDITIONAL_WORKER_NODES: "21"
       BASE_DOMAIN: qe.devcluster.openshift.com
+      FEATURE_SET: TechPreviewNoUpgrade
+      OSSTREAM: rhel-10
       ZONES_COUNT: "3"
     test:
     - ref: openshift-qe-workers-scale
@@ -40,11 +42,13 @@ tests:
       ENABLE_LAYER_3: "false"
       ENABLE_LOCAL_INDEX: "true"
       ES_TYPE: qe
+      FEATURE_SET: TechPreviewNoUpgrade
       IGNORE_JOB_ITERATIONS: "true"
       KB_FLAGS: --local-indexing
       ND_CNI_EXTRA_FLAGS: --churn-mode=objects --churn-delay=1m --churn-percent=50
         --churn-cycles=2
       ND_EXTRA_FLAGS: --churn-mode=objects --churn-delay=1m --churn-percent=50 --churn-cycles=2
+      OSSTREAM: rhel-10
       OUTPUT_FORMAT: JUNIT
       RUN_ORION: deferred
       UDN_ITERATION_MULTIPLIER: "12"
@@ -54,6 +58,33 @@ tests:
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-control-plane
     - chain: openshift-qe-orion-consolidated
+    workflow: openshift-qe-installer-aws
+- as: control-plane-252nodes
+  cron: 0 0 * * 1
+  steps:
+    allow_skip_on_success: true
+    cluster_profile: aws-perfscale
+    env:
+      ADDITIONAL_WORKER_NODES: "249"
+      BASE_DOMAIN: perfscale.devcluster.openshift.com
+      CD_V2_EXTRA_FLAGS: --churn-duration=20m --service-latency
+      COMPUTE_NODE_TYPE: m5.xlarge
+      ENABLE_LAYER_3: "false"
+      FEATURE_SET: TechPreviewNoUpgrade
+      KB_FLAGS: --set=metricsEndpoints.0.step=2m --set=metricsEndpoints.1.step=2m
+        --local-indexing
+      NODE_DENSITY_GC: "false"
+      OPENSHIFT_INFRA_NODE_INSTANCE_TYPE: r5.4xlarge
+      OSSTREAM: rhel-10
+      SET_ENV_BY_PLATFORM: custom
+      SIZE_VARIANT: large
+      UDN_ITERATION_MULTIPLIER: "0.25"
+      USER_TAGS: |
+        TicketId 532
+      ZONES_COUNT: "3"
+    test:
+    - ref: openshift-qe-workers-scale
+    - chain: openshift-qe-control-plane
     workflow: openshift-qe-installer-aws
 - as: control-plane-120nodes
   cron: 0 8 * * 1
@@ -66,10 +97,12 @@ tests:
       CD_V2_EXTRA_FLAGS: --churn-duration=20m --service-latency
       COMPUTE_NODE_TYPE: m5.xlarge
       ENABLE_LAYER_3: "false"
+      FEATURE_SET: TechPreviewNoUpgrade
       KB_FLAGS: --set=metricsEndpoints.0.step=2m --set=metricsEndpoints.1.step=2m
         --local-indexing
       NODE_DENSITY_GC: "false"
       OPENSHIFT_INFRA_NODE_INSTANCE_TYPE: r5.4xlarge
+      OSSTREAM: rhel-10
       SET_ENV_BY_PLATFORM: custom
       SIZE_VARIANT: large
       UDN_ITERATION_MULTIPLIER: "1"
@@ -89,6 +122,8 @@ tests:
       ADDITIONAL_WORKER_NODES: "21"
       BASE_DOMAIN: qe.devcluster.openshift.com
       ENABLE_LAYER_3: "false"
+      FEATURE_SET: TechPreviewNoUpgrade
+      OSSTREAM: rhel-10
       UDN_ITERATION_MULTIPLIER: "3"
       ZONES_COUNT: "3"
     test:
@@ -102,6 +137,8 @@ tests:
     cluster_profile: aws-perfscale-qe
     env:
       BASE_DOMAIN: qe.devcluster.openshift.com
+      FEATURE_SET: TechPreviewNoUpgrade
+      OSSTREAM: rhel-10
       ZONES_COUNT: "3"
     test:
     - chain: openshift-qe-cluster-density-v2
@@ -114,6 +151,8 @@ tests:
     env:
       ADDITIONAL_WORKER_NODES: "21"
       BASE_DOMAIN: qe.devcluster.openshift.com
+      FEATURE_SET: TechPreviewNoUpgrade
+      OSSTREAM: rhel-10
       ZONES_COUNT: "3"
     test:
     - ref: openshift-qe-workers-scale
@@ -128,8 +167,10 @@ tests:
       ADDITIONAL_WORKER_NODES: "6"
       BASE_DOMAIN: perfscale.devcluster.openshift.com
       COMPUTE_NODE_TYPE: m5.2xlarge
+      FEATURE_SET: TechPreviewNoUpgrade
       LOKI_USE_SERVICEMONITOR: "false"
       OPENSHIFT_INFRA_NODE_INSTANCE_TYPE: c5.4xlarge
+      OSSTREAM: rhel-10
       SET_ENV_BY_PLATFORM: custom
       ZONES_COUNT: "3"
     test:
@@ -147,6 +188,8 @@ tests:
       CDV2_ITERATION_MULTIPLIER: "9"
       COMPUTE_NODE_REPLICAS: "3"
       ENABLE_LAYER_3: "false"
+      FEATURE_SET: TechPreviewNoUpgrade
+      OSSTREAM: rhel-10
       UDN_ITERATION_MULTIPLIER: "24"
     test:
     - chain: openshift-qe-control-plane
@@ -159,6 +202,8 @@ tests:
     env:
       BASE_DOMAIN: qe.devcluster.openshift.com
       COMPUTE_NODE_REPLICAS: "3"
+      FEATURE_SET: TechPreviewNoUpgrade
+      OSSTREAM: rhel-10
     test:
     - chain: openshift-qe-node-density-cni
     workflow: openshift-qe-installer-aws
@@ -171,7 +216,9 @@ tests:
       BASE_DOMAIN: qe.devcluster.openshift.com
       COMPUTE_NODE_TYPE: m5.xlarge
       ENABLE_LAYER_3: "true"
+      FEATURE_SET: TechPreviewNoUpgrade
       KB_FLAGS: --local-indexing
+      OSSTREAM: rhel-10
       RUN_ORION: deferred
       UDN_ITERATION_MULTIPLIER: "3"
       VERSION: "5.0"

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-5.0-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-5.0-nightly-x86.yaml
@@ -24,7 +24,7 @@ tests:
       ADDITIONAL_WORKER_NODES: "21"
       BASE_DOMAIN: qe.devcluster.openshift.com
       FEATURE_SET: TechPreviewNoUpgrade
-      OSSTREAM: rhel-10
+      OS_IMAGE_STREAM: rhel-10
       ZONES_COUNT: "3"
     test:
     - ref: openshift-qe-workers-scale
@@ -48,7 +48,7 @@ tests:
       ND_CNI_EXTRA_FLAGS: --churn-mode=objects --churn-delay=1m --churn-percent=50
         --churn-cycles=2
       ND_EXTRA_FLAGS: --churn-mode=objects --churn-delay=1m --churn-percent=50 --churn-cycles=2
-      OSSTREAM: rhel-10
+      OS_IMAGE_STREAM: rhel-10
       OUTPUT_FORMAT: JUNIT
       RUN_ORION: deferred
       UDN_ITERATION_MULTIPLIER: "12"
@@ -60,7 +60,7 @@ tests:
     - chain: openshift-qe-orion-consolidated
     workflow: openshift-qe-installer-aws
 - as: control-plane-252nodes
-  cron: 0 0 * * 1
+  cron: 30 9 * * 1
   steps:
     allow_skip_on_success: true
     cluster_profile: aws-perfscale
@@ -74,8 +74,8 @@ tests:
       KB_FLAGS: --set=metricsEndpoints.0.step=2m --set=metricsEndpoints.1.step=2m
         --local-indexing
       NODE_DENSITY_GC: "false"
-      OPENSHIFT_INFRA_NODE_INSTANCE_TYPE: r5.4xlarge
-      OSSTREAM: rhel-10
+      OPENSHIFT_INFRA_NODE_INSTANCE_TYPE: r5.8xlarge
+      OS_IMAGE_STREAM: rhel-10
       SET_ENV_BY_PLATFORM: custom
       SIZE_VARIANT: large
       UDN_ITERATION_MULTIPLIER: "0.25"
@@ -86,6 +86,7 @@ tests:
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-control-plane
     workflow: openshift-qe-installer-aws
+  timeout: 14h0m0s
 - as: control-plane-120nodes
   cron: 0 8 * * 1
   steps:
@@ -102,7 +103,7 @@ tests:
         --local-indexing
       NODE_DENSITY_GC: "false"
       OPENSHIFT_INFRA_NODE_INSTANCE_TYPE: r5.4xlarge
-      OSSTREAM: rhel-10
+      OS_IMAGE_STREAM: rhel-10
       SET_ENV_BY_PLATFORM: custom
       SIZE_VARIANT: large
       UDN_ITERATION_MULTIPLIER: "1"
@@ -123,7 +124,7 @@ tests:
       BASE_DOMAIN: qe.devcluster.openshift.com
       ENABLE_LAYER_3: "false"
       FEATURE_SET: TechPreviewNoUpgrade
-      OSSTREAM: rhel-10
+      OS_IMAGE_STREAM: rhel-10
       UDN_ITERATION_MULTIPLIER: "3"
       ZONES_COUNT: "3"
     test:
@@ -138,7 +139,7 @@ tests:
     env:
       BASE_DOMAIN: qe.devcluster.openshift.com
       FEATURE_SET: TechPreviewNoUpgrade
-      OSSTREAM: rhel-10
+      OS_IMAGE_STREAM: rhel-10
       ZONES_COUNT: "3"
     test:
     - chain: openshift-qe-cluster-density-v2
@@ -152,7 +153,7 @@ tests:
       ADDITIONAL_WORKER_NODES: "21"
       BASE_DOMAIN: qe.devcluster.openshift.com
       FEATURE_SET: TechPreviewNoUpgrade
-      OSSTREAM: rhel-10
+      OS_IMAGE_STREAM: rhel-10
       ZONES_COUNT: "3"
     test:
     - ref: openshift-qe-workers-scale
@@ -170,7 +171,7 @@ tests:
       FEATURE_SET: TechPreviewNoUpgrade
       LOKI_USE_SERVICEMONITOR: "false"
       OPENSHIFT_INFRA_NODE_INSTANCE_TYPE: c5.4xlarge
-      OSSTREAM: rhel-10
+      OS_IMAGE_STREAM: rhel-10
       SET_ENV_BY_PLATFORM: custom
       ZONES_COUNT: "3"
     test:
@@ -189,7 +190,7 @@ tests:
       COMPUTE_NODE_REPLICAS: "3"
       ENABLE_LAYER_3: "false"
       FEATURE_SET: TechPreviewNoUpgrade
-      OSSTREAM: rhel-10
+      OS_IMAGE_STREAM: rhel-10
       UDN_ITERATION_MULTIPLIER: "24"
     test:
     - chain: openshift-qe-control-plane
@@ -203,7 +204,7 @@ tests:
       BASE_DOMAIN: qe.devcluster.openshift.com
       COMPUTE_NODE_REPLICAS: "3"
       FEATURE_SET: TechPreviewNoUpgrade
-      OSSTREAM: rhel-10
+      OS_IMAGE_STREAM: rhel-10
     test:
     - chain: openshift-qe-node-density-cni
     workflow: openshift-qe-installer-aws
@@ -218,7 +219,7 @@ tests:
       ENABLE_LAYER_3: "true"
       FEATURE_SET: TechPreviewNoUpgrade
       KB_FLAGS: --local-indexing
-      OSSTREAM: rhel-10
+      OS_IMAGE_STREAM: rhel-10
       RUN_ORION: deferred
       UDN_ITERATION_MULTIPLIER: "3"
       VERSION: "5.0"

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-5.0-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-5.0-nightly-x86.yaml
@@ -48,7 +48,6 @@ tests:
       ND_CNI_EXTRA_FLAGS: --churn-mode=objects --churn-delay=1m --churn-percent=50
         --churn-cycles=2
       ND_EXTRA_FLAGS: --churn-mode=objects --churn-delay=1m --churn-percent=50 --churn-cycles=2
-      OS_IMAGE_STREAM: rhel-10
       OUTPUT_FORMAT: JUNIT
       RUN_ORION: deferred
       UDN_ITERATION_MULTIPLIER: "12"

--- a/ci-operator/jobs/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main-periodics.yaml
@@ -4551,10 +4551,11 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build09
-  cron: 0 0 * * 1
+  cron: 30 9 * * 1
   decorate: true
   decoration_config:
     skip_cloning: true
+    timeout: 14h0m0s
   extra_refs:
   - base_ref: main
     org: openshift-eng

--- a/ci-operator/jobs/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main-periodics.yaml
@@ -4551,6 +4551,100 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build09
+  cron: 0 0 * * 1
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-eng
+    repo: ocp-qe-perfscale-ci
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-perfscale
+    ci-operator.openshift.io/variant: aws-5.0-nightly-x86
+    ci.openshift.io/generator: prowgen
+    job-release: "5.0"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-aws-5.0-nightly-x86-control-plane-252nodes
+  reporter_config:
+    slack:
+      channel: '#ocp-qe-scale-ci-results'
+      job_states_to_report:
+      - success
+      - failure
+      - error
+      report_template: '{{if eq .Status.State "success"}} :white_check_mark: Job *{{.Spec.Job}}*
+        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :white_check_mark:
+        {{else}} :warning:  Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+        logs> :warning: {{end}}'
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=control-plane-252nodes
+      - --variant=aws-5.0-nightly-x86
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build09
   cron: 0 3 1,8,15,22 * *
   decorate: true
   decoration_config:


### PR DESCRIPTION
Add FEATURE_SET: TechPreviewNoUpgrade and OSSTREAM: rhel-10 to all tests in the AWS 5.0 nightly perfscale config. 
Also add the control-plane-252nodes job (Monday weekly) matching the 4.22 config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated AWS perfscale nightly tests to use the TechPreview feature set and RHEL 10 image stream across multiple test variants.
* **New Features**
  * Added a weekly scheduled large-scale control-plane test (252 nodes) with extended timeout and churn/metrics settings to exercise higher-scale scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->