### PR TITLE
Add Prometheus alerts-in-firing-state test to STS conformance skip list

### DIFF
--- a/ci-operator/step-registry/rosa/aws/sts/conformance/rosa-aws-sts-conformance-workflow.yaml
+++ b/ci-operator/step-registry/rosa/aws/sts/conformance/rosa-aws-sts-conformance-workflow.yaml
@@ -30,7 +30,8 @@ workflow:
         cloud-provider-aws-e2e.*loadbalancer CLB internal should be reachable with hairpinning traffic\|
         sig-auth.*SCC.*should not have pod creation failures during install\|
         sig-imageregistry.*should redirect on blob pull\|
-        CSI Mock volume expansion.*should record target size in allocated resources
+        CSI Mock volume expansion.*should record target size in allocated resources\|
+        sig-instrumentation.*Prometheus.*shouldn.t report any alerts in firing state apart from Watchdog
     pre:
       - chain: rosa-aws-sts-provision
       - ref: osd-ccs-conf-idp-htpasswd-multi-users


### PR DESCRIPTION
## Summary

- Add the Prometheus `shouldn't report any alerts in firing state` test to the Classic STS conformance skip list
- This test flakes on ROSA Classic STS when cluster operators take longer to settle after provisioning
- Failed on 2 consecutive STS 4.22 nightly runs despite 99.5% pass rate in Sippy across all platforms

## Context

Follow-up to #78574 which fixed the YAML `>-` folding whitespace issue and added several other OCP payload flake skips. The Prometheus alerts test is the last remaining flake blocking STS 4.22 conformance runs.

## Test plan

- [ ] Rehearse `periodic-ci-openshift-release-main-nightly-4.22-e2e-rosa-sts-ovn`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated conformance workflow testing configuration to skip specific test patterns, including CSI volume expansion and Prometheus alert monitoring tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->