### PR TITLE
Harden curl in ironic-image and ironic-agent-image CI configs

### DIFF
--- a/ci-operator/config/openshift/ironic-agent-image/openshift-ironic-agent-image-main.yaml
+++ b/ci-operator/config/openshift/ironic-agent-image/openshift-ironic-agent-image-main.yaml
@@ -27,7 +27,9 @@ raw_steps:
 - pipeline_image_cache_step:
     commands: |
       #NOTE(elfosardo): use ironic repos, cause we're special
-      curl http://base-4-22-rhel-9-server-ironic.ocp.svc > /etc/yum.repos.art/ci/base-4-22-rhel-9-server-ironic.repo
+      curl -f --retry 3 --retry-delay 5 --connect-timeout 10 \
+        -o /etc/yum.repos.art/ci/base-4-22-rhel-9-server-ironic.repo \
+        http://base-4-22-rhel-9-server-ironic.ocp.svc
     from: ocp_4.22_base-rhel9
     to: ironic-agent-base
 releases:

--- a/ci-operator/config/openshift/ironic-agent-image/openshift-ironic-agent-image-main__prevalidation.yaml
+++ b/ci-operator/config/openshift/ironic-agent-image/openshift-ironic-agent-image-main__prevalidation.yaml
@@ -28,7 +28,9 @@ raw_steps:
 - pipeline_image_cache_step:
     commands: |
       #NOTE(elfosardo): use ironic repos, cause we're special
-      curl http://base-4-22-rhel-9-ironic-prevalidation.ocp.svc > /etc/yum.repos.art/ci/base-4-22-rhel-9-ironic-prevalidation.repo
+      curl -f --retry 3 --retry-delay 5 --connect-timeout 10 \
+        -o /etc/yum.repos.art/ci/base-4-22-rhel-9-ironic-prevalidation.repo \
+        http://base-4-22-rhel-9-ironic-prevalidation.ocp.svc
     from: ocp_4.22_base-rhel9
     to: prevalidation-base
 releases:

--- a/ci-operator/config/openshift/ironic-agent-image/openshift-ironic-agent-image-release-4.16.yaml
+++ b/ci-operator/config/openshift/ironic-agent-image/openshift-ironic-agent-image-release-4.16.yaml
@@ -23,7 +23,9 @@ raw_steps:
 - pipeline_image_cache_step:
     commands: |
       #NOTE(elfosardo): use ironic repos, cause we're special
-      curl http://base-4-16-rhel-9-server-ironic.ocp.svc > /etc/yum.repos.d/base-4-16-rhel-9-server-ironic.repo
+      curl -f --retry 3 --retry-delay 5 --connect-timeout 10 \
+        -o /etc/yum.repos.d/base-4-16-rhel-9-server-ironic.repo \
+        http://base-4-16-rhel-9-server-ironic.ocp.svc
     from: ocp_builder_rhel-9-base-openshift-4.16
     to: ironic-agent-base
 releases:

--- a/ci-operator/config/openshift/ironic-agent-image/openshift-ironic-agent-image-release-4.16__prevalidation.yaml
+++ b/ci-operator/config/openshift/ironic-agent-image/openshift-ironic-agent-image-release-4.16__prevalidation.yaml
@@ -22,7 +22,9 @@ promotion:
 raw_steps:
 - pipeline_image_cache_step:
     commands: |
-      curl http://base-4-16-rhel-9-ironic-prevalidation.ocp.svc > /etc/yum.repos.d/base-4-16-rhel-9-ironic-prevalidation.repo
+      curl -f --retry 3 --retry-delay 5 --connect-timeout 10 \
+        -o /etc/yum.repos.d/base-4-16-rhel-9-ironic-prevalidation.repo \
+        http://base-4-16-rhel-9-ironic-prevalidation.ocp.svc
     from: ocp_builder_rhel-9-base-openshift-4.16
     to: prevalidation-base
 releases:

--- a/ci-operator/config/openshift/ironic-agent-image/openshift-ironic-agent-image-release-4.17.yaml
+++ b/ci-operator/config/openshift/ironic-agent-image/openshift-ironic-agent-image-release-4.17.yaml
@@ -23,7 +23,9 @@ raw_steps:
 - pipeline_image_cache_step:
     commands: |
       #NOTE(elfosardo): use ironic repos, cause we're special
