### PR TITLE
Add etcd signer verification and etcd-operator presubmits for ConfigurablePKI feature

### DIFF
--- a/ci-operator/config/openshift/cluster-etcd-operator/openshift-cluster-etcd-operator-main.yaml
+++ b/ci-operator/config/openshift/cluster-etcd-operator/openshift-cluster-etcd-operator-main.yaml
@@ -272,6 +272,35 @@ tests:
           cpu: 100m
       timeout: 3h0m0s
     workflow: ipi-aws
+- always_run: false
+  as: e2e-aws-ovn-pki-default-techpreview
+  optional: true
+  steps:
+    cluster_profile: openshift-org-aws
+    env:
+      EXPECTED_ALGORITHM: ECDSA
+      EXPECTED_KEY_PARAM: secp384r1
+      EXPECTED_PKI_MODE: Default
+      FEATURE_SET: TechPreviewNoUpgrade
+    test:
+    - ref: openshift-installer-pki-verify
+    - ref: openshift-e2e-test
+    workflow: openshift-e2e-aws
+- always_run: false
+  as: e2e-aws-ovn-pki-rsa-techpreview
+  optional: true
+  steps:
+    cluster_profile: openshift-org-aws
+    env:
+      EXPECTED_ALGORITHM: RSA
+      EXPECTED_KEY_PARAM: "4096"
+      FEATURE_SET: TechPreviewNoUpgrade
+      PKI_ALGORITHM: RSA
+      PKI_RSA_KEY_SIZE: "4096"
+    test:
+    - ref: openshift-installer-pki-verify
+    - ref: openshift-e2e-test
+    workflow: openshift-e2e-aws
 - as: e2e-gcp-operator-disruptive
   steps:
     cluster_profile: openshift-org-gcp

--- a/ci-operator/config/openshift/installer/openshift-installer-main.yaml
+++ b/ci-operator/config/openshift/installer/openshift-installer-main.yaml
@@ -279,6 +279,7 @@ tests:
     env:
       EXPECTED_ALGORITHM: ECDSA
       EXPECTED_KEY_PARAM: secp384r1
+      EXPECTED_PKI_MODE: Default
       FEATURE_SET: TechPreviewNoUpgrade
     test:
     - ref: openshift-installer-pki-verify

--- a/ci-operator/config/openshift/installer/openshift-installer-main.yaml
+++ b/ci-operator/config/openshift/installer/openshift-installer-main.yaml
@@ -283,6 +283,7 @@ tests:
     env:
       EXPECTED_ALGORITHM: ECDSA
       EXPECTED_KEY_PARAM: secp384r1
+      EXPECTED_PKI_MODE: Default
       FEATURE_SET: TechPreviewNoUpgrade
     test:
     - ref: openshift-installer-pki-verify

--- a/ci-operator/config/openshift/installer/openshift-installer-release-4.22.yaml
+++ b/ci-operator/config/openshift/installer/openshift-installer-release-4.22.yaml
@@ -279,6 +279,7 @@ tests:
     env:
       EXPECTED_ALGORITHM: ECDSA
       EXPECTED_KEY_PARAM: secp384r1
+      EXPECTED_PKI_MODE: Default
       FEATURE_SET: TechPreviewNoUpgrade
     test:
     - ref: openshift-installer-pki-verify

--- a/ci-operator/config/openshift/installer/openshift-installer-release-4.23.yaml
+++ b/ci-operator/config/openshift/installer/openshift-installer-release-4.23.yaml
@@ -279,6 +279,7 @@ tests:
     env:
       EXPECTED_ALGORITHM: ECDSA
       EXPECTED_KEY_PARAM: secp384r1
+      EXPECTED_PKI_MODE: Default
       FEATURE_SET: TechPreviewNoUpgrade
     test:
     - ref: openshift-installer-pki-verify

--- a/ci-operator/config/openshift/installer/openshift-installer-release-4.23.yaml
+++ b/ci-operator/config/openshift/installer/openshift-installer-release-4.23.yaml
@@ -283,6 +283,7 @@ tests:
     env:
       EXPECTED_ALGORITHM: ECDSA
       EXPECTED_KEY_PARAM: secp384r1
+      EXPECTED_PKI_MODE: Default
       FEATURE_SET: TechPreviewNoUpgrade
     test:
     - ref: openshift-installer-pki-verify

