### PR TITLE
No-Jira: For OTP repo github action to work

### DIFF
--- a/core-services/prow/02_config/openshift/openshift-tests-private/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/openshift-tests-private/_prowconfig.yaml
@@ -6,6 +6,7 @@ tide:
     - approved
     - lgtm
     - staff-eng-approved
+    - staff-eng-required
     missingLabels:
     - backports/unvalidated-commits
     - do-not-merge/hold

--- a/core-services/prow/02_config/openshift/openshift-tests-private/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/openshift-tests-private/_prowconfig.yaml
@@ -5,8 +5,7 @@ tide:
   - labels:
     - approved
     - lgtm
-    - staff-eng-approved
-    - staff-eng-required
+    - staff-eng-approved,no-new-tests
     missingLabels:
     - backports/unvalidated-commits
     - do-not-merge/hold


### PR DESCRIPTION
For github action workflow written for OTP repo [here](https://github.com/openshift/openshift-tests-private/pull/29880) to work another label is needed , PTAL .

@petr-muller @cpmeadors 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated merge readiness process to incorporate a new required label in the approval workflow. This change enhances the merge qualification criteria by adding an additional requirement alongside existing approval checks, refining how pull requests are evaluated for automated merge authorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->