### PR TITLE
MGMT-23627: [EXPERIMENT] add post-failure diagnostics to golden test step

### DIFF
--- a/ci-operator/config/osac-project/osac-installer/osac-project-osac-installer-main.yaml
+++ b/ci-operator/config/osac-project/osac-installer/osac-project-osac-installer-main.yaml
@@ -230,6 +230,78 @@ tests:
         OPENSHIFT_VERSION=4.20
       TEST: test_virtual_network_lifecycle.py
     workflow: osac-project-ofcir-baremetal
+- as: e2e-metal-vmaas-compute-instance-creation-golden
+  capabilities:
+  - intranet
+  run_if_changed: ^(base/|overlays/|scripts/|prerequisites/)
+  steps:
+    cluster_profile: packet-assisted
+    env:
+      TEST: test_compute_instance_creation.py
+    workflow: osac-project-golden-baremetal
+- as: e2e-metal-vmaas-compute-instance-api-fields-golden
+  capabilities:
+  - intranet
+  run_if_changed: ^(base/|overlays/|scripts/|prerequisites/)
+  steps:
+    cluster_profile: packet-assisted
+    env:
+      TEST: test_compute_instance_api_fields.py
+    workflow: osac-project-golden-baremetal
+- as: e2e-metal-vmaas-compute-instance-cli-fields-golden
+  capabilities:
+  - intranet
+  run_if_changed: ^(base/|overlays/|scripts/|prerequisites/)
+  steps:
+    cluster_profile: packet-assisted
+    env:
+      TEST: test_compute_instance_cli_fields.py
+    workflow: osac-project-golden-baremetal
+- as: e2e-metal-vmaas-ci-delete-during-provision-golden
+  capabilities:
+  - intranet
+  run_if_changed: ^(base/|overlays/|scripts/|prerequisites/)
+  steps:
+    cluster_profile: packet-assisted
+    env:
+      TEST: test_compute_instance_delete_during_provision.py
+    workflow: osac-project-golden-baremetal
+- as: e2e-metal-vmaas-compute-instance-restart-golden
+  capabilities:
+  - intranet
+  run_if_changed: ^(base/|overlays/|scripts/|prerequisites/)
+  steps:
+    cluster_profile: packet-assisted
+    env:
+      TEST: test_compute_instance_restart.py
+    workflow: osac-project-golden-baremetal
+- as: e2e-metal-vmaas-compute-instance-restart-negative-golden
+  capabilities:
+  - intranet
+  run_if_changed: ^(base/|overlays/|scripts/|prerequisites/)
+  steps:
+    cluster_profile: packet-assisted
+    env:
+      TEST: test_compute_instance_restart_negative.py
+    workflow: osac-project-golden-baremetal
+- as: e2e-metal-vmaas-subnet-lifecycle-golden
+  capabilities:
+  - intranet
+  run_if_changed: ^(base/|overlays/|scripts/|prerequisites/)
+  steps:
+    cluster_profile: packet-assisted
+    env:
+      TEST: test_subnet_lifecycle.py
+    workflow: osac-project-golden-baremetal
+- as: e2e-metal-vmaas-virtual-network-lifecycle-golden
+  capabilities:
+  - intranet
+  run_if_changed: ^(base/|overlays/|scripts/|prerequisites/)
+  steps:
+    cluster_profile: packet-assisted
+    env:
+      TEST: test_virtual_network_lifecycle.py
+    workflow: osac-project-golden-baremetal
 zz_generated_metadata:
   branch: main
   org: osac-project

--- a/ci-operator/config/osac-project/osac-test-infra/osac-project-osac-test-infra-main.yaml
+++ b/ci-operator/config/osac-project/osac-test-infra/osac-project-osac-test-infra-main.yaml
@@ -202,6 +202,78 @@ tests:
         OPENSHIFT_VERSION=4.20
       TEST: test_virtual_network_lifecycle.py
     workflow: osac-project-ofcir-baremetal
+- as: e2e-metal-vmaas-compute-instance-creation-golden
+  capabilities:
+  - intranet
+  cron: 0 4 * * 1
+  steps:
+    cluster_profile: packet-assisted
+    env:
+      TEST: test_compute_instance_creation.py
+    workflow: osac-project-golden-baremetal
+- as: e2e-metal-vmaas-compute-instance-api-fields-golden
+  capabilities:
+  - intranet
+  cron: 0 8 * * 1
+  steps:
+    cluster_profile: packet-assisted
+    env:
+      TEST: test_compute_instance_api_fields.py
+    workflow: osac-project-golden-baremetal
+- as: e2e-metal-vmaas-compute-instance-cli-fields-golden
+  capabilities:
+  - intranet
+  cron: 0 4 * * 2
+  steps:
+    cluster_profile: packet-assisted
+    env:
+      TEST: test_compute_instance_cli_fields.py
+    workflow: osac-project-golden-baremetal
+- as: e2e-metal-vmaas-ci-delete-during-provision-golden
+  capabilities:
+  - intranet
+  cron: 0 8 * * 2
+  steps:
+    cluster_profile: packet-assisted
+    env:
+      TEST: test_compute_instance_delete_during_provision.py
+    workflow: osac-project-golden-baremetal
+- as: e2e-metal-vmaas-compute-instance-restart-golden
+  capabilities:
+  - intranet
+  cron: 0 4 * * 3
+  steps:
+    cluster_profile: packet-assisted
+    env:
+      TEST: test_compute_instance_restart.py
+    workflow: osac-project-golden-baremetal
+- as: e2e-metal-vmaas-compute-instance-restart-negative-golden
+  capabilities:
+  - intranet
+  cron: 0 8 * * 3
+  steps:
+    cluster_profile: packet-assisted
+    env:
+      TEST: test_compute_instance_restart_negative.py
+    workflow: osac-project-golden-baremetal
+- as: e2e-metal-vmaas-subnet-lifecycle-golden
+  capabilities:
+  - intranet
+  cron: 0 4 * * 4
+  steps:
+    cluster_profile: packet-assisted
+    env:
+      TEST: test_subnet_lifecycle.py
+    workflow: osac-project-golden-baremetal
+- as: e2e-metal-vmaas-virtual-network-lifecycle-golden
+  capabilities:
+  - intranet
+  cron: 0 8 * * 4
+  steps:
+    cluster_profile: packet-assisted
+    env:
+      TEST: test_virtual_network_lifecycle.py
+    workflow: osac-project-golden-baremetal
 zz_generated_metadata:
   branch: main
   org: osac-project

--- a/ci-operator/jobs/osac-project/osac-installer/osac-project-osac-installer-main-presubmits.yaml
+++ b/ci-operator/jobs/osac-project/osac-installer/osac-project-osac-installer-main-presubmits.yaml
@@ -5,7 +5,92 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build03
+    cluster: build11
+    context: ci/prow/e2e-metal-vmaas-ci-delete-during-provision-golden
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      capability/intranet: intranet
+      ci-operator.openshift.io/cloud: packet-edge
+      ci-operator.openshift.io/cloud-cluster-profile: packet-assisted
+      ci.openshift.io/generator: prowgen
+      job-release: "4.20"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-osac-project-osac-installer-main-e2e-metal-vmaas-ci-delete-during-provision-golden
+    rerun_command: /test e2e-metal-vmaas-ci-delete-during-provision-golden
+    run_if_changed: ^(base/|overlays/|scripts/|prerequisites/)
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-metal-vmaas-ci-delete-during-provision-golden
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-metal-vmaas-ci-delete-during-provision-golden,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build11
     context: ci/prow/e2e-metal-vmaas-compute-instance-api-fields
     decorate: true
     decoration_config:
@@ -90,7 +175,92 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build03
+    cluster: build11
+    context: ci/prow/e2e-metal-vmaas-compute-instance-api-fields-golden
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      capability/intranet: intranet
+      ci-operator.openshift.io/cloud: packet-edge
+      ci-operator.openshift.io/cloud-cluster-profile: packet-assisted
+      ci.openshift.io/generator: prowgen
+      job-release: "4.20"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-osac-project-osac-installer-main-e2e-metal-vmaas-compute-instance-api-fields-golden
+    rerun_command: /test e2e-metal-vmaas-compute-instance-api-fields-golden
+    run_if_changed: ^(base/|overlays/|scripts/|prerequisites/)
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-metal-vmaas-compute-instance-api-fields-golden
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-metal-vmaas-compute-instance-api-fields-golden,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build11
     context: ci/prow/e2e-metal-vmaas-compute-instance-cli-fields
     decorate: true
     decoration_config:
@@ -175,7 +345,92 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build03
+    cluster: build11
+    context: ci/prow/e2e-metal-vmaas-compute-instance-cli-fields-golden
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      capability/intranet: intranet
+      ci-operator.openshift.io/cloud: packet-edge
+      ci-operator.openshift.io/cloud-cluster-profile: packet-assisted
+      ci.openshift.io/generator: prowgen
+      job-release: "4.20"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-osac-project-osac-installer-main-e2e-metal-vmaas-compute-instance-cli-fields-golden
+    rerun_command: /test e2e-metal-vmaas-compute-instance-cli-fields-golden
+    run_if_changed: ^(base/|overlays/|scripts/|prerequisites/)
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-metal-vmaas-compute-instance-cli-fields-golden
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-metal-vmaas-compute-instance-cli-fields-golden,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build11
     context: ci/prow/e2e-metal-vmaas-compute-instance-creation
     decorate: true
     decoration_config:
@@ -260,7 +515,92 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build03
+    cluster: build11
+    context: ci/prow/e2e-metal-vmaas-compute-instance-creation-golden
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      capability/intranet: intranet
+      ci-operator.openshift.io/cloud: packet-edge
+      ci-operator.openshift.io/cloud-cluster-profile: packet-assisted
+      ci.openshift.io/generator: prowgen
+      job-release: "4.20"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-osac-project-osac-installer-main-e2e-metal-vmaas-compute-instance-creation-golden
+    rerun_command: /test e2e-metal-vmaas-compute-instance-creation-golden
+    run_if_changed: ^(base/|overlays/|scripts/|prerequisites/)
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-metal-vmaas-compute-instance-creation-golden
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-metal-vmaas-compute-instance-creation-golden,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build11
     context: ci/prow/e2e-metal-vmaas-compute-instance-delete-during-provision
     decorate: true
     decoration_config:
@@ -345,7 +685,7 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build03
+    cluster: build11
     context: ci/prow/e2e-metal-vmaas-compute-instance-restart
     decorate: true
     decoration_config:
@@ -430,7 +770,92 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build03
+    cluster: build11
+    context: ci/prow/e2e-metal-vmaas-compute-instance-restart-golden
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      capability/intranet: intranet
+      ci-operator.openshift.io/cloud: packet-edge
+      ci-operator.openshift.io/cloud-cluster-profile: packet-assisted
+      ci.openshift.io/generator: prowgen
+      job-release: "4.20"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-osac-project-osac-installer-main-e2e-metal-vmaas-compute-instance-restart-golden
+    rerun_command: /test e2e-metal-vmaas-compute-instance-restart-golden
+    run_if_changed: ^(base/|overlays/|scripts/|prerequisites/)
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-metal-vmaas-compute-instance-restart-golden
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-metal-vmaas-compute-instance-restart-golden,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build11
     context: ci/prow/e2e-metal-vmaas-compute-instance-restart-negative
     decorate: true
     decoration_config:
@@ -515,7 +940,92 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build03
+    cluster: build11
+    context: ci/prow/e2e-metal-vmaas-compute-instance-restart-negative-golden
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      capability/intranet: intranet
+      ci-operator.openshift.io/cloud: packet-edge
+      ci-operator.openshift.io/cloud-cluster-profile: packet-assisted
+      ci.openshift.io/generator: prowgen
+      job-release: "4.20"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-osac-project-osac-installer-main-e2e-metal-vmaas-compute-instance-restart-negative-golden
+    rerun_command: /test e2e-metal-vmaas-compute-instance-restart-negative-golden
+    run_if_changed: ^(base/|overlays/|scripts/|prerequisites/)
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-metal-vmaas-compute-instance-restart-negative-golden
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-metal-vmaas-compute-instance-restart-negative-golden,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build11
     context: ci/prow/e2e-metal-vmaas-subnet-lifecycle
     decorate: true
     decoration_config:
@@ -600,7 +1110,92 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build03
+    cluster: build11
+    context: ci/prow/e2e-metal-vmaas-subnet-lifecycle-golden
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      capability/intranet: intranet
+      ci-operator.openshift.io/cloud: packet-edge
+      ci-operator.openshift.io/cloud-cluster-profile: packet-assisted
+      ci.openshift.io/generator: prowgen
+      job-release: "4.20"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-osac-project-osac-installer-main-e2e-metal-vmaas-subnet-lifecycle-golden
+    rerun_command: /test e2e-metal-vmaas-subnet-lifecycle-golden
+    run_if_changed: ^(base/|overlays/|scripts/|prerequisites/)
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-metal-vmaas-subnet-lifecycle-golden
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-metal-vmaas-subnet-lifecycle-golden,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build11
     context: ci/prow/e2e-metal-vmaas-virtual-network-lifecycle
     decorate: true
     decoration_config:
@@ -680,6 +1275,91 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-metal-vmaas-virtual-network-lifecycle,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build11
+    context: ci/prow/e2e-metal-vmaas-virtual-network-lifecycle-golden
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      capability/intranet: intranet
+      ci-operator.openshift.io/cloud: packet-edge
+      ci-operator.openshift.io/cloud-cluster-profile: packet-assisted
+      ci.openshift.io/generator: prowgen
+      job-release: "4.20"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-osac-project-osac-installer-main-e2e-metal-vmaas-virtual-network-lifecycle-golden
+    rerun_command: /test e2e-metal-vmaas-virtual-network-lifecycle-golden
+    run_if_changed: ^(base/|overlays/|scripts/|prerequisites/)
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-metal-vmaas-virtual-network-lifecycle-golden
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-metal-vmaas-virtual-network-lifecycle-golden,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/osac-project/osac-test-infra/osac-project-osac-test-infra-main-periodics.yaml
+++ b/ci-operator/jobs/osac-project/osac-test-infra/osac-project-osac-test-infra-main-periodics.yaml
@@ -1,6 +1,88 @@
 periodics:
 - agent: kubernetes
-  cluster: build03
+  cluster: build11
+  cron: 0 8 * * 2
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: osac-project
+    repo: osac-test-infra
+  labels:
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: packet-edge
+    ci-operator.openshift.io/cloud-cluster-profile: packet-assisted
+    ci.openshift.io/generator: prowgen
+    job-release: "4.20"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-osac-project-osac-test-infra-main-e2e-metal-vmaas-ci-delete-during-provision-golden
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-metal-vmaas-ci-delete-during-provision-golden
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build11
   cron: 0 6 * * 1
   decorate: true
   decoration_config:
