### PR TITLE
CNTRLPLANE-2636:hypershift: add shared-nothing topology kernel isolation CI job

### DIFF
--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.21__periodics.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.21__periodics.yaml
@@ -363,6 +363,25 @@ tests:
       ODF_OPERATOR_SUB_SOURCE: redhat-operators-v4-21
       REDHAT_OPERATORS_INDEX_TAG: v4.21
     workflow: hypershift-kubevirt-baremetalds-conformance-calico
+- as: e2e-kubevirt-metal-shared-nothing-isolation
+  capabilities:
+  - intranet
+  minimum_interval: 168h
+  steps:
+    cluster_profile: equinix-ocp-hcp
+    env:
+      ETCD_STORAGE_CLASS: lvms-vg1
+      KONFLUX_DEPLOY_CATALOG_SOURCE: "true"
+      KONFLUX_DEPLOY_OPERATORS: "true"
+      KONFLUX_DEPLOY_SUBSCRIPTION: "false"
+      LOCAL_STORAGE_OPERATOR_SUB_SOURCE: local-storage-konflux
+      LVM_OPERATOR_SUB_CHANNEL: stable-4.21
+      LVM_OPERATOR_SUB_SOURCE: lvm-catalogsource
+      METALLB_OPERATOR_SUB_SOURCE: metallb-konflux
+      ODF_OPERATOR_SUB_CHANNEL: stable-4.21
+      ODF_OPERATOR_SUB_SOURCE: redhat-operators-v4-21
+      REDHAT_OPERATORS_INDEX_TAG: v4.21
+    workflow: hypershift-kubevirt-baremetalds-conformance-shared-nothing
 - as: e2e-azure-aks-external-oidc-techpreview
   cron: 0 20 9,18,25 * *
   steps:

--- a/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.21-periodics.yaml
+++ b/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.21-periodics.yaml
@@ -2242,6 +2242,90 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
+  cluster: build11
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: release-4.21
+    org: openshift
+    repo: hypershift
+  labels:
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: equinix-ocp-metal
+    ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-hcp
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "4.21"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  minimum_interval: 168h
+  name: periodic-ci-openshift-hypershift-release-4.21-periodics-e2e-kubevirt-metal-shared-nothing-isolation
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-kubevirt-metal-shared-nothing-isolation
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
   cluster: build01
   cron: 0 10 * * *
   decorate: true

--- a/ci-operator/step-registry/hypershift/kubevirt/baremetalds/check-shared-nothing-isolation/OWNERS
+++ b/ci-operator/step-registry/hypershift/kubevirt/baremetalds/check-shared-nothing-isolation/OWNERS
@@ -1,0 +1,11 @@
+approvers:
+- nirarg
+- nunnatsa
+- qinqon
+- orenc1
+options: {}
+reviewers:
+- nirarg
+- nunnatsa
+- qinqon
+- orenc1

