### PR TITLE
fix: stop tarring self-managed cluster dump to prevent sidecar censoring

### DIFF
--- a/ci-operator/step-registry/hypershift/destroy-nested-management-cluster/hypershift-destroy-nested-management-cluster-chain.yaml
+++ b/ci-operator/step-registry/hypershift/destroy-nested-management-cluster/hypershift-destroy-nested-management-cluster-chain.yaml
@@ -20,10 +20,7 @@ chain:
       fi
 
       CLUSTER_NAME="$(echo -n $PROW_JOB_ID|sha256sum|cut -c-10)-mgmt"
-      mkdir -p "${ARTIFACT_DIR}/output"
-      bin/hypershift dump cluster --dump-guest-cluster=true --artifact-dir="${ARTIFACT_DIR}/output" --name="${CLUSTER_NAME}" --namespace="${HYPERSHIFT_NAMESPACE}"
-      tar -cvzf "${ARTIFACT_DIR}/artifacts.tar.gz" "${ARTIFACT_DIR}/output"
-      rm -rf "${ARTIFACT_DIR}/output"
+      bin/hypershift dump cluster --dump-guest-cluster=true --artifact-dir="${ARTIFACT_DIR}/hypershift-dump" --name="${CLUSTER_NAME}" --namespace="${HYPERSHIFT_NAMESPACE}"
     credentials:
     - mount_path: /etc/hypershift-kubeconfig
       name: hypershift-ci-2


### PR DESCRIPTION
## Summary
- Remove tar+rm of cluster dump artifacts in the `hypershift-destroy-nested-management-cluster` chain's `dump-management-cluster` step
- Prow's sidecar secret-censoring was replacing the entire `artifacts.tar.gz` with a "sensitive information removed" placeholder because the cluster dump contains configmaps and SA tokens that match secret patterns
- By leaving raw files in place (matching the pattern used by `hypershift-hostedcluster-dump`), individual non-sensitive files survive censoring and remain browsable in Spyglass

## Test plan
- [ ] Verify dump artifacts are visible in Spyglass after a self-managed Azure e2e run
- [ ] Confirm individual secret-containing files are censored while non-sensitive files (pod YAML, events, deployments) remain readable

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the management cluster destruction workflow by removing intermediate artifact processing steps and temporary directory management operations. Cluster diagnostic data is now written directly to its final destination, eliminating unnecessary file operations and intermediate processing steps. This improvement enhances overall pipeline efficiency and reduces operational overhead in CI/CD cluster testing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->