-      curl http://base-4-17-rhel-9-server-ironic.ocp.svc > /etc/yum.repos.d/base-4-17-rhel-9-server-ironic.repo
+      curl -f --retry 3 --retry-delay 5 --connect-timeout 10 \
+        -o /etc/yum.repos.d/base-4-17-rhel-9-server-ironic.repo \
+        http://base-4-17-rhel-9-server-ironic.ocp.svc
     from: ocp_builder_rhel-9-base-openshift-4.17
     to: ironic-agent-base
 releases:

--- a/ci-operator/config/openshift/ironic-agent-image/openshift-ironic-agent-image-release-4.17__prevalidation.yaml
+++ b/ci-operator/config/openshift/ironic-agent-image/openshift-ironic-agent-image-release-4.17__prevalidation.yaml
@@ -22,7 +22,9 @@ promotion:
 raw_steps:
 - pipeline_image_cache_step:
     commands: |
-      curl http://base-4-17-rhel-9-ironic-prevalidation.ocp.svc > /etc/yum.repos.d/base-4-17-rhel-9-ironic-prevalidation.repo
+      curl -f --retry 3 --retry-delay 5 --connect-timeout 10 \
+        -o /etc/yum.repos.d/base-4-17-rhel-9-ironic-prevalidation.repo \
+        http://base-4-17-rhel-9-ironic-prevalidation.ocp.svc
     from: ocp_builder_rhel-9-base-openshift-4.17
     to: prevalidation-base
 releases:

--- a/ci-operator/config/openshift/ironic-agent-image/openshift-ironic-agent-image-release-4.18.yaml
+++ b/ci-operator/config/openshift/ironic-agent-image/openshift-ironic-agent-image-release-4.18.yaml
@@ -23,7 +23,9 @@ raw_steps:
 - pipeline_image_cache_step:
     commands: |
       #NOTE(elfosardo): use ironic repos, cause we're special
-      curl http://base-4-18-rhel-9-server-ironic.ocp.svc > /etc/yum.repos.d/base-4-18-rhel-9-server-ironic.repo
+      curl -f --retry 3 --retry-delay 5 --connect-timeout 10 \
+        -o /etc/yum.repos.d/base-4-18-rhel-9-server-ironic.repo \
+        http://base-4-18-rhel-9-server-ironic.ocp.svc
     from: ocp_builder_rhel-9-base-openshift-4.18
     to: ironic-agent-base
 releases:

--- a/ci-operator/config/openshift/ironic-agent-image/openshift-ironic-agent-image-release-4.18__prevalidation.yaml
+++ b/ci-operator/config/openshift/ironic-agent-image/openshift-ironic-agent-image-release-4.18__prevalidation.yaml
@@ -23,7 +23,9 @@ raw_steps:
 - pipeline_image_cache_step:
     commands: |
       #NOTE(elfosardo): use ironic repos, cause we're special
-      curl http://base-4-18-rhel-9-ironic-prevalidation.ocp.svc > /etc/yum.repos.d/base-4-18-rhel-9-ironic-prevalidation.repo
+      curl -f --retry 3 --retry-delay 5 --connect-timeout 10 \
+        -o /etc/yum.repos.d/base-4-18-rhel-9-ironic-prevalidation.repo \
+        http://base-4-18-rhel-9-ironic-prevalidation.ocp.svc
     from: ocp_builder_rhel-9-base-openshift-4.18
     to: prevalidation-base
 releases:

--- a/ci-operator/config/openshift/ironic-agent-image/openshift-ironic-agent-image-release-4.19.yaml
+++ b/ci-operator/config/openshift/ironic-agent-image/openshift-ironic-agent-image-release-4.19.yaml
@@ -23,7 +23,9 @@ raw_steps:
 - pipeline_image_cache_step:
     commands: |
       #NOTE(elfosardo): use ironic repos, cause we're special
-      curl http://base-4-19-rhel-9-server-ironic.ocp.svc > /etc/yum.repos.art/ci/base-4-19-rhel-9-server-ironic.repo
+      curl -f --retry 3 --retry-delay 5 --connect-timeout 10 \
+        -o /etc/yum.repos.art/ci/base-4-19-rhel-9-server-ironic.repo \
+        http://base-4-19-rhel-9-server-ironic.ocp.svc
     from: ocp_4.19_base-rhel9
     to: ironic-agent-base
 releases:

--- a/ci-operator/config/openshift/ironic-agent-image/openshift-ironic-agent-image-release-4.19__prevalidation.yaml
+++ b/ci-operator/config/openshift/ironic-agent-image/openshift-ironic-agent-image-release-4.19__prevalidation.yaml
@@ -23,7 +23,9 @@ raw_steps:
 - pipeline_image_cache_step:
     commands: |
       #NOTE(elfosardo): use ironic repos, cause we're special
