### PR TITLE
4.23 informers

### DIFF
--- a/core-services/release-controller/_releases/priv/release-ocp-4.23.json
+++ b/core-services/release-controller/_releases/priv/release-ocp-4.23.json
@@ -117,15 +117,6 @@
                 "name": "periodic-ci-openshift-hypershift-release-4.23-periodics-e2e-aws-ovn-conformance-priv"
             }
         },
-        "install-analysis-all": {
-            "disabled": true,
-            "maxRetries": 2,
-            "multiJobAnalysis": true,
-            "optional": true,
-            "prowJob": {
-                "name": "periodic-ci-openshift-release-main-nightly-4.23-install-analysis-all-priv"
-            }
-        },
         "metal-ipi-ovn-ipv4": {
             "disabled": true,
             "maxRetries": 1,
@@ -140,15 +131,6 @@
             "optional": true,
             "prowJob": {
                 "name": "periodic-ci-openshift-release-main-nightly-4.23-e2e-metal-ipi-ovn-ipv6-priv"
-            }
-        },
-        "overall-analysis-all": {
-            "disabled": true,
-            "maxRetries": 2,
-            "multiJobAnalysis": true,
-            "optional": true,
-            "prowJob": {
-                "name": "periodic-ci-openshift-release-main-nightly-4.23-overall-analysis-all-priv"
             }
         }
     }

--- a/core-services/release-controller/_releases/priv/release-ocp-4.23.json
+++ b/core-services/release-controller/_releases/priv/release-ocp-4.23.json
@@ -10,5 +10,146 @@
     "pullSecretName": "source",
     "referenceMode": "source",
     "to": "release-priv",
