### PR TITLE
WIP: add lp-interop example

### DIFF
--- a/ci-operator/config/RedHatQE/interop-testing/RedHatQE-interop-testing-example__example-ocp4.23-lp-interop.yaml
+++ b/ci-operator/config/RedHatQE/interop-testing/RedHatQE-interop-testing-example__example-ocp4.23-lp-interop.yaml
@@ -1,0 +1,71 @@
+base_images:
+  cli:
+    name: "4.20"
+    namespace: ocp
+    tag: cli
+  ocs-ci-tests:
+    name: ocs-ci-container
+    namespace: ci
+    tag: stable
+  openshift-virtualization-tests:
+    name: openshift-virtualization-tests
+    namespace: ci
+    tag: latest
+build_root:
+  image_stream_tag:
+    name: release
+    namespace: openshift
+    tag: rhel-9-release-golang-1.21-openshift-4.18
+images:
+  items:
+  - build_args:
+    - name: OCP_VERSION
+      value: "4.20"
+    - name: OC_CLI_VERSION
+      value: latest
+    context_dir: cnv-ci
+    dockerfile_path: Dockerfile
+    to: cnv-ci
+releases:
+  latest:
+    candidate:
+      product: ocp
+      stream: nightly
+      version: "4.20"
+resources:
+  '*':
+    requests:
+      cpu: 200m
+      memory: 400Mi
+tests:
+- as: cnv-component-readiness-aws-ipi-ocp420
+  cron: 0 23 31 2 *
+  steps:
+    cluster_profile: aws-cspi-qe
+    env:
+      BASE_DOMAIN: cspilp.interop.ccitredhat.com
+      CNV_SUBSCRIPTION_CHANNEL: candidate
+      COMPUTE_NODE_TYPE: c5n.metal
+      MAP_TESTS: "true"
+      OCP_VERSION: "4.20"
+      ODF_OPERATOR_CHANNEL: stable-4.20
+      ODF_VERSION_MAJOR_MINOR: "4.20"
+      REPORTPORTAL_CMP: CNV-lp-interop
+      USER_TAGS: |
+        scenario cnv
+    post:
+    - ref: mpiit-data-router-reporter
+    - chain: ipi-aws-post
+    pre:
+    - chain: ipi-aws-pre
+    test:
+    - chain: cucushift-installer-check-cluster-health
+    - ref: interop-tests-deploy-odf
+    - ref: interop-tests-ocs-tests
+    - ref: interop-tests-cnv-tests-e2e-deploy
+    - ref: interop-tests-openshift-virtualization-tests
+zz_generated_metadata:
+  branch: example
+  org: RedHatQE
+  repo: interop-testing
+  variant: example-ocp4.23-lp-interop

--- a/ci-operator/jobs/RedHatQE/interop-testing/RedHatQE-interop-testing-example-periodics.yaml
+++ b/ci-operator/jobs/RedHatQE/interop-testing/RedHatQE-interop-testing-example-periodics.yaml
@@ -1,0 +1,84 @@
+periodics:
+- agent: kubernetes
+  cluster: build11
+  cron: 0 23 31 2 *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: example
+    org: RedHatQE
+    repo: interop-testing
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-cspi-qe
+    ci-operator.openshift.io/variant: example-ocp4.23-lp-interop
+    ci.openshift.io/generator: prowgen
+    job-release: "4.20"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-RedHatQE-interop-testing-example-example-ocp4.23-lp-interop-cnv-component-readiness-aws-ipi-ocp420
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=cnv-component-readiness-aws-ipi-ocp420
+      - --variant=example-ocp4.23-lp-interop
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator

--- a/ci-operator/jobs/RedHatQE/interop-testing/RedHatQE-interop-testing-example-presubmits.yaml
+++ b/ci-operator/jobs/RedHatQE/interop-testing/RedHatQE-interop-testing-example-presubmits.yaml
@@ -1,0 +1,60 @@
+presubmits:
+  RedHatQE/interop-testing:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^example$
+    - ^example-
+    cluster: build01
+    context: ci/prow/example-ocp4.23-lp-interop-images
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/variant: example-ocp4.23-lp-interop
+      ci.openshift.io/generator: prowgen
+      job-release: "4.20"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-RedHatQE-interop-testing-example-example-ocp4.23-lp-interop-images
+    rerun_command: /test example-ocp4.23-lp-interop-images
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=[images]
+        - --variant=example-ocp4.23-lp-interop
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )example-ocp4.23-lp-interop-images,?($|\s.*)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added new interop testing configuration for OCP 4.20 with CNV support, enabling AWS-based E2E deployment testing including ODF, OCS, and virtualization components with health checks and pre-validation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->