### PR TITLE
Add vsphere-connected-2 launch job for cluster-bot WINC workflows

### DIFF
--- a/ci-operator/jobs/openshift/release/openshift-release-infra-periodics.yaml
+++ b/ci-operator/jobs/openshift/release/openshift-release-infra-periodics.yaml
@@ -1879,6 +1879,236 @@ periodics:
   cron: '@yearly'
   decorate: true
   labels:
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-connected-2
+    config-type: modern
+    job-architecture: amd64
+    job-env: vsphere-connected-2
+    job-type: launch
+  name: release-openshift-origin-installer-launch-vsphere-connected-2-modern
+  spec:
+    containers:
+    - args:
+      - --give-pr-author-access-to-namespace=true
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --image-mirror-push-secret=/etc/push-secret/.dockerconfigjson
+      - --input-hash=$(BUILD_ID)
+      - --input-hash=$(JOB_NAME)
+      - --namespace=$(NAMESPACE)
+      - --secret-dir=/usr/local/launch-cluster-profile
+      - --secret-dir=/usr/local/pull-secret
+      - --target=launch
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      command:
+      - ci-operator
+      env:
+      - name: RELEASE_IMAGE_INITIAL
+      - name: RELEASE_IMAGE_LATEST
+      - name: CLUSTER_VARIANT
+      - name: CLUSTER_PROFILE
+        value: vsphere-connected-2
+      - name: CLUSTER_DURATION
+        value: "9000"
+      - name: BRANCH
+        value: "4.16"
+      - name: CLUSTER_TYPE
+        value: vsphere
+      - name: UNRESOLVED_CONFIG
+        value: |
+          base_images:
+            upi-installer:
+              name: "$(BRANCH)"
+              namespace: ocp
+              tag: upi-installer
+          resources:
+            '*':
+              limits:
+                memory: 6Gi
+              requests:
+                cpu: 100m
+                memory: 200Mi
+          tests:
+          - as: launch
+            steps:
+              cluster_profile: $(CLUSTER_PROFILE)
+              env:
+                CLUSTER_DURATION: $(CLUSTER_DURATION)
+              test:
+              - ref: clusterbot-wait
+              workflow: openshift-e2e-$(CLUSTER_TYPE)
+          - as: launch-ovn
+            steps:
+              cluster_profile: $(CLUSTER_PROFILE)
+              env:
+                CLUSTER_DURATION: $(CLUSTER_DURATION)
+              test:
+              - ref: clusterbot-wait
+              workflow: openshift-e2e-$(CLUSTER_TYPE)-ovn
+          - as: launch-upi
+            steps:
+              cluster_profile: $(CLUSTER_PROFILE)
+              env:
+                CLUSTER_DURATION: $(CLUSTER_DURATION)
+              test:
+              - ref: clusterbot-wait
+              workflow: upi-$(CLUSTER_TYPE)-clusterbot
+          - as: launch-multi-zone
+            steps:
+              cluster_profile: vsphere-multizone-2
+              env:
+                CLUSTER_DURATION: $(CLUSTER_DURATION)
+              test:
+              - ref: clusterbot-wait
+              workflow: openshift-e2e-$(CLUSTER_TYPE)-zones
+          - as: launch-multi-zone-techpreview
+            steps:
+              cluster_profile: vsphere-multizone-2
+              env:
+                CLUSTER_DURATION: $(CLUSTER_DURATION)
+                FEATURE_SET: TechPreviewNoUpgrade
+              test:
+              - ref: clusterbot-wait
+              workflow: openshift-e2e-$(CLUSTER_TYPE)-zones
+          - as: launch-ovn-hybrid
+            steps:
+              cluster_profile: $(CLUSTER_PROFILE)
+              env:
+                CLUSTER_DURATION: $(CLUSTER_DURATION)
+              test:
+              - ref: clusterbot-wait
+              workflow: ipi-$(CLUSTER_TYPE)-ovn-hybrid-custom-vxlan-port
+          - as: launch-techpreview
+            steps:
+              cluster_profile: $(CLUSTER_PROFILE)
+              env:
+                CLUSTER_DURATION: $(CLUSTER_DURATION)
+                FEATURE_SET: TechPreviewNoUpgrade
+              test:
+              - ref: clusterbot-wait
+              workflow: openshift-e2e-$(CLUSTER_TYPE)
+          - as: launch-devpreview
+            steps:
+              cluster_profile: $(CLUSTER_PROFILE)
+              env:
+                CLUSTER_DURATION: $(CLUSTER_DURATION)
+                FEATURE_SET: DevPreviewNoUpgrade
+              test:
+              - ref: clusterbot-wait
+              workflow: openshift-e2e-$(CLUSTER_TYPE)
+          - as: launch-static-techpreview
+            steps:
+              cluster_profile: $(CLUSTER_PROFILE)
+              env:
+                CLUSTER_DURATION: $(CLUSTER_DURATION)
+                FEATURE_SET: TechPreviewNoUpgrade
+                NETWORK_TYPE: single-tenant
+              test:
+              - ref: clusterbot-wait
+              workflow: openshift-e2e-$(CLUSTER_TYPE)-staticip
+          - as: launch-static
+            steps:
+              cluster_profile: $(CLUSTER_PROFILE)
+              env:
+                CLUSTER_DURATION: $(CLUSTER_DURATION)
+                NETWORK_TYPE: single-tenant
+              test:
+              - ref: clusterbot-wait
+              workflow: openshift-e2e-$(CLUSTER_TYPE)-staticip
+          - as: launch-sdn
+            steps:
+              cluster_profile: $(CLUSTER_PROFILE)
+              env:
+                CLUSTER_DURATION: $(CLUSTER_DURATION)
+              test:
+              - ref: clusterbot-wait
+              workflow: openshift-e2e-$(CLUSTER_TYPE)-sdn
+          - as: launch-dualstack
+            steps:
+              cluster_profile: $(CLUSTER_PROFILE)
+              env:
+                CLUSTER_DURATION: $(CLUSTER_DURATION)
+              test:
+              - ref: clusterbot-wait
+              workflow: openshift-e2e-$(CLUSTER_TYPE)-ovn-dualstack
+          - as: launch-dualstack-primaryv6
+            steps:
+              cluster_profile: $(CLUSTER_PROFILE)
+              env:
+                CLUSTER_DURATION: $(CLUSTER_DURATION)
+                IP_FAMILIES: DualStackIPv6Primary
+              test:
+              - ref: clusterbot-wait
+              workflow: openshift-e2e-$(CLUSTER_TYPE)-ovn-dualstack
+          - as: upgrade
+            steps:
+              cluster_profile: $(CLUSTER_PROFILE)
+              env:
+                TEST_SUITE: "all"
+              workflow: openshift-upgrade-$(CLUSTER_TYPE)
+      - name: JOB_NAME_SAFE
+        value: launch
+      - name: TEST_COMMAND
+        value: sleep $(CLUSTER_DURATION) & wait
+      - name: NAMESPACE
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /usr/local/launch-cluster-profile
+        name: cluster-profile
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/push-secret
+        name: push-secret
+        readOnly: true
+      - mountPath: /usr/local/pull-secret
+        name: release-pull-secret
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: cluster-profile
+      projected:
+        sources:
+        - secret:
+            name: cluster-secrets-vsphere
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: push-secret
+      secret:
+        secretName: registry-push-credentials-ci-central
+    - name: release-pull-secret
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: gcs-credentials
+      secret:
+        secretName: gce-sa-credentials-gcs-publisher
+- agent: kubernetes
+  cluster: vsphere02
+  cron: '@yearly'
+  decorate: true
+  labels:
     ci-operator.openshift.io/cloud-cluster-profile: vsphere-dis-2
     config-type: modern
     job-architecture: amd64


