### PR TITLE
CNF-22982: Update CI triggers and job names for cluster-group-upgrades-operator

### DIFF
--- a/ci-operator/config/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-main.yaml
+++ b/ci-operator/config/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-main.yaml
@@ -21,6 +21,7 @@ images:
     to: cluster-group-upgrades-operator-recovery
   - dockerfile_path: bundle.Dockerfile
     to: cluster-group-upgrades-operator-bundle
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
 operator:
   bundles:
   - dockerfile_path: bundle.Dockerfile
@@ -127,6 +128,7 @@ tests:
     workflow: optional-operators-ci-aws
 - as: security
   optional: true
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
   steps:
     env:
       PROJECT_NAME: cluster-group-upgrades-operator

--- a/ci-operator/config/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.12.yaml
+++ b/ci-operator/config/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.12.yaml
@@ -21,6 +21,7 @@ images:
     to: cluster-group-upgrades-operator-recovery
   - dockerfile_path: bundle.Dockerfile
     to: cluster-group-upgrades-operator-bundle
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
 operator:
   bundles:
   - dockerfile_path: bundle.Dockerfile

--- a/ci-operator/config/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.14.yaml
+++ b/ci-operator/config/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.14.yaml
@@ -21,6 +21,7 @@ images:
     to: cluster-group-upgrades-operator-recovery
   - dockerfile_path: bundle.Dockerfile
     to: cluster-group-upgrades-operator-bundle
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
 operator:
   bundles:
   - dockerfile_path: bundle.Dockerfile

--- a/ci-operator/config/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.16.yaml
+++ b/ci-operator/config/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.16.yaml
@@ -18,6 +18,7 @@ images:
     to: cluster-group-upgrades-operator-recovery
   - dockerfile_path: bundle.Dockerfile
     to: cluster-group-upgrades-operator-bundle
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
 operator:
   bundles:
   - dockerfile_path: bundle.Dockerfile
@@ -107,6 +108,7 @@ tests:
     workflow: optional-operators-ci-aws
 - as: security
   optional: true
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
   steps:
     env:
       PROJECT_NAME: cluster-group-upgrades-operator

--- a/ci-operator/config/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.18.yaml
+++ b/ci-operator/config/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.18.yaml
@@ -18,6 +18,7 @@ images:
     to: cluster-group-upgrades-operator-recovery
   - dockerfile_path: bundle.Dockerfile
     to: cluster-group-upgrades-operator-bundle
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
 operator:
   bundles:
   - dockerfile_path: bundle.Dockerfile
@@ -107,6 +108,7 @@ tests:
     workflow: optional-operators-ci-aws
 - as: security
   optional: true
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
   steps:
     env:
       PROJECT_NAME: cluster-group-upgrades-operator

--- a/ci-operator/config/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.19.yaml
+++ b/ci-operator/config/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.19.yaml
@@ -18,6 +18,7 @@ images:
     to: cluster-group-upgrades-operator-recovery
   - dockerfile_path: bundle.Dockerfile
     to: cluster-group-upgrades-operator-bundle
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
 operator:
   bundles:
   - dockerfile_path: bundle.Dockerfile
@@ -107,6 +108,7 @@ tests:
     workflow: optional-operators-ci-aws
 - as: security
   optional: true
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
   steps:
     env:
       PROJECT_NAME: cluster-group-upgrades-operator

--- a/ci-operator/config/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.20.yaml
+++ b/ci-operator/config/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.20.yaml
@@ -18,6 +18,7 @@ images:
     to: cluster-group-upgrades-operator-recovery
   - dockerfile_path: bundle.Dockerfile
     to: cluster-group-upgrades-operator-bundle
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
 operator:
   bundles:
   - dockerfile_path: bundle.Dockerfile
@@ -107,6 +108,7 @@ tests:
     workflow: optional-operators-ci-aws
 - as: security
   optional: true
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
   steps:
     env:
       PROJECT_NAME: cluster-group-upgrades-operator

--- a/ci-operator/config/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.21.yaml
+++ b/ci-operator/config/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.21.yaml
@@ -81,7 +81,7 @@ tests:
       USER_TAGS: |
         ci-job-source prowci
         ci-job-branch release-4.21
