### PR TITLE
OCPBUGS-84670: OpenStack: fix NFV jobs failing to provision performance profile

### DIFF
--- a/ci-operator/step-registry/openshift/e2e/openstack/nfv/cgroupsv1/openshift-e2e-openstack-nfv-cgroupsv1-workflow.yaml
+++ b/ci-operator/step-registry/openshift/e2e/openstack/nfv/cgroupsv1/openshift-e2e-openstack-nfv-cgroupsv1-workflow.yaml
@@ -4,8 +4,8 @@ workflow:
     allow_best_effort_post_steps: true
     pre:
       - chain: ipi-openstack-pre-cgroupsv1
-      - ref: openstack-provision-performanceprofile
       - ref: openstack-provision-sriov-worker
+      - ref: openstack-provision-performanceprofile
       - ref: operator-pipelines-preflight-prod-health
       - ref: openstack-provision-sriov-operator
       - ref: openstack-provision-sriov-networknodepolicy

--- a/ci-operator/step-registry/openshift/e2e/openstack/nfv/openshift-e2e-openstack-nfv-workflow.yaml
+++ b/ci-operator/step-registry/openshift/e2e/openstack/nfv/openshift-e2e-openstack-nfv-workflow.yaml
@@ -4,8 +4,8 @@ workflow:
     allow_best_effort_post_steps: true
     pre:
       - chain: ipi-openstack-pre
-      - ref: openstack-provision-performanceprofile
       - ref: openstack-provision-sriov-worker
+      - ref: openstack-provision-performanceprofile
       - ref: operator-pipelines-preflight-prod-health
       - ref: openstack-provision-sriov-operator
       - ref: openstack-provision-sriov-networknodepolicy

--- a/ci-operator/step-registry/openstack/provision/performanceprofile/openstack-provision-performanceprofile-commands.sh
+++ b/ci-operator/step-registry/openstack/provision/performanceprofile/openstack-provision-performanceprofile-commands.sh
@@ -5,9 +5,11 @@ set -o errexit
 set -o pipefail
 
 function check_workers_updated() {
-    # Wait up to 2 minutes for PAO to update the worker config
-    INTERVAL=5
-    CNT=24
+    # Wait up to 30 minutes for the performance profile to be applied.
+    # This includes time for NTO to create the MachineConfig and for
+    # the MCO to roll it out to worker nodes (which requires a reboot).
+    INTERVAL=30
+    CNT=60
 
     while [ $((CNT)) -gt 0 ]; do
         READY=false
@@ -15,13 +17,15 @@ function check_workers_updated() {
         do
             name=$(echo "${i}" | awk '{print $1}')
             current_config=$(echo "${i}" | awk '{print $2}')
+            updated=$(echo "${i}" | awk '{print $3}')
+            updating=$(echo "${i}" | awk '{print $4}')
             degraded=$(echo "${i}" | awk '{print $5}')
             degraded_machine_cnt=$(echo "${i}" | awk '{print $9}')
 
-            if [[ "${old_config}" != "${current_config}" && "${degraded}" == "False" && $((degraded_machine_cnt)) -eq 0 ]]; then
+            if [[ "${old_config}" != "${current_config}" && "${updated}" == "True" && "${updating}" == "False" && "${degraded}" == "False" && $((degraded_machine_cnt)) -eq 0 ]]; then
                 READY=true
             else
-                echo "Waiting for mcp ${name} to rollout"
+                echo "Waiting for mcp ${name} to rollout (updated=${updated} updating=${updating} degraded=${degraded})"
                 READY=false
             fi
         done <<< "$(oc get mcp worker --no-headers)"


### PR DESCRIPTION
NTO PR#1474 [1] introduced a bootcmdline synchronization protocol that blocks MachineConfig creation until a Tuned daemon provides bootcmdline data. The NFV workflows install a compact cluster with 0 workers and apply the PerformanceProfile before creating the SR-IOV worker node, so no Tuned daemon exists and NTO blocks forever.

Swap the step order so the SR-IOV worker is created before the PerformanceProfile is applied. Also update check_workers_updated to wait for the full MCP rollout (the worker now reboots to apply the profile) and increase the timeout from 2 to 30 minutes.

[1] https://github.com/openshift/cluster-node-tuning-operator/pull/1474

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized OpenStack NFV workflow step execution sequence.
  * Enhanced performance profile provisioning with extended timeout (up to 30 minutes) and improved rollout status validation to ensure complete configuration deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->