### PR TITLE
Onboard ci-tools-standalone and remove migrated images from ci-tools

### DIFF
--- a/ci-operator/config/openshift/ci-tools-standalone/.config.prowgen
+++ b/ci-operator/config/openshift/ci-tools-standalone/.config.prowgen
@@ -1,0 +1,9 @@
+multi_arch: yes
+slack_reporter:
+- channel: "#ops-testplatform"
+  job_states_to_report:
+  - failure
+  - error
+  report_template: ':failed: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> {{end}}'
+  job_names:
+  - images

--- a/ci-operator/config/openshift/ci-tools-standalone/OWNERS
+++ b/ci-operator/config/openshift/ci-tools-standalone/OWNERS
@@ -1,0 +1,24 @@
+# DO NOT EDIT; this file is auto-generated using https://github.com/openshift/ci-tools.
+# Fetched from https://github.com/openshift/ci-tools-standalone root OWNERS
+# If the repo had OWNERS_ALIASES then the aliases were expanded
+# Logins who are not members of 'openshift' organization were filtered out
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+- droslean
+- jmguzik
+- danilo-gemoli
+- bear-redhat
+- psalajova
+- deepsm007
+- Prucek
+- hector-vido
+reviewers:
+- droslean
+- jmguzik
+- danilo-gemoli
+- bear-redhat
+- psalajova
+- deepsm007
+- Prucek
+- hector-vido

