### PR TITLE
no-jira: gcp-ipi-all-regions: gcp machine types testing adjustments

### DIFF
--- a/ci-operator/config/openshift/verification-tests/openshift-verification-tests-main__installation-nightly-4.22.yaml
+++ b/ci-operator/config/openshift/verification-tests/openshift-verification-tests-main__installation-nightly-4.22.yaml
@@ -1110,19 +1110,16 @@ tests:
         [
           [
               {"column": "OverallResult", "value": "", "operator": "equals"},
-              {"column": "CPFamily", "value": "^(A2|A3|C2|C2D|E2|G2|H3|M1|M2|M3|N1|N2|N2D|T2A|T2D|Z3)$", "operator": "regex"},
-              {"column": "CFamily", "value": "^(A2|A3|C2|C2D|E2|G2|H3|M1|M2|M3|N1|N2|N2D|T2A|T2D|Z3)$", "operator": "regex"}
+              {"column": "CFamily", "value": "^(N2|N2D|N1|E2|T2A|T2D|C2|C2D|A2|G2)$", "operator": "regex"}
           ],
           [
               {"column": "OverallResult", "value": "FAIL", "operator": "equals"},
-              {"column": "CreatedDate", "value": "7", "operator": "days_before"},
-              {"column": "CPFamily", "value": "^(A2|A3|C2|C2D|E2|G2|H3|M1|M2|M3|N1|N2|N2D|T2A|T2D|Z3)$", "operator": "regex"},
-              {"column": "CFamily", "value": "^(A2|A3|C2|C2D|E2|G2|H3|M1|M2|M3|N1|N2|N2D|T2A|T2D|Z3)$", "operator": "regex"}
+              {"column": "CreatedDate", "value": "15", "operator": "days_before"},
+              {"column": "CFamily", "value": "^(N2|N2D|N1|E2|T2A|T2D|C2|C2D|A2|G2)$", "operator": "regex"}
           ],
           [
-              {"column": "CreatedDate", "value": "30", "operator": "days_before"},
-              {"column": "CPFamily", "value": "^(A2|A3|C2|C2D|E2|G2|H3|M1|M2|M3|N1|N2|N2D|T2A|T2D|Z3)$", "operator": "regex"},
-              {"column": "CFamily", "value": "^(A2|A3|C2|C2D|E2|G2|H3|M1|M2|M3|N1|N2|N2D|T2A|T2D|Z3)$", "operator": "regex"}
+              {"column": "CreatedDate", "value": "45", "operator": "days_before"},
+              {"column": "CFamily", "value": "^(N2|N2D|N1|E2|T2A|T2D|C2|C2D|A2|G2)$", "operator": "regex"}
           ]
         ]
       TEST_FILTERS: "57148"
@@ -1143,19 +1140,16 @@ tests:
         [
           [
               {"column": "OverallResult", "value": "", "operator": "equals"},
-              {"column": "CPFamily", "value": "^(A3Ultra|A4|A4X|C3|C3D|C4|C4A|C4D|G4|H4D|M4|N4|N4A|N4D|X4)$", "operator": "regex"},
-              {"column": "CFamily", "value": "^(A3Ultra|A4|A4X|C3|C3D|C4|C4A|C4D|G4|H4D|M4|N4|N4A|N4D|X4)$", "operator": "regex"}
+              {"column": "CFamily", "value": "^(C4D|C4|C4A|C3|C3D|N4|N4A|N4D|Z3|H4D|H3|X4|M4|M3|M2|M1|A4X|A4|A3|A3ULTRA|G4)$", "operator": "regex"}
           ],
           [
               {"column": "OverallResult", "value": "FAIL", "operator": "equals"},
-              {"column": "CreatedDate", "value": "7", "operator": "days_before"},
-              {"column": "CPFamily", "value": "^(A3Ultra|A4|A4X|C3|C3D|C4|C4A|C4D|G4|H4D|M4|N4|N4A|N4D|X4)$", "operator": "regex"},
-              {"column": "CFamily", "value": "^(A3Ultra|A4|A4X|C3|C3D|C4|C4A|C4D|G4|H4D|M4|N4|N4A|N4D|X4)$", "operator": "regex"}
+              {"column": "CreatedDate", "value": "15", "operator": "days_before"},
+              {"column": "CFamily", "value": "^(C4D|C4|C4A|C3|C3D|N4|N4A|N4D|Z3|H4D|H3|X4|M4|M3|M2|M1|A4X|A4|A3|A3ULTRA|G4)$", "operator": "regex"}
           ],
           [
-              {"column": "CreatedDate", "value": "30", "operator": "days_before"},
-              {"column": "CPFamily", "value": "^(A3Ultra|A4|A4X|C3|C3D|C4|C4A|C4D|G4|H4D|M4|N4|N4A|N4D|X4)$", "operator": "regex"},
-              {"column": "CFamily", "value": "^(A3Ultra|A4|A4X|C3|C3D|C4|C4A|C4D|G4|H4D|M4|N4|N4A|N4D|X4)$", "operator": "regex"}
+              {"column": "CreatedDate", "value": "45", "operator": "days_before"},
+              {"column": "CFamily", "value": "^(C4D|C4|C4A|C3|C3D|N4|N4A|N4D|Z3|H4D|H3|X4|M4|M3|M2|M1|A4X|A4|A3|A3ULTRA|G4)$", "operator": "regex"}
           ]
         ]
       TEST_OBJECT: Regions

