### PR TITLE
Add GCP PD CSI image snapshot e2e workflow and CI job

### DIFF
--- a/ci-operator/config/openshift-priv/gcp-pd-csi-driver-operator/openshift-priv-gcp-pd-csi-driver-operator-main.yaml
+++ b/ci-operator/config/openshift-priv/gcp-pd-csi-driver-operator/openshift-priv-gcp-pd-csi-driver-operator-main.yaml
@@ -56,6 +56,12 @@ tests:
     cluster_profile: openshift-org-gcp
     workflow: openshift-e2e-gcp-csi
 - always_run: false
+  as: e2e-gcp-csi-image-snapshot
+  optional: true
+  steps:
+    cluster_profile: openshift-org-gcp
+    workflow: openshift-e2e-gcp-csi-image-snapshot
+- always_run: false
   as: e2e-gcp-csi-c3
   optional: true
   steps:

--- a/ci-operator/config/openshift-priv/gcp-pd-csi-driver-operator/openshift-priv-gcp-pd-csi-driver-operator-release-4.22.yaml
+++ b/ci-operator/config/openshift-priv/gcp-pd-csi-driver-operator/openshift-priv-gcp-pd-csi-driver-operator-release-4.22.yaml
@@ -56,6 +56,12 @@ tests:
     cluster_profile: openshift-org-gcp
     workflow: openshift-e2e-gcp-csi
 - always_run: false
+  as: e2e-gcp-csi-image-snapshot
+  optional: true
+  steps:
+    cluster_profile: openshift-org-gcp
+    workflow: openshift-e2e-gcp-csi-image-snapshot
+- always_run: false
   as: e2e-gcp-csi-c3
   optional: true
   steps:

--- a/ci-operator/config/openshift-priv/gcp-pd-csi-driver-operator/openshift-priv-gcp-pd-csi-driver-operator-release-4.23.yaml
+++ b/ci-operator/config/openshift-priv/gcp-pd-csi-driver-operator/openshift-priv-gcp-pd-csi-driver-operator-release-4.23.yaml
@@ -56,6 +56,12 @@ tests:
     cluster_profile: openshift-org-gcp
     workflow: openshift-e2e-gcp-csi
 - always_run: false
+  as: e2e-gcp-csi-image-snapshot
+  optional: true
+  steps:
+    cluster_profile: openshift-org-gcp
+    workflow: openshift-e2e-gcp-csi-image-snapshot
+- always_run: false
   as: e2e-gcp-csi-c3
   optional: true
   steps:

--- a/ci-operator/config/openshift-priv/gcp-pd-csi-driver-operator/openshift-priv-gcp-pd-csi-driver-operator-release-5.0.yaml
+++ b/ci-operator/config/openshift-priv/gcp-pd-csi-driver-operator/openshift-priv-gcp-pd-csi-driver-operator-release-5.0.yaml
@@ -57,6 +57,12 @@ tests:
     cluster_profile: openshift-org-gcp
     workflow: openshift-e2e-gcp-csi
 - always_run: false
+  as: e2e-gcp-csi-image-snapshot
+  optional: true
+  steps:
+    cluster_profile: openshift-org-gcp
+    workflow: openshift-e2e-gcp-csi-image-snapshot
+- always_run: false
   as: e2e-gcp-csi-c3
   optional: true
   steps:

--- a/ci-operator/config/openshift-priv/gcp-pd-csi-driver-operator/openshift-priv-gcp-pd-csi-driver-operator-release-5.1.yaml
+++ b/ci-operator/config/openshift-priv/gcp-pd-csi-driver-operator/openshift-priv-gcp-pd-csi-driver-operator-release-5.1.yaml
@@ -56,6 +56,12 @@ tests:
     cluster_profile: openshift-org-gcp
     workflow: openshift-e2e-gcp-csi
 - always_run: false
+  as: e2e-gcp-csi-image-snapshot
+  optional: true
+  steps:
+    cluster_profile: openshift-org-gcp
+    workflow: openshift-e2e-gcp-csi-image-snapshot
+- always_run: false
   as: e2e-gcp-csi-c3
   optional: true
   steps:

--- a/ci-operator/config/openshift-priv/gcp-pd-csi-driver/openshift-priv-gcp-pd-csi-driver-master.yaml
+++ b/ci-operator/config/openshift-priv/gcp-pd-csi-driver/openshift-priv-gcp-pd-csi-driver-master.yaml
@@ -54,6 +54,12 @@ tests:
     cluster_profile: openshift-org-gcp
     workflow: openshift-e2e-gcp-csi
 - always_run: false
+  as: e2e-gcp-csi-image-snapshot
+  optional: true
+  steps:
+    cluster_profile: openshift-org-gcp
+    workflow: openshift-e2e-gcp-csi-image-snapshot
+- always_run: false
   as: e2e-gcp-csi-c3
   optional: true
   steps:

--- a/ci-operator/config/openshift-priv/gcp-pd-csi-driver/openshift-priv-gcp-pd-csi-driver-release-4.22.yaml
+++ b/ci-operator/config/openshift-priv/gcp-pd-csi-driver/openshift-priv-gcp-pd-csi-driver-release-4.22.yaml
@@ -54,6 +54,12 @@ tests:
     cluster_profile: openshift-org-gcp
     workflow: openshift-e2e-gcp-csi
 - always_run: false
+  as: e2e-gcp-csi-image-snapshot
+  optional: true
+  steps:
+    cluster_profile: openshift-org-gcp
+    workflow: openshift-e2e-gcp-csi-image-snapshot
+- always_run: false
   as: e2e-gcp-csi-c3
   optional: true
   steps:

--- a/ci-operator/config/openshift-priv/gcp-pd-csi-driver/openshift-priv-gcp-pd-csi-driver-release-4.23.yaml
+++ b/ci-operator/config/openshift-priv/gcp-pd-csi-driver/openshift-priv-gcp-pd-csi-driver-release-4.23.yaml
@@ -54,6 +54,12 @@ tests:
     cluster_profile: openshift-org-gcp
     workflow: openshift-e2e-gcp-csi
 - always_run: false
