### PR TITLE
Refactor CPT Chain

### DIFF
--- a/ci-operator/step-registry/openshift-qe/cluster-density-v2/openshift-qe-cluster-density-v2-chain.yaml
+++ b/ci-operator/step-registry/openshift-qe/cluster-density-v2/openshift-qe-cluster-density-v2-chain.yaml
@@ -3,5 +3,6 @@ chain:
   as: openshift-qe-cluster-density-v2
   steps:
   - ref: openshift-qe-cluster-density-v2
+  - ref: openshift-qe-orion-cluster-density
   documentation: |-
-    This workflow executes cluster density v2 workload using kube-burner ocp wrapper
+    This workflow executes cluster density v2 workload using kube-burner ocp wrapper and runs Orion for change detection

--- a/ci-operator/step-registry/openshift-qe/crd-scale/openshift-qe-crd-scale-chain.yaml
+++ b/ci-operator/step-registry/openshift-qe/crd-scale/openshift-qe-crd-scale-chain.yaml
@@ -3,5 +3,6 @@ chain:
   as: openshift-qe-crd-scale
   steps:
   - ref: openshift-qe-crd-scale
+  - ref: openshift-qe-orion-crd-scale
   documentation: |-
-    This chain executes crd-scale
+    This chain executes crd-scale workload and runs Orion for change detection

--- a/ci-operator/step-registry/openshift-qe/node-density-cni/openshift-qe-node-density-cni-chain.yaml
+++ b/ci-operator/step-registry/openshift-qe/node-density-cni/openshift-qe-node-density-cni-chain.yaml
@@ -3,5 +3,6 @@ chain:
   as: openshift-qe-node-density-cni
   steps:
   - ref: openshift-qe-node-density-cni
+  - ref: openshift-qe-orion-node-density-cni
   documentation: |-
-    This chain executes node density cni workload using kube-burner ocp wrapper
+    This chain executes node density cni workload using kube-burner ocp wrapper and runs Orion for change detection

--- a/ci-operator/step-registry/openshift-qe/node-density/openshift-qe-node-density-chain.yaml
+++ b/ci-operator/step-registry/openshift-qe/node-density/openshift-qe-node-density-chain.yaml
@@ -3,5 +3,6 @@ chain:
   as: openshift-qe-node-density
   steps:
   - ref: openshift-qe-node-density
+  - ref: openshift-qe-orion-node-density
   documentation: |-
-    This workflow executes cluster density v2 workload using kube-burner ocp wrapper
+    This chain executes node density workload using kube-burner ocp wrapper and runs Orion for change detection

--- a/ci-operator/step-registry/openshift-qe/orion/cluster-density/openshift-qe-orion-cluster-density-ref.yaml
+++ b/ci-operator/step-registry/openshift-qe/orion/cluster-density/openshift-qe-orion-cluster-density-ref.yaml
@@ -51,7 +51,7 @@ ref:
     documentation:
       Number of days orion should lookback at results.
   - name: RUN_ORION
-    default: "true"
+    default: "false"
     documentation:
       Determine if we should run Orion or not.
   - name: ORION_CONFIG

--- a/ci-operator/step-registry/openshift-qe/orion/cluster-density/openshift-qe-orion-cluster-density-ref.yaml
+++ b/ci-operator/step-registry/openshift-qe/orion/cluster-density/openshift-qe-orion-cluster-density-ref.yaml
@@ -51,13 +51,13 @@ ref:
     documentation:
       Number of days orion should lookback at results.
   - name: RUN_ORION
-    default: "false"
+    default: "true"
     documentation:
       Determine if we should run Orion or not.
   - name: ORION_CONFIG
-    default: "https://raw.githubusercontent.com/cloud-bulldozer/orion/refs/heads/main/examples/trt-external-payload-cluster-density.yaml"
+    default: ""
     documentation:
-      Var used to tell the step which workload is calling Orion from Orion examples, like cluster-density, node-density, etc.
+      Orion configuration file. When empty, auto-selected based on worker node count and ORION_WORKLOAD_TYPE.
   - name: LOOKBACK_SIZE
     default: ""
     documentation:
@@ -78,6 +78,10 @@ ref:
     default: "kube-burner/kube-burner,kube-burner/kube-burner-ocp,cloud-bulldozer/e2e-benchmarking,openshift/release"
     documentation:
       Comma separated list of repositories to monitor before and after change points.
+  - name: ORION_WORKLOAD_TYPE
+    default: "cluster-density"
+    documentation:
+      Workload type suffix for auto-selecting ORION_CONFIG based on worker node count.
   commands: openshift-qe-orion-cluster-density-commands.sh
   timeout: 6h
   credentials:

--- a/ci-operator/step-registry/openshift-qe/orion/consolidated/openshift-qe-orion-consolidated-chain.yaml
+++ b/ci-operator/step-registry/openshift-qe/orion/consolidated/openshift-qe-orion-consolidated-chain.yaml
@@ -1,10 +1,7 @@
 chain:
   as: openshift-qe-orion-consolidated
   steps:
-  - ref: openshift-qe-orion-node-density
-  - ref: openshift-qe-orion-node-density-cni
-  - ref: openshift-qe-orion-crd-scale
   - ref: openshift-qe-orion-report
   documentation: |-
-    Chain of orion workloads with aggregated summary reporting.
-    Cluster-density-v2 orion now runs inline in its own chain.
+    Aggregated Orion summary reporting.
+    All workload-specific orion steps now run inline in their respective chains.

--- a/ci-operator/step-registry/openshift-qe/orion/consolidated/openshift-qe-orion-consolidated-chain.yaml
+++ b/ci-operator/step-registry/openshift-qe/orion/consolidated/openshift-qe-orion-consolidated-chain.yaml
@@ -1,10 +1,10 @@
 chain:
   as: openshift-qe-orion-consolidated
   steps:
-  - ref: openshift-qe-orion-cluster-density
   - ref: openshift-qe-orion-node-density
   - ref: openshift-qe-orion-node-density-cni
   - ref: openshift-qe-orion-crd-scale
   - ref: openshift-qe-orion-report
   documentation: |-
-    Chain of all orion workloads with aggregated summary reporting.
+    Chain of orion workloads with aggregated summary reporting.
+    Cluster-density-v2 orion now runs inline in its own chain.

--- a/ci-operator/step-registry/openshift-qe/orion/crd-scale/openshift-qe-orion-crd-scale-ref.yaml
+++ b/ci-operator/step-registry/openshift-qe/orion/crd-scale/openshift-qe-orion-crd-scale-ref.yaml
@@ -55,9 +55,9 @@ ref:
     documentation:
       Determine if we should run Orion or not.
   - name: ORION_CONFIG
-    default: "https://raw.githubusercontent.com/cloud-bulldozer/orion/refs/heads/main/examples/trt-external-payload-crd-scale.yaml"
+    default: "examples/trt-external-payload-crd-scale.yaml"
     documentation:
-      Var used to tell the step which workload is calling Orion from examples, like cluster-density, node-density, etc.
+      Orion configuration file. Fixed to single config for crd-scale (no scale variants exist).
   - name: LOOKBACK_SIZE
     default: ""
     documentation:

--- a/ci-operator/step-registry/openshift-qe/orion/node-density-cni/openshift-qe-orion-node-density-cni-ref.yaml
+++ b/ci-operator/step-registry/openshift-qe/orion/node-density-cni/openshift-qe-orion-node-density-cni-ref.yaml
@@ -55,9 +55,9 @@ ref:
     documentation:
       Determine if we should run Orion or not.
   - name: ORION_CONFIG
-    default: "https://raw.githubusercontent.com/cloud-bulldozer/orion/refs/heads/main/examples/trt-external-payload-node-density-cni.yaml"
+    default: ""
     documentation:
-      Var used to tell the step which workload is calling Orion, like cluster-density, node-density, etc.
+      Orion configuration file. When empty, auto-selected based on worker node count and ORION_WORKLOAD_TYPE.
   - name: LOOKBACK_SIZE
     default: ""
     documentation:
@@ -78,6 +78,10 @@ ref:
     default: "kube-burner/kube-burner,kube-burner/kube-burner-ocp,cloud-bulldozer/e2e-benchmarking,openshift/release"
     documentation:
       Comma separated list of repositories to monitor before and after change points.
