### PR TITLE
OpenStack: add tide config for release-4.22 openstack-test

### DIFF
--- a/core-services/prow/02_config/openshift/openstack-test/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/openstack-test/_prowconfig.yaml
@@ -17,6 +17,7 @@ tide:
     - release-4.2
     - release-4.20
     - release-4.21
+    - release-4.22
     - release-4.3
     - release-4.4
     - release-4.5


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Prow configuration to include the `release-4.22` branch in automated testing and merging workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->