### PR TITLE
CMP-4147: Run tls-scanner on CO parallel jobs

### DIFF
--- a/ci-operator/config/ComplianceAsCode/compliance-operator/ComplianceAsCode-compliance-operator-master.yaml
+++ b/ci-operator/config/ComplianceAsCode/compliance-operator/ComplianceAsCode-compliance-operator-master.yaml
@@ -11,6 +11,10 @@ base_images:
     name: rosa-aws-cli
     namespace: ci
     tag: release
+  tls-scanner-tool:
+    name: "4.22"
+    namespace: ocp
+    tag: tls-scanner-tool
 build_root:
   image_stream_tag:
     name: builder
@@ -53,6 +57,10 @@ releases:
     integration:
       include_built_images: true
       name: "4.17"
+      namespace: ocp
+  latest-4-22:
+    integration:
+      name: "4.22"
       namespace: ocp
 resources:
   '*':
@@ -119,6 +127,34 @@ tests:
         requests:
           cpu: 100m
     workflow: ipi-aws
+- as: e2e-aws-deployment
+  skip_if_only_changed: ^.*(md|adoc)$|^LICENSE$|^.github/workflows/*
+  steps:
+    cluster_profile: quay-aws
+    dependencies:
+      OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: release:latest-4-22
+    env:
+      BASE_DOMAIN: quay.devcluster.openshift.com
+      COMPUTE_NODE_TYPE: m5.2xlarge
+      PQC_CHECK: "true"
+      SCAN_NAMESPACE: openshift-compliance
+    test:
+    - as: test
+      cli: latest-4-22
+      commands: make e2e-deployment
+      dependencies:
+      - env: IMAGE_FROM_CI
+        name: compliance-operator
+      - env: CONTENT_IMAGE_FROM_CI
+        name: testcontent
+      - env: OPENSCAP_IMAGE_FROM_CI
+        name: testopenscap
+      from: src
+      resources:
+        requests:
+          cpu: 100m
+    - ref: tls-scanner-run
+    workflow: openshift-e2e-aws-ovn-tls-13
 - as: e2e-rosa
   skip_if_only_changed: ^.*(md|adoc)$|^LICENSE$|^.github/workflows/*
   steps:

--- a/ci-operator/jobs/ComplianceAsCode/compliance-operator/ComplianceAsCode-compliance-operator-master-presubmits.yaml
+++ b/ci-operator/jobs/ComplianceAsCode/compliance-operator/ComplianceAsCode-compliance-operator-master-presubmits.yaml
@@ -6,6 +6,89 @@ presubmits:
     - ^master$
     - ^master-
     cluster: build06
+    context: ci/prow/e2e-aws-deployment
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: quay-aws
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-ComplianceAsCode-compliance-operator-master-e2e-aws-deployment
+    rerun_command: /test e2e-aws-deployment
+    skip_if_only_changed: ^.*(md|adoc)$|^LICENSE$|^.github/workflows/*
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-aws-deployment
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-aws-deployment,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^master$
+    - ^master-
+    cluster: build06
     context: ci/prow/e2e-aws-parallel
     decorate: true
     decoration_config:


### PR DESCRIPTION
The compliance operator already provisions an AWS cluster for CI on each
PR. Let's add the tls-scanner-run step here so that we're also scanning
all the available TLS endpoints in the openshift-compliance namespace to
ensure they're aligned with PQC and TLS consistency goals for OpenShift.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This updates the ComplianceAsCode/compliance-operator CI configuration in openshift/release to run the TLS scanner as part of the AWS e2e deployment job so TLS endpoints in the openshift-compliance namespace are scanned during CI.

Practical changes:
- Adds a base_images entry tls-scanner-tool (name: "4.22", namespace: ocp, tag: tls-scanner-tool).
- Adds a releases entry latest-4-22 (integration name: "4.22", namespace: ocp) and uses it via OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: release:latest-4-22 for the e2e-aws-deployment job.
- Updates e2e-aws-deployment test case:
  - cluster_profile: quay-aws
  - dependencies: OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: release:latest-4-22
  - env: BASE_DOMAIN, COMPUTE_NODE_TYPE: m5.2xlarge, PQC_CHECK: "true", SCAN_NAMESPACE: openshift-compliance
  - test step runs make e2e-deployment in a cli: latest-4-22 container with the compliance-operator, testcontent, and testopenscap image dependencies and modest CPU requests
  - appends a workflow step ref: tls-scanner-run and selects workflow: openshift-e2e-aws-ovn-tls-13 so the TLS scanner executes as part of the job

Notes from PR discussion:
- Author ran rehearsals and requested larger node sizes so the tls-scanner can schedule (COMPUTE_NODE_TYPE is set to m5.2xlarge).
- Rehearsals may fail on older OCP clusters; the TLS/PQC checks target newer OCP (4.22+) which is why latest-4-22 was added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->