--- a/ci-operator/config/openshift/installer/openshift-installer-release-5.0.yaml
+++ b/ci-operator/config/openshift/installer/openshift-installer-release-5.0.yaml
@@ -280,6 +280,7 @@ tests:
     env:
       EXPECTED_ALGORITHM: ECDSA
       EXPECTED_KEY_PARAM: secp384r1
+      EXPECTED_PKI_MODE: Default
       FEATURE_SET: TechPreviewNoUpgrade
     test:
     - ref: openshift-installer-pki-verify

--- a/ci-operator/config/openshift/installer/openshift-installer-release-5.0.yaml
+++ b/ci-operator/config/openshift/installer/openshift-installer-release-5.0.yaml
@@ -284,6 +284,7 @@ tests:
     env:
       EXPECTED_ALGORITHM: ECDSA
       EXPECTED_KEY_PARAM: secp384r1
+      EXPECTED_PKI_MODE: Default
       FEATURE_SET: TechPreviewNoUpgrade
     test:
     - ref: openshift-installer-pki-verify

--- a/ci-operator/config/openshift/installer/openshift-installer-release-5.1.yaml
+++ b/ci-operator/config/openshift/installer/openshift-installer-release-5.1.yaml
@@ -279,6 +279,7 @@ tests:
     env:
       EXPECTED_ALGORITHM: ECDSA
       EXPECTED_KEY_PARAM: secp384r1
+      EXPECTED_PKI_MODE: Default
       FEATURE_SET: TechPreviewNoUpgrade
     test:
     - ref: openshift-installer-pki-verify

--- a/ci-operator/config/openshift/installer/openshift-installer-release-5.1.yaml
+++ b/ci-operator/config/openshift/installer/openshift-installer-release-5.1.yaml
@@ -283,6 +283,7 @@ tests:
     env:
       EXPECTED_ALGORITHM: ECDSA
       EXPECTED_KEY_PARAM: secp384r1
+      EXPECTED_PKI_MODE: Default
       FEATURE_SET: TechPreviewNoUpgrade
     test:
     - ref: openshift-installer-pki-verify

--- a/ci-operator/jobs/openshift/cluster-etcd-operator/openshift-cluster-etcd-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-etcd-operator/openshift-cluster-etcd-operator-main-presubmits.yaml
@@ -809,6 +809,168 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-aws-ovn-etcd-scaling,?($|\s.*)
   - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build07
+    context: ci/prow/e2e-aws-ovn-pki-default-techpreview
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-etcd-operator-main-e2e-aws-ovn-pki-default-techpreview
+    optional: true
+    rerun_command: /test e2e-aws-ovn-pki-default-techpreview
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-aws-ovn-pki-default-techpreview
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-aws-ovn-pki-default-techpreview,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build07
+    context: ci/prow/e2e-aws-ovn-pki-rsa-techpreview
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-etcd-operator-main-e2e-aws-ovn-pki-rsa-techpreview
+    optional: true
+    rerun_command: /test e2e-aws-ovn-pki-rsa-techpreview
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-aws-ovn-pki-rsa-techpreview
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-aws-ovn-pki-rsa-techpreview,?($|\s.*)
+  - agent: kubernetes
     always_run: true
     branches:
     - ^main$

--- a/ci-operator/jobs/openshift/cluster-etcd-operator/openshift-cluster-etcd-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-etcd-operator/openshift-cluster-etcd-operator-main-presubmits.yaml
@@ -849,6 +849,176 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-aws-ovn-etcd-scaling,?($|\s.*)
   - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build07
+    context: ci/prow/e2e-aws-ovn-pki-default-techpreview
+    decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - .ci-operator.yaml
+      - Dockerfile.ocp
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-etcd-operator-main-e2e-aws-ovn-pki-default-techpreview
+    optional: true
+    rerun_command: /test e2e-aws-ovn-pki-default-techpreview
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-aws-ovn-pki-default-techpreview
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-aws-ovn-pki-default-techpreview,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build07
+    context: ci/prow/e2e-aws-ovn-pki-rsa-techpreview
+    decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - .ci-operator.yaml
+      - Dockerfile.ocp
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-etcd-operator-main-e2e-aws-ovn-pki-rsa-techpreview
+    optional: true
+    rerun_command: /test e2e-aws-ovn-pki-rsa-techpreview
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-aws-ovn-pki-rsa-techpreview
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-aws-ovn-pki-rsa-techpreview,?($|\s.*)
+  - agent: kubernetes
     always_run: true
     branches:
     - ^main$

