### PR TITLE
WIP: test OCP 4.12 R2 RPM repo migration via pj-rehearse

### DIFF
--- a/ci-operator/config/openshift/telemeter/openshift-telemeter-release-4.12.yaml
+++ b/ci-operator/config/openshift/telemeter/openshift-telemeter-release-4.12.yaml
@@ -28,7 +28,7 @@ resources:
   '*':
     requests:
       cpu: 100m
-      memory: 200Mi
+      memory: 201Mi
 tests:
 - as: vendor
   commands: GO111MODULE=on make vendor && git diff --exit-code


### PR DESCRIPTION
## Summary

Trivial no-op memory bump (200Mi -> 201Mi) on the telemeter 4.12 CI config to trigger `pj-rehearse`.

The rehearsed image build job will exercise the new R2 CloudFlare RPM endpoints that were migrated in #78292 (`openshift-mirror-list.ci-systems.workers.dev`).

## Testing

If the rehearsed build succeeds, the R2 migration for OCP 4.12 is validated.

**Not intended to merge** - will be closed after rehearsal validates the endpoints.

Related: https://redhat.atlassian.net/browse/ART-14263

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated memory request configuration in the telemeter release-4.12 CI operator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->