### PR TITLE
Align 4.22 ran operators

### DIFF
--- a/ci-operator/config/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main__cnf-ran-standard-4.22.yaml
+++ b/ci-operator/config/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main__cnf-ran-standard-4.22.yaml
@@ -27,13 +27,20 @@ tests:
         [
           {"name":"local-storage-operator","catalog":"redhat-operators-storage-art","fbc_iib_repo":"ose-local-storage-rhel9-operator","nsname":"openshift-local-storage","channel":"stable","og_name":"local-operator-group","subscription_name":"local-storage-operator","deploy_default_config":false,"ns_labels":{"workload.openshift.io/allowed":"management"}},
           {"name":"openshift-gitops-operator","catalog":"redhat-operators","nsname":"openshift-gitops-operator","channel":"latest","catalog_version_override":"4.21","og_name":"openshift-gitops-operator","subscription_name":"openshift-gitops-operator","deploy_default_config":false,"og_spec":{"targetNamespaces":[]}},
-          {"name":"advanced-cluster-management","catalog":"redhat-operators-acm-fbc","fbc_iib_repo":"latest-2.17","ocp_operator_mirror_fbc_image_base":"quay.io:443/acm-d/acm-dev-catalog","nsname":"open-cluster-management","channel":"release-2.17","og_name":"open-cluster-management","subscription_name":"acm-operator-subscription","deploy_default_config":false,"multifile_catalog":true,"og_spec":{"targetNamespaces":["open-cluster-management"]}},
-          {"name":"multicluster-engine","catalog":"redhat-operators-mce-fbc","nsname":"multicluster-engine","fbc_iib_repo":"latest-2.17","ocp_operator_mirror_fbc_image_base":"quay.io:443/acm-d/mce-dev-catalog","channel":"stable-2.17","og_name":"multicluster-engine","subscription_name":"multicluster-engine","deploy_default_config":true,"multifile_catalog":true,"og_spec":{}},
+          {"name":"advanced-cluster-management","catalog":"redhat-operators-acm-fbc","fbc_iib_repo":"latest-2.17","bundle_version":"v2.17","ocp_operator_mirror_fbc_image_base":"quay.io:443/acm-d/acm-dev-catalog","nsname":"open-cluster-management","channel":"release-2.17","og_name":"open-cluster-management","subscription_name":"acm-operator-subscription","deploy_default_config":false,"multifile_catalog":true,"og_spec":{"targetNamespaces":["open-cluster-management"]}},
+          {"name":"multicluster-engine","catalog":"redhat-operators-mce-fbc","nsname":"multicluster-engine","fbc_iib_repo":"latest-2.17","bundle_version":"v2.17","ocp_operator_mirror_fbc_image_base":"quay.io:443/acm-d/mce-dev-catalog","channel":"stable-2.17","og_name":"multicluster-engine","subscription_name":"multicluster-engine","deploy_default_config":true,"multifile_catalog":true,"og_spec":{}},
           {"name":"topology-aware-lifecycle-manager","catalog":"topology-aware-lifecycle-manager-fbc","og_name":"global-operators","nsname":"openshift-operators","fbc_iib_repo":"latest","channel":"stable","deploy_default_config":false,"ocp_operator_mirror_fbc_image_base":"quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-fbc-4-22"},
-          {"name":"cluster-logging","catalog":"redhat-operators","nsname":"openshift-logging","channel":"stable-6.4","catalog_version_override":"4.21","og_name":"cluster-logging","subscription_name":"cluster-logging","og_spec":{"targetNamespaces":[]}}
+          {"name":"cluster-logging","catalog":"redhat-operators","catalog_version_override":"4.21","nsname":"openshift-logging","channel":"stable-6.5","og_name":"cluster-logging","subscription_name":"cluster-logging","og_spec":{"targetNamespaces":[]}}
         ]
       RAN_METRICS_LIST: spoke_general_ocp,hub_general_ocp,sriov,sriov_fec,ptp,acm,talm,gitops,local_storage,logging
       REPORTER_TEMPLATE_NAME: telco-ft-ran-standard-4.22
+      SPOKE_OPERATORS: |
+        [
+          {"name":"sriov-fec","catalog":"certified-operators","catalog_version_override":"4.21","nsname":"vran-acceleration-operators","channel":"stable"},
+          {"name":"ptp-operator","catalog":"redhat-operators-ptp-art","fbc_iib_repo":"ose-ptp-rhel9-operator","nsname":"openshift-ptp","channel":"stable","ns_labels":{"workload.openshift.io/allowed":"management","name":"openshift-ptp"}},
+          {"name":"sriov-network-operator","catalog":"redhat-operators-sriov-art","fbc_iib_repo":"ose-sriov-network-rhel9-operator","nsname":"openshift-sriov-network-operator","channel":"stable","og_name":"sriov-network-operators","subscription_name":"sriov-network-operator-subscription"},
+          {"name":"local-storage-operator","fbc_iib_repo":"ose-local-storage-rhel9-operator","catalog":"redhat-operators-storage-art","nsname":"openshift-local-storage","channel":"stable","og_name":"local-operator-group","subscription_name":"local-storage-operator","deploy_default_config":false,"ns_labels":{"workload.openshift.io/allowed":"management"}}
+        ]
       VERSION: "4.22"
     workflow: telcov10n-functional-cnf-ran-standard-ztp
 zz_generated_metadata:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated advanced-cluster-management and multicluster-engine operators to v2.17
  * Updated cluster-logging from stable-6.4 to stable-6.5
  * Added configurations for sriov-fec, ptp-operator, sriov-network-operator, and local-storage-operator

<!-- end of auto-generated comment: release notes by coderabbit.ai -->