### PR TITLE
Disable blunderbuss for kueue-operator

### DIFF
--- a/core-services/prow/02_config/openshift/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/_pluginconfig.yaml
@@ -50,6 +50,7 @@ plugins:
     - cluster-version-operator
     - cincinnati
     - cincinnati-operator
+    - kueue-operator
     plugins:
     - assign
     - blunderbuss

--- a/core-services/prow/02_config/openshift/kueue-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/kueue-operator/_pluginconfig.yaml
@@ -10,6 +10,29 @@ plugins:
   openshift/kueue-operator:
     plugins:
     - approve
+    - assign
+    - cat
+    - dog
+    - heart
+    - golint
+    - goose
+    - help
+    - hold
+    - jira
+    - label
+    - lgtm
+    - lifecycle
+    - override
+    - pony
+    - retitle
+    - shrug
+    - sigmention
+    - skip
+    - trigger
+    - verify-owners
+    - owners-label
+    - wip
+    - yuks
 triggers:
 - repos:
   - openshift/kueue-operator


### PR DESCRIPTION
This will exclude kueue-operator from plugins a org level and specify all plugins minus blunderbuss at the repo level.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Prow plugin configuration for the kueue-operator repository to exclude it from the OpenShift default plugin set.
  * Expanded the kueue-operator repository configuration with additional Prow plugins to customize its CI/CD behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->