### PR TITLE
Remove e2e-test-registry image build from operator-controller main config

### DIFF
--- a/ci-operator/config/openshift/operator-framework-operator-controller/openshift-operator-framework-operator-controller-main.yaml
+++ b/ci-operator/config/openshift/operator-framework-operator-controller/openshift-operator-framework-operator-controller-main.yaml
@@ -11,13 +11,9 @@ images:
     to: olm-catalogd
   - dockerfile_path: openshift/operator-controller.Dockerfile
     to: olm-operator-controller
-  - dockerfile_path: openshift/registry.Dockerfile
-    to: e2e-test-registry
 promotion:
   to:
-  - excluded_images:
-    - e2e-test-registry
-    name: "5.0"
+  - name: "5.0"
     namespace: ocp
 releases:
   initial:
@@ -82,9 +78,6 @@ tests:
     - as: upstream-e2e
       cli: latest
       commands: make -C openshift test-e2e
-      dependencies:
-      - env: E2E_REGISTRY_IMAGE
-        name: e2e-test-registry
       from: src
       resources:
         requests:
@@ -104,9 +97,6 @@ tests:
       commands: |
         make -C openshift test-e2e
         make -C openshift test-experimental-e2e
-      dependencies:
-      - env: E2E_REGISTRY_IMAGE
-        name: e2e-test-registry
       from: src
       resources:
         requests:

--- a/ci-operator/jobs/openshift/operator-framework-operator-controller/openshift-operator-framework-operator-controller-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/operator-framework-operator-controller/openshift-operator-framework-operator-controller-main-postsubmits.yaml
@@ -11,7 +11,6 @@ postsubmits:
       - .ci-operator.yaml
       - openshift/catalogd.Dockerfile
       - openshift/operator-controller.Dockerfile
-      - openshift/registry.Dockerfile
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen

--- a/ci-operator/jobs/openshift/operator-framework-operator-controller/openshift-operator-framework-operator-controller-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/operator-framework-operator-controller/openshift-operator-framework-operator-controller-main-presubmits.yaml
@@ -13,7 +13,6 @@ presubmits:
       - .ci-operator.yaml
       - openshift/catalogd.Dockerfile
       - openshift/operator-controller.Dockerfile
-      - openshift/registry.Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -81,7 +80,6 @@ presubmits:
       - .ci-operator.yaml
       - openshift/catalogd.Dockerfile
       - openshift/operator-controller.Dockerfile
-      - openshift/registry.Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -148,7 +146,6 @@ presubmits:
       - .ci-operator.yaml
       - openshift/catalogd.Dockerfile
       - openshift/operator-controller.Dockerfile
-      - openshift/registry.Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -233,7 +230,6 @@ presubmits:
       - .ci-operator.yaml
       - openshift/catalogd.Dockerfile
       - openshift/operator-controller.Dockerfile
-      - openshift/registry.Dockerfile
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -319,7 +315,6 @@ presubmits:
       - .ci-operator.yaml
       - openshift/catalogd.Dockerfile
       - openshift/operator-controller.Dockerfile
-      - openshift/registry.Dockerfile
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -405,7 +400,6 @@ presubmits:
       - .ci-operator.yaml
       - openshift/catalogd.Dockerfile
       - openshift/operator-controller.Dockerfile
-      - openshift/registry.Dockerfile
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -492,7 +486,6 @@ presubmits:
       - .ci-operator.yaml
       - openshift/catalogd.Dockerfile
       - openshift/operator-controller.Dockerfile
-      - openshift/registry.Dockerfile
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -578,7 +571,6 @@ presubmits:
       - .ci-operator.yaml
       - openshift/catalogd.Dockerfile
       - openshift/operator-controller.Dockerfile
-      - openshift/registry.Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -785,7 +777,6 @@ presubmits:
       - .ci-operator.yaml
       - openshift/catalogd.Dockerfile
       - openshift/operator-controller.Dockerfile
-      - openshift/registry.Dockerfile
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -872,7 +863,6 @@ presubmits:
       - .ci-operator.yaml
       - openshift/catalogd.Dockerfile
       - openshift/operator-controller.Dockerfile
-      - openshift/registry.Dockerfile
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -959,7 +949,6 @@ presubmits:
       - .ci-operator.yaml
       - openshift/catalogd.Dockerfile
       - openshift/operator-controller.Dockerfile
-      - openshift/registry.Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -1044,7 +1033,6 @@ presubmits:
       - .ci-operator.yaml
       - openshift/catalogd.Dockerfile
       - openshift/operator-controller.Dockerfile
-      - openshift/registry.Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -1111,7 +1099,6 @@ presubmits:
       - .ci-operator.yaml
       - openshift/catalogd.Dockerfile
       - openshift/operator-controller.Dockerfile
-      - openshift/registry.Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -1178,7 +1165,6 @@ presubmits:
       - .ci-operator.yaml
       - openshift/catalogd.Dockerfile
       - openshift/operator-controller.Dockerfile
-      - openshift/registry.Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -1245,7 +1231,6 @@ presubmits:
       - .ci-operator.yaml
       - openshift/catalogd.Dockerfile
       - openshift/operator-controller.Dockerfile
-      - openshift/registry.Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"


### PR DESCRIPTION
## Summary
- Remove the `e2e-test-registry` image build from the main branch CI config for `operator-framework-operator-controller`
- Remove `excluded_images` from promotion config (no longer needed)
- Remove `E2E_REGISTRY_IMAGE` dependency from `openshift-e2e-aws` and `openshift-e2e-aws-techpreview` tests

## Test plan
- [ ] CI passes `make update` validation
- [ ] No remaining references to `e2e-test-registry` in generated job files

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD build configuration to streamline the build and promotion workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->