### PR TITLE
Onboard rh-ecosystem-edge/qe-rhel-jetson to OpenShift CI

### DIFF
--- a/ci-operator/config/rh-ecosystem-edge/qe-rhel-jetson/OWNERS
+++ b/ci-operator/config/rh-ecosystem-edge/qe-rhel-jetson/OWNERS
@@ -1,5 +1,7 @@
 approvers:
 - ggordanired
+- onaim500
 options: {}
 reviewers:
 - ggordanired
+- onaim500

--- a/ci-operator/config/rh-ecosystem-edge/qe-rhel-jetson/OWNERS
+++ b/ci-operator/config/rh-ecosystem-edge/qe-rhel-jetson/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+- ggordanired
+options: {}
+reviewers:
+- ggordanired

--- a/ci-operator/config/rh-ecosystem-edge/qe-rhel-jetson/OWNERS
+++ b/ci-operator/config/rh-ecosystem-edge/qe-rhel-jetson/OWNERS
@@ -1,7 +1,5 @@
 approvers:
 - ggordanired
-- onaim500
 options: {}
 reviewers:
 - ggordanired
-- onaim500

--- a/ci-operator/config/rh-ecosystem-edge/qe-rhel-jetson/OWNERS
+++ b/ci-operator/config/rh-ecosystem-edge/qe-rhel-jetson/OWNERS
@@ -1,7 +1,9 @@
 approvers:
 - ggordanired
 - urilavi2
+- ybrodsky-rh
 options: {}
 reviewers:
 - ggordanired
 - urilavi2
+- ybrodsky-rh

--- a/ci-operator/config/rh-ecosystem-edge/qe-rhel-jetson/rh-ecosystem-edge-qe-rhel-jetson-main.yaml
+++ b/ci-operator/config/rh-ecosystem-edge/qe-rhel-jetson/rh-ecosystem-edge-qe-rhel-jetson-main.yaml
@@ -1,0 +1,48 @@
+base_images:
+  ubi-python:
+    name: ubi-python-312
+    namespace: ocp
+    tag: "9"
+build_root:
+  image_stream_tag:
+    name: release
+    namespace: openshift
+    tag: rhel-9-release-golang-1.23-openshift-4.18
+images:
+  items:
+  - dockerfile_literal: |
+      FROM ubi-python
+      USER 0
+      RUN dnf install -y git && \
+          ln -sf /usr/bin/python3.12 /usr/bin/python && \
+          ln -sf /usr/bin/pip3.12 /usr/bin/pip && \
+          pip install --no-cache-dir ruff pytest PyYAML requests paramiko && \
+          dnf clean all
+      COPY . /workspace/
+      WORKDIR /workspace
+    from: ubi-python
+    inputs:
+      src:
+        paths:
+        - destination_dir: .
+          source_path: /go/src/github.com/rh-ecosystem-edge/qe-rhel-jetson
+    to: qe-rhel-jetson
+resources:
+  '*':
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: lint
+  commands: |
+    cd /workspace
+    ruff check tests/
+  container:
+    from: qe-rhel-jetson
+  skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|OWNERS_ALIASES|PROJECT|LICENSE)$
+zz_generated_metadata:
+  branch: main
+  org: rh-ecosystem-edge
+  repo: qe-rhel-jetson

--- a/ci-operator/jobs/rh-ecosystem-edge/qe-rhel-jetson/OWNERS
+++ b/ci-operator/jobs/rh-ecosystem-edge/qe-rhel-jetson/OWNERS
@@ -1,5 +1,7 @@
 approvers:
 - ggordanired
+- onaim500
 options: {}
 reviewers:
 - ggordanired
+- onaim500

--- a/ci-operator/jobs/rh-ecosystem-edge/qe-rhel-jetson/OWNERS
+++ b/ci-operator/jobs/rh-ecosystem-edge/qe-rhel-jetson/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+- ggordanired
+options: {}
+reviewers:
+- ggordanired

--- a/ci-operator/jobs/rh-ecosystem-edge/qe-rhel-jetson/OWNERS
+++ b/ci-operator/jobs/rh-ecosystem-edge/qe-rhel-jetson/OWNERS
@@ -1,7 +1,5 @@
 approvers:
 - ggordanired
-- onaim500
 options: {}
 reviewers:
 - ggordanired
-- onaim500

--- a/ci-operator/jobs/rh-ecosystem-edge/qe-rhel-jetson/OWNERS
+++ b/ci-operator/jobs/rh-ecosystem-edge/qe-rhel-jetson/OWNERS
@@ -1,7 +1,9 @@
 approvers:
 - ggordanired
 - urilavi2
+- ybrodsky-rh
 options: {}
 reviewers:
 - ggordanired
 - urilavi2
+- ybrodsky-rh

--- a/ci-operator/jobs/rh-ecosystem-edge/qe-rhel-jetson/rh-ecosystem-edge-qe-rhel-jetson-main-presubmits.yaml
+++ b/ci-operator/jobs/rh-ecosystem-edge/qe-rhel-jetson/rh-ecosystem-edge-qe-rhel-jetson-main-presubmits.yaml
@@ -1,0 +1,121 @@
+presubmits:
+  rh-ecosystem-edge/qe-rhel-jetson:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build01
+    context: ci/prow/images
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-rh-ecosystem-edge-qe-rhel-jetson-main-images
+    rerun_command: /test images
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=[images]
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )images,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build01
+    context: ci/prow/lint
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-rh-ecosystem-edge-qe-rhel-jetson-main-lint
+    rerun_command: /test lint
+    skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|OWNERS_ALIASES|PROJECT|LICENSE)$
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=lint
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )lint,?($|\s.*)

