### PR TITLE
adding orion consolidated analysis for 24, 120, 252 nodes

### DIFF
--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.21-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.21-nightly-x86.yaml
@@ -69,7 +69,7 @@ tests:
         --local-indexing
       NODE_DENSITY_GC: "false"
       OPENSHIFT_INFRA_NODE_INSTANCE_TYPE: r5.4xlarge
-      RUN_ORION: "true"
+      RUN_ORION: deferred
       SET_ENV_BY_PLATFORM: custom
       SIZE_VARIANT: large
       UDN_ITERATION_MULTIPLIER: "1"
@@ -91,7 +91,7 @@ tests:
       BASE_DOMAIN: qe.devcluster.openshift.com
       ENABLE_LAYER_3: "false"
       KB_FLAGS: --local-indexing
-      RUN_ORION: "true"
+      RUN_ORION: deferred
       UDN_ITERATION_MULTIPLIER: "3"
       ZONES_COUNT: "3"
     test:

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.21-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.21-nightly-x86.yaml
@@ -69,6 +69,7 @@ tests:
         --local-indexing
       NODE_DENSITY_GC: "false"
       OPENSHIFT_INFRA_NODE_INSTANCE_TYPE: r5.4xlarge
+      RUN_ORION: "true"
       SET_ENV_BY_PLATFORM: custom
       SIZE_VARIANT: large
       UDN_ITERATION_MULTIPLIER: "1"
@@ -78,6 +79,7 @@ tests:
     test:
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-control-plane
+    - chain: openshift-qe-orion-consolidated
     workflow: openshift-qe-installer-aws
 - as: control-plane-24nodes
   cron: 0 5 8-14 * 2
@@ -89,11 +91,13 @@ tests:
       BASE_DOMAIN: qe.devcluster.openshift.com
       ENABLE_LAYER_3: "false"
       KB_FLAGS: --local-indexing
+      RUN_ORION: "true"
       UDN_ITERATION_MULTIPLIER: "3"
       ZONES_COUNT: "3"
     test:
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-control-plane
+    - chain: openshift-qe-orion-consolidated
     workflow: openshift-qe-installer-aws
 - always_run: false
   as: conc-builds-3nodes

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.22-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.22-nightly-x86.yaml
@@ -136,13 +136,12 @@ tests:
       BASE_DOMAIN: qe.devcluster.openshift.com
       ENABLE_LAYER_3: "false"
       KB_FLAGS: --local-indexing
-      RUN_ORION: "true"
+      RUN_ORION: deferred
       UDN_ITERATION_MULTIPLIER: "3"
       ZONES_COUNT: "3"
     test:
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-control-plane
-    - chain: openshift-qe-orion-consolidated
     workflow: openshift-qe-installer-aws-etcd-encryption
 - always_run: false
   as: conc-builds-3nodes
@@ -241,7 +240,7 @@ tests:
       OPENSHIFT_INFRA_NODE_INSTANCE_TYPE: r5.4xlarge
       PODS_PER_NODE: "175"
       PROFILE_TYPE: both
-      RUN_ORION: "true"
+      RUN_ORION: deferred
       SET_ENV_BY_PLATFORM: custom
       SIZE_VARIANT: large
       UDN_ITERATION_MULTIPLIER: "1"
@@ -251,7 +250,6 @@ tests:
     test:
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-control-plane
-    - chain: openshift-qe-orion-consolidated
     workflow: openshift-qe-installer-aws-ovn-ipsec
   timeout: 14h0m0s
 - as: control-plane-ipsec-252nodes
@@ -271,7 +269,7 @@ tests:
       OPENSHIFT_INFRA_NODE_INSTANCE_TYPE: r5.8xlarge
       PODS_PER_NODE: "175"
       PROFILE_TYPE: both
-      RUN_ORION: "true"
+      RUN_ORION: deferred
       SET_ENV_BY_PLATFORM: custom
       SIZE_VARIANT: large
       UDN_ITERATION_MULTIPLIER: "0.25"
