### PR TITLE
Add KServe inference E2E workflow for AWS Neuron

### DIFF
--- a/ci-operator/config/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main__4.21-stable.yaml
+++ b/ci-operator/config/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main__4.21-stable.yaml
@@ -89,6 +89,46 @@ tests:
       OPENSHIFT_VERSION: "4.21"
       REGION: us-west-2
     workflow: aws-neuron-operator-conditional-e2e-rosa
+- always_run: false
+  as: aws-neuron-operator-kserve-e2e
+  steps:
+    allow_best_effort_post_steps: true
+    cluster_profile: aws-edge-infra
+    env:
+      ECO_HWACCEL_NEURON_DEVICE_PLUGIN_IMAGE: public.ecr.aws/neuron/neuron-device-plugin:2.29.94.0
+      ECO_HWACCEL_NEURON_DRIVER_VERSION: 2.25.4.0
+      ECO_HWACCEL_NEURON_DRIVERS_IMAGE: public.ecr.aws/os-partners/neuron-openshift/neuron-kernel-module:2.25.4.0
+      ECO_HWACCEL_NEURON_KSERVE_MODEL_NAME: TinyLlama/TinyLlama-1.1B-Chat-v1.0
+      ECO_HWACCEL_NEURON_KSERVE_VLLM_IMAGE: registry.redhat.io/rhaiis/vllm-neuron-rhel9:3
+      ECO_HWACCEL_NEURON_NODE_METRICS_IMAGE: public.ecr.aws/neuron/neuron-monitor:1.3.0
+      ECO_HWACCEL_NEURON_SCHEDULER_EXTENSION_IMAGE: public.ecr.aws/neuron/neuron-scheduler:2.29.94.0
+      ECO_HWACCEL_NEURON_SCHEDULER_IMAGE: public.ecr.aws/eks-distro/kubernetes/kube-scheduler:v1.32.9-eks-1-32-24
+      OCM_LOGIN_ENV: production
+      OPENSHIFT_VERSION: "4.21"
+      REGION: us-west-2
+      RHOAI_CHANNEL: stable
+      VLLM_NEURON_IMAGE: registry.redhat.io/rhaiis/vllm-neuron-rhel9:3
+    workflow: aws-neuron-operator-kserve-e2e-rosa
+- as: aws-neuron-operator-kserve-e2e-weekly
+  cron: 0 6 * * 3
+  steps:
+    allow_best_effort_post_steps: true
+    cluster_profile: aws-edge-infra
+    env:
+      ECO_HWACCEL_NEURON_DEVICE_PLUGIN_IMAGE: public.ecr.aws/neuron/neuron-device-plugin:2.29.94.0
+      ECO_HWACCEL_NEURON_DRIVER_VERSION: 2.25.4.0
+      ECO_HWACCEL_NEURON_DRIVERS_IMAGE: public.ecr.aws/os-partners/neuron-openshift/neuron-kernel-module:2.25.4.0
+      ECO_HWACCEL_NEURON_KSERVE_MODEL_NAME: TinyLlama/TinyLlama-1.1B-Chat-v1.0
+      ECO_HWACCEL_NEURON_KSERVE_VLLM_IMAGE: registry.redhat.io/rhaiis/vllm-neuron-rhel9:3
+      ECO_HWACCEL_NEURON_NODE_METRICS_IMAGE: public.ecr.aws/neuron/neuron-monitor:1.3.0
+      ECO_HWACCEL_NEURON_SCHEDULER_EXTENSION_IMAGE: public.ecr.aws/neuron/neuron-scheduler:2.29.94.0
+      ECO_HWACCEL_NEURON_SCHEDULER_IMAGE: public.ecr.aws/eks-distro/kubernetes/kube-scheduler:v1.32.9-eks-1-32-24
+      OCM_LOGIN_ENV: production
+      OPENSHIFT_VERSION: "4.21"
+      REGION: us-west-2
+      RHOAI_CHANNEL: stable
+      VLLM_NEURON_IMAGE: registry.redhat.io/rhaiis/vllm-neuron-rhel9:3
+    workflow: aws-neuron-operator-kserve-e2e-rosa
 zz_generated_metadata:
   branch: main
   org: rh-ecosystem-edge

--- a/ci-operator/jobs/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main-periodics.yaml
+++ b/ci-operator/jobs/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main-periodics.yaml
@@ -245,3 +245,84 @@ periodics:
     - name: result-aggregator
       secret:
         secretName: result-aggregator
+- agent: kubernetes
+  cron: 0 6 * * 3
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: rh-ecosystem-edge
+    repo: neuron-ci
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-edge-infra
+    ci-operator.openshift.io/variant: 4.21-stable
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-rh-ecosystem-edge-neuron-ci-main-4.21-stable-aws-neuron-operator-kserve-e2e-weekly
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=aws-neuron-operator-kserve-e2e-weekly
+      - --variant=4.21-stable
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator

