### PR TITLE
MGMT-24194: make osac-installer vmaas E2E tests required

### DIFF
--- a/ci-operator/config/osac-project/osac-installer/osac-project-osac-installer-main.yaml
+++ b/ci-operator/config/osac-project/osac-installer/osac-project-osac-installer-main.yaml
@@ -89,7 +89,6 @@ tests:
 - as: e2e-metal-vmaas-compute-instance-creation
   capabilities:
   - intranet
-  run_if_changed: ^(base/|overlays/|scripts/|prerequisites/)
   steps:
     cluster_profile: packet-assisted
     env:
@@ -107,7 +106,6 @@ tests:
 - as: e2e-metal-vmaas-compute-instance-api-fields
   capabilities:
   - intranet
-  run_if_changed: ^(base/|overlays/|scripts/|prerequisites/)
   steps:
     cluster_profile: packet-assisted
     env:
@@ -125,7 +123,6 @@ tests:
 - as: e2e-metal-vmaas-compute-instance-cli-fields
   capabilities:
   - intranet
-  run_if_changed: ^(base/|overlays/|scripts/|prerequisites/)
   steps:
     cluster_profile: packet-assisted
     env:
@@ -143,7 +140,6 @@ tests:
 - as: e2e-metal-vmaas-compute-instance-delete-during-provision
   capabilities:
   - intranet
-  run_if_changed: ^(base/|overlays/|scripts/|prerequisites/)
   steps:
     cluster_profile: packet-assisted
     env:
@@ -161,7 +157,6 @@ tests:
 - as: e2e-metal-vmaas-compute-instance-restart
   capabilities:
   - intranet
-  run_if_changed: ^(base/|overlays/|scripts/|prerequisites/)
   steps:
     cluster_profile: packet-assisted
     env:
@@ -179,7 +174,6 @@ tests:
 - as: e2e-metal-vmaas-compute-instance-restart-negative
   capabilities:
   - intranet
-  run_if_changed: ^(base/|overlays/|scripts/|prerequisites/)
   steps:
     cluster_profile: packet-assisted
     env:
@@ -197,7 +191,6 @@ tests:
 - as: e2e-metal-vmaas-subnet-lifecycle
   capabilities:
   - intranet
-  run_if_changed: ^(base/|overlays/|scripts/|prerequisites/)
   steps:
     cluster_profile: packet-assisted
     env:
@@ -215,7 +208,6 @@ tests:
 - as: e2e-metal-vmaas-virtual-network-lifecycle
   capabilities:
   - intranet
-  run_if_changed: ^(base/|overlays/|scripts/|prerequisites/)
   steps:
     cluster_profile: packet-assisted
     env:

--- a/ci-operator/jobs/osac-project/osac-installer/osac-project-osac-installer-main-presubmits.yaml
+++ b/ci-operator/jobs/osac-project/osac-installer/osac-project-osac-installer-main-presubmits.yaml
@@ -1,7 +1,7 @@
 presubmits:
   osac-project/osac-installer:
   - agent: kubernetes
-    always_run: false
+    always_run: true
     branches:
     - ^main$
     - ^main-
@@ -19,7 +19,6 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-osac-project-osac-installer-main-e2e-metal-vmaas-compute-instance-api-fields
     rerun_command: /test e2e-metal-vmaas-compute-instance-api-fields
-    run_if_changed: ^(base/|overlays/|scripts/|prerequisites/)
     spec:
       containers:
       - args:
@@ -86,7 +85,7 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-metal-vmaas-compute-instance-api-fields,?($|\s.*)
   - agent: kubernetes
-    always_run: false
+    always_run: true
     branches:
     - ^main$
     - ^main-
@@ -104,7 +103,6 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-osac-project-osac-installer-main-e2e-metal-vmaas-compute-instance-cli-fields
     rerun_command: /test e2e-metal-vmaas-compute-instance-cli-fields
