### PR TITLE
Fix get-pip.py Python 3.9 compatibility for single-node steps

### DIFF
--- a/ci-operator/step-registry/single-node/conf/aws/single-node-conf-aws-commands.sh
+++ b/ci-operator/step-registry/single-node/conf/aws/single-node-conf-aws-commands.sh
@@ -20,7 +20,7 @@ echo "Updating install-config.yaml to a single ${SINGLE_NODE_AWS_INSTANCE_TYPE} 
 OS_VER=$(awk -F= '/^VERSION_ID=/ { print $2 }' /etc/os-release | tr -d '"' | cut -f1 -d'.')
 if [[ ${OS_VER} == "9" ]]; then
     echo "Detected RHEL9, installing pip"
-    curl -L -o /tmp/get-pip.py -w "\nStatus Code: %{http_code}\n" https://bootstrap.pypa.io/get-pip.py
+    curl -L -o /tmp/get-pip.py -w "\nStatus Code: %{http_code}\n" https://bootstrap.pypa.io/pip/3.9/get-pip.py
     python /tmp/get-pip.py
     export PATH=$PATH:$HOME/.local/bin
 fi

--- a/ci-operator/step-registry/single-node/conf/gcp/single-node-conf-gcp-commands.sh
+++ b/ci-operator/step-registry/single-node/conf/gcp/single-node-conf-gcp-commands.sh
@@ -17,7 +17,7 @@ echo "Updating install-config.yaml to a single ${SINGLE_NODE_GCP_INSTANCE_TYPE} 
 OS_VER=$(awk -F= '/^VERSION_ID=/ { print $2 }' /etc/os-release | tr -d '"' | cut -f1 -d'.')
 if [[ ${OS_VER} == "9" ]]; then
     echo "Detected RHEL9, installing pip"
-    curl -L -o /tmp/get-pip.py -w "\nStatus Code: %{http_code}\n" https://bootstrap.pypa.io/get-pip.py
+    curl -L -o /tmp/get-pip.py -w "\nStatus Code: %{http_code}\n" https://bootstrap.pypa.io/pip/3.9/get-pip.py
     python /tmp/get-pip.py
     export PATH=$PATH:$HOME/.local/bin
 fi


### PR DESCRIPTION
The latest get-pip.py from bootstrap.pypa.io now requires Python 3.10+, breaking all single-node GCP and AWS jobs on RHEL9 images which ship Python 3.9. Use the Python 3.9 compatible URL instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Python pip installation configuration for RHEL9 systems to use version-specific bootstrap URLs, improving consistency across AWS and GCP environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->