--- a/ci-operator/jobs/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main-periodics.yaml
+++ b/ci-operator/jobs/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main-periodics.yaml
@@ -246,6 +246,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
+  cluster: build11
   cron: 0 6 * * 3
   decorate: true
   decoration_config:

--- a/ci-operator/jobs/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main-presubmits.yaml
+++ b/ci-operator/jobs/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main-presubmits.yaml
@@ -372,6 +372,89 @@ presubmits:
     branches:
     - ^main$
     - ^main-
+    context: ci/prow/4.21-stable-aws-neuron-operator-kserve-e2e
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: aws-edge-infra
+      ci-operator.openshift.io/variant: 4.21-stable
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-rh-ecosystem-edge-neuron-ci-main-4.21-stable-aws-neuron-operator-kserve-e2e
+    rerun_command: /test 4.21-stable-aws-neuron-operator-kserve-e2e
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=aws-neuron-operator-kserve-e2e
+        - --variant=4.21-stable
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )(4.21-stable-aws-neuron-operator-kserve-e2e|remaining-required),?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
     cluster: build01
     context: ci/prow/4.21-stable-images
     decorate: true

--- a/ci-operator/jobs/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main-presubmits.yaml
+++ b/ci-operator/jobs/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main-presubmits.yaml
@@ -372,6 +372,7 @@ presubmits:
     branches:
     - ^main$
     - ^main-
+    cluster: build01
     context: ci/prow/4.21-stable-aws-neuron-operator-kserve-e2e
     decorate: true
     decoration_config:

--- a/ci-operator/step-registry/aws-neuron-operator/gather/aws-neuron-operator-gather-commands.sh
+++ b/ci-operator/step-registry/aws-neuron-operator/gather/aws-neuron-operator-gather-commands.sh
@@ -45,13 +45,14 @@ if [[ -n "${NEURON_NS}" ]]; then
 fi
 
 KSERVE_DIR="${DUMP_DIR}/kserve"
+INFERENCE_NAMESPACE="${INFERENCE_NAMESPACE:-neuron-inference}"
 mkdir -p "${KSERVE_DIR}"
 oc get inferenceservice -A -o yaml > "${KSERVE_DIR}/inferenceservices.yaml" 2>&1 || true
 oc get servingruntime -A -o yaml > "${KSERVE_DIR}/servingruntimes.yaml" 2>&1 || true
 oc get datasciencecluster -A -o yaml > "${KSERVE_DIR}/datascienceclusters.yaml" 2>&1 || true
 oc get knativeserving -A -o yaml > "${KSERVE_DIR}/knativeserving.yaml" 2>&1 || true
-oc get pods -n neuron-inference -o wide > "${KSERVE_DIR}/inference-pods.txt" 2>&1 || true
-oc get events -n neuron-inference --sort-by='.lastTimestamp' > "${KSERVE_DIR}/inference-events.txt" 2>&1 || true
-oc get ksvc -n neuron-inference -o yaml > "${KSERVE_DIR}/knative-services.yaml" 2>&1 || true
+oc get pods -n "${INFERENCE_NAMESPACE}" -o wide > "${KSERVE_DIR}/inference-pods.txt" 2>&1 || true
+oc get events -n "${INFERENCE_NAMESPACE}" --sort-by='.lastTimestamp' > "${KSERVE_DIR}/inference-events.txt" 2>&1 || true
+oc get ksvc -n "${INFERENCE_NAMESPACE}" -o yaml > "${KSERVE_DIR}/knative-services.yaml" 2>&1 || true
 
 echo "Neuron diagnostic data collected in ${DUMP_DIR}"

--- a/ci-operator/step-registry/aws-neuron-operator/gather/aws-neuron-operator-gather-commands.sh
+++ b/ci-operator/step-registry/aws-neuron-operator/gather/aws-neuron-operator-gather-commands.sh
@@ -44,4 +44,14 @@ if [[ -n "${NEURON_NS}" ]]; then
     oc get events -n "${NEURON_NS}" --sort-by='.lastTimestamp' > "${DUMP_DIR}/neuron-ns-events.txt" 2>&1 || true
 fi
 
