### PR TITLE
Switch rhel-9-codeready-builder-rpms to mirror2 for 4.22, 4.23, 5.0, 5.1

### DIFF
--- a/core-services/release-controller/_repos/ocp-4.22-rhel9.repo
+++ b/core-services/release-controller/_repos/ocp-4.22-rhel9.repo
@@ -61,15 +61,15 @@ failovermethod = priority
 
 [rhel-9-codeready-builder-rpms]
 name = rhel-9-codeready-builder-rpms
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/codeready-builder/os/
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22/rhel-9-codeready-builder-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
 [rhel-9-server-ose]
 name = rhel-9-server-ose
@@ -156,15 +156,15 @@ skip_if_unavailable = true
 
 [rhel-9-codeready-builder-rpms-ppc64le]
 name = rhel-9-codeready-builder-rpms-ppc64le
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/codeready-builder/os/
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22_ppc64le/rhel-9-codeready-builder-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
 [rhel-9-baseos-s390x]
 name = rhel-9-baseos-s390x
@@ -216,15 +216,15 @@ skip_if_unavailable = true
 
 [rhel-9-codeready-builder-rpms-s390x]
 name = rhel-9-codeready-builder-rpms-s390x
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/codeready-builder/os/
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22_s390x/rhel-9-codeready-builder-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
 [rhel-9-baseos-aarch64]
 name = rhel-9-baseos-aarch64
@@ -276,12 +276,12 @@ skip_if_unavailable = true
 
 [rhel-9-codeready-builder-rpms-aarch64]
 name = rhel-9-codeready-builder-rpms-aarch64
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/codeready-builder/os/
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.22_aarch64/rhel-9-codeready-builder-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true

--- a/core-services/release-controller/_repos/ocp-4.23-rhel9.repo
+++ b/core-services/release-controller/_repos/ocp-4.23-rhel9.repo
@@ -156,15 +156,15 @@ skip_if_unavailable = true
 
 [rhel-9-codeready-builder-rpms-ppc64le]
 name = rhel-9-codeready-builder-rpms-ppc64le
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/codeready-builder/os/
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.23_ppc64le/rhel-9-codeready-builder-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
 [rhel-9-baseos-s390x]
 name = rhel-9-baseos-s390x
@@ -216,15 +216,15 @@ skip_if_unavailable = true
 
 [rhel-9-codeready-builder-rpms-s390x]
 name = rhel-9-codeready-builder-rpms-s390x
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/codeready-builder/os/
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.23_s390x/rhel-9-codeready-builder-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
 [rhel-9-baseos-aarch64]
 name = rhel-9-baseos-aarch64
@@ -276,12 +276,12 @@ skip_if_unavailable = true
 
 [rhel-9-codeready-builder-rpms-aarch64]
 name = rhel-9-codeready-builder-rpms-aarch64
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/codeready-builder/os/
+baseurl = https://mirror2.openshift.com/enterprise/reposync/4.23_aarch64/rhel-9-codeready-builder-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true

--- a/core-services/release-controller/_repos/ocp-5.0-rhel9.repo
+++ b/core-services/release-controller/_repos/ocp-5.0-rhel9.repo
@@ -61,15 +61,15 @@ failovermethod = priority
 
 [rhel-9-codeready-builder-rpms]
 name = rhel-9-codeready-builder-rpms
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/codeready-builder/os/
+baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0/rhel-9-codeready-builder-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
 [rhel-9-server-ose]
 name = rhel-9-server-ose
@@ -157,15 +157,15 @@ skip_if_unavailable = true
 
 [rhel-9-codeready-builder-rpms-ppc64le]
 name = rhel-9-codeready-builder-rpms-ppc64le
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/codeready-builder/os/
+baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0_ppc64le/rhel-9-codeready-builder-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
 [rhel-9-baseos-s390x]
 name = rhel-9-baseos-s390x
