### PR TITLE
Exclude autoscaling from kserve LLMISvc E2E

### DIFF
--- a/ci-operator/config/opendatahub-io/kserve/opendatahub-io-kserve-master.yaml
+++ b/ci-operator/config/opendatahub-io/kserve/opendatahub-io-kserve-master.yaml
@@ -344,7 +344,7 @@ tests:
     - as: e2e-llm-inference-service
       cli: latest
       commands: ./test/scripts/openshift-ci/run-e2e-tests.sh "llminferenceservice
-        and cluster_cpu" 2 "llm-d"
+        and cluster_cpu and not autoscaling" 2 "llm-d"
       dependencies:
       - env: KSERVE_CONTROLLER_IMAGE
         name: kserve-controller

--- a/ci-operator/config/opendatahub-io/kserve/opendatahub-io-kserve-release-v0.17.yaml
+++ b/ci-operator/config/opendatahub-io/kserve/opendatahub-io-kserve-release-v0.17.yaml
@@ -318,7 +318,7 @@ tests:
     - as: e2e-llm-inference-service
       cli: latest
       commands: ./test/scripts/openshift-ci/run-e2e-tests.sh "llminferenceservice
-        and cluster_cpu" 2 "llm-d"
+        and cluster_cpu and not autoscaling" 2 "llm-d"
       dependencies:
       - env: KSERVE_CONTROLLER_IMAGE
         name: kserve-controller


### PR DESCRIPTION
## Summary

Adds `and not autoscaling` to the pytest marker for the `e2e-llm-inference-service` Prow job in the kserve master and release-v0.17 configs.

The WVA (Workload Variant Autoscaler) infrastructure (Prometheus, WVA controller, HPA/KEDA) is not installed in these test clusters. Without it, autoscaling tests fail with `ScalingCRDNotFound` because the `VariantAutoscaling` CRD from `llmd.ai/v1alpha1` is missing.

This matches the pattern already used in the upstream `e2e-test-llmisvc.yaml` GHA workflow, which excludes autoscaling from its basic job and runs dedicated autoscaling jobs with full WVA infrastructure.

Companion PRs:
- opendatahub-io/kserve#1445 (sync PR that introduced the autoscaling feature)
- odh-konflux-central (same marker fix for Konflux pipelines)

Supersedes #78557 (stale CI).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test case selection for end-to-end LLM inference service testing to exclude autoscaling test scenarios while maintaining focus on core inference and CPU cluster tests across multiple release configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->