### PR TITLE
Skip conntrack conformance test on Classic STS (OCPBUGS-60610)

### DIFF
--- a/ci-operator/step-registry/rosa/aws/sts/conformance/rosa-aws-sts-conformance-workflow.yaml
+++ b/ci-operator/step-registry/rosa/aws/sts/conformance/rosa-aws-sts-conformance-workflow.yaml
@@ -30,7 +30,8 @@ workflow:
         cloud-provider-aws-e2e.*loadbalancer CLB internal should be reachable with hairpinning traffic\|
         sig-auth.*SCC.*should not have pod creation failures during install\|
         sig-imageregistry.*should redirect on blob pull\|
-        CSI Mock volume expansion.*should record target size in allocated resources
+        CSI Mock volume expansion.*should record target size in allocated resources\|
+        Conntrack proxy implementation should not be vulnerable to the invalid conntrack state bug
     pre:
       - chain: rosa-aws-sts-provision
       - ref: osd-ccs-conf-idp-htpasswd-multi-users


### PR DESCRIPTION
## Summary

- The conntrack proxy conformance test (`Conntrack proxy implementation should not be vulnerable to the invalid conntrack state bug`) is a known upstream issue ([OCPBUGS-60610](https://issues.redhat.com/browse/OCPBUGS-60610)) with a fix in [openshift/kubernetes#2472](https://github.com/openshift/kubernetes/pull/2472)
- Skipping to restore CI signal while the upstream fix is backported
- STS 4.21 had 5 consecutive failures today from this test

## Changes

Adds the conntrack test pattern to `TEST_SKIPS` in the Classic STS conformance workflow. HCP is not affected (4.21 passing).

[OCPBUGS-60610]: https://redhat.atlassian.net/browse/OCPBUGS-60610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated conformance test skip configuration for ROSA AWS STS deployments to exclude additional test cases from validation runs, including an added networking-related skip alongside an existing CSI-related skip. This reduces noisy failures during automated validation and keeps conformance reports focused on actionable issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->