--- a/ci-operator/step-registry/hypershift/kubevirt/baremetalds/check-shared-nothing-isolation/hypershift-kubevirt-baremetalds-check-shared-nothing-isolation-commands.sh
+++ b/ci-operator/step-registry/hypershift/kubevirt/baremetalds/check-shared-nothing-isolation/hypershift-kubevirt-baremetalds-check-shared-nothing-isolation-commands.sh
@@ -1,0 +1,435 @@
+#!/bin/bash
+
+set -exuo pipefail
+
+HCP_CLI="/usr/bin/hcp"
+if [[ ! -f "${HCP_CLI}" ]]; then
+  HCP_CLI="/usr/bin/hypershift"
+fi
+echo "Using ${HCP_CLI} for cli"
+
+if [[ -f "${SHARED_DIR}/proxy-conf.sh" ]]; then
+  # shellcheck source=/dev/null
+  source "${SHARED_DIR}/proxy-conf.sh"
+fi
+
+MCE=${MCE_VERSION:-""}
+if [[ -n "${MCE}" ]]; then
+  CLUSTER_NAMESPACE_PREFIX="local-cluster"
+else
+  CLUSTER_NAMESPACE_PREFIX="clusters"
+fi
+# CLUSTER_A: exactly what hypershift-kubevirt-destroy will compute (20 chars)
+CLUSTER_A="$(echo -n "${PROW_JOB_ID}" | sha256sum | cut -c-20)"
+# CLUSTER_B: 18-char hash + "-b" = 20 chars total, unique name
+JOB_HASH18="$(echo -n "${PROW_JOB_ID}" | sha256sum | cut -c-18)"
+CLUSTER_B="${JOB_HASH18}-b"
+
+# The hypershift-kubevirt-destroy post chain computes:
+#   CLUSTER_NAME="$(echo -n $PROW_JOB_ID|sha256sum|cut -c-20)"
+# That equals ${CLUSTER_A} exactly, so it destroys cluster-a automatically.
+# We destroy cluster-b via the trap below.
+
+RELEASE_IMAGE="${HYPERSHIFT_HC_RELEASE_IMAGE:-${RELEASE_IMAGE_LATEST}}"
+PULL_SECRET_PATH="/etc/ci-pull-credentials/.dockerconfigjson"
+LABEL_KEY="shared-nothing.hypershift.test/cluster"
+ETCD_ARG=""
+
+# ---- Cleanup trap ----
+function cleanup() {
+  echo "=== Cleanup: destroying cluster-b ${CLUSTER_B} ==="
+  "${HCP_CLI}" destroy cluster kubevirt \
+    --name "${CLUSTER_B}" \
+    --namespace "${CLUSTER_NAMESPACE_PREFIX}" \
+    --cluster-grace-period 15m || true
+}
+trap cleanup EXIT
+
+# ---- Step 1: Collect management cluster nodes ----
+echo "=== Collecting management cluster nodes ==="
+NODE_JSON="$(oc get nodes -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')"
+mapfile -t ALL_NODES <<< "${NODE_JSON}"
+NODE_COUNT="${#ALL_NODES[@]}"
+echo "Total nodes: ${NODE_COUNT}"
+
+if [[ "${NODE_COUNT}" -lt 2 ]]; then
+  echo "ERROR: Need at least 2 management cluster nodes for Shared Nothing topology, got ${NODE_COUNT}"
+  exit 1
+fi
+
+# Split: first half → cluster-a, second half → cluster-b
+HALF=$(( NODE_COUNT / 2 ))
+NODES_A=("${ALL_NODES[@]:0:${HALF}}")
+NODES_B=("${ALL_NODES[@]:${HALF}}")
+
+echo "Nodes for ${CLUSTER_A}: ${NODES_A[*]}"
+echo "Nodes for ${CLUSTER_B}: ${NODES_B[*]}"
+
+# ---- Step 2: Label nodes with custom per-cluster label ----
+echo "=== Labeling nodes ==="
+for NODE in "${NODES_A[@]}"; do
+  oc label node "${NODE}" "${LABEL_KEY}=${CLUSTER_A}" --overwrite
+done
+for NODE in "${NODES_B[@]}"; do
+  oc label node "${NODE}" "${LABEL_KEY}=${CLUSTER_B}" --overwrite
+done
+
+# ---- Step 3: Enable wildcard routes (required for kubevirt hosted cluster) ----
+oc patch ingresscontroller -n openshift-ingress-operator default --type=json \
+  -p '[{"op":"add","path":"/spec/routeAdmission","value":{"wildcardPolicy":"WildcardsAllowed"}}]'
+
+# ---- Step 4: Create cluster namespace ----
+oc create namespace "${CLUSTER_NAMESPACE_PREFIX}" --dry-run=client -o yaml | oc apply -f -
+
+# ---- DEBUGGING: Dynamic sleep before cluster creation ----
+# Set DEBUG_SLEEP_SECONDS env var to pause here and inspect cluster state
+# Recommended: DEBUG_SLEEP_SECONDS=3600 (1 hour) for interactive debugging
+# This allows time to:
+#   - Enter the test container (oc rsh or oc debug)
+#   - Manually verify infrastructure setup
+#   - Manually create/inspect both clusters
+#   - Test Shared Nothing topology isolation assertions
+if [[ -n "${DEBUG_SLEEP_SECONDS:-}" ]]; then
+  echo "=== DEBUG MODE: Sleeping for ${DEBUG_SLEEP_SECONDS} seconds ($(( DEBUG_SLEEP_SECONDS / 60 )) minutes) ==="
+  echo ""
+  echo "INFRASTRUCTURE SETUP COMPLETE - Ready for manual debugging:"
+  echo ""
+  echo "1. Node labels applied:"
+  echo "   oc get nodes --show-labels | grep '${LABEL_KEY}'"
+  echo ""
+  echo "2. Cluster namespace created:"
+  echo "   oc get ns ${CLUSTER_NAMESPACE_PREFIX}"
+  echo ""
+  echo "3. Ingress wildcard routes enabled:"
+  echo "   oc get ingresscontroller -n openshift-ingress-operator default -o yaml | grep -A3 routeAdmission"
+  echo ""
+  echo "4. Dedicated node sets:"
+  echo "   Cluster-A nodes: ${NODES_A[*]}"
+  echo "   Cluster-B nodes: ${NODES_B[*]}"
+  echo ""
+  echo "5. Variables available for manual cluster creation:"
+  echo "   CLUSTER_A=${CLUSTER_A}"
+  echo "   CLUSTER_B=${CLUSTER_B}"
+  echo "   CLUSTER_NAMESPACE_PREFIX=${CLUSTER_NAMESPACE_PREFIX}"
+  echo "   LABEL_KEY=${LABEL_KEY}"
+  echo "   RELEASE_IMAGE=${RELEASE_IMAGE}"
+  echo "   HYPERSHIFT_NODE_COUNT=${HYPERSHIFT_NODE_COUNT}"
+  echo "   HYPERSHIFT_NODE_MEMORY=${HYPERSHIFT_NODE_MEMORY}"
+  echo "   HYPERSHIFT_NODE_CPU_CORES=${HYPERSHIFT_NODE_CPU_CORES}"
+  echo "   ETCD_STORAGE_CLASS=${ETCD_STORAGE_CLASS:-<not set>}"
+  echo ""
+  echo "6. To enter this container from another terminal:"
+  echo "   POD_NAME=\$(oc get pod -n <test-namespace> --no-headers | grep check-shared-nothing | awk '{print \$1}')"
+  echo "   oc rsh -n <test-namespace> \${POD_NAME}"
+  echo ""
+  echo "7. Manual cluster creation commands (copy/paste into container shell):"
+  echo "   # Create cluster-a:"
+  echo "   ${HCP_CLI} create cluster kubevirt --name ${CLUSTER_A} --namespace ${CLUSTER_NAMESPACE_PREFIX} --node-pool-replicas ${HYPERSHIFT_NODE_COUNT} --memory ${HYPERSHIFT_NODE_MEMORY}Gi --cores ${HYPERSHIFT_NODE_CPU_CORES} --root-volume-size 64 --release-image ${RELEASE_IMAGE} --pull-secret ${PULL_SECRET_PATH} --generate-ssh --network-type ${HYPERSHIFT_NETWORK_TYPE} --service-cidr 172.32.0.0/16 --cluster-cidr 10.136.0.0/14${ETCD_ARG:+ }${ETCD_ARG}"
+  echo ""
+  echo "   # Patch cluster-a nodeSelector:"
+  echo "   oc patch hostedcluster ${CLUSTER_A} -n ${CLUSTER_NAMESPACE_PREFIX} --type=merge -p '{\"spec\":{\"nodeSelector\":{\"${LABEL_KEY}\":\"${CLUSTER_A}\"}}}'"
+  echo "   oc patch nodepool ${CLUSTER_A} -n ${CLUSTER_NAMESPACE_PREFIX} --type=merge -p '{\"spec\":{\"platform\":{\"kubevirt\":{\"nodeSelector\":{\"${LABEL_KEY}\":\"${CLUSTER_A}\"}}}}}'"
+  echo ""
+  echo "Sleeping... (will auto-resume cluster creation after timeout)"
+
+  SLEEP_START=$(date +%s)
+  SLEEP_END=$(( SLEEP_START + DEBUG_SLEEP_SECONDS ))
+
+  while [[ $(date +%s) -lt ${SLEEP_END} ]]; do
+    REMAINING=$(( SLEEP_END - $(date +%s) ))
+    echo -ne "\rTime remaining: $(( REMAINING / 60 ))m $(( REMAINING % 60 ))s   "
+    sleep 10
+  done
+
+  echo ""
+  echo "=== DEBUG MODE: Sleep timeout reached, resuming automated cluster creation ==="
+fi
+
+# ---- Step 5: Create cluster-a ----
+if [[ -n "${ETCD_STORAGE_CLASS:-}" ]]; then
+  ETCD_ARG="--etcd-storage-class=${ETCD_STORAGE_CLASS}"
+fi
+
+echo "=== Creating hosted cluster ${CLUSTER_A} ==="
+"${HCP_CLI}" create cluster kubevirt \
+  --name "${CLUSTER_A}" \
+  --namespace "${CLUSTER_NAMESPACE_PREFIX}" \
+  --node-pool-replicas "${HYPERSHIFT_NODE_COUNT}" \
+  --memory "${HYPERSHIFT_NODE_MEMORY}Gi" \
+  --cores "${HYPERSHIFT_NODE_CPU_CORES}" \
+  --root-volume-size 64 \
+  --release-image "${RELEASE_IMAGE}" \
+  --pull-secret "${PULL_SECRET_PATH}" \
+  --generate-ssh \
+  --network-type "${HYPERSHIFT_NETWORK_TYPE}" \
+  --service-cidr 172.32.0.0/16 \
+  --cluster-cidr 10.136.0.0/14 \
+  ${ETCD_ARG}
+
+# Patch HostedCluster nodeSelector to dedicate control-plane pods to cluster-a nodes
+oc patch hostedcluster "${CLUSTER_A}" -n "${CLUSTER_NAMESPACE_PREFIX}" --type=merge \
+  -p "{\"spec\":{\"nodeSelector\":{\"${LABEL_KEY}\":\"${CLUSTER_A}\"}}}"
+
+# Patch NodePool kubevirt nodeSelector to dedicate VMIs to cluster-a nodes
+# (The correct API path is spec.platform.kubevirt.nodeSelector, not nodePlacement.nodeSelector)
+NODEPOOL_NAME="${CLUSTER_A}"
+oc patch nodepool "${NODEPOOL_NAME}" -n "${CLUSTER_NAMESPACE_PREFIX}" --type=merge \
+  -p "{\"spec\":{\"platform\":{\"kubevirt\":{\"nodeSelector\":{\"${LABEL_KEY}\":\"${CLUSTER_A}\"}}}}}"
+
+# ---- Step 6: Create cluster-b ----
+echo "=== Creating hosted cluster ${CLUSTER_B} ==="
+"${HCP_CLI}" create cluster kubevirt \
+  --name "${CLUSTER_B}" \
+  --namespace "${CLUSTER_NAMESPACE_PREFIX}" \
+  --node-pool-replicas "${HYPERSHIFT_NODE_COUNT}" \
+  --memory "${HYPERSHIFT_NODE_MEMORY}Gi" \
+  --cores "${HYPERSHIFT_NODE_CPU_CORES}" \
+  --root-volume-size 64 \
+  --release-image "${RELEASE_IMAGE}" \
+  --pull-secret "${PULL_SECRET_PATH}" \
+  --generate-ssh \
+  --network-type "${HYPERSHIFT_NETWORK_TYPE}" \
+  --service-cidr 172.33.0.0/16 \
+  --cluster-cidr 10.140.0.0/14 \
+  ${ETCD_ARG}
+
+oc patch hostedcluster "${CLUSTER_B}" -n "${CLUSTER_NAMESPACE_PREFIX}" --type=merge \
+  -p "{\"spec\":{\"nodeSelector\":{\"${LABEL_KEY}\":\"${CLUSTER_B}\"}}}"
+
+NODEPOOL_NAME_B="${CLUSTER_B}"
+oc patch nodepool "${NODEPOOL_NAME_B}" -n "${CLUSTER_NAMESPACE_PREFIX}" --type=merge \
+  -p "{\"spec\":{\"platform\":{\"kubevirt\":{\"nodeSelector\":{\"${LABEL_KEY}\":\"${CLUSTER_B}\"}}}}}"
+
+# ---- Step 7: Wait for both clusters to be Available ----
+echo "=== Waiting for ${CLUSTER_A} to become Available ==="
+oc wait --timeout=30m --for=condition=Available \
+  --namespace="${CLUSTER_NAMESPACE_PREFIX}" "hostedcluster/${CLUSTER_A}"
+
+echo "=== Waiting for ${CLUSTER_B} to become Available ==="
+oc wait --timeout=30m --for=condition=Available \
+  --namespace="${CLUSTER_NAMESPACE_PREFIX}" "hostedcluster/${CLUSTER_B}"
+
+# ---- Step 7b: Wait for NodePools to have all machines ready ----
+# HostedCluster Available only means the control plane is up; the NodePool VMs
+# may still be importing their boot disk (DataVolume) or waiting to be scheduled.
+# Wait for the NodePool AllMachinesReady condition instead of polling VMI nodeName.
+function wait_nodepool_ready() {
+  local name="$1" ns="$2"
+  local retries=60 interval=30
+  for i in $(seq 1 "${retries}"); do
+    local ready
+    ready=$(oc get nodepool "${name}" -n "${ns}" \
+      -o jsonpath='{.status.conditions[?(@.type=="AllMachinesReady")].status}' 2>/dev/null || true)
+    if [[ "${ready}" == "True" ]]; then
+      echo "  NodePool ${name} AllMachinesReady after $((i * interval))s"
+      return 0
+    fi
+    local msg
+    msg=$(oc get nodepool "${name}" -n "${ns}" \
+      -o jsonpath='{.status.conditions[?(@.type=="AllMachinesReady")].message}' 2>/dev/null || true)
+    echo "  Waiting for NodePool ${name} AllMachinesReady (attempt ${i}/${retries}): ${msg:-(not set)}"
+    sleep "${interval}"
+  done
+  echo "ERROR: NodePool ${name} not ready after $((retries * interval))s"
+  oc get nodepool "${name}" -n "${ns}" -o yaml 2>/dev/null || true
+  return 1
+}
+
+echo "=== Waiting for NodePools to be ready ==="
+wait_nodepool_ready "${CLUSTER_A}" "${CLUSTER_NAMESPACE_PREFIX}"
+wait_nodepool_ready "${CLUSTER_B}" "${CLUSTER_NAMESPACE_PREFIX}"
+
+# ---- Step 8: Collect VMI node placement ----
+echo "=== Collecting VMI node placement ==="
+mapfile -t NODES_USED_BY_A < <(oc get vmi -n "${CLUSTER_NAMESPACE_PREFIX}-${CLUSTER_A}" \
+  -o jsonpath='{range .items[*]}{.status.nodeName}{"\n"}{end}' | sed '/^$/d' | sort -u)
+mapfile -t NODES_USED_BY_B < <(oc get vmi -n "${CLUSTER_NAMESPACE_PREFIX}-${CLUSTER_B}" \
+  -o jsonpath='{range .items[*]}{.status.nodeName}{"\n"}{end}' | sed '/^$/d' | sort -u)
+
+echo "Cluster-A VMIs on nodes: ${NODES_USED_BY_A[*]:-<none>}"
+echo "Cluster-B VMIs on nodes: ${NODES_USED_BY_B[*]:-<none>}"
+
+ISOLATION_FAIL=0
+
+if [[ "${#NODES_USED_BY_A[@]}" -eq 0 ]]; then
+  echo "FAIL: No VMIs with a nodeName found for cluster-a — cannot verify isolation"
+  ISOLATION_FAIL=1
+fi
+if [[ "${#NODES_USED_BY_B[@]}" -eq 0 ]]; then
+  echo "FAIL: No VMIs with a nodeName found for cluster-b — cannot verify isolation"
+  ISOLATION_FAIL=1
+fi
+
+# ---- Step 9: Read boot IDs from dedicated nodes ----
+echo "=== Reading boot IDs from management nodes ==="
+declare -A BOOT_ID_MAP
+for NODE in "${NODES_A[@]}" "${NODES_B[@]}"; do
+  BOOT_ID="$(oc get node "${NODE}" -o jsonpath='{.status.nodeInfo.bootID}')"
+  BOOT_ID_MAP["${NODE}"]="${BOOT_ID}"
+  echo "  ${NODE}: bootID=${BOOT_ID}"
+done
+
+# ---- Step 10: Assertions ----
+echo "=== Assertion 1: VMIs on correct dedicated nodes ==="
+for NODE in "${NODES_USED_BY_A[@]}"; do
+  FOUND=0
+  for DEDICATED in "${NODES_A[@]}"; do
+    if [[ "${NODE}" == "${DEDICATED}" ]]; then
+      FOUND=1
+      break
+    fi
+  done
+  if [[ "${FOUND}" -eq 0 ]]; then
+    echo "FAIL: Cluster-A VMI on node ${NODE} is NOT in cluster-a dedicated set"
+    ISOLATION_FAIL=1
+  fi
+done
+for NODE in "${NODES_USED_BY_B[@]}"; do
+  FOUND=0
+  for DEDICATED in "${NODES_B[@]}"; do
+    if [[ "${NODE}" == "${DEDICATED}" ]]; then
+      FOUND=1
+      break
+    fi
+  done
+  if [[ "${FOUND}" -eq 0 ]]; then
+    echo "FAIL: Cluster-B VMI on node ${NODE} is NOT in cluster-b dedicated set"
+    ISOLATION_FAIL=1
+  fi
+done
+
+echo "=== Assertion 2a: Nodes used by VMIs are disjoint between clusters ==="
+for NODE in "${NODES_USED_BY_A[@]}"; do
+  if [[ " ${NODES_USED_BY_B[*]} " == *" ${NODE} "* ]]; then
+    echo "FAIL: Node ${NODE} is used by both cluster-a and cluster-b VMIs — no kernel isolation"
+    ISOLATION_FAIL=1
+  fi
+done
+
+echo "=== Assertion 2b: Boot IDs are unique across cluster node sets ==="
+declare -A BOOT_ID_TO_NODE
+for NODE in "${NODES_USED_BY_A[@]}" "${NODES_USED_BY_B[@]}"; do
+  BID="${BOOT_ID_MAP[${NODE}]:-}"
+  if [[ -z "${BID}" ]]; then
+    echo "FAIL: No bootID recorded for node '${NODE}'"
+    ISOLATION_FAIL=1
+    continue
+  fi
+  if [[ -n "${BOOT_ID_TO_NODE[${BID}]:-}" ]]; then
+    echo "FAIL: bootID ${BID} is shared by ${BOOT_ID_TO_NODE[${BID}]} and ${NODE}"
+    ISOLATION_FAIL=1
+    continue
+  fi
+  BOOT_ID_TO_NODE["${BID}"]="${NODE}"
+done
+
+# ---- Step 10: Verify cross-cluster network isolation ----
+# The VirtLauncher NetworkPolicy restricts egress from the VMs (guest worker nodes).
+# To test this correctly we must run the connectivity probe from INSIDE the hosted
+# cluster-a (i.e. from a pod scheduled on cluster-a's VMs), not from the management
+# cluster.  Only that way does the probe traffic traverse the virt-launcher network
+# namespace where the NetworkPolicy is enforced.
+echo "=== Assertion 3: Cross-cluster network isolation ==="
+NETWORK_ISOLATION_VERIFIED=0
+
+# --- 3a: Verify NetworkPolicy exists on management cluster for cluster-a ---
+NP_NAME=$(oc get networkpolicy -n "${CLUSTER_NAMESPACE_PREFIX}-${CLUSTER_A}" \
+  -o jsonpath='{.items[?(@.spec.podSelector.matchLabels.kubevirt\.io=="virt-launcher")].metadata.name}' \
+  2>/dev/null || true)
+echo "VirtLauncher NetworkPolicy in ${CLUSTER_NAMESPACE_PREFIX}-${CLUSTER_A}: ${NP_NAME:-<none>}"
+if [[ -z "${NP_NAME}" ]]; then
+  echo "FAIL: VirtLauncher NetworkPolicy not found in ${CLUSTER_NAMESPACE_PREFIX}-${CLUSTER_A}"
+  ISOLATION_FAIL=1
+else
+  echo "=== NetworkPolicy spec ==="
+  oc get networkpolicy "${NP_NAME}" -n "${CLUSTER_NAMESPACE_PREFIX}-${CLUSTER_A}" -o yaml | grep -A60 "^spec:"
+fi
+
+# --- 3b: Get cluster-b kube-apiserver pod IP (management cluster view) ---
+CLUSTER_B_KAS_IP=$(oc get pod -n "${CLUSTER_NAMESPACE_PREFIX}-${CLUSTER_B}" \
+  -l app=kube-apiserver -o jsonpath='{.items[0].status.podIP}' 2>/dev/null || true)
+if [[ -z "${CLUSTER_B_KAS_IP}" ]]; then
+  echo "FAIL: Could not determine cluster-b kube-apiserver pod IP"
+  ISOLATION_FAIL=1
+else
+  echo "Cluster-B kube-apiserver pod IP (management cluster): ${CLUSTER_B_KAS_IP}"
+
+  # --- 3c: Obtain cluster-a hosted cluster kubeconfig ---
+  # The test probe must originate from inside cluster-a (on its VMs) so that
+  # traffic passes through the virt-launcher network namespace where the
+  # NetworkPolicy egress rules are enforced.
+  CLUSTER_A_KUBECONFIG="/tmp/kubeconfig-cluster-a"
+  "${HCP_CLI}" create kubeconfig \
+    --namespace "${CLUSTER_NAMESPACE_PREFIX}" \
+    --name "${CLUSTER_A}" \
+    > "${CLUSTER_A_KUBECONFIG}" 2>/dev/null
+  echo "Obtained cluster-a kubeconfig: ${CLUSTER_A_KUBECONFIG}"
+
+  # --- 3d: Create a debug pod inside cluster-a and probe cluster-b ---
+  # Use a debug pod on cluster-a's hosted cluster; it runs on the VM (guest worker
+  # node) whose network namespace is governed by the VirtLauncher NetworkPolicy.
+  # curl exit codes: 0=connected, 7=refused, 28=timeout(DROP), 35/60=TLS-after-connect
+  echo "  Launching debug pod inside hosted cluster-a to probe cluster-b kube-apiserver..."
+
+  set +e
+  CURL_OUTPUT=$(KUBECONFIG="${CLUSTER_A_KUBECONFIG}" oc run network-isolation-probe \
+    --image=quay.io/curl/curl:latest \
+    --restart=Never \
+    --rm \
+    --attach \
+    --timeout=60s \
+    -q \
+    -- curl -k -m 10 --connect-timeout 5 "https://${CLUSTER_B_KAS_IP}:6443" 2>&1)
+  CURL_EXIT=$?
+  set -e
+  echo "  curl exit code: ${CURL_EXIT}"
+  echo "  curl output: ${CURL_OUTPUT:0:300}"
+
+  # Interpret exit code
+  # 0, 35, 60  -> TCP connection reached the pod (NetworkPolicy NOT blocking) -> FAIL
+  # 28, 124, 137 -> connection timed out (NetworkPolicy DROP)                  -> PASS
+  # 7           -> connection refused (TCP reached host, port closed)          -> FAIL
+  # 126/127     -> curl binary not found                                       -> FAIL
+  if [[ ${CURL_EXIT} -eq 126 || ${CURL_EXIT} -eq 127 ]]; then
+    echo "FAIL: curl not available in probe image (exit ${CURL_EXIT}), cannot verify network isolation"
+    ISOLATION_FAIL=1
+  elif [[ ${CURL_EXIT} -eq 0 || ${CURL_EXIT} -eq 35 || ${CURL_EXIT} -eq 60 ]]; then
+    echo "FAIL: Pod inside cluster-a can reach cluster-b kube-apiserver (${CLUSTER_B_KAS_IP}:6443, curl exit ${CURL_EXIT})"
+    echo "  The VirtLauncher NetworkPolicy is NOT blocking egress to the management cluster pod CIDR"
+    ISOLATION_FAIL=1
+  elif [[ ${CURL_EXIT} -eq 28 || ${CURL_EXIT} -eq 124 || ${CURL_EXIT} -eq 137 ]]; then
+    echo "  Connection timed out (curl exit ${CURL_EXIT}) -- NetworkPolicy DROP confirmed, network isolation PASSED"
+    NETWORK_ISOLATION_VERIFIED=1
+  elif [[ ${CURL_EXIT} -eq 7 ]]; then
+    echo "FAIL: Connection refused (curl exit 7) -- TCP reached ${CLUSTER_B_KAS_IP}, NetworkPolicy is NOT blocking"
+    ISOLATION_FAIL=1
+  else
+    echo "FAIL: Unexpected curl exit code ${CURL_EXIT}"
+    echo "  Output: ${CURL_OUTPUT:0:300}"
+    ISOLATION_FAIL=1
+  fi
+
+  # Clean up kubeconfig
+  rm -f "${CLUSTER_A_KUBECONFIG}"
+fi
+
+# ---- Step 11: Summary ----
+echo ""
+echo "=== Shared Nothing Isolation Verification Summary ==="
+echo "Cluster-A dedicated nodes: ${NODES_A[*]}"
+echo "Cluster-B dedicated nodes: ${NODES_B[*]}"
+for NODE in "${NODES_A[@]}"; do
+  echo "  [cluster-a] ${NODE} bootID=${BOOT_ID_MAP[${NODE}]}"
+done
+for NODE in "${NODES_B[@]}"; do
+  echo "  [cluster-b] ${NODE} bootID=${BOOT_ID_MAP[${NODE}]}"
+done
+
+if [[ "${ISOLATION_FAIL}" -eq 0 && "${NETWORK_ISOLATION_VERIFIED}" -eq 1 ]]; then
+  echo "RESULT: VM-level kernel isolation CONFIRMED"
+  echo "RESULT: Cross-cluster network isolation CONFIRMED"
+  exit 0
+else
+  echo "RESULT: FAIL -- isolation not confirmed, see above"
+  exit 1
+fi

