### PR TITLE
Add build12 canary and ship-status build-farm monitors

### DIFF
--- a/ci-operator/jobs/infra-build-farm-periodics.yaml
+++ b/ci-operator/jobs/infra-build-farm-periodics.yaml
@@ -871,3 +871,36 @@ periodics:
         requests:
           cpu: 100m
           memory: 100Mi
+- agent: kubernetes
+  cluster: build12
+  cron: 0 * * * *
+  decorate: true
+  decoration_config:
+    timeout: 10m0s
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: release
+    workdir: true
+  labels:
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  max_concurrency: 1
+  name: periodic-build-farm-canary-build12
+  reporter_config:
+    slack:
+      channel: '#alerts-testplatform-build-farms'
+      job_states_to_report:
+      - failure
+      - error
+      report_template: Job *{{.Spec.Job}}* failed. <{{.Status.URL}}|View logs>
+  spec:
+    containers:
+    - command:
+      - ./hack/build-farm-canary.sh
+      image: quay-proxy.ci.openshift.org/openshift/ci:ocp_cli-jq_latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 100m
+          memory: 100Mi

--- a/core-services/ship-status/component-monitor-config.yaml
+++ b/core-services/ship-status/component-monitor-config.yaml
@@ -315,6 +315,37 @@ components:
           duration: "2h"
           step: "5m"
           severity: "Degraded"
+    junit_monitor:
+      job_name: "periodic-build-farm-canary-build01"
+      max_age: "2h"
+      severity: "Degraded"
+      artifact_url_style: "gcs"
+      history_runs: 5
+      failed_runs_threshold: 3
+#   - component_slug: "build-farm"
+#     sub_component_slug: "build02"
+#     prometheus_monitor:
+#       prometheus_location:
+#         cluster: "app.ci"
+#         namespace: "openshift-monitoring"
+#         route: "thanos-querier"
+#       queries:
+#         - query: "probe_success{job=\"blackbox\",instance=\"https://console.build02.ci.openshift.org\"} > 0"
+#           duration: "5m"
+#           step: "30s"
+#           severity: "Down"
+#         - query: "rate(prowjob_state_transitions{cluster=\"build02\",state=\"success\"}[2h]) > 0"
+#           duration: "2h"
+#           step: "5m"
+#           severity: "Degraded"
+#     junit_monitor:
+#       job_name: "periodic-build-farm-canary-build02"
+#       max_age: "2h"
+#       severity: "Degraded"
+#       artifact_url_style: "gcs"
+#       history_runs: 5
+#       failed_runs_threshold: 3
+#
   - component_slug: "build-farm"
     sub_component_slug: "build03"
     prometheus_monitor:
@@ -331,6 +362,13 @@ components:
           duration: "2h"
           step: "5m"
           severity: "Degraded"
+    junit_monitor:
+      job_name: "periodic-build-farm-canary-build03"
+      max_age: "2h"
+      severity: "Degraded"
+      artifact_url_style: "gcs"
+      history_runs: 5
+      failed_runs_threshold: 3
   - component_slug: "build-farm"
     sub_component_slug: "build04"
     prometheus_monitor:
@@ -347,6 +385,13 @@ components:
           duration: "2h"
           step: "5m"
           severity: "Degraded"
+    junit_monitor:
+      job_name: "periodic-build-farm-canary-build04"
+      max_age: "2h"
+      severity: "Degraded"
+      artifact_url_style: "gcs"
+      history_runs: 5
+      failed_runs_threshold: 3
   - component_slug: "build-farm"
     sub_component_slug: "build05"
     prometheus_monitor:
@@ -363,6 +408,13 @@ components:
           duration: "2h"
           step: "5m"
           severity: "Degraded"
+    junit_monitor:
+      job_name: "periodic-build-farm-canary-build05"
+      max_age: "2h"
+      severity: "Degraded"
+      artifact_url_style: "gcs"
+      history_runs: 5
+      failed_runs_threshold: 3
   - component_slug: "build-farm"
     sub_component_slug: "build06"
     prometheus_monitor:
@@ -379,6 +431,13 @@ components:
           duration: "2h"
           step: "5m"
           severity: "Degraded"
+    junit_monitor:
+      job_name: "periodic-build-farm-canary-build06"
+      max_age: "2h"
+      severity: "Degraded"
+      artifact_url_style: "gcs"
+      history_runs: 5
+      failed_runs_threshold: 3
   - component_slug: "build-farm"
     sub_component_slug: "build07"
     prometheus_monitor:
@@ -395,6 +454,13 @@ components:
           duration: "2h"
           step: "5m"
           severity: "Degraded"
+    junit_monitor:
+      job_name: "periodic-build-farm-canary-build07"
+      max_age: "2h"
+      severity: "Degraded"
+      artifact_url_style: "gcs"
+      history_runs: 5
+      failed_runs_threshold: 3
   - component_slug: "build-farm"
     sub_component_slug: "build08"
     prometheus_monitor:
@@ -411,6 +477,13 @@ components:
           duration: "2h"
           step: "5m"
           severity: "Degraded"
+    junit_monitor:
+      job_name: "periodic-build-farm-canary-build08"
+      max_age: "2h"
+      severity: "Degraded"
+      artifact_url_style: "gcs"
+      history_runs: 5
+      failed_runs_threshold: 3
   - component_slug: "build-farm"
     sub_component_slug: "build09"
     prometheus_monitor:
@@ -427,6 +500,13 @@ components:
           duration: "2h"
           step: "5m"
           severity: "Degraded"
+    junit_monitor:
+      job_name: "periodic-build-farm-canary-build09"
+      max_age: "2h"
+      severity: "Degraded"
+      artifact_url_style: "gcs"
+      history_runs: 5
+      failed_runs_threshold: 3
   - component_slug: "build-farm"
     sub_component_slug: "build10"
     prometheus_monitor:
@@ -443,6 +523,13 @@ components:
           duration: "2h"
           step: "5m"
           severity: "Degraded"
+    junit_monitor:
+      job_name: "periodic-build-farm-canary-build10"
+      max_age: "2h"
+      severity: "Degraded"
+      artifact_url_style: "gcs"
+      history_runs: 5
+      failed_runs_threshold: 3
   - component_slug: "build-farm"
     sub_component_slug: "build11"
     prometheus_monitor:
@@ -459,4 +546,34 @@ components:
           duration: "2h"
           step: "5m"
           severity: "Degraded"
+    junit_monitor:
+      job_name: "periodic-build-farm-canary-build11"
+      max_age: "2h"
+      severity: "Degraded"
+      artifact_url_style: "gcs"
+      history_runs: 5
+      failed_runs_threshold: 3
+  - component_slug: "build-farm"
+    sub_component_slug: "build12"
+    prometheus_monitor:
+      prometheus_location:
+        cluster: "app.ci"
+        namespace: "openshift-monitoring"
+        route: "thanos-querier"
+      queries:
+        - query: "probe_success{job=\"blackbox\",instance=\"https://console-openshift-console.apps.build12.ci.devcluster.openshift.com\"} > 0"
+          duration: "5m"
+          step: "30s"
+          severity: "Down"
+        - query: "rate(prowjob_state_transitions{cluster=\"build12\",state=\"success\"}[2h]) > 0"
+          duration: "2h"
+          step: "5m"
+          severity: "Degraded"
+    junit_monitor:
+      job_name: "periodic-build-farm-canary-build12"
+      max_age: "2h"
+      severity: "Degraded"
+      artifact_url_style: "gcs"
+      history_runs: 5
+      failed_runs_threshold: 3
   # END: auto-generated build-farm entries

--- a/core-services/ship-status/dashboard-config.yaml
+++ b/core-services/ship-status/dashboard-config.yaml
@@ -372,6 +372,14 @@ components:
           component_monitor: "app-ci-component-monitor"
           auto_resolve: true
         requires_confirmation: false
+#       - name: "Build02"
+#         description: "Build cluster build02"
+#         monitoring:
+#           frequency: 5m
+#           component_monitor: "app-ci-component-monitor"
+#           auto_resolve: true
+#         requires_confirmation: false
+#
       - name: "Build03"
         description: "Build cluster build03"
         monitoring:
@@ -430,6 +438,13 @@ components:
         requires_confirmation: false
       - name: "Build11"
         description: "Build cluster build11"
+        monitoring:
+          frequency: 5m
+          component_monitor: "app-ci-component-monitor"
+          auto_resolve: true
+        requires_confirmation: false
+      - name: "Build12"
+        description: "Build cluster build12"
         monitoring:
           frequency: 5m
           component_monitor: "app-ci-component-monitor"

--- a/hack/generate-build-farm-monitor-config.py
+++ b/hack/generate-build-farm-monitor-config.py
@@ -5,6 +5,8 @@
 import sys
 import yaml
 
