### PR TITLE
DNM/PExt: Review platform external, none in e2e and opct workflows targeting 5.0

### DIFF
--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.16.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.16.yaml
@@ -1183,7 +1183,7 @@ tests:
     - ref: fips-check-art-fips
     workflow: ipi-aws
 - as: e2e-external-aws-ccm
-  cron: '@monthly'
+  cron: '@yearly'
   steps:
     cluster_profile: openshift-org-aws
     env:

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.16.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.16.yaml
@@ -1182,26 +1182,13 @@ tests:
     - ref: fips-check-node-scan
     - ref: fips-check-art-fips
     workflow: ipi-aws
-- as: e2e-external-aws
-  cron: 1 15 16 2 *
-  steps:
-    cluster_profile: openshift-org-aws
-    workflow: openshift-e2e-external-aws
 - as: e2e-external-aws-ccm
-  cron: 23 22 19 11 *
+  cron: '@monthly'
   steps:
     cluster_profile: openshift-org-aws
     env:
       PLATFORM_EXTERNAL_CCM_ENABLED: "yes"
     workflow: openshift-e2e-external-aws
-- as: opct-external-aws-ccm
-  cron: 10 11 8 8 *
-  steps:
-    cluster_profile: openshift-org-aws
-    env:
-      PLATFORM_EXTERNAL_CCM_ENABLED: "yes"
-    workflow: opct-conformance-external-aws
-  timeout: 6h0m0s
 zz_generated_metadata:
   branch: main
   org: openshift

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.17.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.17.yaml
@@ -1144,11 +1144,6 @@ tests:
     - ref: fips-check-node-scan
     - ref: fips-check-art-fips
     workflow: ipi-aws
-- as: e2e-external-aws
-  cron: 38 21 21 10 *
-  steps:
-    cluster_profile: openshift-org-aws
-    workflow: openshift-e2e-external-aws
 - as: e2e-external-aws-ccm
   cron: 4 10 17 6 *
   steps:

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.17.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.17.yaml
@@ -1145,19 +1145,12 @@ tests:
     - ref: fips-check-art-fips
     workflow: ipi-aws
 - as: e2e-external-aws-ccm
-  cron: 4 10 17 6 *
+  cron: '@yearly'
   steps:
     cluster_profile: openshift-org-aws
     env:
       PLATFORM_EXTERNAL_CCM_ENABLED: "yes"
     workflow: openshift-e2e-external-aws
-- as: opct-external-aws-ccm
-  cron: 21 21 28 10 *
-  steps:
-    cluster_profile: openshift-org-aws
-    env:
-      PLATFORM_EXTERNAL_CCM_ENABLED: "yes"
-    workflow: opct-conformance-external-aws
   timeout: 6h0m0s
 - as: e2e-vsphere-ovn-csi-vcf9
   cron: 43,58 0,7 * * *

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.18.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.18.yaml
@@ -1391,20 +1391,16 @@ tests:
   steps:
     cluster_profile: vsphere-elastic
     workflow: upi-vsphere-platform-external-ccm
-- as: e2e-external-aws
-  cron: 40 5 7 9 *
-  steps:
-    cluster_profile: openshift-org-aws
-    workflow: openshift-e2e-external-aws
 - as: e2e-external-aws-ccm
-  cron: 7 20 13 11 *
+  cron: '@monthly'
   steps:
     cluster_profile: openshift-org-aws
     env:
       PLATFORM_EXTERNAL_CCM_ENABLED: "yes"
     workflow: openshift-e2e-external-aws
-- as: opct-external-aws-ccm
-  cron: 17 1 2 6 *
+  timeout: 6h0m0s
+- as: opct-platform-external-aws-ccm
+  cron: '@monthly'
   steps:
     cluster_profile: openshift-org-aws
     env:

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.18.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.18.yaml
@@ -448,11 +448,6 @@ tests:
       FEATURE_SET: CustomNoUpgrade
       MULTI_NIC_IPI: "true"
     workflow: openshift-e2e-vsphere
-- as: e2e-external-vsphere-ccm
-  cron: 46 20 18 6 *
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: upi-vsphere-platform-external-ccm
 - as: e2e-aws-ovn-local-gateway
   cron: 41 8 26 11 *
   steps:
@@ -1391,6 +1386,11 @@ tests:
     - ref: fips-check-node-scan
     - ref: fips-check-art-fips
     workflow: ipi-aws
+- as: e2e-external-vsphere-ccm
+  cron: 46 20 18 6 *
+  steps:
+    cluster_profile: vsphere-elastic
+    workflow: upi-vsphere-platform-external-ccm
 - as: e2e-external-aws
   cron: 40 5 7 9 *
   steps:

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.19.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.19.yaml
@@ -1442,20 +1442,16 @@ tests:
   steps:
     cluster_profile: vsphere-elastic
     workflow: upi-vsphere-platform-external-ccm
-- as: e2e-external-aws
-  cron: 1 17 13,28 * *
-  steps:
-    cluster_profile: openshift-org-aws
-    workflow: openshift-e2e-external-aws
-- as: e2e-external-aws-ccm
-  cron: 37 17 14,16 * *
+- as: e2e-platform-external-aws-ccm
+  cron: '@monthly'
   steps:
     cluster_profile: openshift-org-aws
     env:
       PLATFORM_EXTERNAL_CCM_ENABLED: "yes"
     workflow: openshift-e2e-external-aws
-- as: opct-external-aws-ccm
-  cron: 36 6 5,26 * *
+  timeout: 6h0m0s
+- as: opct-platform-external-aws-ccm
+  cron: '@monthly'
   steps:
     cluster_profile: openshift-org-aws
     env:

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.19.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.19.yaml
@@ -480,11 +480,6 @@ tests:
       FEATURE_SET: TechPreviewNoUpgrade
       MULTI_NIC_IPI: "true"
     workflow: openshift-e2e-vsphere
-- as: e2e-external-vsphere-ccm
-  cron: 3 2 * * 4
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: upi-vsphere-platform-external-ccm
 - as: e2e-aws-ovn-local-gateway
   interval: 168h
   steps:
@@ -1442,6 +1437,11 @@ tests:
     - ref: fips-check-node-scan
     - ref: fips-check-art-fips
     workflow: ipi-aws
+- as: e2e-external-vsphere-ccm
+  cron: 3 2 * * 4
+  steps:
+    cluster_profile: vsphere-elastic
+    workflow: upi-vsphere-platform-external-ccm
 - as: e2e-external-aws
   cron: 1 17 13,28 * *
   steps:

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.20.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.20.yaml
@@ -1563,30 +1563,34 @@ tests:
   steps:
     cluster_profile: vsphere-elastic
     workflow: upi-vsphere-platform-external-ccm
-- as: e2e-external-aws
-  cron: '@weekly'
-  steps:
-    cluster_profile: openshift-org-aws
-    workflow: openshift-e2e-external-aws
-- as: e2e-external-aws-ccm
-  cron: '@weekly'
+- as: e2e-platform-external-aws-ccm
+  cron: '@monthly'
   steps:
     cluster_profile: openshift-org-aws
     env:
       PLATFORM_EXTERNAL_CCM_ENABLED: "yes"
     workflow: openshift-e2e-external-aws
