### PR TITLE
Remove kmm-pull-secret credentials block from KMM test step

### DIFF
--- a/ci-operator/step-registry/aws-neuron-operator/kmm-test/aws-neuron-operator-kmm-test-commands.sh
+++ b/ci-operator/step-registry/aws-neuron-operator/kmm-test/aws-neuron-operator-kmm-test-commands.sh
@@ -28,10 +28,6 @@ if [[ -f "${CLUSTER_PROFILE_DIR}/kmm-pull-secret" ]]; then
     export ECO_HWACCEL_KMM_PULL_SECRET
     ECO_HWACCEL_KMM_PULL_SECRET=$(cat "${CLUSTER_PROFILE_DIR}/kmm-pull-secret")
     echo "KMM pull secret loaded from cluster profile"
-elif [[ -f "/var/run/vault/kmm-pull-secret/kmm-pull-secret" ]]; then
-    export ECO_HWACCEL_KMM_PULL_SECRET
-    ECO_HWACCEL_KMM_PULL_SECRET=$(cat "/var/run/vault/kmm-pull-secret/kmm-pull-secret")
-    echo "KMM pull secret loaded from vault credentials"
 else
     echo "WARNING: No KMM pull secret found, tests requiring external registry may be skipped"
 fi

--- a/ci-operator/step-registry/aws-neuron-operator/kmm-test/aws-neuron-operator-kmm-test-ref.yaml
+++ b/ci-operator/step-registry/aws-neuron-operator/kmm-test/aws-neuron-operator-kmm-test-ref.yaml
@@ -3,10 +3,6 @@ ref:
   from: eco-gotests
   grace_period: 10m
   commands: aws-neuron-operator-kmm-test-commands.sh
-  credentials:
-  - namespace: test-credentials
-    name: kmm-pull-secret
-    mount_path: /var/run/vault/kmm-pull-secret
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
## Summary
- Remove the `credentials` block from `aws-neuron-operator-kmm-test` step ref that required a standalone `kmm-pull-secret` in `test-credentials` namespace
- This secret was never provisioned via `ci-secret-bootstrap`, causing jobs to fail with `secrets "kmm-pull-secret" not found` on build clusters
- The script already reads the pull secret from the cluster profile directory (`aws-edge-infra`) as its primary path, making the vault credentials mount redundant
- Remove the dead vault fallback code path from the commands script

## Failure examples
- Periodic: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-rh-ecosystem-edge-neuron-ci-main-4.19-stable-aws-neuron-operator-e2e-weekly/2050817894454923264
- Presubmit: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_neuron-ci/19/pull-ci-rh-ecosystem-edge-neuron-ci-main-4.19-stable-aws-neuron-operator-e2e/2050879785025933312

## Test plan
- [ ] CI passes (no more `kmm-pull-secret not found` errors)
- [ ] KMM test step loads pull secret from cluster profile directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified KMM pull-secret loading mechanism by removing vault-based fallback logic; secrets now sourced directly from cluster profile directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->