### PR TITLE
fleetshift-poc: add local image mirroring jobs

### DIFF
--- a/ci-operator/config/fleetshift/fleetshift-poc/fleetshift-fleetshift-poc-main.yaml
+++ b/ci-operator/config/fleetshift/fleetshift-poc/fleetshift-fleetshift-poc-main.yaml
@@ -9,6 +9,11 @@ images:
     - arm64
     dockerfile_path: Dockerfile
     to: fleetshift-server
+  - additional_architectures:
+    - arm64
+    dockerfile_path: Dockerfile.local
+    from: fleetshift-server
+    to: fleetshift-server-local
 resources:
   '*':
     requests:
@@ -46,6 +51,39 @@ tests:
       SOURCE_IMAGE_REF: fleetshift-server
     env:
       IMAGE_REPO: fleetshift-server
+      REGISTRY_ORG: stolostron
+    workflow: fleetshift-ci-image-mirror
+- as: pr-image-mirror-local
+  capabilities:
+  - arm64
+  steps:
+    dependencies:
+      SOURCE_IMAGE_REF: fleetshift-server-local
+    env:
+      IMAGE_REPO: fleetshift-server-local
+      REGISTRY_ORG: stolostron
+    workflow: fleetshift-ci-image-mirror
+- as: pr-merge-image-mirror-local-latest
+  capabilities:
+  - arm64
+  postsubmit: true
+  steps:
+    dependencies:
+      SOURCE_IMAGE_REF: fleetshift-server-local
+    env:
+      IMAGE_REPO: fleetshift-server-local
+      IMAGE_TAG: latest
+      REGISTRY_ORG: stolostron
+    workflow: fleetshift-ci-image-mirror
+- as: pr-merge-image-mirror-local-sha
+  capabilities:
+  - arm64
+  postsubmit: true
+  steps:
+    dependencies:
+      SOURCE_IMAGE_REF: fleetshift-server-local
+    env:
+      IMAGE_REPO: fleetshift-server-local
       REGISTRY_ORG: stolostron
     workflow: fleetshift-ci-image-mirror
 zz_generated_metadata:

--- a/ci-operator/jobs/fleetshift/fleetshift-poc/fleetshift-fleetshift-poc-main-postsubmits.yaml
+++ b/ci-operator/jobs/fleetshift/fleetshift-poc/fleetshift-fleetshift-poc-main-postsubmits.yaml
@@ -82,6 +82,146 @@ postsubmits:
       capability/arm64: arm64
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
+    name: branch-ci-fleetshift-fleetshift-poc-main-pr-merge-image-mirror-local-latest
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --target=pr-merge-image-mirror-local-latest
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    cluster: build05
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      capability/arm64: arm64
+      ci.openshift.io/generator: prowgen
+    max_concurrency: 1
+    name: branch-ci-fleetshift-fleetshift-poc-main-pr-merge-image-mirror-local-sha
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --target=pr-merge-image-mirror-local-sha
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    cluster: build05
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      capability/arm64: arm64
+      ci.openshift.io/generator: prowgen
+    max_concurrency: 1
     name: branch-ci-fleetshift-fleetshift-poc-main-pr-merge-image-mirror-sha
     spec:
       containers:

--- a/ci-operator/jobs/fleetshift/fleetshift-poc/fleetshift-fleetshift-poc-main-presubmits.yaml
+++ b/ci-operator/jobs/fleetshift/fleetshift-poc/fleetshift-fleetshift-poc-main-presubmits.yaml
@@ -130,3 +130,77 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )pr-image-mirror,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build03
+    context: ci/prow/pr-image-mirror-local
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      capability/arm64: arm64
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-fleetshift-fleetshift-poc-main-pr-image-mirror-local
+    rerun_command: /test pr-image-mirror-local
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --target=pr-image-mirror-local
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )pr-image-mirror-local,?($|\s.*)


### PR DESCRIPTION
## Summary
- add a second `fleetshift-poc` image build for `fleetshift-server-local` using `Dockerfile.local` on top of `fleetshift-server`
- add presubmit and postsubmit mirror jobs so CI publishes the local-tooling image alongside the production image
- keep the Dockerfile split in the source repo while teaching `release` how to build and mirror both variants

## Test plan
- [x] reviewed the generated config and job diffs
- [x] ran `git diff --check`
- [x] `CONTAINER_ENGINE=docker make jobs && CONTAINER_ENGINE=docker make ci-operator-config && CONTAINER_ENGINE=docker make checkconfig` (blocked locally because Docker on this machine cannot mount `/Repos/...` or `/UbuntuSync/...`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD build pipeline infrastructure with support for local image variants across arm64 architecture. Implemented automated mirror configurations to streamline deployment and testing workflows for pull requests and postsubmit release events, improving system reliability and deployment efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->