-- as: opct-external-aws-ccm
+  timeout: 6h0m0s
+- as: opct-platform-external-aws
   cron: '@weekly'
+  steps:
+    cluster_profile: openshift-org-aws
+    workflow: opct-conformance-external-aws
+  timeout: 6h0m0s
+- as: opct-platform-external-aws-ccm
+  cron: '@yearly'
   steps:
     cluster_profile: openshift-org-aws
     env:
       PLATFORM_EXTERNAL_CCM_ENABLED: "yes"
     workflow: opct-conformance-external-aws
   timeout: 6h0m0s
-- as: opct-external-aws
-  cron: '@weekly'
+- as: opct-platform-none-aws
+  cron: '@yearly'
   steps:
     cluster_profile: openshift-org-aws
+    env:
+      PLATFORM_NONE_ENFORCE: "yes"
     workflow: opct-conformance-external-aws
   timeout: 6h0m0s
 - as: e2e-aws-ovn-kube-apiserver-rollout

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.20.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.20.yaml
@@ -548,11 +548,6 @@ tests:
       FEATURE_SET: CustomNoUpgrade
       MULTI_NIC_IPI: "true"
     workflow: openshift-e2e-vsphere
-- as: e2e-external-vsphere-ccm
-  cron: 27 1 * * 5
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: upi-vsphere-platform-external-ccm
 - as: e2e-aws-ovn-local-gateway
   interval: 168h
   steps:
@@ -1563,6 +1558,11 @@ tests:
     - ref: fips-check-node-scan
     - ref: fips-check-art-fips
     workflow: ipi-aws
+- as: e2e-external-vsphere-ccm
+  cron: 27 1 * * 5
+  steps:
+    cluster_profile: vsphere-elastic
+    workflow: upi-vsphere-platform-external-ccm
 - as: e2e-external-aws
   cron: '@weekly'
   steps:
@@ -1580,7 +1580,16 @@ tests:
   steps:
     cluster_profile: openshift-org-aws
     env:
+      OPCT_CLI_IMAGE: quay.io/opct/opct:v0.6.4-rc.0
       PLATFORM_EXTERNAL_CCM_ENABLED: "yes"
+    workflow: opct-conformance-external-aws
+  timeout: 6h0m0s
+- as: opct-external-aws
+  cron: '@weekly'
+  steps:
+    cluster_profile: openshift-org-aws
+    env:
+      OPCT_CLI_IMAGE: quay.io/opct/opct:v0.6.4-rc.0
     workflow: opct-conformance-external-aws
   timeout: 6h0m0s
 - as: e2e-aws-ovn-kube-apiserver-rollout

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.20.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.20.yaml
@@ -1580,7 +1580,6 @@ tests:
   steps:
     cluster_profile: openshift-org-aws
     env:
-      OPCT_CLI_IMAGE: quay.io/opct/opct:v0.6.4-rc.0
       PLATFORM_EXTERNAL_CCM_ENABLED: "yes"
     workflow: opct-conformance-external-aws
   timeout: 6h0m0s
@@ -1588,8 +1587,6 @@ tests:
   cron: '@weekly'
   steps:
     cluster_profile: openshift-org-aws
-    env:
-      OPCT_CLI_IMAGE: quay.io/opct/opct:v0.6.4-rc.0
     workflow: opct-conformance-external-aws
   timeout: 6h0m0s
 - as: e2e-aws-ovn-kube-apiserver-rollout

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.21.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.21.yaml
@@ -1643,24 +1643,34 @@ tests:
   steps:
     cluster_profile: vsphere-elastic
     workflow: upi-vsphere-platform-external-ccm
-- as: e2e-external-aws
-  cron: '@weekly'
-  steps:
-    cluster_profile: openshift-org-aws
-    workflow: openshift-e2e-external-aws
-- as: e2e-external-aws-ccm
-  cron: '@weekly'
+- as: e2e-platform-external-aws-ccm
+  cron: '@monthly'
   steps:
     cluster_profile: openshift-org-aws
     env:
       PLATFORM_EXTERNAL_CCM_ENABLED: "yes"
     workflow: openshift-e2e-external-aws
-- as: opct-external-aws-ccm
+  timeout: 6h0m0s
+- as: opct-platform-external-aws-ccm
   cron: '@weekly'
   steps:
     cluster_profile: openshift-org-aws
     env:
       PLATFORM_EXTERNAL_CCM_ENABLED: "yes"
+    workflow: opct-conformance-external-aws
+  timeout: 6h0m0s
+- as: opct-platform-external-aws
+  cron: '@yearly'
+  steps:
+    cluster_profile: openshift-org-aws
+    workflow: opct-conformance-external-aws
+  timeout: 6h0m0s
+- as: opct-platform-none-aws
+  cron: '@yearly'
+  steps:
+    cluster_profile: openshift-org-aws
+    env:
+      PLATFORM_NONE_ENFORCE: "yes"
     workflow: opct-conformance-external-aws
   timeout: 6h0m0s
 - as: e2e-aws-ovn-kube-apiserver-rollout

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.21.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.21.yaml
@@ -585,11 +585,6 @@ tests:
       FEATURE_SET: CustomNoUpgrade
       MULTI_NIC_IPI: "true"
     workflow: openshift-e2e-vsphere
-- as: e2e-external-vsphere-ccm
-  cron: 24 7 * * 5
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: upi-vsphere-platform-external-ccm
 - as: e2e-aws-ovn-local-gateway
   interval: 168h
   steps:
@@ -1643,6 +1638,11 @@ tests:
     - ref: fips-check-node-scan
     - ref: fips-check-art-fips
     workflow: ipi-aws
+- as: e2e-external-vsphere-ccm
+  cron: 24 7 * * 5
+  steps:
+    cluster_profile: vsphere-elastic
+    workflow: upi-vsphere-platform-external-ccm
 - as: e2e-external-aws
   cron: '@weekly'
   steps:

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22.yaml
@@ -2193,11 +2193,21 @@ tests:
   steps:
     cluster_profile: vsphere-elastic
     workflow: upi-vsphere-platform-external-ccm
-- as: e2e-external-aws
-  cron: '@weekly'
+  timeout: 6h0m0s
+- as: e2e-platform-external-aws
+  cron: '@yearly'
   steps:
     cluster_profile: openshift-org-aws
     workflow: openshift-e2e-external-aws
+  timeout: 6h0m0s
+- as: e2e-platform-none-aws
+  cron: '@yearly'
+  steps:
+    cluster_profile: openshift-org-aws
+    env:
+      PLATFORM_NONE_ENFORCE: "yes"
+    workflow: openshift-e2e-external-aws
+  timeout: 6h0m0s
 - as: e2e-platform-external-aws-ccm
   cron: '@weekly'
   steps:
@@ -2205,21 +2215,29 @@ tests:
     env:
       PLATFORM_EXTERNAL_CCM_ENABLED: "yes"
     workflow: openshift-e2e-external-aws
