### PR TITLE
DPTP-4833: Disable sigstore verification for 4.22 hive clusterpools

### DIFF
--- a/clusters/hosted-mgmt/hive/pools/openshift-ci/ci-ocp-4-22-0-amd64-aws-us-east-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-ci/ci-ocp-4-22-0-amd64-aws-us-east-1_clusterpool.yaml
@@ -23,6 +23,9 @@ spec:
   installAttemptsLimit: 1
   installConfigSecretTemplateRef:
     name: install-config-aws-us-east-1
+  installerEnv:
+  - name: OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY
+    value: "true"
   labels:
     tp.openshift.io/owner: openshift-ci
   maxSize: 10

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-22-0-amd64-aws-us-east-2_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-22-0-amd64-aws-us-east-2_clusterpool.yaml
@@ -23,6 +23,9 @@ spec:
   installAttemptsLimit: 1
   installConfigSecretTemplateRef:
     name: install-config-aws-us-east-2
+  installerEnv:
+  - name: OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY
+    value: "true"
   labels:
     tp.openshift.io/owner: obs
   maxSize: 20

--- a/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-22-0-fips-amd64-aws-us-east-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/openshift-observability/obs-ocp-4-22-0-fips-amd64-aws-us-east-1_clusterpool.yaml
@@ -24,6 +24,9 @@ spec:
   installAttemptsLimit: 1
   installConfigSecretTemplateRef:
     name: fips-install-config-aws-us-east-1
+  installerEnv:
+  - name: OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY
+    value: "true"
   labels:
     tp.openshift.io/owner: obs
   maxSize: 10

--- a/clusters/hosted-mgmt/hive/pools/rh-openshift-ecosystem/rhoe-ocp-4-22-amd64-aws-us-west-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/rh-openshift-ecosystem/rhoe-ocp-4-22-amd64-aws-us-west-1_clusterpool.yaml
@@ -22,6 +22,9 @@ spec:
   installAttemptsLimit: 1
   installConfigSecretTemplateRef:
     name: install-config-4-22-amd64-aws-us-west-1
+  installerEnv:
+  - name: OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY
+    value: "true"
   labels:
     tp.openshift.io/owner: rh-openshift-ecosystem
   maxSize: 10

--- a/clusters/hosted-mgmt/hive/pools/rh-openshift-ecosystem/rhoe-ocp-4-22-amd64-aws-us-west-2_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/rh-openshift-ecosystem/rhoe-ocp-4-22-amd64-aws-us-west-2_clusterpool.yaml
@@ -22,6 +22,9 @@ spec:
   installAttemptsLimit: 1
   installConfigSecretTemplateRef:
     name: install-config-4-22-amd64-aws-us-west-2
+  installerEnv:
+  - name: OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY
+    value: "true"
   labels:
     tp.openshift.io/owner: rh-openshift-ecosystem
   maxSize: 10


### PR DESCRIPTION
...until they are no longer using nightlies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated cluster provisioning configuration across multiple cluster pools to adjust image policy settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->