### PR TITLE
OCPBUGS-84493,SPLAT-2733: Modified vsphere hybrid jobs to exclude VSphereDriverConfiguratin

### DIFF
--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22.yaml
@@ -1102,7 +1102,7 @@ tests:
       TEST_SKIPS: 'In-tree Volumes \[Driver: vsphere\]'
     workflow: openshift-e2e-vsphere-upi-multi-vcenter
 - as: e2e-vsphere-ovn-hybrid-env-techpreview
-  cron: '@daily'
+  cron: 45 7 * * *
   steps:
     cluster_profile: vsphere-elastic
     env:
@@ -1115,7 +1115,7 @@ tests:
         low level operators
     workflow: openshift-e2e-vsphere-hybrid-env
 - as: e2e-vsphere-ovn-hybrid-env-serial-techpreview
-  cron: '@daily'
+  cron: 50 7 * * *
   steps:
     cluster_profile: vsphere-elastic
     env:
@@ -1124,11 +1124,12 @@ tests:
       NETWORK_TYPE: multi-tenant
       PERSISTENT_MONITORING: "false"
       SETUP_IMAGE_REGISTRY_WITH_PVC: "false"
-      TEST_SKIPS: \[sig-arch\]\[Early\] Operators low level operators
+      TEST_SKIPS: \[FeatureGate:VSphereDriverConfiguration\]\|\[sig-arch\]\[Early\]
+        Operators low level operators
       TEST_SUITE: openshift/conformance/serial
     workflow: openshift-e2e-vsphere-hybrid-env
 - as: e2e-vsphere-ovn-upi-hybrid-env-techpreview
-  cron: '@daily'
+  cron: 55 7 * * *
   steps:
     cluster_profile: vsphere-elastic
     env:

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.23.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.23.yaml
@@ -1065,7 +1065,7 @@ tests:
       TEST_SKIPS: 'In-tree Volumes \[Driver: vsphere\]'
     workflow: openshift-e2e-vsphere-upi-multi-vcenter
 - as: e2e-vsphere-ovn-hybrid-env-techpreview
-  cron: '@weekly'
+  cron: 30 18 * * 1
   steps:
     cluster_profile: vsphere-elastic
     env:
@@ -1078,7 +1078,7 @@ tests:
         low level operators
     workflow: openshift-e2e-vsphere-hybrid-env
 - as: e2e-vsphere-ovn-hybrid-env-serial-techpreview
-  cron: '@weekly'
+  cron: 35 18 * * 1
   steps:
     cluster_profile: vsphere-elastic
     env:
@@ -1087,11 +1087,12 @@ tests:
       NETWORK_TYPE: multi-tenant
       PERSISTENT_MONITORING: "false"
       SETUP_IMAGE_REGISTRY_WITH_PVC: "false"
-      TEST_SKIPS: \[sig-arch\]\[Early\] Operators low level operators
+      TEST_SKIPS: \[FeatureGate:VSphereDriverConfiguration\]\|\[sig-arch\]\[Early\]
+        Operators low level operators
       TEST_SUITE: openshift/conformance/serial
     workflow: openshift-e2e-vsphere-hybrid-env
 - as: e2e-vsphere-ovn-upi-hybrid-env-techpreview
-  cron: '@weekly'
+  cron: 40 18 * * 1
   steps:
     cluster_profile: vsphere-elastic
     env:

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
@@ -1065,7 +1065,7 @@ tests:
       TEST_SKIPS: 'In-tree Volumes \[Driver: vsphere\]'
     workflow: openshift-e2e-vsphere-upi-multi-vcenter
 - as: e2e-vsphere-ovn-hybrid-env-techpreview
-  cron: '@daily'
+  cron: 45 1 * * *
   steps:
     cluster_profile: vsphere-elastic
     env:
@@ -1078,7 +1078,7 @@ tests:
         low level operators
     workflow: openshift-e2e-vsphere-hybrid-env
 - as: e2e-vsphere-ovn-hybrid-env-serial-techpreview
-  cron: '@daily'
+  cron: 50 1 * * *
   steps:
     cluster_profile: vsphere-elastic
     env:
@@ -1087,11 +1087,12 @@ tests:
       NETWORK_TYPE: multi-tenant
       PERSISTENT_MONITORING: "false"
       SETUP_IMAGE_REGISTRY_WITH_PVC: "false"
-      TEST_SKIPS: \[sig-arch\]\[Early\] Operators low level operators
+      TEST_SKIPS: \[FeatureGate:VSphereDriverConfiguration\]\|\[sig-arch\]\[Early\]
+        Operators low level operators
       TEST_SUITE: openshift/conformance/serial
     workflow: openshift-e2e-vsphere-hybrid-env
 - as: e2e-vsphere-ovn-upi-hybrid-env-techpreview
-  cron: '@daily'
+  cron: 50 1 * * *
   steps:
     cluster_profile: vsphere-elastic
     env:


### PR DESCRIPTION
[SPLAT-2733](https://redhat.atlassian.net/browse/SPLAT-2733)

### Changes
- Modified vSphere hybrid env jobs to exclude tests with `[FeatureGate:VSphereDriverConfiguration]`
- Adjusted cron times to be during a slower period

[SPLAT-2733]: https://redhat.atlassian.net/browse/SPLAT-2733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched vSphere hybrid environment test jobs from generic schedules to explicit daily and weekly cron times for more consistent run timing across releases.
  * Expanded test filtering to also exclude tests gated by the VSphereDriverConfiguration feature, combined with the existing low-level operators skip criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->