### PR TITLE
NO_ISSUE: drop temp CI jobs and add members to osac-cicd

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -584,3 +584,6 @@ aliases:
   - akshaynadkarni
   - larsks
   - trewest
+  - danmanor
+  - eranco74
+  - omer-vishlitzky

--- a/ci-operator/config/osac-project/osac-aap/osac-project-osac-aap-main.yaml
+++ b/ci-operator/config/osac-project/osac-aap/osac-project-osac-aap-main.yaml
@@ -3,6 +3,16 @@ build_root:
     name: release
     namespace: openshift
     tag: rhel-9-release-golang-1.25-openshift-4.21
+images:
+  items:
+  - dockerfile_literal: |
+      FROM src
+    from: src
+    to: osac-aap
+promotion:
+  to:
+  - name: latest
+    namespace: osac-project
 resources:
   '*':
     limits:
@@ -10,11 +20,6 @@ resources:
     requests:
       cpu: 100m
       memory: 200Mi
-tests:
-- as: temp
-  commands: echo "Test"
-  container:
-    from: src
 zz_generated_metadata:
   branch: main
   org: osac-project

--- a/ci-operator/config/osac-project/osac-operator/osac-project-osac-operator-main.yaml
+++ b/ci-operator/config/osac-project/osac-operator/osac-project-osac-operator-main.yaml
@@ -3,6 +3,14 @@ build_root:
     name: release
     namespace: openshift
     tag: rhel-9-release-golang-1.24-openshift-4.21
+images:
+  items:
+  - dockerfile_path: Containerfile
+    to: osac-operator
+promotion:
+  to:
+  - name: latest
+    namespace: osac-project
 resources:
   '*':
     limits:
@@ -10,11 +18,6 @@ resources:
     requests:
       cpu: 100m
       memory: 200Mi
-tests:
-- as: temp
-  commands: echo "Test"
-  container:
-    from: src
 zz_generated_metadata:
   branch: main
   org: osac-project

--- a/ci-operator/jobs/osac-project/osac-aap/osac-project-osac-aap-main-postsubmits.yaml
+++ b/ci-operator/jobs/osac-project/osac-aap/osac-project-osac-aap-main-postsubmits.yaml
@@ -1,25 +1,25 @@
-presubmits:
-  osac-project/osac-operator:
+postsubmits:
+  osac-project/osac-aap:
   - agent: kubernetes
     always_run: true
     branches:
     - ^main$
-    - ^main-
-    cluster: build04
-    context: ci/prow/images
+    cluster: build01
     decorate: true
     decoration_config:
       skip_cloning: true
     labels:
+      ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-osac-project-osac-operator-main-images
-    rerun_command: /test images
+    max_concurrency: 1
+    name: branch-ci-osac-project-osac-aap-main-images
     spec:
       containers:
       - args:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --image-mirror-push-secret=/etc/push-secret/.dockerconfigjson
+        - --promote
         - --report-credentials-file=/etc/report/credentials
         - --target=[images]
         command:
@@ -40,6 +40,9 @@ presubmits:
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
+        - mountPath: /etc/push-secret
+          name: push-secret
+          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -51,7 +54,9 @@ presubmits:
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
+      - name: push-secret
+        secret:
+          secretName: registry-push-credentials-ci-central
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )images,?($|\s.*)

--- a/ci-operator/jobs/osac-project/osac-aap/osac-project-osac-aap-main-presubmits.yaml
+++ b/ci-operator/jobs/osac-project/osac-aap/osac-project-osac-aap-main-presubmits.yaml
@@ -6,35 +6,27 @@ presubmits:
     - ^main$
     - ^main-
     cluster: build06
-    context: ci/prow/temp
+    context: ci/prow/images
     decorate: true
     decoration_config:
       skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-osac-project-osac-aap-main-temp
-    rerun_command: /test temp
+    name: pull-ci-osac-project-osac-aap-main-images
+    rerun_command: /test images
     spec:
       containers:
       - args:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --report-credentials-file=/etc/report/credentials
-        - --target=temp
+        - --target=[images]
         command:
         - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
         image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
         imagePullPolicy: Always
         name: ""
-        ports:
-        - containerPort: 8080
-          name: http
         resources:
           requests:
             cpu: 10m
@@ -62,4 +54,4 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )temp,?($|\s.*)
+    trigger: (?m)^/test( | .* )images,?($|\s.*)

--- a/ci-operator/jobs/osac-project/osac-operator/osac-project-osac-operator-main-postsubmits.yaml
+++ b/ci-operator/jobs/osac-project/osac-operator/osac-project-osac-operator-main-postsubmits.yaml
@@ -1,25 +1,25 @@
-presubmits:
+postsubmits:
   osac-project/osac-operator:
   - agent: kubernetes
     always_run: true
     branches:
     - ^main$
-    - ^main-
-    cluster: build04
-    context: ci/prow/images
+    cluster: build01
     decorate: true
     decoration_config:
       skip_cloning: true
     labels:
+      ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-osac-project-osac-operator-main-images
-    rerun_command: /test images
+    max_concurrency: 1
+    name: branch-ci-osac-project-osac-operator-main-images
     spec:
       containers:
       - args:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --image-mirror-push-secret=/etc/push-secret/.dockerconfigjson
+        - --promote
         - --report-credentials-file=/etc/report/credentials
         - --target=[images]
         command:
@@ -40,6 +40,9 @@ presubmits:
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
+        - mountPath: /etc/push-secret
+          name: push-secret
+          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -51,7 +54,9 @@ presubmits:
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
+      - name: push-secret
+        secret:
+          secretName: registry-push-credentials-ci-central
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )images,?($|\s.*)


### PR DESCRIPTION
Drop placeholder `temp` test jobs from osac-aap and osac-operator CI configs.
Add danmanor, eranco74, omer-vishlitzky to the osac-cicd OWNERS alias.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD access aliases by adding three team entries.
  * Removed redundant temporary test steps from two CI pipelines to simplify workflows.
  * Added image build targets and promotion rules so two components are now built and promoted to the latest tag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->