### PR TITLE
GCP-431: feat: pass cloud-network SA to GCP HyperShift e2e tests

### DIFF
--- a/ci-operator/step-registry/hypershift/gcp/hosted-cluster-setup/hypershift-gcp-hosted-cluster-setup-commands.sh
+++ b/ci-operator/step-registry/hypershift/gcp/hosted-cluster-setup/hypershift-gcp-hosted-cluster-setup-commands.sh
@@ -115,8 +115,9 @@ NODEPOOL_SA=$(awk -F'"' '/"nodepool-mgmt"/{print $4}' "${IAM_OUTPUT}")
 CLOUDCONTROLLER_SA=$(awk -F'"' '/"cloud-controller"/{print $4}' "${IAM_OUTPUT}")
 STORAGE_SA=$(awk -F'"' '/"gcp-pd-csi"/{print $4}' "${IAM_OUTPUT}")
 IMAGEREGISTRY_SA=$(awk -F'"' '/"image-registry"/{print $4}' "${IAM_OUTPUT}")
+NETWORK_SA=$(awk -F'"' '/"cloud-network"/{print $4}' "${IAM_OUTPUT}")
 
-if [[ -z "${PROJECT_NUMBER}" || -z "${POOL_ID}" || -z "${PROVIDER_ID}" || -z "${CONTROLPLANE_SA}" || -z "${NODEPOOL_SA}" || -z "${CLOUDCONTROLLER_SA}" || -z "${STORAGE_SA}" || -z "${IMAGEREGISTRY_SA}" ]]; then
+if [[ -z "${PROJECT_NUMBER}" || -z "${POOL_ID}" || -z "${PROVIDER_ID}" || -z "${CONTROLPLANE_SA}" || -z "${NODEPOOL_SA}" || -z "${CLOUDCONTROLLER_SA}" || -z "${STORAGE_SA}" || -z "${IMAGEREGISTRY_SA}" || -z "${NETWORK_SA}" ]]; then
     echo "ERROR: Failed to parse WIF configuration from IAM output"
     cat "${IAM_OUTPUT}"
     exit 1
@@ -131,6 +132,7 @@ echo "${NODEPOOL_SA}" > "${SHARED_DIR}/nodepool-sa"
 echo "${CLOUDCONTROLLER_SA}" > "${SHARED_DIR}/cloudcontroller-sa"
 echo "${STORAGE_SA}" > "${SHARED_DIR}/storage-sa"
 echo "${IMAGEREGISTRY_SA}" > "${SHARED_DIR}/imageregistry-sa"
+echo "${NETWORK_SA}" > "${SHARED_DIR}/network-sa"
 
 echo "WIF configuration saved to SHARED_DIR"
 

--- a/ci-operator/step-registry/hypershift/gcp/run-e2e/hypershift-gcp-run-e2e-commands.sh
+++ b/ci-operator/step-registry/hypershift/gcp/run-e2e/hypershift-gcp-run-e2e-commands.sh
@@ -45,6 +45,7 @@ CONTROLPLANE_SA=""
 CLOUDCONTROLLER_SA=""
 STORAGE_SA=""
 IMAGEREGISTRY_SA=""
+NETWORK_SA=""
 SA_SIGNING_KEY_PATH=""
 
 if [[ -f "${SHARED_DIR}/wif-project-number" ]]; then
@@ -70,6 +71,9 @@ if [[ -f "${SHARED_DIR}/storage-sa" ]]; then
 fi
 if [[ -f "${SHARED_DIR}/imageregistry-sa" ]]; then
     IMAGEREGISTRY_SA="$(<"${SHARED_DIR}/imageregistry-sa")"
+fi
+if [[ -f "${SHARED_DIR}/network-sa" ]]; then
+    NETWORK_SA="$(<"${SHARED_DIR}/network-sa")"
 fi
 if [[ -f "${SHARED_DIR}/sa-signing-key-path" ]]; then
     SA_SIGNING_KEY_PATH="$(<"${SHARED_DIR}/sa-signing-key-path")"
@@ -153,6 +157,7 @@ hack/ci-test-e2e.sh -test.v \
   --e2e.gcp-cloudcontroller-sa="${CLOUDCONTROLLER_SA}" \
   --e2e.gcp-storage-sa="${STORAGE_SA}" \
   --e2e.gcp-imageregistry-sa="${IMAGEREGISTRY_SA}" \
+  --e2e.gcp-network-sa="${NETWORK_SA}" \
   --e2e.gcp-sa-signing-key-path="${SA_SIGNING_KEY_PATH}" \
   --e2e.gcp-oidc-issuer-url="${OIDC_ISSUER_URL}" \
   --e2e.gcp-boot-image="${GCP_BOOT_IMAGE}" \


### PR DESCRIPTION
## Summary
- Extract `cloud-network` SA email from IAM output in hosted-cluster-setup step
- Pass `--e2e.gcp-network-sa` flag to e2e test binary in run-e2e step

## Context
HyperShift PR openshift/hypershift#7824 added e2e flag plumbing for the CNCC
network service account (`--e2e.gcp-network-sa`). The CI step needs to extract
the SA email and pass it through.

## Dependencies
- Requires: openshift/hypershift#7824 (already merged)

## Jira
- [GCP-431](https://issues.redhat.com/browse/GCP-431)

[GCP-431]: https://redhat.atlassian.net/browse/GCP-431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Strengthened validation in cluster setup process with additional identity verification and early failure detection mechanisms.
  * Improved persistence and data flow for identity configuration values between cluster setup and testing workflows.
  * Updated test execution configuration to properly propagate identity-related parameters through the testing pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->