### PR TITLE
MGMT-24194: add OSAC pod log gathering to E2E workflow

### DIFF
--- a/ci-operator/step-registry/osac-project/gather/OWNERS
+++ b/ci-operator/step-registry/osac-project/gather/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+- osac-cicd
+options: {}
+reviewers:
+- osac-cicd

--- a/ci-operator/step-registry/osac-project/gather/osac-project-gather-commands.sh
+++ b/ci-operator/step-registry/osac-project/gather/osac-project-gather-commands.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+set -o nounset
+set -o pipefail
+
+echo "************ osac-project-gather: collecting OSAC pod logs ************"
+
+REMOTE_ARTIFACT_DIR="/tmp/osac-artifacts"
+
+timeout -s 9 10m ssh -F "${SHARED_DIR}/ssh_config" ci_machine bash -s "${E2E_NAMESPACE}" "${REMOTE_ARTIFACT_DIR}" <<'REMOTE_EOF'
+set -o nounset
+set -o pipefail
+
+E2E_NAMESPACE="$1"
+ARTIFACT_DIR="$2"
+
+KUBECONFIG=$(find ${KUBECONFIG} -type f -print -quit 2>/dev/null)
+if [[ -z "${KUBECONFIG}" ]]; then
+    echo "No kubeconfig found, skipping log collection"
+    exit 0
+fi
+
+mkdir -p "${ARTIFACT_DIR}"
+
+echo "Gathering OSAC logs from namespace ${E2E_NAMESPACE}..."
+
+oc get pods -n "${E2E_NAMESPACE}" -o wide > "${ARTIFACT_DIR}/pods.txt" 2>&1 || true
+oc get events -n "${E2E_NAMESPACE}" --sort-by=.lastTimestamp > "${ARTIFACT_DIR}/events.txt" 2>&1 || true
+oc describe pods -n "${E2E_NAMESPACE}" > "${ARTIFACT_DIR}/pods-describe.txt" 2>&1 || true
+oc get deployments -n "${E2E_NAMESPACE}" -o wide > "${ARTIFACT_DIR}/deployments.txt" 2>&1 || true
+oc get jobs -n "${E2E_NAMESPACE}" -o wide > "${ARTIFACT_DIR}/jobs.txt" 2>&1 || true
+oc get statefulsets -n "${E2E_NAMESPACE}" -o wide > "${ARTIFACT_DIR}/statefulsets.txt" 2>&1 || true
+
+for pod in $(oc get pods -n "${E2E_NAMESPACE}" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+    for container in $(oc get pod "${pod}" -n "${E2E_NAMESPACE}" -o jsonpath='{.spec.containers[*].name}' 2>/dev/null); do
+        oc logs "${pod}" -n "${E2E_NAMESPACE}" -c "${container}" > "${ARTIFACT_DIR}/pod-${pod}-${container}.log" 2>&1 || true
+        oc logs "${pod}" -n "${E2E_NAMESPACE}" -c "${container}" --previous > "${ARTIFACT_DIR}/pod-${pod}-${container}-previous.log" 2>/dev/null || true
+    done
+    for container in $(oc get pod "${pod}" -n "${E2E_NAMESPACE}" -o jsonpath='{.spec.initContainers[*].name}' 2>/dev/null); do
+        oc logs "${pod}" -n "${E2E_NAMESPACE}" -c "${container}" > "${ARTIFACT_DIR}/pod-${pod}-init-${container}.log" 2>&1 || true
+    done
+done
+
+for ns in keycloak ansible-aap; do
+    if oc get namespace "${ns}" &>/dev/null; then
+        mkdir -p "${ARTIFACT_DIR}/${ns}"
+        oc get pods -n "${ns}" -o wide > "${ARTIFACT_DIR}/${ns}/pods.txt" 2>&1 || true
+        oc get events -n "${ns}" --sort-by=.lastTimestamp > "${ARTIFACT_DIR}/${ns}/events.txt" 2>&1 || true
+        oc describe pods -n "${ns}" > "${ARTIFACT_DIR}/${ns}/pods-describe.txt" 2>&1 || true
+        oc get deployments -n "${ns}" -o wide > "${ARTIFACT_DIR}/${ns}/deployments.txt" 2>&1 || true
+        oc get jobs -n "${ns}" -o wide > "${ARTIFACT_DIR}/${ns}/jobs.txt" 2>&1 || true
+        oc get statefulsets -n "${ns}" -o wide > "${ARTIFACT_DIR}/${ns}/statefulsets.txt" 2>&1 || true
+        for pod in $(oc get pods -n "${ns}" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+            for container in $(oc get pod "${pod}" -n "${ns}" -o jsonpath='{.spec.containers[*].name}' 2>/dev/null); do
+                oc logs "${pod}" -n "${ns}" -c "${container}" > "${ARTIFACT_DIR}/${ns}/pod-${pod}-${container}.log" 2>&1 || true
+                oc logs "${pod}" -n "${ns}" -c "${container}" --previous > "${ARTIFACT_DIR}/${ns}/pod-${pod}-${container}-previous.log" 2>/dev/null || true
+            done
+            for container in $(oc get pod "${pod}" -n "${ns}" -o jsonpath='{.spec.initContainers[*].name}' 2>/dev/null); do
+                oc logs "${pod}" -n "${ns}" -c "${container}" > "${ARTIFACT_DIR}/${ns}/pod-${pod}-init-${container}.log" 2>&1 || true
+            done
+        done
+    fi
+done
+
+echo "Log collection complete"
+REMOTE_EOF
+
+echo "Copying artifacts from remote machine..."
+timeout -s 9 5m scp -r -F "${SHARED_DIR}/ssh_config" "ci_machine:${REMOTE_ARTIFACT_DIR}" "${ARTIFACT_DIR}/osac-logs" 2>&1 || true
+
+echo "************ osac-project-gather: done ************"

--- a/ci-operator/step-registry/osac-project/gather/osac-project-gather-ref.metadata.json
+++ b/ci-operator/step-registry/osac-project/gather/osac-project-gather-ref.metadata.json
@@ -1,0 +1,11 @@
+{
+	"path": "osac-project/gather/osac-project-gather-ref.yaml",
+	"owners": {
+		"approvers": [
+			"osac-cicd"
+		],
+		"reviewers": [
+			"osac-cicd"
+		]
+	}
+}

--- a/ci-operator/step-registry/osac-project/gather/osac-project-gather-ref.yaml
+++ b/ci-operator/step-registry/osac-project/gather/osac-project-gather-ref.yaml
@@ -1,0 +1,14 @@
+ref:
+  as: osac-project-gather
+  best_effort: true
+  from: dev-scripts
+  timeout: 20m0s
+  commands: osac-project-gather-commands.sh
+  resources:
+    requests:
+      cpu: 100m
+      memory: 200Mi
+  env:
+  - name: E2E_NAMESPACE
+    default: "osac-e2e-ci"
+    documentation: The namespace where OSAC components are deployed

--- a/ci-operator/step-registry/osac-project/ofcir/baremetal/osac-project-ofcir-baremetal-workflow.yaml
+++ b/ci-operator/step-registry/osac-project/ofcir/baremetal/osac-project-ofcir-baremetal-workflow.yaml
@@ -12,6 +12,7 @@ workflow:
     test: 
       - ref: osac-project-baremetal-test 
     post:
+      - ref: osac-project-gather
       - ref: ofcir-gather
       - ref: ofcir-release
     env:


### PR DESCRIPTION
## Summary

https://redhat.atlassian.net/browse/MGMT-24194

Add pod log gathering to the OSAC E2E test workflow. Currently, when tests fail, there are zero application logs in the CI artifacts — only OFCIR infrastructure metadata. This makes debugging failures extremely difficult.

## Changes

**New step: `osac-project-gather`**
- SSHs into the CI machine and collects pod logs, events, and resource descriptions
- Covers the OSAC namespace (`osac-e2e-ci`), plus `keycloak` and `ansible-aap` namespaces
- Collects logs from all containers (including init containers and previous restarts)
- Runs as `best_effort` with 15m timeout so gather failures don't mask test failures
- Writes everything to `$ARTIFACT_DIR/osac-logs/` for Prow artifact archival

**Modified: `osac-project-ofcir-baremetal` workflow**
- Added `osac-project-gather` as the first post step (before `ofcir-gather` and `ofcir-release`)

## Test plan

- [ ] Prow validation checks pass
- [ ] Trigger a test and verify logs appear in the Prow artifacts page under `osac-logs/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated CI log‑gathering step that runs remotely to collect namespace diagnostics (pod/container logs including previous logs, init‑container logs, events, resource descriptions/listings) and retrieves artifacts back to the run; also conditionally gathers additional related namespaces when present.

* **Chores**
  * Added/updated ownership metadata to include an additional approver/reviewer team for the new step and related workflow areas.

* **Integration**
  * Integrated the gather step as a best‑effort post‑step with timeout, resource requests, and a default E2E namespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->