### PR TITLE
cluster imageset: 4.22 to 4-stable

### DIFF
--- a/clusters/hosted-mgmt/hive/pools/ocp-release-4.22.0-rc.1-multi-for-4.22.0-0-to-4.23.0-0_clusterimageset.yaml
+++ b/clusters/hosted-mgmt/hive/pools/ocp-release-4.22.0-rc.1-multi-for-4.22.0-0-to-4.23.0-0_clusterimageset.yaml
@@ -3,10 +3,10 @@ kind: ClusterImageSet
 metadata:
   annotations:
     version_lower: 4.22.0-0
-    version_stream: 4-dev-preview
+    version_stream: 4-stable
     version_upper: 4.23.0-0
   creationTimestamp: null
-  name: ocp-release-4.22.0-ec.5-multi-for-4.22.0-0-to-4.23.0-0
+  name: ocp-release-4.22.0-rc.1-multi-for-4.22.0-0-to-4.23.0-0
 spec:
-  releaseImage: quay.io/openshift-release-dev/ocp-release:4.22.0-ec.5-multi
+  releaseImage: quay.io/openshift-release-dev/ocp-release:4.22.0-rc.1-multi
 status: {}

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-22-0-amd64-aws-us-east-2_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-22-0-amd64-aws-us-east-2_clusterpool.yaml
@@ -10,7 +10,7 @@ metadata:
     region: us-east-2
     version: "4.22"
     version_lower: 4.22.0-0
-    version_stream: 4-dev-preview
+    version_stream: 4-stable
     version_upper: 4.23.0-0
   name: obs-ocp-4-22-amd64-aws-us-east-2
   namespace: openshift-observability-cluster-pool

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-22-0-fips-amd64-aws-us-east-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-22-0-fips-amd64-aws-us-east-1_clusterpool.yaml
@@ -11,7 +11,7 @@ metadata:
     variant: fips
     version: "4.22"
     version_lower: 4.22.0-0
-    version_stream: 4-dev-preview
+    version_stream: 4-stable
     version_upper: 4.23.0-0
   name: obs-ocp-4-22-fips-amd64-aws-us-east-1
   namespace: openshift-observability-cluster-pool


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Transitioned OpenShift observability cluster pool configurations from development preview to stable across multiple variants.
  * Updated the release stream and image references to the 4.22.0-rc.1 release (metadata and release image updated to the rc.1 tag).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->