### PR TITLE
Revert vSphere WINC workflows to use vsphere/vsphere-dis platforms

### DIFF
--- a/core-services/ci-chat-bot/workflows-config.yaml
+++ b/core-services/ci-chat-bot/workflows-config.yaml
@@ -683,7 +683,7 @@ workflows:
   cucushift-installer-rehearse-vsphere-ipi-ovn-shared-to-local-gateway-mode-migration:
     platform: vsphere
   cucushift-installer-rehearse-vsphere-ipi-ovn-winc:
-    platform: vsphere-connected-2
+    platform: vsphere
     base_images:
       upi-installer:
         name: "4.13"
@@ -692,14 +692,14 @@ workflows:
   cucushift-installer-rehearse-vsphere-ipi-proxy:
     platform: vsphere
   cucushift-installer-rehearse-vsphere-ipi-proxy-ovn-winc:
-    platform: vsphere-connected-2
+    platform: vsphere
     base_images:
       upi-installer:
         name: "4.13"
         namespace: ocp
         tag: upi-installer
   cucushift-installer-rehearse-vsphere-ipi-disconnected-ovn-winc:
-    platform: vsphere-dis-2
+    platform: vsphere-dis
     base_images:
       upi-installer:
         name: "4.13"


### PR DESCRIPTION
## Background

PR #78530 changed vSphere WINC workflows to use `platform: vsphere-connected-2` and `platform: vsphere-dis-2` based on incorrect assumption that Windows templates only exist on those vCenters.

## Guidance from vSphere Platform Team

Per discussion in #forum-vsphere-triage:

1. **vsphere-elastic is the required platform** going forward
2. **vsphere-connected-2 is NOT supported** for cluster-bot infrastructure  
3. **vsphere-dis-2 is NOT supported** for cluster-bot (confirmed: "certainly not with vsphere-disconnected-2")
4. If Windows templates are missing → **contact PGE Cloud Ops** to add them to vsphere-elastic vCenters

## Changes in This PR

Reverts platform configuration to correct values:

1. **cucushift-installer-rehearse-vsphere-ipi-ovn-winc:**
   - `platform: vsphere-connected-2` → `platform: vsphere`

2. **cucushift-installer-rehearse-vsphere-ipi-proxy-ovn-winc:**
   - `platform: vsphere-connected-2` → `platform: vsphere`

3. **cucushift-installer-rehearse-vsphere-ipi-disconnected-ovn-winc:**
   - `platform: vsphere-dis-2` → `platform: vsphere-dis`

**Keeps the new workflows** added in PR #78530 (just fixes platform):
- cucushift-installer-rehearse-vsphere-ipi-proxy-ovn-winc
- cucushift-installer-rehearse-vsphere-ipi-disconnected-ovn-winc
- cucushift-installer-rehearse-aws-upi-ovn-winc

## Root Cause

BYOH provisioning fails with:
```
Error: error fetching virtual machine: vm 'windows-golden-images/windows-server-2022-template-qe-20241104' not found
```

**vsphere-elastic is a lease pool** - jobs can land on different vCenters in the pool, and the Windows template is missing from some/all vCenters.

## Next Steps

Open ticket with **#forum-pge-cloud-ops** to add Windows template to all vCenters in vsphere-elastic pool:
- Template path: `windows-golden-images/windows-server-2022-template-qe-20241104`
- Required for: WINC BYOH terraform provisioning

## Related

- Closes PR #78636 (vsphere-connected-2 launch job - not needed)
- Partially reverts PR #78530 (keeps new workflows, fixes platforms)
- Discussion: https://redhat-internal.slack.com/archives/C06V0DZEXGX/p1746014365969259

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated platform configurations for VSphere rehearsal workflows to use refreshed platform identifiers, ensuring CI workflows execute on the correct infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->