+  timeout: 6h0m0s
 - as: opct-platform-external-aws-ccm
-  cron: '@weekly'
+  cron: '@monthly'
   steps:
     cluster_profile: openshift-org-aws
     env:
       PLATFORM_EXTERNAL_CCM_ENABLED: "yes"
     workflow: opct-conformance-external-aws
   timeout: 6h0m0s
-- as: e2e-platform-none-aws
+- as: opct-platform-external-aws
+  cron: '@weekly'
+  steps:
+    cluster_profile: openshift-org-aws
+    workflow: opct-conformance-external-aws
+  timeout: 6h0m0s
+- as: opct-platform-none-aws
   cron: '@weekly'
   steps:
     cluster_profile: openshift-org-aws
     env:
       PLATFORM_NONE_ENFORCE: "yes"
-    workflow: openshift-e2e-external-aws
+    workflow: opct-conformance-external-aws
+  timeout: 6h0m0s
 - as: e2e-aws-ovn-kube-apiserver-rollout
   interval: 168h
   steps:

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22.yaml
@@ -918,11 +918,6 @@ tests:
       FEATURE_SET: CustomNoUpgrade
       MULTI_NIC_IPI: "true"
     workflow: openshift-e2e-vsphere
-- as: e2e-external-vsphere-ccm
-  cron: 26 13 * * 2
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: upi-vsphere-platform-external-ccm
 - as: e2e-aws-ovn-local-gateway
   interval: 168h
   steps:
@@ -2193,19 +2188,24 @@ tests:
     - ref: fips-check-node-scan
     - ref: fips-check-art-fips
     workflow: ipi-aws
+- as: e2e-external-vsphere-ccm
+  cron: 26 13 * * 2
+  steps:
+    cluster_profile: vsphere-elastic
+    workflow: upi-vsphere-platform-external-ccm
 - as: e2e-external-aws
   cron: '@weekly'
   steps:
     cluster_profile: openshift-org-aws
     workflow: openshift-e2e-external-aws
-- as: e2e-external-aws-ccm
+- as: e2e-platform-external-aws-ccm
   cron: '@weekly'
   steps:
     cluster_profile: openshift-org-aws
     env:
       PLATFORM_EXTERNAL_CCM_ENABLED: "yes"
     workflow: openshift-e2e-external-aws
-- as: opct-external-aws-ccm
+- as: opct-platform-external-aws-ccm
   cron: '@weekly'
   steps:
     cluster_profile: openshift-org-aws
@@ -2213,6 +2213,13 @@ tests:
       PLATFORM_EXTERNAL_CCM_ENABLED: "yes"
     workflow: opct-conformance-external-aws
   timeout: 6h0m0s
+- as: e2e-platform-none-aws
+  cron: '@weekly'
+  steps:
+    cluster_profile: openshift-org-aws
+    env:
+      PLATFORM_NONE_ENFORCE: "yes"
+    workflow: openshift-e2e-external-aws
 - as: e2e-aws-ovn-kube-apiserver-rollout
   interval: 168h
   steps:

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.23.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.23.yaml
@@ -881,11 +881,6 @@ tests:
       FEATURE_SET: CustomNoUpgrade
       MULTI_NIC_IPI: "true"
     workflow: openshift-e2e-vsphere
-- as: e2e-external-vsphere-ccm
-  cron: 26 13 * * 2
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: upi-vsphere-platform-external-ccm
 - as: e2e-aws-ovn-local-gateway
   interval: 168h
   steps:
@@ -2153,6 +2148,11 @@ tests:
     - ref: fips-check-node-scan
     - ref: fips-check-art-fips
     workflow: ipi-aws
+- as: e2e-external-vsphere-ccm
+  cron: 26 13 * * 2
+  steps:
+    cluster_profile: vsphere-elastic
+    workflow: upi-vsphere-platform-external-ccm
 - as: e2e-external-aws
   cron: '@weekly'
   steps:

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.23.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.23.yaml
@@ -2153,24 +2153,48 @@ tests:
   steps:
     cluster_profile: vsphere-elastic
     workflow: upi-vsphere-platform-external-ccm
-- as: e2e-external-aws
-  cron: '@weekly'
+- as: e2e-platform-external-aws
+  cron: '@monthly'
   steps:
     cluster_profile: openshift-org-aws
     workflow: openshift-e2e-external-aws
-- as: e2e-external-aws-ccm
-  cron: '@weekly'
+  timeout: 6h0m0s
+- as: e2e-platform-external-aws-ccm
+  cron: '@yearly'
   steps:
     cluster_profile: openshift-org-aws
     env:
       PLATFORM_EXTERNAL_CCM_ENABLED: "yes"
     workflow: openshift-e2e-external-aws
-- as: opct-external-aws-ccm
-  cron: '@weekly'
+  timeout: 6h0m0s
+- as: e2e-platform-none-aws
+  cron: '@yearly'
+  steps:
+    cluster_profile: openshift-org-aws
+    env:
+      PLATFORM_NONE_ENFORCE: "yes"
+    workflow: openshift-e2e-external-aws
+  timeout: 6h0m0s
+- as: opct-platform-external-aws-ccm
+  cron: '@yearly'
   steps:
     cluster_profile: openshift-org-aws
     env:
       PLATFORM_EXTERNAL_CCM_ENABLED: "yes"
+    workflow: opct-conformance-external-aws
+  timeout: 6h0m0s
+- as: opct-platform-external-aws
+  cron: '@monthly'
+  steps:
+    cluster_profile: openshift-org-aws
+    workflow: opct-conformance-external-aws
+  timeout: 6h0m0s
+- as: opct-platform-none-aws
+  cron: '@yearly'
+  steps:
+    cluster_profile: openshift-org-aws
+    env:
+      PLATFORM_NONE_ENFORCE: "yes"
     workflow: opct-conformance-external-aws
   timeout: 6h0m0s
 - as: e2e-aws-ovn-kube-apiserver-rollout

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
@@ -881,11 +881,6 @@ tests:
       FEATURE_SET: CustomNoUpgrade
       MULTI_NIC_IPI: "true"
     workflow: openshift-e2e-vsphere
-- as: e2e-external-vsphere-ccm
-  cron: 5 0 * * 3
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: upi-vsphere-platform-external-ccm
 - as: e2e-aws-ovn-local-gateway
   interval: 168h
   steps:
@@ -2140,6 +2135,11 @@ tests:
     - ref: fips-check-node-scan
     - ref: fips-check-art-fips
     workflow: ipi-aws
+- as: e2e-external-vsphere-ccm
+  cron: 5 0 * * 3
+  steps:
+    cluster_profile: vsphere-elastic
+    workflow: upi-vsphere-platform-external-ccm
 - as: e2e-external-aws
   cron: '@weekly'
   steps:

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
@@ -2140,24 +2140,48 @@ tests:
   steps:
     cluster_profile: vsphere-elastic
     workflow: upi-vsphere-platform-external-ccm
-- as: e2e-external-aws
-  cron: '@weekly'
+- as: e2e-platform-external-aws
+  cron: '@monthly'
   steps:
     cluster_profile: openshift-org-aws
     workflow: openshift-e2e-external-aws
