### PR TITLE
Update quay 3.18 API testing with latest konflux build

### DIFF
--- a/ci-operator/config/quay/quay-tests/quay-quay-tests-master__quay-api.yaml
+++ b/ci-operator/config/quay/quay-tests/quay-quay-tests-master__quay-api.yaml
@@ -133,7 +133,7 @@ tests:
     env:
       BASE_DOMAIN: quayqe.devcluster.openshift.com
       COMPUTE_NODE_TYPE: m5.2xlarge
-      MULTISTAGE_PARAM_OVERRIDE_QUAY_INDEX_IMAGE: quay.io/redhat-user-workloads/quay-eng-tenant/stable-3-18-v4-21@sha256:c69bc0168f3edb272e7e5f10f6e0e60b5b072982affac8813dfacdc3f5f5b64b
+      MULTISTAGE_PARAM_OVERRIDE_QUAY_INDEX_IMAGE: quay.io/redhat-user-workloads/quay-eng-tenant/stable-3-18-v4-21@sha256:f7f0740742d6588794af695a50d47cba3579537935d4996e7cf2a94a9deeaf61
       QUAY_OPERATOR_CHANNEL: stable-3.18
       QUAY_OPERATOR_SOURCE: fbc-operator-catalog
       QUAY_VERSION: "3.18"

--- a/ci-operator/step-registry/quay-tests/test/quay-api/quay-tests-test-quay-api-commands.sh
+++ b/ci-operator/step-registry/quay-tests/test/quay-api/quay-tests-test-quay-api-commands.sh
@@ -20,7 +20,8 @@ npm install
 
 # Determine which Cypress spec to use based on Quay version
 CYPRESS_SPEC="cypress/e2e/quay_api_testing_all.cy.js"
-if [[ "${QUAY_VERSION}" == "3.16" || "${QUAY_VERSION}" == "3.17" ]]; then
+QUAY_MINOR_VERSION=$(echo "${QUAY_VERSION}" | cut -d'.' -f2)
+if [[ "${QUAY_MINOR_VERSION}" -ge 16 ]]; then
     echo "Using new UI spec for Quay version ${QUAY_VERSION}"
     CYPRESS_SPEC="cypress/e2e/quay_api_testing_all_new_ui.cy.js"
 else

--- a/ci-operator/step-registry/quay-tests/test/quay-api/quay-tests-test-quay-api-commands.sh
+++ b/ci-operator/step-registry/quay-tests/test/quay-api/quay-tests-test-quay-api-commands.sh
@@ -35,3 +35,7 @@ mkdir -p $ARTIFACT_DIR/quay_api_testing_cypress_videos || true
 cp cypress/results/quay_api_testing_report.xml $ARTIFACT_DIR/quay_api_testing_report.xml || true
 cp quay_api_testing_report $ARTIFACT_DIR/quay_api_testing_report || true
 cp cypress/videos/* $ARTIFACT_DIR/quay_api_testing_cypress_videos/ || true
+
+# Sleep 4 hours for debugging API testing
+echo "Sleeping 4 hours for debugging..."
+sleep 14400

--- a/ci-operator/step-registry/quay-tests/test/quay-api/quay-tests-test-quay-api-commands.sh
+++ b/ci-operator/step-registry/quay-tests/test/quay-api/quay-tests-test-quay-api-commands.sh
@@ -35,7 +35,3 @@ mkdir -p $ARTIFACT_DIR/quay_api_testing_cypress_videos || true
 cp cypress/results/quay_api_testing_report.xml $ARTIFACT_DIR/quay_api_testing_report.xml || true
 cp quay_api_testing_report $ARTIFACT_DIR/quay_api_testing_report || true
 cp cypress/videos/* $ARTIFACT_DIR/quay_api_testing_cypress_videos/ || true
-
-# Sleep 4 hours for debugging API testing
-echo "Sleeping 4 hours for debugging..."
-sleep 14400

--- a/ci-operator/step-registry/quay-tests/test/quay-api/quay-tests-test-quay-api-ref.yaml
+++ b/ci-operator/step-registry/quay-tests/test/quay-api/quay-tests-test-quay-api-ref.yaml
@@ -10,7 +10,7 @@ ref:
     requests:
       cpu: 10m
       memory: 100Mi
-  timeout: 4h0m0s
+  timeout: 8h0m0s
   grace_period: 15m0s
   credentials:
   - namespace: test-credentials

--- a/ci-operator/step-registry/quay-tests/test/quay-api/quay-tests-test-quay-api-ref.yaml
+++ b/ci-operator/step-registry/quay-tests/test/quay-api/quay-tests-test-quay-api-ref.yaml
@@ -10,7 +10,7 @@ ref:
     requests:
       cpu: 10m
       memory: 100Mi
-  timeout: 8h0m0s
+  timeout: 4h0m0s
   grace_period: 15m0s
   credentials:
   - namespace: test-credentials


### PR DESCRIPTION
## Summary
- Update the quay index image SHA for `stable-3-18-v4-21` to the latest konflux build
- Replace hardcoded version comparison (`== "3.16" || == "3.17"`) with numeric minor version check (`>= 16`) for future-proofing the Cypress spec selection

## Test plan
- [x] Verify the new quay index image SHA resolves correctly
- [x] Verify quay API testing job runs successfully with the updated image
- [x] Confirm version check logic correctly selects the new UI spec for 3.16+

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI pipeline to use a refreshed, pinned image digest for the Quay e2e job.
* **Tests**
  * Improved test automation to select test specs based on parsed minor version (>=16) rather than hardcoded version checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->