### PR TITLE
MGMT-24194: add component installer step and workflow

### DIFF
--- a/ci-operator/step-registry/osac-project/installer/component/OWNERS
+++ b/ci-operator/step-registry/osac-project/installer/component/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+- osac-cicd
+options: {}
+reviewers:
+- osac-cicd

--- a/ci-operator/step-registry/osac-project/installer/component/osac-project-installer-component-commands.sh
+++ b/ci-operator/step-registry/osac-project/installer/component/osac-project-installer-component-commands.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+echo "************ osac-installer-component commands ************"
+echo "--- Running with the following parameters ---"
+echo "E2E_NAMESPACE: ${E2E_NAMESPACE}"
+echo "E2E_KUSTOMIZE_OVERLAY: ${E2E_KUSTOMIZE_OVERLAY}"
+echo "E2E_VM_TEMPLATE: ${E2E_VM_TEMPLATE}"
+echo "OSAC_INSTALLER_IMAGE: ${OSAC_INSTALLER_IMAGE}"
+echo "COMPONENT_IMAGE: ${COMPONENT_IMAGE}"
+echo "COMPONENT_IMAGE_NAME: ${COMPONENT_IMAGE_NAME}"
+echo "AAP_EE_IMAGE_OVERRIDE: ${AAP_EE_IMAGE_OVERRIDE:-}"
+echo "-------------------------------------------"
+
+base64 -d /var/run/osac-installer-aap/license > /tmp/license.zip
+
+timeout -s 9 10m scp -F "${SHARED_DIR}/ssh_config" /tmp/license.zip ci_machine:/tmp/license.zip
+
+timeout -s 9 120m ssh -F "${SHARED_DIR}/ssh_config" ci_machine bash - << EOF|& sed -e 's/.*auths\{0,1\}".*/*** PULL_SECRET ***/g'
+
+export KUBECONFIG=\$(find \${KUBECONFIG} -type f -print -quit)
+
+oc annotate sc lvms-vg1 storageclass.kubernetes.io/is-default-class=true --overwrite
+
+echo "Waiting for OpenShift Virtualization to be ready..."
+oc wait --for=condition=Available hyperconverged/kubevirt-hyperconverged -n openshift-cnv --timeout=900s
+
+cat <<NADEOF | oc apply -f -
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: default
+  namespace: openshift-ovn-kubernetes
+spec:
+  config: '{"cniVersion": "0.4.0", "name": "ovn-kubernetes", "type": "ovn-k8s-cni-overlay"}'
+NADEOF
+
+podman run --authfile /root/pull-secret --rm --network=host \
+-v \${KUBECONFIG}:/root/.kube/config:z \
+-v /root/pull-secret:/installer/overlays/${E2E_KUSTOMIZE_OVERLAY}/files/quay-pull-secret.json:z \
+-v /tmp/license.zip:/installer/overlays/${E2E_KUSTOMIZE_OVERLAY}/files/license.zip:z \
+-e INSTALLER_NAMESPACE=${E2E_NAMESPACE} \
+-e INSTALLER_KUSTOMIZE_OVERLAY=${E2E_KUSTOMIZE_OVERLAY} \
+-e INSTALLER_VM_TEMPLATE=${E2E_VM_TEMPLATE} \
+-e COMPONENT_IMAGE=${COMPONENT_IMAGE} \
+-e COMPONENT_IMAGE_NAME=${COMPONENT_IMAGE_NAME} \
+-e AAP_EE_IMAGE_OVERRIDE=${AAP_EE_IMAGE_OVERRIDE:-} \
+${OSAC_INSTALLER_IMAGE} sh -c '
+set -euo pipefail
+
+COMPONENT_REGISTRY=\${COMPONENT_IMAGE%:*}
+COMPONENT_TAG=\${COMPONENT_IMAGE##*:}
+
+echo "Overriding image \${COMPONENT_IMAGE_NAME} -> \${COMPONENT_IMAGE}"
+cd /installer/base
+
+if ! grep -Fq "name: \${COMPONENT_IMAGE_NAME}" kustomization.yaml; then
+  echo "ERROR: image name \${COMPONENT_IMAGE_NAME} not found in /installer/base/kustomization.yaml" >&2
+  cat kustomization.yaml >&2
+  exit 1
+fi
+
+if grep -A1 "name: \${COMPONENT_IMAGE_NAME}" kustomization.yaml | grep -q "newName:"; then
+  sed -i "\#name: \${COMPONENT_IMAGE_NAME}#,/newTag:/{
+    s|newName:.*|newName: \${COMPONENT_REGISTRY}|
+    s|newTag:.*|newTag: \${COMPONENT_TAG}|
+  }" kustomization.yaml
+else
+  sed -i "\#name: \${COMPONENT_IMAGE_NAME}#{
+    a\\  newName: \${COMPONENT_REGISTRY}
+    n
+    s|newTag:.*|newTag: \${COMPONENT_TAG}|
+  }" kustomization.yaml
+fi
+
+if ! grep -Fq "\${COMPONENT_REGISTRY}" kustomization.yaml || ! grep -Fq "newTag: \${COMPONENT_TAG}" kustomization.yaml; then
+  echo "ERROR: kustomize image override failed — expected \${COMPONENT_REGISTRY}:\${COMPONENT_TAG}" >&2
+  cat kustomization.yaml >&2
+  exit 1
+fi
+
+if [ -n "\${AAP_EE_IMAGE_OVERRIDE}" ]; then
+  overlay_file="/installer/overlays/\${INSTALLER_KUSTOMIZE_OVERLAY}/kustomization.yaml"
+  if ! grep -q "AAP_EE_IMAGE=" "\${overlay_file}"; then
+    echo "ERROR: AAP_EE_IMAGE entry not found in \${overlay_file}" >&2
+    exit 1
+  fi
+  echo "Overriding AAP_EE_IMAGE -> \${COMPONENT_IMAGE}"
+  sed -i "s|AAP_EE_IMAGE=.*|AAP_EE_IMAGE=\${COMPONENT_IMAGE}|" "\${overlay_file}"
+fi
+
+cd /installer
+sh scripts/setup.sh
+'
+
+EOF