-        ci-job-fullname openshift-kni-cluster-group-upgrades-operator-main
+        ci-job-fullname openshift-kni-cluster-group-upgrades-operator-release-4.21
         ci-job-type optional-operators-ci-aws
         ci-repo-name cluster-group-upgrades-operator
         ci-org-name openshift-kni

--- a/ci-operator/config/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.21.yaml
+++ b/ci-operator/config/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.21.yaml
@@ -21,6 +21,7 @@ images:
     to: cluster-group-upgrades-operator-recovery
   - dockerfile_path: bundle.Dockerfile
     to: cluster-group-upgrades-operator-bundle
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
 operator:
   bundles:
   - dockerfile_path: bundle.Dockerfile
@@ -127,6 +128,7 @@ tests:
     workflow: optional-operators-ci-aws
 - as: security
   optional: true
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
   steps:
     env:
       PROJECT_NAME: cluster-group-upgrades-operator

--- a/ci-operator/config/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.22.yaml
+++ b/ci-operator/config/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.22.yaml
@@ -81,7 +81,7 @@ tests:
       USER_TAGS: |
         ci-job-source prowci
         ci-job-branch release-4.22
-        ci-job-fullname openshift-kni-cluster-group-upgrades-operator-main
+        ci-job-fullname openshift-kni-cluster-group-upgrades-operator-release-4.22
         ci-job-type optional-operators-ci-aws
         ci-repo-name cluster-group-upgrades-operator
         ci-org-name openshift-kni

--- a/ci-operator/config/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.22.yaml
+++ b/ci-operator/config/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.22.yaml
@@ -21,6 +21,7 @@ images:
     to: cluster-group-upgrades-operator-recovery
   - dockerfile_path: bundle.Dockerfile
     to: cluster-group-upgrades-operator-bundle
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
 operator:
   bundles:
   - dockerfile_path: bundle.Dockerfile
@@ -127,6 +128,7 @@ tests:
     workflow: optional-operators-ci-aws
 - as: security
   optional: true
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
   steps:
     env:
       PROJECT_NAME: cluster-group-upgrades-operator

--- a/ci-operator/jobs/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-main-presubmits.yaml
@@ -123,7 +123,7 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )ci-job,?($|\s.*)
   - agent: kubernetes
-    always_run: true
+    always_run: false
     branches:
     - ^main$
     - ^main-
@@ -135,6 +135,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-main-images
     rerun_command: /test images
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
     spec:
       containers:
       - args:
@@ -257,7 +258,7 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )integration,?($|\s.*)
   - agent: kubernetes
-    always_run: true
+    always_run: false
     branches:
     - ^main$
     - ^main-
@@ -270,6 +271,7 @@ presubmits:
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-main-security
     optional: true
     rerun_command: /test security
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.12-presubmits.yaml
+++ b/ci-operator/jobs/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.12-presubmits.yaml
@@ -120,7 +120,7 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )ci-job,?($|\s.*)
   - agent: kubernetes
-    always_run: true
+    always_run: false
     branches:
     - ^release-4\.12$
     - ^release-4\.12-
@@ -134,6 +134,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-release-4.12-images
     rerun_command: /test images
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.14-presubmits.yaml
+++ b/ci-operator/jobs/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.14-presubmits.yaml
@@ -120,7 +120,7 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )ci-job,?($|\s.*)
   - agent: kubernetes
-    always_run: true
+    always_run: false
     branches:
     - ^release-4\.14$
     - ^release-4\.14-
@@ -134,6 +134,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-release-4.14-images
     rerun_command: /test images
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.16-presubmits.yaml
+++ b/ci-operator/jobs/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.16-presubmits.yaml
@@ -116,7 +116,7 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )ci-job,?($|\s.*)
   - agent: kubernetes
-    always_run: true
+    always_run: false
     branches:
     - ^release-4\.16$
     - ^release-4\.16-
@@ -128,6 +128,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-release-4.16-images
     rerun_command: /test images
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
     spec:
       containers:
       - args:
@@ -250,7 +251,7 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )integration,?($|\s.*)
   - agent: kubernetes
-    always_run: true
+    always_run: false
     branches:
     - ^release-4\.16$
     - ^release-4\.16-