-    run_if_changed: ^(base/|overlays/|scripts/|prerequisites/)
     spec:
       containers:
       - args:
@@ -171,7 +169,7 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-metal-vmaas-compute-instance-cli-fields,?($|\s.*)
   - agent: kubernetes
-    always_run: false
+    always_run: true
     branches:
     - ^main$
     - ^main-
@@ -189,7 +187,6 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-osac-project-osac-installer-main-e2e-metal-vmaas-compute-instance-creation
     rerun_command: /test e2e-metal-vmaas-compute-instance-creation
-    run_if_changed: ^(base/|overlays/|scripts/|prerequisites/)
     spec:
       containers:
       - args:
@@ -256,7 +253,7 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-metal-vmaas-compute-instance-creation,?($|\s.*)
   - agent: kubernetes
-    always_run: false
+    always_run: true
     branches:
     - ^main$
     - ^main-
@@ -274,7 +271,6 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-osac-project-osac-installer-main-e2e-metal-vmaas-compute-instance-delete-during-provision
     rerun_command: /test e2e-metal-vmaas-compute-instance-delete-during-provision
-    run_if_changed: ^(base/|overlays/|scripts/|prerequisites/)
     spec:
       containers:
       - args:
@@ -341,7 +337,7 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-metal-vmaas-compute-instance-delete-during-provision,?($|\s.*)
   - agent: kubernetes
-    always_run: false
+    always_run: true
     branches:
     - ^main$
     - ^main-
@@ -359,7 +355,6 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-osac-project-osac-installer-main-e2e-metal-vmaas-compute-instance-restart
     rerun_command: /test e2e-metal-vmaas-compute-instance-restart
-    run_if_changed: ^(base/|overlays/|scripts/|prerequisites/)
     spec:
       containers:
       - args:
@@ -426,7 +421,7 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-metal-vmaas-compute-instance-restart,?($|\s.*)
   - agent: kubernetes
-    always_run: false
+    always_run: true
     branches:
     - ^main$
     - ^main-
@@ -444,7 +439,6 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-osac-project-osac-installer-main-e2e-metal-vmaas-compute-instance-restart-negative
     rerun_command: /test e2e-metal-vmaas-compute-instance-restart-negative
-    run_if_changed: ^(base/|overlays/|scripts/|prerequisites/)
     spec:
       containers:
       - args:
@@ -511,7 +505,7 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-metal-vmaas-compute-instance-restart-negative,?($|\s.*)
   - agent: kubernetes
-    always_run: false
+    always_run: true
     branches:
     - ^main$
     - ^main-
@@ -529,7 +523,6 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-osac-project-osac-installer-main-e2e-metal-vmaas-subnet-lifecycle
     rerun_command: /test e2e-metal-vmaas-subnet-lifecycle
-    run_if_changed: ^(base/|overlays/|scripts/|prerequisites/)
     spec:
       containers:
       - args:
@@ -596,7 +589,7 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-metal-vmaas-subnet-lifecycle,?($|\s.*)
   - agent: kubernetes
-    always_run: false
+    always_run: true
     branches:
     - ^main$
     - ^main-
@@ -614,7 +607,6 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-osac-project-osac-installer-main-e2e-metal-vmaas-virtual-network-lifecycle
     rerun_command: /test e2e-metal-vmaas-virtual-network-lifecycle
-    run_if_changed: ^(base/|overlays/|scripts/|prerequisites/)
     spec:
       containers:
       - args:


### PR DESCRIPTION
## Summary

https://redhat.atlassian.net/browse/MGMT-24194

Remove `run_if_changed` from the 8 vmaas E2E tests so they run on every PR instead of only when deployment-related files change.

## Test plan

- [ ] Rehearsal jobs pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified CI/CD test execution configuration by updating trigger conditions for multiple end-to-end test suites, including compute instance, API, CLI, restart, and virtual network lifecycle tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->