+  - name: ORION_WORKLOAD_TYPE
+    default: "node-density-cni"
+    documentation:
+      Workload type suffix for auto-selecting ORION_CONFIG based on worker node count.
   commands: openshift-qe-orion-node-density-cni-commands.sh
   timeout: 6h
   credentials:

--- a/ci-operator/step-registry/openshift-qe/orion/node-density/openshift-qe-orion-node-density-ref.yaml
+++ b/ci-operator/step-registry/openshift-qe/orion/node-density/openshift-qe-orion-node-density-ref.yaml
@@ -55,9 +55,9 @@ ref:
     documentation:
       Determine if we should run Orion or not.
   - name: ORION_CONFIG
-    default: "https://raw.githubusercontent.com/cloud-bulldozer/orion/refs/heads/main/examples/trt-external-payload-node-density.yaml"
+    default: ""
     documentation:
-      Var used to tell the step which workload is calling Orion, like cluster-density, node-density, etc.
+      Orion configuration file. When empty, auto-selected based on worker node count and ORION_WORKLOAD_TYPE.
   - name: LOOKBACK_SIZE
     default: ""
     documentation:
@@ -78,6 +78,10 @@ ref:
     default: "kube-burner/kube-burner,kube-burner/kube-burner-ocp,cloud-bulldozer/e2e-benchmarking,openshift/release"
     documentation:
       Comma separated list of repositories to monitor before and after change points.
+  - name: ORION_WORKLOAD_TYPE
+    default: "node-density"
+    documentation:
+      Workload type suffix for auto-selecting ORION_CONFIG based on worker node count.
   commands: openshift-qe-orion-node-density-commands.sh
   timeout: 6h
   credentials:

--- a/ci-operator/step-registry/openshift-qe/orion/openshift-qe-orion-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/orion/openshift-qe-orion-commands.sh
@@ -71,6 +71,25 @@ if [[ -f "${SHARED_DIR}/proxy-conf.sh" ]]; then
     source "${SHARED_DIR}/proxy-conf.sh"
 fi
 
+# Generic workload auto-config: select ORION_CONFIG based on worker count and workload type
+if [[ -n "${ORION_WORKLOAD_TYPE:-}" ]] && [[ -z "${ORION_CONFIG:-}" ]]; then
+    current_worker_count=$(oc get node -l node-role.kubernetes.io/worker=,node-role.kubernetes.io/infra!=,node-role.kubernetes.io/workload!= --no-headers | grep -c Ready)
+    echo "Current worker count: $current_worker_count"
+
+    if [[ $current_worker_count -ge 200 ]]; then
+        scale_prefix="large-scale"
+    elif [[ $current_worker_count -ge 100 ]]; then
+        scale_prefix="med-scale"
+    elif [[ $current_worker_count -ge 20 ]]; then
+        scale_prefix="small-scale"
+    else
+        scale_prefix="trt-external-payload"
+    fi
+
+    export ORION_CONFIG="examples/${scale_prefix}-${ORION_WORKLOAD_TYPE}.yaml"
+    echo "Auto-selected ORION_CONFIG: $ORION_CONFIG (scale: $scale_prefix, workload: $ORION_WORKLOAD_TYPE)"
+fi
+
 # UDN density: auto-select ORION_CONFIG based on worker count and L2/L3 mode
 if [[ -n "${ENABLE_LAYER_3:-}" ]]; then
     # Get current worker count (excluding infra and workload nodes)

--- a/ci-operator/step-registry/openshift-qe/orion/openshift-qe-orion-ref.yaml
+++ b/ci-operator/step-registry/openshift-qe/orion/openshift-qe-orion-ref.yaml
@@ -80,6 +80,12 @@ ref:
     default: ""
     documentation:
       Comma separated list of repositories to monitor before and after change points.
+  - name: ORION_WORKLOAD_TYPE
+    default: ""
+    documentation:
+      When set, auto-selects ORION_CONFIG based on worker node count and this workload suffix.
+      Matches orion example configs named {scale-prefix}-{ORION_WORKLOAD_TYPE}.yaml.
+      Ignored if ORION_CONFIG is explicitly set.
 
   commands: openshift-qe-orion-commands.sh
   timeout: 6h

