### PR TITLE
Enable lgtm/approve workflow for ga-regression-reports repo

### DIFF
--- a/core-services/prow/02_config/openshift-eng/ga-regression-reports/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-eng/ga-regression-reports/_pluginconfig.yaml
@@ -1,0 +1,80 @@
+approve:
+- repos:
+  - openshift-eng/ga-regression-reports
+  require_self_approval: false
+external_plugins:
+  openshift-eng/ga-regression-reports:
+  - endpoint: http://refresh
+    events:
+    - issue_comment
+    name: refresh
+  - endpoint: http://cherrypick
+    events:
+    - issue_comment
+    - pull_request
+    name: cherrypick
+  - endpoint: http://needs-rebase
+    events:
+    - issue_comment
+    - pull_request
+    name: needs-rebase
+  - endpoint: http://backport-verifier
+    events:
+    - issue_comment
+    - pull_request
+    name: backport-verifier
+  - endpoint: http://payload-testing-prow-plugin
+    events:
+    - issue_comment
+    name: payload-testing-prow-plugin
+  - endpoint: http://jira-lifecycle-plugin
+    events:
+    - issue_comment
+    - pull_request
+    name: jira-lifecycle-plugin
+  - endpoint: http://pipeline-controller
+    events:
+    - pull_request
+    - issue_comment
+    name: pipeline-controller
+  - endpoint: http://multi-pr-prow-plugin
+    events:
+    - issue_comment
+    name: multi-pr-prow-plugin
+lgtm:
+- repos:
+  - openshift-eng/ga-regression-reports
+  review_acts_as_lgtm: true
+plugins:
+  openshift-eng/ga-regression-reports:
+    plugins:
+    - assign
+    - blunderbuss
+    - cat
+    - dog
+    - heart
+    - golint
+    - goose
+    - help
+    - hold
+    - jira
+    - label
+    - lgtm
+    - lifecycle
+    - override
+    - pony
+    - retitle
+    - shrug
+    - sigmention
+    - skip
+    - trigger
+    - verify-owners
+    - owners-label
+    - wip
+    - yuks
+    - approve
+triggers:
+- repos:
+  - openshift-eng/ga-regression-reports
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-eng/ga-regression-reports/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift-eng/ga-regression-reports/_prowconfig.yaml
@@ -1,0 +1,14 @@
+tide:
+  queries:
+  - labels:
+    - approved
+    - lgtm
+    missingLabels:
+    - backports/unvalidated-commits
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - jira/invalid-bug
+    - needs-rebase
+    repos:
+    - openshift-eng/ga-regression-reports


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Configured automated pull request review and merge workflow for the regression-reports repository.
  * Enabled approval + LGTM handling (reviews count as LGTM) and disabled self-approval; certain labels block merging (backports, do-not-merge, needs-rebase, invalid/jira, etc.).
  * Added multiple comment-triggered actions for common repo tasks and limited trusted automated execution to the merge bot.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->