-      curl http://base-4-19-rhel-9-ironic-prevalidation.ocp.svc > /etc/yum.repos.art/ci/base-4-19-rhel-9-ironic-prevalidation.repo
+      curl -f --retry 3 --retry-delay 5 --connect-timeout 10 \
+        -o /etc/yum.repos.art/ci/base-4-19-rhel-9-ironic-prevalidation.repo \
+        http://base-4-19-rhel-9-ironic-prevalidation.ocp.svc
     from: ocp_4.19_base-rhel9
     to: prevalidation-base
 releases:

--- a/ci-operator/config/openshift/ironic-agent-image/openshift-ironic-agent-image-release-4.20.yaml
+++ b/ci-operator/config/openshift/ironic-agent-image/openshift-ironic-agent-image-release-4.20.yaml
@@ -23,7 +23,9 @@ raw_steps:
 - pipeline_image_cache_step:
     commands: |
       #NOTE(elfosardo): use ironic repos, cause we're special
-      curl http://base-4-20-rhel-9-server-ironic.ocp.svc > /etc/yum.repos.art/ci/base-4-20-rhel-9-server-ironic.repo
+      curl -f --retry 3 --retry-delay 5 --connect-timeout 10 \
+        -o /etc/yum.repos.art/ci/base-4-20-rhel-9-server-ironic.repo \
+        http://base-4-20-rhel-9-server-ironic.ocp.svc
     from: ocp_4.20_base-rhel9
     to: ironic-agent-base
 releases:

--- a/ci-operator/config/openshift/ironic-agent-image/openshift-ironic-agent-image-release-4.20__prevalidation.yaml
+++ b/ci-operator/config/openshift/ironic-agent-image/openshift-ironic-agent-image-release-4.20__prevalidation.yaml
@@ -23,7 +23,9 @@ raw_steps:
 - pipeline_image_cache_step:
     commands: |
       #NOTE(elfosardo): use ironic repos, cause we're special
-      curl http://base-4-20-rhel-9-ironic-prevalidation.ocp.svc > /etc/yum.repos.art/ci/base-4-20-rhel-9-ironic-prevalidation.repo
+      curl -f --retry 3 --retry-delay 5 --connect-timeout 10 \
+        -o /etc/yum.repos.art/ci/base-4-20-rhel-9-ironic-prevalidation.repo \
+        http://base-4-20-rhel-9-ironic-prevalidation.ocp.svc
     from: ocp_4.20_base-rhel9
     to: prevalidation-base
 releases:

--- a/ci-operator/config/openshift/ironic-agent-image/openshift-ironic-agent-image-release-4.21.yaml
+++ b/ci-operator/config/openshift/ironic-agent-image/openshift-ironic-agent-image-release-4.21.yaml
@@ -23,7 +23,9 @@ raw_steps:
 - pipeline_image_cache_step:
     commands: |
       #NOTE(elfosardo): use ironic repos, cause we're special
-      curl http://base-4-21-rhel-9-server-ironic.ocp.svc > /etc/yum.repos.art/ci/base-4-21-rhel-9-server-ironic.repo
+      curl -f --retry 3 --retry-delay 5 --connect-timeout 10 \
+        -o /etc/yum.repos.art/ci/base-4-21-rhel-9-server-ironic.repo \
+        http://base-4-21-rhel-9-server-ironic.ocp.svc
     from: ocp_4.21_base-rhel9
     to: ironic-agent-base
 releases:

--- a/ci-operator/config/openshift/ironic-agent-image/openshift-ironic-agent-image-release-4.21__prevalidation.yaml
+++ b/ci-operator/config/openshift/ironic-agent-image/openshift-ironic-agent-image-release-4.21__prevalidation.yaml
@@ -24,7 +24,9 @@ raw_steps:
 - pipeline_image_cache_step:
     commands: |
       #NOTE(elfosardo): use ironic repos, cause we're special
-      curl http://base-4-21-rhel-9-ironic-prevalidation.ocp.svc > /etc/yum.repos.art/ci/base-4-21-rhel-9-ironic-prevalidation.repo
+      curl -f --retry 3 --retry-delay 5 --connect-timeout 10 \
+        -o /etc/yum.repos.art/ci/base-4-21-rhel-9-ironic-prevalidation.repo \
+        http://base-4-21-rhel-9-ironic-prevalidation.ocp.svc
     from: ocp_4.21_base-rhel9
     to: prevalidation-base
 releases:

