### PR TITLE
[DNM] Check bastion host in aws/gcp/azure ci enviornment

### DIFF
--- a/ci-operator/step-registry/openshift/e2e/aws/ovn/openshift-e2e-aws-ovn-workflow.yaml
+++ b/ci-operator/step-registry/openshift/e2e/aws/ovn/openshift-e2e-aws-ovn-workflow.yaml
@@ -7,6 +7,7 @@ workflow:
     - ref: ovn-conf
     - ref: rhcos-conf-osstream
     - chain: ipi-install
+    - chain: aws-provision-bastionhost
     test:
     - ref: openshift-e2e-test
     post:

--- a/ci-operator/step-registry/openshift/e2e/test/openshift-e2e-test-commands.sh
+++ b/ci-operator/step-registry/openshift/e2e/test/openshift-e2e-test-commands.sh
@@ -552,6 +552,9 @@ done
 
 echo "[$(date)] All imagestreams are imported."
 
+echo "sleep for 5h"
+sleep 5h
+
 case "${TEST_TYPE}" in
 upgrade-conformance)
     upgrade_conformance


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

The network artifact collection step now waits five hours before gathering artifacts. This supports delayed bastion host access checks in AWS, GCP, and Azure CI environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->