### PR TITLE
opendatahub: Increase 4.20 pool maxConcurrent from 6 to 10

### DIFF
--- a/clusters/hosted-mgmt/hive/pools/opendatahub/opendatahub-ocp-4-20-amd64-aws_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/opendatahub/opendatahub-ocp-4-20-amd64-aws_clusterpool.yaml
@@ -25,7 +25,7 @@ spec:
     name: opendatahub-install-config-aws
   labels:
     tp.openshift.io/owner: opendatahub
-  maxConcurrent: 6
+  maxConcurrent: 10
   maxSize: 40
   platform:
     aws:


### PR DESCRIPTION
Increase 4.20 pool maxConcurrent from 6 to 10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the maximum concurrent operations limit from 6 to 10 for improved resource management and throughput.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->