### PR TITLE
Set ARO-RP periodic job timeouts to 3h0m0s

### DIFF
--- a/ci-operator/step-registry/aro-classic/test/persistent/aro-classic-test-persistent-ref.yaml
+++ b/ci-operator/step-registry/aro-classic/test/persistent/aro-classic-test-persistent-ref.yaml
@@ -6,6 +6,7 @@ ref:
     requests:
       cpu: 1000m
       memory: 1Gi
+  timeout: 3h0m0s
   env:
     - name: LOCATION
       default: ""


### PR DESCRIPTION
Set ARO-RP periodic job timeouts to 3h0m0s. I'm getting pretty frequent timeouts, and it looks like the default timeout is two hours. From my observation, these tests take about 2 hours.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended timeout configuration for test execution to accommodate longer-running test scenarios and improve reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->