-- as: e2e-external-aws-ccm
-  cron: '@weekly'
+  timeout: 6h0m0s
+- as: e2e-platform-external-aws-ccm
+  cron: '@yearly'
   steps:
     cluster_profile: openshift-org-aws
     env:
       PLATFORM_EXTERNAL_CCM_ENABLED: "yes"
     workflow: openshift-e2e-external-aws
-- as: opct-external-aws-ccm
-  cron: '@weekly'
+  timeout: 6h0m0s
+- as: e2e-platform-none-aws
+  cron: '@yearly'
+  steps:
+    cluster_profile: openshift-org-aws
+    env:
+      PLATFORM_NONE_ENFORCE: "yes"
+    workflow: openshift-e2e-external-aws
+  timeout: 6h0m0s
+- as: opct-platform-external-aws-ccm
+  cron: '@yearly'
   steps:
     cluster_profile: openshift-org-aws
     env:
       PLATFORM_EXTERNAL_CCM_ENABLED: "yes"
+    workflow: opct-conformance-external-aws
+  timeout: 6h0m0s
+- as: opct-platform-external-aws
+  cron: '@monthly'
+  steps:
+    cluster_profile: openshift-org-aws
+    workflow: opct-conformance-external-aws
+  timeout: 6h0m0s
+- as: opct-platform-none-aws
+  cron: '@yearly'
+  steps:
+    cluster_profile: openshift-org-aws
+    env:
+      PLATFORM_NONE_ENFORCE: "yes"
     workflow: opct-conformance-external-aws
   timeout: 6h0m0s
 - as: e2e-aws-ovn-kube-apiserver-rollout

--- a/ci-operator/config/redhat-openshift-ecosystem/opct/redhat-openshift-ecosystem-opct-main__4.17.yaml
+++ b/ci-operator/config/redhat-openshift-ecosystem/opct/redhat-openshift-ecosystem-opct-main__4.17.yaml
@@ -12,7 +12,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: rhel-8-release-golang-1.23-openshift-4.17
+    tag: rhel-9-release-golang-1.25-openshift-4.23
 releases:
   initial:
     release:
@@ -39,19 +39,6 @@ resources:
       cpu: "3"
       memory: 5Gi
 tests:
-- as: platform-none-vsphere
-  cron: 0 0 1,15 * 3
-  steps:
-    cluster_profile: vsphere-elastic
-    workflow: opct-test-platform-none-vsphere
-- as: platform-none-vsphere-upgrade
-  cron: 0 5 1,15 * 3
-  steps:
-    cluster_profile: vsphere-elastic
-    env:
-      OPCT_RUN_MODE: upgrade
-      UPGRADE_TO_CHANNEL_TYPE: candidate
-    workflow: opct-test-platform-none-vsphere
 - as: platform-external-vsphere
   cron: 0 12 1,15 * 3
   steps:

--- a/ci-operator/config/redhat-openshift-ecosystem/opct/redhat-openshift-ecosystem-opct-main__4.18.yaml
+++ b/ci-operator/config/redhat-openshift-ecosystem/opct/redhat-openshift-ecosystem-opct-main__4.18.yaml
@@ -12,7 +12,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: rhel-8-release-golang-1.23-openshift-4.18
+    tag: rhel-9-release-golang-1.25-openshift-4.23
 releases:
   initial:
     release:

--- a/ci-operator/config/redhat-openshift-ecosystem/opct/redhat-openshift-ecosystem-opct-main__4.20.yaml
+++ b/ci-operator/config/redhat-openshift-ecosystem/opct/redhat-openshift-ecosystem-opct-main__4.20.yaml
@@ -12,7 +12,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: rhel-8-release-golang-1.23-openshift-4.19
+    tag: rhel-9-release-golang-1.25-openshift-4.23
 releases:
   initial:
     integration:
@@ -23,9 +23,9 @@ releases:
       channel: fast
       version: "4.19"
   latest:
-    candidate:
-      product: ocp
-      stream: nightly
+    release:
+      architecture: amd64
+      channel: fast
       version: "4.20"
 resources:
   '*':
@@ -39,12 +39,33 @@ resources:
       cpu: "3"
       memory: 5Gi
 tests:
+- as: platform-none-vsphere
+  cron: 0 0 * * 2
+  steps:
+    cluster_profile: vsphere-elastic
+    workflow: opct-test-platform-none-vsphere
+- as: platform-none-vsphere-upgrade
+  cron: 0 1 * * 2
+  steps:
+    cluster_profile: vsphere-elastic
+    env:
+      OPCT_RUN_MODE: upgrade
+      UPGRADE_TO_CHANNEL_TYPE: candidate
+    workflow: opct-test-platform-none-vsphere
 - as: platform-external-vsphere
-  cron: 44 23 * * 5
+  cron: 0 2 * * 2
   steps:
     cluster_profile: vsphere-elastic
     env:
       PLATFORM_NAME: vsphere
+    workflow: opct-test-platform-external-vsphere
+- as: platform-external-vsphere-upgrade
+  cron: 0 3 * * 2
+  steps:
+    cluster_profile: vsphere-elastic
+    env:
+      OPCT_RUN_MODE: upgrade
+      UPGRADE_TO_CHANNEL_TYPE: candidate
     workflow: opct-test-platform-external-vsphere
 zz_generated_metadata:
   branch: main

--- a/ci-operator/config/redhat-openshift-ecosystem/opct/redhat-openshift-ecosystem-opct-main__4.21.yaml
+++ b/ci-operator/config/redhat-openshift-ecosystem/opct/redhat-openshift-ecosystem-opct-main__4.21.yaml
@@ -12,7 +12,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: rhel-8-release-golang-1.23-openshift-4.20
+    tag: rhel-9-release-golang-1.25-openshift-4.23
 releases:
   initial:
     integration:
@@ -23,9 +23,9 @@ releases:
       channel: fast
       version: "4.20"
   latest:
-    candidate:
-      product: ocp
-      stream: nightly
+    release:
+      architecture: amd64
+      channel: fast
       version: "4.21"
 resources:
   '*':

--- a/ci-operator/config/redhat-openshift-ecosystem/opct/redhat-openshift-ecosystem-opct-main__4.22.yaml
+++ b/ci-operator/config/redhat-openshift-ecosystem/opct/redhat-openshift-ecosystem-opct-main__4.22.yaml
@@ -12,7 +12,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: rhel-8-release-golang-1.25-openshift-4.21
+    tag: rhel-9-release-golang-1.25-openshift-4.23
 releases:
   initial:
     integration:

--- a/ci-operator/config/redhat-openshift-ecosystem/opct/redhat-openshift-ecosystem-opct-main__4.23.yaml
+++ b/ci-operator/config/redhat-openshift-ecosystem/opct/redhat-openshift-ecosystem-opct-main__4.23.yaml
@@ -1,6 +1,6 @@
 base_images:
   upi-installer:
-    name: "4.19"
+    name: "4.21"
     namespace: ocp
     tag: upi-installer
   vsphere-ci-python:
@@ -16,17 +16,17 @@ build_root:
 releases:
   initial:
     integration:
