### PR TITLE
SREP-4676: skip the tests for OCPFeatureGate:AWSServiceLBNetworkSecurityGroup

### DIFF
--- a/ci-operator/step-registry/rosa/aws/sts/conformance/rosa-aws-sts-conformance-workflow.yaml
+++ b/ci-operator/step-registry/rosa/aws/sts/conformance/rosa-aws-sts-conformance-workflow.yaml
@@ -21,7 +21,7 @@ workflow:
         NetworkPolicy between server and client should allow ingress access from updated pod\|
         CPU Partitioning cluster infrastructure should be configured correctly\|
         Managed cluster should set requests but not limits\|
-        Managed cluster should ensure platform components have system-\* priority class associated\|cloud-provider-aws-e2e.*loadbalancer NLB internal should be reachable with hairpinning traffic\|sig-network-edge.*GatewayAPIController\|sig-olmv1.*NewOLM.*Catalog should serve FBC
+        Managed cluster should ensure platform components have system-\* priority class associated\|\[cloud-provider-aws-e2e\] loadbalancer NLB internal should be reachable with hairpinning traffic\|\[cloud-provider-aws-e2e\] loadbalancer NLB should be reachable with target-node-labels\|sig-network-edge.*GatewayAPIController\|sig-olmv1.*NewOLM.*Catalog should serve FBC\|\[cloud-provider-aws-e2e-openshift\] loadbalancer NLB \[OCPFeatureGate:AWSServiceLBNetworkSecurityGroup\]
     pre:
       - chain: rosa-aws-sts-provision
       - ref: osd-ccs-conf-idp-htpasswd-multi-users


### PR DESCRIPTION
All the testings failed with error and not suitable for rosa sts cluster
```
operation error Elastic Load Balancing v2: DescribeLoadBalancers, exceeded maximum number of attempts, 3, 
get identity: get credentials: failed to refresh cached credentials, no EC2 IMDS role found, operation error ec2imds:
 GetMetadata, exceeded maximum number of attempts, 3, request send failed, Get "http://169.254.169.254/latest/
meta-data/iam/security-credentials/": dial tcp 169.254.169.254:80: connect: connection refused}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the ROSA AWS STS conformance test skip configuration to exclude specific loadbalancer network security group validation tests from execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->