+KSERVE_DIR="${DUMP_DIR}/kserve"
+mkdir -p "${KSERVE_DIR}"
+oc get inferenceservice -A -o yaml > "${KSERVE_DIR}/inferenceservices.yaml" 2>&1 || true
+oc get servingruntime -A -o yaml > "${KSERVE_DIR}/servingruntimes.yaml" 2>&1 || true
+oc get datasciencecluster -A -o yaml > "${KSERVE_DIR}/datascienceclusters.yaml" 2>&1 || true
+oc get knativeserving -A -o yaml > "${KSERVE_DIR}/knativeserving.yaml" 2>&1 || true
+oc get pods -n neuron-inference -o wide > "${KSERVE_DIR}/inference-pods.txt" 2>&1 || true
+oc get events -n neuron-inference --sort-by='.lastTimestamp' > "${KSERVE_DIR}/inference-events.txt" 2>&1 || true
+oc get ksvc -n neuron-inference -o yaml > "${KSERVE_DIR}/knative-services.yaml" 2>&1 || true
+
 echo "Neuron diagnostic data collected in ${DUMP_DIR}"

--- a/ci-operator/step-registry/aws-neuron-operator/install-kserve-deps/OWNERS
+++ b/ci-operator/step-registry/aws-neuron-operator/install-kserve-deps/OWNERS
@@ -1,0 +1,9 @@
+approvers:
+- ggordaniRed
+- ybrodsky-rh
+- yevgeny-shnaidman
+options: {}
+reviewers:
+- ggordaniRed
+- ybrodsky-rh
+- yevgeny-shnaidman

