### PR TITLE
Disabling threshold for virt runs

### DIFF
--- a/ci-operator/step-registry/openshift-qe/virt-density-nomount/openshift-qe-virt-density-nomount-ref.yaml
+++ b/ci-operator/step-registry/openshift-qe/virt-density-nomount/openshift-qe-virt-density-nomount-ref.yaml
@@ -48,9 +48,9 @@ ref:
     documentation: |-
       Kube-burner indexing profile type
   - name: VMI_READY_THRESHOLD
-    default: "240"
+    default: "0"
     documentation: |-
-      VMI ready timeout threshold
+      VMI ready timeout threshold. A value of 0 gets ignored.
   - name: VMS_PER_NODE
     default: "200"
     documentation: |-

--- a/ci-operator/step-registry/openshift-qe/virt-density/openshift-qe-virt-density-ref.yaml
+++ b/ci-operator/step-registry/openshift-qe/virt-density/openshift-qe-virt-density-ref.yaml
@@ -48,9 +48,9 @@ ref:
     documentation: |-
       Kube-burner indexing profile type
   - name: VMI_READY_THRESHOLD
-    default: "240"
+    default: "0"
     documentation: |-
-      VMI ready timeout threshold
+      VMI ready timeout threshold. A value of 0 gets ignored.
   - name: VMS_PER_NODE
     default: "200"
     documentation: |-

--- a/ci-operator/step-registry/openshift-qe/virt-udn-density/openshift-qe-virt-udn-density-ref.yaml
+++ b/ci-operator/step-registry/openshift-qe/virt-udn-density/openshift-qe-virt-udn-density-ref.yaml
@@ -52,8 +52,8 @@ ref:
     documentation: |-
       Kube-burner indexing profile type
   - name: VMI_READY_THRESHOLD
-    default: "90"
+    default: "0"
     documentation: |-
-      VMI ready timeout threshold
+      VMI ready timeout threshold. A value of 0 gets ignored.
   documentation: >-
     This step runs the perfscale virt-density-udn workload in the deployed cluster, needs CNV to be deployed.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default configuration for virtual machine instance ready threshold across test step registries. A threshold value of 0 is now ignored by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->