### PR TITLE
SREP-4676: skip non-applicapable test for rosa hcp conformance

### DIFF
--- a/ci-operator/step-registry/rosa/aws/hcp/conformance/rosa-aws-hcp-conformance-workflow.yaml
+++ b/ci-operator/step-registry/rosa/aws/hcp/conformance/rosa-aws-hcp-conformance-workflow.yaml
@@ -30,7 +30,7 @@ workflow:
         DRA.*kubelet.*DynamicResourceAllocation\|
         InPlacePodVerticalScaling.*decrease memory limit below usage\|
         CSI Mock volume expansion Expansion with recovery recovery should not be possible\|
-        CSI Mock volume expansion Expansion with recovery should allow recovery if controller expansion fails with final error\|cloud-provider-aws-e2e.*loadbalancer NLB internal should be reachable with hairpinning traffic\|cloud-provider-aws-e2e.*loadbalancer NLB should be reachable with target-node-labels
+        CSI Mock volume expansion Expansion with recovery should allow recovery if controller expansion fails with final error\|cloud-provider-aws-e2e.*loadbalancer NLB internal should be reachable with hairpinning traffic\|cloud-provider-aws-e2e.*loadbalancer NLB should be reachable with target-node-labels\|\[Monitor:apiserver-incluster-availability\]\[Jira:\\"kube-apiserver\\"\] monitor test apiserver-incluster-availability
     pre:
       - chain: rosa-aws-sts-hcp-provision
       - ref: osd-ccs-conf-idp-htpasswd-multi-users


### PR DESCRIPTION
[Monitor:apiserver-incluster-availability][Jira:"kube-apiserver"] monitor test apiserver-incluster-availability setup
Failed with 
```
{  failed during setup
both the HYPERSHIFT_MANAGEMENT_CLUSTER_KUBECONFIG and the HYPERSHIFT_MANAGEMENT_CLUSTER_NAMESPACE env var must be set}
```
we do not have the env to set

[Monitor:apiserver-incluster-availability][Jira:"kube-apiserver"] monitor test apiserver-incluster-availability collection
failed with invalid memory address or nil pointer, should be a symptom of the previous setup failed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI test configuration to skip additional monitor availability checks during conformance testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->