@@ -281,7 +279,6 @@ tests:
     test:
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-control-plane
-    - chain: openshift-qe-orion-consolidated
     workflow: openshift-qe-installer-aws-ovn-ipsec
   timeout: 14h0m0s
 - as: data-path-ipsec-9nodes

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.22-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.22-nightly-x86.yaml
@@ -136,7 +136,6 @@ tests:
       BASE_DOMAIN: qe.devcluster.openshift.com
       ENABLE_LAYER_3: "false"
       KB_FLAGS: --local-indexing
-      RUN_ORION: deferred
       UDN_ITERATION_MULTIPLIER: "3"
       ZONES_COUNT: "3"
     test:
@@ -240,7 +239,6 @@ tests:
       OPENSHIFT_INFRA_NODE_INSTANCE_TYPE: r5.4xlarge
       PODS_PER_NODE: "175"
       PROFILE_TYPE: both
-      RUN_ORION: deferred
       SET_ENV_BY_PLATFORM: custom
       SIZE_VARIANT: large
       UDN_ITERATION_MULTIPLIER: "1"
@@ -269,7 +267,6 @@ tests:
       OPENSHIFT_INFRA_NODE_INSTANCE_TYPE: r5.8xlarge
       PODS_PER_NODE: "175"
       PROFILE_TYPE: both
-      RUN_ORION: deferred
       SET_ENV_BY_PLATFORM: custom
       SIZE_VARIANT: large
       UDN_ITERATION_MULTIPLIER: "0.25"

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.22-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.22-nightly-x86.yaml
@@ -69,6 +69,7 @@ tests:
         --local-indexing
       NODE_DENSITY_GC: "false"
       OPENSHIFT_INFRA_NODE_INSTANCE_TYPE: r5.8xlarge
+      RUN_ORION: "true"
       SET_ENV_BY_PLATFORM: custom
       SIZE_VARIANT: large
       UDN_ITERATION_MULTIPLIER: "0.25"
@@ -78,6 +79,7 @@ tests:
     test:
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-control-plane
+    - chain: openshift-qe-orion-consolidated
     workflow: openshift-qe-installer-aws
   timeout: 14h0m0s
 - as: control-plane-120nodes
@@ -95,6 +97,7 @@ tests:
         --local-indexing
       NODE_DENSITY_GC: "false"
       OPENSHIFT_INFRA_NODE_INSTANCE_TYPE: r5.4xlarge
+      RUN_ORION: "true"
       SET_ENV_BY_PLATFORM: custom
       SIZE_VARIANT: large
       UDN_ITERATION_MULTIPLIER: "1"
@@ -104,6 +107,7 @@ tests:
     test:
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-control-plane
+    - chain: openshift-qe-orion-consolidated
     workflow: openshift-qe-installer-aws
 - as: control-plane-24nodes
   cron: 0 5 * * 6,2,4,5
@@ -115,11 +119,13 @@ tests:
       BASE_DOMAIN: qe.devcluster.openshift.com
       ENABLE_LAYER_3: "false"
       KB_FLAGS: --local-indexing
+      RUN_ORION: "true"
       UDN_ITERATION_MULTIPLIER: "3"
       ZONES_COUNT: "3"
     test:
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-control-plane
+    - chain: openshift-qe-orion-consolidated
     workflow: openshift-qe-installer-aws
 - as: control-plane-etcdencrypt-24nodes
   cron: 0 3 * * 3
@@ -130,11 +136,13 @@ tests:
       BASE_DOMAIN: qe.devcluster.openshift.com
       ENABLE_LAYER_3: "false"
       KB_FLAGS: --local-indexing
+      RUN_ORION: "true"
       UDN_ITERATION_MULTIPLIER: "3"
       ZONES_COUNT: "3"
     test:
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-control-plane
+    - chain: openshift-qe-orion-consolidated
     workflow: openshift-qe-installer-aws-etcd-encryption
 - always_run: false
   as: conc-builds-3nodes
@@ -233,6 +241,7 @@ tests:
       OPENSHIFT_INFRA_NODE_INSTANCE_TYPE: r5.4xlarge
       PODS_PER_NODE: "175"
       PROFILE_TYPE: both
