### PR TITLE
Add rosa-e2e nightly jobs for 4.19, 4.23, and 5.0

### DIFF
--- a/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__periodics.yaml
+++ b/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__periodics.yaml
@@ -30,6 +30,18 @@ resources:
       cpu: 100m
       memory: 200Mi
 tests:
+- as: rosa-hcp-e2e-nightly-4-19
+  cron: 30 2 * * *
+  steps:
+    cluster_profile: rosa-e2e-01
+    env:
+      CHANNEL_GROUP: nightly
+      ENABLE_BILLING_ACCOUNT: "yes"
+      HOSTED_CP: "true"
+      OCM_LOGIN_ENV: staging
+      OPENSHIFT_VERSION: "4.19"
+      REPLICAS: "3"
+    workflow: rosa-e2e
 - as: rosa-hcp-e2e-nightly-4-20
   cron: 0 3 * * *
   steps:
@@ -64,6 +76,30 @@ tests:
       HOSTED_CP: "true"
       OCM_LOGIN_ENV: staging
       OPENSHIFT_VERSION: "4.22"
+      REPLICAS: "3"
+    workflow: rosa-e2e
+- as: rosa-hcp-e2e-nightly-4-23
+  cron: 30 4 * * *
+  steps:
+    cluster_profile: rosa-e2e-01
+    env:
+      CHANNEL_GROUP: nightly
+      ENABLE_BILLING_ACCOUNT: "yes"
+      HOSTED_CP: "true"
+      OCM_LOGIN_ENV: staging
+      OPENSHIFT_VERSION: "4.23"
+      REPLICAS: "3"
+    workflow: rosa-e2e
+- as: rosa-hcp-e2e-nightly-5-0
+  cron: 0 5 * * *
+  steps:
+    cluster_profile: rosa-e2e-01
+    env:
+      CHANNEL_GROUP: nightly
+      ENABLE_BILLING_ACCOUNT: "yes"
+      HOSTED_CP: "true"
+      OCM_LOGIN_ENV: staging
+      OPENSHIFT_VERSION: "5.0"
       REPLICAS: "3"
     workflow: rosa-e2e
 zz_generated_metadata:

--- a/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-periodics.yaml
@@ -281,6 +281,89 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build09
+  cron: 30 2 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-online
+    repo: rosa-e2e
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: rosa-e2e-01
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-online-rosa-e2e-main-periodics-rosa-hcp-e2e-nightly-4-19
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=rosa-hcp-e2e-nightly-4-19
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build09
   cron: 0 3 * * *
   decorate: true
   decoration_config:
@@ -472,6 +555,172 @@ periodics:
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
       - --target=rosa-hcp-e2e-nightly-4-22
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build09
+  cron: 30 4 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-online
+    repo: rosa-e2e
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: rosa-e2e-01
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-online-rosa-e2e-main-periodics-rosa-hcp-e2e-nightly-4-23
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=rosa-hcp-e2e-nightly-4-23
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build09
+  cron: 0 5 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-online
+    repo: rosa-e2e
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: rosa-e2e-01
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-online-rosa-e2e-main-periodics-rosa-hcp-e2e-nightly-5-0
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=rosa-hcp-e2e-nightly-5-0
       - --variant=periodics
       command:
       - ci-operator

--- a/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-periodics.yaml
@@ -800,9 +800,9 @@ periodics:
       - failure
       - error
       report_template: |-
-        {{if eq .Status.State "success"}} :white_check_mark: ROSA CI Daily Status: all tracked jobs healthy. <{{.Status.URL}}|Full report> | <https://sippy.dptools.openshift.org/sippy-ng/release/rosa-stage|Sippy>
-        <https://prow.ci.openshift.org/?type=periodic&job=*rosa-hcp-e2e-nightly*|ROSA E2E> | <https://prow.ci.openshift.org/?type=periodic&job=*ocm-fvt*rosa*|OCM FVT> | <https://prow.ci.openshift.org/?type=periodic&job=*main-nightly-*e2e-rosa-*-ovn|Conformance> {{else}} :x: ROSA CI Daily Status: some jobs failing. <{{.Status.URL}}|Full report> | <https://sippy.dptools.openshift.org/sippy-ng/release/rosa-stage|Sippy>
-        <https://prow.ci.openshift.org/?type=periodic&job=*rosa-hcp-e2e-nightly*|ROSA E2E> | <https://prow.ci.openshift.org/?type=periodic&job=*ocm-fvt*rosa*|OCM FVT> | <https://prow.ci.openshift.org/?type=periodic&job=*main-nightly-*e2e-rosa-*-ovn|Conformance> {{end}}
+        {{if eq .Status.State "success"}}:large_green_circle: *ROSA CI Daily Status:* all jobs passing{{else}}:red_circle: *ROSA CI Daily Status:* failures detected{{end}} (<{{.Status.URL}}|Full report>)
+        <https://prow.ci.openshift.org/?type=periodic&job=*rosa-hcp-e2e-nightly*|ROSA E2E> | <https://prow.ci.openshift.org/?type=periodic&job=*ocm-fvt*rosa*|OCM FVT> | <https://prow.ci.openshift.org/?type=periodic&job=*main-nightly-*e2e-rosa-hcp-ovn|HCP Conformance> | <https://prow.ci.openshift.org/?type=periodic&job=*main-nightly-*e2e-rosa-sts-ovn|Classic STS Conformance>
+        :bar_chart: <https://sippy.dptools.openshift.org/sippy-ng/release/rosa-stage|Sippy>
   spec:
     containers:
     - args:


### PR DESCRIPTION
## Summary

Expand rosa-e2e HCP nightly coverage from 4.20-4.22 to the full range of active versions.

## Changes

Adds 3 new periodic rosa-e2e nightly jobs:
- `rosa-hcp-e2e-nightly-4-19` (02:30 UTC)
- `rosa-hcp-e2e-nightly-4-23` (04:30 UTC)
- `rosa-hcp-e2e-nightly-5-0` (05:00 UTC)

These use the same `rosa-e2e` workflow and `rosa-e2e-01` cluster profile as the existing 4.20-4.22 jobs.

## Context

The daily CI status report (rosa-ci-daily-status) tracks rosa-e2e, HCP conformance, and Classic STS conformance across 4.19-5.0. The rosa-e2e nightly jobs were missing 4.19, 4.23, and 5.0 coverage.

## Test plan

- [ ] Rehearse one of the new jobs to verify it provisions and runs correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added nightly automated tests for OpenShift versions 4.19, 4.23, and 5.0 with distinct scheduling to validate functionality across multiple platform releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->