--- a/ci-operator/step-registry/aws-neuron-operator/install-kserve-deps/aws-neuron-operator-install-kserve-deps-commands.sh
+++ b/ci-operator/step-registry/aws-neuron-operator/install-kserve-deps/aws-neuron-operator-install-kserve-deps-commands.sh
@@ -1,0 +1,278 @@
+#!/bin/bash
+
+set -o nounset
+set -o pipefail
+
+echo "Installing KServe inference stack dependencies"
+
+export KUBECONFIG="${SHARED_DIR}/kubeconfig"
+
+wait_for_csv() {
+    local ns="${1}"
+    local name_prefix="${2}"
+    local timeout="${3:-600}"
+    local elapsed=0
+
+    echo "Waiting for CSV starting with '${name_prefix}' in namespace '${ns}' to reach Succeeded..."
+    while [[ ${elapsed} -lt ${timeout} ]]; do
+        local phase
+        phase=$(oc get csv -n "${ns}" -o json 2>/dev/null \
+            | jq -r ".items[] | select(.metadata.name | startswith(\"${name_prefix}\")) | .status.phase" \
+            | head -1)
+        if [[ "${phase}" == "Succeeded" ]]; then
+            echo "CSV '${name_prefix}' reached Succeeded in ${elapsed}s"
+            return 0
+        fi
+        sleep 15
+        elapsed=$((elapsed + 15))
+    done
+    echo "ERROR: CSV '${name_prefix}' did not reach Succeeded within ${timeout}s (last phase: ${phase:-unknown})"
+    oc get csv -n "${ns}" -o wide 2>/dev/null || true
+    return 1
+}
+
+# --- 1. Install Service Mesh operator ---
+echo "=== Installing Service Mesh operator ==="
+oc apply -f - <<'EOF'
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: servicemeshoperator
+  namespace: openshift-operators
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: servicemeshoperator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+EOF
+
+# --- 2. Install Serverless operator ---
+echo "=== Installing Serverless operator ==="
+oc apply -f - <<'EOF'
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-serverless
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-serverless
+  namespace: openshift-serverless
+spec: {}
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: serverless-operator
+  namespace: openshift-serverless
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: serverless-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+EOF
+
+# --- 3. Install RHOAI operator ---
+echo "=== Installing OpenShift AI (RHOAI) operator ==="
+oc apply -f - <<EOF
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: redhat-ods-operator
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: rhods-operator
+  namespace: redhat-ods-operator
+spec: {}
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: rhods-operator
+  namespace: redhat-ods-operator
+spec:
+  channel: ${RHOAI_CHANNEL}
+  installPlanApproval: Automatic
+  name: rhods-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+EOF
+
+# --- 4. Wait for all CSVs ---
+echo "=== Waiting for operator CSVs ==="
+wait_for_csv "openshift-operators" "servicemeshoperator" 600 || exit 1
+wait_for_csv "openshift-serverless" "serverless-operator" 600 || exit 1
+wait_for_csv "redhat-ods-operator" "rhods-operator" 600 || exit 1
+echo "All operator CSVs reached Succeeded"
+
+# --- 5. Create DataScienceCluster ---
+echo "=== Creating DataScienceCluster ==="
+oc apply -f - <<'EOF'
+apiVersion: datasciencecluster.opendatahub.io/v1
+kind: DataScienceCluster
+metadata:
+  name: default-dsc
+spec:
+  components:
+    codeflare:
+      managementState: Removed
+    dashboard:
+      managementState: Managed
+    datasciencepipelines:
+      managementState: Removed
+    kserve:
+      managementState: Managed
+      serving:
+        ingressGateway:
+          certificate:
+            type: SelfSigned
+        managementState: Managed
+    kueue:
+      managementState: Removed
+    modelmeshserving:
+      managementState: Removed
+    modelregistry:
+      managementState: Removed
+    ray:
+      managementState: Removed
+    trainingoperator:
+      managementState: Removed
+    trustyai:
+      managementState: Removed
+    workbenches:
+      managementState: Removed
+EOF
+
+echo "Waiting for DataScienceCluster to reach Ready..."
+oc wait --for=jsonpath='{.status.phase}'=Ready datasciencecluster/default-dsc --timeout=600s || {
+    echo "ERROR: DataScienceCluster did not reach Ready"
+    oc get datasciencecluster default-dsc -o yaml 2>/dev/null || true
+    exit 1
+}
+echo "DataScienceCluster is Ready"
+
+# --- 6. Configure inference namespace ---
+echo "=== Configuring inference namespace ==="
+oc create namespace "${KSERVE_INFERENCE_NAMESPACE}" 2>/dev/null || true
+oc label namespace "${KSERVE_INFERENCE_NAMESPACE}" istio-injection=enabled --overwrite
+
+# --- 7. Patch Knative Serving config ---
+echo "=== Patching Knative Serving config ==="
+KNATIVE_TIMEOUT=300
+KNATIVE_ELAPSED=0
+while [[ ${KNATIVE_ELAPSED} -lt ${KNATIVE_TIMEOUT} ]]; do
+    if oc get configmap config-deployment -n knative-serving &>/dev/null; then
+        oc patch configmap config-deployment -n knative-serving --type=merge \
+            -p '{"data":{"registries-skipping-tag-resolving":"kind.local,ko.local,dev.local,registry.redhat.io"}}' || true
+        echo "Knative Serving config-deployment patched"
+        break
+    fi
+    sleep 10
+    KNATIVE_ELAPSED=$((KNATIVE_ELAPSED + 10))
+done
+if [[ ${KNATIVE_ELAPSED} -ge ${KNATIVE_TIMEOUT} ]]; then
+    echo "WARNING: knative-serving/config-deployment configmap not found within ${KNATIVE_TIMEOUT}s"
+fi
+
+# --- 8. Create ServingRuntime ---
+echo "=== Creating vllm-neuron ServingRuntime ==="
+oc apply -f - <<EOF
+apiVersion: serving.kserve.io/v1alpha1
+kind: ServingRuntime
+metadata:
+  name: vllm-neuron-runtime
+  namespace: ${KSERVE_INFERENCE_NAMESPACE}
+  annotations:
+    openshift.io/display-name: "vLLM for AWS Neuron"
+    opendatahub.io/recommended-accelerators: '["neuron.amazonaws.com"]'
+    sidecar.istio.io/inject: "true"
+    serving.knative.openshift.io/enablePassthrough: "true"
+spec:
+  multiModel: false
+  supportedModelFormats:
+  - autoSelect: true
+    name: vllm-neuron
+  containers:
+  - name: kserve-container
+    image: ${VLLM_NEURON_IMAGE}
+    command:
+    - python3
+    - -m
+    - vllm.entrypoints.openai.api_server
+    args:
+    - --port=8080
+    - --model=/mnt/models
+    - --served-model-name={{.Name}}
+    - --tensor-parallel-size=${TENSOR_PARALLEL_SIZE}
+    - --max-num-seqs=${MAX_NUM_SEQS}
+    - --max-model-len=${MAX_MODEL_LEN}
+    - --disable-frontend-multiprocessing
+    - --enable-chunked-prefill=false
+    - --enable-prefix-caching=false
+    env:
+    - name: NEURON_COMPILE_CACHE_URL
+      value: /mnt/models/neuron-compiled-artifacts
+    ports:
+    - containerPort: 8080
+      protocol: TCP
+    readinessProbe:
+      httpGet:
+        path: /health
+        port: 8080
+      initialDelaySeconds: 900
+      periodSeconds: 10
+    livenessProbe:
+      httpGet:
+        path: /health
+        port: 8080
+      initialDelaySeconds: 900
+      periodSeconds: 10
+    volumeMounts:
+    - name: shm
+      mountPath: /dev/shm
+    - name: neuron-compile
+      mountPath: /mnt/models/neuron-compiled-artifacts
+  volumes:
+  - name: shm
+    emptyDir:
+      medium: Memory
+      sizeLimit: 2Gi
+  - name: neuron-compile
+    emptyDir: {}
+EOF
+
+# --- 9. Create HF token secret and ServiceAccount ---
+echo "=== Setting up model access credentials ==="
+if [[ -f "${CLUSTER_PROFILE_DIR}/hf-token" ]]; then
+    HF_TOKEN=$(cat "${CLUSTER_PROFILE_DIR}/hf-token")
+    oc apply -f - <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hf-token
+  namespace: ${KSERVE_INFERENCE_NAMESPACE}
+type: Opaque
+stringData:
+  HF_TOKEN: ${HF_TOKEN}
+EOF
+    echo "HF token secret created"
+else
+    echo "WARNING: No HF token found at ${CLUSTER_PROFILE_DIR}/hf-token"
+fi
+
+oc apply -f - <<EOF
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kserve-neuron-sa
+  namespace: ${KSERVE_INFERENCE_NAMESPACE}
+secrets:
+- name: hf-token
+EOF
+
+echo "KServe inference stack installation complete"