+  as: e2e-gcp-csi-image-snapshot
+  optional: true
+  steps:
+    cluster_profile: openshift-org-gcp
+    workflow: openshift-e2e-gcp-csi-image-snapshot
+- always_run: false
   as: e2e-gcp-csi-c3
   optional: true
   steps:

--- a/ci-operator/config/openshift-priv/gcp-pd-csi-driver/openshift-priv-gcp-pd-csi-driver-release-5.0.yaml
+++ b/ci-operator/config/openshift-priv/gcp-pd-csi-driver/openshift-priv-gcp-pd-csi-driver-release-5.0.yaml
@@ -55,6 +55,12 @@ tests:
     cluster_profile: openshift-org-gcp
     workflow: openshift-e2e-gcp-csi
 - always_run: false
+  as: e2e-gcp-csi-image-snapshot
+  optional: true
+  steps:
+    cluster_profile: openshift-org-gcp
+    workflow: openshift-e2e-gcp-csi-image-snapshot
+- always_run: false
   as: e2e-gcp-csi-c3
   optional: true
   steps:

--- a/ci-operator/config/openshift-priv/gcp-pd-csi-driver/openshift-priv-gcp-pd-csi-driver-release-5.1.yaml
+++ b/ci-operator/config/openshift-priv/gcp-pd-csi-driver/openshift-priv-gcp-pd-csi-driver-release-5.1.yaml
@@ -54,6 +54,12 @@ tests:
     cluster_profile: openshift-org-gcp
     workflow: openshift-e2e-gcp-csi
 - always_run: false
+  as: e2e-gcp-csi-image-snapshot
+  optional: true
+  steps:
+    cluster_profile: openshift-org-gcp
+    workflow: openshift-e2e-gcp-csi-image-snapshot
+- always_run: false
   as: e2e-gcp-csi-c3
   optional: true
   steps:

--- a/ci-operator/config/openshift/gcp-pd-csi-driver-operator/openshift-gcp-pd-csi-driver-operator-main.yaml
+++ b/ci-operator/config/openshift/gcp-pd-csi-driver-operator/openshift-gcp-pd-csi-driver-operator-main.yaml
@@ -53,6 +53,12 @@ tests:
     cluster_profile: openshift-org-gcp
     workflow: openshift-e2e-gcp-csi
 - always_run: false
+  as: e2e-gcp-csi-image-snapshot
+  optional: true
+  steps:
+    cluster_profile: openshift-org-gcp
+    workflow: openshift-e2e-gcp-csi-image-snapshot
+- always_run: false
   as: e2e-gcp-csi-c3
   optional: true
   steps:

--- a/ci-operator/config/openshift/gcp-pd-csi-driver-operator/openshift-gcp-pd-csi-driver-operator-release-4.22.yaml
+++ b/ci-operator/config/openshift/gcp-pd-csi-driver-operator/openshift-gcp-pd-csi-driver-operator-release-4.22.yaml
@@ -53,6 +53,12 @@ tests:
     cluster_profile: openshift-org-gcp
     workflow: openshift-e2e-gcp-csi
 - always_run: false
+  as: e2e-gcp-csi-image-snapshot
+  optional: true
+  steps:
+    cluster_profile: openshift-org-gcp
+    workflow: openshift-e2e-gcp-csi-image-snapshot
+- always_run: false
   as: e2e-gcp-csi-c3
   optional: true
   steps:

--- a/ci-operator/config/openshift/gcp-pd-csi-driver-operator/openshift-gcp-pd-csi-driver-operator-release-4.22__periodics.yaml
+++ b/ci-operator/config/openshift/gcp-pd-csi-driver-operator/openshift-gcp-pd-csi-driver-operator-release-4.22__periodics.yaml
@@ -34,6 +34,11 @@ tests:
     env:
       COMPUTE_NODE_TYPE: n4-standard-4
     workflow: openshift-e2e-gcp-csi-custom-worker
+- as: periodic-e2e-gcp-csi-image-snapshot
+  cron: 25 8 * * 2
+  steps:
+    cluster_profile: openshift-org-gcp
+    workflow: openshift-e2e-gcp-csi-image-snapshot
 zz_generated_metadata:
   branch: release-4.22
   org: openshift

--- a/ci-operator/config/openshift/gcp-pd-csi-driver-operator/openshift-gcp-pd-csi-driver-operator-release-4.23.yaml
+++ b/ci-operator/config/openshift/gcp-pd-csi-driver-operator/openshift-gcp-pd-csi-driver-operator-release-4.23.yaml
@@ -53,6 +53,12 @@ tests:
     cluster_profile: openshift-org-gcp
     workflow: openshift-e2e-gcp-csi
 - always_run: false
+  as: e2e-gcp-csi-image-snapshot
+  optional: true
+  steps:
+    cluster_profile: openshift-org-gcp
+    workflow: openshift-e2e-gcp-csi-image-snapshot
+- always_run: false
   as: e2e-gcp-csi-c3
   optional: true
   steps:

--- a/ci-operator/config/openshift/gcp-pd-csi-driver-operator/openshift-gcp-pd-csi-driver-operator-release-4.23__periodics.yaml
+++ b/ci-operator/config/openshift/gcp-pd-csi-driver-operator/openshift-gcp-pd-csi-driver-operator-release-4.23__periodics.yaml
@@ -34,6 +34,11 @@ tests:
     env:
       COMPUTE_NODE_TYPE: n4-standard-4
     workflow: openshift-e2e-gcp-csi-custom-worker
+- as: periodic-e2e-gcp-csi-image-snapshot
+  cron: 25 8 * * 2
+  steps:
+    cluster_profile: openshift-org-gcp
+    workflow: openshift-e2e-gcp-csi-image-snapshot
 zz_generated_metadata:
   branch: release-4.23
   org: openshift

--- a/ci-operator/config/openshift/gcp-pd-csi-driver-operator/openshift-gcp-pd-csi-driver-operator-release-5.0.yaml
+++ b/ci-operator/config/openshift/gcp-pd-csi-driver-operator/openshift-gcp-pd-csi-driver-operator-release-5.0.yaml
@@ -54,6 +54,12 @@ tests:
     cluster_profile: openshift-org-gcp
     workflow: openshift-e2e-gcp-csi
 - always_run: false