--- a/ci-operator/config/openshift/ironic-agent-image/openshift-ironic-agent-image-release-4.22.yaml
+++ b/ci-operator/config/openshift/ironic-agent-image/openshift-ironic-agent-image-release-4.22.yaml
@@ -27,7 +27,9 @@ raw_steps:
 - pipeline_image_cache_step:
     commands: |
       #NOTE(elfosardo): use ironic repos, cause we're special
-      curl http://base-4-22-rhel-9-server-ironic.ocp.svc > /etc/yum.repos.art/ci/base-4-22-rhel-9-server-ironic.repo
+      curl -f --retry 3 --retry-delay 5 --connect-timeout 10 \
+        -o /etc/yum.repos.art/ci/base-4-22-rhel-9-server-ironic.repo \
+        http://base-4-22-rhel-9-server-ironic.ocp.svc
     from: ocp_4.22_base-rhel9
     to: ironic-agent-base
 releases:

--- a/ci-operator/config/openshift/ironic-agent-image/openshift-ironic-agent-image-release-4.22__prevalidation.yaml
+++ b/ci-operator/config/openshift/ironic-agent-image/openshift-ironic-agent-image-release-4.22__prevalidation.yaml
@@ -27,7 +27,9 @@ raw_steps:
 - pipeline_image_cache_step:
     commands: |
       #NOTE(elfosardo): use ironic repos, cause we're special
-      curl http://base-4-22-rhel-9-ironic-prevalidation.ocp.svc > /etc/yum.repos.art/ci/base-4-22-rhel-9-ironic-prevalidation.repo
+      curl -f --retry 3 --retry-delay 5 --connect-timeout 10 \
+        -o /etc/yum.repos.art/ci/base-4-22-rhel-9-ironic-prevalidation.repo \
+        http://base-4-22-rhel-9-ironic-prevalidation.ocp.svc
     from: ocp_4.22_base-rhel9
     to: prevalidation-base
 releases:

--- a/ci-operator/config/openshift/ironic-agent-image/openshift-ironic-agent-image-release-4.23.yaml
+++ b/ci-operator/config/openshift/ironic-agent-image/openshift-ironic-agent-image-release-4.23.yaml
@@ -27,7 +27,9 @@ raw_steps:
 - pipeline_image_cache_step:
     commands: |
       #NOTE(elfosardo): use ironic repos, cause we're special
-      curl http://base-4-22-rhel-9-server-ironic.ocp.svc > /etc/yum.repos.art/ci/base-4-22-rhel-9-server-ironic.repo
+      curl -f --retry 3 --retry-delay 5 --connect-timeout 10 \
+        -o /etc/yum.repos.art/ci/base-4-22-rhel-9-server-ironic.repo \
+        http://base-4-22-rhel-9-server-ironic.ocp.svc
     from: ocp_4.22_base-rhel9
     to: ironic-agent-base
 releases:

--- a/ci-operator/config/openshift/ironic-agent-image/openshift-ironic-agent-image-release-5.0.yaml
+++ b/ci-operator/config/openshift/ironic-agent-image/openshift-ironic-agent-image-release-5.0.yaml
@@ -28,7 +28,9 @@ raw_steps:
 - pipeline_image_cache_step:
     commands: |
       #NOTE(elfosardo): use ironic repos, cause we're special
-      curl http://base-4-22-rhel-9-server-ironic.ocp.svc > /etc/yum.repos.art/ci/base-4-22-rhel-9-server-ironic.repo
+      curl -f --retry 3 --retry-delay 5 --connect-timeout 10 \
+        -o /etc/yum.repos.art/ci/base-4-22-rhel-9-server-ironic.repo \
+        http://base-4-22-rhel-9-server-ironic.ocp.svc
     from: ocp_4.22_base-rhel9
     to: ironic-agent-base
 releases:

--- a/ci-operator/config/openshift/ironic-agent-image/openshift-ironic-agent-image-release-5.1.yaml
+++ b/ci-operator/config/openshift/ironic-agent-image/openshift-ironic-agent-image-release-5.1.yaml
@@ -27,7 +27,9 @@ raw_steps:
 - pipeline_image_cache_step:
     commands: |
       #NOTE(elfosardo): use ironic repos, cause we're special
-      curl http://base-4-22-rhel-9-server-ironic.ocp.svc > /etc/yum.repos.art/ci/base-4-22-rhel-9-server-ironic.repo
+      curl -f --retry 3 --retry-delay 5 --connect-timeout 10 \
+        -o /etc/yum.repos.art/ci/base-4-22-rhel-9-server-ironic.repo \
+        http://base-4-22-rhel-9-server-ironic.ocp.svc
     from: ocp_4.22_base-rhel9
     to: ironic-agent-base
 releases:

