### PR TITLE
CNF-23327: Switch oran-o2ims build root to from_repository

### DIFF
--- a/ci-operator/config/openshift-kni/oran-o2ims/openshift-kni-oran-o2ims-main.yaml
+++ b/ci-operator/config/openshift-kni/oran-o2ims/openshift-kni-oran-o2ims-main.yaml
@@ -9,8 +9,7 @@ base_images:
     tag: "9"
 binary_build_commands: make binary
 build_root:
-  project_image:
-    dockerfile_path: Dockerfile.tools
+  from_repository: true
 images:
   items:
   - dockerfile_path: Dockerfile
@@ -57,7 +56,13 @@ test_binary_build_commands: |
   ./hack/install-markdownlint.sh
 tests:
 - as: ci-job
-  commands: make ci-job
+  commands: |
+    unset VERSION
+    unset GOFLAGS
+    export XDG_CACHE_HOME=/tmp/.cache
+    export XDG_CONFIG_HOME=/tmp/.config
+    export XDG_DATA_HOME=/tmp/.local/share
+    make ci-job
   container:
     from: src
   skip_if_only_changed: ^\.tekton/.*|^\.konflux/.*|^docs/|LICENSE|OWNERS|\.md$|^hack$

--- a/ci-operator/jobs/openshift-kni/oran-o2ims/openshift-kni-oran-o2ims-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift-kni/oran-o2ims/openshift-kni-oran-o2ims-main-postsubmits.yaml
@@ -6,8 +6,6 @@ postsubmits:
     - ^main$
     cluster: build03
     decorate: true
-    decoration_config:
-      skip_cloning: true
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen

--- a/ci-operator/jobs/openshift-kni/oran-o2ims/openshift-kni-oran-o2ims-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-kni/oran-o2ims/openshift-kni-oran-o2ims-main-presubmits.yaml
@@ -8,8 +8,6 @@ presubmits:
     cluster: build03
     context: ci/prow/ci-bundle-operator-bundle
     decorate: true
-    decoration_config:
-      skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -63,8 +61,6 @@ presubmits:
     cluster: build03
     context: ci/prow/ci-job
     decorate: true
-    decoration_config:
-      skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -127,8 +123,6 @@ presubmits:
     cluster: build03
     context: ci/prow/images
     decorate: true
-    decoration_config:
-      skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -183,8 +177,6 @@ presubmits:
     cluster: build03
     context: ci/prow/markdownlint
     decorate: true
-    decoration_config:
-      skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -247,8 +239,6 @@ presubmits:
     cluster: build09
     context: ci/prow/scorecard
     decorate: true
-    decoration_config:
-      skip_cloning: true
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: aws-telco


### PR DESCRIPTION
Change the oran-o2ims CI build root from project_image (Dockerfile.tools) to from_repository, which reads .ci-operator.yaml from the PR under test. This allows Go version upgrades and other build environment changes to be tested atomically in a single PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to optimize the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->