--- a/ci-operator/step-registry/osac-project/installer/component/osac-project-installer-component-ref.metadata.json
+++ b/ci-operator/step-registry/osac-project/installer/component/osac-project-installer-component-ref.metadata.json
@@ -1,0 +1,11 @@
+{
+	"path": "osac-project/installer/component/osac-project-installer-component-ref.yaml",
+	"owners": {
+		"approvers": [
+			"osac-cicd"
+		],
+		"reviewers": [
+			"osac-cicd"
+		]
+	}
+}

--- a/ci-operator/step-registry/osac-project/installer/component/osac-project-installer-component-ref.yaml
+++ b/ci-operator/step-registry/osac-project/installer/component/osac-project-installer-component-ref.yaml
@@ -1,0 +1,34 @@
+ref:
+  as: osac-project-installer-component
+  from: dev-scripts
+  dependencies:
+  - name: osac-installer
+    env: OSAC_INSTALLER_IMAGE
+  - name: component-image
+    env: COMPONENT_IMAGE
+  grace_period: 10m
+  timeout: 3h0m0s
+  commands: osac-project-installer-component-commands.sh
+  resources:
+    requests:
+      cpu: 100m
+      memory: 200Mi
+  credentials:
+  - namespace: test-credentials
+    name: osac-installer-aap
+    mount_path: /var/run/osac-installer-aap
+  env:
+  - name: E2E_NAMESPACE
+    default: "osac-e2e-ci"
+    documentation: The namespace to use for the e2e tests
+  - name: E2E_KUSTOMIZE_OVERLAY
+    default: "vmaas-ci"
+    documentation: The kustomize overlay to use for the e2e tests
+  - name: E2E_VM_TEMPLATE
+    default: "osac.templates.ocp_virt_vm"
+    documentation: The template to use for the e2e tests
+  - name: COMPONENT_IMAGE_NAME
+    documentation: The image name in base/kustomization.yaml to replace (e.g. ghcr.io/osac-project/fulfillment-service)
+  - name: AAP_EE_IMAGE_OVERRIDE
+    default: ""
+    documentation: If non-empty, also override AAP_EE_IMAGE in the overlay kustomization to use COMPONENT_IMAGE

--- a/ci-operator/step-registry/osac-project/ofcir/baremetal/component/OWNERS
+++ b/ci-operator/step-registry/osac-project/ofcir/baremetal/component/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+- osac-cicd
+options: {}
+reviewers:
+- osac-cicd