--- a/ci-operator/step-registry/openshift-qe/orion/report/openshift-qe-orion-report-ref.yaml
+++ b/ci-operator/step-registry/openshift-qe/orion/report/openshift-qe-orion-report-ref.yaml
@@ -17,6 +17,18 @@ ref:
     default: "false"
     documentation:
       When false, the report step is skipped. Set to deferred at test level to enable deferred failure reporting.
+  - name: ES_TYPE
+    default: "qe"
+    documentation:
+      Elasticsearch type. Declared here so standalone configs using the consolidated chain can override it.
+  - name: OUTPUT_FORMAT
+    default: "TEXT"
+    documentation:
+      Output format. Declared here so standalone configs using the consolidated chain can override it.
+  - name: VERSION
+    default: ""
+    documentation:
+      OCP version. Declared here so standalone configs using the consolidated chain can override it.
   commands: openshift-qe-orion-report-commands.sh
   timeout: 30m
   resources:

--- a/ci-operator/step-registry/stackrox/perfscale/stackrox-perfscale-chain.yaml
+++ b/ci-operator/step-registry/stackrox/perfscale/stackrox-perfscale-chain.yaml
@@ -2,7 +2,6 @@ chain:
   as: stackrox-perfscale
   steps:
   - chain: openshift-qe-cluster-density-v2
-  - ref: openshift-qe-orion-cluster-density
   - chain: openshift-qe-node-density
   # TODO: fix scanner failing in cni and reenable:
   # - chain: openshift-qe-node-density-cni

--- a/ci-operator/step-registry/stackrox/perfscale/stackrox-perfscale-chain.yaml
+++ b/ci-operator/step-registry/stackrox/perfscale/stackrox-perfscale-chain.yaml
@@ -2,10 +2,10 @@ chain:
   as: stackrox-perfscale
   steps:
   - chain: openshift-qe-cluster-density-v2
-  - chain: openshift-qe-node-density
+  - ref: openshift-qe-node-density
   # TODO: fix scanner failing in cni and reenable:
-  # - chain: openshift-qe-node-density-cni
-  - chain: openshift-qe-crd-scale
+  # - ref: openshift-qe-node-density-cni
+  - ref: openshift-qe-crd-scale
   env:
   - name: ES_BENCHMARK_INDEX
     default: "ripsaw-kube-burner*"


### PR DESCRIPTION
## Inline Orion regression detection for all control-plane workloads

### Summary

Embeds Orion change-point detection inline in every control-plane workload chain (cluster-density-v2, node-density, node-density-cni, crd-scale), following the same pattern already implemented for UDN density. Adds automatic config selection based on worker node count so the correct Orion config is used for any cluster size (6/24/120/252 nodes). For crd-scale, a single fixed config is used regardless of node count since no scale-tier variants exist.

### Changes

#### Shared / generic

- **`openshift-qe-orion-commands.sh`** — Added generic `ORION_WORKLOAD_TYPE` auto-config selection block that maps worker count to the appropriate orion example config (`trt-external-payload` / `small-scale` / `med-scale` / `large-scale`). Placed before the existing UDN-specific `ENABLE_LAYER_3` block. Only fires when `ORION_WORKLOAD_TYPE` is set and `ORION_CONFIG` is empty.
- **`openshift-qe-orion-ref.yaml`** — Added `ORION_WORKLOAD_TYPE` env var with empty default to the base orion ref for documentation/completeness.

#### cluster-density-v2

- **`openshift-qe-orion-cluster-density-ref.yaml`** — Changed `RUN_ORION` default to `true`, blanked `ORION_CONFIG` (triggers auto-selection), added `ORION_WORKLOAD_TYPE=cluster-density`.
- **`openshift-qe-cluster-density-v2-chain.yaml`** — Added `ref: openshift-qe-orion-cluster-density` after the workload ref.

#### node-density-cni

