### PR TITLE
WIP: test OCP 4.12 R2 RPM repo migration via ironic-image rehearsal

### DIFF
--- a/ci-operator/config/openshift/ironic-image/openshift-ironic-image-release-4.12.yaml
+++ b/ci-operator/config/openshift/ironic-image/openshift-ironic-image-release-4.12.yaml
@@ -40,7 +40,7 @@ resources:
   '*':
     requests:
       cpu: 100m
-      memory: 200Mi
+      memory: 201Mi
 tests:
 - as: e2e-metal-ipi-bm
   capabilities:


### PR DESCRIPTION
## Summary

Trivial no-op memory bump (200Mi -> 201Mi) on the ironic-image 4.12 CI config to trigger `pj-rehearse`.

The ironic-image build is ideal for this test because it explicitly:
1. Curls the `.repo` configmap (`base-4-12-rhel-9-server-ironic.ocp.svc`)
2. Runs `dnf install` against those repos during image build

The rehearsed `images` job will exercise the new R2 CloudFlare RPM endpoints that were migrated in #78292 (`openshift-mirror-list.ci-systems.workers.dev`).

## Testing

The build log for the rehearsed images job should show RPM downloads from the new R2 endpoint. Build success = R2 migration validated for ironic RPMs.

**Not intended to merge** - will be closed after rehearsal validates the endpoints.

Related: https://redhat.atlassian.net/browse/ART-14263

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default memory resource allocation to optimize system configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->