### PR TITLE
OCPSTRAT-3036: Bump volume and memory for openshift/kubernetes unit tests

### DIFF
--- a/ci-operator/config/openshift/kubernetes/openshift-kubernetes-master.yaml
+++ b/ci-operator/config/openshift/kubernetes/openshift-kubernetes-master.yaml
@@ -216,7 +216,7 @@ resources:
   unit:
     requests:
       cpu: "6"
-      memory: 8Gi
+      memory: 10Gi
   verify:
     requests:
       cpu: "3"

--- a/ci-operator/config/openshift/kubernetes/openshift-kubernetes-master.yaml
+++ b/ci-operator/config/openshift/kubernetes/openshift-kubernetes-master.yaml
@@ -228,7 +228,7 @@ tests:
   container:
     from: src
     memory_backed_volume:
-      size: 8Gi
+      size: 10Gi
 - as: integration
   commands: ARTIFACTS="${ARTIFACT_DIR}" TMPDIR=/tmp/volume openshift-hack/test-integration.sh
   container:


### PR DESCRIPTION
Bump volume and memory for openshift/kubernetes unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased memory allocation for the unit test container from 8Gi to 10Gi.
  * Increased memory-backed test volume size from 8Gi to 10Gi.
  * Impact: provides more memory capacity for unit test execution and test-backed volumes, reducing risk of memory-related failures during tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->