--- a/ci-operator/step-registry/aws-neuron-operator/install-kserve-deps/aws-neuron-operator-install-kserve-deps-commands.sh
+++ b/ci-operator/step-registry/aws-neuron-operator/install-kserve-deps/aws-neuron-operator-install-kserve-deps-commands.sh
@@ -167,16 +167,18 @@ KNATIVE_TIMEOUT=300
 KNATIVE_ELAPSED=0
 while [[ ${KNATIVE_ELAPSED} -lt ${KNATIVE_TIMEOUT} ]]; do
     if oc get configmap config-deployment -n knative-serving &>/dev/null; then
-        oc patch configmap config-deployment -n knative-serving --type=merge \
-            -p '{"data":{"registries-skipping-tag-resolving":"kind.local,ko.local,dev.local,registry.redhat.io"}}' || true
-        echo "Knative Serving config-deployment patched"
-        break
+        if oc patch configmap config-deployment -n knative-serving --type=merge \
+            -p '{"data":{"registries-skipping-tag-resolving":"kind.local,ko.local,dev.local,registry.redhat.io"}}'; then
+            echo "Knative Serving config-deployment patched"
+            break
+        fi
     fi
     sleep 10
     KNATIVE_ELAPSED=$((KNATIVE_ELAPSED + 10))
 done
 if [[ ${KNATIVE_ELAPSED} -ge ${KNATIVE_TIMEOUT} ]]; then
-    echo "WARNING: knative-serving/config-deployment configmap not found within ${KNATIVE_TIMEOUT}s"
+    echo "ERROR: knative-serving/config-deployment configmap could not be patched within ${KNATIVE_TIMEOUT}s"
+    exit 1
 fi
 
 # --- 8. Create ServingRuntime ---

--- a/ci-operator/step-registry/aws-neuron-operator/install-kserve-deps/aws-neuron-operator-install-kserve-deps-ref.metadata.json
+++ b/ci-operator/step-registry/aws-neuron-operator/install-kserve-deps/aws-neuron-operator-install-kserve-deps-ref.metadata.json
@@ -1,0 +1,15 @@
+{
+	"path": "aws-neuron-operator/install-kserve-deps/aws-neuron-operator-install-kserve-deps-ref.yaml",
+	"owners": {
+		"approvers": [
+			"ggordaniRed",
+			"ybrodsky-rh",
+			"yevgeny-shnaidman"
+		],
+		"reviewers": [
+			"ggordaniRed",
+			"ybrodsky-rh",
+			"yevgeny-shnaidman"
+		]
+	}
+}

--- a/ci-operator/step-registry/aws-neuron-operator/install-kserve-deps/aws-neuron-operator-install-kserve-deps-ref.yaml
+++ b/ci-operator/step-registry/aws-neuron-operator/install-kserve-deps/aws-neuron-operator-install-kserve-deps-ref.yaml
@@ -1,0 +1,38 @@
+ref:
+  as: aws-neuron-operator-install-kserve-deps
+  from_image:
+    namespace: ocp
+    name: cli-jq
+    tag: latest
+  grace_period: 5m
+  commands: aws-neuron-operator-install-kserve-deps-commands.sh
+  resources:
+    requests:
+      cpu: 100m
+      memory: 200Mi
+  timeout: 45m
+  env:
+  - name: RHOAI_CHANNEL
+    default: "stable"
+    documentation: OLM channel for the RHOAI (rhods-operator) subscription.
+  - name: KSERVE_INFERENCE_NAMESPACE
+    default: "neuron-inference"
+    documentation: Namespace where KServe InferenceServices will be deployed.
+  - name: VLLM_NEURON_IMAGE
+    default: "registry.redhat.io/rhaiis/vllm-neuron-rhel9:3"
+    documentation: vLLM Neuron serving runtime container image.
+  - name: TENSOR_PARALLEL_SIZE
+    default: "1"
+    documentation: Tensor parallel size for the vLLM Neuron serving runtime.
+  - name: MAX_NUM_SEQS
+    default: "4"
+    documentation: Max number of concurrent sequences for the vLLM Neuron serving runtime.
+  - name: MAX_MODEL_LEN
+    default: "4096"
+    documentation: Max model context length for the vLLM Neuron serving runtime.
+  documentation: |-
+    Installs the KServe inference stack on an already-provisioned ROSA HCP
+    cluster with Neuron operators. Deploys Service Mesh, Serverless, and
+    OpenShift AI (RHOAI) operators via OLM, creates a DataScienceCluster
+    with KServe enabled, configures the inference namespace, and deploys
+    the vllm-neuron ServingRuntime.

