### PR TITLE
Strip whitespace from TEST_SKIPS in hypershift-conformance chain

### DIFF
--- a/ci-operator/step-registry/hypershift/conformance/hypershift-conformance-chain.yaml
+++ b/ci-operator/step-registry/hypershift/conformance/hypershift-conformance-chain.yaml
@@ -203,6 +203,8 @@ chain:
       fi
 
       if [[ -n "${TEST_SKIPS}" ]]; then
+          # Strip whitespace around \| separators injected by YAML >- folding
+          TEST_SKIPS=$(echo "$TEST_SKIPS" | sed 's/ *\\|/\\|/g; s/\\| */\\|/g')
           TESTS="$(openshift-tests run --dry-run --provider "${TEST_PROVIDER}" "${TEST_SUITE}")"
           echo "${TESTS}" | grep -v "${TEST_SKIPS}" >/tmp/tests
           if [[ -n "${TEST_INCLUDES}" ]]; then

--- a/ci-operator/step-registry/rosa/aws/hcp/conformance/rosa-aws-hcp-conformance-workflow.yaml
+++ b/ci-operator/step-registry/rosa/aws/hcp/conformance/rosa-aws-hcp-conformance-workflow.yaml
@@ -30,7 +30,10 @@ workflow:
         DRA.*kubelet.*DynamicResourceAllocation\|
         InPlacePodVerticalScaling.*decrease memory limit below usage\|
         CSI Mock volume expansion Expansion with recovery recovery should not be possible\|
-        CSI Mock volume expansion Expansion with recovery should allow recovery if controller expansion fails with final error\|cloud-provider-aws-e2e.*loadbalancer NLB internal should be reachable with hairpinning traffic\|cloud-provider-aws-e2e.*loadbalancer NLB should be reachable with target-node-labels\|\[Monitor:apiserver-incluster-availability\]\[Jira:\\"kube-apiserver\\"\] monitor test apiserver-incluster-availability
+        CSI Mock volume expansion Expansion with recovery should allow recovery if controller expansion fails with final error\|
+        cloud-provider-aws-e2e.*loadbalancer NLB internal should be reachable with hairpinning traffic\|
+        cloud-provider-aws-e2e.*loadbalancer NLB should be reachable with target-node-labels\|
+        Monitor:apiserver-incluster-availability.*monitor test apiserver-incluster-availability
     pre:
       - chain: rosa-aws-sts-hcp-provision
       - ref: osd-ccs-conf-idp-htpasswd-multi-users


### PR DESCRIPTION
## Summary

Add preprocessing to `hypershift-conformance` chain to strip whitespace around `\|` separators in `TEST_SKIPS` before passing to `grep`. This fixes the YAML `>-` folding issue that breaks skip patterns matching bracket-adjacent test names (e.g., `[DRA]`, `[cloud-provider-aws-e2e]`).

Also cleans up the ROSA HCP conformance skip list to one-pattern-per-line for readability.

## Why

YAML `>-` converts newlines to spaces, injecting whitespace into `grep` BRE alternatives. Patterns like `DRA.*kubelet.*DynamicResourceAllocation` fail because they get a leading space (` DRA`) that doesn't match the test name `[DRA] kubelet...` (no space before `DRA`, only `[`).

The one-line `sed` fix strips spaces around `\|` so all patterns work regardless of YAML formatting. This benefits all consumers of `hypershift-conformance`, not just ROSA.

## Test plan

- [ ] Rehearse `periodic-ci-openshift-release-main-nightly-4.22-e2e-rosa-hcp-ovn`

/cc @csrwng @jparrill


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test skip pattern normalization in hypershift conformance workflow for consistent regex interpretation.
  * Reorganized test skip entries in ROSA HCP conformance workflow with refined pattern matching for improved clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->