+      RUN_ORION: "true"
       SET_ENV_BY_PLATFORM: custom
       SIZE_VARIANT: large
       UDN_ITERATION_MULTIPLIER: "1"
@@ -242,6 +251,7 @@ tests:
     test:
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-control-plane
+    - chain: openshift-qe-orion-consolidated
     workflow: openshift-qe-installer-aws-ovn-ipsec
   timeout: 14h0m0s
 - as: control-plane-ipsec-252nodes
@@ -261,6 +271,7 @@ tests:
       OPENSHIFT_INFRA_NODE_INSTANCE_TYPE: r5.8xlarge
       PODS_PER_NODE: "175"
       PROFILE_TYPE: both
+      RUN_ORION: "true"
       SET_ENV_BY_PLATFORM: custom
       SIZE_VARIANT: large
       UDN_ITERATION_MULTIPLIER: "0.25"
@@ -270,6 +281,7 @@ tests:
     test:
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-control-plane
+    - chain: openshift-qe-orion-consolidated
     workflow: openshift-qe-installer-aws-ovn-ipsec
   timeout: 14h0m0s
 - as: data-path-ipsec-9nodes

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.23-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.23-nightly-x86.yaml
@@ -134,12 +134,13 @@ tests:
       ADDITIONAL_WORKER_NODES: "21"
       BASE_DOMAIN: qe.devcluster.openshift.com
       ENABLE_LAYER_3: "false"
-      RUN_ORION: deferred
+      RUN_ORION: "true"
       UDN_ITERATION_MULTIPLIER: "3"
       ZONES_COUNT: "3"
     test:
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-control-plane
+    - chain: openshift-qe-orion-consolidated
     workflow: openshift-qe-installer-aws-etcd-encryption
 - always_run: false
   as: conc-builds-3nodes
@@ -235,7 +236,7 @@ tests:
       NODE_DENSITY_GC: "false"
       OPENSHIFT_INFRA_NODE_INSTANCE_TYPE: r5.4xlarge
       PROFILE_TYPE: both
-      RUN_ORION: deferred
+      RUN_ORION: "true"
       SET_ENV_BY_PLATFORM: custom
       SIZE_VARIANT: large
       UDN_ITERATION_MULTIPLIER: "1"
@@ -245,6 +246,7 @@ tests:
     test:
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-control-plane
+    - chain: openshift-qe-orion-consolidated
     workflow: openshift-qe-installer-aws-ovn-ipsec
 - always_run: false
   as: control-plane-ipsec-252nodes
@@ -260,7 +262,7 @@ tests:
       NODE_DENSITY_GC: "false"
       OPENSHIFT_INFRA_NODE_INSTANCE_TYPE: r5.8xlarge
       PROFILE_TYPE: both
-      RUN_ORION: deferred
+      RUN_ORION: "true"
       SET_ENV_BY_PLATFORM: custom
       SIZE_VARIANT: large
       UDN_ITERATION_MULTIPLIER: "0.5"
@@ -270,6 +272,7 @@ tests:
     test:
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-control-plane
+    - chain: openshift-qe-orion-consolidated
     workflow: openshift-qe-installer-aws-ovn-ipsec
 - always_run: false
   as: data-path-ipsec-9nodes

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.23-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.23-nightly-x86.yaml
@@ -234,7 +234,6 @@ tests:
       NODE_DENSITY_GC: "false"
       OPENSHIFT_INFRA_NODE_INSTANCE_TYPE: r5.4xlarge
       PROFILE_TYPE: both
-      RUN_ORION: "true"
       SET_ENV_BY_PLATFORM: custom
       SIZE_VARIANT: large
       UDN_ITERATION_MULTIPLIER: "1"
@@ -244,7 +243,6 @@ tests:
     test:
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-control-plane
-    - chain: openshift-qe-orion-consolidated
     workflow: openshift-qe-installer-aws-ovn-ipsec
 - always_run: false
   as: control-plane-ipsec-252nodes

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.23-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.23-nightly-x86.yaml
@@ -134,13 +134,11 @@ tests:
       ADDITIONAL_WORKER_NODES: "21"
       BASE_DOMAIN: qe.devcluster.openshift.com
       ENABLE_LAYER_3: "false"