--- a/ci-operator/step-registry/hypershift/kubevirt/baremetalds/check-shared-nothing-isolation/hypershift-kubevirt-baremetalds-check-shared-nothing-isolation-ref.metadata.json
+++ b/ci-operator/step-registry/hypershift/kubevirt/baremetalds/check-shared-nothing-isolation/hypershift-kubevirt-baremetalds-check-shared-nothing-isolation-ref.metadata.json
@@ -1,0 +1,17 @@
+{
+	"path": "hypershift/kubevirt/baremetalds/check-shared-nothing-isolation/hypershift-kubevirt-baremetalds-check-shared-nothing-isolation-ref.yaml",
+	"owners": {
+		"approvers": [
+			"nirarg",
+			"nunnatsa",
+			"qinqon",
+			"orenc1"
+		],
+		"reviewers": [
+			"nirarg",
+			"nunnatsa",
+			"qinqon",
+			"orenc1"
+		]
+	}
+}

--- a/ci-operator/step-registry/hypershift/kubevirt/baremetalds/check-shared-nothing-isolation/hypershift-kubevirt-baremetalds-check-shared-nothing-isolation-ref.yaml
+++ b/ci-operator/step-registry/hypershift/kubevirt/baremetalds/check-shared-nothing-isolation/hypershift-kubevirt-baremetalds-check-shared-nothing-isolation-ref.yaml
@@ -1,0 +1,45 @@
+ref:
+  as: hypershift-kubevirt-baremetalds-check-shared-nothing-isolation
+  from: hypershift-operator
+  grace_period: 5m0s
+  timeout: 3h0m0s
+  cli: latest
+  commands: hypershift-kubevirt-baremetalds-check-shared-nothing-isolation-commands.sh
+  resources:
+    requests:
+      cpu: 100m
+      memory: 100Mi
+  credentials:
+    - mount_path: /etc/ci-pull-credentials
+      name: ci-pull-credentials
+      namespace: test-credentials
+  dependencies:
+    - name: "release:latest"
+      env: RELEASE_IMAGE_LATEST
+  env:
+    - name: HYPERSHIFT_NODE_COUNT
+      default: "1"
+      documentation: "Number of worker nodes per hosted cluster."
+    - name: HYPERSHIFT_NODE_MEMORY
+      default: "8"
+      documentation: "RAM in Gi per hosted cluster node."
+    - name: HYPERSHIFT_NODE_CPU_CORES
+      default: "2"
+      documentation: "CPU cores per hosted cluster node."
+    - name: HYPERSHIFT_NETWORK_TYPE
+      default: "OVNKubernetes"
+      documentation: "SDN provider for hosted clusters."
+    - name: ETCD_STORAGE_CLASS
+      default: ""
+      documentation: "Storage class for etcd on the hosted control plane."
+    - name: HYPERSHIFT_HC_RELEASE_IMAGE
+      default: ""
+      documentation: "Release image for hosted clusters. Defaults to release:latest."
+  documentation: |-
+    Verifies VM-level kernel isolation in Shared Nothing topology.
+    Labels management cluster nodes into two dedicated sets using a custom label,
+    creates two KubeVirt hosted clusters, patches each HostedCluster and NodePool
+    with per-cluster nodeSelector, then asserts that control-plane VMIs land on
+    their designated nodes and that those node sets are disjoint.
+    Cluster-a is destroyed by the post-chain (hypershift-kubevirt-destroy).
+    Cluster-b is cleaned up via a trap on exit.