--- a/ci-operator/config/openshift/ironic-image/openshift-ironic-image-main.yaml
+++ b/ci-operator/config/openshift/ironic-image/openshift-ironic-image-main.yaml
@@ -26,7 +26,9 @@ raw_steps:
 - pipeline_image_cache_step:
     commands: |
       #NOTE(elfosardo): use ironic repos, cause we're special
-      curl http://base-4-22-rhel-9-server-ironic.ocp.svc > /etc/yum.repos.art/ci/base-4-22-rhel-9-server-ironic.repo
+      curl -f --retry 3 --retry-delay 5 --connect-timeout 10 \
+        -o /etc/yum.repos.art/ci/base-4-22-rhel-9-server-ironic.repo \
+        http://base-4-22-rhel-9-server-ironic.ocp.svc
     from: ocp_4.22_base-rhel9
     to: ironic-base
 releases:

--- a/ci-operator/config/openshift/ironic-image/openshift-ironic-image-main__prevalidation.yaml
+++ b/ci-operator/config/openshift/ironic-image/openshift-ironic-image-main__prevalidation.yaml
@@ -27,7 +27,9 @@ raw_steps:
 - pipeline_image_cache_step:
     commands: |
       #NOTE(elfosardo): use ironic repos, cause we're special
-      curl http://base-4-22-rhel-9-ironic-prevalidation.ocp.svc > /etc/yum.repos.art/ci/base-4-22-rhel-9-ironic-prevalidation.repo
+      curl -f --retry 3 --retry-delay 5 --connect-timeout 10 \
+        -o /etc/yum.repos.art/ci/base-4-22-rhel-9-ironic-prevalidation.repo \
+        http://base-4-22-rhel-9-ironic-prevalidation.ocp.svc
     from: ocp_4.22_base-rhel9
     to: prevalidation-base
 releases:

--- a/ci-operator/config/openshift/ironic-image/openshift-ironic-image-release-4.16.yaml
+++ b/ci-operator/config/openshift/ironic-image/openshift-ironic-image-release-4.16.yaml
@@ -23,7 +23,9 @@ raw_steps:
 - pipeline_image_cache_step:
     commands: |
       #NOTE(elfosardo): use ironic repos, cause we're special
-      curl http://base-4-16-rhel-9-server-ironic.ocp.svc > /etc/yum.repos.d/base-4-16-rhel-9-server-ironic.repo
+      curl -f --retry 3 --retry-delay 5 --connect-timeout 10 \
+        -o /etc/yum.repos.d/base-4-16-rhel-9-server-ironic.repo \
+        http://base-4-16-rhel-9-server-ironic.ocp.svc
     from: ocp_builder_rhel-9-base-openshift-4.16
     to: ironic-base
 releases:

--- a/ci-operator/config/openshift/ironic-image/openshift-ironic-image-release-4.16__prevalidation.yaml
+++ b/ci-operator/config/openshift/ironic-image/openshift-ironic-image-release-4.16__prevalidation.yaml
@@ -22,7 +22,9 @@ promotion:
 raw_steps:
 - pipeline_image_cache_step:
     commands: |
-      curl http://base-4-16-rhel-9-ironic-prevalidation.ocp.svc > /etc/yum.repos.d/base-4-16-rhel-9-ironic-prevalidation.repo
+      curl -f --retry 3 --retry-delay 5 --connect-timeout 10 \
+        -o /etc/yum.repos.d/base-4-16-rhel-9-ironic-prevalidation.repo \
+        http://base-4-16-rhel-9-ironic-prevalidation.ocp.svc
     from: ocp_builder_rhel-9-base-openshift-4.16
     to: prevalidation-base
 releases:

--- a/ci-operator/config/openshift/ironic-image/openshift-ironic-image-release-4.17.yaml
+++ b/ci-operator/config/openshift/ironic-image/openshift-ironic-image-release-4.17.yaml
@@ -23,7 +23,9 @@ raw_steps:
 - pipeline_image_cache_step:
     commands: |
       #NOTE(elfosardo): use ironic repos, cause we're special
-      curl http://base-4-17-rhel-9-server-ironic.ocp.svc > /etc/yum.repos.d/base-4-17-rhel-9-server-ironic.repo
+      curl -f --retry 3 --retry-delay 5 --connect-timeout 10 \
+        -o /etc/yum.repos.d/base-4-17-rhel-9-server-ironic.repo \
+        http://base-4-17-rhel-9-server-ironic.ocp.svc
     from: ocp_builder_rhel-9-base-openshift-4.17
     to: ironic-base
 releases:

--- a/ci-operator/config/openshift/ironic-image/openshift-ironic-image-release-4.17__prevalidation.yaml
+++ b/ci-operator/config/openshift/ironic-image/openshift-ironic-image-release-4.17__prevalidation.yaml
@@ -22,7 +22,9 @@ promotion:
 raw_steps:
 - pipeline_image_cache_step:
     commands: |
-      curl http://base-4-17-rhel-9-ironic-prevalidation.ocp.svc > /etc/yum.repos.d/base-4-17-rhel-9-ironic-prevalidation.repo
+      curl -f --retry 3 --retry-delay 5 --connect-timeout 10 \
+        -o /etc/yum.repos.d/base-4-17-rhel-9-ironic-prevalidation.repo \
+        http://base-4-17-rhel-9-ironic-prevalidation.ocp.svc
     from: ocp_builder_rhel-9-base-openshift-4.17
     to: prevalidation-base
 releases:

--- a/ci-operator/config/openshift/ironic-image/openshift-ironic-image-release-4.18.yaml
+++ b/ci-operator/config/openshift/ironic-image/openshift-ironic-image-release-4.18.yaml
@@ -23,7 +23,9 @@ raw_steps:
 - pipeline_image_cache_step:
     commands: |
       #NOTE(elfosardo): use ironic repos, cause we're special
-      curl http://base-4-18-rhel-9-server-ironic.ocp.svc > /etc/yum.repos.d/base-4-18-rhel-9-server-ironic.repo
+      curl -f --retry 3 --retry-delay 5 --connect-timeout 10 \
+        -o /etc/yum.repos.d/base-4-18-rhel-9-server-ironic.repo \
+        http://base-4-18-rhel-9-server-ironic.ocp.svc
     from: ocp_builder_rhel-9-base-openshift-4.18
     to: ironic-base
 releases:

--- a/ci-operator/config/openshift/ironic-image/openshift-ironic-image-release-4.18__prevalidation.yaml
+++ b/ci-operator/config/openshift/ironic-image/openshift-ironic-image-release-4.18__prevalidation.yaml
@@ -23,7 +23,9 @@ raw_steps:
 - pipeline_image_cache_step:
     commands: |
       #NOTE(elfosardo): use ironic repos, cause we're special
-      curl http://base-4-18-rhel-9-ironic-prevalidation.ocp.svc > /etc/yum.repos.d/base-4-18-rhel-9-ironic-prevalidation.repo
+      curl -f --retry 3 --retry-delay 5 --connect-timeout 10 \
+        -o /etc/yum.repos.d/base-4-18-rhel-9-ironic-prevalidation.repo \
+        http://base-4-18-rhel-9-ironic-prevalidation.ocp.svc
     from: ocp_builder_rhel-9-base-openshift-4.18
     to: prevalidation-base
 releases:

--- a/ci-operator/config/openshift/ironic-image/openshift-ironic-image-release-4.19.yaml
+++ b/ci-operator/config/openshift/ironic-image/openshift-ironic-image-release-4.19.yaml
@@ -23,7 +23,9 @@ raw_steps:
 - pipeline_image_cache_step:
     commands: |
       #NOTE(elfosardo): use ironic repos, cause we're special
-      curl http://base-4-19-rhel-9-server-ironic.ocp.svc > /etc/yum.repos.art/ci/base-4-19-rhel-9-server-ironic.repo
+      curl -f --retry 3 --retry-delay 5 --connect-timeout 10 \
+        -o /etc/yum.repos.art/ci/base-4-19-rhel-9-server-ironic.repo \
+        http://base-4-19-rhel-9-server-ironic.ocp.svc
     from: ocp_4.19_base-rhel9
     to: ironic-base
 releases:

--- a/ci-operator/config/openshift/ironic-image/openshift-ironic-image-release-4.19__prevalidation.yaml
+++ b/ci-operator/config/openshift/ironic-image/openshift-ironic-image-release-4.19__prevalidation.yaml
@@ -23,7 +23,9 @@ raw_steps:
 - pipeline_image_cache_step:
     commands: |
       #NOTE(elfosardo): use ironic repos, cause we're special