-      RUN_ORION: "true"
       UDN_ITERATION_MULTIPLIER: "3"
       ZONES_COUNT: "3"
     test:
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-control-plane
-    - chain: openshift-qe-orion-consolidated
     workflow: openshift-qe-installer-aws-etcd-encryption
 - always_run: false
   as: conc-builds-3nodes
@@ -262,7 +260,6 @@ tests:
       NODE_DENSITY_GC: "false"
       OPENSHIFT_INFRA_NODE_INSTANCE_TYPE: r5.8xlarge
       PROFILE_TYPE: both
-      RUN_ORION: "true"
       SET_ENV_BY_PLATFORM: custom
       SIZE_VARIANT: large
       UDN_ITERATION_MULTIPLIER: "0.5"
@@ -272,7 +269,6 @@ tests:
     test:
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-control-plane
-    - chain: openshift-qe-orion-consolidated
     workflow: openshift-qe-installer-aws-ovn-ipsec
 - always_run: false
   as: data-path-ipsec-9nodes

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.23-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.23-nightly-x86.yaml
@@ -134,13 +134,12 @@ tests:
       ADDITIONAL_WORKER_NODES: "21"
       BASE_DOMAIN: qe.devcluster.openshift.com
       ENABLE_LAYER_3: "false"
-      RUN_ORION: "true"
+      RUN_ORION: deferred
       UDN_ITERATION_MULTIPLIER: "3"
       ZONES_COUNT: "3"
     test:
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-control-plane
-    - chain: openshift-qe-orion-consolidated
     workflow: openshift-qe-installer-aws-etcd-encryption
 - always_run: false
   as: conc-builds-3nodes
@@ -236,7 +235,7 @@ tests:
       NODE_DENSITY_GC: "false"
       OPENSHIFT_INFRA_NODE_INSTANCE_TYPE: r5.4xlarge
       PROFILE_TYPE: both
-      RUN_ORION: "true"
+      RUN_ORION: deferred
       SET_ENV_BY_PLATFORM: custom
       SIZE_VARIANT: large
       UDN_ITERATION_MULTIPLIER: "1"
@@ -246,7 +245,6 @@ tests:
     test:
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-control-plane
-    - chain: openshift-qe-orion-consolidated
     workflow: openshift-qe-installer-aws-ovn-ipsec
 - always_run: false
   as: control-plane-ipsec-252nodes
@@ -262,7 +260,7 @@ tests:
       NODE_DENSITY_GC: "false"
       OPENSHIFT_INFRA_NODE_INSTANCE_TYPE: r5.8xlarge
       PROFILE_TYPE: both
-      RUN_ORION: "true"
+      RUN_ORION: deferred
       SET_ENV_BY_PLATFORM: custom
       SIZE_VARIANT: large
       UDN_ITERATION_MULTIPLIER: "0.5"
@@ -272,7 +270,6 @@ tests:
     test:
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-control-plane
-    - chain: openshift-qe-orion-consolidated
     workflow: openshift-qe-installer-aws-ovn-ipsec
 - always_run: false
   as: data-path-ipsec-9nodes

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.23-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.23-nightly-x86.yaml
@@ -69,6 +69,7 @@ tests:
         --local-indexing
       NODE_DENSITY_GC: "false"
       OPENSHIFT_INFRA_NODE_INSTANCE_TYPE: r5.8xlarge
+      RUN_ORION: "true"
       SET_ENV_BY_PLATFORM: custom
       SIZE_VARIANT: large
       UDN_ITERATION_MULTIPLIER: "0.5"
@@ -78,6 +79,7 @@ tests:
     test:
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-control-plane
+    - chain: openshift-qe-orion-consolidated
     workflow: openshift-qe-installer-aws
 - always_run: false
   as: control-plane-120nodes
@@ -94,6 +96,7 @@ tests:
         --local-indexing
       NODE_DENSITY_GC: "false"
       OPENSHIFT_INFRA_NODE_INSTANCE_TYPE: r5.4xlarge