--- a/ci-operator/step-registry/osac-project/ofcir/baremetal/component/osac-project-ofcir-baremetal-component-workflow.metadata.json
+++ b/ci-operator/step-registry/osac-project/ofcir/baremetal/component/osac-project-ofcir-baremetal-component-workflow.metadata.json
@@ -1,0 +1,11 @@
+{
+	"path": "osac-project/ofcir/baremetal/component/osac-project-ofcir-baremetal-component-workflow.yaml",
+	"owners": {
+		"approvers": [
+			"osac-cicd"
+		],
+		"reviewers": [
+			"osac-cicd"
+		]
+	}
+}

--- a/ci-operator/step-registry/osac-project/ofcir/baremetal/component/osac-project-ofcir-baremetal-component-workflow.yaml
+++ b/ci-operator/step-registry/osac-project/ofcir/baremetal/component/osac-project-ofcir-baremetal-component-workflow.yaml
@@ -1,0 +1,23 @@
+workflow:
+  as: osac-project-ofcir-baremetal-component
+  steps:
+    cluster_profile: packet-assisted
+    allow_best_effort_post_steps: true
+    allow_skip_on_success: true
+    pre:
+      - ref: ofcir-acquire
+      - ref: assisted-ofcir-setup
+      - chain: assisted-common-pre
+      - ref: osac-project-installer-component
+    test:
+      - ref: osac-project-baremetal-test
+    post:
+      - ref: ofcir-gather
+      - ref: ofcir-release
+    env:
+      CLUSTERTYPE: "assisted_medium_el9"
+  documentation: |-
+    This workflow executes the common end-to-end osac-test-infra test suite on a cluster
+    provisioned by running assisted-installer on a packet server. Unlike the base workflow,
+    this variant overrides a single component image with a CI-built version from a PR,
+    enabling E2E validation of component repo changes before merge.


### PR DESCRIPTION
## Summary

https://redhat.atlassian.net/browse/MGMT-24194

Adds shared CI infrastructure for running vmaas E2E tests on component repo PRs (fulfillment-service, osac-operator, osac-aap).

### Why new step/workflow?

The existing `osac-project-installer` step deploys OSAC using the promoted osac-installer image, which pins component versions via kustomize image tags (e.g., `ghcr.io/osac-project/fulfillment-service:sha-f2cd619`). When testing a component PR, we need the deployed cluster to run the PR's code, not the released version.

The new `osac-project-installer-component` step extends the existing one by patching the osac-installer image at runtime before deploying:

1. **Overrides the kustomize image tag** in `base/kustomization.yaml` — replaces the pinned SHA tag with the CI-built image from the PR, so the cluster deploys the PR's container image
2. **Overrides `AAP_EE_IMAGE`** in the overlay kustomization (osac-aap only) — so AAP runs playbooks using the PR's execution environment instead of the released one

### New components

- **Step:** `osac-project-installer-component` — accepts `COMPONENT_IMAGE` (CI-built image pull spec) and `COMPONENT_IMAGE_NAME` (kustomize image name to replace), patches kustomization before running `setup.sh`
- **Workflow:** `osac-project-ofcir-baremetal-component` — identical to `osac-project-ofcir-baremetal` but uses the new installer step

### How component repos use it

Each component repo's CI config builds two images:
1. The component's container image from the PR source
2. A modified osac-installer image with the PR's manifests overlaid on the submodule

Then the test definition overrides dependencies:
```yaml
dependencies:
  OSAC_INSTALLER_IMAGE: osac-installer-with-pr   # modified installer with PR manifests
  COMPONENT_IMAGE: fulfillment-service-pr         # PR's container image
env:
  COMPONENT_IMAGE_NAME: ghcr.io/osac-project/fulfillment-service  # which image to replace
```

## Test plan

- [ ] Prow validation checks pass
- [ ] Merge before component repo PRs (#78716, #78717, #78718)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added new CI step-registry components for the OSAC installer and baremetal variant, including a runtime command script and component reference.
  * Added ownership/governance entries for the new CI components (approvers/reviewers/options).
* **Tests**
  * Introduced a new workflow to run the end-to-end test suite on Packet-provisioned servers with defaults, resource limits, credential mounts, and image-override inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->