-      curl http://base-4-19-rhel-9-ironic-prevalidation.ocp.svc > /etc/yum.repos.art/ci/base-4-19-rhel-9-ironic-prevalidation.repo
+      curl -f --retry 3 --retry-delay 5 --connect-timeout 10 \
+        -o /etc/yum.repos.art/ci/base-4-19-rhel-9-ironic-prevalidation.repo \
+        http://base-4-19-rhel-9-ironic-prevalidation.ocp.svc
     from: ocp_4.19_base-rhel9
     to: prevalidation-base
 releases:

--- a/ci-operator/config/openshift/ironic-image/openshift-ironic-image-release-4.20.yaml
+++ b/ci-operator/config/openshift/ironic-image/openshift-ironic-image-release-4.20.yaml
@@ -23,7 +23,9 @@ raw_steps:
 - pipeline_image_cache_step:
     commands: |
       #NOTE(elfosardo): use ironic repos, cause we're special
-      curl http://base-4-20-rhel-9-server-ironic.ocp.svc > /etc/yum.repos.art/ci/base-4-20-rhel-9-server-ironic.repo
+      curl -f --retry 3 --retry-delay 5 --connect-timeout 10 \
+        -o /etc/yum.repos.art/ci/base-4-20-rhel-9-server-ironic.repo \
+        http://base-4-20-rhel-9-server-ironic.ocp.svc
     from: ocp_4.20_base-rhel9
     to: ironic-base
 releases:

--- a/ci-operator/config/openshift/ironic-image/openshift-ironic-image-release-4.20__prevalidation.yaml
+++ b/ci-operator/config/openshift/ironic-image/openshift-ironic-image-release-4.20__prevalidation.yaml
@@ -23,7 +23,9 @@ raw_steps:
 - pipeline_image_cache_step:
     commands: |
       #NOTE(elfosardo): use ironic repos, cause we're special
-      curl http://base-4-20-rhel-9-ironic-prevalidation.ocp.svc > /etc/yum.repos.art/ci/base-4-20-rhel-9-ironic-prevalidation.repo
+      curl -f --retry 3 --retry-delay 5 --connect-timeout 10 \
+        -o /etc/yum.repos.art/ci/base-4-20-rhel-9-ironic-prevalidation.repo \
+        http://base-4-20-rhel-9-ironic-prevalidation.ocp.svc
     from: ocp_4.20_base-rhel9
     to: prevalidation-base
 releases:

--- a/ci-operator/config/openshift/ironic-image/openshift-ironic-image-release-4.21.yaml
+++ b/ci-operator/config/openshift/ironic-image/openshift-ironic-image-release-4.21.yaml
@@ -22,7 +22,9 @@ raw_steps:
 - pipeline_image_cache_step:
     commands: |
       #NOTE(elfosardo): use ironic repos, cause we're special
-      curl http://base-4-21-rhel-9-server-ironic.ocp.svc > /etc/yum.repos.art/ci/base-4-21-rhel-9-server-ironic.repo
+      curl -f --retry 3 --retry-delay 5 --connect-timeout 10 \
+        -o /etc/yum.repos.art/ci/base-4-21-rhel-9-server-ironic.repo \
+        http://base-4-21-rhel-9-server-ironic.ocp.svc
     from: ocp_4.21_base-rhel9
     to: ironic-base
 releases:

--- a/ci-operator/config/openshift/ironic-image/openshift-ironic-image-release-4.21__prevalidation.yaml
+++ b/ci-operator/config/openshift/ironic-image/openshift-ironic-image-release-4.21__prevalidation.yaml
@@ -23,7 +23,9 @@ raw_steps:
 - pipeline_image_cache_step:
     commands: |
       #NOTE(elfosardo): use ironic repos, cause we're special
-      curl http://base-4-21-rhel-9-ironic-prevalidation.ocp.svc > /etc/yum.repos.art/ci/base-4-21-rhel-9-ironic-prevalidation.repo
+      curl -f --retry 3 --retry-delay 5 --connect-timeout 10 \
+        -o /etc/yum.repos.art/ci/base-4-21-rhel-9-ironic-prevalidation.repo \
+        http://base-4-21-rhel-9-ironic-prevalidation.ocp.svc
     from: ocp_4.21_base-rhel9
     to: prevalidation-base
 releases:

--- a/ci-operator/config/openshift/ironic-image/openshift-ironic-image-release-4.22.yaml
+++ b/ci-operator/config/openshift/ironic-image/openshift-ironic-image-release-4.22.yaml
@@ -26,7 +26,9 @@ raw_steps:
 - pipeline_image_cache_step:
     commands: |
       #NOTE(elfosardo): use ironic repos, cause we're special
