### PR TITLE
Publish cluster-health-analyzer image to quay.io/openshiftanalytics

### DIFF
--- a/ci-operator/config/openshift/cluster-health-analyzer/openshift-cluster-health-analyzer-main.yaml
+++ b/ci-operator/config/openshift/cluster-health-analyzer/openshift-cluster-health-analyzer-main.yaml
@@ -24,6 +24,11 @@ images:
   items:
   - dockerfile_path: Dockerfile
     to: cluster-health-analyzer
+promotion:
+  to:
+  - namespace: osa
+    tag: latest
+    tag_by_commit: true
 resources:
   '*':
     limits:

--- a/ci-operator/jobs/openshift/cluster-health-analyzer/openshift-cluster-health-analyzer-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-health-analyzer/openshift-cluster-health-analyzer-main-postsubmits.yaml
@@ -1,0 +1,62 @@
+postsubmits:
+  openshift/cluster-health-analyzer:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    cluster: build01
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/is-promotion: "true"
+      ci.openshift.io/generator: prowgen
+    max_concurrency: 1
+    name: branch-ci-openshift-cluster-health-analyzer-main-images
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --image-mirror-push-secret=/etc/push-secret/.dockerconfigjson
+        - --promote
+        - --report-credentials-file=/etc/report/credentials
+        - --target=[images]
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/push-secret
+          name: push-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: push-secret
+        secret:
+          secretName: registry-push-credentials-ci-central
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator

--- a/core-services/image-mirroring/osa/mapping_osa_quay
+++ b/core-services/image-mirroring/osa/mapping_osa_quay
@@ -1,2 +1,3 @@
+registry.ci.openshift.org/osa/cluster-health-analyzer:* quay.io/openshiftanalytics/cluster-health-analyzer
 registry.ci.openshift.org/osa/incluster-anomaly:* quay.io/openshiftanalytics/incluster-anomaly
 registry.ci.openshift.org/osa/observability-analytics-operator:* quay.io/openshiftanalytics/observability-analytics-operator


### PR DESCRIPTION
Add promotion to the osa namespace and image mirroring mapping so that the cluster-health-analyzer image is automatically published to quay.io/openshiftanalytics/cluster-health-analyzer:latest after each merge to main.

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI configuration to enable automated image promotion for cluster-health-analyzer with commit-based tag generation.
  * Added image mirroring mapping to distribute cluster-health-analyzer images to external registries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->