### PR TITLE
feat: add safety evals for agentic skills

### DIFF
--- a/ci-operator/config/openshift/agentic-skills/openshift-agentic-skills-main.yaml
+++ b/ci-operator/config/openshift/agentic-skills/openshift-agentic-skills-main.yaml
@@ -1,9 +1,26 @@
+base_images:
+  python-311:
+    name: ubi-python-311
+    namespace: ocp
+    tag: "9"
 build_root:
   from_repository: true
 images:
   items:
   - dockerfile_path: Containerfile
     to: agentic-skills
+  - dockerfile_literal: |
+      FROM python-311
+      COPY . /src
+      WORKDIR /src
+      RUN pip install cisco-ai-skill-scanner
+    from: python-311
+    inputs:
+      src:
+        paths:
+        - destination_dir: .
+          source_path: /go/src/github.com/openshift/agentic-skills/.
+    to: skill-scanner
 promotion:
   to:
   - name: "5.0"
@@ -23,9 +40,12 @@ resources:
       memory: 200Mi
 tests:
 - as: eval
-  commands: echo FIXME actual tests
+  commands: |
+    skill-scanner scan-all . --recursive --check-overlap --format json \
+      --fail-on-severity medium \
+      --output "${ARTIFACT_DIR}/skill-scanner-report.json"
   container:
-    from: src
+    from: skill-scanner
   skip_if_only_changed: ^(README\.md|OWNERS|LICENSE|AGENTS\.md|CLAUDE\.md|\.gitignore)$
 zz_generated_metadata:
   branch: main


### PR DESCRIPTION
This PR adds a first pass at safety evals for skills being contributed to the agentic-skills repo

This uses the [cisco-ai skill-scanner repo](https://github.com/cisco-ai-defense/skill-scanner/tree/main) to do the skill safety scanning. This supports lots of static analysis of skills, as well as llm based analysis.

For now this PR only adds in statis analysis as we need to figure out Vault access to get llm credentials into CI before the llm based analysis will work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Replaced placeholder test with an automated quality scanner that runs during CI.
  * Scans recursively, produces a JSON report artifact, and causes CI failure for medium-or-higher severity issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->