### PR TITLE
ARO-HCP: raise aro-hcp-test-local-run step timeout

### DIFF
--- a/ci-operator/step-registry/aro-hcp/test/local/run/aro-hcp-test-local-run-ref.yaml
+++ b/ci-operator/step-registry/aro-hcp/test/local/run/aro-hcp-test-local-run-ref.yaml
@@ -10,6 +10,7 @@ ref:
       name: cluster-secrets-aro-hcp-dev
       mount_path: /var/run/aro-hcp-dev
   grace_period: 30s
+  timeout: 4h0m0s
   resources:
     requests:
       cpu: 1000m


### PR DESCRIPTION
The `aro-hcp-test-local-run` step (used by the `e2e-parallel` presubmit job in
Azure/ARO-HCP) does not set an explicit timeout, so it defaults to Prow's 2h
step Pod activeDeadlineSeconds. The sibling step `aro-hcp-test-persistent` (used
for int/stg/prod e2e) already sets `timeout: 4h0m0s`.

The e2e suite has grown from ~24 to ~40+ specs since March 2026, primarily due
to version-parametrized tests (z-stream upgrade expanded to 5 versions,
multiversion cluster creation, nodepool upgrades, etc.). With 20 identity lease
slots, the suite now requires 2 full waves of ~65 minutes each (~130 min total),
which exceeds the 2h default. This has caused a steady increase in
"Process did not finish before 2h0m0s timeout" failures — from 2 occurrences in
mid-March to 6-15 per day by late April, affecting ~18% of all e2e-parallel runs
on April 28.

Setting `timeout: 4h0m0s` matches what `aro-hcp-test-persistent` already uses
and provides sufficient headroom.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test execution timeout configuration for improved CI/CD pipeline reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->