### PR TITLE
opendatahub-operator: Skip main operator e2e tests when only cloud manager code changes

### DIFF
--- a/ci-operator/config/opendatahub-io/opendatahub-operator/opendatahub-io-opendatahub-operator-main.yaml
+++ b/ci-operator/config/opendatahub-io/opendatahub-operator/opendatahub-io-opendatahub-operator-main.yaml
@@ -64,7 +64,7 @@ tests:
     product: ocp
     timeout: 2h0m0s
     version: "4.20"
-  skip_if_only_changed: ^\.github/|^docs/|\.[mM][dD]$|^.gitignore$|^golangci|^crd-ref-docs\.config|^OWNERS$|^PROJECT$|^LICENSE$|^OWNERS_ALIASES$|^cmd/[^/]+/|^[^/]+\.(yaml|yml)$|^.gitleaksignore$|^.yamllint$
+  skip_if_only_changed: ^\.github/|^docs/|\.[mM][dD]$|^.gitignore$|^golangci|^crd-ref-docs\.config|^OWNERS$|^PROJECT$|^LICENSE$|^OWNERS_ALIASES$|^cmd/[^/]+/|^[^/]+\.(yaml|yml)$|^.gitleaksignore$|^.yamllint$|^api/cloudmanager/|^config/cloudmanager/|^internal/controller/cloudmanager/|^pkg/controller/cloudmanager/|^tests/e2e/cloudmanager/|^hack/update-cloudmanager-rbac\.sh$|^pkg/operatorconfig/cloudmanager\.go$|^pkg/utils/test/cloudmanager/
   steps:
     allow_best_effort_post_steps: true
     allow_skip_on_success: true
@@ -113,7 +113,7 @@ tests:
     product: ocp
     timeout: 2h0m0s
     version: "4.20"
-  skip_if_only_changed: ^\.github/|^docs/|\.[mM][dD]$|^.gitignore$|^golangci|^crd-ref-docs\.config|^OWNERS$|^PROJECT$|^LICENSE$|^OWNERS_ALIASES$|^cmd/[^/]+/|^[^/]+\.(yaml|yml)$|^.gitleaksignore$|^.yamllint$
+  skip_if_only_changed: ^\.github/|^docs/|\.[mM][dD]$|^.gitignore$|^golangci|^crd-ref-docs\.config|^OWNERS$|^PROJECT$|^LICENSE$|^OWNERS_ALIASES$|^cmd/[^/]+/|^[^/]+\.(yaml|yml)$|^.gitleaksignore$|^.yamllint$|^api/cloudmanager/|^config/cloudmanager/|^internal/controller/cloudmanager/|^pkg/controller/cloudmanager/|^tests/e2e/cloudmanager/|^hack/update-cloudmanager-rbac\.sh$|^pkg/operatorconfig/cloudmanager\.go$|^pkg/utils/test/cloudmanager/
   steps:
     allow_best_effort_post_steps: true
     allow_skip_on_success: true

--- a/ci-operator/jobs/opendatahub-io/opendatahub-operator/opendatahub-io-opendatahub-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/opendatahub-io/opendatahub-operator/opendatahub-io-opendatahub-operator-main-presubmits.yaml
@@ -71,7 +71,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-opendatahub-io-opendatahub-operator-main-opendatahub-operator-e2e
     rerun_command: /test opendatahub-operator-e2e
-    skip_if_only_changed: ^\.github/|^docs/|\.[mM][dD]$|^.gitignore$|^golangci|^crd-ref-docs\.config|^OWNERS$|^PROJECT$|^LICENSE$|^OWNERS_ALIASES$|^cmd/[^/]+/|^[^/]+\.(yaml|yml)$|^.gitleaksignore$|^.yamllint$
+    skip_if_only_changed: ^\.github/|^docs/|\.[mM][dD]$|^.gitignore$|^golangci|^crd-ref-docs\.config|^OWNERS$|^PROJECT$|^LICENSE$|^OWNERS_ALIASES$|^cmd/[^/]+/|^[^/]+\.(yaml|yml)$|^.gitleaksignore$|^.yamllint$|^api/cloudmanager/|^config/cloudmanager/|^internal/controller/cloudmanager/|^pkg/controller/cloudmanager/|^tests/e2e/cloudmanager/|^hack/update-cloudmanager-rbac\.sh$|^pkg/operatorconfig/cloudmanager\.go$|^pkg/utils/test/cloudmanager/
     spec:
       containers:
       - args:
@@ -159,7 +159,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-opendatahub-io-opendatahub-operator-main-opendatahub-operator-rhoai-e2e
     rerun_command: /test opendatahub-operator-rhoai-e2e
-    skip_if_only_changed: ^\.github/|^docs/|\.[mM][dD]$|^.gitignore$|^golangci|^crd-ref-docs\.config|^OWNERS$|^PROJECT$|^LICENSE$|^OWNERS_ALIASES$|^cmd/[^/]+/|^[^/]+\.(yaml|yml)$|^.gitleaksignore$|^.yamllint$
+    skip_if_only_changed: ^\.github/|^docs/|\.[mM][dD]$|^.gitignore$|^golangci|^crd-ref-docs\.config|^OWNERS$|^PROJECT$|^LICENSE$|^OWNERS_ALIASES$|^cmd/[^/]+/|^[^/]+\.(yaml|yml)$|^.gitleaksignore$|^.yamllint$|^api/cloudmanager/|^config/cloudmanager/|^internal/controller/cloudmanager/|^pkg/controller/cloudmanager/|^tests/e2e/cloudmanager/|^hack/update-cloudmanager-rbac\.sh$|^pkg/operatorconfig/cloudmanager\.go$|^pkg/utils/test/cloudmanager/
     spec:
       containers:
       - args:


### PR DESCRIPTION

Add cloud manager path prefixes to skip_if_only_changed regex on the two e2e test definitions. When a PR only touches CCM-scoped files the e2e jobs are now skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI configuration updated to skip full end-to-end runs when changes are limited to CloudManager-related code, tests, RBAC, or operator configuration. This reduces unnecessary builds, shortens pipeline runtime, and speeds feedback for unrelated changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->