### PR TITLE
fix: add --dns-zone-rg-name to Azure self-managed destroy step

### DIFF
--- a/ci-operator/step-registry/hypershift/azure/destroy/hypershift-azure-destroy-chain.yaml
+++ b/ci-operator/step-registry/hypershift/azure/destroy/hypershift-azure-destroy-chain.yaml
@@ -16,6 +16,9 @@ chain:
     - name: USE_HYPERSHIFT_AZURE_CREDS
       default: "false"
       documentation: "Whether to use the generic CI account or the HyperShift OSD account for the guest clusters infra. For the infra created for the clusters"
+    - name: DNS_ZONE_RG_NAME
+      default: "os4-common"
+      documentation: "dns zone resource group"
     - name: CLI
       default: ""
       documentation: "hcp or hypershift cli path"
@@ -39,6 +42,7 @@ chain:
         --azure-creds=${AZURE_CREDS} \
         --name ${CLUSTER_NAME} \
         --location ${HC_LOCATION} \
+        --dns-zone-rg-name=${DNS_ZONE_RG_NAME} \
         --cluster-grace-period 40m
       )
 

--- a/ci-operator/step-registry/hypershift/destroy-nested-management-cluster/hypershift-destroy-nested-management-cluster-chain.yaml
+++ b/ci-operator/step-registry/hypershift/destroy-nested-management-cluster/hypershift-destroy-nested-management-cluster-chain.yaml
@@ -86,6 +86,7 @@ chain:
           --name="${CLUSTER_NAME}" \
           --namespace="${HYPERSHIFT_NAMESPACE}" \
           --location=${HYPERSHIFT_AZURE_LOCATION} \
+          --dns-zone-rg-name=os4-common \
           --cluster-grace-period 40m
       else
         echo "Destroying AWS management cluster ${CLUSTER_NAME}"


### PR DESCRIPTION
## Summary
- openshift/hypershift#8322 made `--dns-zone-rg-name` a required flag on `hypershift destroy cluster azure`
- Two destroy chains were not passing it, causing every Azure HyperShift job to fail during cleanup and leak Azure clusters:
  - **`hypershift-destroy-nested-management-cluster`**: used by `e2e-azure-self-managed` jobs — adds `--dns-zone-rg-name=os4-common` to the destroy command (matching the create step)
  - **`hypershift-azure-destroy`**: used by AKS conformance and 12+ cucushift Azure HyperShift workflows — adds `DNS_ZONE_RG_NAME` env var (default `os4-common`, matching the create chain) and passes it to the destroy command

## Test plan
- [ ] Verify rehearsal of `pull-ci-openshift-hypershift-main-e2e-azure-self-managed` passes the destroy step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Azure management cluster destruction to include DNS zone resource group configuration.
  * Made the DNS zone resource group name configurable (defaults to os4-common) and passed to the destroy operation so teardown targets the correct DNS zone, improving cleanup reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->