### PR TITLE
CNF-22982: Create new upgrade jobs for 4.14 to 4.16 and 4.16 to 4.18

### DIFF
--- a/ci-operator/config/openshift-kni/lifecycle-agent/openshift-kni-lifecycle-agent-release-4.16__nightly-4.16-upgrade-from-stable-4.14.yaml
+++ b/ci-operator/config/openshift-kni/lifecycle-agent/openshift-kni-lifecycle-agent-release-4.16__nightly-4.16-upgrade-from-stable-4.14.yaml
@@ -1,0 +1,119 @@
+base_images:
+  bip-orchestrate-vm:
+    name: bip-orchestrate-vm
+    namespace: edge-infrastructure
+    tag: latest
+  ib-orchestrate-vm:
+    name: ib-orchestrate-vm
+    namespace: edge-infrastructure
+    tag: latest
+  lifecycle-agent-operator:
+    name: "4.16"
+    namespace: ocp-kni
+    tag: lifecycle-agent-operator
+  lifecycle-agent-operator-bundle:
+    name: "4.16"
+    namespace: ocp-kni
+    tag: lifecycle-agent-operator-bundle
+  recert:
+    name: recert
+    namespace: edge-infrastructure
+    tag: release-4.16
+  tests:
+    name: "4.16"
+    namespace: ocp
+    tag: tests
+releases:
+  latest:
+    integration:
+      name: "4.16"
+      namespace: ocp
+resources:
+  '*':
+    requests:
+      cpu: 10m
+      memory: 100Mi
+tests:
+- as: image-based-upgrade-e2e-serial-conformance
+  interval: 24h
+  steps:
+    cluster_profile: openshift-org-aws
+    dependencies:
+      BIP_ORCHESTRATE_VM_REF: pipeline:bip-orchestrate-vm
+      IB_ORCHESTRATE_VM_REF: pipeline:ib-orchestrate-vm
+      LCA_PULL_REF: pipeline:lifecycle-agent-operator
+      OO_BUNDLE: pipeline:lifecycle-agent-operator-bundle
+      RECERT_IMAGE: pipeline:recert
+      TESTS_PULL_REF: pipeline:tests
+    env:
+      OCP_BASE_IMAGE_SOURCE: ci
+      OCP_BASE_VERSION: "4.16"
+      OCP_TARGET_IMAGE_SOURCE: release
+      OCP_TARGET_VERSION: "4.14"
+      SEED_IMAGE_TAG_FORMAT: e2e
+    workflow: openshift-image-based-upgrade-e2e
+- as: image-based-upgrade-e2e-serial-conformance-baseline
+  interval: 24h
+  steps:
+    cluster_profile: openshift-org-aws
+    dependencies:
+      BIP_ORCHESTRATE_VM_REF: pipeline:bip-orchestrate-vm
+      IB_ORCHESTRATE_VM_REF: pipeline:ib-orchestrate-vm
+      LCA_PULL_REF: pipeline:lifecycle-agent-operator
+      OO_BUNDLE: pipeline:lifecycle-agent-operator-bundle
+      RECERT_IMAGE: pipeline:recert
+      TESTS_PULL_REF: pipeline:tests
+    env:
+      CREATE_CLUSTER_ONLY: "true"
+      OCP_BASE_IMAGE_SOURCE: ci
+      OCP_BASE_VERSION: "4.16"
+      SEED_IMAGE_TAG_FORMAT: e2e
+      TEST_CLUSTER: seed
+      TEST_SKIPS: NTO should SNO installation does not finish due to wait for non-existing
+        machine-config
+    workflow: openshift-image-based-upgrade-e2e-baseline
+- as: image-based-upgrade-e2e-parallel-conformance
+  interval: 24h
+  steps:
+    cluster_profile: openshift-org-aws
+    dependencies:
+      BIP_ORCHESTRATE_VM_REF: pipeline:bip-orchestrate-vm
+      IB_ORCHESTRATE_VM_REF: pipeline:ib-orchestrate-vm
+      LCA_PULL_REF: pipeline:lifecycle-agent-operator
+      OO_BUNDLE: pipeline:lifecycle-agent-operator-bundle
+      RECERT_IMAGE: pipeline:recert
+      TESTS_PULL_REF: pipeline:tests
+    env:
+      CONFORMANCE_SUITE: openshift/conformance/parallel
+      OCP_BASE_IMAGE_SOURCE: ci
+      OCP_BASE_VERSION: "4.16"
+      OCP_TARGET_IMAGE_SOURCE: release
+      OCP_TARGET_VERSION: "4.14"
+      SEED_IMAGE_TAG_FORMAT: e2e
+    workflow: openshift-image-based-upgrade-e2e
+- as: image-based-upgrade-e2e-parallel-conformance-baseline
+  interval: 24h
+  steps:
+    cluster_profile: openshift-org-aws
+    dependencies:
+      BIP_ORCHESTRATE_VM_REF: pipeline:bip-orchestrate-vm
+      IB_ORCHESTRATE_VM_REF: pipeline:ib-orchestrate-vm
+      LCA_PULL_REF: pipeline:lifecycle-agent-operator
+      OO_BUNDLE: pipeline:lifecycle-agent-operator-bundle
+      RECERT_IMAGE: pipeline:recert
+      TESTS_PULL_REF: pipeline:tests
+    env:
+      CONFORMANCE_SUITE: openshift/conformance/parallel
+      CREATE_CLUSTER_ONLY: "true"
+      OCP_BASE_IMAGE_SOURCE: ci
+      OCP_BASE_VERSION: "4.16"
+      SEED_IMAGE_TAG_FORMAT: e2e
+      TEST_CLUSTER: seed
+      TEST_SKIPS: NTO should SNO installation does not finish due to wait for non-existing
+        machine-config
+    workflow: openshift-image-based-upgrade-e2e-baseline
+zz_generated_metadata:
+  branch: release-4.16
+  org: openshift-kni
+  repo: lifecycle-agent
+  variant: nightly-4.16-upgrade-from-stable-4.14