--- a/ci-operator/step-registry/aws-neuron-operator/kserve-e2e-rosa/OWNERS
+++ b/ci-operator/step-registry/aws-neuron-operator/kserve-e2e-rosa/OWNERS
@@ -1,0 +1,9 @@
+approvers:
+- ggordaniRed
+- ybrodsky-rh
+- yevgeny-shnaidman
+options: {}
+reviewers:
+- ggordaniRed
+- ybrodsky-rh
+- yevgeny-shnaidman

--- a/ci-operator/step-registry/aws-neuron-operator/kserve-e2e-rosa/aws-neuron-operator-kserve-e2e-rosa-workflow.metadata.json
+++ b/ci-operator/step-registry/aws-neuron-operator/kserve-e2e-rosa/aws-neuron-operator-kserve-e2e-rosa-workflow.metadata.json
@@ -1,0 +1,15 @@
+{
+	"path": "aws-neuron-operator/kserve-e2e-rosa/aws-neuron-operator-kserve-e2e-rosa-workflow.yaml",
+	"owners": {
+		"approvers": [
+			"ggordaniRed",
+			"ybrodsky-rh",
+			"yevgeny-shnaidman"
+		],
+		"reviewers": [
+			"ggordaniRed",
+			"ybrodsky-rh",
+			"yevgeny-shnaidman"
+		]
+	}
+}

--- a/ci-operator/step-registry/aws-neuron-operator/kserve-e2e-rosa/aws-neuron-operator-kserve-e2e-rosa-workflow.yaml
+++ b/ci-operator/step-registry/aws-neuron-operator/kserve-e2e-rosa/aws-neuron-operator-kserve-e2e-rosa-workflow.yaml
@@ -1,0 +1,48 @@
+workflow:
+  as: aws-neuron-operator-kserve-e2e-rosa
+  steps:
+    env:
+      HOSTED_CP: "true"
+      ENABLE_BYOVPC: "true"
+      ZONES_COUNT: "1"
+      COMPUTE_MACHINE_TYPE: "inf2.8xlarge"
+      REPLICAS: "2"
+      OCM_LOGIN_ENV: "production"
+      REGION: "us-west-2"
+    pre:
+    # Clean up stale VPC stack from previous failed runs, then provision
+    - ref: aws-neuron-operator-cleanup-vpc
+    - ref: aws-provision-vpc-shared
+    - ref: aws-provision-tags-for-byo-vpc-ocm-pre
+    # OIDC and account roles setup
+    - chain: rosa-sts-oidc-config-create
+    # Custom cluster provision step that handles "zero egress" CLI bug
+    - ref: aws-neuron-operator-rosa-cluster-provision
+    - ref: rosa-cluster-wait-ready-cluster
+    - ref: rosa-cluster-notify-error
+    - ref: rosa-conf-idp-htpasswd
+    - ref: rosa-cluster-wait-ready-nodes
+    - ref: rosa-cluster-wait-ready-operators
+    - ref: aws-provision-tags-for-byo-vpc
+    # Additional configuration
+    - ref: osd-ccs-conf-idp-htpasswd-multi-users
+    # Install Neuron operators (NFD, KMM, Neuron operator + DeviceConfig)
+    - ref: aws-neuron-operator-install-operators
+    # Install KServe inference stack (Service Mesh, Serverless, RHOAI, DSC, ServingRuntime)
+    - ref: aws-neuron-operator-install-kserve-deps
+    test:
+    - ref: aws-neuron-operator-kserve-test
+    post:
+    - ref: aws-neuron-operator-gather
+    - ref: aws-neuron-operator-rosa-cluster-deprovision
+      best_effort: true
+    - chain: rosa-sts-oidc-config-delete
+      best_effort: true
+    - ref: aws-deprovision-stacks
+      best_effort: true
+      timeout: 30m
+  documentation: |-
+    Provisions a ROSA HCP cluster with AWS Inferentia (inf2.8xlarge) nodes,
+    installs the Neuron operator stack and KServe inference stack (Service Mesh,
+    Serverless, OpenShift AI), then runs KServe inference tests using the
+    vllm-neuron ServingRuntime with eco-gotests.

