### PR TITLE
Use OCP 4.22 cluster profile for Tracing UI CI jobs

### DIFF
--- a/ci-operator/config/openshift/distributed-tracing-console-plugin/openshift-distributed-tracing-console-plugin-main__upstream-amd64-aws.yaml
+++ b/ci-operator/config/openshift/distributed-tracing-console-plugin/openshift-distributed-tracing-console-plugin-main__upstream-amd64-aws.yaml
@@ -1,3 +1,16 @@
+base_images:
+  cli:
+    name: "4.22"
+    namespace: ocp
+    tag: cli
+  operator-sdk:
+    name: "4.22"
+    namespace: origin
+    tag: operator-sdk
+  upi-installer:
+    name: "4.22"
+    namespace: ocp
+    tag: upi-installer
 build_root:
   image_stream_tag:
     name: builder
@@ -12,6 +25,12 @@ images:
   - context_dir: .
     dockerfile_path: tests/Dockerfile
     to: tracing-ui-tests-runner
+releases:
+  latest:
+    candidate:
+      product: ocp
+      stream: nightly
+      version: "4.22"
 resources:
   '*':
     limits:
@@ -31,19 +50,13 @@ tests:
     test:
     - ref: fips-check-image-scan
 - as: e2e
-  cluster_claim:
-    architecture: amd64
-    cloud: aws
-    labels:
-      region: us-east-2
-    owner: obs
-    product: ocp
-    timeout: 1h0m0s
-    version: "4.22"
   steps:
+    cluster_profile: azure-observability
+    env:
+      BASE_DOMAIN: observability.azure.devcluster.openshift.com
     test:
     - ref: distributed-tracing-tests-tracing-ui-upstream
-    workflow: generic-claim
+    workflow: cucushift-installer-rehearse-azure-ipi
 zz_generated_metadata:
   branch: main
   org: openshift

--- a/ci-operator/config/openshift/distributed-tracing-console-plugin/openshift-distributed-tracing-console-plugin-release-coo-ocp-4.15__upstream-amd64-aws.yaml
+++ b/ci-operator/config/openshift/distributed-tracing-console-plugin/openshift-distributed-tracing-console-plugin-release-coo-ocp-4.15__upstream-amd64-aws.yaml
@@ -31,9 +31,21 @@ tests:
     test:
     - ref: fips-check-image-scan
 - as: e2e
-  commands: echo "test"
-  container:
-    from: distributed-tracing-console-plugin-test
+  cluster_claim:
+    architecture: amd64
+    cloud: aws
+    labels:
+      region: us-east-2
+    owner: obs
+    product: ocp
+    timeout: 1h0m0s
+    version: "4.15"
+  steps:
+    env:
+      CYPRESS_SKIP_TESTS: -Lightspeed
+    test:
+    - ref: distributed-tracing-tests-tracing-ui-upstream
+    workflow: generic-claim
 zz_generated_metadata:
   branch: release-coo-ocp-4.15
   org: openshift

--- a/ci-operator/config/openshift/distributed-tracing-console-plugin/openshift-distributed-tracing-console-plugin-release-coo-ocp-4.22__upstream-amd64-aws.yaml
+++ b/ci-operator/config/openshift/distributed-tracing-console-plugin/openshift-distributed-tracing-console-plugin-release-coo-ocp-4.22__upstream-amd64-aws.yaml
@@ -1,3 +1,16 @@
+base_images:
+  cli:
+    name: "4.22"
+    namespace: ocp
+    tag: cli
+  operator-sdk:
+    name: "4.22"
+    namespace: origin
+    tag: operator-sdk
+  upi-installer:
+    name: "4.22"
+    namespace: ocp
+    tag: upi-installer
 build_root:
   image_stream_tag:
     name: builder
@@ -12,6 +25,12 @@ images:
   - context_dir: .
     dockerfile_path: tests/Dockerfile
     to: tracing-ui-tests-runner
+releases:
+  latest:
+    candidate:
+      product: ocp
+      stream: nightly
+      version: "4.22"
 resources:
   '*':
     limits:
@@ -31,19 +50,13 @@ tests:
     test:
     - ref: fips-check-image-scan
 - as: e2e
-  cluster_claim:
-    architecture: amd64
-    cloud: aws
-    labels:
-      region: us-east-2
-    owner: obs
-    product: ocp
-    timeout: 1h0m0s
-    version: "4.22"
   steps:
+    cluster_profile: azure-observability
+    env:
+      BASE_DOMAIN: observability.azure.devcluster.openshift.com
     test:
     - ref: distributed-tracing-tests-tracing-ui-upstream
-    workflow: generic-claim
+    workflow: cucushift-installer-rehearse-azure-ipi
 zz_generated_metadata:
   branch: release-coo-ocp-4.22
   org: openshift