--- a/ci-operator/config/openshift/ci-tools-standalone/openshift-ci-tools-standalone-main.yaml
+++ b/ci-operator/config/openshift/ci-tools-standalone/openshift-ci-tools-standalone-main.yaml
@@ -1,0 +1,326 @@
+base_images:
+  golangci-lint:
+    name: golangci-lint
+    namespace: ci
+    tag: latest
+  os:
+    name: ubi-minimal
+    namespace: ocp
+    tag: "9"
+binary_build_commands: make production-install
+build_root:
+  from_repository: true
+images:
+  items:
+  - additional_architectures:
+    - arm64
+    context_dir: images/backport-verifier/
+    from: os
+    inputs:
+      bin:
+        paths:
+        - destination_dir: .
+          source_path: /go/bin/backport-verifier
+    to: backport-verifier
+  - additional_architectures:
+    - arm64
+    dockerfile_literal: |-
+      FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+      ADD ci-scheduling-webhook /usr/bin/ci-scheduling-webhook
+      ENTRYPOINT ["/usr/bin/ci-scheduling-webhook"]
+    from: os
+    inputs:
+      bin:
+        paths:
+        - destination_dir: .
+          source_path: /go/bin/ci-scheduling-webhook
+    to: ci-scheduling-webhook
+  - additional_architectures:
+    - arm64
+    context_dir: images/determinize-peribolos/
+    from: os
+    inputs:
+      bin:
+        paths:
+        - destination_dir: .
+          source_path: /go/bin/determinize-peribolos
+    to: determinize-peribolos
+  - additional_architectures:
+    - arm64
+    context_dir: images/gpu-scheduling-webhook/
+    from: os
+    inputs:
+      bin:
+        paths:
+        - destination_dir: .
+          source_path: /go/bin/gpu-scheduling-webhook
+    to: gpu-scheduling-webhook
+  - context_dir: images/helpdesk-faq/
+    from: os
+    inputs:
+      bin:
+        paths:
+        - destination_dir: .
+          source_path: /go/bin/helpdesk-faq
+    to: helpdesk-faq
+  - additional_architectures:
+    - arm64
+    context_dir: images/pipeline-controller/
+    from: os
+    inputs:
+      bin:
+        paths:
+        - destination_dir: .
+          source_path: /go/bin/pipeline-controller
+    to: pipeline-controller
+  - additional_architectures:
+    - arm64
+    context_dir: images/pr-reminder/
+    from: os
+    inputs:
+      bin:
+        paths:
+        - destination_dir: .
+          source_path: /go/bin/pr-reminder
+    to: pr-reminder
+  - additional_architectures:
+    - arm64
+    context_dir: images/publicize/
+    from: os
+    inputs:
+      bin:
+        paths:
+        - destination_dir: .
+          source_path: /go/bin/publicize
+    to: publicize
+  - dockerfile_literal: |-
+      FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+      RUN microdnf install -y git && microdnf clean all && rm -rf /var/cache/dnf
+      ADD retester /usr/bin/retester
+      ENTRYPOINT ["/usr/bin/retester"]
+    from: os
+    inputs:
+      bin:
+        paths:
+        - destination_dir: .
+          source_path: /go/bin/retester
+    to: retester
+promotion:
+  to:
+  - namespace: ci
+    tag: latest
+resources:
+  '*':
+    requests:
+      cpu: "1"
+      memory: 1Gi
+  unit:
+    requests:
+      cpu: "2"
+      memory: 2Gi
+tests:
+- as: unit
+  commands: make test
+  container:
+    from: src
+  node_architecture: arm64
+- as: format
+  commands: make format
+  container:
+    from: src
+  node_architecture: arm64
+- as: lint
+  commands: make lint
+  container:
+    from: golangci-lint
+- as: validate-vendor
+  commands: make validate-vendor
+  container:
+    from: src
+  node_architecture: arm64
+- as: security
+  optional: true
+  steps:
+    test:
+    - as: ci-tools-standalone-security
+      commands: |
+        #!/bin/bash
+
+        SNYK_TOKEN="$(cat $SNYK_TOKEN_PATH)"
+        export SNYK_TOKEN
+
+        SNYK_DIR=/tmp/snyk
+        mkdir -p ${SNYK_DIR}
+        ARCH=$(uname -m | sed -e 's/x86_64/amd64/;s/aarch64/arm64/')
+
+        SNYK_URL="https://static.snyk.io/cli/latest/snyk-linux"
+        if [ "$ARCH" != "amd64" ]; then
+            SNYK_URL="https://static.snyk.io/cli/latest/snyk-linux-${ARCH}"
+        fi
+
+        curl "${SNYK_URL}" -o $SNYK_DIR/snyk
+        chmod +x ${SNYK_DIR}/snyk
+
+        echo snyk installed to ${SNYK_DIR}
+        ${SNYK_DIR}/snyk --version
+
+        if ! [ -x "$(command -v jq)" ]; then
+            case ${ARCH} in
+                arm64)
+                  JQ_CHECKSUM="ab57ee39075db4a23f899d396ecef3c6e58f6aada35bfee472468210bd126940"
+                ;;
+                amd64)
+                  JQ_CHECKSUM="2f312b9587b1c1eddf3a53f9a0b7d276b9b7b94576c85bda22808ca950569716"
+                ;;
+                *)
+                  echo "Unsupported architecture: ${ARCH}"
+                  exit 1
+            esac
+
+            curl -Lo ${SNYK_DIR}/jq "https://github.com/jqlang/jq/releases/download/jq-1.7/jq-linux-${ARCH}"
+
+            actual_checksum=$(sha256sum ${SNYK_DIR}/jq | cut -d ' ' -f 1)
+            if [ "${actual_checksum}" != "${JQ_CHECKSUM}" ]; then
+                echo "Checksum of downloaded JQ didn't match expected checksum"
+                exit 1
+            fi
+
+            chmod +x ${SNYK_DIR}/jq
+            export PATH=${PATH}:${SNYK_DIR}
+        fi
+
+        CLONE_REFS=$(echo $CLONEREFS_OPTIONS | jq -r ".refs | map(select(.base_ref == \"$(git rev-parse --abbrev-ref HEAD)\")) | if length > 1 then del(.[] | select(.repo == \"release\" and .org == \"openshift\")) else . end | .[]")
+
+        if [ -z "${PROJECT_NAME}" ]; then
+            PROJECT_NAME=$(echo $CLONE_REFS | jq -r "( .org + \"/\" + .repo )")
+        fi
+
+        snyk_deps() {
+            if [ "$SNYK_ENABLE_DEPS_SCAN" != "true" ]; then
+                echo "Skipping snyk dependencies scan"
+                return 0
+            fi
+            echo Starting snyk dependencies scan
+            PARAMS=(--project-name="$PROJECT_NAME" --org="$ORG_NAME")
+            if [ "$ALL_PROJECTS" = "true" ]; then
+                PARAMS+=(--all-projects)
+            fi
+            if [ "$SNYK_DEPS_ADDITIONAL_ARGS" ]; then
+                read -a PARAMS <<<"$SNYK_DEPS_ADDITIONAL_ARGS"
+            fi
+            ${SNYK_DIR}/snyk test "${PARAMS[@]}"
+        }
+
+        snyk_code() {
+            if [ "$SNYK_ENABLE_CODE_SCAN" != "true" ]; then
+                echo "Skipping snyk code scan"
+                return 0
+            fi
+            echo Starting snyk code scan
+            PARAMS=(--project-name="$PROJECT_NAME" --org="$ORG_NAME"  --sarif-file-output="${ARTIFACT_DIR}/snyk.sarif.json" --report)
+            if [ "$SNYK_CODE_ADDITIONAL_ARGS" ]; then
+                read -a PARAMS <<<"$SNYK_CODE_ADDITIONAL_ARGS"
+            fi
+
+            if [ -z "${TARGET_REFERENCE}" ]; then
+                TARGET_REFERENCE=$(echo $CLONE_REFS | jq -r .base_ref | tr '.' '-')
+            fi
+            PARAMS+=(--target-reference="${TARGET_REFERENCE}")
+
+            ${SNYK_DIR}/snyk code test "${PARAMS[@]}"
+            local rc=$?
+            echo Full vulnerabilities report is available at ${ARTIFACT_DIR}/snyk.sarif.json
+            return $rc
+        }
+
+        pre_execution_hook_cmd() {
+            local rc=0
+            echo "Running pre-execution hook"
+            if [ "$SNYK_PRE_EXECUTION_HOOK_CMD" ]; then
+                eval "$SNYK_PRE_EXECUTION_HOOK_CMD"
+                rc=$?
+            else
+                echo "No pre-execution hook defined"
+            fi
+            echo "Pre-execution hook completed"
+            return "$rc"
+        }
+
+        pre_execution_hook_script() {
+            local rc=0
+            echo "Running pre-execution hook script"
+            if [ "$SNYK_PRE_EXECUTION_HOOK_SCRIPT" ] && [ -f "$SNYK_PRE_EXECUTION_HOOK_SCRIPT" ]; then
+                # shellcheck source=/dev/null
+                source "$SNYK_PRE_EXECUTION_HOOK_SCRIPT"
+                rc=$?
+            else
+                echo "No pre-execution hook script defined"
+            fi
+            echo "Pre-execution hook script completed"
+            return "$rc"
+        }
+
+        declare -a cmd_order=(
+            pre_execution_hook_cmd
+            pre_execution_hook_script
+            snyk_deps
+            snyk_code
+        )
+
+        declare -a error_messages=(
+            "pre-execution hook command failed"
+            "pre-execution hook script failed"
+            "snyk dependencies scan failed"
+            "snyk code scan failed"
+        )
+
+        all_successful=true
+        for idx in "${!cmd_order[@]}"; do
+            if ! ${cmd_order[idx]}; then
+                all_successful=false
+                echo "${error_messages[idx]}"
+            fi
+        done
+
+        if [ "$all_successful" = "false" ]; then
+            exit 1
+        fi
+      credentials:
+      - collection: test-platform-infra
+        field: api-token
+        group: snyk-credentials
+        mount_path: /snyk-credentials
+      env:
+      - default: ci-tools-standalone
+        name: PROJECT_NAME
+      - default: openshift-ci-internal
+        name: ORG_NAME
+      - default: "false"
+        name: ALL_PROJECTS
+      - default: /snyk-credentials/api-token
+        name: SNYK_TOKEN_PATH
+      - default: "true"
+        name: SNYK_ENABLE_CODE_SCAN
+      - default: "false"
+        name: SNYK_ENABLE_DEPS_SCAN
+      - default: ""
+        name: TARGET_REFERENCE
+      - default: ""
+        name: SNYK_CODE_ADDITIONAL_ARGS
+      - default: ""
+        name: SNYK_DEPS_ADDITIONAL_ARGS
+      - default: ""
+        name: SNYK_PRE_EXECUTION_HOOK_SCRIPT
+      - default: ""
+        name: SNYK_PRE_EXECUTION_HOOK_CMD
+      from: src
+      grace_period: 5m0s
+      resources:
+        requests:
+          cpu: 100m
+          memory: 100Mi
+      timeout: 10m0s
+zz_generated_metadata:
+  branch: main
+  org: openshift
+  repo: ci-tools-standalone

