### PR TITLE
aws-account-operator: Add prek validation to PROW CI

### DIFF
--- a/ci-operator/config/openshift/aws-account-operator/openshift-aws-account-operator-master.yaml
+++ b/ci-operator/config/openshift/aws-account-operator/openshift-aws-account-operator-master.yaml
@@ -4,6 +4,14 @@ images:
   items:
   - dockerfile_path: build/Dockerfile
     to: aws-account-operator
+  - dockerfile_literal: |
+      FROM src
+      RUN PREK_VERSION="$(tr -d '[:space:]' < .prek-version 2>/dev/null || true)" \
+        && PREK_VERSION="${PREK_VERSION:-v0.3.9}" \
+        && curl -fsSL "https://github.com/j178/prek/releases/download/${PREK_VERSION}/prek-x86_64-unknown-linux-gnu.tar.gz" \
+        | tar xzf - --strip-components=1 -C /usr/local/bin/ prek-x86_64-unknown-linux-gnu/prek
+    from: src
+    to: prek-runner
 resources:
   '*':
     limits:
@@ -46,6 +54,19 @@ tests:
   commands: make validate
   container:
     from: src
+  skip_if_only_changed: ^(?:\.tekton|\.github)|\.md$|^(?:\.gitignore|OWNERS|LICENSE)$
+- as: prek
+  commands: |
+    export PREK_HOME=/tmp/prek
+    git init
+    git add -A
+    if [ -x hack/ci.sh ]; then
+      ./hack/ci.sh
+    else
+      prek run --all-files
+    fi
+  container:
+    from: prek-runner
   skip_if_only_changed: ^(?:\.tekton|\.github)|\.md$|^(?:\.gitignore|OWNERS|LICENSE)$
 - always_run: false
   as: integration-test

--- a/ci-operator/config/openshift/aws-account-operator/openshift-aws-account-operator-master.yaml
+++ b/ci-operator/config/openshift/aws-account-operator/openshift-aws-account-operator-master.yaml
@@ -58,6 +58,7 @@ tests:
 - as: prek
   commands: |
     export PREK_HOME=/tmp/prek
+    cd /go/src/github.com/openshift/aws-account-operator
     git init
     git add -A
     if [ -x hack/ci.sh ]; then

--- a/ci-operator/jobs/openshift/aws-account-operator/openshift-aws-account-operator-master-presubmits.yaml
+++ b/ci-operator/jobs/openshift/aws-account-operator/openshift-aws-account-operator-master-presubmits.yaml
@@ -277,6 +277,68 @@ presubmits:
     - ^master$
     - ^master-
     cluster: build06
+    context: ci/prow/prek
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-aws-account-operator-master-prek
+    rerun_command: /test prek
+    skip_if_only_changed: ^(?:\.tekton|\.github)|\.md$|^(?:\.gitignore|OWNERS|LICENSE)$
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=prek
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )prek,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^master$
+    - ^master-
+    cluster: build06
     context: ci/prow/test
     decorate: true
     labels:


### PR DESCRIPTION
Add prek-based pre-commit validation to aws-account-operator CI pipeline.

## Changes

- Add `prek-runner` image that builds on top of `aws-account-operator` image
  - Installs git and prek from release pinned in `.prek-version`
- Add `prek` test that runs `hack/ci.sh` (or falls back to `prek run --all-files`)
- Configure test to skip for documentation-only changes

## Dependencies

- Requires aws-account-operator https://github.com/openshift/aws-account-operator/pull/975 to be merged first (provides `.prek-version` and `hack/ci.sh`)

## Testing

The prek test will run automatically in CI once this PR is merged and aws-account-operator has the prek infrastructure in place.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI updated to add a dedicated "prek-runner" build image to improve isolation and consistency of job execution.

* **Tests**
  * Added a new CI test step that prepares a temporary workspace and runs the project's test script if present, otherwise falling back to an automated fallback runner to ensure broader, more reliable test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->