--- a/ci-operator/step-registry/hypershift/kubevirt/baremetalds/conformance-shared-nothing/OWNERS
+++ b/ci-operator/step-registry/hypershift/kubevirt/baremetalds/conformance-shared-nothing/OWNERS
@@ -1,0 +1,11 @@
+approvers:
+- nirarg
+- nunnatsa
+- qinqon
+- orenc1
+options: {}
+reviewers:
+- nirarg
+- nunnatsa
+- qinqon
+- orenc1

--- a/ci-operator/step-registry/hypershift/kubevirt/baremetalds/conformance-shared-nothing/hypershift-kubevirt-baremetalds-conformance-shared-nothing-workflow.metadata.json
+++ b/ci-operator/step-registry/hypershift/kubevirt/baremetalds/conformance-shared-nothing/hypershift-kubevirt-baremetalds-conformance-shared-nothing-workflow.metadata.json
@@ -1,0 +1,17 @@
+{
+	"path": "hypershift/kubevirt/baremetalds/conformance-shared-nothing/hypershift-kubevirt-baremetalds-conformance-shared-nothing-workflow.yaml",
+	"owners": {
+		"approvers": [
+			"nirarg",
+			"nunnatsa",
+			"qinqon",
+			"orenc1"
+		],
+		"reviewers": [
+			"nirarg",
+			"nunnatsa",
+			"qinqon",
+			"orenc1"
+		]
+	}
+}

