### PR TITLE
CNTRLPLANE-3351: enable CPU resource request overrides for Azure self-managed e2e

### DIFF
--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-main.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-main.yaml
@@ -233,6 +233,7 @@ tests:
       OCP_IMAGE_N2: release:n2minor
     env:
       CI_TESTS_RUN: ^(TestCreateCluster$|TestAutoscaling|TestNodePool|TestUpgradeControlPlane|TestHAEtcdChaos|TestAzureOAuthLoadBalancer|TestAzurePrivateTopology)$
+      E2E_RESOURCE_REQUEST_OVERRIDES: "1"
       ENABLE_HYPERSHIFT_CERT_ROTATION_SCALE: "true"
       HYPERSHIFT_AZURE_LOCATION: centralus
     post:

--- a/ci-operator/step-registry/hypershift/azure/run-e2e-self-managed/hypershift-azure-run-e2e-self-managed-ref.yaml
+++ b/ci-operator/step-registry/hypershift/azure/run-e2e-self-managed/hypershift-azure-run-e2e-self-managed-ref.yaml
@@ -60,6 +60,9 @@ ref:
     - default: ""
       name: AZURE_PRIVATE_NAT_SUBNET_ID
       documentation: "Azure resource ID of the NAT subnet for Private Link Service. Exported as env var for TestAzurePrivateTopology."
+    - default: ""
+      name: E2E_RESOURCE_REQUEST_OVERRIDES
+      documentation: "Set to '1' to add CPU resource request override annotations to e2e HostedClusters, preventing scheduler over-packing on management nodes."
   from: hypershift-tests
   grace_period: 30m0s
   resources:


### PR DESCRIPTION
## What this PR does / why we need it:

Sets `E2E_RESOURCE_REQUEST_OVERRIDES=1` for the `e2e-azure-self-managed` job to activate CPU request overrides on control plane pods. This prevents the scheduler from over-packing hosted clusters onto management nodes, which causes CPU starvation and e2e test timeouts.

The env var is declared in the `hypershift-azure-run-e2e-self-managed` step ref and consumed by the Go test code in `openshift/hypershift` (see openshift/hypershift#8385).

## Which issue(s) this PR fixes:

Fixes [CNTRLPLANE-3351](https://redhat.atlassian.net/browse/CNTRLPLANE-3351)

## Special notes for your reviewer:

- Companion PR: openshift/hypershift#8385
- Based on analysis from openshift/hypershift#8350 by @csrwng
- The overrides are opt-in: only jobs with `E2E_RESOURCE_REQUEST_OVERRIDES=1` in their env block are affected

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

[CNTRLPLANE-3351]: https://redhat.atlassian.net/browse/CNTRLPLANE-3351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Azure test configuration to prevent scheduler resource over-packing on management nodes.
  * Added configurable resource request override controls for test environments, enabling better CPU resource allocation and more reliable test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->