+  as: e2e-gcp-csi-image-snapshot
+  optional: true
+  steps:
+    cluster_profile: openshift-org-gcp
+    workflow: openshift-e2e-gcp-csi-image-snapshot
+- always_run: false
   as: e2e-gcp-csi-c3
   optional: true
   steps:

--- a/ci-operator/config/openshift/gcp-pd-csi-driver-operator/openshift-gcp-pd-csi-driver-operator-release-5.0__periodics.yaml
+++ b/ci-operator/config/openshift/gcp-pd-csi-driver-operator/openshift-gcp-pd-csi-driver-operator-release-5.0__periodics.yaml
@@ -34,6 +34,11 @@ tests:
     env:
       COMPUTE_NODE_TYPE: n4-standard-4
     workflow: openshift-e2e-gcp-csi-custom-worker
+- as: periodic-e2e-gcp-csi-image-snapshot
+  cron: 25 8 * * 2
+  steps:
+    cluster_profile: openshift-org-gcp
+    workflow: openshift-e2e-gcp-csi-image-snapshot
 zz_generated_metadata:
   branch: release-5.0
   org: openshift

--- a/ci-operator/config/openshift/gcp-pd-csi-driver-operator/openshift-gcp-pd-csi-driver-operator-release-5.1.yaml
+++ b/ci-operator/config/openshift/gcp-pd-csi-driver-operator/openshift-gcp-pd-csi-driver-operator-release-5.1.yaml
@@ -53,6 +53,12 @@ tests:
     cluster_profile: openshift-org-gcp
     workflow: openshift-e2e-gcp-csi
 - always_run: false
+  as: e2e-gcp-csi-image-snapshot
+  optional: true
+  steps:
+    cluster_profile: openshift-org-gcp
+    workflow: openshift-e2e-gcp-csi-image-snapshot
+- always_run: false
   as: e2e-gcp-csi-c3
   optional: true
   steps:

--- a/ci-operator/config/openshift/gcp-pd-csi-driver/openshift-gcp-pd-csi-driver-master.yaml
+++ b/ci-operator/config/openshift/gcp-pd-csi-driver/openshift-gcp-pd-csi-driver-master.yaml
@@ -52,6 +52,12 @@ tests:
     cluster_profile: openshift-org-gcp
     workflow: openshift-e2e-gcp-csi
 - always_run: false
+  as: e2e-gcp-csi-image-snapshot
+  optional: true
+  steps:
+    cluster_profile: openshift-org-gcp
+    workflow: openshift-e2e-gcp-csi-image-snapshot
+- always_run: false
   as: e2e-gcp-csi-c3
   optional: true
   steps:

--- a/ci-operator/config/openshift/gcp-pd-csi-driver/openshift-gcp-pd-csi-driver-release-4.22.yaml
+++ b/ci-operator/config/openshift/gcp-pd-csi-driver/openshift-gcp-pd-csi-driver-release-4.22.yaml
@@ -52,6 +52,12 @@ tests:
     cluster_profile: openshift-org-gcp
     workflow: openshift-e2e-gcp-csi
 - always_run: false
+  as: e2e-gcp-csi-image-snapshot
+  optional: true
+  steps:
+    cluster_profile: openshift-org-gcp
+    workflow: openshift-e2e-gcp-csi-image-snapshot
+- always_run: false
   as: e2e-gcp-csi-c3
   optional: true
   steps:

--- a/ci-operator/config/openshift/gcp-pd-csi-driver/openshift-gcp-pd-csi-driver-release-4.23.yaml
+++ b/ci-operator/config/openshift/gcp-pd-csi-driver/openshift-gcp-pd-csi-driver-release-4.23.yaml
@@ -52,6 +52,12 @@ tests:
     cluster_profile: openshift-org-gcp
     workflow: openshift-e2e-gcp-csi
 - always_run: false
+  as: e2e-gcp-csi-image-snapshot
+  optional: true
+  steps:
+    cluster_profile: openshift-org-gcp
+    workflow: openshift-e2e-gcp-csi-image-snapshot
+- always_run: false
   as: e2e-gcp-csi-c3
   optional: true
   steps:

--- a/ci-operator/config/openshift/gcp-pd-csi-driver/openshift-gcp-pd-csi-driver-release-5.0.yaml
+++ b/ci-operator/config/openshift/gcp-pd-csi-driver/openshift-gcp-pd-csi-driver-release-5.0.yaml
@@ -53,6 +53,12 @@ tests:
     cluster_profile: openshift-org-gcp
     workflow: openshift-e2e-gcp-csi
 - always_run: false
+  as: e2e-gcp-csi-image-snapshot
+  optional: true
+  steps:
+    cluster_profile: openshift-org-gcp
+    workflow: openshift-e2e-gcp-csi-image-snapshot
+- always_run: false
   as: e2e-gcp-csi-c3
   optional: true
   steps:

--- a/ci-operator/config/openshift/gcp-pd-csi-driver/openshift-gcp-pd-csi-driver-release-5.1.yaml
+++ b/ci-operator/config/openshift/gcp-pd-csi-driver/openshift-gcp-pd-csi-driver-release-5.1.yaml
@@ -52,6 +52,12 @@ tests:
     cluster_profile: openshift-org-gcp
     workflow: openshift-e2e-gcp-csi
 - always_run: false
+  as: e2e-gcp-csi-image-snapshot
+  optional: true
+  steps:
+    cluster_profile: openshift-org-gcp
+    workflow: openshift-e2e-gcp-csi-image-snapshot
+- always_run: false
   as: e2e-gcp-csi-c3
   optional: true
   steps:

--- a/ci-operator/jobs/openshift-priv/gcp-pd-csi-driver-operator/openshift-priv-gcp-pd-csi-driver-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/gcp-pd-csi-driver-operator/openshift-priv-gcp-pd-csi-driver-operator-main-presubmits.yaml
@@ -363,6 +363,97 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-gcp-csi-extended,?($|\s.*)
   - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build04
