### PR TITLE
Add missing RBAC config for openstack-lightspeed registry access

### DIFF
--- a/ci-operator/jobs/infra-image-mirroring.yaml
+++ b/ci-operator/jobs/infra-image-mirroring.yaml
@@ -869,7 +869,7 @@ periodics:
       - mountPath: /tmp/user/.docker/config.json
         name: push
         readOnly: true
-        subPath: .dockerconfigjson
+        subPath: config.json
       - mountPath: /etc/imagemirror
         name: config
     volumes:

--- a/clusters/app.ci/registry-access/openstack-lightspeed/OWNERS
+++ b/clusters/app.ci/registry-access/openstack-lightspeed/OWNERS
@@ -1,0 +1,9 @@
+approvers:
+- umago
+- lpiwowar
+- Akrog
+options: {}
+reviewers:
+- umago
+- lpiwowar
+- Akrog

--- a/clusters/app.ci/registry-access/openstack-lightspeed/admin_manifest.yaml
+++ b/clusters/app.ci/registry-access/openstack-lightspeed/admin_manifest.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false,Delete=confirm
+  name: openstack-lightspeed
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: image-puller
+  namespace: openstack-lightspeed
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:image-puller
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:unauthenticated
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:authenticated


### PR DESCRIPTION
This PR completes the setup initiated in #77611 by adding the necessary RBAC configuration for the openstack-lightspeed RAG image mirroring job.

According to the CI mirroring requirements [1], images promoted to a new namespace should create a folder in clusters/app.ci/registry-access with the name of the namespace, containing the manifests of the namespace and the RBAC regarding to that namespace. Provide an OWNERS file to allow your team to make changes to those manifests.

The files added in this PR should have been included in the PR #77611, but they were overlooked.

[1]
https://docs.ci.openshift.org/how-tos/mirroring-to-quay/#requirements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added configuration for OpenStack Lightspeed registry access management
  * Established Kubernetes namespace with Argo CD synchronization policies and role bindings for container image access
<!-- end of auto-generated comment: release notes by coderabbit.ai -->