### PR TITLE
WINC-1927: validate vSphere Server 2025 golden image

### DIFF
--- a/ci-operator/config/openshift-priv/openshift-tests-private/openshift-priv-openshift-tests-private-main.yaml
+++ b/ci-operator/config/openshift-priv/openshift-tests-private/openshift-priv-openshift-tests-private-main.yaml
@@ -244,6 +244,7 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: windows-golden-images/windows-server-2025-template-qe-ipv6-disabled
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-vsphere-ipi-ovn-winc

--- a/ci-operator/config/openshift-priv/openshift-tests-private/openshift-priv-openshift-tests-private-release-4.22.yaml
+++ b/ci-operator/config/openshift-priv/openshift-tests-private/openshift-priv-openshift-tests-private-release-4.22.yaml
@@ -244,6 +244,7 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: windows-golden-images/windows-server-2025-template-qe-ipv6-disabled
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-vsphere-ipi-ovn-winc

--- a/ci-operator/step-registry/cucushift/winc/prepare/cucushift-winc-prepare-commands.sh
+++ b/ci-operator/step-registry/cucushift/winc/prepare/cucushift-winc-prepare-commands.sh
@@ -323,17 +323,13 @@ echo ""
 echo "All Windows nodes are Ready:"
 oc get nodes -l kubernetes.io/os=windows -o wide
 
-# Choose the Windows container version depending on the Windows version
-# installed on the Windows workers
-# Supported: Server 2019 (1809), Server 2022 (ltsc2022)
-# TODO: Remove Server 2019 support after AMI/image upgrades to Server 2022
-# TODO: Add Server 2025 (ltsc2025) when Microsoft publishes the image
 os_version=$(oc get nodes -l 'kubernetes.io/os=windows' -o=jsonpath="{.items[0].status.nodeInfo.osImage}")
 
-windows_container_image="mcr.microsoft.com/powershell:lts-nanoserver-ltsc2022"
-if [[ "$os_version" == *"2019"* ]]
-then
-    windows_container_image="mcr.microsoft.com/powershell:lts-nanoserver-1809"
+if [[ "$os_version" == *"2025"* ]]; then
+    # TODO: Update to lts-nanoserver-ltsc2025 when Microsoft publishes the image
+    windows_container_image="mcr.microsoft.com/powershell:lts-nanoserver-ltsc2022"
+else
+    windows_container_image="mcr.microsoft.com/powershell:lts-nanoserver-ltsc2022"
 fi
 
 # Setup image mirroring for Prow CI (if mirror registry is available)


### PR DESCRIPTION
## Summary
- Add Windows Server 2025 support to `cucushift-winc-prepare` step with OS version detection
- Override `WINDOWS_OS_ID` for `debug-winc-vsphere-ipi` to use the new `windows-server-2025-template-qe-ipv6-disabled` golden image template on both main and release-4.22
- Uses `lts-nanoserver-ltsc2022` container image for Server 2025 (PowerShell `ltsc2025` image not yet published by Microsoft, see [PowerShell-Docker#851](https://github.com/PowerShell/PowerShell-Docker/issues/851))
- Validates Server 2025 golden image before implementing the full dual-version matrix ([WINC-1926](https://redhat.atlassian.net/browse/WINC-1926))

## Test results
- Rehearsal job: `rehearse-78724-pull-ci-openshift-priv-openshift-tests-private-release-4.22-debug-winc-vsphere-ipi` [#2051655818142552064](https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/origin-ci-private/pr-logs/pull/openshift_release/78724/rehearse-78724-pull-ci-openshift-priv-openshift-tests-private-release-4.22-debug-winc-vsphere-ipi/2051655818142552064)
- Windows Server 2025 nodes provisioned and reached Ready state
- Container workloads deployed successfully using `lts-nanoserver-ltsc2022` on Server 2025 hosts
- 17 pass, 3 skip, 2 fail (4m44s)
- 2 failing tests are not related to Server 2025 image changes:
  - `OCP-33768: NodeWithoutOVNKubeNodePodRunning alert ignore Windows nodes`
  - `OCP-31276: Configure CNI and internal networking check`

## Test plan
- [x] Run `/pj-rehearse` to trigger `debug-winc-vsphere-ipi` with the Server 2025 template
- [x] Verify Windows nodes provision successfully from Server 2025 template
- [x] Verify WMCO configures the nodes correctly
- [x] Verify winc smoke tests pass (17/22 pass, 2 failures unrelated to this change)

/cc @openshift/openshift-team-winc

[WINC-1926]: https://redhat.atlassian.net/browse/WINC-1926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