--- a/ci-operator/config/openshift/ci-tools/openshift-ci-tools-main.yaml
+++ b/ci-operator/config/openshift/ci-tools/openshift-ci-tools-main.yaml
@@ -42,26 +42,6 @@ images:
     to: pod-scaler
   - additional_architectures:
     - arm64
-    context_dir: images/pr-reminder/
-    from: os
-    inputs:
-      bin:
-        paths:
-        - destination_dir: .
-          source_path: /go/bin/pr-reminder
-    to: pr-reminder
-  - additional_architectures:
-    - arm64
-    context_dir: images/pipeline-controller/
-    from: os
-    inputs:
-      bin:
-        paths:
-        - destination_dir: .
-          source_path: /go/bin/pipeline-controller
-    to: pipeline-controller
-  - additional_architectures:
-    - arm64
     context_dir: images/check-gh-automation/
     from: os
     inputs:
@@ -384,16 +364,6 @@ images:
     to: determinize-ci-operator
   - additional_architectures:
     - arm64
-    context_dir: images/determinize-peribolos/
-    from: os
-    inputs:
-      bin:
-        paths:
-        - destination_dir: .
-          source_path: /go/bin/determinize-peribolos
-    to: determinize-peribolos
-  - additional_architectures:
-    - arm64
     context_dir: images/applyconfig
     from: os
     inputs:
