### PR TITLE
[tls-scanner] Add compute node type to tls13-pqc-readiness job

### DIFF
--- a/ci-operator/config/openshift/tls-scanner/openshift-tls-scanner-main.yaml
+++ b/ci-operator/config/openshift/tls-scanner/openshift-tls-scanner-main.yaml
@@ -107,6 +107,7 @@ tests:
   steps:
     cluster_profile: openshift-org-aws
     env:
+      COMPUTE_NODE_TYPE: m5.4xlarge
       PQC_CHECK: "true"
     test:
     - ref: tls-scanner-run

--- a/ci-operator/config/openshift/tls-scanner/openshift-tls-scanner-release-4.23.yaml
+++ b/ci-operator/config/openshift/tls-scanner/openshift-tls-scanner-release-4.23.yaml
@@ -88,6 +88,7 @@ tests:
   steps:
     cluster_profile: openshift-org-aws
     env:
+      COMPUTE_NODE_TYPE: m5.4xlarge
       PQC_CHECK: "true"
     test:
     - ref: tls-scanner-run

--- a/ci-operator/config/openshift/tls-scanner/openshift-tls-scanner-release-5.0.yaml
+++ b/ci-operator/config/openshift/tls-scanner/openshift-tls-scanner-release-5.0.yaml
@@ -89,6 +89,7 @@ tests:
   steps:
     cluster_profile: openshift-org-aws
     env:
+      COMPUTE_NODE_TYPE: m5.4xlarge
       PQC_CHECK: "true"
     test:
     - ref: tls-scanner-run

--- a/ci-operator/config/openshift/tls-scanner/openshift-tls-scanner-release-5.1.yaml
+++ b/ci-operator/config/openshift/tls-scanner/openshift-tls-scanner-release-5.1.yaml
@@ -88,6 +88,7 @@ tests:
   steps:
     cluster_profile: openshift-org-aws
     env:
+      COMPUTE_NODE_TYPE: m5.4xlarge
       PQC_CHECK: "true"
     test:
     - ref: tls-scanner-run


### PR DESCRIPTION
Adds compute node type to `tls13-pqc-readiness job` job to allocate a node with the required 4 cores

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test infrastructure configuration across multiple release branches to standardize compute resource allocation for post-quantum cryptography readiness testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->