### PR TITLE
OCPBUGS-84684: fix: exclude sensitive logs from dump tarball

### DIFF
--- a/ci-operator/step-registry/hypershift/destroy-nested-management-cluster/hypershift-destroy-nested-management-cluster-chain.yaml
+++ b/ci-operator/step-registry/hypershift/destroy-nested-management-cluster/hypershift-destroy-nested-management-cluster-chain.yaml
@@ -22,7 +22,13 @@ chain:
       CLUSTER_NAME="$(echo -n $PROW_JOB_ID|sha256sum|cut -c-10)-mgmt"
       mkdir -p "${ARTIFACT_DIR}/output"
       bin/hypershift dump cluster --dump-guest-cluster=true --artifact-dir="${ARTIFACT_DIR}/output" --name="${CLUSTER_NAME}" --namespace="${HYPERSHIFT_NAMESPACE}"
-      tar -cvzf "${ARTIFACT_DIR}/artifacts.tar.gz" "${ARTIFACT_DIR}/output"
+
+      # Azure dump logs trigger leaktk/gcs-filter censoring; exclude them so the tarball survives
+      TAR_EXCLUDES=""
+      if [[ "${CLOUD_PROVIDER}" == "Azure" ]]; then
+        TAR_EXCLUDES='--exclude=*ignition-server*.log --exclude=*audit-logs.log'
+      fi
+      tar -cvzf "${ARTIFACT_DIR}/artifacts.tar.gz" ${TAR_EXCLUDES} "${ARTIFACT_DIR}/output"
       rm -rf "${ARTIFACT_DIR}/output"
     credentials:
     - mount_path: /etc/hypershift-kubeconfig

--- a/ci-operator/step-registry/hypershift/destroy-nested-management-cluster/hypershift-destroy-nested-management-cluster-chain.yaml
+++ b/ci-operator/step-registry/hypershift/destroy-nested-management-cluster/hypershift-destroy-nested-management-cluster-chain.yaml
@@ -27,6 +27,10 @@ chain:
       TAR_EXCLUDES=""
       if [[ "${CLOUD_PROVIDER}" == "Azure" ]]; then
         TAR_EXCLUDES='--exclude=*ignition-server*.log --exclude=*audit-logs.log'
+        mkdir -p "${ARTIFACT_DIR}/excluded-logs"
+        find "${ARTIFACT_DIR}/output" -name "*ignition-server*.log" -o -name "*audit-logs.log" | while read f; do
+          cp "$f" "${ARTIFACT_DIR}/excluded-logs/"
+        done
       fi
       tar -cvzf "${ARTIFACT_DIR}/artifacts.tar.gz" ${TAR_EXCLUDES} "${ARTIFACT_DIR}/output"
       rm -rf "${ARTIFACT_DIR}/output"


### PR DESCRIPTION
## Summary
- Excludes ignition-server logs and audit-logs from the management cluster dump tarball
- These two file patterns trigger the `leaktk/gcs-filter` Cloud Function (gitleaks-based secret scanner), which replaces the **entire tarball** with a "potentially sensitive information" notice
- With the exclusions, the tarball survives and all other dump artifacts remain accessible

## Root Cause
The `leaktk/gcs-filter` Cloud Function monitors GCS buckets post-upload and scans files using gitleaks rules. When it detects a match inside a tarball, it replaces the entire file — losing all dump artifacts. The two files that trigger detection are:
- `*ignition-server*.log` — ignition server logs containing embedded certificates and tokens
- `*audit-logs.log` — OAuth API server audit logs containing bearer tokens in request headers

Evidence from [Cesar's PR #78214](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/78214/rehearse-78214-pull-ci-openshift-hypershift-main-e2e-azure-self-managed/2048799772231340032) which dumped files without tarring confirmed only these 2 files (out of thousands) were censored.

## Test plan
- [ ] Rehearsal job `pull-ci-openshift-hypershift-main-e2e-azure-self-managed` produces a tarball that is not censored by gcs-filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI artifact packaging: archives now conditionally exclude certain Azure-specific log files to reduce archive size and avoid exposing sensitive logs.
  * Excluded log files are copied aside into a separate location prior to packaging so they remain available.
  * Existing cleanup behavior for intermediate output remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->