### PR TITLE
OAPE-422: onboard openshift-eng/oape-ai-e2e

### DIFF
--- a/ci-operator/config/openshift-eng/oape-ai-e2e/OWNERS
+++ b/ci-operator/config/openshift-eng/oape-ai-e2e/OWNERS
@@ -1,0 +1,21 @@
+# DO NOT EDIT; this file is auto-generated using https://github.com/openshift/ci-tools.
+# Fetched from https://github.com/openshift-eng/ocp-build-data root OWNERS
+# If the repo had OWNERS_ALIASES then the aliases were expanded
+# Logins who are not members of 'openshift' organization were filtered out
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+- swghosh
+- mytreya-rh
+- rausingh-rh
+- shivprakashmuley
+options: {}
+reviewers:
+- PillaiManish
+- mytreya-rh
+- neha037
+- rausingh-rh
+- siddhibhor-56
+- chiragkyal
+- shivprakashmuley
+- swghosh

--- a/ci-operator/config/openshift-eng/oape-ai-e2e/openshift-eng-oape-ai-e2e-main.yaml
+++ b/ci-operator/config/openshift-eng/oape-ai-e2e/openshift-eng-oape-ai-e2e-main.yaml
@@ -1,0 +1,30 @@
+binary_build_commands: cd go-server && go install .
+build_root:
+  image_stream_tag:
+    name: release
+    namespace: openshift
+    tag: golang-1.23
+images:
+  items:
+  - dockerfile_path: images/agent-worker.Dockerfile
+    to: agent-worker
+  - dockerfile_path: images/gh-token-minter.Dockerfile
+    to: gh-token-minter
+  - dockerfile_path: images/go-server.Dockerfile
+    to: go-server
+promotion:
+  to:
+  - name: ai-e2e-agent
+    namespace: oape
+    tag_by_commit: true
+resources:
+  '*':
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+zz_generated_metadata:
+  branch: main
+  org: openshift-eng
+  repo: oape-ai-e2e

--- a/ci-operator/jobs/openshift-eng/oape-ai-e2e/OWNERS
+++ b/ci-operator/jobs/openshift-eng/oape-ai-e2e/OWNERS
@@ -1,0 +1,21 @@
+# DO NOT EDIT; this file is auto-generated using https://github.com/openshift/ci-tools.
+# Fetched from https://github.com/openshift-eng/ocp-build-data root OWNERS
+# If the repo had OWNERS_ALIASES then the aliases were expanded
+# Logins who are not members of 'openshift' organization were filtered out
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+- swghosh
+- mytreya-rh
+- rausingh-rh
+- shivprakashmuley
+options: {}
+reviewers:
+- PillaiManish
+- mytreya-rh
+- neha037
+- rausingh-rh
+- siddhibhor-56
+- chiragkyal
+- shivprakashmuley
+- swghosh

--- a/ci-operator/jobs/openshift-eng/oape-ai-e2e/openshift-eng-oape-ai-e2e-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift-eng/oape-ai-e2e/openshift-eng-oape-ai-e2e-main-postsubmits.yaml
@@ -1,0 +1,62 @@
+postsubmits:
+  openshift-eng/oape-ai-e2e:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    cluster: build01
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/is-promotion: "true"
+      ci.openshift.io/generator: prowgen
+    max_concurrency: 1
+    name: branch-ci-openshift-eng-oape-ai-e2e-main-images
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --image-mirror-push-secret=/etc/push-secret/.dockerconfigjson
+        - --promote
+        - --report-credentials-file=/etc/report/credentials
+        - --target=[images]
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/push-secret
+          name: push-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: push-secret
+        secret:
+          secretName: registry-push-credentials-ci-central
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator

--- a/ci-operator/jobs/openshift-eng/oape-ai-e2e/openshift-eng-oape-ai-e2e-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-eng/oape-ai-e2e/openshift-eng-oape-ai-e2e-main-presubmits.yaml
@@ -1,0 +1,57 @@
+presubmits:
+  openshift-eng/oape-ai-e2e:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build01
+    context: ci/prow/images
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-eng-oape-ai-e2e-main-images
+    rerun_command: /test images
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=[images]
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )images,?($|\s.*)

--- a/core-services/prow/02_config/openshift-eng/oape-ai-e2e/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-eng/oape-ai-e2e/_pluginconfig.yaml
@@ -1,0 +1,80 @@
+approve:
+- repos:
+  - openshift-eng/oape-ai-e2e
+  require_self_approval: false
+external_plugins:
+  openshift-eng/oape-ai-e2e:
+  - endpoint: http://refresh
+    events:
+    - issue_comment
+    name: refresh
+  - endpoint: http://cherrypick
+    events:
+    - issue_comment
+    - pull_request
+    name: cherrypick
+  - endpoint: http://needs-rebase
+    events:
+    - issue_comment
+    - pull_request
+    name: needs-rebase
+  - endpoint: http://backport-verifier
+    events:
+    - issue_comment
+    - pull_request
+    name: backport-verifier
+  - endpoint: http://payload-testing-prow-plugin
+    events:
+    - issue_comment
+    name: payload-testing-prow-plugin
+  - endpoint: http://jira-lifecycle-plugin
+    events:
+    - issue_comment
+    - pull_request
+    name: jira-lifecycle-plugin
+  - endpoint: http://pipeline-controller
+    events:
+    - pull_request
+    - issue_comment
+    name: pipeline-controller
+  - endpoint: http://multi-pr-prow-plugin
+    events:
+    - issue_comment
+    name: multi-pr-prow-plugin
+lgtm:
+- repos:
+  - openshift-eng/oape-ai-e2e
+  review_acts_as_lgtm: true
+plugins:
+  openshift-eng/oape-ai-e2e:
+    plugins:
+    - assign
+    - blunderbuss
+    - cat
+    - dog
+    - heart
+    - golint
+    - goose
+    - help
+    - hold
+    - jira
+    - label
+    - lgtm
+    - lifecycle
+    - override
+    - pony
+    - retitle
+    - shrug
+    - sigmention
+    - skip
+    - trigger
+    - verify-owners
+    - owners-label
+    - wip
+    - yuks
+    - approve
+triggers:
+- repos:
+  - openshift-eng/oape-ai-e2e
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-eng/oape-ai-e2e/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift-eng/oape-ai-e2e/_prowconfig.yaml
@@ -1,0 +1,14 @@
+tide:
+  queries:
+  - labels:
+    - approved
+    - lgtm
+    missingLabels:
+    - backports/unvalidated-commits
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - jira/invalid-bug
+    - needs-rebase
+    repos:
+    - openshift-eng/oape-ai-e2e


### PR DESCRIPTION
Adds CI and Prow configs for the openshift-eng/oape-ai-e2e repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated CI pipeline: automated Go build, three container images produced, commit-based image promotion, and default resource requests/limits.

* **Chores**
  * Added repository automation: approval/LGTM behavior, many automation plugins with event hooks, and merge-eligibility/tide rules.
  * Added OWNERS file declaring approvers and reviewers for the repo.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->