--- a/ci-operator/step-registry/aws-neuron-operator/kserve-test/OWNERS
+++ b/ci-operator/step-registry/aws-neuron-operator/kserve-test/OWNERS
@@ -1,0 +1,9 @@
+approvers:
+- ggordaniRed
+- ybrodsky-rh
+- yevgeny-shnaidman
+options: {}
+reviewers:
+- ggordaniRed
+- ybrodsky-rh
+- yevgeny-shnaidman

--- a/ci-operator/step-registry/aws-neuron-operator/kserve-test/aws-neuron-operator-kserve-test-commands.sh
+++ b/ci-operator/step-registry/aws-neuron-operator/kserve-test/aws-neuron-operator-kserve-test-commands.sh
@@ -19,7 +19,6 @@ cd /home/testuser || exit 1
 export ECO_TEST_FEATURES="neuron"
 export ECO_TEST_LABELS="neuron && kserve"
 export ECO_TEST_VERBOSE="true"
-export ECO_VERBOSE_LEVEL="100"
 export ECO_DUMP_FAILED_TESTS="${ECO_DUMP_FAILED_TESTS:-true}"
 export ECO_REPORTS_DUMP_DIR="${ARTIFACT_DIR}"
 

--- a/ci-operator/step-registry/aws-neuron-operator/kserve-test/aws-neuron-operator-kserve-test-commands.sh
+++ b/ci-operator/step-registry/aws-neuron-operator/kserve-test/aws-neuron-operator-kserve-test-commands.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+set -o nounset
+set -o pipefail
+
+echo "Starting KServe inference tests"
+
+export KUBECONFIG="${SHARED_DIR}/kubeconfig"
+mkdir -p "${ARTIFACT_DIR}"
+
+if [[ -f "${CLUSTER_PROFILE_DIR}/hf-token" ]]; then
+    export ECO_HWACCEL_NEURON_HF_TOKEN
+    ECO_HWACCEL_NEURON_HF_TOKEN=$(cat "${CLUSTER_PROFILE_DIR}/hf-token")
+    echo "HuggingFace token loaded from cluster profile"
+fi
+
+cd /home/testuser || exit 1
+
+export ECO_TEST_FEATURES="neuron"
+export ECO_TEST_LABELS="neuron && kserve"
+export ECO_TEST_VERBOSE="true"
+export ECO_VERBOSE_LEVEL="100"
+export ECO_DUMP_FAILED_TESTS="${ECO_DUMP_FAILED_TESTS:-true}"
+export ECO_REPORTS_DUMP_DIR="${ARTIFACT_DIR}"
+
+echo "Running KServe tests with labels: ${ECO_TEST_LABELS}"
+
+TEST_EXIT_CODE=0
+
+ginkgo --label-filter="${ECO_TEST_LABELS}" \
+    --timeout=40m \
+    --v \
+    --keep-going \
+    --junit-report=junit_neuron_kserve.xml \
+    --output-dir="${ARTIFACT_DIR}" \
+    ./tests/hw-accel/neuron/... || TEST_EXIT_CODE=$?
+
+if [[ ${TEST_EXIT_CODE} -eq 0 ]]; then
+    echo "SUCCESS" > "${ARTIFACT_DIR}/kserve_inference.status"
+    echo "KServe inference tests passed"
+else
+    echo "FAILURE" > "${ARTIFACT_DIR}/kserve_inference.status"
+    echo "KServe inference tests failed with exit code ${TEST_EXIT_CODE}"
+fi
+
+echo "=== Collecting KServe debug info ==="
+debug_dir="${ARTIFACT_DIR}/debug-kserve"
+mkdir -p "${debug_dir}"
+
+NS="${ECO_HWACCEL_NEURON_KSERVE_NAMESPACE:-neuron-inference}"
+oc get inferenceservice -n "${NS}" -o yaml > "${debug_dir}/inferenceservices.yaml" 2>&1 || true
+oc get servingruntime -n "${NS}" -o yaml > "${debug_dir}/servingruntimes.yaml" 2>&1 || true
+oc get ksvc -n "${NS}" -o yaml > "${debug_dir}/knative-services.yaml" 2>&1 || true
+oc get pods -n "${NS}" -o wide > "${debug_dir}/inference-pods.txt" 2>&1 || true
+oc get events -n "${NS}" --sort-by='.lastTimestamp' > "${debug_dir}/inference-events.txt" 2>&1 || true
+for pod in $(oc get pods -n "${NS}" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || true); do
+    oc describe pod -n "${NS}" "${pod}" > "${debug_dir}/${pod}-describe.txt" 2>&1 || true
+    for container in $(oc get pod -n "${NS}" "${pod}" -o jsonpath='{.spec.containers[*].name}' 2>/dev/null || true); do
+        oc logs -n "${NS}" "${pod}" -c "${container}" --tail=500 > "${debug_dir}/${pod}-${container}.log" 2>&1 || true
+    done
+done
+oc get datasciencecluster -o yaml > "${debug_dir}/datasciencecluster.yaml" 2>&1 || true
+echo "=== KServe debug info collected ==="
+
+echo "KServe inference tests completed"
+exit ${TEST_EXIT_CODE}

