### PR TITLE
Skip Prometheus failing rules evaluation in HCP conformance

### DIFF
--- a/ci-operator/step-registry/rosa/aws/hcp/conformance/rosa-aws-hcp-conformance-workflow.yaml
+++ b/ci-operator/step-registry/rosa/aws/hcp/conformance/rosa-aws-hcp-conformance-workflow.yaml
@@ -33,7 +33,8 @@ workflow:
         CSI Mock volume expansion Expansion with recovery should allow recovery if controller expansion fails with final error\|
         cloud-provider-aws-e2e.*loadbalancer NLB internal should be reachable with hairpinning traffic\|
         cloud-provider-aws-e2e.*loadbalancer NLB should be reachable with target-node-labels\|
-        Monitor:apiserver-incluster-availability.*monitor test apiserver-incluster-availability
+        Monitor:apiserver-incluster-availability.*monitor test apiserver-incluster-availability\|
+        shouldn.t have failing rules evaluation
     pre:
       - chain: rosa-aws-sts-hcp-provision
       - ref: osd-ccs-conf-idp-htpasswd-multi-users


### PR DESCRIPTION
## Summary

- Add `shouldn.t have failing rules evaluation` to TEST_SKIPS in the HCP conformance workflow
- This test (`[sig-instrumentation] Prometheus... shouldn't have failing rules evaluation`) is a low-rate upstream flake (0.6% fail rate in Sippy 4.21, up from 0.2%)
- No open upstream bugs filed; not ROSA-specific

## Test plan

- [ ] Wait for pj-rehearse REHEARSALNOTIFIER
- [ ] Run rehearsals for affected conformance periodic
- [ ] Verify skip pattern matches the full test name in dry-run output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test skip patterns in CI workflow configuration to improve test execution handling and ensure proper pattern separation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->