--- a/ci-operator/config/openshift/verification-tests/openshift-verification-tests-main__installation-nightly-5.0.yaml
+++ b/ci-operator/config/openshift/verification-tests/openshift-verification-tests-main__installation-nightly-5.0.yaml
@@ -1084,19 +1084,16 @@ tests:
         [
           [
               {"column": "OverallResult", "value": "", "operator": "equals"},
-              {"column": "CPFamily", "value": "^(A2|A3|C2|C2D|E2|G2|H3|M1|M2|M3|N1|N2|N2D|T2A|T2D|Z3)$", "operator": "regex"},
-              {"column": "CFamily", "value": "^(A2|A3|C2|C2D|E2|G2|H3|M1|M2|M3|N1|N2|N2D|T2A|T2D|Z3)$", "operator": "regex"}
+              {"column": "CFamily", "value": "^(N2|N2D|N1|E2|T2A|T2D|C2|C2D|A2|G2)$", "operator": "regex"}
           ],
           [
               {"column": "OverallResult", "value": "FAIL", "operator": "equals"},
-              {"column": "CreatedDate", "value": "7", "operator": "days_before"},
-              {"column": "CPFamily", "value": "^(A2|A3|C2|C2D|E2|G2|H3|M1|M2|M3|N1|N2|N2D|T2A|T2D|Z3)$", "operator": "regex"},
-              {"column": "CFamily", "value": "^(A2|A3|C2|C2D|E2|G2|H3|M1|M2|M3|N1|N2|N2D|T2A|T2D|Z3)$", "operator": "regex"}
+              {"column": "CreatedDate", "value": "15", "operator": "days_before"},
+              {"column": "CFamily", "value": "^(N2|N2D|N1|E2|T2A|T2D|C2|C2D|A2|G2)$", "operator": "regex"}
           ],
           [
-              {"column": "CreatedDate", "value": "30", "operator": "days_before"},
-              {"column": "CPFamily", "value": "^(A2|A3|C2|C2D|E2|G2|H3|M1|M2|M3|N1|N2|N2D|T2A|T2D|Z3)$", "operator": "regex"},
-              {"column": "CFamily", "value": "^(A2|A3|C2|C2D|E2|G2|H3|M1|M2|M3|N1|N2|N2D|T2A|T2D|Z3)$", "operator": "regex"}
+              {"column": "CreatedDate", "value": "45", "operator": "days_before"},
+              {"column": "CFamily", "value": "^(N2|N2D|N1|E2|T2A|T2D|C2|C2D|A2|G2)$", "operator": "regex"}
           ]
         ]
       TEST_FILTERS: "57148"
@@ -1117,19 +1114,16 @@ tests:
         [
           [
               {"column": "OverallResult", "value": "", "operator": "equals"},
-              {"column": "CPFamily", "value": "^(A3Ultra|A4|A4X|C3|C3D|C4|C4A|C4D|G4|H4D|M4|N4|N4A|N4D|X4)$", "operator": "regex"},
-              {"column": "CFamily", "value": "^(A3Ultra|A4|A4X|C3|C3D|C4|C4A|C4D|G4|H4D|M4|N4|N4A|N4D|X4)$", "operator": "regex"}
+              {"column": "CFamily", "value": "^(C4D|C4|C4A|C3|C3D|N4|N4A|N4D|Z3|H4D|H3|X4|M4|M3|M2|M1|A4X|A4|A3|A3ULTRA|G4)$", "operator": "regex"}
           ],
           [
               {"column": "OverallResult", "value": "FAIL", "operator": "equals"},
-              {"column": "CreatedDate", "value": "7", "operator": "days_before"},
-              {"column": "CPFamily", "value": "^(A3Ultra|A4|A4X|C3|C3D|C4|C4A|C4D|G4|H4D|M4|N4|N4A|N4D|X4)$", "operator": "regex"},
-              {"column": "CFamily", "value": "^(A3Ultra|A4|A4X|C3|C3D|C4|C4A|C4D|G4|H4D|M4|N4|N4A|N4D|X4)$", "operator": "regex"}
+              {"column": "CreatedDate", "value": "15", "operator": "days_before"},
+              {"column": "CFamily", "value": "^(C4D|C4|C4A|C3|C3D|N4|N4A|N4D|Z3|H4D|H3|X4|M4|M3|M2|M1|A4X|A4|A3|A3ULTRA|G4)$", "operator": "regex"}
           ],
           [
-              {"column": "CreatedDate", "value": "30", "operator": "days_before"},
-              {"column": "CPFamily", "value": "^(A3Ultra|A4|A4X|C3|C3D|C4|C4A|C4D|G4|H4D|M4|N4|N4A|N4D|X4)$", "operator": "regex"},
-              {"column": "CFamily", "value": "^(A3Ultra|A4|A4X|C3|C3D|C4|C4A|C4D|G4|H4D|M4|N4|N4A|N4D|X4)$", "operator": "regex"}
+              {"column": "CreatedDate", "value": "45", "operator": "days_before"},
+              {"column": "CFamily", "value": "^(C4D|C4|C4A|C3|C3D|N4|N4A|N4D|Z3|H4D|H3|X4|M4|M3|M2|M1|A4X|A4|A3|A3ULTRA|G4)$", "operator": "regex"}
           ]
         ]
       TEST_OBJECT: Regions

