### PR TITLE
neuron-ci: exclude simple-kmod tests from KMM sanity on ROSA

### DIFF
--- a/ci-operator/step-registry/aws-neuron-operator/kmm-test/aws-neuron-operator-kmm-test-ref.yaml
+++ b/ci-operator/step-registry/aws-neuron-operator/kmm-test/aws-neuron-operator-kmm-test-ref.yaml
@@ -13,7 +13,7 @@ ref:
     default: "modules"
     documentation: The eco-gotests feature directories to run for KMM tests (space-separated).
   - name: KMM_TEST_LABELS
-    default: "kmm-sanity && !bmc"
+    default: "kmm-sanity && !bmc && !simple-kmod"
     documentation: Ginkgo label filter expression for KMM test selection.
   - name: ECO_HWACCEL_KMM_REGISTRY
     default: "quay.io/ocp-edge-qe"


### PR DESCRIPTION
## Summary
- Exclude `simple-kmod` (external-registry) tests from KMM sanity on ROSA — the cluster profile pull secret doesn't have push access to `quay.io/ocp-edge-qe`
- Also exclude `bmc` tests which require bare metal controllers not available on ROSA

## Changes
- Updated `KMM_TEST_LABELS` default in `aws-neuron-operator-kmm-test-ref.yaml` from `"kmm-sanity"` to `"kmm-sanity && !bmc && !simple-kmod"`

## Test plan
- [ ] Run `pull-ci-rh-ecosystem-edge-neuron-ci-main-4.20-stable-aws-neuron-operator-e2e` and verify KMM tests pass (simple-kmod specs skipped)