### PR TITLE
prow: enable rerun/abort for Azure/ARO-HCP jobs

### DIFF
--- a/core-services/prow/02_config/_config.yaml
+++ b/core-services/prow/02_config/_config.yaml
@@ -24,6 +24,10 @@ deck:
       - AlexNPavel
       - jupierce
       - petr-muller
+  - repo: Azure/ARO-HCP
+    rerun_auth_configs:
+      github_users:
+      - raelga
   - repo: openshift/multiarch-tuning-operator
     rerun_auth_configs:
       github_team_slugs:


### PR DESCRIPTION
### What

Add `rerun_auth_configs` for `repo: Azure/ARO-HCP` so team members can rerun and abort jobs from Prow Deck.

### Why

During ITN-2026-00126, multiple postsubmit E2E jobs queued up and nobody could abort stale runs from the Prow UI. Currently only the default `test-platform` team and a few global users have rerun/abort permissions for Azure/ARO-HCP jobs.

### JIRA

[AROSLSRE-749](https://redhat.atlassian.net/browse/AROSLSRE-749)

[AROSLSRE-749]: https://redhat.atlassian.net/browse/AROSLSRE-749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