+    context: ci/prow/e2e-gcp-csi-image-snapshot
+    decorate: true
+    decoration_config:
+      oauth_token_secret:
+        key: oauth
+        name: github-credentials-openshift-ci-robot-private-git-cloner
+    hidden: true
+    labels:
+      ci-operator.openshift.io/cloud: gcp
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-priv-gcp-pd-csi-driver-operator-main-e2e-gcp-csi-image-snapshot
+    optional: true
+    path_alias: github.com/openshift/gcp-pd-csi-driver-operator
+    rerun_command: /test e2e-gcp-csi-image-snapshot
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-gcp-csi-image-snapshot
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-gcp-csi-image-snapshot,?($|\s.*)
+  - agent: kubernetes
     always_run: true
     branches:
     - ^main$

--- a/ci-operator/jobs/openshift-priv/gcp-pd-csi-driver-operator/openshift-priv-gcp-pd-csi-driver-operator-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/gcp-pd-csi-driver-operator/openshift-priv-gcp-pd-csi-driver-operator-release-4.22-presubmits.yaml
@@ -363,6 +363,97 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-gcp-csi-extended,?($|\s.*)
   - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.22$
+    - ^release-4\.22-
+    cluster: build04
+    context: ci/prow/e2e-gcp-csi-image-snapshot
+    decorate: true
+    decoration_config:
+      oauth_token_secret:
+        key: oauth
+        name: github-credentials-openshift-ci-robot-private-git-cloner
+    hidden: true
+    labels:
+      ci-operator.openshift.io/cloud: gcp
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-priv-gcp-pd-csi-driver-operator-release-4.22-e2e-gcp-csi-image-snapshot
+    optional: true
+    path_alias: github.com/openshift/gcp-pd-csi-driver-operator
+    rerun_command: /test e2e-gcp-csi-image-snapshot
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-gcp-csi-image-snapshot
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-gcp-csi-image-snapshot,?($|\s.*)
+  - agent: kubernetes
     always_run: true
     branches:
     - ^release-4\.22$

--- a/ci-operator/jobs/openshift-priv/gcp-pd-csi-driver-operator/openshift-priv-gcp-pd-csi-driver-operator-release-4.23-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/gcp-pd-csi-driver-operator/openshift-priv-gcp-pd-csi-driver-operator-release-4.23-presubmits.yaml
@@ -363,6 +363,97 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-gcp-csi-extended,?($|\s.*)
   - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.23$
+    - ^release-4\.23-
+    cluster: build04
+    context: ci/prow/e2e-gcp-csi-image-snapshot
+    decorate: true
+    decoration_config:
+      oauth_token_secret:
+        key: oauth
+        name: github-credentials-openshift-ci-robot-private-git-cloner
+    hidden: true
+    labels:
+      ci-operator.openshift.io/cloud: gcp
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-priv-gcp-pd-csi-driver-operator-release-4.23-e2e-gcp-csi-image-snapshot
+    optional: true
+    path_alias: github.com/openshift/gcp-pd-csi-driver-operator
+    rerun_command: /test e2e-gcp-csi-image-snapshot
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-gcp-csi-image-snapshot
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-gcp-csi-image-snapshot,?($|\s.*)
+  - agent: kubernetes
     always_run: true
     branches:
     - ^release-4\.23$

--- a/ci-operator/jobs/openshift-priv/gcp-pd-csi-driver-operator/openshift-priv-gcp-pd-csi-driver-operator-release-5.0-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/gcp-pd-csi-driver-operator/openshift-priv-gcp-pd-csi-driver-operator-release-5.0-presubmits.yaml
@@ -363,6 +363,97 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-gcp-csi-extended,?($|\s.*)
   - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-5\.0$
+    - ^release-5\.0-
+    cluster: build08
+    context: ci/prow/e2e-gcp-csi-image-snapshot
+    decorate: true
+    decoration_config:
+      oauth_token_secret:
+        key: oauth
+        name: github-credentials-openshift-ci-robot-private-git-cloner
+    hidden: true
+    labels:
+      ci-operator.openshift.io/cloud: gcp
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-priv-gcp-pd-csi-driver-operator-release-5.0-e2e-gcp-csi-image-snapshot
+    optional: true
+    path_alias: github.com/openshift/gcp-pd-csi-driver-operator
+    rerun_command: /test e2e-gcp-csi-image-snapshot
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-gcp-csi-image-snapshot
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-gcp-csi-image-snapshot,?($|\s.*)
+  - agent: kubernetes
     always_run: true
     branches:
     - ^release-5\.0$

--- a/ci-operator/jobs/openshift-priv/gcp-pd-csi-driver-operator/openshift-priv-gcp-pd-csi-driver-operator-release-5.1-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/gcp-pd-csi-driver-operator/openshift-priv-gcp-pd-csi-driver-operator-release-5.1-presubmits.yaml
@@ -363,6 +363,97 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-gcp-csi-extended,?($|\s.*)
   - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-5\.1$
+    - ^release-5\.1-
+    cluster: build08
+    context: ci/prow/e2e-gcp-csi-image-snapshot
+    decorate: true
+    decoration_config:
+      oauth_token_secret:
+        key: oauth
+        name: github-credentials-openshift-ci-robot-private-git-cloner
+    hidden: true
+    labels:
+      ci-operator.openshift.io/cloud: gcp
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-priv-gcp-pd-csi-driver-operator-release-5.1-e2e-gcp-csi-image-snapshot
+    optional: true
+    path_alias: github.com/openshift/gcp-pd-csi-driver-operator
+    rerun_command: /test e2e-gcp-csi-image-snapshot
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-gcp-csi-image-snapshot
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-gcp-csi-image-snapshot,?($|\s.*)
+  - agent: kubernetes
     always_run: true
     branches:
     - ^release-5\.1$

--- a/ci-operator/jobs/openshift-priv/gcp-pd-csi-driver/openshift-priv-gcp-pd-csi-driver-master-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/gcp-pd-csi-driver/openshift-priv-gcp-pd-csi-driver-master-presubmits.yaml
@@ -363,6 +363,97 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-gcp-csi-extended,?($|\s.*)
   - agent: kubernetes
