### PR TITLE
NO-JIRA: fix: resolve pip install error on rhel9

### DIFF
--- a/ci-operator/step-registry/single-node/conf/aws/single-node-conf-aws-commands.sh
+++ b/ci-operator/step-registry/single-node/conf/aws/single-node-conf-aws-commands.sh
@@ -17,12 +17,14 @@ echo "Updating install-config.yaml to a single ${SINGLE_NODE_AWS_INSTANCE_TYPE} 
 # RHEL9 based images do not contain pip3, we need to install it. Multiple jobs rely on the installer image
 # so simply using something like upi-installer will break things since some jobs use stable payload which
 # does not include upi-installer.
-OS_VER=$(awk -F= '/^VERSION_ID=/ { print $2 }' /etc/os-release | tr -d '"' | cut -f1 -d'.')
-if [[ ${OS_VER} == "9" ]]; then
+OS_VER="$(awk -F= '/^VERSION_ID=/ { print $2 }' /etc/os-release | tr -d '"' | cut -f1 -d'.')"
+if [[ "${OS_VER}" == "9" ]]; then
     echo "Detected RHEL9, installing pip"
-    curl -L -o /tmp/get-pip.py -w "\nStatus Code: %{http_code}\n" https://bootstrap.pypa.io/get-pip.py
-    python /tmp/get-pip.py
-    export PATH=$PATH:$HOME/.local/bin
+    py_mm="$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
+    curl -fSL --connect-timeout 30 --max-time 120 -o /tmp/get-pip.py "https://bootstrap.pypa.io/pip/${py_mm}/get-pip.py"
+    python3 /tmp/get-pip.py --user
+    rm -f /tmp/get-pip.py
+    export PATH="${PATH}:${HOME}/.local/bin"
 fi
 
 


### PR DESCRIPTION
added version check for pip to install explicit version of pip depending on which python version this resolves version updates that happen in upstream pip install scripts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced RHEL9 environment detection with safer string comparisons
  * Improved pip installation reliability with dynamic Python version detection and stricter error handling
  * Strengthened network operations with timeout protection and fail-fast mechanisms

* **Chores**
  * Added proper cleanup of temporary installation artifacts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->