### PR TITLE
FIO: Fix breaking change in bundle tests

### DIFF
--- a/ci-operator/config/openshift/file-integrity-operator/openshift-file-integrity-operator-master.yaml
+++ b/ci-operator/config/openshift/file-integrity-operator/openshift-file-integrity-operator-master.yaml
@@ -4,7 +4,7 @@ base_images:
     namespace: ci
     tag: latest
   operator-sdk:
-    name: "5.0"
+    name: "4.19"
     namespace: origin
     tag: operator-sdk
   rosa-aws-cli:


### PR DESCRIPTION
The image for 5.0 doesn't exist.

https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_file-integrity-operator/788/pull-ci-openshift-file-integrity-operator-master-e2e-bundle-aws/2049813438909124608

https://github.com/openshift/release/pull/77697 inadvertently bumped our operator-sdk version.
The changes are not related to `operator-sdk` version, but this config matched the `config-brancher` and got bumped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build environment configuration for CI/OpenShift operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->