### PR TITLE
WIP: hold a telco5g baremetal cluster

### DIFF
--- a/ci-operator/step-registry/telco5g/cluster-setup/telco5g-cluster-setup-commands.sh
+++ b/ci-operator/step-registry/telco5g/cluster-setup/telco5g-cluster-setup-commands.sh
@@ -306,7 +306,7 @@ cat << EOF > $SHARED_DIR/destroy-cluster.yml
   tasks:
 
   - name: Delete deployment plan
-    shell: kcli delete plan -y ${PLAN_NAME}
+    shell: echo "Not destroying ${PLAN_NAME}"
     args:
       chdir: ~/kcli-openshift4-baremetal
 

--- a/ci-operator/step-registry/telco5g/hcp-cluster-setup/telco5g-hcp-cluster-setup-commands.sh
+++ b/ci-operator/step-registry/telco5g/hcp-cluster-setup/telco5g-hcp-cluster-setup-commands.sh
@@ -168,12 +168,7 @@ cat << EOF > $SHARED_DIR/delete-sno.yml
   tasks:
 
     - name: Remove existing SNO
-      include_role:
-        name: virtual_sno
-        tasks_from: deletion.yml
-      vars:
-        vsno_name: $SNO_NAME
-        vsno_domain_name: $SNO_DOMAIN
+      command: echo "Not deleting sno $SNO_NAME"
 
 EOF
 

--- a/ci-operator/step-registry/telco5g/mno-ztp-cluster-setup/telco5g-mno-ztp-cluster-setup-commands.sh
+++ b/ci-operator/step-registry/telco5g/mno-ztp-cluster-setup/telco5g-mno-ztp-cluster-setup-commands.sh
@@ -146,12 +146,7 @@ cat << EOF > $SHARED_DIR/delete-sno.yml
   tasks:
 
     - name: Remove existing SNO
-      include_role:
-        name: virtual_sno
-        tasks_from: deletion.yml
-      vars:
-        vsno_name: $SNO_NAME
-        vsno_domain_name: $SNO_DOMAIN
+      command: echo "Not deleting $SNO_NAME"
 
 EOF
 
@@ -181,7 +176,7 @@ cat << EOF > $SHARED_DIR/delete-mno-hosts.yml
       register: vms
 
     - name: Delete virtual machines if exists
-      command: kcli delete vm {{ item }} --yes
+      command: echo 'Not deleting {{ item }}'
       when: vms.stdout != ""
       loop: "{{ vms.stdout_lines }}"
 
@@ -195,7 +190,7 @@ if [[ -n "$ADD_BM_HOST" ]]; then
       register: vms
 
     - name: Delete virtual machines if exists
-      command: kcli delete vm {{ item }} --yes
+      command: echo 'Not deleting {{ item }}'
       when: vms.stdout != ""
       loop: "{{ vms.stdout_lines }}"
 

--- a/ci-operator/step-registry/telco5g/sno-ztp-cluster-setup/telco5g-sno-ztp-cluster-setup-commands.sh
+++ b/ci-operator/step-registry/telco5g/sno-ztp-cluster-setup/telco5g-sno-ztp-cluster-setup-commands.sh
@@ -160,12 +160,7 @@ cat << EOF > $SHARED_DIR/delete-sno.yml
   tasks:
 
     - name: Remove existing SNO
-      include_role:
-        name: virtual_sno
-        tasks_from: deletion.yml
-      vars:
-        vsno_name: $SNO_NAME
-        vsno_domain_name: $SNO_DOMAIN
+      command: echo "Not deleting $SNO_NAME"
 
 EOF
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR modifies OpenShift CI infrastructure configuration to prevent automatic cleanup and deletion of telco5g baremetal test clusters. The changes affect four cluster setup step scripts that are part of the telco5g testing pipeline.

## Changes Made

The PR replaces cluster teardown/deletion operations with no-op print statements across four telco5g cluster setup steps:

- **telco5g-cluster-setup-commands.sh**: Prevents deletion of the deployment plan (changed from `kcli delete plan` to printing "Not destroying")
- **telco5g-hcp-cluster-setup-commands.sh**: Prevents deletion of the hyperconverged SNO (changed from invoking the `virtual_sno` deletion role to echoing "Not deleting sno")
- **telco5g-mno-ztp-cluster-setup-commands.sh**: Prevents deletion of SNO and virtual machines (replaced multiple `kcli delete` commands with echo statements)
- **telco5g-sno-ztp-cluster-setup-commands.sh**: Prevents deletion of the SNO (changed from invoking the deletion role to echoing "Not deleting")

## Practical Impact

These changes effectively "hold" baremetal clusters created during telco5g test runs instead of tearing them down after tests complete. This allows the clusters to persist for manual inspection, debugging, or reuse in subsequent test runs. The author has validated these changes through multiple CI rehearse runs of the affected telco5g periodic jobs across versions 4.22, 4.23, and 5.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->