### PR TITLE
Introduce the new cluster profiles' ownership schema

### DIFF
--- a/ci-operator/step-registry/cluster-profiles/README.md
+++ b/ci-operator/step-registry/cluster-profiles/README.md
@@ -4,14 +4,18 @@ This folder contains configuration related to cluster profiles.
 
 The `cluster-profiles-config.yaml` file contains a list of cluster profiles whose owners wish for them to be private; their usage restricted to specific organizations and repositories.
 
-### Intended use
-An owner in the owners list is an `org` with the option to specify `repos`.
+## Intended use
+Ownership of a cluster profile is defined in two ways, depending from which CI system the owner comes from.
+
+### OpenShift CI
+An owner in `OpenShift CI` is an `org` with the option to specify `repos`.
 When an `org` specifies one or more `repos`, the usage of the cluster profile is limited to those specified repositories.
 If a cluster profile doesn't have the `owners` field defined, its usage remains unrestricted.
 
 **Example 1: Restricting access to multiple repositories:**
 ```yaml
-- profile: cluster-profile-name
+cluster_profiles:
+- name: cluster-profile-name
   owners:
     - org: org
       repos:
@@ -21,7 +25,8 @@ If a cluster profile doesn't have the `owners` field defined, its usage remains 
 
 **Example 2: Restricting access to more than one org:**
 ```yaml
-- profile: cluster-profile-name
+cluster_profiles:
+- name: cluster-profile-name
   owners:
     - org: org
       repos:
