### PR TITLE
Fix DRA skip pattern in HCP conformance workflow

### DIFF
--- a/ci-operator/step-registry/rosa/aws/hcp/conformance/rosa-aws-hcp-conformance-workflow.yaml
+++ b/ci-operator/step-registry/rosa/aws/hcp/conformance/rosa-aws-hcp-conformance-workflow.yaml
@@ -26,9 +26,7 @@ workflow:
         Node Lifecycle should run through the lifecycle of a node\|
         check registry.redhat.io is available and samples operator can import sample imagestreams\|
         NetworkPolicy between server and client should allow ingress access from updated pod\|
-        In-tree Volumes.*local.*blockfs.*subPath should support file as subpath\|
-        DRA.*kubelet.*DynamicResourceAllocation\|
-        InPlacePodVerticalScaling.*decrease memory limit below usage\|
+        In-tree Volumes.*local.*blockfs.*subPath should support file as subpath\|InPlacePodVerticalScaling.*decrease memory limit below usage\|DRA.*kubelet.*DynamicResourceAllocation\|
         CSI Mock volume expansion Expansion with recovery recovery should not be possible\|
         CSI Mock volume expansion Expansion with recovery should allow recovery if controller expansion fails with final error\|cloud-provider-aws-e2e.*loadbalancer NLB internal should be reachable with hairpinning traffic\|cloud-provider-aws-e2e.*loadbalancer NLB should be reachable with target-node-labels\|\[Monitor:apiserver-incluster-availability\]\[Jira:\\"kube-apiserver\\"\] monitor test apiserver-incluster-availability
     pre:


### PR DESCRIPTION
## Summary

Fix DRA and InPlacePodVerticalScaling skip patterns in the HCP conformance workflow that were broken by YAML `>-` folding (same root cause as #78480).

Both patterns match text right after `[` in test names (`[DRA]`, `[Feature:InPlacePodVerticalScaling]`), so the leading space from YAML folding prevents the grep match.

HCP conformance only. STS conformance is handled separately.

## Test plan

- [ ] Verify HCP conformance 4.22 passes with DRA test skipped


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized test skip pattern configuration in continuous integration workflow for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->