### PR TITLE
telco5g: Fix image version for 4.22 tests

### DIFF
--- a/ci-operator/step-registry/telco5g/cnf/tests/telco5g-cnf-tests-commands.sh
+++ b/ci-operator/step-registry/telco5g/cnf/tests/telco5g-cnf-tests-commands.sh
@@ -647,7 +647,7 @@ else
     export CNF_BRANCH="release-${T5CI_VERSION}"
     # TARGET_RELEASE is used by cnf-features-deploy. If not set, it defaults to the main branch
     export TARGET_RELEASE=$CNF_BRANCH
-    export CNF_TESTS_IMAGE="cnf-tests:${T5CI_VERSION}"
+    export CNF_TESTS_IMAGE="cnf-tests:4.21"
 fi
 
 CNF_REPO_DIR=${CNF_REPO_DIR:-"$(mktemp -d -t cnf-XXXXX)/cnf-features-deploy"}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated CNF test infrastructure to use a pinned container image version for improved test consistency and reliability across specific component version scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->