### PR TITLE
Increase max concurrency for postsubmit jobs

### DIFF
--- a/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main.yaml
+++ b/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main.yaml
@@ -476,6 +476,7 @@ tests:
     workflow: aro-hcp-local-e2e
   timeout: 10h0m0s
 - as: global-pipeline-postsubmit
+  max_concurrency: 4
   postsubmit: true
   run_if_changed: ^(?:config/config\.yaml|observability/observability\.yaml|dev-infrastructure/.*)$
   steps:
@@ -488,11 +489,13 @@ tests:
     test:
     - ref: aro-hcp-provision-global-pipeline
 - as: images-push-postsubmit
+  max_concurrency: 4
   postsubmit: true
   steps:
     test:
     - ref: aro-hcp-images-push
 - as: cspr-pipeline-postsubmit
+  max_concurrency: 4
   postsubmit: true
   steps:
     env:

--- a/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__e2e.yaml
+++ b/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__e2e.yaml
@@ -22,6 +22,7 @@ resources:
       memory: 10Gi
 tests:
 - as: integration-e2e-parallel
+  max_concurrency: 4
   postsubmit: true
   run_if_changed: ^$
   steps:
@@ -40,6 +41,7 @@ tests:
       resource_type: aro-hcp-test-msi-containers-int
     workflow: aro-hcp-e2e
 - as: stage-e2e-parallel
+  max_concurrency: 4
   postsubmit: true
   run_if_changed: ^$
   steps:
@@ -58,6 +60,7 @@ tests:
       resource_type: aro-hcp-test-msi-containers-stg
     workflow: aro-hcp-e2e
 - as: prod-e2e-parallel
+  max_concurrency: 4
   postsubmit: true
   run_if_changed: ^$
   steps:

--- a/ci-operator/jobs/Azure/ARO-HCP/Azure-ARO-HCP-main-postsubmits.yaml
+++ b/ci-operator/jobs/Azure/ARO-HCP/Azure-ARO-HCP-main-postsubmits.yaml
@@ -70,7 +70,7 @@ postsubmits:
       skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
-    max_concurrency: 1
+    max_concurrency: 4
     name: branch-ci-Azure-ARO-HCP-main-cspr-pipeline-postsubmit
     reporter_config:
       slack:
@@ -148,7 +148,7 @@ postsubmits:
     labels:
       ci-operator.openshift.io/variant: e2e
       ci.openshift.io/generator: prowgen
-    max_concurrency: 1
+    max_concurrency: 4
     name: branch-ci-Azure-ARO-HCP-main-e2e-integration-e2e-parallel
     reporter_config:
       slack:
@@ -228,7 +228,7 @@ postsubmits:
     labels:
       ci-operator.openshift.io/variant: e2e
       ci.openshift.io/generator: prowgen
-    max_concurrency: 1
+    max_concurrency: 4
     name: branch-ci-Azure-ARO-HCP-main-e2e-prod-e2e-parallel
     reporter_config:
       slack:
@@ -308,7 +308,7 @@ postsubmits:
     labels:
       ci-operator.openshift.io/variant: e2e
       ci.openshift.io/generator: prowgen
-    max_concurrency: 1
+    max_concurrency: 4
     name: branch-ci-Azure-ARO-HCP-main-e2e-stage-e2e-parallel
     reporter_config:
       slack:
@@ -387,7 +387,7 @@ postsubmits:
       skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
-    max_concurrency: 1
+    max_concurrency: 4
     name: branch-ci-Azure-ARO-HCP-main-global-pipeline-postsubmit
     reporter_config:
       slack:
@@ -526,7 +526,7 @@ postsubmits:
       skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
-    max_concurrency: 1
+    max_concurrency: 4
     name: branch-ci-Azure-ARO-HCP-main-images-push-postsubmit
     reporter_config:
       slack:


### PR DESCRIPTION
https://redhat-internal.slack.com/archives/CBN38N3MW/p1777479900849889?thread_ts=1777477520.017929&cid=CBN38N3MW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI test pipelines to enforce concurrency limits for postsubmit and end-to-end workflows across integration, staging, and production environments, reducing simultaneous runs to optimize resource usage and improve reliability. This helps prevent overload during deployments and provides more predictable test execution timing. No functional code changes included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->