### PR TITLE
AWS custom-dns: Increase the frequency of runs temporarily

### DIFF
--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
@@ -1631,7 +1631,7 @@ tests:
       - observers-resource-watch
     workflow: openshift-e2e-gcp-custom-dns
 - as: e2e-aws-custom-dns-techpreview
-  interval: 168h
+  interval: 12h
   steps:
     cluster_profile: aws-qe
     env:


### PR DESCRIPTION
Currently the aws-custom-dns-techpreview job runs once per week. Increasing frequency to 12h until it is promoted and then will lower frequency again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased execution frequency of custom DNS preview testing from weekly to every 12 hours for more frequent validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->