--- a/ci-operator/config/openshift-kni/lifecycle-agent/openshift-kni-lifecycle-agent-release-4.18__nightly-4.18-upgrade-from-stable-4.16.yaml
+++ b/ci-operator/config/openshift-kni/lifecycle-agent/openshift-kni-lifecycle-agent-release-4.18__nightly-4.18-upgrade-from-stable-4.16.yaml
@@ -1,0 +1,115 @@
+base_images:
+  bip-orchestrate-vm:
+    name: bip-orchestrate-vm
+    namespace: edge-infrastructure
+    tag: latest
+  ib-orchestrate-vm:
+    name: ib-orchestrate-vm
+    namespace: edge-infrastructure
+    tag: latest
+  lifecycle-agent-operator:
+    name: "4.18"
+    namespace: ocp-kni
+    tag: lifecycle-agent-operator
+  lifecycle-agent-operator-bundle:
+    name: "4.18"
+    namespace: ocp-kni
+    tag: lifecycle-agent-operator-bundle
+  recert:
+    name: recert
+    namespace: edge-infrastructure
+    tag: release-4.18
+  tests:
+    name: "4.18"
+    namespace: ocp
+    tag: tests
+releases:
+  latest:
+    integration:
+      name: "4.18"
+      namespace: ocp
+resources:
+  '*':
+    requests:
+      cpu: 10m
+      memory: 100Mi
+tests:
+- as: image-based-upgrade-e2e-serial-conformance
+  interval: 24h
+  steps:
+    cluster_profile: openshift-org-aws
+    dependencies:
+      BIP_ORCHESTRATE_VM_REF: pipeline:bip-orchestrate-vm
+      IB_ORCHESTRATE_VM_REF: pipeline:ib-orchestrate-vm
+      LCA_PULL_REF: pipeline:lifecycle-agent-operator
+      OO_BUNDLE: pipeline:lifecycle-agent-operator-bundle
+      RECERT_IMAGE: pipeline:recert
+      TESTS_PULL_REF: pipeline:tests
+    env:
+      OCP_BASE_IMAGE_SOURCE: ci
+      OCP_BASE_VERSION: "4.18"
+      OCP_TARGET_IMAGE_SOURCE: release
+      OCP_TARGET_VERSION: "4.16"
+      SEED_IMAGE_TAG_FORMAT: e2e
+    workflow: openshift-image-based-upgrade-e2e
+- as: image-based-upgrade-e2e-serial-conformance-baseline
+  interval: 24h
+  steps:
+    cluster_profile: openshift-org-aws
+    dependencies:
+      BIP_ORCHESTRATE_VM_REF: pipeline:bip-orchestrate-vm
+      IB_ORCHESTRATE_VM_REF: pipeline:ib-orchestrate-vm
+      LCA_PULL_REF: pipeline:lifecycle-agent-operator
+      OO_BUNDLE: pipeline:lifecycle-agent-operator-bundle
+      RECERT_IMAGE: pipeline:recert
+      TESTS_PULL_REF: pipeline:tests
+    env:
+      CREATE_CLUSTER_ONLY: "true"
+      OCP_BASE_IMAGE_SOURCE: ci
+      OCP_BASE_VERSION: "4.18"
+      SEED_IMAGE_TAG_FORMAT: e2e
+      TEST_CLUSTER: seed
+    workflow: openshift-image-based-upgrade-e2e-baseline
+- as: image-based-upgrade-e2e-parallel-conformance
+  interval: 24h
+  steps:
+    cluster_profile: openshift-org-aws
+    dependencies:
+      BIP_ORCHESTRATE_VM_REF: pipeline:bip-orchestrate-vm
+      IB_ORCHESTRATE_VM_REF: pipeline:ib-orchestrate-vm
+      LCA_PULL_REF: pipeline:lifecycle-agent-operator
+      OO_BUNDLE: pipeline:lifecycle-agent-operator-bundle
+      RECERT_IMAGE: pipeline:recert
+      TESTS_PULL_REF: pipeline:tests
+    env:
+      CONFORMANCE_SUITE: openshift/conformance/parallel
+      OCP_BASE_IMAGE_SOURCE: ci
+      OCP_BASE_VERSION: "4.18"
+      OCP_TARGET_IMAGE_SOURCE: release
+      OCP_TARGET_VERSION: "4.16"
+      SEED_IMAGE_TAG_FORMAT: e2e
+    workflow: openshift-image-based-upgrade-e2e
+- as: image-based-upgrade-e2e-parallel-conformance-baseline
+  interval: 24h
+  steps:
+    cluster_profile: openshift-org-aws
+    dependencies:
+      BIP_ORCHESTRATE_VM_REF: pipeline:bip-orchestrate-vm
+      IB_ORCHESTRATE_VM_REF: pipeline:ib-orchestrate-vm
+      LCA_PULL_REF: pipeline:lifecycle-agent-operator
+      OO_BUNDLE: pipeline:lifecycle-agent-operator-bundle
+      RECERT_IMAGE: pipeline:recert
+      TESTS_PULL_REF: pipeline:tests
+    env:
+      CONFORMANCE_SUITE: openshift/conformance/parallel
+      CREATE_CLUSTER_ONLY: "true"
+      OCP_BASE_IMAGE_SOURCE: ci
+      OCP_BASE_VERSION: "4.18"
+      SEED_IMAGE_TAG_FORMAT: e2e
+      TEST_CLUSTER: seed
+    workflow: openshift-image-based-upgrade-e2e-baseline
+zz_generated_metadata:
+  branch: release-4.18
+  org: openshift-kni
+  repo: lifecycle-agent
+  variant: nightly-4.18-upgrade-from-stable-4.16