+    always_run: false
+    branches:
+    - ^master$
+    - ^master-
+    cluster: build08
+    context: ci/prow/e2e-gcp-csi-image-snapshot
+    decorate: true
+    decoration_config:
+      oauth_token_secret:
+        key: oauth
+        name: github-credentials-openshift-ci-robot-private-git-cloner
+    hidden: true
+    labels:
+      ci-operator.openshift.io/cloud: gcp
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-priv-gcp-pd-csi-driver-master-e2e-gcp-csi-image-snapshot
+    optional: true
+    path_alias: sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
+    rerun_command: /test e2e-gcp-csi-image-snapshot
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-gcp-csi-image-snapshot
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-gcp-csi-image-snapshot,?($|\s.*)
+  - agent: kubernetes
     always_run: true
     branches:
     - ^master$

--- a/ci-operator/jobs/openshift-priv/gcp-pd-csi-driver/openshift-priv-gcp-pd-csi-driver-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/gcp-pd-csi-driver/openshift-priv-gcp-pd-csi-driver-release-4.22-presubmits.yaml
@@ -363,6 +363,97 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-gcp-csi-extended,?($|\s.*)
   - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.22$
+    - ^release-4\.22-
+    cluster: build08
+    context: ci/prow/e2e-gcp-csi-image-snapshot
+    decorate: true
+    decoration_config:
+      oauth_token_secret:
+        key: oauth
+        name: github-credentials-openshift-ci-robot-private-git-cloner
+    hidden: true
+    labels:
+      ci-operator.openshift.io/cloud: gcp
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-priv-gcp-pd-csi-driver-release-4.22-e2e-gcp-csi-image-snapshot
+    optional: true
+    path_alias: sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
+    rerun_command: /test e2e-gcp-csi-image-snapshot
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-gcp-csi-image-snapshot
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-gcp-csi-image-snapshot,?($|\s.*)
+  - agent: kubernetes
     always_run: true
     branches:
     - ^release-4\.22$

--- a/ci-operator/jobs/openshift-priv/gcp-pd-csi-driver/openshift-priv-gcp-pd-csi-driver-release-4.23-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/gcp-pd-csi-driver/openshift-priv-gcp-pd-csi-driver-release-4.23-presubmits.yaml
@@ -363,6 +363,97 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-gcp-csi-extended,?($|\s.*)
   - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.23$
+    - ^release-4\.23-
+    cluster: build08
+    context: ci/prow/e2e-gcp-csi-image-snapshot
+    decorate: true
+    decoration_config:
+      oauth_token_secret:
+        key: oauth
+        name: github-credentials-openshift-ci-robot-private-git-cloner
+    hidden: true
+    labels:
+      ci-operator.openshift.io/cloud: gcp
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-priv-gcp-pd-csi-driver-release-4.23-e2e-gcp-csi-image-snapshot
+    optional: true
+    path_alias: sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
+    rerun_command: /test e2e-gcp-csi-image-snapshot
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-gcp-csi-image-snapshot
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-gcp-csi-image-snapshot,?($|\s.*)
+  - agent: kubernetes
     always_run: true
     branches:
     - ^release-4\.23$

--- a/ci-operator/jobs/openshift-priv/gcp-pd-csi-driver/openshift-priv-gcp-pd-csi-driver-release-5.0-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/gcp-pd-csi-driver/openshift-priv-gcp-pd-csi-driver-release-5.0-presubmits.yaml
@@ -363,6 +363,97 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-gcp-csi-extended,?($|\s.*)
   - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-5\.0$
+    - ^release-5\.0-
+    cluster: build04
+    context: ci/prow/e2e-gcp-csi-image-snapshot
+    decorate: true
+    decoration_config:
+      oauth_token_secret:
+        key: oauth
+        name: github-credentials-openshift-ci-robot-private-git-cloner
+    hidden: true
+    labels:
+      ci-operator.openshift.io/cloud: gcp
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-priv-gcp-pd-csi-driver-release-5.0-e2e-gcp-csi-image-snapshot
+    optional: true
+    path_alias: sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
+    rerun_command: /test e2e-gcp-csi-image-snapshot
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-gcp-csi-image-snapshot
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-gcp-csi-image-snapshot,?($|\s.*)
+  - agent: kubernetes
     always_run: true
     branches:
     - ^release-5\.0$

--- a/ci-operator/jobs/openshift-priv/gcp-pd-csi-driver/openshift-priv-gcp-pd-csi-driver-release-5.1-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/gcp-pd-csi-driver/openshift-priv-gcp-pd-csi-driver-release-5.1-presubmits.yaml
@@ -363,6 +363,97 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-gcp-csi-extended,?($|\s.*)
   - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-5\.1$
+    - ^release-5\.1-
+    cluster: build04
+    context: ci/prow/e2e-gcp-csi-image-snapshot
+    decorate: true
+    decoration_config:
+      oauth_token_secret:
+        key: oauth
+        name: github-credentials-openshift-ci-robot-private-git-cloner
+    hidden: true
+    labels:
+      ci-operator.openshift.io/cloud: gcp
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-priv-gcp-pd-csi-driver-release-5.1-e2e-gcp-csi-image-snapshot
+    optional: true
+    path_alias: sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
+    rerun_command: /test e2e-gcp-csi-image-snapshot
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-gcp-csi-image-snapshot
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-gcp-csi-image-snapshot,?($|\s.*)
+  - agent: kubernetes
     always_run: true
     branches:
     - ^release-5\.1$

--- a/ci-operator/jobs/openshift/gcp-pd-csi-driver-operator/openshift-gcp-pd-csi-driver-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/gcp-pd-csi-driver-operator/openshift-gcp-pd-csi-driver-operator-main-presubmits.yaml
@@ -323,6 +323,87 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-gcp-csi-extended,?($|\s.*)
   - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build08
+    context: ci/prow/e2e-gcp-csi-image-snapshot
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: gcp
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-gcp-pd-csi-driver-operator-main-e2e-gcp-csi-image-snapshot
+    optional: true
+    rerun_command: /test e2e-gcp-csi-image-snapshot
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-gcp-csi-image-snapshot
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-gcp-csi-image-snapshot,?($|\s.*)
+  - agent: kubernetes
     always_run: true
     branches:
     - ^main$