@@ -598,26 +568,6 @@ images:
     to: generate-registry-metadata
   - additional_architectures:
     - arm64
-    context_dir: images/publicize/
-    from: os
-    inputs:
-      bin:
-        paths:
-        - destination_dir: .
-          source_path: /go/bin/publicize
-    to: publicize
-  - additional_architectures:
-    - arm64
-    context_dir: images/backport-verifier/
-    from: os
-    inputs:
-      bin:
-        paths:
-        - destination_dir: .
-          source_path: /go/bin/backport-verifier
-    to: backport-verifier
-  - additional_architectures:
-    - arm64
     context_dir: images/serviceaccount-secret-rotation-trigger
     from: os
     inputs:
@@ -694,19 +644,6 @@ images:
         - destination_dir: .
           source_path: /go/bin/vault-secret-collection-manager
     to: vault-secret-collection-manager
-  - dockerfile_literal: |-
-      FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
-      ADD bugzilla-config-manager /usr/bin/bugzilla-config-manager
-      ADD prcreator /usr/bin/prcreator
-    from: os
-    inputs:
-      bin:
-        paths:
-        - destination_dir: .
-          source_path: /go/bin/bugzilla-config-manager
-        - destination_dir: .
-          source_path: /go/bin/prcreator
-    to: bugzilla-config-manager
   - dockerfile_literal: |-
       FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
       RUN microdnf install -y git && microdnf clean all && rm -rf /var/cache/dnf
@@ -807,18 +744,6 @@ images:
     to: sync-rover-groups
   - dockerfile_literal: |-
       FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
