### PR TITLE
NO-JIRA: feat: add certrotation lane with rhcos10 for tnf

### DIFF
--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
@@ -643,6 +643,23 @@ tests:
         BMC_DRIVER="redfish"
       TEST_SUITE: openshift/etcd/certrotation
     workflow: baremetalds-two-node-fencing
+- as: e2e-metal-two-node-fencing-certrotation-rhcos10-techpreview
+  capabilities:
+  - intranet
+  cron: 31 3,14 * * *
+  steps:
+    cluster_profile: equinix-edge-enablement
+    env:
+      DEVSCRIPTS_CONFIG: |
+        IP_STACK=v4
+        NUM_MASTERS=2
+        MASTER_MEMORY=32768
+        NUM_WORKERS=0
+        BMC_DRIVER="redfish"
+        FEATURE_SET=TechPreviewNoUpgrade
+      OSSTREAM: rhel-10
+      TEST_SUITE: openshift/etcd/certrotation
+    workflow: baremetalds-two-node-fencing
 - as: e2e-metal-ovn-two-node-fencing
   capabilities:
   - intranet


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a recurring automated test that exercises etcd certificate rotation with two-node fencing on bare-metal using RHEL 10 and Tech Preview features. It runs regularly to validate IPv4, a two-master topology, and related fencing behavior for certificate rotation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->