### PR TITLE
Run integration tests

### DIFF
--- a/ci-operator/config/3scale/3scale-operator/3scale-3scale-operator-master.yaml
+++ b/ci-operator/config/3scale/3scale-operator/3scale-3scale-operator-master.yaml
@@ -37,6 +37,20 @@ tests:
         requests:
           cpu: 100m
     workflow: ipi-aws
+- as: test-integration
+  steps:
+    cluster_profile: openshift-org-aws
+    test:
+    - as: test-integration
+      cli: latest
+      commands: |
+        unset GOFLAGS
+        make test-integration
+      from: src
+      resources:
+        requests:
+          cpu: 100m
+    workflow: ipi-aws
 zz_generated_metadata:
   branch: master
   org: 3scale

--- a/ci-operator/jobs/3scale/3scale-operator/3scale-3scale-operator-master-presubmits.yaml
+++ b/ci-operator/jobs/3scale/3scale-operator/3scale-3scale-operator-master-presubmits.yaml
@@ -87,6 +87,88 @@ presubmits:
     branches:
     - ^master$
     - ^master-
+    cluster: build09
+    context: ci/prow/test-integration
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-3scale-3scale-operator-master-test-integration
+    rerun_command: /test test-integration
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=test-integration
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )test-integration,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^master$
+    - ^master-
     cluster: build01
     context: ci/prow/test-unit
     decorate: true


### PR DESCRIPTION
Due to recent change here https://github.com/3scale/3scale-operator/pull/1156, we now need an extra step to run integration tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new integration test to the CI pipeline to run full integration checks as part of the release workflow.
  * The CI update runs the integration suite on a cloud-based workflow with allocated compute resources to catch regressions earlier and improve overall quality assurance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->