--- a/ci-operator/jobs/openshift/gcp-pd-csi-driver-operator/openshift-gcp-pd-csi-driver-operator-release-4.22-periodics.yaml
+++ b/ci-operator/jobs/openshift/gcp-pd-csi-driver-operator/openshift-gcp-pd-csi-driver-operator-release-4.22-periodics.yaml
@@ -90,6 +90,87 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build04
+  cron: 25 8 * * 2
+  decorate: true
+  extra_refs:
+  - base_ref: release-4.22
+    org: openshift
+    repo: gcp-pd-csi-driver-operator
+  labels:
+    ci-operator.openshift.io/cloud: gcp
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-gcp-pd-csi-driver-operator-release-4.22-periodics-periodic-e2e-gcp-csi-image-snapshot
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=periodic-e2e-gcp-csi-image-snapshot
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build04
   cron: 2 10 * * 5
   decorate: true
   extra_refs:

--- a/ci-operator/jobs/openshift/gcp-pd-csi-driver-operator/openshift-gcp-pd-csi-driver-operator-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift/gcp-pd-csi-driver-operator/openshift-gcp-pd-csi-driver-operator-release-4.22-presubmits.yaml
@@ -323,6 +323,87 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-gcp-csi-extended,?($|\s.*)
   - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.22$
+    - ^release-4\.22-
+    cluster: build08
+    context: ci/prow/e2e-gcp-csi-image-snapshot
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: gcp
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-gcp-pd-csi-driver-operator-release-4.22-e2e-gcp-csi-image-snapshot
+    optional: true
+    rerun_command: /test e2e-gcp-csi-image-snapshot
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-gcp-csi-image-snapshot
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-gcp-csi-image-snapshot,?($|\s.*)
+  - agent: kubernetes
     always_run: true
     branches:
     - ^release-4\.22$

--- a/ci-operator/jobs/openshift/gcp-pd-csi-driver-operator/openshift-gcp-pd-csi-driver-operator-release-4.23-periodics.yaml
+++ b/ci-operator/jobs/openshift/gcp-pd-csi-driver-operator/openshift-gcp-pd-csi-driver-operator-release-4.23-periodics.yaml
@@ -90,6 +90,87 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build04
+  cron: 25 8 * * 2
+  decorate: true
+  extra_refs:
+  - base_ref: release-4.23
+    org: openshift
+    repo: gcp-pd-csi-driver-operator
+  labels:
+    ci-operator.openshift.io/cloud: gcp
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "4.23"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-gcp-pd-csi-driver-operator-release-4.23-periodics-periodic-e2e-gcp-csi-image-snapshot
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=periodic-e2e-gcp-csi-image-snapshot
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build04
   cron: 2 10 * * 5
   decorate: true
   extra_refs:

--- a/ci-operator/jobs/openshift/gcp-pd-csi-driver-operator/openshift-gcp-pd-csi-driver-operator-release-4.23-presubmits.yaml
+++ b/ci-operator/jobs/openshift/gcp-pd-csi-driver-operator/openshift-gcp-pd-csi-driver-operator-release-4.23-presubmits.yaml
@@ -323,6 +323,87 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-gcp-csi-extended,?($|\s.*)
   - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.23$
+    - ^release-4\.23-
+    cluster: build08
+    context: ci/prow/e2e-gcp-csi-image-snapshot
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: gcp
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-gcp-pd-csi-driver-operator-release-4.23-e2e-gcp-csi-image-snapshot
+    optional: true
+    rerun_command: /test e2e-gcp-csi-image-snapshot
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-gcp-csi-image-snapshot
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-gcp-csi-image-snapshot,?($|\s.*)
+  - agent: kubernetes
     always_run: true
     branches:
     - ^release-4\.23$

--- a/ci-operator/jobs/openshift/gcp-pd-csi-driver-operator/openshift-gcp-pd-csi-driver-operator-release-5.0-periodics.yaml
+++ b/ci-operator/jobs/openshift/gcp-pd-csi-driver-operator/openshift-gcp-pd-csi-driver-operator-release-5.0-periodics.yaml
@@ -90,6 +90,87 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
+  cron: 25 8 * * 2
+  decorate: true
+  extra_refs:
+  - base_ref: release-5.0
+    org: openshift
+    repo: gcp-pd-csi-driver-operator
+  labels:
+    ci-operator.openshift.io/cloud: gcp
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "5.0"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-gcp-pd-csi-driver-operator-release-5.0-periodics-periodic-e2e-gcp-csi-image-snapshot
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=periodic-e2e-gcp-csi-image-snapshot
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build08
   cron: 2 10 * * 5
   decorate: true
   extra_refs:

--- a/ci-operator/jobs/openshift/gcp-pd-csi-driver-operator/openshift-gcp-pd-csi-driver-operator-release-5.0-presubmits.yaml
+++ b/ci-operator/jobs/openshift/gcp-pd-csi-driver-operator/openshift-gcp-pd-csi-driver-operator-release-5.0-presubmits.yaml
@@ -323,6 +323,87 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-gcp-csi-extended,?($|\s.*)
   - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-5\.0$
+    - ^release-5\.0-
+    cluster: build04
+    context: ci/prow/e2e-gcp-csi-image-snapshot
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: gcp
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-gcp-pd-csi-driver-operator-release-5.0-e2e-gcp-csi-image-snapshot
+    optional: true
+    rerun_command: /test e2e-gcp-csi-image-snapshot
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-gcp-csi-image-snapshot
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-gcp-csi-image-snapshot,?($|\s.*)
+  - agent: kubernetes
     always_run: true
     branches:
     - ^release-5\.0$

--- a/ci-operator/jobs/openshift/gcp-pd-csi-driver-operator/openshift-gcp-pd-csi-driver-operator-release-5.1-presubmits.yaml
+++ b/ci-operator/jobs/openshift/gcp-pd-csi-driver-operator/openshift-gcp-pd-csi-driver-operator-release-5.1-presubmits.yaml
@@ -323,6 +323,87 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-gcp-csi-extended,?($|\s.*)
   - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-5\.1$
