### PR TITLE
OCPBUGS-84684: skip tarring Azure dump artifacts to avoid gcs-filter censoring

### DIFF
--- a/ci-operator/step-registry/hypershift/destroy-nested-management-cluster/hypershift-destroy-nested-management-cluster-chain.yaml
+++ b/ci-operator/step-registry/hypershift/destroy-nested-management-cluster/hypershift-destroy-nested-management-cluster-chain.yaml
@@ -23,17 +23,12 @@ chain:
       mkdir -p "${ARTIFACT_DIR}/output"
       bin/hypershift dump cluster --dump-guest-cluster=true --artifact-dir="${ARTIFACT_DIR}/output" --name="${CLUSTER_NAME}" --namespace="${HYPERSHIFT_NAMESPACE}"
 
-      # Azure dump logs trigger leaktk/gcs-filter censoring; exclude them so the tarball survives
-      TAR_EXCLUDES=""
-      if [[ "${CLOUD_PROVIDER}" == "Azure" ]]; then
-        TAR_EXCLUDES='--exclude=*ignition-server*.log --exclude=*audit-logs.log'
-        mkdir -p "${ARTIFACT_DIR}/excluded-logs"
-        find "${ARTIFACT_DIR}/output" -name "*ignition-server*.log" -o -name "*audit-logs.log" | while read f; do
-          cp "$f" "${ARTIFACT_DIR}/excluded-logs/"
-        done
+      # Azure dump logs trigger leaktk/gcs-filter censoring of tarballs; skip tarring for Azure
+      # so individual files upload directly and only the sensitive ones get censored
+      if [[ "${CLOUD_PROVIDER}" != "Azure" ]]; then
+        tar -cvzf "${ARTIFACT_DIR}/artifacts.tar.gz" "${ARTIFACT_DIR}/output"
+        rm -rf "${ARTIFACT_DIR}/output"
       fi
-      tar -cvzf "${ARTIFACT_DIR}/artifacts.tar.gz" ${TAR_EXCLUDES} "${ARTIFACT_DIR}/output"
-      rm -rf "${ARTIFACT_DIR}/output"
     credentials:
     - mount_path: /etc/hypershift-kubeconfig
       name: hypershift-ci-2


### PR DESCRIPTION
## Summary
- Stops tarring Azure management cluster dump artifacts so `leaktk/gcs-filter` only censors individual sensitive files instead of the entire archive
- The previous approach (#78555) excluded specific files from the tarball, but gcs-filter was still censoring the whole tar
- Non-Azure providers (AWS) continue to tar as before

## Root Cause
`leaktk/gcs-filter` scans uploaded tarballs and replaces the **entire file** when it detects secrets (ignition-server logs with certs, audit-logs with bearer tokens). Excluding those files from the tar was not sufficient — the tarball was still being censored. By not tarring Azure artifacts at all, the individual files upload directly and only the specific sensitive ones get replaced.

## Test plan
- [ ] Rehearsal job `pull-ci-openshift-hypershift-main-e2e-azure-self-managed` produces dump artifacts that are individually accessible (not a censored tarball)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated artifact packaging logic for nested management cluster destruction in CI/CD pipelines. Azure cloud provider configuration modified to streamline artifact handling, while other cloud providers now create compressed artifact archives with simplified cleanup processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->