### PR TITLE
Remove skip.txt only for job that do not contain network

### DIFF
--- a/ci-operator/step-registry/telcov10n/functional/cnf-network/trigger-job/telcov10n-functional-cnf-network-trigger-job-commands.sh
+++ b/ci-operator/step-registry/telcov10n/functional/cnf-network/trigger-job/telcov10n-functional-cnf-network-trigger-job-commands.sh
@@ -2,6 +2,13 @@
 set -e
 set -o pipefail
 
+# if job name does not include network, we remove the skip.txt to allow cascade triggering
+echo "Validate JOB NAME variable: ${JOB_NAME}"
+if [[ "${JOB_NAME}" != *"network"* ]]; then
+  echo "JOB NAME does not include network — removing skip.txt"
+  rm -f "${SHARED_DIR}/skip.txt"
+fi
+
 echo "Checking if the job should be skipped..."
 if [ -f "${SHARED_DIR}/skip.txt" ]; then
   echo "Detected skip.txt file — skipping the job"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed job skip logic for CNF network functional tests to ensure proper execution when job names contain "network" criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->