--- a/ci-operator/step-registry/aws-neuron-operator/kserve-test/aws-neuron-operator-kserve-test-ref.metadata.json
+++ b/ci-operator/step-registry/aws-neuron-operator/kserve-test/aws-neuron-operator-kserve-test-ref.metadata.json
@@ -1,0 +1,15 @@
+{
+	"path": "aws-neuron-operator/kserve-test/aws-neuron-operator-kserve-test-ref.yaml",
+	"owners": {
+		"approvers": [
+			"ggordaniRed",
+			"ybrodsky-rh",
+			"yevgeny-shnaidman"
+		],
+		"reviewers": [
+			"ggordaniRed",
+			"ybrodsky-rh",
+			"yevgeny-shnaidman"
+		]
+	}
+}

--- a/ci-operator/step-registry/aws-neuron-operator/kserve-test/aws-neuron-operator-kserve-test-ref.yaml
+++ b/ci-operator/step-registry/aws-neuron-operator/kserve-test/aws-neuron-operator-kserve-test-ref.yaml
@@ -1,0 +1,28 @@
+ref:
+  as: aws-neuron-operator-kserve-test
+  from: eco-gotests
+  grace_period: 10m
+  commands: aws-neuron-operator-kserve-test-commands.sh
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+  timeout: 45m
+  env:
+  - name: ECO_HWACCEL_NEURON_KSERVE_MODEL_NAME
+    default: "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
+    documentation: HuggingFace model to deploy via KServe InferenceService.
+  - name: ECO_HWACCEL_NEURON_KSERVE_VLLM_IMAGE
+    default: "registry.redhat.io/rhaiis/vllm-neuron-rhel9:3"
+    documentation: vLLM Neuron container image for the ServingRuntime.
+  - name: ECO_HWACCEL_NEURON_KSERVE_NAMESPACE
+    default: "neuron-inference"
+    documentation: Namespace where KServe resources are deployed.
+  - name: ECO_HWACCEL_NEURON_KSERVE_TENSOR_PARALLEL_SIZE
+    default: "1"
+    documentation: Tensor parallel size for KServe vLLM Neuron runtime.
+  documentation: |-
+    Runs KServe inference tests using eco-gotests on a ROSA HCP cluster
+    where the KServe stack (Service Mesh, Serverless, RHOAI) is already
+    installed. Deploys a vllm-neuron ServingRuntime and InferenceService,
+    validates inference endpoint responds correctly.


### PR DESCRIPTION
## Summary
- Add Prow CI steps and workflow for testing KServe/OpenShift AI model serving on AWS Neuron hardware (inf2 instances)
- New `install-kserve-deps` step: installs Service Mesh, Serverless, RHOAI operators, creates DataScienceCluster with KServe enabled, deploys vllm-neuron ServingRuntime
- New `kserve-test` step: runs eco-gotests KServe suite with label filter `neuron && kserve`
- New `kserve-e2e-rosa` workflow: standalone E2E combining Neuron operator + KServe stack setup
- On-demand (`aws-neuron-operator-kserve-e2e`) and weekly Wednesday cron (`aws-neuron-operator-kserve-e2e-weekly`) job entries
- KServe diagnostics collection added to gather step

## Dependencies
- eco-goinfra KServe builders: rh-ecosystem-edge/eco-goinfra#1337
- eco-gotests KServe test suite: rh-ecosystem-edge/eco-gotests#1356

## Test plan
- [ ] CI rehearsal validates step-registry syntax
- [ ] `make update` generates correct job configs (needs container engine — CI will verify)
- [ ] After eco-goinfra/eco-gotests merges, trigger on-demand: `/test aws-neuron-operator-kserve-e2e`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * KServe-based end-to-end testing for the AWS Neuron operator with vLLM Neuron runtime
  * AWS ROSA cluster provisioning targeting Inferentia instances for KServe inference tests
  * KServe inference service deployment and validation with JUnit test reporting and success/failure status artifacts
  * Weekly scheduled CI run for the KServe e2e workflow
  * CI step to install KServe/RHOAI/Serverless stack and provision a KServe-enabled DataScienceCluster
* **Diagnostics**
  * Enhanced collection of KServe/Knative debug output and per-pod logs/events
<!-- end of auto-generated comment: release notes by coderabbit.ai -->