--- a/ci-operator/jobs/openshift/distributed-tracing-console-plugin/openshift-distributed-tracing-console-plugin-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/distributed-tracing-console-plugin/openshift-distributed-tracing-console-plugin-main-presubmits.yaml
@@ -11,8 +11,11 @@ presubmits:
     decoration_config:
       skip_cloning: true
     labels:
+      ci-operator.openshift.io/cloud: azure4
+      ci-operator.openshift.io/cloud-cluster-profile: azure-observability
       ci-operator.openshift.io/variant: upstream-amd64-aws
       ci.openshift.io/generator: prowgen
+      job-release: "4.22"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-distributed-tracing-console-plugin-main-upstream-amd64-aws-e2e
     rerun_command: /test upstream-amd64-aws-e2e
@@ -20,7 +23,6 @@ presubmits:
       containers:
       - args:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --hive-kubeconfig=/secrets/hive-hive-credentials/kubeconfig
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
@@ -53,9 +55,6 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
-        - mountPath: /secrets/hive-hive-credentials
-          name: hive-hive-credentials
-          readOnly: true
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
@@ -76,9 +75,6 @@ presubmits:
       - name: ci-pull-credentials
         secret:
           secretName: ci-pull-credentials
-      - name: hive-hive-credentials
-        secret:
-          secretName: hive-hive-credentials
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
@@ -102,6 +98,7 @@ presubmits:
     labels:
       ci-operator.openshift.io/variant: upstream-amd64-aws
       ci.openshift.io/generator: prowgen
+      job-release: "4.22"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-distributed-tracing-console-plugin-main-upstream-amd64-aws-fips-image-scan
     rerun_command: /test upstream-amd64-aws-fips-image-scan
@@ -112,6 +109,7 @@ presubmits:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
         - --target=fips-image-scan
         - --variant=upstream-amd64-aws
         command:
@@ -134,6 +132,9 @@ presubmits:
         - mountPath: /etc/boskos
           name: boskos
           readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
@@ -154,6 +155,9 @@ presubmits:
           - key: credentials
             path: credentials
           secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
@@ -177,6 +181,7 @@ presubmits:
     labels:
       ci-operator.openshift.io/variant: upstream-amd64-aws
       ci.openshift.io/generator: prowgen
+      job-release: "4.22"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-distributed-tracing-console-plugin-main-upstream-amd64-aws-images
     rerun_command: /test upstream-amd64-aws-images
@@ -234,6 +239,7 @@ presubmits:
     labels:
       ci-operator.openshift.io/variant: upstream-amd64-aws
       ci.openshift.io/generator: prowgen
+      job-release: "4.22"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-distributed-tracing-console-plugin-main-upstream-amd64-aws-lint
     rerun_command: /test upstream-amd64-aws-lint

--- a/ci-operator/jobs/openshift/distributed-tracing-console-plugin/openshift-distributed-tracing-console-plugin-release-coo-ocp-4.15-presubmits.yaml
+++ b/ci-operator/jobs/openshift/distributed-tracing-console-plugin/openshift-distributed-tracing-console-plugin-release-coo-ocp-4.15-presubmits.yaml
@@ -20,8 +20,11 @@ presubmits:
       containers:
       - args:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --hive-kubeconfig=/secrets/hive-hive-credentials/kubeconfig
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
         - --target=e2e
         - --variant=upstream-amd64-aws
         command:
@@ -41,8 +44,17 @@ presubmits:
           requests:
             cpu: 10m
         volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
         - mountPath: /secrets/gcs
           name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/hive-hive-credentials
+          name: hive-hive-credentials
           readOnly: true
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
@@ -55,6 +67,18 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: hive-hive-credentials
+        secret:
+          secretName: hive-hive-credentials
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher

--- a/ci-operator/jobs/openshift/distributed-tracing-console-plugin/openshift-distributed-tracing-console-plugin-release-coo-ocp-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift/distributed-tracing-console-plugin/openshift-distributed-tracing-console-plugin-release-coo-ocp-4.22-presubmits.yaml
@@ -11,8 +11,11 @@ presubmits:
     decoration_config:
       skip_cloning: true
     labels:
+      ci-operator.openshift.io/cloud: azure4
+      ci-operator.openshift.io/cloud-cluster-profile: azure-observability
       ci-operator.openshift.io/variant: upstream-amd64-aws
       ci.openshift.io/generator: prowgen
+      job-release: "4.22"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-distributed-tracing-console-plugin-release-coo-ocp-4.22-upstream-amd64-aws-e2e
     rerun_command: /test upstream-amd64-aws-e2e