@@ -82,7 +164,89 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build03
+  cluster: build11
+  cron: 0 8 * * 1
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: osac-project
+    repo: osac-test-infra
+  labels:
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: packet-edge
+    ci-operator.openshift.io/cloud-cluster-profile: packet-assisted
+    ci.openshift.io/generator: prowgen
+    job-release: "4.20"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-osac-project-osac-test-infra-main-e2e-metal-vmaas-compute-instance-api-fields-golden
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-metal-vmaas-compute-instance-api-fields-golden
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build11
   cron: 0 2 * * 2
   decorate: true
   decoration_config:
@@ -164,7 +328,89 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build03
+  cluster: build11
+  cron: 0 4 * * 2
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: osac-project
+    repo: osac-test-infra
+  labels:
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: packet-edge
+    ci-operator.openshift.io/cloud-cluster-profile: packet-assisted
+    ci.openshift.io/generator: prowgen
+    job-release: "4.20"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-osac-project-osac-test-infra-main-e2e-metal-vmaas-compute-instance-cli-fields-golden
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-metal-vmaas-compute-instance-cli-fields-golden
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build11
   cron: 0 2 * * 1
   decorate: true
   decoration_config:
@@ -246,7 +492,89 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build03
+  cluster: build11
+  cron: 0 4 * * 1
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: osac-project
+    repo: osac-test-infra
+  labels:
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: packet-edge
+    ci-operator.openshift.io/cloud-cluster-profile: packet-assisted
+    ci.openshift.io/generator: prowgen
+    job-release: "4.20"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-osac-project-osac-test-infra-main-e2e-metal-vmaas-compute-instance-creation-golden
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-metal-vmaas-compute-instance-creation-golden
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build11
   cron: 0 6 * * 2
   decorate: true
   decoration_config:
@@ -328,7 +656,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build03
+  cluster: build11
   cron: 0 2 * * 3
   decorate: true
   decoration_config:
@@ -410,7 +738,89 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build03
+  cluster: build11
+  cron: 0 4 * * 3
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: osac-project
+    repo: osac-test-infra
+  labels:
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: packet-edge
+    ci-operator.openshift.io/cloud-cluster-profile: packet-assisted
+    ci.openshift.io/generator: prowgen
+    job-release: "4.20"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-osac-project-osac-test-infra-main-e2e-metal-vmaas-compute-instance-restart-golden
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-metal-vmaas-compute-instance-restart-golden
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build11
   cron: 0 6 * * 3
   decorate: true
   decoration_config:
@@ -492,7 +902,89 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build03
+  cluster: build11
+  cron: 0 8 * * 3
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: osac-project
+    repo: osac-test-infra
+  labels:
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: packet-edge
+    ci-operator.openshift.io/cloud-cluster-profile: packet-assisted
+    ci.openshift.io/generator: prowgen
+    job-release: "4.20"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-osac-project-osac-test-infra-main-e2e-metal-vmaas-compute-instance-restart-negative-golden
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-metal-vmaas-compute-instance-restart-negative-golden
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build11
   cron: 0 2 * * 4
   decorate: true
   decoration_config:
@@ -574,7 +1066,89 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build03
+  cluster: build11
+  cron: 0 4 * * 4
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: osac-project
+    repo: osac-test-infra
+  labels:
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: packet-edge
+    ci-operator.openshift.io/cloud-cluster-profile: packet-assisted
+    ci.openshift.io/generator: prowgen
+    job-release: "4.20"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-osac-project-osac-test-infra-main-e2e-metal-vmaas-subnet-lifecycle-golden
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-metal-vmaas-subnet-lifecycle-golden
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build11
   cron: 0 6 * * 4
   decorate: true
   decoration_config:
@@ -600,6 +1174,88 @@ periodics:
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
       - --target=e2e-metal-vmaas-virtual-network-lifecycle
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build11
+  cron: 0 8 * * 4
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: osac-project
+    repo: osac-test-infra
+  labels:
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: packet-edge
+    ci-operator.openshift.io/cloud-cluster-profile: packet-assisted
+    ci.openshift.io/generator: prowgen
+    job-release: "4.20"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-osac-project-osac-test-infra-main-e2e-metal-vmaas-virtual-network-lifecycle-golden
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-metal-vmaas-virtual-network-lifecycle-golden
       command:
       - ci-operator
       env:

--- a/ci-operator/step-registry/osac-project/golden/OWNERS
+++ b/ci-operator/step-registry/osac-project/golden/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+- osac-cicd
+options: {}
+reviewers:
+- osac-cicd

--- a/ci-operator/step-registry/osac-project/golden/baremetal/OWNERS
+++ b/ci-operator/step-registry/osac-project/golden/baremetal/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+- osac-cicd
+options: {}
+reviewers:
+- osac-cicd

--- a/ci-operator/step-registry/osac-project/golden/baremetal/osac-project-golden-baremetal-workflow.metadata.json
+++ b/ci-operator/step-registry/osac-project/golden/baremetal/osac-project-golden-baremetal-workflow.metadata.json
@@ -1,0 +1,11 @@
+{
+	"path": "osac-project/golden/baremetal/osac-project-golden-baremetal-workflow.yaml",
+	"owners": {
+		"approvers": [
+			"osac-cicd"
+		],
+		"reviewers": [
+			"osac-cicd"
+		]
+	}
+}

--- a/ci-operator/step-registry/osac-project/golden/baremetal/osac-project-golden-baremetal-workflow.yaml
+++ b/ci-operator/step-registry/osac-project/golden/baremetal/osac-project-golden-baremetal-workflow.yaml
@@ -1,0 +1,22 @@
+workflow:
+  as: osac-project-golden-baremetal
+  steps:
+    cluster_profile: packet-assisted
+    allow_best_effort_post_steps: true
+    allow_skip_on_success: true
+    pre:
+      - ref: ofcir-acquire
+      - ref: assisted-ofcir-setup
+      - ref: ipi-install-rbac
+      - ref: osac-project-golden-setup
+    test:
+      - ref: osac-project-golden-test
+    post:
+      - ref: ofcir-gather
+      - ref: ofcir-release
+    env:
+      CLUSTERTYPE: "assisted_medium_el9"
+  documentation: |-
+    Executes OSAC E2E tests using pre-built golden QCOW2 images instead of
+    installing OCP and OSAC from scratch. Acquires a bare metal host via OFCIR,
+    boots golden VMs with pre-installed clusters, and runs the test suite.

--- a/ci-operator/step-registry/osac-project/golden/setup/OWNERS
+++ b/ci-operator/step-registry/osac-project/golden/setup/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+- osac-cicd
+options: {}
+reviewers:
+- osac-cicd