+    - ^release-5\.1-
+    cluster: build04
+    context: ci/prow/e2e-gcp-csi-image-snapshot
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: gcp
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-gcp-pd-csi-driver-operator-release-5.1-e2e-gcp-csi-image-snapshot
+    optional: true
+    rerun_command: /test e2e-gcp-csi-image-snapshot
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-gcp-csi-image-snapshot
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-gcp-csi-image-snapshot,?($|\s.*)
+  - agent: kubernetes
     always_run: true
     branches:
     - ^release-5\.1$

--- a/ci-operator/jobs/openshift/gcp-pd-csi-driver/openshift-gcp-pd-csi-driver-master-presubmits.yaml
+++ b/ci-operator/jobs/openshift/gcp-pd-csi-driver/openshift-gcp-pd-csi-driver-master-presubmits.yaml
@@ -327,6 +327,88 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-gcp-csi-extended,?($|\s.*)
   - agent: kubernetes
+    always_run: false
+    branches:
+    - ^master$
+    - ^master-
+    cluster: build04
+    context: ci/prow/e2e-gcp-csi-image-snapshot
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: gcp
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-gcp-pd-csi-driver-master-e2e-gcp-csi-image-snapshot
+    optional: true
+    path_alias: sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
+    rerun_command: /test e2e-gcp-csi-image-snapshot
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-gcp-csi-image-snapshot
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-gcp-csi-image-snapshot,?($|\s.*)
+  - agent: kubernetes
     always_run: true
     branches:
     - ^master$

--- a/ci-operator/jobs/openshift/gcp-pd-csi-driver/openshift-gcp-pd-csi-driver-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift/gcp-pd-csi-driver/openshift-gcp-pd-csi-driver-release-4.22-presubmits.yaml
@@ -327,6 +327,88 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-gcp-csi-extended,?($|\s.*)
   - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.22$
+    - ^release-4\.22-
+    cluster: build04
+    context: ci/prow/e2e-gcp-csi-image-snapshot
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: gcp
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-gcp-pd-csi-driver-release-4.22-e2e-gcp-csi-image-snapshot
+    optional: true
+    path_alias: sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
+    rerun_command: /test e2e-gcp-csi-image-snapshot
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-gcp-csi-image-snapshot
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-gcp-csi-image-snapshot,?($|\s.*)
+  - agent: kubernetes
     always_run: true
     branches:
     - ^release-4\.22$

--- a/ci-operator/jobs/openshift/gcp-pd-csi-driver/openshift-gcp-pd-csi-driver-release-4.23-presubmits.yaml
+++ b/ci-operator/jobs/openshift/gcp-pd-csi-driver/openshift-gcp-pd-csi-driver-release-4.23-presubmits.yaml
@@ -327,6 +327,88 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-gcp-csi-extended,?($|\s.*)
   - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.23$
+    - ^release-4\.23-
+    cluster: build04
+    context: ci/prow/e2e-gcp-csi-image-snapshot
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: gcp
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-gcp-pd-csi-driver-release-4.23-e2e-gcp-csi-image-snapshot
+    optional: true
+    path_alias: sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
+    rerun_command: /test e2e-gcp-csi-image-snapshot
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-gcp-csi-image-snapshot
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-gcp-csi-image-snapshot,?($|\s.*)
+  - agent: kubernetes
     always_run: true
     branches:
     - ^release-4\.23$

--- a/ci-operator/jobs/openshift/gcp-pd-csi-driver/openshift-gcp-pd-csi-driver-release-5.0-presubmits.yaml
+++ b/ci-operator/jobs/openshift/gcp-pd-csi-driver/openshift-gcp-pd-csi-driver-release-5.0-presubmits.yaml
@@ -327,6 +327,88 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-gcp-csi-extended,?($|\s.*)
   - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-5\.0$
+    - ^release-5\.0-
+    cluster: build08
+    context: ci/prow/e2e-gcp-csi-image-snapshot
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: gcp
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-gcp-pd-csi-driver-release-5.0-e2e-gcp-csi-image-snapshot
+    optional: true
+    path_alias: sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
+    rerun_command: /test e2e-gcp-csi-image-snapshot
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-gcp-csi-image-snapshot
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-gcp-csi-image-snapshot,?($|\s.*)
+  - agent: kubernetes
     always_run: true
     branches:
     - ^release-5\.0$

--- a/ci-operator/jobs/openshift/gcp-pd-csi-driver/openshift-gcp-pd-csi-driver-release-5.1-presubmits.yaml
+++ b/ci-operator/jobs/openshift/gcp-pd-csi-driver/openshift-gcp-pd-csi-driver-release-5.1-presubmits.yaml
@@ -327,6 +327,88 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-gcp-csi-extended,?($|\s.*)
   - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-5\.1$
+    - ^release-5\.1-
+    cluster: build08
+    context: ci/prow/e2e-gcp-csi-image-snapshot
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: gcp
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-gcp-pd-csi-driver-release-5.1-e2e-gcp-csi-image-snapshot
+    optional: true
+    path_alias: sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
+    rerun_command: /test e2e-gcp-csi-image-snapshot
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-gcp-csi-image-snapshot
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-gcp-csi-image-snapshot,?($|\s.*)
+  - agent: kubernetes
     always_run: true
     branches:
     - ^release-5\.1$

--- a/ci-operator/step-registry/openshift/e2e/gcp/csi/image-snapshot/OWNERS
+++ b/ci-operator/step-registry/openshift/e2e/gcp/csi/image-snapshot/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+- storage-approvers
+
+reviewers:
+- storage-reviewers

--- a/ci-operator/step-registry/openshift/e2e/gcp/csi/image-snapshot/openshift-e2e-gcp-csi-image-snapshot-workflow.metadata.json
+++ b/ci-operator/step-registry/openshift/e2e/gcp/csi/image-snapshot/openshift-e2e-gcp-csi-image-snapshot-workflow.metadata.json
@@ -1,0 +1,11 @@
+{
+	"path": "openshift/e2e/gcp/csi/image-snapshot/openshift-e2e-gcp-csi-image-snapshot-workflow.yaml",
+	"owners": {
+		"approvers": [
+			"storage-approvers"
+		],
+		"reviewers": [
+			"storage-reviewers"
+		]
+	}
+}