-    "verify": {}
+    "verify": {
+        "aws-ovn-serial-1of2": {
+            "disabled": true,
+            "maxRetries": 1,
+            "optional": true,
+            "prowJob": {
+                "name": "periodic-ci-openshift-release-main-nightly-4.23-e2e-aws-ovn-serial-1of2-priv"
+            }
+        },
+        "aws-ovn-serial-2of2": {
+            "disabled": true,
+            "maxRetries": 1,
+            "optional": true,
+            "prowJob": {
+                "name": "periodic-ci-openshift-release-main-nightly-4.23-e2e-aws-ovn-serial-2of2-priv"
+            }
+        },
+        "aws-ovn-single-node-upgrade-4.23-micro": {
+            "disabled": true,
+            "maxRetries": 2,
+            "optional": true,
+            "prowJob": {
+                "name": "periodic-ci-openshift-release-main-ci-4.23-e2e-aws-upgrade-ovn-single-node-priv"
+            },
+            "upgrade": true
+        },
+        "aws-ovn-techpreview": {
+            "disabled": true,
+            "maxRetries": 1,
+            "optional": true,
+            "prowJob": {
+                "name": "periodic-ci-openshift-release-main-ci-4.23-e2e-aws-ovn-techpreview-priv"
+            }
+        },
+        "aws-ovn-techpreview-serial-1of3": {
+            "disabled": true,
+            "maxRetries": 1,
+            "optional": true,
+            "prowJob": {
+                "name": "periodic-ci-openshift-release-main-ci-4.23-e2e-aws-ovn-techpreview-serial-1of3-priv"
+            }
+        },
+        "aws-ovn-techpreview-serial-2of3": {
+            "disabled": true,
+            "maxRetries": 1,
+            "optional": true,
+            "prowJob": {
+                "name": "periodic-ci-openshift-release-main-ci-4.23-e2e-aws-ovn-techpreview-serial-2of3-priv"
+            }
+        },
+        "aws-ovn-techpreview-serial-3of3": {
+            "disabled": true,
+            "maxRetries": 1,
+            "optional": true,
+            "prowJob": {
+                "name": "periodic-ci-openshift-release-main-ci-4.23-e2e-aws-ovn-techpreview-serial-3of3-priv"
+            }
+        },
+        "aws-ovn-upgrade-4.23-micro-fips": {
+            "disabled": true,
+            "maxRetries": 2,
+            "optional": true,
+            "prowJob": {
+                "name": "periodic-ci-openshift-release-main-nightly-4.23-e2e-aws-ovn-upgrade-fips-priv"
+            },
+            "upgrade": true
+        },
+        "azure-ovn-upgrade-4.23-micro": {
+            "disabled": true,
+            "maxRetries": 2,
+            "optional": true,
+            "prowJob": {
+                "name": "periodic-ci-openshift-release-main-ci-4.23-e2e-azure-ovn-upgrade-priv"
+            },
+            "upgrade": true
+        },
+        "fips-scan": {
+            "disabled": true,
+            "maxRetries": 2,
+            "optional": true,
+            "prowJob": {
+                "name": "periodic-ci-openshift-release-main-nightly-4.23-fips-payload-scan-priv"
+            }
+        },
+        "gcp-ovn-rt-upgrade-4.23-minor": {
+            "disabled": true,
+            "maxRetries": 2,
+            "optional": true,
+            "prowJob": {
+                "name": "periodic-ci-openshift-release-main-ci-4.23-upgrade-from-stable-4.22-e2e-gcp-ovn-rt-upgrade-priv"
+            },
+            "upgrade": true,
+            "upgradeFromRelease": {
+                "candidate": {
+                    "stream": "nightly",
+                    "version": "4.22"
+                }
+            }
+        },
+        "hypershift-ovn-conformance-4.23": {
+            "disabled": true,
+            "maxRetries": 2,
+            "optional": true,
+            "prowJob": {
+                "name": "periodic-ci-openshift-hypershift-release-4.23-periodics-e2e-aws-ovn-conformance-priv"
+            }
+        },
+        "install-analysis-all": {
+            "disabled": true,
+            "maxRetries": 2,
+            "multiJobAnalysis": true,
+            "optional": true,
+            "prowJob": {
+                "name": "periodic-ci-openshift-release-main-nightly-4.23-install-analysis-all-priv"
+            }
+        },
+        "metal-ipi-ovn-ipv4": {
+            "disabled": true,
+            "maxRetries": 1,
+            "optional": true,
+            "prowJob": {
+                "name": "periodic-ci-openshift-release-main-nightly-4.23-e2e-metal-ipi-ovn-ipv4-priv"
+            }
+        },
+        "metal-ipi-ovn-ipv6": {
+            "disabled": true,
+            "maxRetries": 1,
+            "optional": true,
+            "prowJob": {
+                "name": "periodic-ci-openshift-release-main-nightly-4.23-e2e-metal-ipi-ovn-ipv6-priv"
+            }
+        },
+        "overall-analysis-all": {
+            "disabled": true,
+            "maxRetries": 2,
+            "multiJobAnalysis": true,
+            "optional": true,
+            "prowJob": {
+                "name": "periodic-ci-openshift-release-main-nightly-4.23-overall-analysis-all-priv"
+            }
+        }
+    }
 }

--- a/core-services/release-controller/_releases/release-ocp-4.23-ci.json
+++ b/core-services/release-controller/_releases/release-ocp-4.23-ci.json
@@ -17,5 +17,58 @@
       }
     }
   },