+# Console URLs must match blackbox targets (see clusters/app.ci/.../blackbox_probe.yaml).
+# Clusters with blocked: true in _clusters.yaml are emitted as commented YAML blocks.
 CONSOLE_URLS = {
     "build01": "https://console.build01.ci.openshift.org",
     "build02": "https://console.build02.ci.openshift.org",
@@ -17,7 +19,10 @@ CONSOLE_URLS = {
     "build09": "https://console-openshift-console.apps.build09.ci.devcluster.openshift.com",
     "build10": "https://console-openshift-console.apps.build10.ci.devcluster.openshift.com",
     "build11": "https://console-openshift-console.apps.build11.ci.devcluster.openshift.com",
+    "build12": "https://console-openshift-console.apps.build12.ci.devcluster.openshift.com",
 }
+
+BUILD_ORDER = [f"build{i:02d}" for i in range(1, 13)]
 
 
 def splice(path, begin, end, body):
@@ -27,51 +32,87 @@ def splice(path, begin, end, body):
     if bi == -1 or ei == -1:
         sys.exit(f"markers not found in {path}")
     with open(path, "w", encoding="utf-8") as fh:
-        fh.write(t[:bi] + begin + body + end + t[ei + len(end):])
+        fh.write(t[:bi] + begin + body + end + t[ei + len(end) :])
 
 
-with open("core-services/sanitize-prow-jobs/_clusters.yaml", encoding="utf-8") as f:
-    data = yaml.safe_load(f)
+def yaml_comment_block(body: str) -> str:
+    out = []
+    for line in body.splitlines(keepends=True):
+        if line.endswith("\n"):
+            core, nl = line[:-1], "\n"
+        else:
+            core, nl = line, ""
+        if core.strip() == "":
+            out.append("#\n")
+        else:
+            out.append("# " + core + nl)
+    return "".join(out)
 
-clusters = sorted(
-    {c["name"]: c.get("blocked", False) for entries in data.values() for c in entries if c["name"] in CONSOLE_URLS}.items()
-)
 
-monitor_body = ""
-dash_body = ""
-
-for name, blocked in clusters:
-    if blocked:
-        continue
-    console = CONSOLE_URLS[name]
-    monitor_body += f"""\
+def monitor_entry(cluster_name: str, console_url: str) -> str:
+    return f"""\
   - component_slug: "build-farm"
-    sub_component_slug: "{name}"
+    sub_component_slug: "{cluster_name}"
     prometheus_monitor:
       prometheus_location:
         cluster: "app.ci"
         namespace: "openshift-monitoring"
         route: "thanos-querier"
       queries:
-        - query: "probe_success{{job=\\"blackbox\\",instance=\\"{console}\\"}} > 0"
+        - query: "probe_success{{job=\\"blackbox\\",instance=\\"{console_url}\\"}} > 0"
           duration: "5m"
           step: "30s"
           severity: "Down"
-        - query: "rate(prowjob_state_transitions{{cluster=\\"{name}\\",state=\\"success\\"}}[2h]) > 0"
+        - query: "rate(prowjob_state_transitions{{cluster=\\"{cluster_name}\\",state=\\"success\\"}}[2h]) > 0"
           duration: "2h"
           step: "5m"
           severity: "Degraded"
+    junit_monitor:
+      job_name: "periodic-build-farm-canary-{cluster_name}"
+      max_age: "2h"
+      severity: "Degraded"
+      artifact_url_style: "gcs"
+      history_runs: 5
+      failed_runs_threshold: 3
 """
 
-    display = "Build" + name[5:]
-    dash_body += f'      - name: "{display}"\n        description: "Build cluster {name}"\n'
-    dash_body += """\
+
+def dash_entry(cluster_name: str) -> str:
+    display = "Build" + cluster_name[5:]
+    return f"""\
+      - name: "{display}"
+        description: "Build cluster {cluster_name}"
         monitoring:
           frequency: 5m
           component_monitor: "app-ci-component-monitor"
           auto_resolve: true
         requires_confirmation: false
 """
+
+
+with open("core-services/sanitize-prow-jobs/_clusters.yaml", encoding="utf-8") as f:
+    data = yaml.safe_load(f)
+
+blocked_by_name = {
+    c["name"]: c.get("blocked", False) for entries in data.values() for c in entries if "name" in c
+}
+
+monitor_body = ""
+dash_body = ""
+
+for name in BUILD_ORDER:
+    if name not in CONSOLE_URLS:
+        continue
+    console = CONSOLE_URLS[name]
+    blocked = blocked_by_name.get(name, False)
+    if blocked:
+        monitor_body += yaml_comment_block(monitor_entry(name, console))
+        monitor_body += "#\n"
+        dash_body += yaml_comment_block(dash_entry(name))
+        dash_body += "#\n"
+    else:
+        monitor_body += monitor_entry(name, console)
+        dash_body += dash_entry(name)
 
 splice(
     "core-services/ship-status/component-monitor-config.yaml",
@@ -86,5 +127,10 @@ splice(
     dash_body,
 )
 
-for name, blocked in clusters:
-    print(f"  {name}: {'blocked' if blocked else 'active'}")
+for name in BUILD_ORDER:
+    if name not in CONSOLE_URLS:
+        continue
+    if blocked_by_name.get(name, False):
+        print(f"  {name}: commented-out (blocked in _clusters.yaml)")
+    else:
+        print(f"  {name}: active")


### PR DESCRIPTION
depends on https://github.com/openshift-eng/ship-status-dash/pull/80

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Build12 to the build-farm dashboard and active component tracking; Build02 remains commented out.
  * Enabled JUnit-based canary monitoring for build01 and build03–build12 with consistent evaluation parameters.

* **Chores**
  * Improved monitor/dashboard generation to deterministically include new clusters, respect an allowlist of console URLs, and emit commented-out entries for blocked clusters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->