### PR TITLE
[WIP] Move powervs-9 from Sao Paulo to Washington DC

### DIFF
--- a/ci-operator/step-registry/ipi/conf/powervs/ipi-conf-powervs-commands.sh
+++ b/ci-operator/step-registry/ipi/conf/powervs/ipi-conf-powervs-commands.sh
@@ -95,11 +95,11 @@ if [[ -n "${CLUSTER_NAME_MODIFIER}" ]]; then
     "fran-powervs-8-quota-slice-3")
       CLUSTER_NAME="p-fran-3-${CLUSTER_NAME_MODIFIER}"
     ;;
-    "sao04-powervs-9-quota-slice-0")
-      CLUSTER_NAME="p-sao04-0-${CLUSTER_NAME_MODIFIER}"
+    "wdc04-powervs-9-quota-slice-0")
+      CLUSTER_NAME="p-wdc04-0-${CLUSTER_NAME_MODIFIER}"
     ;;
-    "sao04-powervs-9-quota-slice-1")
-      CLUSTER_NAME="p-sao04-1-${CLUSTER_NAME_MODIFIER}"
+    "wdc04-powervs-9-quota-slice-1")
+      CLUSTER_NAME="p-wdc04-1-${CLUSTER_NAME_MODIFIER}"
     ;;
     "mad02-powervs-5-quota-slice-0")
       CLUSTER_NAME="p-mad02-0-${CLUSTER_NAME_MODIFIER}"
@@ -166,17 +166,17 @@ case "${LEASED_RESOURCE}" in
       POWERVS_ZONE=eu-de-2
       VPCREGION=eu-de
    ;;
-   "sao04-powervs-9-quota-slice-0")
-      POWERVS_SERVICE_INSTANCE_ID=$(cat "/var/run/powervs-ipi-cicd-secrets/powervs-creds/POWERVS_SERVICE_INSTANCE_ID_SAO04-0")
-      POWERVS_REGION=sao
-      POWERVS_ZONE=sao04
-      VPCREGION=br-sao
+   "wdc04-powervs-9-quota-slice-0")
+      POWERVS_SERVICE_INSTANCE_ID=$(cat "/var/run/powervs-ipi-cicd-secrets/powervs-creds/POWERVS_SERVICE_INSTANCE_ID_WDC04-0")
+      POWERVS_REGION=us-east
+      POWERVS_ZONE=wdc04
+      VPCREGION=us-east
    ;;
-   "sao04-powervs-9-quota-slice-1")
-      POWERVS_SERVICE_INSTANCE_ID=$(cat "/var/run/powervs-ipi-cicd-secrets/powervs-creds/POWERVS_SERVICE_INSTANCE_ID_SAO04-1")
-      POWERVS_REGION=sao
-      POWERVS_ZONE=sao04
-      VPCREGION=br-sao
+   "wdc04-powervs-9-quota-slice-1")
+      POWERVS_SERVICE_INSTANCE_ID=$(cat "/var/run/powervs-ipi-cicd-secrets/powervs-creds/POWERVS_SERVICE_INSTANCE_ID_WDC04-1")
+      POWERVS_REGION=us-east
+      POWERVS_ZONE=wdc04
+      VPCREGION=us-east
    ;;
    "lon04-powervs-6-quota-slice-0")
       POWERVS_SERVICE_INSTANCE_ID=$(cat "/var/run/powervs-ipi-cicd-secrets/powervs-creds/POWERVS_SERVICE_INSTANCE_ID_LON04-0")

--- a/core-services/prow/02_config/_boskos.yaml
+++ b/core-services/prow/02_config/_boskos.yaml
@@ -5432,8 +5432,8 @@ resources:
   state: free
   type: powervs-8-quota-slice
 - names:
-  - sao04-powervs-9-quota-slice-0
-  - sao04-powervs-9-quota-slice-1
+  - wdc04-powervs-9-quota-slice-0
+  - wdc04-powervs-9-quota-slice-1
   state: free
   type: powervs-9-quota-slice
 - names:

--- a/core-services/prow/02_config/generate-boskos.py
+++ b/core-services/prow/02_config/generate-boskos.py
@@ -747,7 +747,7 @@ for i in range(4):
     CONFIG['powervs-8-quota-slice']['fran-powervs-8-quota-slice-{}'.format(i)] = 1
 
 for i in range(2):
-    CONFIG['powervs-9-quota-slice']['sao04-powervs-9-quota-slice-{}'.format(i)] = 1
+    CONFIG['powervs-9-quota-slice']['wdc04-powervs-9-quota-slice-{}'.format(i)] = 1
 
 for i in range(300):
     CONFIG['aro-hcp-test-msi-containers-dev']['aro-hcp-test-msi-containers-dev-{}'.format(i)] = 1


### PR DESCRIPTION
Move powervs-9 lease configuration for PowerVS Sao Paulo region (zone sao04) with 2 quota slices to Washington DC.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Migrated CI/CD infrastructure resources from São Paulo to Washington DC region for PowerVS quota allocations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->