### PR TITLE
NO-JIRA: feat: add gh-token image to ci namespace

### DIFF
--- a/ci-operator/config/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main.yaml
+++ b/ci-operator/config/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main.yaml
@@ -11,36 +11,67 @@ build_root:
 images:
   items:
   - dockerfile_literal: |
+      FROM root
+      ARG GH_TOKEN_VER=2.0.8
+      ARG GH_TOKEN_SHA=867d9ebf7dd18e67e2599f0f890f3f41b8673e88c4394a32a05476024c41ea0f
+      RUN set -eu; \
+            f=/tmp/gh-token.download; rm -f "$f"; \
+            n=1; max=5; delay=1; \
+            until curl -sSL --fail --connect-timeout 10 --max-time 120 \
+              --retry 3 --retry-delay 2 \
+              "https://github.com/Link-/gh-token/releases/download/v${GH_TOKEN_VER}/linux-amd64" \
+              -o "$f"; do \
+              rm -f "$f"; \
+              [ "$n" -ge "$max" ] && exit 1; \
+              sleep "$delay"; \
+              delay=$((delay * 2)); \
+              n=$((n+1)); \
+            done; \
+            echo "${GH_TOKEN_SHA}  $f" | sha256sum -c -; \
+            install -m 0755 "$f" /usr/local/bin/gh-token; \
+            rm -f "$f"
+    from: root
+    to: gh-token
+  - dockerfile_literal: |
       FROM src
       USER 0:0
-      RUN GH_TOKEN_VER=2.0.8 && GH_TOKEN_SHA=867d9ebf7dd18e67e2599f0f890f3f41b8673e88c4394a32a05476024c41ea0f && \
-          curl -sSL --connect-timeout 10 --max-time 120 --fail \
-            "https://github.com/Link-/gh-token/releases/download/v${GH_TOKEN_VER}/linux-amd64" \
-            -o /usr/local/bin/gh-token && \
-          echo "${GH_TOKEN_SHA}  /usr/local/bin/gh-token" | sha256sum -c - && \
-          chmod +x /usr/local/bin/gh-token
+      COPY ghtoken/gh-token /usr/local/bin/gh-token
+      RUN chmod +x /usr/local/bin/gh-token
       COPY . /opt/app-root/src/
       WORKDIR /opt/app-root/src/
     from: src
+    inputs:
+      gh-token:
+        paths:
+        - destination_dir: ghtoken
+          source_path: /usr/local/bin/gh-token
     to: edge-tooling
   - dockerfile_literal: |
       FROM pipeline:claude-ai-helpers
       USER 0:0
-      COPY gotoken/gh-token /usr/local/bin/gh-token
+      COPY ghtoken/gh-token /usr/local/bin/gh-token
       RUN chmod +x /usr/local/bin/gh-token
       COPY repo/ /opt/app-root/src/edge-tooling
       WORKDIR /opt/app-root/src/edge-tooling
     from: claude-ai-helpers
     inputs:
-      edge-tooling:
+      gh-token:
         paths:
-        - destination_dir: gotoken
+        - destination_dir: ghtoken
           source_path: /usr/local/bin/gh-token
       src:
         paths:
         - destination_dir: repo
           source_path: /go/src/github.com/openshift-eng/edge-tooling/.
     to: edge-tooling-ai-helpers
+promotion:
+  to:
+  - additional_images:
+      gh-token: gh-token
+    excluded_images:
+    - '*'
+    namespace: ci
+    tag: latest
 resources:
   '*':
     requests:

--- a/ci-operator/jobs/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main-postsubmits.yaml
@@ -1,0 +1,70 @@
+postsubmits:
+  openshift-eng/edge-tooling:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    cluster: build01
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/is-promotion: "true"
+      ci.openshift.io/generator: prowgen
+    max_concurrency: 1
+    name: branch-ci-openshift-eng-edge-tooling-main-images
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --image-mirror-push-secret=/etc/push-secret/.dockerconfigjson
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --promote
+        - --report-credentials-file=/etc/report/credentials
+        - --target=[images]
+        - --target=gh-token
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/push-secret
+          name: push-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: github-credentials-openshift-ci-robot-private-git-cloner
+        secret:
+          secretName: github-credentials-openshift-ci-robot-private-git-cloner
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: push-secret
+        secret:
+          secretName: registry-push-credentials-ci-central
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator

--- a/ci-operator/jobs/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main-presubmits.yaml
@@ -23,6 +23,7 @@ presubmits:
         - --oauth-token-path=/usr/local/github-credentials/oauth
         - --report-credentials-file=/etc/report/credentials
         - --target=[images]
+        - --target=gh-token
         command:
         - ci-operator
         image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest

--- a/core-services/sanitize-prow-jobs/_config.yaml
+++ b/core-services/sanitize-prow-jobs/_config.yaml
@@ -375,6 +375,7 @@ buildFarm:
       - stackrox-scanner-master-presubmits.yaml
       - openshift-priv-cloud-event-proxy-release-4.9-presubmits.yaml
       - openshift-eng-edge-tooling-main-presubmits.yaml
+      - openshift-eng-edge-tooling-main-postsubmits.yaml
       - devfile-registry-main-presubmits.yaml
       - openshift-priv-velero-plugin-for-microsoft-azure-oadp-1.4-presubmits.yaml
       - openshift-ironic-hardware-inventory-recorder-image-master-presubmits.yaml


### PR DESCRIPTION
added build config for gh-token to supplemental ci image tooling 
updated edge-tooling repo to use new image

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Revised build pipeline to produce and verify a dedicated intermediate artifact, adjust how it’s included in downstream images, and publish only that artifact to the CI registry.
  * Extended CI configuration to include additional postsubmit job definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->