-  "verify": {}
+  "verify": {
+    "aws-ovn-upgrade-4.23-minor": {
+      "optional": true,
+      "maxRetries": 2,
+      "prowJob": {
+        "name": "periodic-ci-openshift-release-main-ci-4.23-upgrade-from-stable-4.22-e2e-aws-ovn-upgrade"
+      },
+      "upgrade": true,
+      "upgradeFromRelease": {
+        "candidate": {
+          "stream": "ci",
+          "version": "4.22"
+        }
+      }
+    },
+    "azure-ovn-upgrade-4.23-minor": {
+      "optional": true,
+      "maxRetries": 2,
+      "prowJob": {
+        "name": "periodic-ci-openshift-release-main-ci-4.23-upgrade-from-stable-4.22-e2e-azure-ovn-upgrade"
+      },
+      "upgrade": true,
+      "upgradeFromRelease": {
+        "candidate": {
+          "stream": "ci",
+          "version": "4.22"
+        }
+      }
+    },
+    "gcp-ovn-upgrade-4.23-micro": {
+      "optional": true,
+      "maxRetries": 2,
+      "prowJob": {
+        "name": "periodic-ci-openshift-release-main-ci-4.23-e2e-gcp-ovn-upgrade"
+      },
+      "upgrade": true
+    },
+    "hypershift-e2e-aws": {
+      "optional": true,
+      "maxRetries": 1,
+      "prowJob": {
+        "name": "periodic-ci-openshift-hypershift-release-4.23-periodics-e2e-aws-ovn"
+      },
+      "upgrade": true
+    },
+    "hypershift-e2e-aks": {
+      "optional": true,
+      "maxRetries": 1,
+      "prowJob": {
+        "name": "periodic-ci-openshift-hypershift-release-4.23-periodics-e2e-aks"
+      },
+      "upgrade": true
+    }
+  }
 }

--- a/core-services/release-controller/_releases/release-ocp-4.23.json
+++ b/core-services/release-controller/_releases/release-ocp-4.23.json
@@ -17,5 +17,130 @@
       }
     }
   },
-  "verify": {}
+  "verify": {
+    "aws-ovn-upgrade-4.23-micro-fips": {
+      "optional": true,
+      "maxRetries": 2,
+      "prowJob": {
+        "name": "periodic-ci-openshift-release-main-nightly-4.23-e2e-aws-ovn-upgrade-fips"
+      },
+      "upgrade": true
+    },
+    "azure-ovn-upgrade-4.23-micro": {
+      "optional": true,
+      "maxRetries": 2,
+      "prowJob": {
+        "name": "periodic-ci-openshift-release-main-ci-4.23-e2e-azure-ovn-upgrade"
+      },
+      "upgrade": true
+    },
+    "gcp-ovn-rt-upgrade-4.23-minor": {
+      "optional": true,
+      "maxRetries": 2,
+      "prowJob": {
+        "name": "periodic-ci-openshift-release-main-ci-4.23-upgrade-from-stable-4.22-e2e-gcp-ovn-rt-upgrade"
+      },
+      "upgrade": true,
+      "upgradeFromRelease": {
+        "candidate": {
+          "stream": "nightly",
+          "version": "4.22"
+        }
+      }
+    },
+    "hypershift-ovn-conformance-4.23": {
+      "optional": true,
+      "maxRetries": 2,
+      "prowJob": {
+        "name": "periodic-ci-openshift-hypershift-release-4.23-periodics-e2e-aws-ovn-conformance"
+      }
+    },
+    "aws-ovn-single-node-upgrade-4.23-micro": {
+      "optional": true,
+      "maxRetries": 2,
+      "prowJob": {
+        "name": "periodic-ci-openshift-release-main-ci-4.23-e2e-aws-upgrade-ovn-single-node"
+      },
+      "upgrade": true
+    },
+    "aws-ovn-serial-1of2": {
+      "optional": true,
+      "maxRetries": 1,
+      "prowJob": {
+        "name": "periodic-ci-openshift-release-main-nightly-4.23-e2e-aws-ovn-serial-1of2"
+      }
+    },
+    "aws-ovn-serial-2of2": {
+      "optional": true,
+      "maxRetries": 1,
+      "prowJob": {
+        "name": "periodic-ci-openshift-release-main-nightly-4.23-e2e-aws-ovn-serial-2of2"
+      }
+    },
+    "aws-ovn-techpreview": {
+      "optional": true,
+      "maxRetries": 1,
+      "prowJob": {
+        "name": "periodic-ci-openshift-release-main-ci-4.23-e2e-aws-ovn-techpreview"
+      }
+    },
+    "aws-ovn-techpreview-serial-1of3": {
+      "optional": true,
+      "maxRetries": 1,
+      "prowJob": {
+        "name": "periodic-ci-openshift-release-main-ci-4.23-e2e-aws-ovn-techpreview-serial-1of3"
+      }
+    },
+    "aws-ovn-techpreview-serial-2of3": {
+      "optional": true,
+      "maxRetries": 1,
+      "prowJob": {
+        "name": "periodic-ci-openshift-release-main-ci-4.23-e2e-aws-ovn-techpreview-serial-2of3"
+      }
+    },
+    "aws-ovn-techpreview-serial-3of3": {
+      "optional": true,
+      "maxRetries": 1,
+      "prowJob": {
+        "name": "periodic-ci-openshift-release-main-ci-4.23-e2e-aws-ovn-techpreview-serial-3of3"
+      }
+    },
+    "install-analysis-all": {
+      "optional": true,
+      "maxRetries": 2,
+      "multiJobAnalysis": true,
+      "prowJob": {
+        "name": "periodic-ci-openshift-release-main-nightly-4.23-install-analysis-all"
+      }
+    },
+    "metal-ipi-ovn-ipv6": {
+      "optional": true,
+      "maxRetries": 1,
+      "prowJob": {
+        "name": "periodic-ci-openshift-release-main-nightly-4.23-e2e-metal-ipi-ovn-ipv6"
+      }
+    },
+    "metal-ipi-ovn-ipv4": {
+      "optional": true,
+      "maxRetries": 1,
+      "prowJob": {
+        "name": "periodic-ci-openshift-release-main-nightly-4.23-e2e-metal-ipi-ovn-ipv4"
+      }
+    },
+    "overall-analysis-all": {
+      "optional": true,
+      "maxRetries": 2,
+      "multiJobAnalysis": true,
+      "prowJob": {
+        "name": "periodic-ci-openshift-release-main-nightly-4.23-overall-analysis-all"
+      }
+    },
+    "fips-scan": {
+      "optional": true,
+      "maxRetries": 2,
+      "prowJob": {
+        "name": "periodic-ci-openshift-release-main-nightly-4.23-fips-payload-scan"
+      }
+    }
+  }
 }

