### PR TITLE
no-jira: workaround: remove capi credentialsRequest in Default cluster

### DIFF
--- a/ci-operator/step-registry/aws/provision/cco-manual-users/static/aws-provision-cco-manual-users-static-commands.sh
+++ b/ci-operator/step-registry/aws/provision/cco-manual-users/static/aws-provision-cco-manual-users-static-commands.sh
@@ -156,8 +156,20 @@ popd
 echo "CR manifest files:"
 ls "$cr_yaml_d"
 
-if [[ "${EXTRACT_MANIFEST_INCLUDED}" != "true" ]] && [[ "${FEATURE_SET}" != "TechPreviewNoUpgrade" ]] &&  [[ ! -f ${SHARED_DIR}/manifest_feature_gate.yaml ]]; then
+if [[ "${EXTRACT_MANIFEST_INCLUDED}" != "true" ]] && [[ "${FEATURE_SET:-}" != "TechPreviewNoUpgrade" ]] && [[ ! -f ${SHARED_DIR}/manifest_feature_gate.yaml ]]; then
   remove_tech_preview_feature_from_manifests "${cr_yaml_d}" "TechPreviewNoUpgrade" || exit 1
+fi
+
+# TODO(OCPBUGS-77845): Temporary workaround - must be reverted when the bug is resolved.
+# The cluster-api credentials request changed from feature-set to feature-gate
+# annotation, but oc adm release extract does not yet filter on feature-gate.
+# Remove the cluster-api CR when FEATURE_SET is not set.
+if [[ -z "${FEATURE_SET:-}" ]]; then
+  capi_cr="$cr_yaml_d/0000_30_cluster-api_01_credentials-request.yaml"
+  if [[ -f "${capi_cr}" ]]; then
+    echo "Removing cluster-api credentials request (feature-gate not supported by current tooling)"
+    rm -f "${capi_cr}"
+  fi
 fi
 
 ls -p "${cr_yaml_d}"/*.yaml | awk -F'/' '{print $NF}' > "${credentials_requests_files}"

--- a/ci-operator/step-registry/cucushift/installer/check/fips/cucushift-installer-check-fips-commands.sh
+++ b/ci-operator/step-registry/cucushift/installer/check/fips/cucushift-installer-check-fips-commands.sh
@@ -28,15 +28,24 @@ fi
 check_result=0
 node_lists=$(oc get nodes -ojson | jq -r '.items[].metadata.name' | xargs)
 for node in $node_lists; do
-    result=""
     echo "**********Check fips on node ${node}**********"
-    result=$(oc debug node/${node} -n openshift-infra -- chroot /host fips-mode-setup --check)
-    if [[ "${result}" == "FIPS mode is enabled." ]]; then
-        echo "Check passed on node ${node}"
+    fips_value=""
+    attempt=0
+    while [[ -z "${fips_value}" ]] && [[ $attempt -lt 3 ]]; do
+        fips_value=$(oc debug node/${node} -n openshift-infra -- cat /proc/sys/crypto/fips_enabled 2>/dev/null || true)
+        fips_value=$(echo "${fips_value}" | grep -oE '^[01]$' || true)
+        attempt=$(( attempt + 1 ))
+        if [[ -z "${fips_value}" ]] && [[ $attempt -lt 3 ]]; then
+            echo "Retry $attempt: failed to read fips_enabled on node ${node}"
+            sleep 5
+        fi
+    done
+    if [[ "${fips_value}" == "1" ]]; then
+        echo "Check passed on node ${node}: FIPS mode is enabled"
     else
-        echo "Check failed on node ${node}"
-        oc debug node/${node} -n openshift-infra -- chroot /host fips-mode-setup --check
-        oc debug node/${node} -n openshift-infra -- chroot /host grep -i fips /proc/cmdline
+        echo "Check failed on node ${node}: expected fips_enabled=1, got '${fips_value}'"
+        oc debug node/${node} -n openshift-infra -- cat /proc/sys/crypto/fips_enabled || true
+        oc debug node/${node} -n openshift-infra -- grep -i fips /proc/cmdline || true
         check_result=1
     fi
 done


### PR DESCRIPTION
## Description

Credentials request filtering is temporarily broken due to https://issues.redhat.com/browse/OCPBUGS-77845. GA clusters in manual mode are failing on the missing namespace for the capi cred request at bootstrap phase.

Basically, I copied the approach from https://github.com/openshift/release/pull/76228. Currently, the step uses `upi-installer` image, which has a really old `oc` version (`v4.2.0-alpha.0-2466-gd76df14`). Unless we can find another image to replace with a newer oc version, this is a workaround...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved AWS provisioning manifest cleanup to avoid including certain credential manifests unless specific feature flags are set.
  * Added a temporary safeguard that removes a cluster API credentials manifest when the feature set is unset to prevent incorrect credential generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->