### PR TITLE
Don't recreate override config in aro hcp deprov step

### DIFF
--- a/ci-operator/step-registry/aro-hcp/deprovision/environment/aro-hcp-deprovision-environment-commands.sh
+++ b/ci-operator/step-registry/aro-hcp/deprovision/environment/aro-hcp-deprovision-environment-commands.sh
@@ -11,21 +11,12 @@ export AZURE_TENANT_ID; AZURE_TENANT_ID=$(cat "${CLUSTER_PROFILE_DIR}/tenant")
 export AZURE_CLIENT_SECRET; AZURE_CLIENT_SECRET=$(cat "${CLUSTER_PROFILE_DIR}/client-secret")
 export AZURE_TOKEN_CREDENTIALS=prod
 
-INFRA_SUB_NAME=$(cat "${CLUSTER_PROFILE_DIR}/infra-${INFRA_SHARD}-subscription-name")
 INFRA_SUB_ID=$(cat "${CLUSTER_PROFILE_DIR}/infra-${INFRA_SHARD}-subscription-id")
-DEPLOY_ENV="prow"
 
 az login --service-principal -u "${AZURE_CLIENT_ID}" -p "${AZURE_CLIENT_SECRET}" --tenant "${AZURE_TENANT_ID}" --output none
 az account set --subscription "${INFRA_SUB_ID}"
 
-OVERRIDE_CONFIG_FILE=${OVERRIDE_CONFIG_FILE:-/tmp/rp-override-config-$(date +%s).yaml}
-
-yq eval -n "
-  .clouds.dev.environments.${DEPLOY_ENV}.defaults.svc.subscription.key = \"${INFRA_SUB_NAME}\" |
-  .clouds.dev.environments.${DEPLOY_ENV}.defaults.mgmt.subscription.key = \"${INFRA_SUB_NAME}\"
-" > "${OVERRIDE_CONFIG_FILE}"
-echo "Created override config at: ${OVERRIDE_CONFIG_FILE}"
-cat "${OVERRIDE_CONFIG_FILE}"
+OVERRIDE_CONFIG_FILE="${SHARED_DIR}/config-override.yaml"
 
 unset GOFLAGS
 make -o tooling/templatize/templatize cleanup-entrypoint/Region \

--- a/ci-operator/step-registry/aro-hcp/provision/environment/aro-hcp-provision-environment-commands.sh
+++ b/ci-operator/step-registry/aro-hcp/provision/environment/aro-hcp-provision-environment-commands.sh
@@ -52,7 +52,7 @@ else
 fi
 echo "USE_OC_LOGIN_REGISTRIES set to: ${USE_OC_LOGIN_REGISTRIES}"
 
-OVERRIDE_CONFIG_FILE=${OVERRIDE_CONFIG_FILE:-/tmp/rp-override-config-$(date +%s).yaml}
+OVERRIDE_CONFIG_FILE="${SHARED_DIR}/config-override.yaml"
 
 MSI_MOCK_CLIENT_ID=$(yq ".miMockPool.\"${LEASED_MSI_MOCK_SP}\".clientId" dev-infrastructure/openshift-ci/msi-mock-pool.yaml)
 MSI_MOCK_PRINCIPAL_ID=$(yq ".miMockPool.\"${LEASED_MSI_MOCK_SP}\".principalId" dev-infrastructure/openshift-ci/msi-mock-pool.yaml)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Provisioning workflow now uses fixed configuration file locations from shared resources instead of generating timestamped files during each run
  * Deprovisioning workflow simplified to reference pre-existing configuration override files instead of creating new dynamic overrides
  * Reduces infrastructure complexity and file system operations during deployment cycles

<!-- end of auto-generated comment: release notes by coderabbit.ai -->