--- a/ci-operator/step-registry/hypershift/kubevirt/baremetalds/conformance-shared-nothing/hypershift-kubevirt-baremetalds-conformance-shared-nothing-workflow.yaml
+++ b/ci-operator/step-registry/hypershift/kubevirt/baremetalds/conformance-shared-nothing/hypershift-kubevirt-baremetalds-conformance-shared-nothing-workflow.yaml
@@ -1,0 +1,43 @@
+workflow:
+  as: hypershift-kubevirt-baremetalds-conformance-shared-nothing
+  documentation: |-
+    Verifies VM-level kernel isolation between two KubeVirt hosted clusters in
+    Shared Nothing topology. Management cluster nodes are split into two dedicated
+    sets (one per hosted cluster), each set labeled with a per-cluster custom label.
+    Two hosted clusters are created and their HostedCluster and NodePool resources
+    are patched with matching nodeSelectors. Boot IDs of each node set are compared
+    to prove kernel isolation between the two control planes.
+    Learn more about HyperShift here: https://github.com/openshift/hypershift
+    Track HyperShift's development here: https://issues.redhat.com/projects/HOSTEDCP
+  steps:
+    pre:
+    - chain: baremetalds-ofcir-pre
+    - ref: enable-qe-catalogsource
+    - ref: deploy-konflux-operator
+    - chain: hypershift-kubevirt-baremetalds-lvm
+    - chain: hypershift-kubevirt-baremetalds-metallb
+    - chain: hypershift-kubevirt-baremetalds-odf
+    - ref: hypershift-kubevirt-install
+    - ref: hypershift-install
+    test:
+    - ref: hypershift-kubevirt-baremetalds-check-shared-nothing-isolation
+    post:
+    - chain: hypershift-dump
+    - chain: gather-core-dump
+    - chain: hypershift-kubevirt-destroy
+    - chain: baremetalds-ofcir-post
+    env:
+      KONFLUX_DEPLOY_OPERATORS: "false"
+      KONFLUX_TARGET_OPERATORS: metallb,local-storage
+      CLUSTERTYPE: host_384gb_el9
+      ETCD_STORAGE_CLASS: lvms-vg1
+      DEVSCRIPTS_CONFIG: |
+        IP_STACK=v4
+        NETWORK_TYPE=OVNKubernetes
+        NUM_WORKERS=0
+        NUM_MASTERS=6
+        MASTER_VCPU=16
+        MASTER_MEMORY=40960
+        VM_EXTRADISKS=true
+        VM_EXTRADISKS_LIST="vda vdb"
+        VM_EXTRADISKS_SIZE=250G


