### PR TITLE
HYPERFLEET-877 - ci: bump hyperfleet-hooks to v0.1.2

### DIFF
--- a/ci-operator/step-registry/hyperfleet/commitlint/hyperfleet-commitlint-commands.sh
+++ b/ci-operator/step-registry/hyperfleet/commitlint/hyperfleet-commitlint-commands.sh
@@ -9,15 +9,14 @@ if [ -z "${PULL_BASE_SHA:-}" ]; then
     exit 1
 fi
 
-export HOME=/tmp
-export GOPATH=/tmp/go
-export GOMODCACHE=/tmp/go-mod
-export GOCACHE=/tmp/go-build
-export PATH="$GOPATH/bin:$PATH"
-unset GOFLAGS
+HOOKS_VERSION="v0.1.2"
+HOOKS_URL="https://github.com/openshift-hyperfleet/hyperfleet-hooks/releases/download/${HOOKS_VERSION}/hyperfleet-hooks-linux-amd64"
+HOOKS_BIN="/tmp/hyperfleet-hooks"
 
-echo "Installing hyperfleet-hooks..."
-go install github.com/openshift-hyperfleet/hyperfleet-hooks/cmd/hyperfleet-hooks@v0.1.1
+echo "Downloading hyperfleet-hooks ${HOOKS_VERSION}..."
+curl -fsSL -o "${HOOKS_BIN}" "${HOOKS_URL}"
+chmod +x "${HOOKS_BIN}"
+export PATH="/tmp:$PATH"
 
 echo "Running commitlint validation..."
 hyperfleet-hooks commitlint --pr


### PR DESCRIPTION
## Summary

- **Blocker fix**: v0.1.1 validates the entire repository history instead of only PR commits, causing `validate-commits` to fail on all PRs (e.g. [hyperfleet-api#115](https://github.com/openshift-hyperfleet/hyperfleet-api/pull/115))
- Bump `hyperfleet-hooks` from v0.1.1 to v0.1.2 which replaces go-git linear walk with `git rev-list` to correctly compute the PR commit range
- Replace `go install` (~3min compile) with pre-built binary download from GitHub releases (~2s)

## Test plan

- [x] Fix validated with unit tests including diverged branch scenario
- [ ] Verify via rehearsal that `validate-commits` passes on PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Switched CI tooling installation to use a prebuilt binary (v0.1.2) instead of building from source, improving pipeline reliability and reducing runtime/setup variability.
  * Simplified installation and PATH handling to speed CI steps and make commit-lint checks more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->