--- a/ci-operator/step-registry/openshift/installer/pki/verify/openshift-installer-pki-verify-commands.sh
+++ b/ci-operator/step-registry/openshift/installer/pki/verify/openshift-installer-pki-verify-commands.sh
@@ -17,6 +17,8 @@ declare -a SIGNERS=(
   "kube-apiserver-lb-signer|loadbalancer-serving-signer|openshift-kube-apiserver-operator|tls.crt"
   "kube-control-plane-signer|kube-control-plane-signer|openshift-kube-apiserver-operator|tls.crt"
   "aggregator-signer|aggregator-client-signer|openshift-kube-apiserver-operator|tls.crt"
+  "etcd-signer|etcd-signer|openshift-etcd|tls.crt"
+  "etcd-metrics-signer|etcd-metrics-signer|openshift-etcd|tls.crt"
 )
 
 # Map expected algorithm to openssl output strings
@@ -126,10 +128,10 @@ else
 
   # Check mode
   mode=$(echo "${pki_cr}" | grep "mode:" | head -1 | awk '{print $2}' || true)
-  if [[ "${mode}" == "Custom" ]]; then
-    echo "  Mode: Custom - OK"
+  if [[ "${mode}" == "${EXPECTED_PKI_MODE}" ]]; then
+    echo "  Mode: ${EXPECTED_PKI_MODE} - OK"
   else
-    echo "  FAIL: Expected mode 'Custom', got '${mode:-not set}'" | tee -a "${ARTIFACT_LOG}"
+    echo "  FAIL: Expected mode '${EXPECTED_PKI_MODE}', got '${mode:-not set}'" | tee -a "${ARTIFACT_LOG}"
     pki_status="FAIL"
   fi
 

--- a/ci-operator/step-registry/openshift/installer/pki/verify/openshift-installer-pki-verify-ref.yaml
+++ b/ci-operator/step-registry/openshift/installer/pki/verify/openshift-installer-pki-verify-ref.yaml
@@ -18,9 +18,15 @@ ref:
         Expected key parameter for signer certificates.
         For RSA: key size in bits (e.g., "4096").
         For ECDSA: curve OID name (e.g., "secp384r1" for P-384, "prime256v1" for P-256).
+    - name: EXPECTED_PKI_MODE
+      default: "Custom"
+      documentation: |-
+        Expected mode field on the PKI custom resource.
+        "Custom" when pki.signerCertificates is explicitly set in install-config.
+        "Default" when ConfigurablePKI is enabled but pki section is omitted.
   documentation: |-
-    Verifies that installer-generated signer CA certificates use the expected
-    public key algorithm and key parameters. Also verifies the PKI custom
-    resource exists with the correct mode and profile. Checks 7 signer secrets
+    Verifies that signer CA certificates use the expected public key algorithm
+    and key parameters. Also verifies the PKI custom resource exists with the
+    correct mode. Checks 9 signer secrets (7 installer-generated + 2 etcd)
     accessible as cluster secrets post-install and produces a pass/fail summary
     table with full certificate details written to the artifact directory.


### PR DESCRIPTION
Follow up to https://github.com/openshift/release/pull/77043
Adding tests for https://github.com/openshift/cluster-etcd-operator/pull/1593

## Summary
  - Extend `openshift-installer-pki-verify` to unconditionally check etcd-signer and etcd-metrics-signer secrets (9 total, up from 7)
  - Add `EXPECTED_PKI_MODE` env var to support `mode: Default` (pki section omitted) vs `mode: Custom` (explicit pki.signerCertificates)
  - Add optional PKI presubmit jobs to cluster-etcd-operator main config (`e2e-aws-ovn-pki-default-techpreview`, `e2e-aws-ovn-pki-rsa-techpreview`)

  ## Test plan
  - `/test e2e-aws-ovn-pki-default-techpreview` on etcd-operator PR validates ECDSA P-384 default behavior
  - `/test e2e-aws-ovn-pki-rsa-techpreview` on etcd-operator PR validates explicit RSA-4096 override

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added E2E test jobs for validating ECDSA (secp384r1) default and RSA 4096 PKI modes on AWS.
  * Enhanced PKI verification to support validating expected PKI modes across installer versions.
  * Extended PKI verification to include etcd-related PKI signer secrets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->