### PR TITLE
Skip Prometheus failing rules evaluation in Classic STS conformance

### DIFF
--- a/ci-operator/step-registry/rosa/aws/sts/conformance/rosa-aws-sts-conformance-workflow.yaml
+++ b/ci-operator/step-registry/rosa/aws/sts/conformance/rosa-aws-sts-conformance-workflow.yaml
@@ -30,7 +30,8 @@ workflow:
         cloud-provider-aws-e2e.*loadbalancer CLB internal should be reachable with hairpinning traffic\|
         sig-auth.*SCC.*should not have pod creation failures during install\|
         sig-imageregistry.*should redirect on blob pull\|
-        CSI Mock volume expansion.*should record target size in allocated resources
+        CSI Mock volume expansion.*should record target size in allocated resources\|
+        shouldn.t have failing rules evaluation
     pre:
       - chain: rosa-aws-sts-provision
       - ref: osd-ccs-conf-idp-htpasswd-multi-users


### PR DESCRIPTION
## Summary

- Add `shouldn.t have failing rules evaluation` to TEST_SKIPS in the Classic STS conformance workflow
- This test (`[sig-instrumentation] Prometheus... shouldn't have failing rules evaluation`) is a low-rate upstream flake (0.6% fail rate in Sippy 4.21, up from 0.2%)
- No open upstream bugs filed; not ROSA-specific

## Test plan

- [ ] Wait for pj-rehearse REHEARSALNOTIFIER
- [ ] Run rehearsals for affected conformance periodic
- [ ] Verify skip pattern matches the full test name in dry-run output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated conformance test validation rules for ROSA AWS STS to skip additional test patterns during execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->