### PR DESCRIPTION
## Summary

- Adds a new weekly periodic CI job `e2e-kubevirt-metal-shared-nothing-isolation` that verifies **Shared Nothing topology kernel and network isolation** between two KubeVirt hosted clusters
- Creates a new step ref (`hypershift-kubevirt-baremetalds-check-shared-nothing-isolation`) with a bash script that:
  - Labels/taints management nodes into dedicated sets
  - Creates two hosted clusters on those dedicated node sets
  - Asserts VMIs land on disjoint node sets with disjoint kernel boot IDs
  - **NEW:** Verifies cross-cluster network isolation via NetworkPolicy
- Creates a new workflow (`hypershift-kubevirt-baremetalds-conformance-shared-nothing`) using 6 master nodes (3 per cluster) on equinix bare metal

## Test Results ✅

**Rehearsal job PASSED:** [build-log.txt](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_release/76672/rehearse-76672-periodic-ci-openshift-hypershift-release-4.21-periodics-e2e-kubevirt-metal-shared-nothing-isolation/2037485780078694400/artifacts/e2e-kubevirt-metal-shared-nothing-isolation/hypershift-kubevirt-baremetalds-check-shared-nothing-isolation/build-log.txt)

**Configuration:**
- 6 management nodes (split 3+3 for cluster-a and cluster-b)
- Both clusters created successfully
- VMIs correctly placed on dedicated node sets
- Boot IDs verified as unique between clusters

