### PR TITLE
qci-pruner: log digest when deleting prune retention tags

### DIFF
--- a/hack/qci_registry_pruner.py
+++ b/hack/qci_registry_pruner.py
@@ -160,8 +160,13 @@ def create_tag(repository: str, tag: str, manifest_digest: str, token: str):
         return False
 
 
-def delete_tag(repository: str, tag: str, token: str) -> bool:
+def delete_tag(repository: str, tag: str, token: str, *, log_prune_digest: bool = False) -> bool:
     """Delete a tag from a quay.io repository. Returns True on success, False on failure."""
+    digest_part = None
+    if log_prune_digest:
+        digest = get_tag_manifest_digest(repository, tag, token)
+        digest_part = digest if digest else 'manifest_digest_unknown'
+
     delete_url = f"https://quay.io/api/v1/repository/{repository}/tag/{tag}"
     headers = {
         "Authorization": f"Bearer {token}"
@@ -175,7 +180,10 @@ def delete_tag(repository: str, tag: str, token: str) -> bool:
         with urllib.request.urlopen(request) as response:
             response_data = response.read()
             if response.status == 204:
-                logging.info('Successfully deleted %s', tag)
+                if log_prune_digest:
+                    logging.debug('Removed %s %s', tag, digest_part)
+                else:
+                    logging.info('Successfully deleted %s', tag)
                 return True
             logging.error("Failed to delete tag '%s': %d %s", tag, response.status, response_data)
             return False
@@ -462,7 +470,9 @@ def run(args, start_time):  # pylint: disable=too-many-statements,redefined-oute
                 if days_difference > ttl_days and image_tag not in prune_target_tags:
                     prune_target_tags.add(image_tag)
                     if confirm:
-                        delete_futures.append(delete_executor.submit(delete_tag, QUAY_CI_REPO, image_tag, token))
+                        delete_futures.append(delete_executor.submit(
+                            lambda r=QUAY_CI_REPO, tg=image_tag, tk=token: delete_tag(
+                                r, tg, tk, log_prune_digest=True)))
                     else:
                         logging.debug('Would have removed %s', image_tag)
 


### PR DESCRIPTION
/cc @openshift/test-platform 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced logging for registry tag deletion operations to include manifest digest information for improved tracking and auditing of pruned tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->