### PR TITLE
no-jira: chore(osso,rodoo): add missing release-22 branch tide configuration

### DIFF
--- a/core-services/prow/02_config/openshift/run-once-duration-override-operator/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/run-once-duration-override-operator/_prowconfig.yaml
@@ -1,6 +1,24 @@
 tide:
   queries:
   - includedBranches:
+    - openshift-4.22
+    - release-4.22
+    labels:
+    - approved
+    - backport-risk-assessed
+    - jira/valid-bug
+    - lgtm
+    - verified
+    missingLabels:
+    - backports/unvalidated-commits
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - jira/invalid-bug
+    - needs-rebase
+    repos:
+    - openshift/run-once-duration-override-operator
+  - includedBranches:
     - openshift-4.13
     - openshift-4.14
     - openshift-4.15

--- a/core-services/prow/02_config/openshift/run-once-duration-override/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/run-once-duration-override/_prowconfig.yaml
@@ -1,6 +1,24 @@
 tide:
   queries:
   - includedBranches:
+    - openshift-4.22
+    - release-4.22
+    labels:
+    - approved
+    - backport-risk-assessed
+    - jira/valid-bug
+    - lgtm
+    - verified
+    missingLabels:
+    - backports/unvalidated-commits
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - jira/invalid-bug
+    - needs-rebase
+    repos:
+    - openshift/run-once-duration-override
+  - includedBranches:
     - openshift-4.13
     - openshift-4.14
     - openshift-4.15

--- a/core-services/prow/02_config/openshift/secondary-scheduler-operator/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/secondary-scheduler-operator/_prowconfig.yaml
@@ -1,6 +1,24 @@
 tide:
   queries:
   - includedBranches:
+    - openshift-4.22
+    - release-4.22
+    labels:
+    - approved
+    - backport-risk-assessed
+    - jira/valid-bug
+    - lgtm
+    - verified
+    missingLabels:
+    - backports/unvalidated-commits
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - jira/invalid-bug
+    - needs-rebase
+    repos:
+    - openshift/secondary-scheduler-operator
+  - includedBranches:
     - openshift-4.10
     - openshift-4.11
     - openshift-4.12


### PR DESCRIPTION
ssia

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added support for OpenShift 4.22 branches (openshift-4.22 and release-4.22) across multiple operator CI configurations.
  * Tightened merge validation by adding the backports/unvalidated-commits label to missing-label checks and reordering missing-label rules for affected branch selectors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->