--- a/ci-operator/config/openshift/verification-tests/openshift-verification-tests-main__installer-rehearse-4.22.yaml
+++ b/ci-operator/config/openshift/verification-tests/openshift-verification-tests-main__installer-rehearse-4.22.yaml
@@ -101,11 +101,14 @@ tests:
     dependencies:
       OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: release:multi-latest
     env:
-      COMPUTE_NODE_REPLICAS: "2"
-      COMPUTE_SERVICE_ACCOUNT: jiwei-worker-sa
-      CONTROL_PLANE_SERVICE_ACCOUNT: jiwei-control-plane-sa
-      XPN_MINIMAL_PERMISSIONS_WITHOUT_DNS: "yes"
-    workflow: cucushift-installer-rehearse-gcp-ipi-xpn-custom-dns
+      CLUSTER_PARAMETER_SELECT_CONDITIONS: |
+        [
+          [
+              {"column": "CFamily", "value": "M4", "operator": "equals"}
+          ]
+        ]
+      TEST_OBJECT: Regions
+    workflow: cucushift-installer-rehearse-gcp-cases-clusters
 - as: installer-rehearse-gcp2
   cron: '@yearly'
   steps:
@@ -114,23 +117,26 @@ tests:
     dependencies:
       OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: release:multi-latest
     env:
-      COMPUTE_NODE_REPLICAS: "2"
-      COMPUTE_SERVICE_ACCOUNT: jiwei-worker-sa
-      CONTROL_PLANE_SERVICE_ACCOUNT: jiwei-control-plane-sa
-      XPN_MINIMAL_PERMISSIONS_WITHOUT_DNS: "yes"
-    workflow: cucushift-installer-rehearse-gcp-ipi-xpn-custom-dns-private
+      CLUSTER_PARAMETER_SELECT_CONDITIONS: |
+        [
+          [
+              {"column": "CFamily", "value": "C4D", "operator": "equals"}
+          ]
+        ]
+      TEST_OBJECT: Regions
+    workflow: cucushift-installer-rehearse-gcp-cases-clusters
 - as: installer-rehearse-gcp-regions
   cron: '@yearly'
   steps:
     allow_skip_on_success: true
     cluster_profile: gcp-qe
     dependencies:
-      OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: release:arm64-latest
+      OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: release:multi-latest
     env:
       CLUSTER_PARAMETER_SELECT_CONDITIONS: |
         [
           [
-              {"column": "Region", "value": "europe-west4", "operator": "equals"}
+              {"column": "CFamily", "value": "Z3", "operator": "equals"}
           ]
         ]
       TEST_FILTERS: "57148"

--- a/ci-operator/step-registry/cucushift/installer/rehearse/gcp/cases/clusters/provision/cucushift-installer-rehearse-gcp-cases-clusters-provision-commands.sh
+++ b/ci-operator/step-registry/cucushift/installer/rehearse/gcp/cases/clusters/provision/cucushift-installer-rehearse-gcp-cases-clusters-provision-commands.sh
@@ -24,6 +24,18 @@ echo '{}' > "$OUT_RESULT"
 IC_COMPUTE_NODE_COUNT=2
 IC_CONTROL_PLANE_NODE_COUNT=3
 
