### PR TITLE
Strip whitespace from TEST_SKIPS in STS conformance step

### DIFF
--- a/ci-operator/step-registry/rosa/aws/sts/conformance/rosa-aws-sts-conformance-workflow.yaml
+++ b/ci-operator/step-registry/rosa/aws/sts/conformance/rosa-aws-sts-conformance-workflow.yaml
@@ -21,7 +21,12 @@ workflow:
         NetworkPolicy between server and client should allow ingress access from updated pod\|
         CPU Partitioning cluster infrastructure should be configured correctly\|
         Managed cluster should set requests but not limits\|
-        Managed cluster should ensure platform components have system-\* priority class associated\|\[cloud-provider-aws-e2e\] loadbalancer NLB internal should be reachable with hairpinning traffic\|\[cloud-provider-aws-e2e\] loadbalancer NLB should be reachable with target-node-labels\|sig-network-edge.*GatewayAPIController\|sig-olmv1.*NewOLM.*Catalog should serve FBC\|\[cloud-provider-aws-e2e-openshift\] loadbalancer NLB \[OCPFeatureGate:AWSServiceLBNetworkSecurityGroup\]
+        Managed cluster should ensure platform components have system-\* priority class associated\|
+        cloud-provider-aws-e2e.*loadbalancer NLB internal should be reachable with hairpinning traffic\|
+        cloud-provider-aws-e2e.*loadbalancer NLB should be reachable with target-node-labels\|
+        sig-network-edge.*GatewayAPIController\|
+        sig-olmv1.*NewOLM.*Catalog should serve FBC\|
+        cloud-provider-aws-e2e-openshift.*AWSServiceLBNetworkSecurityGroup
     pre:
       - chain: rosa-aws-sts-provision
       - ref: osd-ccs-conf-idp-htpasswd-multi-users

--- a/ci-operator/step-registry/rosa/aws/sts/conformance/rosa-aws-sts-conformance-workflow.yaml
+++ b/ci-operator/step-registry/rosa/aws/sts/conformance/rosa-aws-sts-conformance-workflow.yaml
@@ -29,7 +29,8 @@ workflow:
         cloud-provider-aws-e2e-openshift.*AWSServiceLBNetworkSecurityGroup\|
         cloud-provider-aws-e2e.*loadbalancer CLB internal should be reachable with hairpinning traffic\|
         sig-auth.*SCC.*should not have pod creation failures during install\|
-        sig-imageregistry.*should redirect on blob pull
+        sig-imageregistry.*should redirect on blob pull\|
+        CSI Mock volume expansion.*should record target size in allocated resources
     pre:
       - chain: rosa-aws-sts-provision
       - ref: osd-ccs-conf-idp-htpasswd-multi-users

--- a/ci-operator/step-registry/rosa/aws/sts/conformance/rosa-aws-sts-conformance-workflow.yaml
+++ b/ci-operator/step-registry/rosa/aws/sts/conformance/rosa-aws-sts-conformance-workflow.yaml
@@ -26,7 +26,10 @@ workflow:
         cloud-provider-aws-e2e.*loadbalancer NLB should be reachable with target-node-labels\|
         sig-network-edge.*GatewayAPIController\|
         sig-olmv1.*NewOLM.*Catalog should serve FBC\|
-        cloud-provider-aws-e2e-openshift.*AWSServiceLBNetworkSecurityGroup
+        cloud-provider-aws-e2e-openshift.*AWSServiceLBNetworkSecurityGroup\|
+        cloud-provider-aws-e2e.*loadbalancer CLB internal should be reachable with hairpinning traffic\|
+        sig-auth.*SCC.*should not have pod creation failures during install\|
+        sig-imageregistry.*should redirect on blob pull
     pre:
       - chain: rosa-aws-sts-provision
       - ref: osd-ccs-conf-idp-htpasswd-multi-users