-      RUN microdnf install -y git && microdnf clean all && rm -rf /var/cache/dnf
-      ADD retester /usr/bin/retester
-      ENTRYPOINT ["/usr/bin/retester"]
-    from: os
-    inputs:
-      bin:
-        paths:
-        - destination_dir: .
-          source_path: /go/bin/retester
-    to: retester
-  - dockerfile_literal: |-
-      FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
       ADD image-graph-generator /usr/bin/image-graph-generator
       ENTRYPOINT ["/usr/bin/image-graph-generator"]
     from: os
@@ -838,37 +763,6 @@ images:
         - destination_dir: .
           source_path: /usr/local/bin/oc
     to: multi-arch-builder-controller
-  - additional_architectures:
-    - arm64
-    dockerfile_literal: |-
-      FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
-      ADD ci-scheduling-webhook /usr/bin/ci-scheduling-webhook
-      ENTRYPOINT ["/usr/bin/ci-scheduling-webhook"]
-    from: os
-    inputs:
-      bin:
-        paths:
-        - destination_dir: .
-          source_path: /go/bin/ci-scheduling-webhook
-    to: ci-scheduling-webhook
-  - additional_architectures:
-    - arm64
-    context_dir: images/gpu-scheduling-webhook
-    from: os
-    inputs:
-      bin:
-        paths:
-        - destination_dir: .
-          source_path: /go/bin/gpu-scheduling-webhook
-    to: gpu-scheduling-webhook
-  - context_dir: images/helpdesk-faq/
-    from: os
-    inputs:
-      bin:
-        paths:
-        - destination_dir: .
-          source_path: /go/bin/helpdesk-faq
-    to: helpdesk-faq
 promotion:
   to:
   - namespace: ci

--- a/ci-operator/jobs/openshift/ci-tools-standalone/OWNERS
+++ b/ci-operator/jobs/openshift/ci-tools-standalone/OWNERS
@@ -1,0 +1,18 @@
+approvers:
+- droslean
+- jmguzik
+- danilo-gemoli
+- bear-redhat
+- psalajova
+- deepsm007
+- Prucek
+- hector-vido
+reviewers:
+- droslean
+- jmguzik
+- danilo-gemoli
+- bear-redhat
+- psalajova
+- deepsm007
+- Prucek
+- hector-vido

--- a/ci-operator/jobs/openshift/ci-tools-standalone/openshift-ci-tools-standalone-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/ci-tools-standalone/openshift-ci-tools-standalone-main-postsubmits.yaml
@@ -1,0 +1,69 @@
+postsubmits:
+  openshift/ci-tools-standalone:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    cluster: build10
+    decorate: true
+    labels:
+      capability/arm64: arm64
+      ci-operator.openshift.io/is-promotion: "true"
+      ci.openshift.io/generator: prowgen
+    max_concurrency: 1
+    name: branch-ci-openshift-ci-tools-standalone-main-images
+    reporter_config:
+      slack:
+        channel: '#ops-testplatform'
+        job_states_to_report:
+        - failure
+        - error
+        report_template: ':failed: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*.
+          <{{.Status.URL}}|View logs> {{end}}'
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --image-mirror-push-secret=/etc/push-secret/.dockerconfigjson
+        - --promote
+        - --report-credentials-file=/etc/report/credentials
+        - --target=[images]
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/push-secret
+          name: push-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: push-secret
+        secret:
+          secretName: registry-push-credentials-ci-central
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator

