### PR TITLE
WIP - Override kube-burner version for ipsec-nodes

### DIFF
--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__4.21-nightly-control-plane.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__4.21-nightly-control-plane.yaml
@@ -38,6 +38,7 @@ tests:
       EXTRA_FLAGS: --churn-duration=20m --service-latency
       NODE_DENSITY_GC: "false"
       OPENSHIFT_INFRA_NODE_INSTANCE_TYPE: r5.4xlarge
+      PODS_PER_NODE: "175"
       PROFILE_TYPE: both
       SET_ENV_BY_PLATFORM: custom
       SIZE_VARIANT: large

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__4.22-nightly-control-plane.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__4.22-nightly-control-plane.yaml
@@ -38,6 +38,7 @@ tests:
       EXTRA_FLAGS: --churn-duration=20m --service-latency
       NODE_DENSITY_GC: "false"
       OPENSHIFT_INFRA_NODE_INSTANCE_TYPE: r5.4xlarge
+      PODS_PER_NODE: "175"
       PROFILE_TYPE: both
       SET_ENV_BY_PLATFORM: custom
       SIZE_VARIANT: large

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.22-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.22-nightly-x86.yaml
@@ -231,7 +231,8 @@ tests:
         --local-indexing
       NODE_DENSITY_GC: "false"
       OPENSHIFT_INFRA_NODE_INSTANCE_TYPE: r5.4xlarge
-      PODS_PER_NODE: "175"
+      PODS_PER_NODE: "200"
+      KUBE_BURNER_VERSION: "1.11.0"
       PROFILE_TYPE: both
       SET_ENV_BY_PLATFORM: custom
       SIZE_VARIANT: large

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.22-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.22-nightly-x86.yaml
@@ -231,8 +231,7 @@ tests:
         --local-indexing
       NODE_DENSITY_GC: "false"
       OPENSHIFT_INFRA_NODE_INSTANCE_TYPE: r5.4xlarge
-      PODS_PER_NODE: "200"
-      KUBE_BURNER_VERSION: "1.11.0"
+      PODS_PER_NODE: "175"
       PROFILE_TYPE: both
       SET_ENV_BY_PLATFORM: custom
       SIZE_VARIANT: large

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.23-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.23-nightly-x86.yaml
@@ -227,6 +227,7 @@ tests:
       ENABLE_LAYER_3: "false"
       NODE_DENSITY_GC: "false"
       OPENSHIFT_INFRA_NODE_INSTANCE_TYPE: r5.4xlarge
+      PODS_PER_NODE: "175"
       PROFILE_TYPE: both
       SET_ENV_BY_PLATFORM: custom
       SIZE_VARIANT: large


### PR DESCRIPTION
For isolating changes with: [PERFSCALE-4705](https://redhat.atlassian.net/browse/PERFSCALE-4705)

[PERFSCALE-4705]: https://redhat.atlassian.net/browse/PERFSCALE-4705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test configurations for OpenShift 4.21, 4.22, and 4.23 nightly builds to adjust pod density parameters in performance and scale test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->