--- a/ci-operator/step-registry/openshift/e2e/gcp/csi/image-snapshot/openshift-e2e-gcp-csi-image-snapshot-workflow.yaml
+++ b/ci-operator/step-registry/openshift/e2e/gcp/csi/image-snapshot/openshift-e2e-gcp-csi-image-snapshot-workflow.yaml
@@ -1,0 +1,24 @@
+workflow:
+  as: openshift-e2e-gcp-csi-image-snapshot
+  steps:
+    pre:
+    - chain: ipi-gcp-pre
+    - ref: storage-conf-csi-gcp-pd
+    - ref: storage-obj-save
+    test:
+    - ref: openshift-e2e-test
+    post:
+    - ref: storage-obj-check
+    - chain: ipi-gcp-post
+    env:
+      IMAGE_VOLUME_SNAPSHOT_MANIFEST: image-snapshot
+      TEST_CSI_DRIVER_MANIFEST: manifest-gcp-pd.yaml
+      TEST_OCP_CSI_DRIVER_MANIFEST: ocp-manifest-gcp-pd.yaml
+      TEST_SUITE: openshift/csi
+      # Limit to upstream-style snapshot tests; default e2e-gcp-csi covers the full openshift/csi suite.
+      TEST_ARGS: --run VolumeSnapshotDataSource
+  documentation: |-
+    Same topology as openshift-e2e-gcp-csi, using gcp-pd-csi-driver-operator test/e2e/image-snapshot-manifest.yaml
+    and openshift/csi with a narrow --run filter for snapshot-related tests only.
+    Periodics are configured only for release-4.22+ operator branches.
+    storage-conf uses IMAGE_VOLUME_SNAPSHOT_MANIFEST=image-snapshot to select these files.

--- a/ci-operator/step-registry/storage/conf/csi-gcp-pd/storage-conf-csi-gcp-pd-commands.sh
+++ b/ci-operator/step-registry/storage/conf/csi-gcp-pd/storage-conf-csi-gcp-pd-commands.sh
@@ -4,7 +4,11 @@ set -o nounset
 set -o pipefail
 
 cd /go/src/github.com/openshift/gcp-pd-csi-driver-operator
-if [ "${COMPUTE_DISK_TYPE}" == "hyperdisk-balanced" ]; then
+if [ "${IMAGE_VOLUME_SNAPSHOT_MANIFEST:-}" = "image-snapshot" ]; then
+    echo "Copying image-snapshot-manifest.yaml to ${SHARED_DIR}/${TEST_CSI_DRIVER_MANIFEST}"
+    cp "test/e2e/image-snapshot-manifest.yaml" "${SHARED_DIR}/${TEST_CSI_DRIVER_MANIFEST}"
+    cat "${SHARED_DIR}/${TEST_CSI_DRIVER_MANIFEST}"
+elif [ "${COMPUTE_DISK_TYPE}" == "hyperdisk-balanced" ]; then
     # Using hyperdisk-balanced worker
     cp test/e2e/hyperdisk-manifest.yaml ${SHARED_DIR}/${TEST_CSI_DRIVER_MANIFEST}
 else

--- a/ci-operator/step-registry/storage/conf/csi-gcp-pd/storage-conf-csi-gcp-pd-ref.yaml
+++ b/ci-operator/step-registry/storage/conf/csi-gcp-pd/storage-conf-csi-gcp-pd-ref.yaml
@@ -30,6 +30,12 @@ ref:
     default: "pd-balanced"
     documentation: |-
       It defines the osDisk type for GCP compute nodes.
+  - name: IMAGE_VOLUME_SNAPSHOT_MANIFEST
+    default: ""
+    documentation: |-
+      When set to "image-snapshot", copies test/e2e/image-snapshot-manifest.yaml instead of the default
+      or hyperdisk manifest (e.g. SnapshotClass uses FromExistingClassName for operator-managed VolumeSnapshotClass).
+      Leave empty for existing behavior.
   documentation: |-
     The csi-gcp-pd step creates ${SHARED_DIR}/${TEST_CSI_DRIVER_MANIFEST} for
     GCP PD CSI driver, which is consumed by openshift-e2e-test step to


### PR DESCRIPTION
## Summary

Adds a dedicated openshift-e2e-gcp-csi-image-snapshot workflow so GCP PD CSI can run narrow openshift/csi snapshot tests (including VolumeSnapshotDataSource) without changing the default e2e-gcp-csi path for every consumer.


### Changes

- New workflow under openshift/e2e/gcp/csi/image-snapshot/ with the same pre/post chain as the standard GCP CSI e2e, plus env for TEST_SUITE, TEST_ARGS, and image-snapshot mode.

- storage-conf-csi-gcp-pd gains env for image-snapshot mode: when enabled, it copies the image-snapshot driver manifest from the operator test/e2e/ tree into SHARED_DIR using the same style as the existing manifest copy path.

- CI jobs: Optional e2e-gcp-csi-image-snapshot presubmits on main/master and 4.22 / 4.23 / 5.0 / 5.1 for openshift/gcp-pd-csi-driver, openshift/gcp-pd-csi-driver-operator, and matching openshift-priv configs.

- periodic-e2e-gcp-csi-image-snapshot on 4.22, 4.23, and 5.0 operator periodics only (cron as in __periodics.yaml); not duplicated on older releases.


### Coordination

The gcp-pd-csi-driver-operator repository must have the referenced test/e2e/ files on the branches these jobs use (image-snapshot manifest). Opened this [PR](https://github.com/openshift/gcp-pd-csi-driver-operator/pull/178) to add those manifests files on operator repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an optional end-to-end test for GCP CSI image-snapshot across releases and master; validates image snapshot operations and object verification on GCP and does not run by default.
  * New periodic jobs schedule the image-snapshot workflow.

* **Chores**
  * Added ownership metadata and configuration to support the new image-snapshot workflow.
  * Introduced configuration options and setup changes to enable image-snapshot mode in test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->