@@ -30,5 +35,57 @@ If a cluster profile doesn't have the `owners` field defined, its usage remains 
     - org: org3
 ```
 
-### Future Plans
+### Konflux CI
+An owner in `Konflux CI` is a `tenant` along with the `cluster`'s name it is defined into.
+
+**Example 1: Map a tenant to a single cluster**
+```yaml
+cluster_profiles:
+- name: cluster-profile-name
+  owners:
+    - konflux:
+        tenant: foobar
+        clusters:
+          - kflux-prd-rh02
+```
+
+**Example 2: Cluster groups**  
+Since Konflux CI defines a separate sets of clusters per environment, it might be convenient referring to a `cluster_group` name rather than repeating the same names over and over.
+```yaml
+konflux:
+  cluster_groups:
+    prod:
+      - stone-prd-rh01
+      - kflux-prd-rh02
+      - kflux-prd-rh03
+    staging:
+      - stone-stg-rh01
+      - stone-stage-p01
+
+cluster_profiles:
+- name: cluster-profile-name-1
+  owners:
+    - konflux:
+        tenant: foobar
+        cluster_groups:
+          - prod
+```
+
+Using both `clusters` and `cluster_groups` is allowed: the result is a list that contains the clusters defined in `clusters` and in each `clusters_groups`.
+```yaml
+- name: cluster-profile-name-2
+  owners:
+    - konflux:
+        tenant: foobar
+        clusters:
+          - dev
+        cluster_groups:
+          - staging
+```
+The resulting cluster list from the example above is: `["dev", "stone-stg-rh01", "stone-stage-p01"]`.
+
+Konflux's environments are defined in [https://konflux.pages.redhat.com/docs/users/cluster-info/cluster-info.html](https://konflux.pages.redhat.com/docs/users/cluster-info/cluster-info.html).
+
+
+## Future Plans
 We plan to move cluster profiles here, allowing them to exist as a configuration file instead of as code in `ci-tools` as is described in our [documentation](https://docs.ci.openshift.org/docs/how-tos/adding-a-cluster-profile/).

--- a/ci-operator/step-registry/cluster-profiles/cluster-profiles-config.yaml
+++ b/ci-operator/step-registry/cluster-profiles/cluster-profiles-config.yaml
@@ -1,4 +1,6 @@
-- owners:
+cluster_profiles:
+- name: aws
+  owners:
   - org: 3scale
     repos:
     - 3scale-operator
@@ -101,8 +103,8 @@
     repos:
     - multicluster-observability-operator
     - observatorium-operator
-  profile: aws
-- owners:
+- name: aws-2
+  owners:
   - org: 3scale
     repos:
     - 3scale-operator
@@ -204,8 +206,8 @@
     repos:
     - multicluster-observability-operator
     - observatorium-operator
-  profile: aws-2
-- owners:
+- name: aws-3
+  owners:
   - org: 3scale
     repos:
     - 3scale-operator
@@ -309,8 +311,8 @@
     repos:
     - multicluster-observability-operator
     - observatorium-operator
-  profile: aws-3
-- owners:
+- name: aws-4
+  owners:
   - org: 3scale
     repos:
     - 3scale-operator
@@ -411,8 +413,8 @@
     repos:
     - multicluster-observability-operator
     - observatorium-operator
-  profile: aws-4
-- owners:
+- name: aws-5
+  owners:
   - org: 3scale
     repos:
     - 3scale-operator
@@ -513,8 +515,8 @@
     repos:
     - multicluster-observability-operator
     - observatorium-operator
-  profile: aws-5
-- owners:
+- name: aws-qe
+  owners:
   - org: insights-onprem
     repos:
     - cost-onprem-chart
@@ -564,30 +566,30 @@
     - bip-orchestrate-vm
     - ib-orchestrate-vm
     - recert
-  profile: aws-qe
-- owners:
+- name: aws-1-qe
+  owners:
   - org: openshift
     repos:
     - openshift-tests-private
     - verification-tests
-  profile: aws-1-qe
-- owners:
+- name: aws-c2s-qe
+  owners:
   - org: openshift
     repos:
     - openshift-tests-private
-  profile: aws-c2s-qe
-- owners:
+- name: aws-sc2s-qe
+  owners:
   - org: openshift
     repos:
     - openshift-tests-private
-  profile: aws-sc2s-qe
-- owners:
+- name: aws-usgov-qe
+  owners:
   - org: openshift
     repos:
     - openshift-tests-private
     - verification-tests
-  profile: aws-usgov-qe
-- owners:
+- name: aws-eusc
+  owners:
   - org: openshift
     repos:
     - csi-operator
@@ -597,13 +599,13 @@
   - org: openshift-priv
     repos:
     - installer
-  profile: aws-eusc
-- owners:
+- name: aws-autorelease-qe
+  owners:
   - org: openshift
     repos:
     - openshift-tests-private
-  profile: aws-autorelease-qe
-- owners:
+- name: azure-qe
+  owners:
   - org: openshift
     repos:
     - azure-disk-csi-driver
@@ -639,25 +641,25 @@
   - org: redhat-chaos
     repos:
     - prow-scripts
-  profile: azure-qe
-- owners:
+- name: azuremag-qe
+  owners:
   - org: openshift
     repos:
     - openshift-tests-private
     - verification-tests
-  profile: azuremag-qe
-- owners:
+- name: azurestack-qe
+  owners:
   - org: openshift
     repos:
     - openshift-tests-private
     - verification-tests
-  profile: azurestack-qe
-- owners:
+- name: azure-autorelease-qe
+  owners:
   - org: openshift
     repos:
     - openshift-tests-private
-  profile: azure-autorelease-qe
-- owners:
+- name: gcp-qe
+  owners:
   - org: openshift
     repos:
     - cluster-api-provider-gcp
@@ -683,19 +685,19 @@
     - gcp-pd-csi-driver-operator
     - installer
     - openshift-tests-private
-  profile: gcp-qe
-- owners:
+- name: gcp-qe-c3-metal
+  owners:
   - org: openshift
     repos:
     - openshift-tests-private
     - verification-tests
-  profile: gcp-qe-c3-metal
-- owners:
+- name: gcp-autorelease-qe
+  owners:
   - org: openshift
     repos:
     - openshift-tests-private
-  profile: gcp-autorelease-qe
-- owners:
+- name: gcp
+  owners:
   - org: ViaQ
     repos:
     - logging-fluentd
@@ -730,12 +732,12 @@
   - org: red-hat-data-services
     repos:
     - opendatahub-operator
-  profile: gcp
-- owners:
+- name: gcp-openshift-gce-devel-ci-2
+  owners:
   - org: openshift
   - org: openshift-priv
-  profile: gcp-openshift-gce-devel-ci-2
-- owners:
+- name: gcp-observability
+  owners:
   - org: openshift
   - org: openshift-power-monitoring
     repos:
@@ -745,8 +747,8 @@
     repos:
     - obs-mcp
     - observability-operator
-  profile: gcp-observability
-- owners:
+- name: azure-observability
+  owners:
   - org: openshift
   - org: openshift-power-monitoring
     repos:
@@ -755,8 +757,8 @@
   - org: rhobs
     repos:
     - observability-operator
-  profile: azure-observability
-- owners:
+- name: gcp-3
+  owners:
   - org: ViaQ
     repos:
     - logging-fluentd
@@ -775,21 +777,21 @@
   - org: red-hat-data-services
     repos:
     - opendatahub-operator
-  profile: gcp-3
-- owners:
+- name: aws-opendatahub
+  owners:
   - org: opendatahub-io
   - org: red-hat-data-services
   - org: trustyai-explainability
-  profile: aws-opendatahub
-- owners:
+- name: gcp-opendatahub
+  owners:
   - org: opendatahub-io
   - org: red-hat-data-services
   - org: trustyai-explainability
-  profile: gcp-opendatahub
-- owners:
+- name: medik8s-aws
+  owners:
   - org: medik8s
-  profile: medik8s-aws
-- owners:
+- name: aws-telco
+  owners:
   - org: openshift-kni
     repos:
     - cluster-group-upgrades-operator
@@ -808,21 +810,21 @@
     - downstream-ptp-operator-monorepo
     - hw-event-proxy
     - hw-event-proxy-operator
-  profile: aws-telco
-- owners:
+- name: gitops-aws
+  owners:
   - org: redhat-developer
     repos:
     - gitops-backend
     - gitops-operator
     - kam
-  profile: gitops-aws
-- owners:
+- name: osl-gcp
+  owners:
   - org: crc-org
     repos:
     - crc
     - snc
-  profile: osl-gcp
-- owners:
+- name: aws-edge-infra
+  owners:
   - org: rh-ecosystem-edge
     repos:
     - amd-ci
@@ -833,8 +835,8 @@
     - neuron-ci
     - nvidia-ci
     - recert
-  profile: aws-edge-infra
-- owners:
+- name: rh-openshift-ecosystem
+  owners:
   - org: redhat-openshift-ecosystem
     repos:
     - certified-operators
@@ -850,72 +852,72 @@
     - preflight-trigger
     - redhat-marketplace-operators
     - redhat-marketplace-operators-preprod
-  profile: rh-openshift-ecosystem
-- owners:
+- name: odf-aws
+  owners:
   - org: red-hat-storage
-  profile: odf-aws
-- owners:
+- name: aws-serverless
+  owners:
   - org: openshift-knative
-  profile: aws-serverless
-- owners:
+- name: devsandboxci-aws
+  owners:
   - org: codeready-toolchain
   - org: kubesaw
-  profile: devsandboxci-aws
-- profile: vsphere-connected-2
+- name: vsphere-connected-2
   secret: cluster-secrets-vsphere
-- profile: vsphere-dis-2
+- name: vsphere-dis-2
   secret: cluster-secrets-vsphere
-- profile: vsphere-elastic
+- name: vsphere-elastic
   secret: cluster-secrets-vsphere
-- profile: vsphere-multizone-2
+- name: vsphere-multizone-2
   secret: cluster-secrets-vsphere
-- owners:
+- name: aro-redhat-tenant
+  owners:
   - org: openshift
     repos:
     - aro-e2e
-  profile: aro-redhat-tenant
-- profile: azure-hcp-qe
+- name: azure-hcp-qe
   secret: cluster-secrets-azure-hcp-qe
-- profile: azure-hcp-ha-qe
+- name: azure-hcp-ha-qe
   secret: cluster-secrets-azure-hcp-qe
-- owners:
+- name: aws-lp-chaos
+  owners:
   - org: redhat-chaos
     repos:
     - lp-chaos
-  profile: aws-lp-chaos
-- owners:
+- name: metal-redhat-gs
+  owners:
   - org: RedHatQE
     repos:
     - interop-testing
   - org: redhat-chaos
     repos:
     - lp-chaos
-  profile: metal-redhat-gs
-- owners:
+- name: aro-classic-int
+  owners:
   - org: Azure
-  profile: aro-classic-int
-- owners:
+- name: aro-classic-stg
+  owners:
   - org: Azure
-  profile: aro-classic-stg
-- owners:
+- name: aro-classic-prod
+  owners:
   - org: Azure
-  profile: aro-classic-prod
-- owners:
+- name: aro-classic-dev
+  owners:
   - org: Azure
-  profile: aro-classic-dev
-- owners:
+- name: aro-hcp-int
+  owners:
   - org: Azure
-  profile: aro-hcp-int
-- owners:
+- name: aro-hcp-stg
+  owners:
   - org: Azure
-  profile: aro-hcp-stg
-- owners:
+- name: aro-hcp-prod
+  owners:
   - org: Azure
-  profile: aro-hcp-prod
-- owners:
+- name: aro-hcp-dev
+  owners:
   - org: Azure
-  profile: aro-hcp-dev
-- owners:
+- name: aws-cspi-qe
+  owners:
   - org: 3scale-qe
     repos:
     - 3scale-deploy
@@ -1031,38 +1033,37 @@
   - org: windup
     repos:
     - windup-ui-tests
-  profile: aws-cspi-qe
-- owners:
+- name: aws-sandboxed-containers-operator
+  owners:
   - org: openshift
     repos:
     - sandboxed-containers-operator
-  profile: aws-sandboxed-containers-operator
-- owners:
+- name: rosa-regional-platform-int
+  owners:
   - org: openshift-online
     repos:
     - rosa-regional-platform
     - rosa-regional-platform-internal
-  profile: rosa-regional-platform-int
-- owners:
+- name: hypershift-gcp
+  owners:
   - org: openshift
     repos:
     - hypershift
   - org: openshift-priv
     repos:
     - hypershift
-  profile: hypershift-gcp
-- owners:
+- name: rosa-e2e-01
+  owners:
   - org: openshift
   - org: openshift-online
-  profile: rosa-e2e-01
   secret: cluster-secrets-rosa-e2e-01
-- owners:
+- name: rosa-e2e-02
+  owners:
   - org: openshift
   - org: openshift-online
-  profile: rosa-e2e-02
   secret: cluster-secrets-rosa-e2e-02
-- owners:
+- name: rosa-e2e-03
+  owners:
   - org: openshift
   - org: openshift-online
-  profile: rosa-e2e-03
   secret: cluster-secrets-rosa-e2e-03


### PR DESCRIPTION
The new schema has been defined in https://github.com/openshift/ci-tools/pull/5148

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded cluster profiles documentation with new sections on intended use, ownership mapping, and cluster group configuration examples.

* **Chores**
  * Updated cluster profiles configuration schema for improved consistency and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->