--- a/core-services/release-controller/_releases/release-ocp-4.23.json
+++ b/core-services/release-controller/_releases/release-ocp-4.23.json
@@ -105,14 +105,6 @@
         "name": "periodic-ci-openshift-release-main-ci-4.23-e2e-aws-ovn-techpreview-serial-3of3"
       }
     },
-    "install-analysis-all": {
-      "optional": true,
-      "maxRetries": 2,
-      "multiJobAnalysis": true,
-      "prowJob": {
-        "name": "periodic-ci-openshift-release-main-nightly-4.23-install-analysis-all"
-      }
-    },
     "metal-ipi-ovn-ipv6": {
       "optional": true,
       "maxRetries": 1,
@@ -125,14 +117,6 @@
       "maxRetries": 1,
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-nightly-4.23-e2e-metal-ipi-ovn-ipv4"
-      }
-    },
-    "overall-analysis-all": {
-      "optional": true,
-      "maxRetries": 2,
-      "multiJobAnalysis": true,
-      "prowJob": {
-        "name": "periodic-ci-openshift-release-main-nightly-4.23-overall-analysis-all"
       }
     },
     "fips-scan": {


### PR DESCRIPTION
Start priming 4.23 payload validation using historically blocking jobs configured as informing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded release verification for OCP 4.23 with multiple new optional upgrade and conformance checks across AWS, Azure, GCP and bare-metal.
  * Added targeted upgrade testing from 4.22 for CI/nightly candidates, FIPS compliance scans, varied networking scenarios (OVN IPv4/IPv6, serial partitions, single-node), and tuned per-check retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->