### PR TITLE
mom: use build_root from repository

### DIFF
--- a/ci-operator/config/openshift/multi-operator-manager/openshift-multi-operator-manager-master.yaml
+++ b/ci-operator/config/openshift/multi-operator-manager/openshift-multi-operator-manager-master.yaml
@@ -5,10 +5,7 @@ base_images:
     tag: base
 binary_build_commands: make build
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-9-release-golang-1.22-openshift-4.19
+  from_repository: true
 promotion:
   to:
   - name: "5.0"


### PR DESCRIPTION
use `build_root: from_repository: true` so the go ver is controlled by the repo's `.ci-operator.yaml` instead of being hardcoded.

matches what we have for [kas-o](https://github.com/openshift/release/blob/3ae9d702a4e1da8f985855f12621c98cc545702a/ci-operator/config/openshift/cluster-kube-apiserver-operator/openshift-cluster-kube-apiserver-operator-main.yaml#L4)


should unblock https://github.com/openshift/multi-operator-manager/pull/69 and https://github.com/openshift/multi-operator-manager/pull/67

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to use repository-derived build root settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->