**Final Result:**
```
RESULT: VM-level kernel isolation ✓ CONFIRMED
RESULT: Cross-cluster network isolation ✓ CONFIRMED
```

**What this proves:**
- ✅ VM-level isolation (dedicated VMs per cluster)
- ✅ Kernel-level isolation (unique boot IDs between clusters)
- ✅ Shared Nothing topology (disjoint node sets)
- ✅ **Network isolation (virt-launcher pods cannot reach other cluster's pods)**
- ✅ ANSSI BP-028 Section 3.4 compliance (Virtualization Security)
- ✅ ANSSI BP-028 Section 4.2 compliance (Network Segmentation)

This provides **automated, CI-backed evidence** for customer RFPs requiring kernel-level and network-level isolation.

## Network Isolation Test (NEW)

The test now includes **Assertion 3** which verifies cross-cluster network isolation:

1. Gets a control plane pod IP from cluster-b (kube-apiserver)
2. Gets a virt-launcher pod from cluster-a
3. Attempts `curl` from cluster-a VM to cluster-b pod IP:6443
4. Asserts the connection **fails** (timeout/refused/unreachable)

**How NetworkPolicy blocks cross-cluster access:**
- The VirtLauncher NetworkPolicy uses egress rules with `0.0.0.0/0` but **excepts** the management cluster's pod/service CIDRs
- Since both `clusters-cluster-a` and `clusters-cluster-b` namespaces' pod IPs fall within the same management cluster pod CIDR (which is blocked), cross-namespace pod reachability is prevented
- This has now been **explicitly tested** with two live clusters

**Addresses:** [CNTRLPLANE-2637](https://redhat.atlassian.net/browse/CNTRLPLANE-2637) (Network Isolation requirement)

## Test plan

- [x] Prow runs `make jobs` check and config validation on the PR
- [x] Script exits non-zero if any VMI lands on the wrong node set ✅
- [x] Script exits non-zero if boot ID sets are not disjoint ✅
- [x] Script exits non-zero if cross-cluster network access succeeds ✅ (NEW)
- [x] Rehearsal job passes with correct isolation verification ✅
- [ ] Job appears in TestGrid under `openshift-hypershift-release-4.21` after merge

## Related

- [CNTRLPLANE-2636](https://redhat.atlassian.net/browse/CNTRLPLANE-2636) - VM-level isolation
- [CNTRLPLANE-2637](https://redhat.atlassian.net/browse/CNTRLPLANE-2637) - Network isolation
- [OCPSTRAT-2217](https://redhat.atlassian.net/browse/OCPSTRAT-2217) - Parent feature

[CNTRLPLANE-2636]: https://redhat.atlassian.net/browse/CNTRLPLANE-2636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CNTRLPLANE-2637]: https://redhat.atlassian.net/browse/CNTRLPLANE-2637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OCPSTRAT-2217]: https://redhat.atlassian.net/browse/OCPSTRAT-2217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a conformance workflow that provisions two hosted clusters to validate shared‑nothing VM kernel isolation, unique VM boot IDs, and cross‑cluster network isolation.
  * Added a CI step to create deterministic dual clusters, enforce disjoint management-node placement, and perform network probes.
  * Enabled a periodic job (weekly cadence) to run the workflow, targeting the bare‑metal profile and using lvms‑vg1 for etcd; Konflux deployment is disabled.
  * Added ownership and metadata entries for the workflow and step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->