### PR TITLE
NO-ISSUE: Onboard openshift/lightspeed-team-harness to Prow

### DIFF
--- a/core-services/prow/02_config/openshift/lightspeed-team-harness/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/lightspeed-team-harness/_pluginconfig.yaml
@@ -1,0 +1,12 @@
+approve:
+- repos:
+  - openshift/lightspeed-team-harness
+  require_self_approval: false
+lgtm:
+- repos:
+  - openshift/lightspeed-team-harness
+  review_acts_as_lgtm: true
+plugins:
+  openshift/lightspeed-team-harness:
+    plugins:
+    - approve

--- a/core-services/prow/02_config/openshift/lightspeed-team-harness/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/lightspeed-team-harness/_prowconfig.yaml
@@ -1,0 +1,14 @@
+tide:
+  queries:
+  - labels:
+    - approved
+    - lgtm
+    missingLabels:
+    - backports/unvalidated-commits
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - jira/invalid-bug
+    - needs-rebase
+    repos:
+    - openshift/lightspeed-team-harness


### PR DESCRIPTION
## Summary
- Onboards `openshift/lightspeed-team-harness` to Prow by adding plugin and tide configuration
- Enables `approve` and `lgtm` plugins so PRs can be merged via `/approve` and `/lgtm` commands

## Details
The repo is a skills directory with no CI tests or image builds needed. This PR only adds the Prow plugin configuration to enable PR approval workflows.

## Test plan
- [ ] Verify Prow webhook delivery is working for the repo (repo may need to be added to the Prow GitHub app if private)
- [ ] After merge, confirm `/approve` and `/lgtm` commands function on PRs


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured pull request automation including approval plugin and LGTM review processing.
  * Set up automated merge criteria requiring both approval and LGTM labels on pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->