-      name: "4.19"
+      name: "4.23"
       namespace: ocp
   initial-minor:
     release:
       channel: fast
-      version: "4.18"
+      version: "4.22"
   latest:
-    release:
-      architecture: amd64
-      channel: fast
-      version: "4.19"
+    candidate:
+      product: ocp
+      stream: nightly
+      version: "4.23"
 resources:
   '*':
     limits:
@@ -40,12 +40,12 @@ resources:
       memory: 5Gi
 tests:
 - as: platform-none-vsphere
-  cron: 0 0 * * 2
+  cron: 0 0 * * 3
   steps:
     cluster_profile: vsphere-elastic
     workflow: opct-test-platform-none-vsphere
 - as: platform-none-vsphere-upgrade
-  cron: 0 1 * * 2
+  cron: 0 1 * * 3
   steps:
     cluster_profile: vsphere-elastic
     env:
@@ -53,14 +53,14 @@ tests:
       UPGRADE_TO_CHANNEL_TYPE: candidate
     workflow: opct-test-platform-none-vsphere
 - as: platform-external-vsphere
-  cron: 0 2 * * 2
+  cron: 0 2 * * 3
   steps:
     cluster_profile: vsphere-elastic
     env:
       PLATFORM_NAME: vsphere
     workflow: opct-test-platform-external-vsphere
 - as: platform-external-vsphere-upgrade
-  cron: 0 3 * * 2
+  cron: 0 3 * * 3
   steps:
     cluster_profile: vsphere-elastic
     env:
@@ -71,4 +71,4 @@ zz_generated_metadata:
   branch: main
   org: redhat-openshift-ecosystem
   repo: opct
-  variant: "4.19"
+  variant: "4.23"

--- a/ci-operator/config/redhat-openshift-ecosystem/opct/redhat-openshift-ecosystem-opct-main__5.0.yaml
+++ b/ci-operator/config/redhat-openshift-ecosystem/opct/redhat-openshift-ecosystem-opct-main__5.0.yaml
@@ -1,6 +1,6 @@
 base_images:
   upi-installer:
-    name: "4.19"
+    name: "4.21"
     namespace: ocp
     tag: upi-installer
   vsphere-ci-python:
@@ -16,17 +16,17 @@ build_root:
 releases:
   initial:
     integration:
-      name: "4.19"
+      name: "5.0"
       namespace: ocp
   initial-minor:
     release:
       channel: fast
-      version: "4.18"
+      version: "4.22"
   latest:
-    release:
-      architecture: amd64
-      channel: fast
-      version: "4.19"
+    candidate:
+      product: ocp
+      stream: nightly
+      version: "5.0"
 resources:
   '*':
     limits:
@@ -40,12 +40,12 @@ resources:
       memory: 5Gi
 tests:
 - as: platform-none-vsphere
-  cron: 0 0 * * 2
+  cron: 0 0 * * 3
   steps:
     cluster_profile: vsphere-elastic
     workflow: opct-test-platform-none-vsphere
 - as: platform-none-vsphere-upgrade
-  cron: 0 1 * * 2
+  cron: 0 1 * * 3
   steps:
     cluster_profile: vsphere-elastic
     env:
@@ -53,14 +53,14 @@ tests:
       UPGRADE_TO_CHANNEL_TYPE: candidate
     workflow: opct-test-platform-none-vsphere
 - as: platform-external-vsphere
-  cron: 0 2 * * 2
+  cron: 0 2 * * 3
   steps:
     cluster_profile: vsphere-elastic
     env:
       PLATFORM_NAME: vsphere
     workflow: opct-test-platform-external-vsphere
 - as: platform-external-vsphere-upgrade
-  cron: 0 3 * * 2
+  cron: 0 3 * * 3
   steps:
     cluster_profile: vsphere-elastic
     env:
@@ -71,4 +71,4 @@ zz_generated_metadata:
   branch: main
   org: redhat-openshift-ecosystem
   repo: opct
-  variant: "4.19"
+  variant: "5.0"

