### PR TITLE
Switch rhel-9-codeready-builder-rpms to mirror2 for 4.23

### DIFF
--- a/core-services/release-controller/_repos/ocp-4.23-rhel9.repo
+++ b/core-services/release-controller/_repos/ocp-4.23-rhel9.repo
@@ -61,7 +61,7 @@ failovermethod = priority
 
 [rhel-9-codeready-builder-rpms]
 name = rhel-9-codeready-builder-rpms
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-9-codeready-builder-rpms
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.23/rhel-9-codeready-builder-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false

--- a/core-services/release-controller/_repos/ocp-4.23-rhel9.repo
+++ b/core-services/release-controller/_repos/ocp-4.23-rhel9.repo
@@ -61,15 +61,15 @@ failovermethod = priority
 
 [rhel-9-codeready-builder-rpms]
 name = rhel-9-codeready-builder-rpms
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/codeready-builder/os/
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-9-codeready-builder-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
 [rhel-9-server-ose]
 name = rhel-9-server-ose


### PR DESCRIPTION
## Summary
- Switch the x86_64 `rhel-9-codeready-builder-rpms` repo in `ocp-4.23-rhel9.repo` from CDN (`cdn.redhat.com`) to mirror2 (`mirror2.openshift.com`) using the 4.23 reposync path
- Replace SSL cert auth (`sslclientkey`/`sslclientcert`) with username/password auth to match other mirror2 entries
- Add `skip_if_unavailable = true` for consistency with other mirror2 repos

## Test plan
- [ ] Verify the mirror2 URL `https://mirror2.openshift.com/enterprise/reposync/4.23/rhel-9-codeready-builder-rpms/repodata/` resolves correctly
- [ ] Validate repo file with `/test-repo-files ocp-4.23-rhel9`
- [ ] Confirm CI builds using this repo file can resolve codeready-builder packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to point to an alternate mirror endpoint.
  * Switched repository authentication to use credential files for basic auth instead of client certificate/key.
  * Enabled automatic skip/failover when the repository is unavailable to improve resilience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->