+REGION=""
+CONTROL_PLANE_INSTANCE_TYPE=""
+CONTROL_PLANE_INSTANCE_TYPE_FAMILY=""
+CONTROL_PLANE_ARCH=""
+CONTROL_PLANE_ZONES=""
+COMPUTE_INSTANCE_TYPE=""
+COMPUTE_INSTANCE_TYPE_FAMILY=""
+COMPUTE_ARCH=""
+COMPUTE_ZONES=""
+INSTALL_RESULT=""
+CREATED_DATE=""
+
 function is_empty() {
   local v="$1"
   if [[ "$v" == "" ]] || [[ "$v" == "null" ]]; then
@@ -47,7 +59,7 @@ function current_date() { date -u +"%Y-%m-%d %H:%M:%S%z"; }
 function update_result() {
   local k=$1
   local v=${2:-}
-  cat <<< "$(jq -r --argjson kv "{\"$k\":\"$v\"}" '. + $kv' "$OUT_RESULT")" > "$OUT_RESULT"
+  cat <<< "$(jq --arg k "$k" --arg v "$v" '. + {($k): $v}' "$OUT_RESULT")" > "$OUT_RESULT"
 }
 
 function post_actions() {
@@ -80,9 +92,11 @@ function post_actions() {
   update_result "CPType" "${CONTROL_PLANE_INSTANCE_TYPE}"
   update_result "CPFamily" "${CONTROL_PLANE_INSTANCE_TYPE_FAMILY}"
   update_result "CPArch" "${CONTROL_PLANE_ARCH}"
+  update_result "CPZones" "${CONTROL_PLANE_ZONES}"
   update_result "CType" "${COMPUTE_INSTANCE_TYPE}"
   update_result "CFamily" "${COMPUTE_INSTANCE_TYPE_FAMILY}"
   update_result "CArch" "${COMPUTE_ARCH}"
+  update_result "CZones" "${COMPUTE_ZONES}"
   update_result "Install" "${INSTALL_RESULT}"
   update_result "CreatedDate" "${CREATED_DATE}"
   update_result "Job" "$(echo "${JOB_SPEC}" | jq -r '.job')"
@@ -111,18 +125,30 @@ REGION="$(jq -r '.Region' "${OUT_SELECT_DICT}")"
 CONTROL_PLANE_INSTANCE_TYPE="$(jq -r '.CPType' "${OUT_SELECT_DICT}")"
 CONTROL_PLANE_INSTANCE_TYPE_FAMILY="$(jq -r '.CPFamily' "${OUT_SELECT_DICT}")"
 CONTROL_PLANE_ARCH="$(jq -r '.CPArch' "${OUT_SELECT_DICT}")"
+CONTROL_PLANE_ZONES="$(jq -r '.CPZones' "${OUT_SELECT_DICT}")"
 
 COMPUTE_INSTANCE_TYPE="$(jq -r '.CType' "${OUT_SELECT_DICT}")"
 COMPUTE_INSTANCE_TYPE_FAMILY="$(jq -r '.CFamily' "${OUT_SELECT_DICT}")"
 COMPUTE_ARCH="$(jq -r '.CArch' "${OUT_SELECT_DICT}")"
+COMPUTE_ZONES="$(jq -r '.CZones' "${OUT_SELECT_DICT}")"
 
-# Set default architectures if not specified
-if is_empty "$CONTROL_PLANE_ARCH"; then
-  CONTROL_PLANE_ARCH="arm64"
+if [[ -n "${COMPUTE_ZONES}" ]] && [[ "${COMPUTE_ZONES}" != "null" ]]; then
+  FIRST_COMPUTE_ZONE=$(echo "${COMPUTE_ZONES}" | jq -r '.[0]' 2>/dev/null || echo "${COMPUTE_ZONES}" | awk -F',' '{print $1}')
+  FIRST_COMPUTE_ZONE="${FIRST_COMPUTE_ZONE//[\"\[\]]/}"
+else
+  FIRST_COMPUTE_ZONE=""
 fi
 
-if is_empty "$COMPUTE_ARCH"; then
-  COMPUTE_ARCH="arm64"
+if is_empty "${CONTROL_PLANE_ARCH}"; then
+  # Default ARCH is determined by each platform.
+  # For GCP, if not explicitly requested, we assume amd64 is safe default, 
+  # but some arm jobs expect arm64 if unspecified. We'll default to amd64 
+  # unless overridden dynamically later.
+  CONTROL_PLANE_ARCH="amd64"
+fi
+
+if is_empty "${COMPUTE_ARCH}"; then
+  COMPUTE_ARCH="amd64"
 fi
 
 echo "$(date -u --rfc-3339=seconds) - Creating cluster in region ${REGION}:"
@@ -176,6 +202,186 @@ sshKey: |
 EOF
 }
 
+function patch_region_project() {
+  local config=$1
+  echo "$(date -u --rfc-3339=seconds) - Patch region and projectID"
+  export REGION
+  yq-v4 eval -i '.platform.gcp.region = env(REGION)' "${config}"
+  export GOOGLE_PROJECT_ID
+  yq-v4 eval -i '.platform.gcp.projectID = env(GOOGLE_PROJECT_ID)' "${config}"
+}
+
+function patch_instance_type_and_os_disk() {
+  local config=$1
+  local role=$2
+  local machine_type=$3
+  local family=$4
+
+  echo "$(date -u --rfc-3339=seconds) - Patch instance type and osDisk.diskType for ${role}"
+  
+  local yq_path=""
+  if [[ "${role}" == "control-plane" ]]; then
+    yq_path=".controlPlane.platform.gcp"
+  else
+    yq_path=".compute[0].platform.gcp"
+  fi
+
+  if [[ -n "${machine_type}" ]]; then
+    export machine_type
+    yq-v4 eval -i "${yq_path}.type = env(machine_type)" "${config}"
+
+    case ${family} in
+      Z3)
+        echo "$(date -u --rfc-3339=seconds) - Patching onHostMaintenance to Migrate for Z3 machine series"
+        export ON_HOST_MAINTENANCE="Migrate"
+        yq-v4 eval -i "${yq_path}.onHostMaintenance = env(ON_HOST_MAINTENANCE)" "${config}"
+        ;;
+      X4)
+        echo "$(date -u --rfc-3339=seconds) - Patching onHostMaintenance to Terminate for X4 machine series"
+        export ON_HOST_MAINTENANCE="Terminate"
+        yq-v4 eval -i "${yq_path}.onHostMaintenance = env(ON_HOST_MAINTENANCE)" "${config}"
+        ;;
+    esac
+
+    # Patch OS disk type for machine series only supporting hyperdisk-balanced
+    case ${family} in
+      C4D|C4|C4A|N4|N4A|N4D|H4D|H3|X4|M4|A4X|A4|G4|A3ULTRA)
+        export OS_DISK_TYPE="hyperdisk-balanced"
+        yq-v4 eval -i "${yq_path}.osDisk.diskType = env(OS_DISK_TYPE)" "${config}"
+        ;;
+    esac
+  fi
+}
+
+function patch_availability_zones() {
+  local config=$1
+  local role=$2
+  local machine_type=$3
+  local manual_zones=$4
+
+  echo "$(date -u --rfc-3339=seconds) - Patch availability zones for ${role} using machine type ${machine_type}"
+  
+  local yq_path=""
+  if [[ "${role}" == "control-plane" ]]; then
+    yq_path=".controlPlane.platform.gcp.zones"
+  else
+    yq_path=".compute[0].platform.gcp.zones"
+  fi
+
+  local availability_zones=()
+  if [[ -n "${manual_zones}" ]] && [[ "${manual_zones}" != "null" ]]; then
+    readarray -t availability_zones < <(echo "${manual_zones}" | jq -r '.[]' 2>/dev/null || echo "${manual_zones}" | tr ',' '\n' | sed 's/^[ \t]*//;s/[ \t]*$//')
+  else
+    readarray -t availability_zones < <(gcloud compute regions describe "${REGION}" | grep 'https://www.googleapis.com/compute/v1/projects/.*/zones/' | sed 's#- https://www.googleapis.com/compute/v1/projects/[_a-zA-Z0-9-]*/zones/##g')
+  fi
+
+  local found_az=false
+  for ZONE_NAME in "${availability_zones[@]}"
+  do
+    if gcloud compute machine-types describe "${machine_type}" --zone "${ZONE_NAME}" >/dev/null 2>&1; then
+      if [[ "${role}" == "worker" ]] && [[ -z "${FIRST_COMPUTE_ZONE}" ]]; then
+        export FIRST_COMPUTE_ZONE="${ZONE_NAME}"
+      fi
+      export ZONE_NAME
+      yq-v4 eval -i "${yq_path} += [env(ZONE_NAME)]" "${config}"
+      found_az=true
+    else
+      echo "Skip zone '${ZONE_NAME}' for machine type '${machine_type}'."
+    fi
+  done
+
+  if ! ${found_az}; then
+    echo "$(date -u --rfc-3339=seconds) - ERROR: Failed to find availability zone for ${role} with machine type ${machine_type}."
+    exit 1
+  fi
+}
+
+function patch_worker_machineset() {
+  local install_dir=$1
+  local machine_type=$2
+  local family=$3
+  local zone=$4
+
+  echo "$(date -u --rfc-3339=seconds) - Patching worker MachineSet for zone ${zone} with ${machine_type}"
+
+  local target_ms=""
+  # Search for the MachineSet that corresponds to the target zone
+  for ms in "${install_dir}/openshift/99_openshift-cluster-api_worker-machineset-"*.yaml; do
+    # Skip if glob didn't match any files
+    [[ -e "$ms" ]] || continue
+    
+    ms_zone=$(yq-v4 eval '.spec.template.spec.providerSpec.value.zone' "$ms")
+    if [[ "$ms_zone" == "$zone" ]]; then
+      target_ms="$ms"
+      break
+    fi
+  done
+  
+  if [[ -z "${target_ms}" ]]; then
+    echo "ERROR: MachineSet for zone ${zone} not found after generating manifests."
+    exit 1
+  fi
+
+  echo "$(date -u --rfc-3339=seconds) - Patching ${target_ms} to use ${machine_type} and 1 replica"
+  export machine_type
+  yq-v4 eval -i '.spec.template.spec.providerSpec.value.machineType = env(machine_type)' "${target_ms}"
+  yq-v4 eval -i '.spec.replicas = 1' "${target_ms}"
+
+  # Patch onHostMaintenance for machines with accelerators, and specific machine series
+  local machine_info
+  machine_info=$(gcloud compute machine-types describe "${machine_type}" --zone "${zone}" --format="json")
+  local accelerators
+  accelerators=$(echo "${machine_info}" | jq -r 'if has("accelerators") then (.accelerators | length) else 0 end')
+  
+  if [[ "${accelerators}" -gt 0 ]]; then
+    echo "$(date -u --rfc-3339=seconds) - Patching onHostMaintenance to Terminate for machine with accelerators"
+    yq-v4 eval -i '.spec.template.spec.providerSpec.value.onHostMaintenance = "Terminate"' "${target_ms}"
+  fi
+
+  case ${family} in
+    Z3)
+      echo "$(date -u --rfc-3339=seconds) - Patching onHostMaintenance to Migrate for Z3 machine series"
+      yq-v4 eval -i '.spec.template.spec.providerSpec.value.onHostMaintenance = "Migrate"' "${target_ms}"
+      ;;
+    X4)
+      echo "$(date -u --rfc-3339=seconds) - Patching onHostMaintenance to Terminate for X4 machine series"
+      yq-v4 eval -i '.spec.template.spec.providerSpec.value.onHostMaintenance = "Terminate"' "${target_ms}"
+      ;;
+  esac
+
+  # Patch OS disk type if needed
+  case ${family} in
+    C4D|C4|C4A|N4|N4A|N4D|H4D|H3|X4|M4|A4X|A4|G4|A3ULTRA)
+      export OS_DISK_TYPE="hyperdisk-balanced"
+      yq-v4 eval -i '.spec.template.spec.providerSpec.value.disks[0].type = env(OS_DISK_TYPE)' "${target_ms}"
+      ;;
+  esac
+
+  if [[ "${machine_type}" == "a3-highgpu-1g" ]]; then
+    echo "$(date -u --rfc-3339=seconds) - Patching preemptible to true for a3-highgpu-1g"
+    yq-v4 eval -i '.spec.template.spec.providerSpec.value.preemptible = true' "${target_ms}"
+  fi
+
+  echo "$(date -u --rfc-3339=seconds) - Debug: Patched providerSpec for ${target_ms}:"
+  yq-v4 eval '.spec.template.spec.providerSpec.value' "${target_ms}"
+
+  # Adjust other MachineSets to maintain IC_COMPUTE_NODE_COUNT total workers
+  local current_total_workers=1
+  for ms in $(ls "${install_dir}/openshift/99_openshift-cluster-api_worker-machineset-"*.yaml | sort); do
+    if [[ "$(realpath "${ms}")" == "$(realpath "${target_ms}")" ]]; then
+      continue
+    fi
+    if [[ ${current_total_workers} -lt ${IC_COMPUTE_NODE_COUNT} ]]; then
+      echo "$(date -u --rfc-3339=seconds) - Setting replicas to 1 for ${ms} (default N2)"
+      yq-v4 eval -i '.spec.replicas = 1' "${ms}"
+      current_total_workers=$((current_total_workers + 1))
+    else
+      echo "$(date -u --rfc-3339=seconds) - Setting replicas to 0 for ${ms}"
+      yq-v4 eval -i '.spec.replicas = 0' "${ms}"
+    fi
+  done
+}
+
 ret=0
 
 CLUSTER_NAME="${NAMESPACE}-${UNIQUE_HASH}"
