### PR TITLE
feat(GCP-431): pass network service account to v2 GKE create chain

### DIFF
--- a/ci-operator/step-registry/hypershift/gcp/create/hypershift-gcp-create-chain.yaml
+++ b/ci-operator/step-registry/hypershift/gcp/create/hypershift-gcp-create-chain.yaml
@@ -34,6 +34,7 @@ chain:
       CLOUDCONTROLLER_SA="$(<"${SHARED_DIR}/cloudcontroller-sa")"
       STORAGE_SA="$(<"${SHARED_DIR}/storage-sa")"
       IMAGEREGISTRY_SA="$(<"${SHARED_DIR}/imageregistry-sa")"
+      NETWORK_SA="$(<"${SHARED_DIR}/network-sa")"
       SA_SIGNING_KEY_PATH="$(<"${SHARED_DIR}/sa-signing-key-path")"
 
       # Construct base domain and OIDC issuer URL
@@ -72,6 +73,7 @@ chain:
         --cloud-controller-service-account "${CLOUDCONTROLLER_SA}" \
         --storage-service-account "${STORAGE_SA}" \
         --image-registry-service-account "${IMAGEREGISTRY_SA}" \
+        --network-service-account "${NETWORK_SA}" \
         --service-account-signing-key-path "${SA_SIGNING_KEY_PATH}" \
         --oidc-issuer-url "${OIDC_ISSUER_URL}" \
         --boot-image "${GCP_BOOT_IMAGE}" \


### PR DESCRIPTION
## Summary

- The v2 GKE e2e workflow (`hypershift-gcp-gke-e2e-v2`) creates a hosted cluster directly via the hypershift CLI in the `hypershift-gcp-create` chain
- Since [openshift/hypershift#7824](https://github.com/openshift/hypershift/pull/7824) made `--network-service-account` a required flag, the chain must read the `network-sa` saved to `SHARED_DIR` by `hypershift-gcp-hosted-cluster-setup` and forward it to the CLI
- This is a follow-up to #77415, which fixed the same issue for the v1 (`hypershift-gcp-run-e2e`) flow

## Test plan

- [ ] Rehearse `/test e2e-v2-gke` on a hypershift PR that touches GCP code paths and verify the `create-hostedcluster` step no longer fails with `required flag(s) "network-service-account" not set`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Network service account configuration now available for GCP hosted cluster provisioning, allowing specification of network service accounts during cluster creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->