@@ -263,6 +264,7 @@ presubmits:
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-release-4.16-security
     optional: true
     rerun_command: /test security
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.18-presubmits.yaml
+++ b/ci-operator/jobs/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.18-presubmits.yaml
@@ -116,7 +116,7 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )ci-job,?($|\s.*)
   - agent: kubernetes
-    always_run: true
+    always_run: false
     branches:
     - ^release-4\.18$
     - ^release-4\.18-
@@ -128,6 +128,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-release-4.18-images
     rerun_command: /test images
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
     spec:
       containers:
       - args:
@@ -250,7 +251,7 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )integration,?($|\s.*)
   - agent: kubernetes
-    always_run: true
+    always_run: false
     branches:
     - ^release-4\.18$
     - ^release-4\.18-
@@ -263,6 +264,7 @@ presubmits:
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-release-4.18-security
     optional: true
     rerun_command: /test security
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.19-presubmits.yaml
+++ b/ci-operator/jobs/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.19-presubmits.yaml
@@ -116,7 +116,7 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )ci-job,?($|\s.*)
   - agent: kubernetes
-    always_run: true
+    always_run: false
     branches:
     - ^release-4\.19$
     - ^release-4\.19-
@@ -128,6 +128,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-release-4.19-images
     rerun_command: /test images
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
     spec:
       containers:
       - args:
@@ -250,7 +251,7 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )integration,?($|\s.*)
   - agent: kubernetes
-    always_run: true
+    always_run: false
     branches:
     - ^release-4\.19$
     - ^release-4\.19-
@@ -263,6 +264,7 @@ presubmits:
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-release-4.19-security
     optional: true
     rerun_command: /test security
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.20-presubmits.yaml
+++ b/ci-operator/jobs/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.20-presubmits.yaml
@@ -116,7 +116,7 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )ci-job,?($|\s.*)
   - agent: kubernetes
-    always_run: true
+    always_run: false
     branches:
     - ^release-4\.20$
     - ^release-4\.20-
@@ -128,6 +128,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-release-4.20-images
     rerun_command: /test images
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
     spec:
       containers:
       - args:
@@ -250,7 +251,7 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )integration,?($|\s.*)
   - agent: kubernetes
-    always_run: true
+    always_run: false
     branches:
     - ^release-4\.20$
     - ^release-4\.20-
@@ -263,6 +264,7 @@ presubmits:
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-release-4.20-security
     optional: true
     rerun_command: /test security
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.21-presubmits.yaml
+++ b/ci-operator/jobs/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.21-presubmits.yaml
@@ -123,7 +123,7 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )ci-job,?($|\s.*)
   - agent: kubernetes
-    always_run: true
+    always_run: false
     branches:
     - ^release-4\.21$
     - ^release-4\.21-
@@ -135,6 +135,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-release-4.21-images
     rerun_command: /test images
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
     spec:
       containers:
       - args:
@@ -257,7 +258,7 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )integration,?($|\s.*)
   - agent: kubernetes
-    always_run: true
+    always_run: false
     branches:
     - ^release-4\.21$
     - ^release-4\.21-
@@ -270,6 +271,7 @@ presubmits:
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-release-4.21-security
     optional: true
     rerun_command: /test security
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.22-presubmits.yaml
@@ -123,7 +123,7 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )ci-job,?($|\s.*)
   - agent: kubernetes
-    always_run: true
+    always_run: false
     branches:
     - ^release-4\.22$
     - ^release-4\.22-
@@ -135,6 +135,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-release-4.22-images
     rerun_command: /test images
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
     spec:
       containers:
       - args:
@@ -257,7 +258,7 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )integration,?($|\s.*)
   - agent: kubernetes
-    always_run: true
+    always_run: false
     branches:
     - ^release-4\.22$
     - ^release-4\.22-
@@ -270,6 +271,7 @@ presubmits:
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-release-4.22-security
     optional: true
     rerun_command: /test security
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
     spec:
       containers:
       - args:


### PR DESCRIPTION
- Update CI triggers so jobs are not triggered by trivial (doc, readme, etc) or unrelated (konflux, tekton, etc) changes
- Update names used in 4.21/4.22 jobs to no longer be duplicates of the main branch jobs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI configurations to optimize pipeline execution across multiple release branches. Bundle image builds and security tests now skip when changes are limited to documentation, metadata, or configuration files, reducing unnecessary CI work while maintaining code quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->