@@ -202,64 +408,63 @@ GOOGLE_PROJECT_ID="$(< ${CLUSTER_PROFILE_DIR}/openshift_gcp_project)"
 gcloud auth activate-service-account --key-file="${GOOGLE_CLOUD_KEYFILE_JSON}"
 gcloud config set project "${GOOGLE_PROJECT_ID}"
 
-echo "$(date -u --rfc-3339=seconds) - Patch region and projectID"
-export REGION
-yq-v4 eval -i '.platform.gcp.region = env(REGION)' "${CONFIG}"
-export GOOGLE_PROJECT_ID
-yq-v4 eval -i '.platform.gcp.projectID = env(GOOGLE_PROJECT_ID)' "${CONFIG}"
+patch_region_project "${CONFIG}"
 
-echo "$(date -u --rfc-3339=seconds) - Patch instance types and osDisk.diskType"
-if [[ ${CONTROL_PLANE_INSTANCE_TYPE} != "" ]]; then
-  export CONTROL_PLANE_INSTANCE_TYPE
-  yq-v4 eval -i '.controlPlane.platform.gcp.type = env(CONTROL_PLANE_INSTANCE_TYPE)' "${CONFIG}"
-
-  # Patch OS disk type for machine series only supporting hyperdisk-balanced, or not supporting the default pd-ssd
-  # FYI https://github.com/openshift/installer/pull/10271
-  case ${CONTROL_PLANE_INSTANCE_TYPE_FAMILY} in
-    C4D|C4|C4A|N4|N4A|N4D|H4D|H3|X4|M4|A4X|A4|G4|A3ULTRA)
-      export OS_DISK_TYPE="hyperdisk-balanced"
-      yq-v4 eval -i '.controlPlane.platform.gcp.osDisk.diskType = env(OS_DISK_TYPE)' "${CONFIG}"
-      ;;
-  esac
-fi
-if [[ ${COMPUTE_INSTANCE_TYPE} != "" ]]; then
-  export COMPUTE_INSTANCE_TYPE
-  yq-v4 eval -i '.compute[0].platform.gcp.type = env(COMPUTE_INSTANCE_TYPE)' "${CONFIG}"
-
-  # Patch OS disk type for machine series only supporting hyperdisk-balanced, or not supporting the default pd-ssd
-  # FYI https://github.com/openshift/installer/pull/10271
-  case ${COMPUTE_INSTANCE_TYPE_FAMILY} in
-    C4D|C4|C4A|N4|N4A|N4D|H4D|H3|X4|M4|A4X|A4|G4|A3ULTRA)
-      export OS_DISK_TYPE="hyperdisk-balanced"
-    yq-v4 eval -i '.compute[0].platform.gcp.osDisk.diskType = env(OS_DISK_TYPE)' "${CONFIG}"
-    ;;
-  esac
+# Ensure FIRST_COMPUTE_ZONE is populated for machine inspection
+if [[ -z "${FIRST_COMPUTE_ZONE}" ]]; then
+  echo "$(date -u --rfc-3339=seconds) - Dynamically finding a supported zone for ${COMPUTE_INSTANCE_TYPE}"
+  readarray -t availability_zones < <(gcloud compute regions describe "${REGION}" | grep 'https://www.googleapis.com/compute/v1/projects/.*/zones/' | sed 's#- https://www.googleapis.com/compute/v1/projects/[_a-zA-Z0-9-]*/zones/##g')
+  for ZONE_NAME in "${availability_zones[@]}"; do
+    if gcloud compute machine-types describe "${COMPUTE_INSTANCE_TYPE}" --zone "${ZONE_NAME}" >/dev/null 2>&1; then
+      export FIRST_COMPUTE_ZONE="${ZONE_NAME}"
+      break
+    fi
+  done
+  if [[ -z "${FIRST_COMPUTE_ZONE}" ]]; then
+    echo "$(date -u --rfc-3339=seconds) - ERROR: Failed to find availability zone supporting ${COMPUTE_INSTANCE_TYPE}."
+    exit 1
+  fi
 fi
 