### PR DESCRIPTION
## Problem

Cluster-bot workflows using `platform: vsphere-connected-2` (from PR #78530) fail with:

```
configuration error, unable to find prow job matching 
job-architecture=amd64,job-env=vsphere-connected-2,job-type=launch
```

**Root cause:** No launch job exists with `job-env: vsphere-connected-2`.

The existing vsphere launch job hardcodes `CLUSTER_PROFILE=vsphere-elastic`, which points to vcenter.ci.ibmc.devcluster.openshift.com (no Windows templates).

## Solution

Add new launch job: `release-openshift-origin-installer-launch-vsphere-connected-2-modern`

**Key configuration:**
- `job-env: vsphere-connected-2` - matches workflows-config.yaml platform
- `cloud-cluster-profile: vsphere-connected-2` - proper label
- `CLUSTER_PROFILE: vsphere-connected-2` - uses vcenter-2.devqe.ibmc.devcluster.openshift.com with Windows templates

## What This Fixes

Enables these cluster-bot commands from PR #78530 to work:

```bash
workflow-launch cucushift-installer-rehearse-vsphere-ipi-ovn-winc 4.22
workflow-launch cucushift-installer-rehearse-vsphere-ipi-proxy-ovn-winc 4.22
```

Both will now correctly use vcenter-2.devqe.ibmc.devcluster.openshift.com where Windows golden images exist.

## Testing

After merge, cluster-bot will be able to:
1. Match platform: vsphere-connected-2 to job-env: vsphere-connected-2
2. Launch jobs with CLUSTER_PROFILE: vsphere-connected-2
3. Successfully provision Windows workers from templates on the correct vCenter

Completes the fix started in PR #78530.