### PR TITLE
Add algif_aead_init kernel blacklist to AWS e2e and ipsec serial workflows

### DIFF
--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
@@ -1157,6 +1157,7 @@ tests:
       enable:
       - observers-resource-watch
     pre:
+    - ref: openshift-manifests-disable-algif-aead
     - chain: ipi-aws-pre
     - ref: fips-check
     workflow: openshift-e2e-aws
@@ -1235,6 +1236,7 @@ tests:
       enable:
       - observers-resource-watch
     pre:
+    - ref: openshift-manifests-disable-algif-aead
     - chain: ipi-aws-pre
     - ref: fips-check
     workflow: openshift-e2e-aws

--- a/ci-operator/step-registry/openshift/e2e/aws/openshift-e2e-aws-workflow.yaml
+++ b/ci-operator/step-registry/openshift/e2e/aws/openshift-e2e-aws-workflow.yaml
@@ -3,6 +3,7 @@ workflow:
   steps:
     allow_best_effort_post_steps: true
     pre:
+    - ref: openshift-manifests-disable-algif-aead
     - chain: ipi-aws-pre
     test:
     - ref: openshift-e2e-test

--- a/ci-operator/step-registry/openshift/e2e/aws/ovn/openshift-e2e-aws-ovn-workflow.yaml
+++ b/ci-operator/step-registry/openshift/e2e/aws/ovn/openshift-e2e-aws-ovn-workflow.yaml
@@ -6,6 +6,7 @@ workflow:
     - chain: ipi-conf-aws
     - ref: ovn-conf
     - ref: rhcos-conf-osstream
+    - ref: openshift-manifests-disable-algif-aead
     - chain: ipi-install
     test:
     - ref: openshift-e2e-test

--- a/ci-operator/step-registry/openshift/e2e/aws/ovn/serial-ipsec/openshift-e2e-aws-ovn-serial-ipsec-workflow.yaml
+++ b/ci-operator/step-registry/openshift/e2e/aws/ovn/serial-ipsec/openshift-e2e-aws-ovn-serial-ipsec-workflow.yaml
@@ -6,6 +6,7 @@ workflow:
     - chain: ipi-conf-aws
     - ref: ovn-conf
     - ref: ovn-conf-ipsec-manifest
+    - ref: openshift-manifests-disable-algif-aead
     - chain: ipi-install
     - ref: deploy-konflux-operator
     test:

--- a/ci-operator/step-registry/openshift/manifests/disable-algif-aead/OWNERS
+++ b/ci-operator/step-registry/openshift/manifests/disable-algif-aead/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- sdodson
+reviewers:
+- sdodson

--- a/ci-operator/step-registry/openshift/manifests/disable-algif-aead/openshift-manifests-disable-algif-aead-commands.sh
+++ b/ci-operator/step-registry/openshift/manifests/disable-algif-aead/openshift-manifests-disable-algif-aead-commands.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+cat > "${SHARED_DIR}/manifest_mc-master-disable-algif-aead.yml" << EOF
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: 99-master-disable-algif-aead
+spec:
+  kernelArguments:
+    - initcall_blacklist=algif_aead_init
+EOF
+
+cat > "${SHARED_DIR}/manifest_mc-worker-disable-algif-aead.yml" << EOF
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 99-worker-disable-algif-aead
+spec:
+  kernelArguments:
+    - initcall_blacklist=algif_aead_init
+EOF

--- a/ci-operator/step-registry/openshift/manifests/disable-algif-aead/openshift-manifests-disable-algif-aead-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/manifests/disable-algif-aead/openshift-manifests-disable-algif-aead-ref.metadata.json
@@ -1,0 +1,11 @@
+{
+	"path": "openshift/manifests/disable-algif-aead/openshift-manifests-disable-algif-aead-ref.yaml",
+	"owners": {
+		"approvers": [
+			"sdodson"
+		],
+		"reviewers": [
+			"sdodson"
+		]
+	}
+}

--- a/ci-operator/step-registry/openshift/manifests/disable-algif-aead/openshift-manifests-disable-algif-aead-ref.yaml
+++ b/ci-operator/step-registry/openshift/manifests/disable-algif-aead/openshift-manifests-disable-algif-aead-ref.yaml
@@ -1,0 +1,10 @@
+ref:
+  as: openshift-manifests-disable-algif-aead
+  from: cli
+  commands: openshift-manifests-disable-algif-aead-commands.sh
+  resources:
+    requests:
+      cpu: 100m
+      memory: 100Mi
+  documentation: |-
+    This step adds MachineConfigs to blacklist the algif_aead_init kernel initcall on all nodes.


### PR DESCRIPTION
## Summary
- Adds new step-registry ref `openshift-manifests-disable-algif-aead` that injects MachineConfig manifests to blacklist the `algif_aead_init` kernel initcall on all nodes (master + worker)
- Adds the ref to `openshift-e2e-aws`, `openshift-e2e-aws-ovn`, and `openshift-e2e-aws-ovn-serial-ipsec` workflows

## Test plan
- [ ] Rehearse `periodic-ci-openshift-release-main-ci-5.0-e2e-aws-ovn`
- [ ] Rehearse `periodic-ci-openshift-release-main-nightly-5.0-e2e-aws-ovn-fips`
- [ ] Rehearse `periodic-ci-openshift-release-main-nightly-5.0-e2e-aws-ovn-serial-ipsec`
- [ ] Verify nodes boot with `initcall_blacklist=algif_aead_init` kernel argument

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Update multiple AWS E2E workflows to run an extra pre-install manifest step before installation.
  * Add ownership and registry metadata for the new manifest step.

* **New Features**
  * Add an automated manifest generator that creates MachineConfigs to disable a specific kernel initcall on masters and workers during test provisioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->