-echo "$(date -u --rfc-3339=seconds) - Patch availability zones"
-found_az_for_control_plane=false
-found_az_for_comute=false
-readarray -t availability_zones < <(gcloud compute regions describe "${REGION}" | grep 'https://www.googleapis.com/compute/v1/projects/.*/zones/' | sed 's#- https://www.googleapis.com/compute/v1/projects/[_a-zA-Z0-9-]*/zones/##g')
-for ZONE_NAME in "${availability_zones[@]}"
-do
-  if gcloud compute machine-types describe "${CONTROL_PLANE_INSTANCE_TYPE}" --zone "${ZONE_NAME}"; then
-    export ZONE_NAME
-    yq-v4 eval -i '.controlPlane.platform.gcp.zones += [env(ZONE_NAME)]' "${CONFIG}"
-    found_az_for_control_plane=true
-  else
-    echo "Skip zone '${ZONE_NAME}' for machine type '${CONTROL_PLANE_INSTANCE_TYPE}'."
-  fi
-  if gcloud compute machine-types describe "${COMPUTE_INSTANCE_TYPE}" --zone "${ZONE_NAME}"; then
-    export ZONE_NAME
-    yq-v4 eval -i '.compute[0].platform.gcp.zones += [env(ZONE_NAME)]' "${CONFIG}"
-    found_az_for_comute=true
-  else
-    echo "Skip zone '${ZONE_NAME}' for machine type '${COMPUTE_INSTANCE_TYPE}'."
-  fi
-done
-if ! (${found_az_for_control_plane} && ${found_az_for_comute}); then
-  echo "$(date -u --rfc-3339=seconds) - ERROR: Failed to find availability zone for control-plane and/or compute."
-  exit 1
+# Determine if the machine is "High Resource"
+echo "$(date -u --rfc-3339=seconds) - Inspecting machine type ${COMPUTE_INSTANCE_TYPE} in zone ${FIRST_COMPUTE_ZONE}"
+MACHINE_INFO=$(gcloud compute machine-types describe "${COMPUTE_INSTANCE_TYPE}" --zone "${FIRST_COMPUTE_ZONE}" --format="json")
+GUEST_CPUS=$(echo "${MACHINE_INFO}" | jq -r '.guestCpus // 0')
+MEMORY_MB=$(echo "${MACHINE_INFO}" | jq -r '.memoryMb // 0')
+ACCELERATORS=$(echo "${MACHINE_INFO}" | jq -r 'if has("accelerators") then (.accelerators | length) else 0 end')
+
+IS_EXPENSIVE_MACHINE=false
+# Criteria: much higher resources (>= 16 vCPUs and >= 64GB RAM), or having accelerators.
+if [[ "${ACCELERATORS}" -gt 0 ]] || { [[ "${GUEST_CPUS}" -ge 16 ]] && [[ "${MEMORY_MB}" -ge 65536 ]]; }; then
+    IS_EXPENSIVE_MACHINE=true
+    echo "$(date -u --rfc-3339=seconds) - High-resource/accelerator machine detected (vCPUs=${GUEST_CPUS}, memoryMb=${MEMORY_MB}, accelerators=${ACCELERATORS}). Will use Scenario 1 (patch one worker)."
+else
+    echo "$(date -u --rfc-3339=seconds) - Standard machine detected. Will use Scenario 2 (direct install-config)."
+fi
+
+if [[ "${IS_EXPENSIVE_MACHINE}" == "true" ]]; then
+    # Scenario 1: Use specified control-plane but default worker for initial config
+    DEFAULT_COMPUTE_INSTANCE_TYPE="n2-standard-2"
+    DEFAULT_COMPUTE_FAMILY="N2"
+    if [[ "${COMPUTE_ARCH}" == "arm64" ]]; then
+        DEFAULT_COMPUTE_INSTANCE_TYPE="t2a-standard-2"
+        DEFAULT_COMPUTE_FAMILY="T2A"
+    fi
+    echo "$(date -u --rfc-3339=seconds) - Using specified control-plane (${CONTROL_PLANE_INSTANCE_TYPE}) and default worker (${DEFAULT_COMPUTE_INSTANCE_TYPE}) for initial config"
+    patch_instance_type_and_os_disk "${CONFIG}" "control-plane" "${CONTROL_PLANE_INSTANCE_TYPE}" "${CONTROL_PLANE_INSTANCE_TYPE_FAMILY}"
+    patch_instance_type_and_os_disk "${CONFIG}" "worker" "${DEFAULT_COMPUTE_INSTANCE_TYPE}" "${DEFAULT_COMPUTE_FAMILY}"
+    
+    # Filter zones to ensure they support the specified control plane type and the default worker type
+    patch_availability_zones "${CONFIG}" "control-plane" "${CONTROL_PLANE_INSTANCE_TYPE}" "${CONTROL_PLANE_ZONES}"
+    patch_availability_zones "${CONFIG}" "worker" "${DEFAULT_COMPUTE_INSTANCE_TYPE}" "${COMPUTE_ZONES}"
+else
+    # Scenario 2: Use specified types directly
+    patch_instance_type_and_os_disk "${CONFIG}" "control-plane" "${CONTROL_PLANE_INSTANCE_TYPE}" "${CONTROL_PLANE_INSTANCE_TYPE_FAMILY}"
+    patch_instance_type_and_os_disk "${CONFIG}" "worker" "${COMPUTE_INSTANCE_TYPE}" "${COMPUTE_INSTANCE_TYPE_FAMILY}"
+    
+    # Filter zones based directly on the specified types
+    patch_availability_zones "${CONFIG}" "control-plane" "${CONTROL_PLANE_INSTANCE_TYPE}" "${CONTROL_PLANE_ZONES}"
+    patch_availability_zones "${CONFIG}" "worker" "${COMPUTE_INSTANCE_TYPE}" "${COMPUTE_ZONES}"
 fi
 
 echo "install-config.yaml:"