-      curl http://base-4-22-rhel-9-server-ironic.ocp.svc > /etc/yum.repos.art/ci/base-4-22-rhel-9-server-ironic.repo
+      curl -f --retry 3 --retry-delay 5 --connect-timeout 10 \
+        -o /etc/yum.repos.art/ci/base-4-22-rhel-9-server-ironic.repo \
+        http://base-4-22-rhel-9-server-ironic.ocp.svc
     from: ocp_4.22_base-rhel9
     to: ironic-base
 releases:

--- a/ci-operator/config/openshift/ironic-image/openshift-ironic-image-release-4.22__prevalidation.yaml
+++ b/ci-operator/config/openshift/ironic-image/openshift-ironic-image-release-4.22__prevalidation.yaml
@@ -27,7 +27,9 @@ raw_steps:
 - pipeline_image_cache_step:
     commands: |
       #NOTE(elfosardo): use ironic repos, cause we're special
-      curl http://base-4-22-rhel-9-ironic-prevalidation.ocp.svc > /etc/yum.repos.art/ci/base-4-22-rhel-9-ironic-prevalidation.repo
+      curl -f --retry 3 --retry-delay 5 --connect-timeout 10 \
+        -o /etc/yum.repos.art/ci/base-4-22-rhel-9-ironic-prevalidation.repo \
+        http://base-4-22-rhel-9-ironic-prevalidation.ocp.svc
     from: ocp_4.22_base-rhel9
     to: prevalidation-base
 releases:

--- a/ci-operator/config/openshift/ironic-image/openshift-ironic-image-release-4.23.yaml
+++ b/ci-operator/config/openshift/ironic-image/openshift-ironic-image-release-4.23.yaml
@@ -26,7 +26,9 @@ raw_steps:
 - pipeline_image_cache_step:
     commands: |
       #NOTE(elfosardo): use ironic repos, cause we're special
-      curl http://base-4-22-rhel-9-server-ironic.ocp.svc > /etc/yum.repos.art/ci/base-4-22-rhel-9-server-ironic.repo
+      curl -f --retry 3 --retry-delay 5 --connect-timeout 10 \
+        -o /etc/yum.repos.art/ci/base-4-22-rhel-9-server-ironic.repo \
+        http://base-4-22-rhel-9-server-ironic.ocp.svc
     from: ocp_4.22_base-rhel9
     to: ironic-base
 releases:

--- a/ci-operator/config/openshift/ironic-image/openshift-ironic-image-release-5.0.yaml
+++ b/ci-operator/config/openshift/ironic-image/openshift-ironic-image-release-5.0.yaml
@@ -27,7 +27,9 @@ raw_steps:
 - pipeline_image_cache_step:
     commands: |
       #NOTE(elfosardo): use ironic repos, cause we're special
-      curl http://base-4-22-rhel-9-server-ironic.ocp.svc > /etc/yum.repos.art/ci/base-4-22-rhel-9-server-ironic.repo
+      curl -f --retry 3 --retry-delay 5 --connect-timeout 10 \
+        -o /etc/yum.repos.art/ci/base-4-22-rhel-9-server-ironic.repo \
+        http://base-4-22-rhel-9-server-ironic.ocp.svc
     from: ocp_4.22_base-rhel9
     to: ironic-base
 releases:

--- a/ci-operator/config/openshift/ironic-image/openshift-ironic-image-release-5.1.yaml
+++ b/ci-operator/config/openshift/ironic-image/openshift-ironic-image-release-5.1.yaml
@@ -26,7 +26,9 @@ raw_steps:
 - pipeline_image_cache_step:
     commands: |
       #NOTE(elfosardo): use ironic repos, cause we're special
-      curl http://base-4-22-rhel-9-server-ironic.ocp.svc > /etc/yum.repos.art/ci/base-4-22-rhel-9-server-ironic.repo
+      curl -f --retry 3 --retry-delay 5 --connect-timeout 10 \
+        -o /etc/yum.repos.art/ci/base-4-22-rhel-9-server-ironic.repo \
+        http://base-4-22-rhel-9-server-ironic.ocp.svc
     from: ocp_4.22_base-rhel9
     to: ironic-base
 releases:


### PR DESCRIPTION
Add -f (fail on HTTP errors), --retry 3, --retry-delay 5, and --connect-timeout 10 to the curl commands that fetch ironic repo files during image builds. This prevents silent failures where an HTTP error page would be written into the .repo file, and adds resilience against transient network issues. Applied to configs for releases 4.16+.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced CI/CD pipeline reliability by strengthening repository download mechanisms with improved error handling, automatic retry logic, and connection timeout safeguards across all build configurations to mitigate transient network failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->