--- a/ci-operator/step-registry/osac-project/golden/setup/osac-project-golden-setup-commands.sh
+++ b/ci-operator/step-registry/osac-project/golden/setup/osac-project-golden-setup-commands.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+echo "Setting up golden image environment"
+
+echo "Merging pull secrets..."
+jq -s '.[0] * .[1]' \
+  "${CLUSTER_PROFILE_DIR}/pull-secret" \
+  "/var/run/vault/brew-registry-redhat-io-pull-secret/pull-secret" \
+  > /tmp/merged-pull-secret
+scp -F "${SHARED_DIR}/ssh_config" /tmp/merged-pull-secret ci_machine:/root/pull-secret
+
+timeout -s 9 35m ssh -F "${SHARED_DIR}/ssh_config" ci_machine bash -s \
+  "${GOLDEN_HUB_IMAGE}" "${GOLDEN_VIRT_IMAGE}" <<'REMOTE_EOF'
+set -euo pipefail
+
+GOLDEN_HUB_IMAGE="$1"
+GOLDEN_VIRT_IMAGE="$2"
+GOLDEN_DIR="/data/golden"
+PULL_SECRET="/root/pull-secret"
+
+dnf install -y libvirt qemu-kvm podman dnsmasq
+systemctl enable --now libvirtd
+
+mkdir -p ~/.config/containers
+cat > ~/.config/containers/containers.conf <<CONFEOF
+[engine]
+image_parallel_copies = 20
+CONFEOF
+
+mkdir -p "${GOLDEN_DIR}/hub" "${GOLDEN_DIR}/virt"
+
+echo "Pulling golden images..."
+podman pull --authfile "${PULL_SECRET}" "${GOLDEN_HUB_IMAGE}" &
+podman pull --authfile "${PULL_SECRET}" "${GOLDEN_VIRT_IMAGE}" &
+wait
+
+echo "Extracting hub..."
+podman create --name golden-hub "${GOLDEN_HUB_IMAGE}"
+podman cp golden-hub:/ "${GOLDEN_DIR}/hub/"
+podman rm golden-hub
+
+echo "Extracting virt..."
+podman create --name golden-virt "${GOLDEN_VIRT_IMAGE}"
+podman cp golden-virt:/ "${GOLDEN_DIR}/virt/"
+podman rm golden-virt
+
+echo "Reassembling QCOW2s from chunks..."
+cat "${GOLDEN_DIR}/hub/hub-os.chunk."* > "${GOLDEN_DIR}/hub/hub-os.qcow2"
+rm -f "${GOLDEN_DIR}/hub/hub-os.chunk."*
+cat "${GOLDEN_DIR}/hub/hub-data.chunk."* > "${GOLDEN_DIR}/hub/hub-data.qcow2"
+rm -f "${GOLDEN_DIR}/hub/hub-data.chunk."*
+cat "${GOLDEN_DIR}/virt/virt-os.chunk."* > "${GOLDEN_DIR}/virt/virt-os.qcow2"
+rm -f "${GOLDEN_DIR}/virt/virt-os.chunk."*
+cat "${GOLDEN_DIR}/virt/virt-data.chunk."* > "${GOLDEN_DIR}/virt/virt-data.qcow2"
+rm -f "${GOLDEN_DIR}/virt/virt-data.chunk."*
+
+echo "Creating networks..."
+virsh net-define "${GOLDEN_DIR}/hub/hub-network.xml"
+virsh net-start test-infra-net-d55276d8
+virsh net-define "${GOLDEN_DIR}/virt/virt-network.xml"
+virsh net-start test-infra-net-ad07fc71
+
+echo "Fixing domain XMLs..."
+python3 "${GOLDEN_DIR}/hub/fix-domain-xml.py" \
+  "${GOLDEN_DIR}/hub/hub-domain.xml" \
+  "${GOLDEN_DIR}/hub/hub-domain-fixed.xml" \
+  "${GOLDEN_DIR}/hub/hub-os.qcow2" \
+  "${GOLDEN_DIR}/hub/hub-data.qcow2" \
+  "osac-extra-disk3" \
+  "test-infra-net-d55276d8"
+
+python3 "${GOLDEN_DIR}/virt/fix-domain-xml.py" \
+  "${GOLDEN_DIR}/virt/virt-domain.xml" \
+  "${GOLDEN_DIR}/virt/virt-domain-fixed.xml" \
+  "${GOLDEN_DIR}/virt/virt-os.qcow2" \
+  "${GOLDEN_DIR}/virt/virt-data.qcow2" \
+  "disk2" \
+  "test-infra-net-ad07fc71"
+
+echo "Configuring DNS for cluster hostnames..."
+cat > /etc/dnsmasq.d/golden-clusters.conf <<DNSEOF
+address=/test-infra-cluster-d55276d8.redhat.com/192.168.131.10
+address=/test-infra-cluster-ad07fc71.redhat.com/192.168.130.10
+DNSEOF
+systemctl enable --now dnsmasq
+echo "nameserver 127.0.0.1" > /etc/resolv.conf.golden
+cat /etc/resolv.conf >> /etc/resolv.conf.golden
+cp /etc/resolv.conf.golden /etc/resolv.conf
+
+echo "Starting VMs..."
+virsh define "${GOLDEN_DIR}/hub/hub-domain-fixed.xml"
+virsh start test-infra-cluster-d55276d8-master-0
+virsh define "${GOLDEN_DIR}/virt/virt-domain-fixed.xml"
+virsh start test-infra-cluster-ad07fc71-master-0
+
+echo "Waiting for cluster APIs and ingress routers..."
+for endpoint in "https://192.168.131.10:6443/readyz" "https://192.168.130.10:6443/readyz" "https://192.168.131.10:443/" "https://192.168.130.10:443/"; do
+  ready=false
+  for i in $(seq 1 60); do
+    if curl -sk --connect-timeout 5 "${endpoint}" 2>/dev/null; then
+      echo "${endpoint} reachable (${i}0s)"
+      ready=true
+      break
+    fi
+    sleep 10
+  done
+  if [[ "${ready}" != "true" ]]; then
+    echo "ERROR: ${endpoint} did not become reachable within 600 seconds"
+    exit 1
+  fi
+done
+
+echo "Waiting for OSAC fulfillment service..."
+ready=false
+for i in $(seq 1 60); do
+  if code=$(curl -sk --connect-timeout 5 -o /dev/null -w '%{http_code}' \
+    https://fulfillment-api-osac-e2e-ci.apps.test-infra-cluster-d55276d8.redhat.com/); then
+    if [[ "${code}" != "503" ]]; then
+      echo "Fulfillment API ready (${i}0s, HTTP ${code})"
+      ready=true
+      break
+    fi
+  fi
+  sleep 10
+done
+if [[ "${ready}" != "true" ]]; then
+  echo "ERROR: Fulfillment API did not become ready within 600 seconds"
+  exit 1
+fi
+
+mkdir -p /root/.kube
+cp "${GOLDEN_DIR}/hub/hub-kubeconfig" /root/.kube/config
+cp "${GOLDEN_DIR}/virt/virt-kubeconfig" /root/virt-kubeconfig
+echo 'export KUBECONFIG=/root/.kube/config' >> /root/.bashrc
+
+echo "Golden image setup complete"
+REMOTE_EOF
+
+echo "Copying virt kubeconfig to shared dir..."
+scp -F "${SHARED_DIR}/ssh_config" ci_machine:/root/virt-kubeconfig "${SHARED_DIR}/virt-kubeconfig"
+
+echo "Golden setup complete"

--- a/ci-operator/step-registry/osac-project/golden/setup/osac-project-golden-setup-commands.sh
+++ b/ci-operator/step-registry/osac-project/golden/setup/osac-project-golden-setup-commands.sh
@@ -72,6 +72,18 @@ virsh net-start test-infra-net-d55276d8
 virsh net-define "${GOLDEN_DIR}/virt/virt-network.xml"
 virsh net-start test-infra-net-ad07fc71
 
+echo "$(date +%T) Configuring cross-network forwarding..."
+echo "--- Host firewall state before fix ---"
+iptables -L FORWARD -n 2>&1 | head -5 || true
+firewall-cmd --zone=libvirt --list-all 2>&1 || echo "no firewalld libvirt zone"
+systemctl stop firewalld 2>/dev/null || true
+systemctl disable firewalld 2>/dev/null || true
+iptables -P FORWARD ACCEPT
+iptables -I FORWARD -s 192.168.131.0/24 -d 192.168.130.0/24 -j ACCEPT
+iptables -I FORWARD -s 192.168.130.0/24 -d 192.168.131.0/24 -j ACCEPT
+echo "--- Host firewall state after fix ---"
+iptables -L FORWARD -n 2>&1 | head -10 || true
+
 echo "$(date +%T) Fixing domain XMLs..."
 python3 "${GOLDEN_DIR}/hub/fix-domain-xml.py" \
   "${GOLDEN_DIR}/hub/hub-domain.xml" \
@@ -152,6 +164,15 @@ if [[ "${failed}" -ne 0 ]]; then
 fi
 
 echo "$(date +%T) All endpoints ready"
+
+echo "$(date +%T) Testing cross-VM connectivity (hub -> virt API)..."
+echo "From host:"
+curl -sk --connect-timeout 5 https://192.168.130.10:6443/readyz 2>&1 || echo "FAILED from host"
+echo ""
+echo "From hub VM:"
+ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 core@192.168.131.10 \
+  "curl -sk --connect-timeout 5 https://192.168.130.10:6443/readyz 2>&1" || echo "CROSS-VM CONNECTIVITY FAILED"
+echo ""
 
 mkdir -p /root/.kube
 cp "${GOLDEN_DIR}/hub/hub-kubeconfig" /root/.kube/config

--- a/ci-operator/step-registry/osac-project/golden/setup/osac-project-golden-setup-commands.sh
+++ b/ci-operator/step-registry/osac-project/golden/setup/osac-project-golden-setup-commands.sh
@@ -158,27 +158,68 @@ cp "${GOLDEN_DIR}/hub/hub-kubeconfig" /root/.kube/config
 cp "${GOLDEN_DIR}/virt/virt-kubeconfig" /root/virt-kubeconfig
 echo 'export KUBECONFIG=/root/.kube/config' >> /root/.bashrc
 
-echo "$(date +%T) Checking cluster health..."
-echo "--- Hub cluster pods in osac-e2e-ci namespace ---"
-oc --kubeconfig=/root/.kube/config get pods -n osac-e2e-ci -o wide 2>&1 || true
-echo "--- Hub cluster deployments in osac-e2e-ci namespace ---"
-oc --kubeconfig=/root/.kube/config get deployments -n osac-e2e-ci 2>&1 || true
-echo "--- Hub cluster nodes ---"
-oc --kubeconfig=/root/.kube/config get nodes 2>&1 || true
-echo "--- Hub cluster clusteroperators (degraded) ---"
-oc --kubeconfig=/root/.kube/config get co 2>&1 | grep -E 'NAME|False|True.*True' || true
-echo "--- Virt cluster nodes ---"
-oc --kubeconfig=/root/virt-kubeconfig get nodes 2>&1 || true
-echo "--- Virt cluster KubeVirt status ---"
-oc --kubeconfig=/root/virt-kubeconfig get kubevirt -A 2>&1 || true
-echo "--- Virt cluster pods not ready in openshift-cnv ---"
-oc --kubeconfig=/root/virt-kubeconfig get pods -n openshift-cnv --field-selector=status.phase!=Running 2>&1 || true
+HUB_KC="/root/.kube/config"
+VIRT_KC="/root/virt-kubeconfig"
+
+echo "$(date +%T) Waiting for ingress router..."
+oc --kubeconfig="${HUB_KC}" rollout status deployment/router-default -n openshift-ingress --timeout=300s 2>&1 || true
 
 echo "$(date +%T) Waiting for OSAC deployments to be available..."
-for dep in $(oc --kubeconfig=/root/.kube/config get deployments -n osac-e2e-ci -o name 2>/dev/null); do
+for dep in $(oc --kubeconfig="${HUB_KC}" get deployments -n osac-e2e-ci -o name 2>/dev/null); do
   echo "$(date +%T) Waiting for ${dep}..."
-  oc --kubeconfig=/root/.kube/config rollout status "${dep}" -n osac-e2e-ci --timeout=300s 2>&1 || true
+  oc --kubeconfig="${HUB_KC}" rollout status "${dep}" -n osac-e2e-ci --timeout=300s 2>&1 || true
 done
+
+echo "$(date +%T) Waiting for cluster operators to stabilize..."
+for i in $(seq 1 30); do
+  progressing=$(oc --kubeconfig="${HUB_KC}" get co -o jsonpath='{range .items[*]}{.metadata.name}={.status.conditions[?(@.type=="Progressing")].status}{" "}{end}' 2>/dev/null \
+    | tr ' ' '\n' | grep '=True' || true)
+  if [[ -z "${progressing}" ]]; then
+    echo "$(date +%T) All cluster operators stable (${i}0s)"
+    break
+  fi
+  echo "$(date +%T) Still progressing: ${progressing}"
+  sleep 10
+done
+
+echo "$(date +%T) Waiting for OSAC operator pod to stabilize..."
+for i in $(seq 1 30); do
+  restarts=$(oc --kubeconfig="${HUB_KC}" get pods -n osac-e2e-ci -l control-plane=controller-manager \
+    -o jsonpath='{.items[0].status.containerStatuses[0].restartCount}' 2>/dev/null || echo "-1")
+  ready=$(oc --kubeconfig="${HUB_KC}" get pods -n osac-e2e-ci -l control-plane=controller-manager \
+    -o jsonpath='{.items[0].status.containerStatuses[0].ready}' 2>/dev/null || echo "false")
+  if [[ "${ready}" == "true" ]]; then
+    sleep 10
+    new_restarts=$(oc --kubeconfig="${HUB_KC}" get pods -n osac-e2e-ci -l control-plane=controller-manager \
+      -o jsonpath='{.items[0].status.containerStatuses[0].restartCount}' 2>/dev/null || echo "-1")
+    if [[ "${restarts}" == "${new_restarts}" ]]; then
+      echo "$(date +%T) OSAC operator stable (ready, no restarts in 10s, total restarts: ${restarts})"
+      break
+    fi
+    echo "$(date +%T) OSAC operator restarted (${restarts} -> ${new_restarts}), waiting..."
+  else
+    echo "$(date +%T) OSAC operator not ready yet (restarts: ${restarts})"
+    sleep 10
+  fi
+done
+
+echo "$(date +%T) Cluster health snapshot..."
+echo "--- Hub deployments in osac-e2e-ci ---"
+oc --kubeconfig="${HUB_KC}" get deployments -n osac-e2e-ci 2>&1 || true
+echo "--- Hub pods in osac-e2e-ci ---"
+oc --kubeconfig="${HUB_KC}" get pods -n osac-e2e-ci -o wide 2>&1 || true
+echo "--- Hub cluster operators ---"
+oc --kubeconfig="${HUB_KC}" get co 2>&1 || true
+echo "--- Hub nodes ---"
+oc --kubeconfig="${HUB_KC}" get nodes 2>&1 || true
+echo "--- Virt nodes ---"
+oc --kubeconfig="${VIRT_KC}" get nodes 2>&1 || true
+echo "--- Virt KubeVirt status ---"
+oc --kubeconfig="${VIRT_KC}" get kubevirt -A 2>&1 || true
+echo "--- OSAC operator logs (last 50 lines) ---"
+oc --kubeconfig="${HUB_KC}" logs deployment/osac-operator-controller-manager -n osac-e2e-ci --tail=50 2>&1 || true
+echo "--- Fulfillment controller logs (last 30 lines) ---"
+oc --kubeconfig="${HUB_KC}" logs deployment/fulfillment-controller -n osac-e2e-ci --tail=30 2>&1 || true
 
 echo "$(date +%T) Golden image setup complete"
 REMOTE_EOF

--- a/ci-operator/step-registry/osac-project/golden/setup/osac-project-golden-setup-commands.sh
+++ b/ci-operator/step-registry/osac-project/golden/setup/osac-project-golden-setup-commands.sh
@@ -4,16 +4,16 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
-echo "Setting up golden image environment"
+echo "$(date +%T) Setting up golden image environment"
 
-echo "Merging pull secrets..."
+echo "$(date +%T) Merging pull secrets..."
 jq -s '.[0] * .[1]' \
   "${CLUSTER_PROFILE_DIR}/pull-secret" \
   "/var/run/vault/brew-registry-redhat-io-pull-secret/pull-secret" \
   > /tmp/merged-pull-secret
 scp -F "${SHARED_DIR}/ssh_config" /tmp/merged-pull-secret ci_machine:/root/pull-secret
 
-timeout -s 9 35m ssh -F "${SHARED_DIR}/ssh_config" ci_machine bash -s \
+timeout -s 9 50m ssh -F "${SHARED_DIR}/ssh_config" ci_machine bash -s \
   "${GOLDEN_HUB_IMAGE}" "${GOLDEN_VIRT_IMAGE}" <<'REMOTE_EOF'
 set -euo pipefail
 
@@ -22,6 +22,7 @@ GOLDEN_VIRT_IMAGE="$2"
 GOLDEN_DIR="/data/golden"
 PULL_SECRET="/root/pull-secret"
 
+echo "$(date +%T) Installing packages..."
 dnf install -y libvirt qemu-kvm podman dnsmasq
 systemctl enable --now libvirtd
 
@@ -33,22 +34,24 @@ CONFEOF
 
 mkdir -p "${GOLDEN_DIR}/hub" "${GOLDEN_DIR}/virt"
 
-echo "Pulling golden images..."
+echo "$(date +%T) Pulling golden images..."
 podman pull --authfile "${PULL_SECRET}" "${GOLDEN_HUB_IMAGE}" &
 podman pull --authfile "${PULL_SECRET}" "${GOLDEN_VIRT_IMAGE}" &
 wait
+echo "$(date +%T) Pull complete"
 
-echo "Extracting hub..."
+echo "$(date +%T) Extracting hub..."
 podman create --name golden-hub "${GOLDEN_HUB_IMAGE}"
 podman cp golden-hub:/ "${GOLDEN_DIR}/hub/"
 podman rm golden-hub
 
-echo "Extracting virt..."
+echo "$(date +%T) Extracting virt..."
 podman create --name golden-virt "${GOLDEN_VIRT_IMAGE}"
 podman cp golden-virt:/ "${GOLDEN_DIR}/virt/"
 podman rm golden-virt
+echo "$(date +%T) Extraction complete"
 
-echo "Reassembling QCOW2s from chunks..."
+echo "$(date +%T) Reassembling QCOW2s from chunks..."
 cat "${GOLDEN_DIR}/hub/hub-os.chunk."* > "${GOLDEN_DIR}/hub/hub-os.qcow2"
 rm -f "${GOLDEN_DIR}/hub/hub-os.chunk."*
 cat "${GOLDEN_DIR}/hub/hub-data.chunk."* > "${GOLDEN_DIR}/hub/hub-data.qcow2"
@@ -57,14 +60,15 @@ cat "${GOLDEN_DIR}/virt/virt-os.chunk."* > "${GOLDEN_DIR}/virt/virt-os.qcow2"
 rm -f "${GOLDEN_DIR}/virt/virt-os.chunk."*
 cat "${GOLDEN_DIR}/virt/virt-data.chunk."* > "${GOLDEN_DIR}/virt/virt-data.qcow2"
 rm -f "${GOLDEN_DIR}/virt/virt-data.chunk."*
+echo "$(date +%T) Reassembly complete"
 
-echo "Creating networks..."
+echo "$(date +%T) Creating networks..."
 virsh net-define "${GOLDEN_DIR}/hub/hub-network.xml"
 virsh net-start test-infra-net-d55276d8
 virsh net-define "${GOLDEN_DIR}/virt/virt-network.xml"
 virsh net-start test-infra-net-ad07fc71
 
-echo "Fixing domain XMLs..."
+echo "$(date +%T) Fixing domain XMLs..."
 python3 "${GOLDEN_DIR}/hub/fix-domain-xml.py" \
   "${GOLDEN_DIR}/hub/hub-domain.xml" \
   "${GOLDEN_DIR}/hub/hub-domain-fixed.xml" \
@@ -81,7 +85,7 @@ python3 "${GOLDEN_DIR}/virt/fix-domain-xml.py" \
   "disk2" \
   "test-infra-net-ad07fc71"
 
-echo "Configuring DNS for cluster hostnames..."
+echo "$(date +%T) Configuring DNS for cluster hostnames..."
 cat > /etc/dnsmasq.d/golden-clusters.conf <<DNSEOF
 address=/test-infra-cluster-d55276d8.redhat.com/192.168.131.10
 address=/test-infra-cluster-ad07fc71.redhat.com/192.168.130.10
@@ -91,56 +95,69 @@ echo "nameserver 127.0.0.1" > /etc/resolv.conf.golden
 cat /etc/resolv.conf >> /etc/resolv.conf.golden
 cp /etc/resolv.conf.golden /etc/resolv.conf
 
-echo "Starting VMs..."
+echo "$(date +%T) Starting VMs..."
 virsh define "${GOLDEN_DIR}/hub/hub-domain-fixed.xml"
 virsh start test-infra-cluster-d55276d8-master-0
 virsh define "${GOLDEN_DIR}/virt/virt-domain-fixed.xml"
 virsh start test-infra-cluster-ad07fc71-master-0
 
-echo "Waiting for cluster APIs and ingress routers..."
-for endpoint in "https://192.168.131.10:6443/readyz" "https://192.168.130.10:6443/readyz" "https://192.168.131.10:443/" "https://192.168.130.10:443/"; do
-  ready=false
+echo "$(date +%T) Waiting for all endpoints (parallel)..."
+
+wait_for_endpoint() {
+  local endpoint="$1"
+  local label="$2"
   for i in $(seq 1 60); do
     if curl -sk --connect-timeout 5 "${endpoint}" 2>/dev/null; then
-      echo "${endpoint} reachable (${i}0s)"
-      ready=true
-      break
+      echo "$(date +%T) ${label} reachable (${i}0s)"
+      return 0
     fi
     sleep 10
   done
-  if [[ "${ready}" != "true" ]]; then
-    echo "ERROR: ${endpoint} did not become reachable within 600 seconds"
-    exit 1
-  fi
-done
+  echo "$(date +%T) ERROR: ${label} did not become reachable within 600s"
+  return 1
+}
 
-echo "Waiting for OSAC fulfillment service..."
-ready=false
-for i in $(seq 1 60); do
-  if code=$(curl -sk --connect-timeout 5 -o /dev/null -w '%{http_code}' \
-    https://fulfillment-api-osac-e2e-ci.apps.test-infra-cluster-d55276d8.redhat.com/); then
-    if [[ "${code}" != "503" ]]; then
-      echo "Fulfillment API ready (${i}0s, HTTP ${code})"
-      ready=true
-      break
+wait_for_fulfillment() {
+  for i in $(seq 1 60); do
+    if code=$(curl -sk --connect-timeout 5 -o /dev/null -w '%{http_code}' \
+      https://fulfillment-api-osac-e2e-ci.apps.test-infra-cluster-d55276d8.redhat.com/); then
+      if [[ "${code}" != "503" ]]; then
+        echo "$(date +%T) Fulfillment API ready (${i}0s, HTTP ${code})"
+        return 0
+      fi
     fi
-  fi
-  sleep 10
+    sleep 10
+  done
+  echo "$(date +%T) ERROR: Fulfillment API did not become ready within 600s"
+  return 1
+}
+
+wait_for_endpoint "https://192.168.131.10:6443/readyz" "Hub API (6443)" &
+wait_for_endpoint "https://192.168.130.10:6443/readyz" "Virt API (6443)" &
+wait_for_endpoint "https://192.168.131.10:443/" "Hub ingress (443)" &
+wait_for_endpoint "https://192.168.130.10:443/" "Virt ingress (443)" &
+wait_for_fulfillment &
+
+failed=0
+for pid in $(jobs -p); do
+  wait "${pid}" || failed=1
 done
-if [[ "${ready}" != "true" ]]; then
-  echo "ERROR: Fulfillment API did not become ready within 600 seconds"
+if [[ "${failed}" -ne 0 ]]; then
+  echo "$(date +%T) ERROR: One or more endpoints failed readiness checks"
   exit 1
 fi
+
+echo "$(date +%T) All endpoints ready"
 
 mkdir -p /root/.kube
 cp "${GOLDEN_DIR}/hub/hub-kubeconfig" /root/.kube/config
 cp "${GOLDEN_DIR}/virt/virt-kubeconfig" /root/virt-kubeconfig
 echo 'export KUBECONFIG=/root/.kube/config' >> /root/.bashrc
 
-echo "Golden image setup complete"
+echo "$(date +%T) Golden image setup complete"
 REMOTE_EOF
 
-echo "Copying virt kubeconfig to shared dir..."
+echo "$(date +%T) Copying virt kubeconfig to shared dir..."
 scp -F "${SHARED_DIR}/ssh_config" ci_machine:/root/virt-kubeconfig "${SHARED_DIR}/virt-kubeconfig"
 
-echo "Golden setup complete"
+echo "$(date +%T) Golden setup complete"

--- a/ci-operator/step-registry/osac-project/golden/setup/osac-project-golden-setup-commands.sh
+++ b/ci-operator/step-registry/osac-project/golden/setup/osac-project-golden-setup-commands.sh
@@ -26,6 +26,10 @@ echo "$(date +%T) Installing packages..."
 dnf install -y libvirt qemu-kvm podman dnsmasq
 systemctl enable --now libvirtd
 
+echo "$(date +%T) Installing oc client..."
+curl -sL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz \
+  | tar xzf - -C /usr/local/bin oc kubectl
+
 mkdir -p ~/.config/containers
 cat > ~/.config/containers/containers.conf <<CONFEOF
 [engine]
@@ -153,6 +157,28 @@ mkdir -p /root/.kube
 cp "${GOLDEN_DIR}/hub/hub-kubeconfig" /root/.kube/config
 cp "${GOLDEN_DIR}/virt/virt-kubeconfig" /root/virt-kubeconfig
 echo 'export KUBECONFIG=/root/.kube/config' >> /root/.bashrc
+
+echo "$(date +%T) Checking cluster health..."
+echo "--- Hub cluster pods in osac-e2e-ci namespace ---"
+oc --kubeconfig=/root/.kube/config get pods -n osac-e2e-ci -o wide 2>&1 || true
+echo "--- Hub cluster deployments in osac-e2e-ci namespace ---"
+oc --kubeconfig=/root/.kube/config get deployments -n osac-e2e-ci 2>&1 || true
+echo "--- Hub cluster nodes ---"
+oc --kubeconfig=/root/.kube/config get nodes 2>&1 || true
+echo "--- Hub cluster clusteroperators (degraded) ---"
+oc --kubeconfig=/root/.kube/config get co 2>&1 | grep -E 'NAME|False|True.*True' || true
+echo "--- Virt cluster nodes ---"
+oc --kubeconfig=/root/virt-kubeconfig get nodes 2>&1 || true
+echo "--- Virt cluster KubeVirt status ---"
+oc --kubeconfig=/root/virt-kubeconfig get kubevirt -A 2>&1 || true
+echo "--- Virt cluster pods not ready in openshift-cnv ---"
+oc --kubeconfig=/root/virt-kubeconfig get pods -n openshift-cnv --field-selector=status.phase!=Running 2>&1 || true
+
+echo "$(date +%T) Waiting for OSAC deployments to be available..."
+for dep in $(oc --kubeconfig=/root/.kube/config get deployments -n osac-e2e-ci -o name 2>/dev/null); do
+  echo "$(date +%T) Waiting for ${dep}..."
+  oc --kubeconfig=/root/.kube/config rollout status "${dep}" -n osac-e2e-ci --timeout=300s 2>&1 || true
+done
 
 echo "$(date +%T) Golden image setup complete"
 REMOTE_EOF

--- a/ci-operator/step-registry/osac-project/golden/setup/osac-project-golden-setup-ref.metadata.json
+++ b/ci-operator/step-registry/osac-project/golden/setup/osac-project-golden-setup-ref.metadata.json
@@ -1,0 +1,11 @@
+{
+	"path": "osac-project/golden/setup/osac-project-golden-setup-ref.yaml",
+	"owners": {
+		"approvers": [
+			"osac-cicd"
+		],
+		"reviewers": [
+			"osac-cicd"
+		]
+	}
+}

--- a/ci-operator/step-registry/osac-project/golden/setup/osac-project-golden-setup-ref.yaml
+++ b/ci-operator/step-registry/osac-project/golden/setup/osac-project-golden-setup-ref.yaml
@@ -2,7 +2,7 @@ ref:
   as: osac-project-golden-setup
   from: dev-scripts
   grace_period: 10m
-  timeout: 45m0s
+  timeout: 1h0m0s
   commands: osac-project-golden-setup-commands.sh
   resources:
     requests:

--- a/ci-operator/step-registry/osac-project/golden/setup/osac-project-golden-setup-ref.yaml
+++ b/ci-operator/step-registry/osac-project/golden/setup/osac-project-golden-setup-ref.yaml
@@ -1,0 +1,25 @@
+ref:
+  as: osac-project-golden-setup
+  from: dev-scripts
+  grace_period: 10m
+  timeout: 45m0s
+  commands: osac-project-golden-setup-commands.sh
+  resources:
+    requests:
+      cpu: 100m
+      memory: 200Mi
+  credentials:
+  - namespace: test-credentials
+    name: edge-group-brew-registry-redhat-io-pull-secret
+    mount_path: /var/run/vault/brew-registry-redhat-io-pull-secret
+  env:
+  - name: GOLDEN_HUB_IMAGE
+    default: "quay.io/rh-ee-ovishlit/golden-test-attempt:hub-chunked"
+    documentation: Container image containing the hub cluster golden QCOW2 (chunked layers)
+  - name: GOLDEN_VIRT_IMAGE
+    default: "quay.io/rh-ee-ovishlit/golden-test-attempt:virt-chunked"
+    documentation: Container image containing the virt cluster golden QCOW2 (chunked layers)
+  documentation: |-
+    Sets up pre-built golden QCOW2 images on a bare metal host, creating
+    libvirt VMs with pre-installed OCP+OSAC (hub) and OCP+CNV+LVMS (virt).
+    Replaces the assisted-common-pre chain and osac-project-installer step.

--- a/ci-operator/step-registry/osac-project/golden/test/OWNERS
+++ b/ci-operator/step-registry/osac-project/golden/test/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+- osac-cicd
+options: {}
+reviewers:
+- osac-cicd

--- a/ci-operator/step-registry/osac-project/golden/test/osac-project-golden-test-commands.sh
+++ b/ci-operator/step-registry/osac-project/golden/test/osac-project-golden-test-commands.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+echo "Running OSAC E2E test (golden): ${TEST}"
+
+timeout -s 9 60m ssh -F "${SHARED_DIR}/ssh_config" ci_machine bash -s "${TEST}" "${E2E_NAMESPACE}" "${E2E_VM_TEMPLATE}" "${E2E_CLUSTER_TEMPLATE}" "${OSAC_TEST_IMAGE}" <<'REMOTE_EOF'
+set -euo pipefail
+
+TEST="$1"
+E2E_NAMESPACE="$2"
+E2E_VM_TEMPLATE="$3"
+E2E_CLUSTER_TEMPLATE="$4"
+OSAC_TEST_IMAGE="$5"
+
+KUBECONFIG="${KUBECONFIG:-/root/.kube/config}"
+[[ ! -f "${KUBECONFIG}" ]] && echo "ERROR: No kubeconfig found at ${KUBECONFIG}" && exit 1
+
+PULL_SECRET_PATH="/root/pull-secret"
+
+set +x
+podman run --authfile "${PULL_SECRET_PATH}" --rm --network=host \
+  -v "${KUBECONFIG}:/root/.kube/config:z" \
+  -v "${PULL_SECRET_PATH}:/root/pull-secret:z" \
+  -v "/root/virt-kubeconfig:/root/virt-kubeconfig:z" \
+  -e KUBECONFIG=/root/.kube/config \
+  -e OSAC_VM_KUBECONFIG=/root/virt-kubeconfig \
+  -e OSAC_NAMESPACE="${E2E_NAMESPACE}" \
+  -e OSAC_VM_TEMPLATE="${E2E_VM_TEMPLATE}" \
+  -e OSAC_CLUSTER_TEMPLATE="${E2E_CLUSTER_TEMPLATE}" \
+  -e OSAC_PULL_SECRET_PATH=/root/pull-secret \
+  "${OSAC_TEST_IMAGE}" \
+  make test TEST="${TEST}"
+REMOTE_EOF
+
+echo "Test completed"

--- a/ci-operator/step-registry/osac-project/golden/test/osac-project-golden-test-commands.sh
+++ b/ci-operator/step-registry/osac-project/golden/test/osac-project-golden-test-commands.sh
@@ -20,6 +20,40 @@ KUBECONFIG="${KUBECONFIG:-/root/.kube/config}"
 
 PULL_SECRET_PATH="/root/pull-secret"
 
+dump_diagnostics() {
+  echo ""
+  echo "$(date +%T) ========== POST-FAILURE DIAGNOSTICS =========="
+  echo "--- Host memory ---"
+  free -h 2>&1 || true
+  echo "--- Hub API reachable? ---"
+  curl -sk --connect-timeout 5 https://192.168.131.10:6443/readyz 2>&1 || echo "HUB API UNREACHABLE"
+  echo ""
+  echo "--- Virt API reachable? ---"
+  curl -sk --connect-timeout 5 https://192.168.130.10:6443/readyz 2>&1 || echo "VIRT API UNREACHABLE"
+  echo ""
+  echo "--- OSAC pods ---"
+  oc --kubeconfig="${KUBECONFIG}" get pods -n "${E2E_NAMESPACE}" 2>&1 || true
+  echo "--- OSAC deployments ---"
+  oc --kubeconfig="${KUBECONFIG}" get deployments -n "${E2E_NAMESPACE}" 2>&1 || true
+  echo "--- Recent events ---"
+  oc --kubeconfig="${KUBECONFIG}" get events -n "${E2E_NAMESPACE}" --sort-by=.lastTimestamp 2>&1 | tail -30 || true
+  echo "--- OSAC operator logs (last 50) ---"
+  oc --kubeconfig="${KUBECONFIG}" logs deployment/osac-operator-controller-manager -n "${E2E_NAMESPACE}" --tail=50 2>&1 || true
+  echo "--- Fulfillment controller logs (last 30) ---"
+  oc --kubeconfig="${KUBECONFIG}" logs deployment/fulfillment-controller -n "${E2E_NAMESPACE}" --tail=30 2>&1 || true
+  echo "--- Fulfillment gRPC server logs (last 30) ---"
+  oc --kubeconfig="${KUBECONFIG}" logs deployment/fulfillment-grpc-server -n "${E2E_NAMESPACE}" --tail=30 2>&1 || true
+  echo "--- Authorino logs (last 30) ---"
+  oc --kubeconfig="${KUBECONFIG}" logs deployment/authorino -n "${E2E_NAMESPACE}" --tail=30 2>&1 || true
+  echo "--- Host dmesg (OOM) ---"
+  dmesg 2>&1 | grep -i "oom\|killed process\|out of memory" | tail -10 || echo "no OOM"
+  echo "--- VM status ---"
+  virsh list --all 2>&1 || true
+  echo "$(date +%T) ========== END DIAGNOSTICS =========="
+}
+
+trap dump_diagnostics ERR
+
 set +x
 podman run --authfile "${PULL_SECRET_PATH}" --rm --network=host \
   -v "${KUBECONFIG}:/root/.kube/config:z" \

--- a/ci-operator/step-registry/osac-project/golden/test/osac-project-golden-test-ref.metadata.json
+++ b/ci-operator/step-registry/osac-project/golden/test/osac-project-golden-test-ref.metadata.json
@@ -1,0 +1,11 @@
+{
+	"path": "osac-project/golden/test/osac-project-golden-test-ref.yaml",
+	"owners": {
+		"approvers": [
+			"osac-cicd"
+		],
+		"reviewers": [
+			"osac-cicd"
+		]
+	}
+}

--- a/ci-operator/step-registry/osac-project/golden/test/osac-project-golden-test-ref.yaml
+++ b/ci-operator/step-registry/osac-project/golden/test/osac-project-golden-test-ref.yaml
@@ -1,0 +1,25 @@
+ref:
+  as: osac-project-golden-test
+  from: dev-scripts
+  dependencies:
+  - name: osac-test-infra
+    env: OSAC_TEST_IMAGE
+  grace_period: 10m
+  timeout: 3h0m0s
+  commands: osac-project-golden-test-commands.sh
+  resources:
+    requests:
+      cpu: 100m
+      memory: 200Mi
+  env:
+  - name: TEST
+    documentation: The test file to run (e.g. test_compute_instance_creation.py)
+  - name: E2E_NAMESPACE
+    default: "osac-e2e-ci"
+    documentation: The namespace to use for the e2e tests
+  - name: E2E_VM_TEMPLATE
+    default: "osac.templates.ocp_virt_vm"
+    documentation: The VM template to use for the e2e tests
+  - name: E2E_CLUSTER_TEMPLATE
+    default: "osac.templates.ocp_4_17_small"
+    documentation: The cluster template to use for CaaS e2e tests


### PR DESCRIPTION
## Summary
- Experiment: add a trap that dumps cluster state on test failure
- Dumps: host memory, API reachability, pod status, events, operator/fulfillment/authorino logs, dmesg OOM kills
- Critical because Prow censors test logs when they contain JWT tokens from grpcurl commands
- Even if tests fail, we get diagnostic data in the setup log

## Test plan
- [ ] On any test failure, check the build log for POST-FAILURE DIAGNOSTICS section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added eight new golden baremetal end-to-end test jobs covering compute instance lifecycle operations, API/CLI field validation, delete-during-provision scenarios, restart operations with negative test cases, and subnet/virtual network lifecycle configurations
  * Introduced setup workflow and test automation infrastructure for pre-built golden image environments on baremetal hosts, including comprehensive readiness validation and diagnostics capture

<!-- end of auto-generated comment: release notes by coderabbit.ai -->