### PR TITLE
scale down serverless 4.20 clusterpool (migrated to 4.21)

### DIFF
--- a/clusters/hosted-mgmt/hive/pools/serverless/serverless-ocp-4-20-amd64-aws-us-east-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/serverless/serverless-ocp-4-20-amd64-aws-us-east-1_clusterpool.yaml
@@ -33,7 +33,7 @@ spec:
       region: us-east-1
   pullSecretRef:
     name: pull-secret
-  size: 4
+  size: 0
   skipMachinePools: true
 status:
   ready: 0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated cluster pool configuration to adjust provisioned capacity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->