### PR TITLE
quay/quay: encrypt kubeconfig artifacts to prevent ci-operator censoring

### DIFF
--- a/ci-operator/config/quay/quay/quay-quay-master__claim.yaml
+++ b/ci-operator/config/quay/quay/quay-quay-master__claim.yaml
@@ -24,11 +24,23 @@ tests:
     test:
     - as: export-kubeconfig
       commands: |
-        cp "${KUBECONFIG}" "${ARTIFACT_DIR}/kubeconfig"
-        cp "${KUBEADMIN_PASSWORD_FILE}" "${ARTIFACT_DIR}/kubeadmin-password" 2>/dev/null || true
+        openssl enc -aes-256-cbc -pbkdf2 \
+          -pass file:/var/run/encryption-key/kubeconfig-encryption-key \
+          -in "${KUBECONFIG}" \
+          -out "${ARTIFACT_DIR}/kubeconfig.enc"
+        if [[ -f "${KUBEADMIN_PASSWORD_FILE}" ]]; then
+          openssl enc -aes-256-cbc -pbkdf2 \
+            -pass file:/var/run/encryption-key/kubeconfig-encryption-key \
+            -in "${KUBEADMIN_PASSWORD_FILE}" \
+            -out "${ARTIFACT_DIR}/kubeadmin-password.enc"
+        fi
         oc whoami --show-server
         oc get clusterversion
-        echo "Kubeconfig exported to artifacts."
+        echo "Encrypted kubeconfig exported to artifacts."
+      credentials:
+      - mount_path: /var/run/encryption-key
+        name: quay-ambient-ci-kubeconfig-encryption
+        namespace: test-credentials
       from: cli
       resources:
         requests:


### PR DESCRIPTION
## Summary

- The \`export-kubeconfig\` step in \`periodic-ci-quay-quay-master-claim-claim-cluster\` was copying the raw kubeconfig to \`\$ARTIFACT_DIR\`.
- ci-operator censors sensitive content before uploading to GCS, so the downloaded kubeconfig ends up as all-X's and is unusable.
- This PR encrypts the kubeconfig (and kubeadmin-password) with AES-256-CBC (OpenSSL \`pbkdf2\`) before writing to \`\$ARTIFACT_DIR\`. The ciphertext doesn't match any known censoring patterns and is uploaded intact.

## What changed

\`ci-operator/config/quay/quay/quay-quay-master__claim.yaml\` — \`export-kubeconfig\` inline step:

- Added a \`credentials\` block mounting Secret \`quay-ambient-ci-kubeconfig-encryption\` (namespace: \`test-credentials\`) at \`/var/run/encryption-key\`.
- Replaced plain \`cp\` commands with \`openssl enc -aes-256-cbc -pbkdf2\`, writing \`kubeconfig.enc\` and \`kubeadmin-password.enc\`.

The generated ProwJob YAML (\`quay-quay-master-periodics.yaml\`) is **unchanged** — step-level \`credentials\` are managed by ci-operator at runtime, not in the outer ProwJob spec.

## Secret provisioning (self-service via Vault)

Per the [OpenShift CI secret guide](https://docs.ci.openshift.org/how-tos/adding-a-new-secret-to-ci/), the encryption key must be created by the team in Vault:

1. Create a secret collection at [selfservice.vault.ci.openshift.org](https://selfservice.vault.ci.openshift.org/)
2. Add a secret at [vault.ci.openshift.org](https://vault.ci.openshift.org/) under \`kv/<collection>\` with:
   - \`kubeconfig-encryption-key\`: the passphrase
   - \`secretsync/target-namespace\`: \`test-credentials\`
   - \`secretsync/target-name\`: \`quay-ambient-ci-kubeconfig-encryption\`

Vault will sync the Secret to all build clusters within 30 minutes.

## Decrypting the artifact

\`\`\`bash
openssl enc -d -aes-256-cbc -pbkdf2 \
  -pass pass:<passphrase> \
  -in kubeconfig.enc \
  -out kubeconfig
\`\`\`

## Test plan

- [ ] Secret \`quay-ambient-ci-kubeconfig-encryption\` provisioned in Vault and synced to \`test-credentials\`
- [ ] Rehearsal of \`periodic-ci-quay-quay-master-claim-claim-cluster\` passes
- [ ] \`kubeconfig.enc\` present and non-empty in GCS artifacts
- [ ] File is not all-X's (ci-operator did not censor it)
- [ ] Decryption with the passphrase produces a valid kubeconfig

🤖 Generated with [Claude Code](https://claude.com/claude-code)