--- a/ci-operator/jobs/openshift/ci-tools-standalone/openshift-ci-tools-standalone-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/ci-tools-standalone/openshift-ci-tools-standalone-main-presubmits.yaml
@@ -1,0 +1,383 @@
+presubmits:
+  openshift/ci-tools-standalone:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build09
+    context: ci/prow/format
+    decorate: true
+    labels:
+      capability/arm64: arm64
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-ci-tools-standalone-main-format
+    rerun_command: /test format
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=format
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )format,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build09
+    context: ci/prow/images
+    decorate: true
+    labels:
+      capability/arm64: arm64
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-ci-tools-standalone-main-images
+    reporter_config:
+      slack:
+        channel: '#ops-testplatform'
+        job_states_to_report:
+        - failure
+        - error
+        report_template: ':failed: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*.
+          <{{.Status.URL}}|View logs> {{end}}'
+    rerun_command: /test images
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=[images]
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )images,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build01
+    context: ci/prow/lint
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-ci-tools-standalone-main-lint
+    rerun_command: /test lint
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=lint
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )lint,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build01
+    context: ci/prow/security
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-ci-tools-standalone-main-security
+    optional: true
+    rerun_command: /test security
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --target=security
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )security,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build09
+    context: ci/prow/unit
+    decorate: true
+    labels:
+      capability/arm64: arm64
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-ci-tools-standalone-main-unit
+    rerun_command: /test unit
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=unit
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )unit,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build09
+    context: ci/prow/validate-vendor
+    decorate: true
+    labels:
+      capability/arm64: arm64
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-ci-tools-standalone-main-validate-vendor
+    rerun_command: /test validate-vendor
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=validate-vendor
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )validate-vendor,?($|\s.*)

--- a/core-services/prow/02_config/openshift/ci-tools-standalone/OWNERS
+++ b/core-services/prow/02_config/openshift/ci-tools-standalone/OWNERS
@@ -1,0 +1,24 @@
+# DO NOT EDIT; this file is auto-generated using https://github.com/openshift/ci-tools.
+# Fetched from https://github.com/openshift/ci-tools-standalone root OWNERS
+# If the repo had OWNERS_ALIASES then the aliases were expanded
+# Logins who are not members of 'openshift' organization were filtered out
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+- droslean
+- jmguzik
+- danilo-gemoli
+- bear-redhat
+- psalajova
+- deepsm007
+- Prucek
+- hector-vido
+reviewers:
+- droslean
+- jmguzik
+- danilo-gemoli
+- bear-redhat
+- psalajova
+- deepsm007
+- Prucek
+- hector-vido

--- a/core-services/prow/02_config/openshift/ci-tools-standalone/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/ci-tools-standalone/_pluginconfig.yaml
@@ -1,0 +1,15 @@
+approve:
+- commandHelpLink: https://go.k8s.io/bot-commands
+  ignore_review_state: false
+  lgtm_acts_as_approve: true
+  repos:
+  - openshift/ci-tools-standalone
+lgtm:
+- repos:
+  - openshift/ci-tools-standalone
+  review_acts_as_lgtm: true
+  trusted_team_for_sticky_lgtm: test-platform
+plugins:
+  openshift/ci-tools-standalone:
+    plugins:
+    - approve

--- a/core-services/prow/02_config/openshift/ci-tools-standalone/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/ci-tools-standalone/_prowconfig.yaml
@@ -1,0 +1,14 @@
+tide:
+  queries:
+  - labels:
+    - approved
+    - lgtm
+    missingLabels:
+    - backports/unvalidated-commits
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - jira/invalid-bug
+    - needs-rebase
+    repos:
+    - openshift/ci-tools-standalone


### PR DESCRIPTION
Add CI configuration for the new openshift/ci-tools-standalone repository:
- ci-operator config with image builds, unit/format/lint/validate-vendor/security tests
- Prow plugin config (approve, lgtm, tide)
- Generated presubmit and postsubmit job definitions

Remove image definitions from ci-tools for tools that have been migrated:
- backport-verifier, ci-scheduling-webhook, determinize-peribolos, gpu-scheduling-webhook, helpdesk-faq, pipeline-controller, pr-reminder, publicize, retester
- Also removes bugzilla-config-manager (previously deleted from ci-tools)


Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a standalone CI/CD pipeline with multi-architecture build and promotion for multiple tools.
  * Updated container image build definitions and resource/test configurations.
  * Established repository approval/review rules and Tide-based merge criteria.
* **New Features**
  * Slack reporting for failed image build jobs to the operations channel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->