+      RUN_ORION: "true"
       SET_ENV_BY_PLATFORM: custom
       SIZE_VARIANT: large
       UDN_ITERATION_MULTIPLIER: "1"
@@ -103,6 +106,7 @@ tests:
     test:
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-control-plane
+    - chain: openshift-qe-orion-consolidated
     workflow: openshift-qe-installer-aws
 - always_run: false
   as: control-plane-24nodes
@@ -114,11 +118,13 @@ tests:
       BASE_DOMAIN: qe.devcluster.openshift.com
       ENABLE_LAYER_3: "false"
       KB_FLAGS: --local-indexing
+      RUN_ORION: "true"
       UDN_ITERATION_MULTIPLIER: "3"
       ZONES_COUNT: "3"
     test:
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-control-plane
+    - chain: openshift-qe-orion-consolidated
     workflow: openshift-qe-installer-aws
 - always_run: false
   as: control-plane-etcdencrypt-24nodes
@@ -128,11 +134,13 @@ tests:
       ADDITIONAL_WORKER_NODES: "21"
       BASE_DOMAIN: qe.devcluster.openshift.com
       ENABLE_LAYER_3: "false"
+      RUN_ORION: "true"
       UDN_ITERATION_MULTIPLIER: "3"
       ZONES_COUNT: "3"
     test:
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-control-plane
+    - chain: openshift-qe-orion-consolidated
     workflow: openshift-qe-installer-aws-etcd-encryption
 - always_run: false
   as: conc-builds-3nodes
@@ -228,6 +236,7 @@ tests:
       NODE_DENSITY_GC: "false"
       OPENSHIFT_INFRA_NODE_INSTANCE_TYPE: r5.4xlarge
       PROFILE_TYPE: both
+      RUN_ORION: "true"
       SET_ENV_BY_PLATFORM: custom
       SIZE_VARIANT: large
       UDN_ITERATION_MULTIPLIER: "1"
@@ -237,6 +246,7 @@ tests:
     test:
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-control-plane
+    - chain: openshift-qe-orion-consolidated
     workflow: openshift-qe-installer-aws-ovn-ipsec
 - always_run: false
   as: control-plane-ipsec-252nodes
@@ -252,6 +262,7 @@ tests:
       NODE_DENSITY_GC: "false"
       OPENSHIFT_INFRA_NODE_INSTANCE_TYPE: r5.8xlarge
       PROFILE_TYPE: both
+      RUN_ORION: "true"
       SET_ENV_BY_PLATFORM: custom
       SIZE_VARIANT: large
       UDN_ITERATION_MULTIPLIER: "0.5"
@@ -261,6 +272,7 @@ tests:
     test:
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-control-plane
+    - chain: openshift-qe-orion-consolidated
     workflow: openshift-qe-installer-aws-ovn-ipsec
 - always_run: false
   as: data-path-ipsec-9nodes

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.23-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-4.23-nightly-x86.yaml
@@ -407,7 +407,6 @@ tests:
       NODE_DENSITY_GC: "false"
       OPENSHIFT_INFRA_NODE_INSTANCE_TYPE: r5.4xlarge
       PROFILE_TYPE: both
-      RUN_ORION: "true"
       SET_ENV_BY_PLATFORM: custom
       SIZE_VARIANT: large
       UDN_ITERATION_MULTIPLIER: "1"
@@ -417,7 +416,6 @@ tests:
     test:
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-control-plane
-    - chain: openshift-qe-orion-consolidated
     workflow: openshift-qe-installer-aws-ovn-ipsec
 - always_run: false
   as: control-plane-ipsec-252nodes

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-5.0-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__aws-5.0-nightly-x86.yaml
@@ -70,6 +70,7 @@ tests:
         --local-indexing
       NODE_DENSITY_GC: "false"
       OPENSHIFT_INFRA_NODE_INSTANCE_TYPE: r5.4xlarge
+      RUN_ORION: "true"
       SET_ENV_BY_PLATFORM: custom
       SIZE_VARIANT: large
       UDN_ITERATION_MULTIPLIER: "1"