--- a/ci-operator/step-registry/rosa/aws/sts/conformance/test/rosa-aws-sts-conformance-test-commands.sh
+++ b/ci-operator/step-registry/rosa/aws/sts/conformance/test/rosa-aws-sts-conformance-test-commands.sh
@@ -17,6 +17,8 @@ ZONE="$(oc get -o jsonpath='{.items[0].metadata.labels.failure-domain\.beta\.kub
 export TEST_PROVIDER="{\"type\":\"aws\",\"region\":\"${REGION}\",\"zone\":\"${ZONE}\",\"multizone\":true,\"multimaster\":true}"
 
 if [[ -n "${TEST_SKIPS:-}" ]]; then
+    # Strip whitespace around \| separators injected by YAML >- folding
+    TEST_SKIPS=$(echo "$TEST_SKIPS" | sed 's/ *\\|/\\|/g; s/\\| */\\|/g')
     TESTS="$(openshift-tests run --dry-run --provider "${TEST_PROVIDER}" "${TEST_SUITE}")"
     echo "${TESTS}" | grep -v "${TEST_SKIPS}" >/tmp/tests || { echo 'Error: all tests were filtered out by TEST_SKIPS regex:'; echo "$TEST_SKIPS"; exit 1; }
     echo "Skipping tests:"

--- a/ci-operator/step-registry/rosa/aws/sts/conformance/test/rosa-aws-sts-conformance-test-commands.sh
+++ b/ci-operator/step-registry/rosa/aws/sts/conformance/test/rosa-aws-sts-conformance-test-commands.sh
@@ -38,10 +38,9 @@ set +x
 set -e
 
 if [[ "${SKIP_MONITOR_TEST:-}" == "true" ]] && [[ ${exit_code} -ne 0 ]]; then
-    total_failures=$(grep -c "Suite run returned error:" /tmp/openshift-tests.log || true)
-    monitor_failures=$(grep -c "failed due to a MonitorTest failure" /tmp/openshift-tests.log || true)
-    if [[ ${total_failures} -gt 0 ]] && [[ ${total_failures} -eq ${monitor_failures} ]]; then
-        echo "Overriding MonitorTest-only failure (SKIP_MONITOR_TEST=true, ${monitor_failures} monitor failure(s), no blocking test failures)"
+    if grep -q 'failed due to a MonitorTest failure' /tmp/openshift-tests.log && \
+       ! grep -q 'Blocking test failures:' /tmp/openshift-tests.log; then
+        echo "Overriding MonitorTest-only failure (SKIP_MONITOR_TEST=true, no blocking test failures)"
         exit_code=0
     fi
 fi


### PR DESCRIPTION
## Summary

Add preprocessing to strip whitespace around `\|` separators in `TEST_SKIPS` before passing to `grep`. This fixes the YAML `>-` folding issue at the source, allowing all skip patterns to be on clean separate lines regardless of whether they match bracket-adjacent test names.

Cleans up the STS conformance skip list from the concatenated same-line format back to one-pattern-per-line for readability.

Classic STS conformance only. HCP conformance fix proposed separately.

## Why

YAML `>-` converts newlines to spaces, injecting whitespace into `grep` BRE alternatives. Rather than working around this by concatenating patterns on the same line (fragile, hard to maintain), strip the spaces in the script before use.

## Test plan

- [ ] Rehearse `periodic-ci-openshift-release-main-nightly-4.22-e2e-rosa-sts-ovn`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reorganized and generalized CI test-skip patterns to broaden matching and suppress noisy AWS- and SIG-related failures (load balancer, CLB/NLB hairpinning, gateway, OLM, auth/SCC, image-registry redirects, CSI volume-expansion, and related OpenShift AWS cases).
  * Made skip parsing more robust in dry-run filtering by normalizing separator whitespace so YAML folding or injected spaces no longer break skip rules.
  * Adjusted monitor-test failure handling so monitor-only failures are overridden only when no blocking failures are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->