--- a/core-services/prow/02_config/rh-ecosystem-edge/qe-rhel-jetson/_pluginconfig.yaml
+++ b/core-services/prow/02_config/rh-ecosystem-edge/qe-rhel-jetson/_pluginconfig.yaml
@@ -45,11 +45,6 @@ lgtm:
 - repos:
   - rh-ecosystem-edge/qe-rhel-jetson
   review_acts_as_lgtm: true
-triggers:
-- repos:
-  - rh-ecosystem-edge/qe-rhel-jetson
-  trusted_apps:
-  - openshift-merge-bot
 plugins:
   rh-ecosystem-edge/qe-rhel-jetson:
     plugins:
@@ -78,3 +73,8 @@ plugins:
     - wip
     - yuks
     - approve
+triggers:
+- repos:
+  - rh-ecosystem-edge/qe-rhel-jetson
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/rh-ecosystem-edge/qe-rhel-jetson/_pluginconfig.yaml
+++ b/core-services/prow/02_config/rh-ecosystem-edge/qe-rhel-jetson/_pluginconfig.yaml
@@ -45,6 +45,11 @@ lgtm:
 - repos:
   - rh-ecosystem-edge/qe-rhel-jetson
   review_acts_as_lgtm: true
+triggers:
+- repos:
+  - rh-ecosystem-edge/qe-rhel-jetson
+  trusted_apps:
+  - openshift-merge-bot
 plugins:
   rh-ecosystem-edge/qe-rhel-jetson:
     plugins:

--- a/core-services/prow/02_config/rh-ecosystem-edge/qe-rhel-jetson/_pluginconfig.yaml
+++ b/core-services/prow/02_config/rh-ecosystem-edge/qe-rhel-jetson/_pluginconfig.yaml
@@ -1,0 +1,75 @@
+approve:
+- repos:
+  - rh-ecosystem-edge/qe-rhel-jetson
+  require_self_approval: false
+external_plugins:
+  rh-ecosystem-edge/qe-rhel-jetson:
+  - endpoint: http://refresh
+    events:
+    - issue_comment
+    name: refresh
+  - endpoint: http://cherrypick
+    events:
+    - issue_comment
+    - pull_request
+    name: cherrypick
+  - endpoint: http://needs-rebase
+    events:
+    - issue_comment
+    - pull_request
+    name: needs-rebase
+  - endpoint: http://backport-verifier
+    events:
+    - issue_comment
+    - pull_request
+    name: backport-verifier
+  - endpoint: http://payload-testing-prow-plugin
+    events:
+    - issue_comment
+    name: payload-testing-prow-plugin
+  - endpoint: http://jira-lifecycle-plugin
+    events:
+    - issue_comment
+    - pull_request
+    name: jira-lifecycle-plugin
+  - endpoint: http://pipeline-controller
+    events:
+    - pull_request
+    - issue_comment
+    name: pipeline-controller
+  - endpoint: http://multi-pr-prow-plugin
+    events:
+    - issue_comment
+    name: multi-pr-prow-plugin
+lgtm:
+- repos:
+  - rh-ecosystem-edge/qe-rhel-jetson
+  review_acts_as_lgtm: true
+plugins:
+  rh-ecosystem-edge/qe-rhel-jetson:
+    plugins:
+    - assign
+    - blunderbuss
+    - cat
+    - dog
+    - heart
+    - golint
+    - goose
+    - help
+    - hold
+    - jira
+    - label
+    - lgtm
+    - lifecycle
+    - override
+    - pony
+    - retitle
+    - shrug
+    - sigmention
+    - skip
+    - trigger
+    - verify-owners
+    - owners-label
+    - wip
+    - yuks
+    - approve

--- a/core-services/prow/02_config/rh-ecosystem-edge/qe-rhel-jetson/_pluginconfig.yaml
+++ b/core-services/prow/02_config/rh-ecosystem-edge/qe-rhel-jetson/_pluginconfig.yaml
@@ -74,7 +74,9 @@ plugins:
     - yuks
     - approve
 triggers:
-- repos:
+- org_invite:
+    prominent: {}
+  repos:
   - rh-ecosystem-edge/qe-rhel-jetson
   trusted_apps:
   - openshift-merge-bot

--- a/core-services/prow/02_config/rh-ecosystem-edge/qe-rhel-jetson/_prowconfig.yaml
+++ b/core-services/prow/02_config/rh-ecosystem-edge/qe-rhel-jetson/_prowconfig.yaml
@@ -1,0 +1,14 @@
+tide:
+  queries:
+  - labels:
+    - approved
+    - lgtm
+    missingLabels:
+    - backports/unvalidated-commits
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - jira/invalid-bug
+    - needs-rebase
+    repos:
+    - rh-ecosystem-edge/qe-rhel-jetson


### PR DESCRIPTION
Adds CI operator config, generated Prow jobs, and Prow plugin/tide config for the qe-rhel-jetson repository. Sets up a Python 3.12 (UBI9) test image with a lint presubmit using ruff. Hardware-based tests (Beaker/Jumpstarter) will follow in a subsequent PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated CI pipeline with linting and test steps for the repository.
  * Configured repository approval and reviewer settings to authorize designated approvers.
  * Enabled repository-level Prow plugins and triggers for review, merge automation, and integration with external tooling.
  * Defined Tide rules to allow automatic merging when approvals and quality checks are satisfied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->