### PR TITLE
TRT-2622: segregate informing tests in spyglass

### DIFF
--- a/clusters/app.ci/prow/staging/prow-config.yaml
+++ b/clusters/app.ci/prow/staging/prow-config.yaml
@@ -32,6 +32,11 @@ data:
          - build-log.txt
        - lens:
            name: junit
+           config:
+             groups:
+             - name: "Informing tests"
+               selector: "properties/property[@name='lifecycle' and @value='informing']"
+               collapsed: true
          required_files:
          - .*/junit.*\.xml
        - lens:

--- a/core-services/prow/02_config/_config.yaml
+++ b/core-services/prow/02_config/_config.yaml
@@ -239,6 +239,11 @@ deck:
       required_files:
       - ^build-log.txt
     - lens:
+        config:
+          groups:
+          - collapsed: true
+            name: Informing tests
+            selector: properties/property[@name='lifecycle' and @value='informing']
         name: junit
       optional_files:
       - .*/monitor.*\.xml


### PR DESCRIPTION
Once deck is updated to include https://github.com/kubernetes-sigs/prow/pull/694 we can merge this to separate out informing tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Test reporting UI now groups JUnit results labeled as informational into a collapsed "Informing tests" section within the test viewer, improving organization and making critical failures easier to spot.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->