--- a/ci-operator/jobs/redhat-openshift-ecosystem/opct/redhat-openshift-ecosystem-opct-main-periodics.yaml
+++ b/ci-operator/jobs/redhat-openshift-ecosystem/opct/redhat-openshift-ecosystem-opct-main-periodics.yaml
@@ -181,186 +181,6 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: vsphere02
-  cron: 0 0 1,15 * 3
-  decorate: true
-  decoration_config:
-    skip_cloning: true
-  extra_refs:
-  - base_ref: main
-    org: redhat-openshift-ecosystem
-    repo: opct
-  labels:
-    ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
-    ci-operator.openshift.io/variant: "4.17"
-    ci.openshift.io/generator: prowgen
-    pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-redhat-openshift-ecosystem-opct-main-4.17-platform-none-vsphere
-  reporter_config:
-    slack:
-      channel: '#forum-opct-updates'
-      job_states_to_report:
-      - failure
-      - error
-      report_template: |
-        :red_jenkins_circle: :workflow::external-link::vsphere: Periodical job *{{.Spec.Job}}* ended with *{{.Status.State}}*. (<{{.Status.URL}}|View logs>) (<https://prow.ci.openshift.org/job-history/gs/test-platform-results/logs/{{.Spec.Job}}|View history>)
-  spec:
-    containers:
-    - args:
-      - --gcs-upload-secret=/secrets/gcs/service-account.json
-      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-      - --lease-server-credentials-file=/etc/boskos/credentials
-      - --report-credentials-file=/etc/report/credentials
-      - --secret-dir=/secrets/ci-pull-credentials
-      - --target=platform-none-vsphere
-      - --variant=4.17
-      command:
-      - ci-operator
-      env:
-      - name: HTTP_SERVER_IP
-        valueFrom:
-          fieldRef:
-            fieldPath: status.podIP
-      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-      imagePullPolicy: Always
-      name: ""
-      ports:
-      - containerPort: 8080
-        name: http
-      resources:
-        requests:
-          cpu: 10m
-      volumeMounts:
-      - mountPath: /etc/boskos
-        name: boskos
-        readOnly: true
-      - mountPath: /secrets/ci-pull-credentials
-        name: ci-pull-credentials
-        readOnly: true
-      - mountPath: /secrets/gcs
-        name: gcs-credentials
-        readOnly: true
-      - mountPath: /secrets/manifest-tool
-        name: manifest-tool-local-pusher
-        readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
-      - mountPath: /etc/report
-        name: result-aggregator
-        readOnly: true
-    serviceAccountName: ci-operator
-    volumes:
-    - name: boskos
-      secret:
-        items:
-        - key: credentials
-          path: credentials
-        secretName: boskos-credentials
-    - name: ci-pull-credentials
-      secret:
-        secretName: ci-pull-credentials
-    - name: manifest-tool-local-pusher
-      secret:
-        secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
-    - name: result-aggregator
-      secret:
-        secretName: result-aggregator
-- agent: kubernetes
-  cluster: vsphere02
-  cron: 0 5 1,15 * 3
-  decorate: true
-  decoration_config:
-    skip_cloning: true
-  extra_refs:
-  - base_ref: main
-    org: redhat-openshift-ecosystem
-    repo: opct
-  labels:
-    ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
-    ci-operator.openshift.io/variant: "4.17"
-    ci.openshift.io/generator: prowgen
-    pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-redhat-openshift-ecosystem-opct-main-4.17-platform-none-vsphere-upgrade
-  reporter_config:
-    slack:
-      channel: '#forum-opct-updates'
-      job_states_to_report:
-      - failure
-      - error
-      report_template: |
-        :red_jenkins_circle: :workflow::external-link::vsphere: Periodical job *{{.Spec.Job}}* ended with *{{.Status.State}}*. (<{{.Status.URL}}|View logs>) (<https://prow.ci.openshift.org/job-history/gs/test-platform-results/logs/{{.Spec.Job}}|View history>)
-  spec:
-    containers:
-    - args:
-      - --gcs-upload-secret=/secrets/gcs/service-account.json
-      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-      - --lease-server-credentials-file=/etc/boskos/credentials
-      - --report-credentials-file=/etc/report/credentials
-      - --secret-dir=/secrets/ci-pull-credentials
-      - --target=platform-none-vsphere-upgrade
-      - --variant=4.17
-      command:
-      - ci-operator
-      env:
-      - name: HTTP_SERVER_IP
-        valueFrom:
-          fieldRef:
-            fieldPath: status.podIP
-      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-      imagePullPolicy: Always
-      name: ""
-      ports:
-      - containerPort: 8080
-        name: http
-      resources:
-        requests:
-          cpu: 10m
-      volumeMounts:
-      - mountPath: /etc/boskos
-        name: boskos
-        readOnly: true
-      - mountPath: /secrets/ci-pull-credentials
-        name: ci-pull-credentials
-        readOnly: true
-      - mountPath: /secrets/gcs
-        name: gcs-credentials
-        readOnly: true
-      - mountPath: /secrets/manifest-tool
-        name: manifest-tool-local-pusher
-        readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
-      - mountPath: /etc/report
-        name: result-aggregator
-        readOnly: true
-    serviceAccountName: ci-operator
-    volumes:
-    - name: boskos
-      secret:
-        items:
-        - key: credentials
-          path: credentials
-        secretName: boskos-credentials
-    - name: ci-pull-credentials
-      secret:
-        secretName: ci-pull-credentials
-    - name: manifest-tool-local-pusher
-      secret:
-        secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
-    - name: result-aggregator
-      secret:
-        secretName: result-aggregator
-- agent: kubernetes
-  cluster: vsphere02
   cron: 0 12 1,15 * 4
   decorate: true
   decoration_config:
@@ -721,7 +541,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: vsphere02
-  cron: 17 5 * * 3
+  cron: 0 2 * * 2
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -811,7 +631,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: vsphere02
-  cron: 30 14 * * 4
+  cron: 0 3 * * 2
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -901,7 +721,187 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: vsphere02
-  cron: 44 23 * * 5
+  cron: 0 0 * * 2
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: redhat-openshift-ecosystem
+    repo: opct
+  labels:
+    ci-operator.openshift.io/cloud: vsphere
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+    ci-operator.openshift.io/variant: "4.19"
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-redhat-openshift-ecosystem-opct-main-4.19-platform-none-vsphere
+  reporter_config:
+    slack:
+      channel: '#forum-opct-updates'
+      job_states_to_report:
+      - failure
+      - error
+      report_template: |
+        :red_jenkins_circle: :workflow::external-link::vsphere: Periodical job *{{.Spec.Job}}* ended with *{{.Status.State}}*. (<{{.Status.URL}}|View logs>) (<https://prow.ci.openshift.org/job-history/gs/test-platform-results/logs/{{.Spec.Job}}|View history>)
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=platform-none-vsphere
+      - --variant=4.19
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: vsphere02
+  cron: 0 1 * * 2
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: redhat-openshift-ecosystem
+    repo: opct
+  labels:
+    ci-operator.openshift.io/cloud: vsphere
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+    ci-operator.openshift.io/variant: "4.19"
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-redhat-openshift-ecosystem-opct-main-4.19-platform-none-vsphere-upgrade
+  reporter_config:
+    slack:
+      channel: '#forum-opct-updates'
+      job_states_to_report:
+      - failure
+      - error
+      report_template: |
+        :red_jenkins_circle: :workflow::external-link::vsphere: Periodical job *{{.Spec.Job}}* ended with *{{.Status.State}}*. (<{{.Status.URL}}|View logs>) (<https://prow.ci.openshift.org/job-history/gs/test-platform-results/logs/{{.Spec.Job}}|View history>)
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=platform-none-vsphere-upgrade
+      - --variant=4.19
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: vsphere02
+  cron: 0 2 * * 2
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -914,7 +914,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: "4.20"
     ci.openshift.io/generator: prowgen
-    job-release: "4.20"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-redhat-openshift-ecosystem-opct-main-4.20-platform-external-vsphere
   reporter_config:
@@ -992,6 +991,276 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: vsphere02
+  cron: 0 3 * * 2
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: redhat-openshift-ecosystem
+    repo: opct
+  labels:
+    ci-operator.openshift.io/cloud: vsphere
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+    ci-operator.openshift.io/variant: "4.20"
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-redhat-openshift-ecosystem-opct-main-4.20-platform-external-vsphere-upgrade
+  reporter_config:
+    slack:
+      channel: '#forum-opct-updates'
+      job_states_to_report:
+      - failure
+      - error
+      report_template: |
+        :red_jenkins_circle: :workflow::external-link::vsphere: Periodical job *{{.Spec.Job}}* ended with *{{.Status.State}}*. (<{{.Status.URL}}|View logs>) (<https://prow.ci.openshift.org/job-history/gs/test-platform-results/logs/{{.Spec.Job}}|View history>)
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=platform-external-vsphere-upgrade
+      - --variant=4.20
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: vsphere02
+  cron: 0 0 * * 2
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: redhat-openshift-ecosystem
+    repo: opct
+  labels:
+    ci-operator.openshift.io/cloud: vsphere
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+    ci-operator.openshift.io/variant: "4.20"
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-redhat-openshift-ecosystem-opct-main-4.20-platform-none-vsphere
+  reporter_config:
+    slack:
+      channel: '#forum-opct-updates'
+      job_states_to_report:
+      - failure
+      - error
+      report_template: |
+        :red_jenkins_circle: :workflow::external-link::vsphere: Periodical job *{{.Spec.Job}}* ended with *{{.Status.State}}*. (<{{.Status.URL}}|View logs>) (<https://prow.ci.openshift.org/job-history/gs/test-platform-results/logs/{{.Spec.Job}}|View history>)
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=platform-none-vsphere
+      - --variant=4.20
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: vsphere02
+  cron: 0 1 * * 2
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: redhat-openshift-ecosystem
+    repo: opct
+  labels:
+    ci-operator.openshift.io/cloud: vsphere
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+    ci-operator.openshift.io/variant: "4.20"
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-redhat-openshift-ecosystem-opct-main-4.20-platform-none-vsphere-upgrade
+  reporter_config:
+    slack:
+      channel: '#forum-opct-updates'
+      job_states_to_report:
+      - failure
+      - error
+      report_template: |
+        :red_jenkins_circle: :workflow::external-link::vsphere: Periodical job *{{.Spec.Job}}* ended with *{{.Status.State}}*. (<{{.Status.URL}}|View logs>) (<https://prow.ci.openshift.org/job-history/gs/test-platform-results/logs/{{.Spec.Job}}|View history>)
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=platform-none-vsphere-upgrade
+      - --variant=4.20
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: vsphere02
   cron: 0 2 * * 2
   decorate: true
   decoration_config:
@@ -1005,7 +1274,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: "4.21"
     ci.openshift.io/generator: prowgen
-    job-release: "4.21"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-redhat-openshift-ecosystem-opct-main-4.21-platform-external-vsphere
   reporter_config:
@@ -1096,7 +1364,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: "4.21"
     ci.openshift.io/generator: prowgen
-    job-release: "4.21"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-redhat-openshift-ecosystem-opct-main-4.21-platform-external-vsphere-upgrade
   reporter_config:
@@ -1187,7 +1454,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: "4.21"
     ci.openshift.io/generator: prowgen
-    job-release: "4.21"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-redhat-openshift-ecosystem-opct-main-4.21-platform-none-vsphere
   reporter_config:
@@ -1278,7 +1544,6 @@ periodics:
     ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: "4.21"
     ci.openshift.io/generator: prowgen
-    job-release: "4.21"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-redhat-openshift-ecosystem-opct-main-4.21-platform-none-vsphere-upgrade
   reporter_config:
@@ -1663,6 +1928,734 @@ periodics:
       - --secret-dir=/secrets/ci-pull-credentials
       - --target=platform-none-vsphere-upgrade
       - --variant=4.22
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: vsphere02
+  cron: 0 2 * * 3
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: redhat-openshift-ecosystem
+    repo: opct
+  labels:
+    ci-operator.openshift.io/cloud: vsphere
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+    ci-operator.openshift.io/variant: "4.23"
+    ci.openshift.io/generator: prowgen
+    job-release: "4.23"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-redhat-openshift-ecosystem-opct-main-4.23-platform-external-vsphere
+  reporter_config:
+    slack:
+      channel: '#forum-opct-updates'
+      job_states_to_report:
+      - failure
+      - error
+      report_template: |
+        :red_jenkins_circle: :workflow::external-link::vsphere: Periodical job *{{.Spec.Job}}* ended with *{{.Status.State}}*. (<{{.Status.URL}}|View logs>) (<https://prow.ci.openshift.org/job-history/gs/test-platform-results/logs/{{.Spec.Job}}|View history>)
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=platform-external-vsphere
+      - --variant=4.23
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: vsphere02
+  cron: 0 3 * * 3
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: redhat-openshift-ecosystem
+    repo: opct
+  labels:
+    ci-operator.openshift.io/cloud: vsphere
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+    ci-operator.openshift.io/variant: "4.23"
+    ci.openshift.io/generator: prowgen
+    job-release: "4.23"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-redhat-openshift-ecosystem-opct-main-4.23-platform-external-vsphere-upgrade
+  reporter_config:
+    slack:
+      channel: '#forum-opct-updates'
+      job_states_to_report:
+      - failure
+      - error
+      report_template: |
+        :red_jenkins_circle: :workflow::external-link::vsphere: Periodical job *{{.Spec.Job}}* ended with *{{.Status.State}}*. (<{{.Status.URL}}|View logs>) (<https://prow.ci.openshift.org/job-history/gs/test-platform-results/logs/{{.Spec.Job}}|View history>)
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=platform-external-vsphere-upgrade
+      - --variant=4.23
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: vsphere02
+  cron: 0 0 * * 3
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: redhat-openshift-ecosystem
+    repo: opct
+  labels:
+    ci-operator.openshift.io/cloud: vsphere
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+    ci-operator.openshift.io/variant: "4.23"
+    ci.openshift.io/generator: prowgen
+    job-release: "4.23"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-redhat-openshift-ecosystem-opct-main-4.23-platform-none-vsphere
+  reporter_config:
+    slack:
+      channel: '#forum-opct-updates'
+      job_states_to_report:
+      - failure
+      - error
+      report_template: |
+        :red_jenkins_circle: :workflow::external-link::vsphere: Periodical job *{{.Spec.Job}}* ended with *{{.Status.State}}*. (<{{.Status.URL}}|View logs>) (<https://prow.ci.openshift.org/job-history/gs/test-platform-results/logs/{{.Spec.Job}}|View history>)
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=platform-none-vsphere
+      - --variant=4.23
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: vsphere02
+  cron: 0 1 * * 3
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: redhat-openshift-ecosystem
+    repo: opct
+  labels:
+    ci-operator.openshift.io/cloud: vsphere
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+    ci-operator.openshift.io/variant: "4.23"
+    ci.openshift.io/generator: prowgen
+    job-release: "4.23"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-redhat-openshift-ecosystem-opct-main-4.23-platform-none-vsphere-upgrade
+  reporter_config:
+    slack:
+      channel: '#forum-opct-updates'
+      job_states_to_report:
+      - failure
+      - error
+      report_template: |
+        :red_jenkins_circle: :workflow::external-link::vsphere: Periodical job *{{.Spec.Job}}* ended with *{{.Status.State}}*. (<{{.Status.URL}}|View logs>) (<https://prow.ci.openshift.org/job-history/gs/test-platform-results/logs/{{.Spec.Job}}|View history>)
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=platform-none-vsphere-upgrade
+      - --variant=4.23
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: vsphere02
+  cron: 0 2 * * 3
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: redhat-openshift-ecosystem
+    repo: opct
+  labels:
+    ci-operator.openshift.io/cloud: vsphere
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+    ci-operator.openshift.io/variant: "5.0"
+    ci.openshift.io/generator: prowgen
+    job-release: "5.0"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-redhat-openshift-ecosystem-opct-main-5.0-platform-external-vsphere
+  reporter_config:
+    slack:
+      channel: '#forum-opct-updates'
+      job_states_to_report:
+      - failure
+      - error
+      report_template: |
+        :red_jenkins_circle: :workflow::external-link::vsphere: Periodical job *{{.Spec.Job}}* ended with *{{.Status.State}}*. (<{{.Status.URL}}|View logs>) (<https://prow.ci.openshift.org/job-history/gs/test-platform-results/logs/{{.Spec.Job}}|View history>)
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=platform-external-vsphere
+      - --variant=5.0
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: vsphere02
+  cron: 0 3 * * 3
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: redhat-openshift-ecosystem
+    repo: opct
+  labels:
+    ci-operator.openshift.io/cloud: vsphere
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+    ci-operator.openshift.io/variant: "5.0"
+    ci.openshift.io/generator: prowgen
+    job-release: "5.0"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-redhat-openshift-ecosystem-opct-main-5.0-platform-external-vsphere-upgrade
+  reporter_config:
+    slack:
+      channel: '#forum-opct-updates'
+      job_states_to_report:
+      - failure
+      - error
+      report_template: |
+        :red_jenkins_circle: :workflow::external-link::vsphere: Periodical job *{{.Spec.Job}}* ended with *{{.Status.State}}*. (<{{.Status.URL}}|View logs>) (<https://prow.ci.openshift.org/job-history/gs/test-platform-results/logs/{{.Spec.Job}}|View history>)
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=platform-external-vsphere-upgrade
+      - --variant=5.0
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: vsphere02
+  cron: 0 0 * * 3
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: redhat-openshift-ecosystem
+    repo: opct
+  labels:
+    ci-operator.openshift.io/cloud: vsphere
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+    ci-operator.openshift.io/variant: "5.0"
+    ci.openshift.io/generator: prowgen
+    job-release: "5.0"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-redhat-openshift-ecosystem-opct-main-5.0-platform-none-vsphere
+  reporter_config:
+    slack:
+      channel: '#forum-opct-updates'
+      job_states_to_report:
+      - failure
+      - error
+      report_template: |
+        :red_jenkins_circle: :workflow::external-link::vsphere: Periodical job *{{.Spec.Job}}* ended with *{{.Status.State}}*. (<{{.Status.URL}}|View logs>) (<https://prow.ci.openshift.org/job-history/gs/test-platform-results/logs/{{.Spec.Job}}|View history>)
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=platform-none-vsphere
+      - --variant=5.0
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: vsphere02
+  cron: 0 1 * * 3
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: redhat-openshift-ecosystem
+    repo: opct
+  labels:
+    ci-operator.openshift.io/cloud: vsphere
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+    ci-operator.openshift.io/variant: "5.0"
+    ci.openshift.io/generator: prowgen
+    job-release: "5.0"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-redhat-openshift-ecosystem-opct-main-5.0-platform-none-vsphere-upgrade
+  reporter_config:
+    slack:
+      channel: '#forum-opct-updates'
+      job_states_to_report:
+      - failure
+      - error
+      report_template: |
+        :red_jenkins_circle: :workflow::external-link::vsphere: Periodical job *{{.Spec.Job}}* ended with *{{.Status.State}}*. (<{{.Status.URL}}|View logs>) (<https://prow.ci.openshift.org/job-history/gs/test-platform-results/logs/{{.Spec.Job}}|View history>)
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=platform-none-vsphere-upgrade
+      - --variant=5.0
       command:
       - ci-operator
       env:

--- a/ci-operator/step-registry/opct/conformance/external-aws/opct-conformance-external-aws-workflow.yaml
+++ b/ci-operator/step-registry/opct/conformance/external-aws/opct-conformance-external-aws-workflow.yaml
@@ -17,7 +17,7 @@ workflow:
     env:
       PROVIDER_NAME: aws
       PLATFORM_EXTERNAL_CCM_ENABLED: no
-      OPCT_CLI_IMAGE: "quay.io/opct/opct:v0.6.2"
+      OPCT_CLI_IMAGE: "quay.io/opct/opct:v0.6.4-rc.1"
   documentation: |-
     The OPCT Conformance External E2E workflow executes the common end-to-end test suite using
     OPCT tool.

--- a/ci-operator/step-registry/opct/conformance/test/results/opct-conformance-test-results-commands.sh
+++ b/ci-operator/step-registry/opct/conformance/test/results/opct-conformance-test-results-commands.sh
@@ -59,12 +59,13 @@ collect_inspect || true
 retrieve_artifact || true
 show_results || true
 
-# Check if job is running in OPCT repo to skip upload results to
+# Check if job is running in OPCT workflow in allowed job ref to skip upload results to
 # OPCT storage.
 show_reader "Consolidating artifacts as Baseline Results"
 INVALID_OPCT_REPO="true"
 VALID_REPOS=("redhat-openshift-ecosystem-provider-certification-tool")
 VALID_REPOS+=("redhat-openshift-ecosystem-opct")
+VALID_REPOS+=("periodic-ci-openshift-release-main")
 show_msg "Checking if JOB name is allowed to upload results: ${JOB_NAME}"
 for VR in "${VALID_REPOS[@]}"; do
   if [[ $JOB_NAME == *"$VR"* ]]; then
@@ -72,7 +73,7 @@ for VR in "${VALID_REPOS[@]}"; do
   fi
 done
 
-# Ignore persisting data in non OPCT/repo jobs
+# Ignore persisting data from unexpected jobs
 if [[ "${INVALID_OPCT_REPO}" == "true" ]]; then
   show_msg "# WARNING: Job $JOB_NAME is not allowed to persist baseline results, ignoring it."
   exit 0

--- a/ci-operator/step-registry/platform-external/pre/conf/platform-external-pre-conf-commands.sh
+++ b/ci-operator/step-registry/platform-external/pre/conf/platform-external-pre-conf-commands.sh
@@ -54,12 +54,27 @@ fi
 # Patch the install-config.yaml
 #
 log "Creating install-config.yaml patch"
-cat > "${PATCH}" << EOF
-baseDomain: ${CLUSTER_BASE_DOMAIN}
+
+# Setting up platform type
+if [[ "${PLATFORM_NONE_ENFORCE}" == "yes" ]]; then
+  log "Setting up platform type: none"
+  cat > "${PATCH}" << EOF
+platform:
+  none: {}
+EOF
+else
+  log "Setting up platform type: external with provider name: ${PROVIDER_NAME} and cloud controller manager: ${CONFIG_PLATFORM_EXTERNAL_CCM}"
+  cat > "${PATCH}" << EOF
 platform:
   external:
     platformName: ${PROVIDER_NAME}
     cloudControllerManager: ${CONFIG_PLATFORM_EXTERNAL_CCM}
+EOF
+fi
+
+log "Configuring domain, publish, and node topology"
+cat >> "${PATCH}" << EOF
+baseDomain: ${CLUSTER_BASE_DOMAIN}
 compute:
 - name: worker
   replicas: 3

--- a/ci-operator/step-registry/platform-external/pre/conf/platform-external-pre-conf-ref.yaml
+++ b/ci-operator/step-registry/platform-external/pre/conf/platform-external-pre-conf-ref.yaml
@@ -39,4 +39,7 @@ ref:
       A) mount the install-config.yaml,
       B) pull the CCM image, when CCM is enabled, to mount the CCM deployment manifest,
       C) openshift-tests pulls tests image.
-
+  - name: PLATFORM_NONE_ENFORCE
+    default: "no"
+    documentation: |-
+      When set to "yes", the platform type will be set to "none" in the install-config.yaml.


### PR DESCRIPTION
DNM

Deep summary https://github.com/openshift/release/pull/78511#issuecomment-4338857577

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added platform-none and platform-external test variants for AWS and vSphere across multiple releases.
  * New OPCT configurations for OpenShift 4.23 and 5.0; added option to force the "none" platform variant.

* **Chores**
  * Updated OPCT build roots to RHEL 9 / Go 1.25 and bumped OPCT CLI image.
  * Reorganized, renamed and rescheduled external AWS/vSphere test jobs; added OPCT job variants and explicit timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->