--- a/ci-operator/jobs/openshift-kni/lifecycle-agent/openshift-kni-lifecycle-agent-release-4.16-periodics.yaml
+++ b/ci-operator/jobs/openshift-kni/lifecycle-agent/openshift-kni-lifecycle-agent-release-4.16-periodics.yaml
@@ -175,3 +175,379 @@ periodics:
     - name: result-aggregator
       secret:
         secretName: result-aggregator
+- agent: kubernetes
+  cluster: build03
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: release-4.16
+    org: openshift-kni
+    repo: lifecycle-agent
+  interval: 24h
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
+    ci-operator.openshift.io/variant: nightly-4.16-upgrade-from-stable-4.14
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-kni-lifecycle-agent-release-4.16-nightly-4.16-upgrade-from-stable-4.14-image-based-upgrade-e2e-parallel-conformance
+  reporter_config:
+    slack:
+      channel: '#image-based-ci'
+      job_states_to_report:
+      - failure
+      - success
+      - error
+      - aborted
+      report_template: '{{if eq .Status.State "success"}} :slack-green: Job *{{.Spec.Job}}*
+        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> {{else}} :alert-siren:
+        Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+        logs> {{end}}'
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=image-based-upgrade-e2e-parallel-conformance
+      - --variant=nightly-4.16-upgrade-from-stable-4.14
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build03
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: release-4.16
+    org: openshift-kni
+    repo: lifecycle-agent
+  interval: 24h
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
+    ci-operator.openshift.io/variant: nightly-4.16-upgrade-from-stable-4.14
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-kni-lifecycle-agent-release-4.16-nightly-4.16-upgrade-from-stable-4.14-image-based-upgrade-e2e-parallel-conformance-baseline
+  reporter_config:
+    slack:
+      channel: '#image-based-ci'
+      job_states_to_report:
+      - failure
+      - success
+      - error
+      - aborted
+      report_template: '{{if eq .Status.State "success"}} :slack-green: Job *{{.Spec.Job}}*
+        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> {{else}} :alert-siren:
+        Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+        logs> {{end}}'
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=image-based-upgrade-e2e-parallel-conformance-baseline
+      - --variant=nightly-4.16-upgrade-from-stable-4.14
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build03
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: release-4.16
+    org: openshift-kni
+    repo: lifecycle-agent
+  interval: 24h
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
+    ci-operator.openshift.io/variant: nightly-4.16-upgrade-from-stable-4.14
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-kni-lifecycle-agent-release-4.16-nightly-4.16-upgrade-from-stable-4.14-image-based-upgrade-e2e-serial-conformance
+  reporter_config:
+    slack:
+      channel: '#image-based-ci'
+      job_states_to_report:
+      - failure
+      - success
+      - error
+      - aborted
+      report_template: '{{if eq .Status.State "success"}} :slack-green: Job *{{.Spec.Job}}*
+        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> {{else}} :alert-siren:
+        Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+        logs> {{end}}'
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=image-based-upgrade-e2e-serial-conformance
+      - --variant=nightly-4.16-upgrade-from-stable-4.14
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build03
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: release-4.16
+    org: openshift-kni
+    repo: lifecycle-agent
+  interval: 24h
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
+    ci-operator.openshift.io/variant: nightly-4.16-upgrade-from-stable-4.14
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-kni-lifecycle-agent-release-4.16-nightly-4.16-upgrade-from-stable-4.14-image-based-upgrade-e2e-serial-conformance-baseline
+  reporter_config:
+    slack:
+      channel: '#image-based-ci'
+      job_states_to_report:
+      - failure
+      - success
+      - error
+      - aborted
+      report_template: '{{if eq .Status.State "success"}} :slack-green: Job *{{.Spec.Job}}*
+        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> {{else}} :alert-siren:
+        Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+        logs> {{end}}'
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=image-based-upgrade-e2e-serial-conformance-baseline
+      - --variant=nightly-4.16-upgrade-from-stable-4.14
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator

--- a/ci-operator/jobs/openshift-kni/lifecycle-agent/openshift-kni-lifecycle-agent-release-4.18-periodics.yaml
+++ b/ci-operator/jobs/openshift-kni/lifecycle-agent/openshift-kni-lifecycle-agent-release-4.18-periodics.yaml
@@ -175,3 +175,379 @@ periodics:
     - name: result-aggregator
       secret:
         secretName: result-aggregator
+- agent: kubernetes
+  cluster: build03
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: release-4.18
+    org: openshift-kni
+    repo: lifecycle-agent
+  interval: 24h
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
+    ci-operator.openshift.io/variant: nightly-4.18-upgrade-from-stable-4.16
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-kni-lifecycle-agent-release-4.18-nightly-4.18-upgrade-from-stable-4.16-image-based-upgrade-e2e-parallel-conformance
+  reporter_config:
+    slack:
+      channel: '#image-based-ci'
+      job_states_to_report:
+      - failure
+      - success
+      - error
+      - aborted
+      report_template: '{{if eq .Status.State "success"}} :slack-green: Job *{{.Spec.Job}}*
+        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> {{else}} :alert-siren:
+        Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+        logs> {{end}}'
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=image-based-upgrade-e2e-parallel-conformance
+      - --variant=nightly-4.18-upgrade-from-stable-4.16
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build03
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: release-4.18
+    org: openshift-kni
+    repo: lifecycle-agent
+  interval: 24h
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
+    ci-operator.openshift.io/variant: nightly-4.18-upgrade-from-stable-4.16
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-kni-lifecycle-agent-release-4.18-nightly-4.18-upgrade-from-stable-4.16-image-based-upgrade-e2e-parallel-conformance-baseline
+  reporter_config:
+    slack:
+      channel: '#image-based-ci'
+      job_states_to_report:
+      - failure
+      - success
+      - error
+      - aborted
+      report_template: '{{if eq .Status.State "success"}} :slack-green: Job *{{.Spec.Job}}*
+        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> {{else}} :alert-siren:
+        Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+        logs> {{end}}'
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=image-based-upgrade-e2e-parallel-conformance-baseline
+      - --variant=nightly-4.18-upgrade-from-stable-4.16
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build03
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: release-4.18
+    org: openshift-kni
+    repo: lifecycle-agent
+  interval: 24h
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
+    ci-operator.openshift.io/variant: nightly-4.18-upgrade-from-stable-4.16
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-kni-lifecycle-agent-release-4.18-nightly-4.18-upgrade-from-stable-4.16-image-based-upgrade-e2e-serial-conformance
+  reporter_config:
+    slack:
+      channel: '#image-based-ci'
+      job_states_to_report:
+      - failure
+      - success
+      - error
+      - aborted
+      report_template: '{{if eq .Status.State "success"}} :slack-green: Job *{{.Spec.Job}}*
+        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> {{else}} :alert-siren:
+        Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+        logs> {{end}}'
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=image-based-upgrade-e2e-serial-conformance
+      - --variant=nightly-4.18-upgrade-from-stable-4.16
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build03
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: release-4.18
+    org: openshift-kni
+    repo: lifecycle-agent
+  interval: 24h
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
+    ci-operator.openshift.io/variant: nightly-4.18-upgrade-from-stable-4.16
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-kni-lifecycle-agent-release-4.18-nightly-4.18-upgrade-from-stable-4.16-image-based-upgrade-e2e-serial-conformance-baseline
+  reporter_config:
+    slack:
+      channel: '#image-based-ci'
+      job_states_to_report:
+      - failure
+      - success
+      - error
+      - aborted
+      report_template: '{{if eq .Status.State "success"}} :slack-green: Job *{{.Spec.Job}}*
+        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> {{else}} :alert-siren:
+        Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+        logs> {{end}}'
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=image-based-upgrade-e2e-serial-conformance-baseline
+      - --variant=nightly-4.18-upgrade-from-stable-4.16
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator


### PR DESCRIPTION
- Since we don't have 4.15 and 4.17 any more we should use these versions instead

Assisted-by: Cursor/auto
AI-attribution: AIA,Primarily AI-generated,Human-initiated,Reviewed,Cursor/auto,v1.0
For more information on AI attribution statements, see: https://aiattribution.github.io/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

This PR adds two new CI operator configuration files to support testing image-based upgrade paths for the lifecycle-agent component in OpenShift:

### What Changed
- **`openshift-kni-lifecycle-agent-release-4.16__nightly-4.16-upgrade-from-stable-4.14.yaml`**: New configuration file defining CI tests for upgrading from OpenShift 4.14 to 4.16
- **`openshift-kni-lifecycle-agent-release-4.18__nightly-4.18-upgrade-from-stable-4.16.yaml`**: New configuration file defining CI tests for upgrading from OpenShift 4.16 to 4.18

### Why These Changes
The PR addresses the fact that OpenShift versions 4.15 and 4.17 are no longer available. This means the lifecycle-agent component needs CI jobs to test direct upgrade paths that skip these intermediate versions (4.14→4.16 and 4.16→4.18), rather than the typical sequential upgrade testing.

### What Each Configuration Does
Both files follow the same pattern as existing upgrade test configurations in the repository. Each defines:
- **Base image references**: Container images for BIP/IB orchestrate VMs, lifecycle-agent operator, operator bundle, recert, and test images
- **E2E test jobs**: Four scheduled image-based upgrade test jobs per file (serial/parallel × conformance/baseline variants)
- **Upgrade parameters**: Configures the base and target image versions and sources via environment variables
- **Resource requests**: Sets compute resource constraints for the test jobs

This completes the lifecycle-agent upgrade testing matrix for the current release streams in the OpenShift CI infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->