### PR TITLE
Set minimal collectionProfile for cluster monitoring

### DIFF
--- a/ci-operator/config/openshift-eng/ocp-perfscale/openshift-eng-ocp-perfscale-main__aws-4.22-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-perfscale/openshift-eng-ocp-perfscale-main__aws-4.22-nightly-x86.yaml
@@ -192,7 +192,7 @@ tests:
       {{else}} :warning:  Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
       logs> :warning: {{end}}'
   steps:
-    allow_skip_on_success: true
+    allow_skip_on_success: false
     cluster_profile: aws-perfscale-qe
     env:
       ADDITIONAL_WORKER_NODES: "21"

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.22-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.22-nightly-x86.yaml
@@ -132,7 +132,7 @@ tests:
 - as: control-plane-24nodes
   cron: 0 5 * * 6,2,4,5
   steps:
-    allow_skip_on_success: true
+    allow_skip_on_success: false
     cluster_profile: aws-perfscale-qe
     env:
       ADDITIONAL_WORKER_NODES: "21"

--- a/ci-operator/step-registry/openshift-qe/move-pods-infra/openshift-qe-move-pods-infra-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/move-pods-infra/openshift-qe-move-pods-infra-commands.sh
@@ -246,6 +246,7 @@ data:
         value: reserved
         effect: NoExecute
     prometheusK8s:
+      collectionProfile: minimal
       nodeSelector:
         node-role.kubernetes.io/infra: ""
       tolerations:
@@ -348,6 +349,7 @@ data:
         value: reserved
         effect: NoExecute
     prometheusK8s:
+      collectionProfile: minimal
       retention: ${OPENSHIFT_PROMETHEUS_RETENTION_PERIOD}
       nodeSelector:
         node-role.kubernetes.io/infra: ""


### PR DESCRIPTION
Signed-off-by: Andrew Collins <ancollin@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Cluster monitoring ConfigMaps now use the `minimal` Prometheus collection profile, including PVC-enabled configurations.
- The 24-node control-plane perfscale job no longer skips when a previous run succeeds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->