### PR TITLE
Reduce Azure self-managed e2e management cluster nodes from 6 to 2

### DIFF
--- a/ci-operator/step-registry/hypershift/azure/e2e/self-managed/hypershift-azure-e2e-self-managed-workflow.yaml
+++ b/ci-operator/step-registry/hypershift/azure/e2e/self-managed/hypershift-azure-e2e-self-managed-workflow.yaml
@@ -31,7 +31,7 @@ workflow:
     - ref: hypershift-install
     env:
       CLOUD_PROVIDER: "Azure"
-      HYPERSHIFT_NODE_COUNT: "6"
+      HYPERSHIFT_NODE_COUNT: "2"
       HYPERSHIFT_AZURE_LOCATION: "centralus"
       AZURE_SELF_MANAGED: "true"
       HYPERSHIFT_EXTERNAL_DNS_DOMAIN: "aks-e2e.hypershift.azure.devcluster.openshift.com"


### PR DESCRIPTION
## Summary

- Reduce `HYPERSHIFT_NODE_COUNT` from `6` to `2` in the `e2e-azure-self-managed` workflow
- With 3 availability zones, this gives 6 management cluster nodes (down from 18)

## Context

PR #78133 increased node count to 6 and added 3 availability zones, resulting in 18 management cluster nodes (6 × 3 zones). This is excessive — 2 nodes per zone (6 total) provides sufficient capacity.

## Test plan

- [ ] Verify `e2e-azure-self-managed` presubmit passes with reduced node count

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Azure e2e self-managed test environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->