### PR TITLE
Fix KMM test vault secret mounting and remove verbose logging

### DIFF
--- a/ci-operator/step-registry/aws-neuron-operator/kmm-test/aws-neuron-operator-kmm-test-commands.sh
+++ b/ci-operator/step-registry/aws-neuron-operator/kmm-test/aws-neuron-operator-kmm-test-commands.sh
@@ -28,9 +28,9 @@ if [[ -f "${CLUSTER_PROFILE_DIR}/kmm-pull-secret" ]]; then
     export ECO_HWACCEL_KMM_PULL_SECRET
     ECO_HWACCEL_KMM_PULL_SECRET=$(cat "${CLUSTER_PROFILE_DIR}/kmm-pull-secret")
     echo "KMM pull secret loaded from cluster profile"
-elif [[ -f "/var/run/vault/kmm-pull-secret/pull-secret" ]]; then
+elif [[ -f "/var/run/vault/kmm-pull-secret/kmm-pull-secret" ]]; then
     export ECO_HWACCEL_KMM_PULL_SECRET
-    ECO_HWACCEL_KMM_PULL_SECRET=$(cat "/var/run/vault/kmm-pull-secret/pull-secret")
+    ECO_HWACCEL_KMM_PULL_SECRET=$(cat "/var/run/vault/kmm-pull-secret/kmm-pull-secret")
     echo "KMM pull secret loaded from vault credentials"
 else
     echo "WARNING: No KMM pull secret found, tests requiring external registry may be skipped"

--- a/ci-operator/step-registry/aws-neuron-operator/kmm-test/aws-neuron-operator-kmm-test-commands.sh
+++ b/ci-operator/step-registry/aws-neuron-operator/kmm-test/aws-neuron-operator-kmm-test-commands.sh
@@ -41,7 +41,6 @@ cd /home/testuser || exit 1
 export ECO_TEST_FEATURES="${KMM_TEST_FEATURES:-modules}"
 export ECO_TEST_LABELS="${KMM_TEST_LABELS:-kmm-sanity && !bmc}"
 export ECO_TEST_VERBOSE="true"
-export ECO_VERBOSE_LEVEL="100"
 export ECO_DUMP_FAILED_TESTS="${ECO_DUMP_FAILED_TESTS:-true}"
 export ECO_REPORTS_DUMP_DIR="${ARTIFACT_DIR}"
 

--- a/ci-operator/step-registry/aws-neuron-operator/kmm-test/aws-neuron-operator-kmm-test-ref.yaml
+++ b/ci-operator/step-registry/aws-neuron-operator/kmm-test/aws-neuron-operator-kmm-test-ref.yaml
@@ -3,6 +3,10 @@ ref:
   from: eco-gotests
   grace_period: 10m
   commands: aws-neuron-operator-kmm-test-commands.sh
+  credentials:
+  - namespace: test-credentials
+    name: kmm-pull-secret
+    mount_path: /var/run/vault/kmm-pull-secret
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
## Summary
- Mount `kmm-pull-secret` vault credential in `kmm-test` step so tests that push to the external registry (`quay.io/ocp-edge-qe`) can authenticate
- Fix vault key name to match actual key (`kmm-pull-secret`, not `pull-secret`)
- Remove `ECO_VERBOSE_LEVEL=100` — level 100 klog output prints values matching loaded secrets, causing the Prow sidecar to wipe the entire build log ("sensitive information removed"), making failures impossible to debug

## Test plan
- [ ] Retrigger KMM test on neuron-ci PR — `should build and push image to quay` and `should deploy prebuild image` should now pass with registry auth
- [ ] Verify build logs survive (no more 76-byte wiped logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)