### PR TITLE
Add option to browbeat to run workflow

### DIFF
--- a/ci-operator/step-registry/openshift-qe/rhoso/browbeat-run/openshift-qe-rhoso-browbeat-run-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/rhoso/browbeat-run/openshift-qe-rhoso-browbeat-run-commands.sh
@@ -33,6 +33,7 @@ ssh root@${bastion} "
   export ES_SERVER=\"${es_host}\"
   export KUBECONFIG=\"${kubeconfig}\"
   export BENCHMARK=\"${WORKLOAD:-}\"
+  export WORKLOAD_TYPE=\"${WORKLOAD_TYPE:-rally}\"
   JOB_START=\\\$(date -u +\"%Y-%m-%dT%H:%M:%SZ\")
   rm -rf cpt-browbeat-configs
   git clone https://gitlab.cee.redhat.com/eng/openstack/team/performance-and-scale/cpt-browbeat-configs.git
@@ -47,10 +48,11 @@ ssh root@${bastion} "
   sed -i \"s|cloud_name: .*|cloud_name: cpt-${build_id}|\" browbeat-config.yaml
   sed -i \"s|host: .*|host: ${es_host}|\" browbeat-config.yaml
   source .browbeat-venv/bin/activate
-  log_file=\"browbeat-rally-${WORKLOAD}-${build_id}.log\"
+  workload_type=\"${WORKLOAD_TYPE:-rally}\"
+  log_file=\"browbeat-\\\${workload_type}-${WORKLOAD}-${build_id}.log\"
   export BROWBEAT_LOG=\"\\\$(pwd)/\\\${log_file}\"
   set -o pipefail
-  python3 browbeat.py rally 2>&1 | tee \"\\\$log_file\"
+  python3 browbeat.py \\\${workload_type} 2>&1 | tee \"\\\$log_file\"
   deactivate
   JOB_END=\\\$(date -u +\"%Y-%m-%dT%H:%M:%SZ\")
   export JOB_START JOB_END BROWBEAT_LOG

--- a/ci-operator/step-registry/openshift-qe/rhoso/browbeat-run/openshift-qe-rhoso-browbeat-run-ref.yaml
+++ b/ci-operator/step-registry/openshift-qe/rhoso/browbeat-run/openshift-qe-rhoso-browbeat-run-ref.yaml
@@ -9,6 +9,10 @@ ref:
     default: ""
     documentation: |-
       Browbeat workload to run (e.g., nova). Required.
+  - name: WORKLOAD_TYPE
+    default: "rally"
+    documentation: |-
+      Browbeat workload type to run (rally, shaker, workflow). Defaults to rally.
   commands: openshift-qe-rhoso-browbeat-run-commands.sh
   timeout: 4h0m0s
   resources:


### PR DESCRIPTION
browbeat has option to run run workflow, this PR enables option to run any workload type like rally or workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable workload type option for Browbeat runs (default: "rally").
  * Log filenames now include the selected workload type for better organization and traceability.
  * Browbeat execution now uses the chosen workload type at runtime so runs and outputs reflect that selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->