@@ -20,7 +23,6 @@ presubmits:
       containers:
       - args:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --hive-kubeconfig=/secrets/hive-hive-credentials/kubeconfig
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
@@ -53,9 +55,6 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
-        - mountPath: /secrets/hive-hive-credentials
-          name: hive-hive-credentials
-          readOnly: true
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
@@ -76,9 +75,6 @@ presubmits:
       - name: ci-pull-credentials
         secret:
           secretName: ci-pull-credentials
-      - name: hive-hive-credentials
-        secret:
-          secretName: hive-hive-credentials
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
@@ -102,6 +98,7 @@ presubmits:
     labels:
       ci-operator.openshift.io/variant: upstream-amd64-aws
       ci.openshift.io/generator: prowgen
+      job-release: "4.22"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-distributed-tracing-console-plugin-release-coo-ocp-4.22-upstream-amd64-aws-fips-image-scan
     rerun_command: /test upstream-amd64-aws-fips-image-scan
@@ -112,6 +109,7 @@ presubmits:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
         - --target=fips-image-scan
         - --variant=upstream-amd64-aws
         command:
@@ -134,6 +132,9 @@ presubmits:
         - mountPath: /etc/boskos
           name: boskos
           readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
@@ -154,6 +155,9 @@ presubmits:
           - key: credentials
             path: credentials
           secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
@@ -177,6 +181,7 @@ presubmits:
     labels:
       ci-operator.openshift.io/variant: upstream-amd64-aws
       ci.openshift.io/generator: prowgen
+      job-release: "4.22"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-distributed-tracing-console-plugin-release-coo-ocp-4.22-upstream-amd64-aws-images
     rerun_command: /test upstream-amd64-aws-images
@@ -234,6 +239,7 @@ presubmits:
     labels:
       ci-operator.openshift.io/variant: upstream-amd64-aws
       ci.openshift.io/generator: prowgen
+      job-release: "4.22"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-distributed-tracing-console-plugin-release-coo-ocp-4.22-upstream-amd64-aws-lint
     rerun_command: /test upstream-amd64-aws-lint

--- a/ci-operator/step-registry/distributed-tracing/tests/tracing-ui/upstream/distributed-tracing-tests-tracing-ui-upstream-commands.sh
+++ b/ci-operator/step-registry/distributed-tracing/tests/tracing-ui/upstream/distributed-tracing-tests-tracing-ui-upstream-commands.sh
@@ -15,6 +15,7 @@ vars=(
   CYPRESS_LIGHTSPEED_CONSOLE_IMAGE
   CYPRESS_LIGHTSPEED_PROVIDER_URL
   CYPRESS_LIGHTSPEED_PROVIDER_TOKEN
+  CYPRESS_SKIP_TESTS
 )
 
 # Loop through each variable.
@@ -165,5 +166,11 @@ export CYPRESS_CACHE_FOLDER=/tmp/Cypress
 # Install npm modules
 npm install
 
-# Run the Cypress tests
-npm run test-cypress-console-headless
+# Run the Cypress tests with grep filter if CYPRESS_SKIP_TESTS is set
+if [[ -n "${CYPRESS_SKIP_TESTS:-}" ]]; then
+  echo "Running Cypress tests with grep pattern: ${CYPRESS_SKIP_TESTS}"
+  npx cypress run --browser chrome --headless --env grep="${CYPRESS_SKIP_TESTS}",grepOmitFiltered=true
+else
+  echo "Running all Cypress tests"
+  npm run test-cypress-console-headless
+fi

--- a/ci-operator/step-registry/distributed-tracing/tests/tracing-ui/upstream/distributed-tracing-tests-tracing-ui-upstream-ref.yaml
+++ b/ci-operator/step-registry/distributed-tracing/tests/tracing-ui/upstream/distributed-tracing-tests-tracing-ui-upstream-ref.yaml
@@ -39,6 +39,9 @@ ref:
   - name: CYPRESS_LIGHTSPEED_PROVIDER_TOKEN
     default: ""
     documentation: "Set the var to configure Lightspeed API authentication token for AI-powered trace analysis integration."
+  - name: CYPRESS_SKIP_TESTS
+    default: ""
+    documentation: "Set the var to skip specific tests using cypress grep negative pattern. Examples: '-Lightspeed' to skip single pattern, or '~Lightspeed|~Debug|~WIP' to skip multiple patterns. See https://www.npmjs.com/package/@cypress/grep for pattern syntax."
   dependencies:
   - name: "distributed-tracing-console-plugin"
     env: CYPRESS_DT_CONSOLE_IMAGE


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned CI pipelines to OpenShift 4.22 and aligned base images and release selection.
  * Migrated several e2e runs from AWS cluster-claim flows to Azure-based profiles and set corresponding base domain values.
  * Replaced placeholder container tests with cluster-driven test executions for more realistic validation.

* **New Features**
  * Added support for skipping specific Cypress tests via a new environment flag for test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->