@@ -283,6 +488,15 @@ if [ $install_ret -ne 0 ]; then
   INSTALL_RESULT="FAIL"
 else
   echo "$(date -u --rfc-3339=seconds) - Created manifests."
+  
+  if [[ "${IS_EXPENSIVE_MACHINE}" == "true" ]]; then
+    if [[ -n "${FIRST_COMPUTE_ZONE}" ]]; then
+      patch_worker_machineset "${INSTALL_DIR}" "${COMPUTE_INSTANCE_TYPE}" "${COMPUTE_INSTANCE_TYPE_FAMILY}" "${FIRST_COMPUTE_ZONE}"
+    else
+      echo "ERROR: Could not determine a valid compute zone for patching."
+      exit 1
+    fi
+  fi
 fi
 
 # ---------------------------------------


### PR DESCRIPTION
[CORS-4286](https://redhat.atlassian.net/browse/CORS-4286) Add support for g2 GPU series on GCP
[OCPBUGS-74390](https://redhat.atlassian.net/browse/OCPBUGS-74390) [GCP] installing with m3 machine types failed with error like 'failed to create install config: [controlPlane.platform.gcp.type: Not found: "m3"'

The updated logic:
- **Scenario 1**: if CType has accelerators, or has >= 16 vCPUs and >= 64GB memory, the machine type is taken as expensive, only apply the type to one worker machine, by patching the worker's machine set YAML file (for example, the rehearsal [test](https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/qe-private-deck/pr-logs/pull/openshift_release/77048/rehearse-77048-periodic-ci-openshift-verification-tests-main-installer-rehearse-4.22-installer-rehearse-gcp/2041719247347912704), where CType being m4-hypermem-16 - 16 vCPUs & 248 GB memory)
- **Scenario 2**: otherwise, all the two worker machines will use the machine type, by patching the install-config YAML file (for example, the rehearsal [test](https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/qe-private-deck/pr-logs/pull/openshift_release/77048/rehearse-77048-periodic-ci-openshift-verification-tests-main-installer-rehearse-4.22-installer-rehearse-gcp-regions/2041756475545620480), where CType being z3-highmem-8-highlssd - 8 vCPUs & 64 GB memory)


Continuing https://github.com/openshift/release/pull/77048, and a follow-up for https://github.com/openshift/release/pull/78590

[CORS-4286]: https://redhat.atlassian.net/browse/CORS-4286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OCPBUGS-74390]: https://redhat.atlassian.net/browse/OCPBUGS-74390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated verification test configurations to refine cluster selection filters and increase date thresholds for failure handling.
  * Switched rehearsal workflows and removed certain compute/XPN environment settings.
* **Enhancements**
  * Improved GCP provisioning for rehearsals: persistent zone lists, derived compute zone selection, safer result merging, defaulted CPU architecture to amd64, and smarter handling of machine types, zones, and instance patching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->