### PR TITLE
OTA-1836: CVO: Add optional strict TLS modern profile presubmit job

### DIFF
--- a/ci-operator/config/openshift/cluster-version-operator/openshift-cluster-version-operator-main.yaml
+++ b/ci-operator/config/openshift/cluster-version-operator/openshift-cluster-version-operator-main.yaml
@@ -198,7 +198,7 @@ tests:
     from: src
   skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
 - always_run: false
-  as: tls-scanner
+  as: tls-scanner-default-profile
   optional: true
   steps:
     cluster_profile: openshift-org-aws
@@ -206,6 +206,20 @@ tests:
       COMPUTE_NODE_TYPE: m5.2xlarge
       SCAN_NAMESPACE: openshift-cluster-version
     test:
+    - ref: tls-scanner-run
+    workflow: ipi-aws
+- always_run: false
+  as: tls-scanner-modern-profile
+  optional: true
+  steps:
+    cluster_profile: openshift-org-aws
+    env:
+      COMPUTE_NODE_TYPE: m5.2xlarge
+      SCAN_NAMESPACE: openshift-cluster-version
+      TLS_13_ENABLE_TLS_ADHERENCE: "true"
+      TLS_13_TLS_ADHERENCE_POLICY: StrictAllComponents
+    test:
+    - ref: tls-13
     - ref: tls-scanner-run
     workflow: ipi-aws
 zz_generated_metadata:

--- a/ci-operator/jobs/openshift/cluster-version-operator/openshift-cluster-version-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-version-operator/openshift-cluster-version-operator-main-presubmits.yaml
@@ -1541,16 +1541,16 @@ presubmits:
     - ^main$
     - ^main-
     cluster: build11
-    context: ci/prow/tls-scanner
+    context: ci/prow/tls-scanner-default-profile
     decorate: true
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-version-operator-main-tls-scanner
+    name: pull-ci-openshift-cluster-version-operator-main-tls-scanner-default-profile
     optional: true
-    rerun_command: /test tls-scanner
+    rerun_command: /test tls-scanner-default-profile
     spec:
       containers:
       - args:
@@ -1559,7 +1559,7 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=tls-scanner
+        - --target=tls-scanner-default-profile
         command:
         - ci-operator
         env:
@@ -1615,7 +1615,88 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )tls-scanner,?($|\s.*)
+    trigger: (?m)^/test( | .* )tls-scanner-default-profile,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build11
+    context: ci/prow/tls-scanner-modern-profile
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-version-operator-main-tls-scanner-modern-profile
+    optional: true
+    rerun_command: /test tls-scanner-modern-profile
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=tls-scanner-modern-profile
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )tls-scanner-modern-profile,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reorganized TLS security testing configuration to improve validation coverage
  * Added modern TLS profile testing with TLS 13 compliance verification to the continuous integration pipeline
<!-- end of auto-generated comment: release notes by coderabbit.ai -->