- **`openshift-qe-orion-node-density-cni-ref.yaml`** — Changed `RUN_ORION` default to `true`, blanked `ORION_CONFIG` (triggers auto-selection), added `ORION_WORKLOAD_TYPE=node-density-cni`.
- **`openshift-qe-node-density-cni-chain.yaml`** — Added `ref: openshift-qe-orion-node-density-cni` after the workload ref.

#### node-density

- **`openshift-qe-orion-node-density-ref.yaml`** — Changed `RUN_ORION` default to `true`, blanked `ORION_CONFIG` (triggers auto-selection), added `ORION_WORKLOAD_TYPE=node-density`.
- **`openshift-qe-node-density-chain.yaml`** — Added `ref: openshift-qe-orion-node-density` after the workload ref.

#### crd-scale

- **`openshift-qe-orion-crd-scale-ref.yaml`** — Changed `RUN_ORION` default to `true`, set `ORION_CONFIG=examples/trt-external-payload-crd-scale.yaml` (fixed config, no scale-tier variants exist). No `ORION_WORKLOAD_TYPE` needed since auto-selection is skipped when `ORION_CONFIG` is non-empty.
- **`openshift-qe-crd-scale-chain.yaml`** — Added `ref: openshift-qe-orion-crd-scale` after the workload ref.

#### Consolidated chain

- **`openshift-qe-orion-consolidated-chain.yaml`** — Removed all four workload-specific orion refs (cluster-density, node-density, node-density-cni, crd-scale). Chain now contains only `openshift-qe-orion-report`. All CI jobs using consolidated also run control-plane first, so workload orion now executes inline — no gap.
- **`openshift-qe-orion-report-ref.yaml`** — Added `ES_TYPE`, `OUTPUT_FORMAT`, `VERSION` env var declarations so standalone CI configs (e.g. `cloud-bulldozer/orion` `payload-control-plane-6nodes-nodeploy`) that override these vars at the test level still pass validation.

#### Stackrox backward-compatibility

- **`stackrox-perfscale-chain.yaml`** — Removed explicit `ref: openshift-qe-orion-cluster-density` (now included via CDv2 chain). Switched `node-density` and `crd-scale` from `chain:` to `ref:` so Stackrox uses the workload refs directly, bypassing the inline orion refs. This preserves exact pre-change behavior: Stackrox runs orion only for cluster-density-v2 with its own chain-level `ORION_CONFIG` override.

### Backward compatibility

- **50+ CI configs using `orion-consolidated`** — All safe. Every one runs `openshift-qe-control-plane` before `orion-consolidated`, so all workload orion now runs inline via control-plane.
- **Jobs with `RUN_ORION=false`** (e.g., ovn-kubernetes) — Still skip orion. Test-level env override takes precedence over the ref default.
- **Jobs with `RUN_ORION=true`** (e.g., perfscale-ci) — Now get auto-selected configs matched to actual cluster size instead of always using the 6-node config.
- **Stackrox** — Unaffected. Uses `ref:` for node-density and crd-scale (workload only, no inline orion). CDv2 chain still includes inline orion; Stackrox's chain-level `ORION_CONFIG` and `RUN_ORION` overrides propagate into it, so behavior is unchanged.
- **Standalone `nodeploy` configs** — Pass validation via env var declarations on the report ref. Report step gracefully handles the absence of upstream orion JSON artifacts.

### Test results

Validated on `payload-control-plane-6nodes` (4.22 nightly, 6-node AWS). All workloads and inline orion steps succeeded:

| Step | Duration | Status |
|------|----------|--------|
| cluster-density-v2 | 28m11s | succeeded |
| orion-cluster-density | 54s | succeeded |
| node-density-cni | 13m24s | succeeded |
| orion-node-density-cni | 1m30s | succeeded |
| crd-scale | 2m25s | succeeded |
| orion-crd-scale | 54s | succeeded |
| node-density | 11m12s | succeeded |
| orion-node-density | 6m0s | succeeded |
| udn-density-pods | 12m3s | succeeded |
| orion-udn-density | 59s | succeeded |
| orion-report | 10s | succeeded |

### Future Recommendation.

- UDN's `ENABLE_LAYER_3` block can optionally be refactored to use `ORION_WORKLOAD_TYPE=udn-l2` / `udn-l3`.

/cc @mohit-sheth