### PR TITLE
Remove vsphere rhcos9-10 mixed jobs and set cron for vsphere rhcos9 jobs

### DIFF
--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
@@ -969,26 +969,12 @@ tests:
         In-tree Volumes \[Driver: vsphere\] \[Testpattern: Pre-provisioned PV'
     workflow: openshift-e2e-vsphere
 - as: e2e-vsphere-ovn-rhcos9-techpreview
-  interval: 24h
+  cron: 17 6 * * *
   steps:
     cluster_profile: vsphere-elastic
     env:
       FEATURE_SET: TechPreviewNoUpgrade
       OS_IMAGE_STREAM: rhel-9
-      TEST_SKIPS: 'In-tree Volumes \[Driver: vsphere\] \[Testpattern: Inline-volume\|
-        In-tree Volumes \[Driver: vsphere\] \[Testpattern: Pre-provisioned PV'
-    observers:
-      enable:
-      - observers-resource-watch
-    workflow: openshift-e2e-vsphere
-- as: e2e-vsphere-ovn-rhcos9-10-techpreview
-  interval: 24h
-  steps:
-    cluster_profile: vsphere-elastic
-    env:
-      FEATURE_SET: TechPreviewNoUpgrade
-      OS_IMAGE_STREAM: rhel-9
-      OS_IMAGE_STREAM_MCP_WORKER: rhel-10
       TEST_SKIPS: 'In-tree Volumes \[Driver: vsphere\] \[Testpattern: Inline-volume\|
         In-tree Volumes \[Driver: vsphere\] \[Testpattern: Pre-provisioned PV'
     observers:
@@ -1038,7 +1024,7 @@ tests:
         on the same node
     workflow: openshift-e2e-vsphere-ovn
 - as: e2e-vsphere-ovn-rhcos9-techpreview-ovn
-  interval: 24h
+  cron: 13 19 * * *
   steps:
     cluster_profile: vsphere-elastic
     env:
@@ -1049,25 +1035,6 @@ tests:
     observers:
       enable:
       - observers-resource-watch
-    workflow: openshift-e2e-vsphere-ovn
-- as: e2e-vsphere-ovn-rhcos9-10-techpreview-ovn
-  interval: 24h
-  steps:
-    cluster_profile: vsphere-elastic
-    env:
-      FEATURE_SET: TechPreviewNoUpgrade
-      OS_IMAGE_STREAM: rhel-9
-      OS_IMAGE_STREAM_MCP_WORKER: rhel-10
-      TEST_SKIPS: provisioning should mount multiple PV pointing to the same storage
-        on the same node
-    observers:
-      enable:
-      - observers-resource-watch
-    pre:
-    - chain: ipi-conf-vsphere
-    - ref: ovn-conf
-    - ref: rhcos-conf-osstream
-    - chain: ipi-install-vsphere
     workflow: openshift-e2e-vsphere-ovn
 - as: e2e-vsphere-ovn-vcf9
   cron: 23,53 12,19 * * *
@@ -1104,26 +1071,12 @@ tests:
         on the same node
     workflow: openshift-e2e-vsphere-serial
 - as: e2e-vsphere-ovn-serial-rhcos9-techpreview
-  interval: 24h
+  cron: 2 20 * * *
   steps:
     cluster_profile: vsphere-elastic
     env:
       FEATURE_SET: TechPreviewNoUpgrade
       OS_IMAGE_STREAM: rhel-9
-      TEST_SKIPS: provisioning should mount multiple PV pointing to the same storage
-        on the same node
-    observers:
-      enable:
-      - observers-resource-watch
-    workflow: openshift-e2e-vsphere-serial
-- as: e2e-vsphere-ovn-serial-rhcos9-10-techpreview
-  interval: 24h
-  steps:
-    cluster_profile: vsphere-elastic
-    env:
-      FEATURE_SET: TechPreviewNoUpgrade
-      OS_IMAGE_STREAM: rhel-9
-      OS_IMAGE_STREAM_MCP_WORKER: rhel-10
       TEST_SKIPS: provisioning should mount multiple PV pointing to the same storage
         on the same node
     observers:
@@ -1139,24 +1092,12 @@ tests:
     workflow: openshift-e2e-vsphere-serial
   timeout: 5h0m0s
 - as: e2e-vsphere-ovn-rhcos9-techpreview-serial
-  interval: 24h
+  cron: 3 22 * * *
   steps:
     cluster_profile: vsphere-elastic
     env:
       FEATURE_SET: TechPreviewNoUpgrade
       OS_IMAGE_STREAM: rhel-9
-    observers:
-      enable:
-      - observers-resource-watch
-    workflow: openshift-e2e-vsphere-serial
-- as: e2e-vsphere-ovn-rhcos9-10-techpreview-serial
-  interval: 24h
-  steps:
-    cluster_profile: vsphere-elastic
-    env:
-      FEATURE_SET: TechPreviewNoUpgrade
-      OS_IMAGE_STREAM: rhel-9
-      OS_IMAGE_STREAM_MCP_WORKER: rhel-10
     observers:
       enable:
       - observers-resource-watch


### PR DESCRIPTION
Remove the 4 vsphere rhcos9-10 mixed cluster jobs added by #77144 and convert the 4 vsphere rhcos9 jobs from interval: 24h to daily cron schedules at low-impact times based on the vsphere heatmap analysis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized vSphere TechPreview test job scheduling by converting from fixed intervals to cron-based schedules.
  * Simplified test configurations to improve CI efficiency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->