@@ -79,6 +80,7 @@ tests:
     test:
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-control-plane
+    - chain: openshift-qe-orion-consolidated
     workflow: openshift-qe-installer-aws
 - as: control-plane-24nodes
   cron: 0 5 * * 2,5
@@ -89,11 +91,13 @@ tests:
       ADDITIONAL_WORKER_NODES: "21"
       BASE_DOMAIN: qe.devcluster.openshift.com
       ENABLE_LAYER_3: "false"
+      RUN_ORION: "true"
       UDN_ITERATION_MULTIPLIER: "3"
       ZONES_COUNT: "3"
     test:
     - ref: openshift-qe-workers-scale
     - chain: openshift-qe-control-plane
+    - chain: openshift-qe-orion-consolidated
     workflow: openshift-qe-installer-aws
 - always_run: false
   as: compact-cp-3nodes


### PR DESCRIPTION
## Summary

Enable Orion consolidated run for control-plane tests at 24, 120, and 252 node scales (we only have it for 6 nodes now)

## Changes

  Standard tests (10 total):
  - Add RUN_ORION: "true" environment variable (defer for 4.21)
  - Add openshift-qe-orion-consolidated chain after openshift-qe-control-plane

## Tests Updated (10 total)

  ## Tests Updated

  | Version | Standard Tests (RUN_ORION: "true" + chain) | Deferred Tests (RUN_ORION: "deferred", + chain) |        
  |---------|---------------------------------------------|--------------------------------------------------|
  | 4.21 | - | control-plane-120nodes, control-plane-24nodes |                                                       
  | 4.22 | control-plane-252nodes, control-plane-120nodes, control-plane-24nodes | - |                                                      
  | 4.23 | control-plane-252nodes, control-plane-120nodes, control-plane-24nodes | - |                                                      
  | 5.0 | control-plane-120nodes, control-plane-24nodes | - |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR updates OpenShift CI job definitions in the openshift/release repository (ci-operator configs under ci-operator/config/openshift-eng/ocp-qe-perfscale-ci) to enable the Orion consolidated analysis for control-plane perfscale tests at larger scales.

Practical changes:
- Enables Orion consolidated analysis by setting RUN_ORION and chaining the openshift-qe-orion-consolidated test chain immediately after openshift-qe-control-plane for the listed control-plane jobs.
- Affected flows and variants:
  - 4.21 nightly (aws): control-plane-24nodes and control-plane-120nodes — RUN_ORION set to "deferred" (Orion runs deferred).
  - 4.22 nightly (aws): control-plane-24nodes, control-plane-120nodes, control-plane-252nodes — RUN_ORION="true" and adds openshift-qe-orion-consolidated to the test sequence.
  - 4.23 nightly (aws): control-plane-24nodes, control-plane-120nodes, control-plane-252nodes — RUN_ORION="true" and adds openshift-qe-orion-consolidated to the test sequence (some 4.23 variants explicitly deferred where noted).
  - 5.0 nightly (aws): control-plane-24nodes and control-plane-120nodes — RUN_ORION="true" and adds openshift-qe-orion-consolidated; some 5.0 variants left deferred per file.
- Files changed are ci-operator job YAMLs for the ocp-qe-perfscale-ci flows (per the PR: aws-4.21, aws-4.22, aws-4.23, aws-5.0 nightly YAMLs). The change is CI configuration only — no product code changed.

Operational notes from the author’s comments:
- The author ran rehearsals; some rehearsals passed and produced Orion artifacts (regression CSVs/HTML reports), indicating the new chain executes when RUN_ORION is enabled.
- Several rehearsals for 4.23 failed during cluster provisioning due to the ingress operator not becoming ready; the author asked which GitHub repo should be inspected to diagnose that pj-rehearse provisioning failure (this is an operational troubleshooting question separate from the CI config changes).

Overall: this PR expands Orion consolidated analysis coverage for control-plane perfscale jobs across multiple OpenShift minor releases and node scales by adding RUN_ORION and inserting the consolidated Orion chain into the control-plane test sequences (with 4.21/other specific variants deliberately deferred).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->