### PR TITLE
chore: delete unused tooling images

### DIFF
--- a/ci-operator/config/openshift/ci-tools/openshift-ci-tools-main.yaml
+++ b/ci-operator/config/openshift/ci-tools/openshift-ci-tools-main.yaml
@@ -204,16 +204,6 @@ images:
     to: multi-pr-prow-plugin
   - additional_architectures:
     - arm64
-    context_dir: images/ai-plugin/
-    from: os
-    inputs:
-      bin:
-        paths:
-        - destination_dir: .
-          source_path: /go/bin/ai-plugin
-    to: ai-plugin
-  - additional_architectures:
-    - arm64
     context_dir: images/pj-rehearse/
     from: os
     inputs:
@@ -694,19 +684,6 @@ images:
         - destination_dir: .
           source_path: /go/bin/vault-secret-collection-manager
     to: vault-secret-collection-manager
-  - dockerfile_literal: |-
-      FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
-      ADD bugzilla-config-manager /usr/bin/bugzilla-config-manager
-      ADD prcreator /usr/bin/prcreator
-    from: os
-    inputs:
-      bin:
-        paths:
-        - destination_dir: .
-          source_path: /go/bin/bugzilla-config-manager
-        - destination_dir: .
-          source_path: /go/bin/prcreator
-    to: bugzilla-config-manager
   - dockerfile_literal: |-
       FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
       RUN microdnf install -y git && microdnf clean all && rm -rf /var/cache/dnf


### PR DESCRIPTION
solves failing postsubmit: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/branch-ci-openshift-ci-tools-main-images/2049475052272881664

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed image build specifications from continuous integration pipeline configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->