### PR TITLE
Add env var to skip chain trigger in curl triggers

### DIFF
--- a/ci-operator/step-registry/telcov10n/functional/cnf-network/trigger-job/telcov10n-functional-cnf-network-trigger-job-commands.sh
+++ b/ci-operator/step-registry/telcov10n/functional/cnf-network/trigger-job/telcov10n-functional-cnf-network-trigger-job-commands.sh
@@ -8,7 +8,14 @@ if [ -f "${SHARED_DIR}/skip.txt" ]; then
   exit 0
 fi
 
-echo "Set tigger TOKEN env var"
+# Only trigger the next job in the chain if SKIP_CHAIN_TRIGGER is not set
+# When manually triggering via curl, pass: "MULTISTAGE_PARAM_OVERRIDE_SKIP_CHAIN_TRIGGER": "true"
+if [ "${SKIP_CHAIN_TRIGGER}" == "true" ]; then
+  echo "SKIP_CHAIN_TRIGGER is set to true — skipping chain trigger to prevent cascade"
+  exit 0
+fi
+
+echo "Set trigger TOKEN env var"
 TOKEN=$(cat /var/prow-trigger-token/token)
 
 curl -v -X POST \

--- a/ci-operator/step-registry/telcov10n/functional/cnf-network/trigger-job/telcov10n-functional-cnf-network-trigger-job-ref.yaml
+++ b/ci-operator/step-registry/telcov10n/functional/cnf-network/trigger-job/telcov10n-functional-cnf-network-trigger-job-ref.yaml
@@ -20,3 +20,6 @@ ref:
     - name: JOB_TYPE
       default: ""
       documentation: The type of job
+    - name: SKIP_CHAIN_TRIGGER
+      default: "false"
+      documentation: Set to 'true' to skip triggering the next job (JOB_NAME) in the version chain (for curl triggers)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for skipping subsequent job triggers via a new configuration option, allowing users to control whether chained jobs execute in their CI/CD pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->