### PR TITLE
OCM-23814: Migrate HCP Y-upgrade FVT job to Prow, stagger cron schedules, fix PR links

### DIFF
--- a/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__ocm-fvt-rosa-hcp-staging.yaml
+++ b/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__ocm-fvt-rosa-hcp-staging.yaml
@@ -207,6 +207,43 @@ tests:
   secrets:
   - mount_path: /usr/local/cs-qe-credentials
     name: cs-qe-credentials
+- as: ocm-fvt-periodic-cs-rosa-hcp-y-upgrade-staging-main
+  capabilities:
+  - nested-podman
+  commands: |
+    JOB_LINK="https://prow.ci.openshift.org/view/gs/test-platform-results/"
+    if [ -n "${PULL_NUMBER:-}" ]; then
+      JOB_LINK="${JOB_LINK}pr-logs/pull/openshift_release/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
+    else
+      JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
+    fi
+
+    env -i bash --norc --noprofile << EOF > /tmp/podman.env
+    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
+    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
+    export ENABLE_JIRA_REPORTING=true
+    export JOB_LINK="${JOB_LINK}"
+    source /usr/local/cs-qe-credentials/ocm-tokens
+    source /usr/local/cs-qe-credentials/jira-cred
+    env | grep -v '^_='
+    EOF
+
+    podman run \
+    --authfile /usr/local/cs-qe-credentials/.dockerconfigjson \
+    --env-file /tmp/podman.env \
+    -v /usr/local/cs-qe-credentials:/credentials:ro,z \
+    --rm \
+    quay.io/redhat-services-prod/ocmci/ocmci:latest \
+    ocmtest test --service cms --job cs-rosa-hcp-y-upgrade-staging-main --reportJiraTicket
+  container:
+    from: nested-podman
+    memory_backed_volume:
+      size: 1Gi
+  cron: 0 9 * * *
+  nested_podman: true
+  secrets:
+  - mount_path: /usr/local/cs-qe-credentials
+    name: cs-qe-credentials
 zz_generated_metadata:
   branch: main
   org: openshift-online

--- a/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-periodics.yaml
@@ -1153,6 +1153,78 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build06
+  cron: 0 9 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-online
+    repo: rosa-e2e
+  labels:
+    capability/nested-podman: nested-podman
+    ci-operator.openshift.io/variant: ocm-fvt-rosa-hcp-staging
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-online-rosa-e2e-main-ocm-fvt-rosa-hcp-staging-ocm-fvt-periodic-cs-rosa-hcp-y-upgrade-staging-main
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/cs-qe-credentials
+      - --target=ocm-fvt-periodic-cs-rosa-hcp-y-upgrade-staging-main
+      - --variant=ocm-fvt-rosa-hcp-staging
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /secrets/cs-qe-credentials
+        name: cs-qe-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: cs-qe-credentials
+      secret:
+        secretName: cs-qe-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build06
   cron: 0 8 * * *
   decorate: true
   decoration_config:


### PR DESCRIPTION
## Summary

- Add HCP Y-stream upgrade FVT periodic job to Prow (staging)
- Stagger all 5 FVT job cron schedules across 06:30-09:00 UTC to avoid resource contention
- Fix JOB_LINK PR path from `openshift-online_rosa-e2e` to `openshift_release` across all FVT jobs

## New job

| Job | ocmtest --job | Cron (UTC) | Jira |
|-----|---------------|------------|------|
| ocm-fvt-periodic-cs-rosa-hcp-y-upgrade-staging-main | cs-rosa-hcp-y-upgrade-staging-main | 09:00 | [OCM-23814](https://redhat.atlassian.net/browse/OCM-23814) |

## Staggered cron schedule (all 5 FVT jobs)

| Time (UTC) | Job |
|------------|-----|
| 06:30 | cs-rosa-ad-staging-main |
| 07:00 | cs-rosa-sts-ad-integration-main |
| 07:30 | cs-rosa-sts-ad-staging-main |
| 08:00 | cs-rosa-hcp-ad-staging-main (existing) |
| 09:00 | cs-rosa-hcp-y-upgrade-staging-main (new) |

## Dropped

Integration jobs (cs-rosa-hcp-ad-integration-main, cs-rosa-hcp-ad-integration-regional-main) removed. The `cs-qe-credentials` secret is missing tokens for Trial, ROSA, orgAdmin, and global connection types needed by integration FVT. Tracked in [OCM-23797](https://redhat.atlassian.net/browse/OCM-23797) and [OCM-23819](https://redhat.atlassian.net/browse/OCM-23819).

## Test plan

- [ ] CI checks pass (prow-config-semantics, yamllint)
- [ ] pj-rehearse validates Y-upgrade job
- [ ] After merge, job appears in Prow at 09:00 UTC next day

[OCM-23814]: https://redhat.atlassian.net/browse/OCM-23814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OCM-23797]: https://redhat.atlassian.net/browse/OCM-23797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted cron schedules for several periodic CMS tests to optimize CI timing.
  * Standardized PR job result links to a single results path for consistent reporting.
  * Renamed and standardized the shared VPC credentials environment variable across jobs.
  * Made nested runtime and credential mounting explicit for an existing periodic job to improve reliability.
* **New Features**
  * Added a new scheduled periodic upgrade test that prepares the runtime, sources credentials, emits debug info, and runs the upgrade check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->