@@ -217,15 +217,15 @@ skip_if_unavailable = true
 
 [rhel-9-codeready-builder-rpms-s390x]
 name = rhel-9-codeready-builder-rpms-s390x
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/codeready-builder/os/
+baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0_s390x/rhel-9-codeready-builder-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
 [rhel-9-baseos-aarch64]
 name = rhel-9-baseos-aarch64
@@ -277,12 +277,12 @@ skip_if_unavailable = true
 
 [rhel-9-codeready-builder-rpms-aarch64]
 name = rhel-9-codeready-builder-rpms-aarch64
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/codeready-builder/os/
+baseurl = https://mirror2.openshift.com/enterprise/reposync/5.0_aarch64/rhel-9-codeready-builder-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true

--- a/core-services/release-controller/_repos/ocp-5.1-rhel9.repo
+++ b/core-services/release-controller/_repos/ocp-5.1-rhel9.repo
@@ -61,15 +61,15 @@ failovermethod = priority
 
 [rhel-9-codeready-builder-rpms]
 name = rhel-9-codeready-builder-rpms
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/codeready-builder/os/
+baseurl = https://mirror2.openshift.com/enterprise/reposync/5.1/rhel-9-codeready-builder-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
 [rhel-9-server-ose]
 name = rhel-9-server-ose
@@ -156,15 +156,15 @@ skip_if_unavailable = true
 
 [rhel-9-codeready-builder-rpms-ppc64le]
 name = rhel-9-codeready-builder-rpms-ppc64le
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/codeready-builder/os/
+baseurl = https://mirror2.openshift.com/enterprise/reposync/5.1_ppc64le/rhel-9-codeready-builder-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
 [rhel-9-baseos-s390x]
 name = rhel-9-baseos-s390x
@@ -216,15 +216,15 @@ skip_if_unavailable = true
 
 [rhel-9-codeready-builder-rpms-s390x]
 name = rhel-9-codeready-builder-rpms-s390x
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/codeready-builder/os/
+baseurl = https://mirror2.openshift.com/enterprise/reposync/5.1_s390x/rhel-9-codeready-builder-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true
 
 [rhel-9-baseos-aarch64]
 name = rhel-9-baseos-aarch64
@@ -276,12 +276,12 @@ skip_if_unavailable = true
 
 [rhel-9-codeready-builder-rpms-aarch64]
 name = rhel-9-codeready-builder-rpms-aarch64
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/codeready-builder/os/
+baseurl = https://mirror2.openshift.com/enterprise/reposync/5.1_aarch64/rhel-9-codeready-builder-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0
-# https://projects.engineering.redhat.com/browse/RCM-65421
-sslclientkey = /tmp/key/rh-cdn.pem
-sslclientcert = /tmp/key/rh-cdn.pem
+username_file = /tmp/mirror-enterprise-basic-auth/username
+password_file = /tmp/mirror-enterprise-basic-auth/password
 failovermethod = priority
+skip_if_unavailable = true


### PR DESCRIPTION
## Summary
- Switch all arch variants (x86_64, ppc64le, s390x, aarch64) of `rhel-9-codeready-builder-rpms` from CDN (`cdn.redhat.com`) to mirror2 (`mirror2.openshift.com`) across `ocp-4.22-rhel9.repo`, `ocp-4.23-rhel9.repo`, `ocp-5.0-rhel9.repo`, and `ocp-5.1-rhel9.repo`
- Replace SSL cert auth (`sslclientkey`/`sslclientcert`) with username/password auth to match other mirror2 entries
- Add `skip_if_unavailable = true` for consistency with other mirror2 repos

## Test plan
- [ ] Verify mirror2 URLs resolve correctly for each version and arch
- [ ] Validate repo files with `/test-repo-files`
- [ ] Confirm CI builds using these repo files can resolve codeready-builder packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configurations for OCP versions 4.22, 4.23, 5.0, and 5.1 with new endpoint sources.
  * Modified repository authentication methods across multiple system architectures.
  * Added fault tolerance to gracefully handle unavailable repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->