### PR TITLE
Add CI jobs for Proxy 1.30 (OSSM-3.4)

### DIFF
--- a/ci-operator/config/openshift-service-mesh/proxy/openshift-service-mesh-proxy-release-1.30.yaml
+++ b/ci-operator/config/openshift-service-mesh/proxy/openshift-service-mesh-proxy-release-1.30.yaml
@@ -1,0 +1,338 @@
+base_images:
+  cli:
+    name: "4.21"
+    namespace: ocp
+    tag: cli
+build_root:
+  image_stream_tag:
+    name: maistra-builder
+    namespace: ci
+    tag: "3.4"
+  use_build_cache: true
+releases:
+  latest:
+    release:
+      architecture: multi
+      channel: stable
+      version: "4.21"
+resources:
+  '*':
+    requests:
+      cpu: 200m
+      memory: 200Mi
+tests:
+- as: unit
+  steps:
+    cluster_profile: ossm-aws
+    env:
+      CI: "true"
+      COMPUTE_NODE_REPLICAS: "1"
+      COMPUTE_NODE_TYPE: m5d.8xlarge
+      LOCAL_CPU_RESOURCES: "30"
+      LOCAL_JOBS: "30"
+      LOCAL_RAM_RESOURCES: "61440"
+      MAISTRA_BUILDER_IMAGE: quay.io/maistra-dev/maistra-builder:3.4
+      MAISTRA_NAMESPACE: maistra-e2e-test
+      MAISTRA_SC_POD: maistra-proxy-test-pod
+    test:
+    - as: copy-src
+      cli: latest
+      commands: |
+        tar cf - . | oc exec -i -n "${MAISTRA_NAMESPACE}" "${MAISTRA_SC_POD}" -- tar xf - -C /work/
+      env:
+      - name: MAISTRA_NAMESPACE
+      - name: MAISTRA_SC_POD
+      from: src
+      resources:
+        requests:
+          cpu: 100m
+          memory: 100Mi
+      timeout: 20m0s
+    - as: unit
+      cli: latest
+      commands: |
+        oc rsh -n "${MAISTRA_NAMESPACE}" "${MAISTRA_SC_POD}" \
+          sh -c \
+          "export CI=${CI}; \
+           export LOCAL_CPU_RESOURCES=${LOCAL_CPU_RESOURCES}; \
+           export LOCAL_RAM_RESOURCES=${LOCAL_RAM_RESOURCES}; \
+           export LOCAL_JOBS=${LOCAL_JOBS}; \
+          ./ossm/ci/pre-submit.sh"
+        oc cp "${MAISTRA_NAMESPACE}"/"${MAISTRA_SC_POD}":"${ARTIFACT_DIR}"/. "${ARTIFACT_DIR}"
+      env:
+      - name: MAISTRA_NAMESPACE
+      - name: MAISTRA_SC_POD
+      - name: CI
+      - name: LOCAL_CPU_RESOURCES
+      - name: LOCAL_RAM_RESOURCES
+      - name: LOCAL_JOBS
+      from: src
+      resources:
+        requests:
+          cpu: 100m
+          memory: 100Mi
+      timeout: 8h0m0s
+    workflow: servicemesh-proxy-e2e-aws
+- as: unit-arm
+  steps:
+    cluster_profile: ossm-aws
+    env:
+      CI: "true"
+      COMPUTE_NODE_REPLICAS: "1"
+      COMPUTE_NODE_TYPE: m8gd.8xlarge
+      LOCAL_CPU_RESOURCES: "30"
+      LOCAL_JOBS: "30"
+      LOCAL_RAM_RESOURCES: "61440"
+      MAISTRA_BUILDER_IMAGE: quay.io/maistra-dev/maistra-builder:3.4
+      MAISTRA_NAMESPACE: maistra-e2e-test
+      MAISTRA_SC_POD: maistra-proxy-test-pod
+      OCP_ARCH: arm64
+    test:
+    - as: copy-src
+      cli: latest
+      commands: |
+        tar cf - . | oc exec -i -n "${MAISTRA_NAMESPACE}" "${MAISTRA_SC_POD}" -- tar xf - -C /work/
+      env:
+      - name: MAISTRA_NAMESPACE
+      - name: MAISTRA_SC_POD
+      from: src
+      resources:
+        requests:
+          cpu: 100m
+          memory: 100Mi
+      timeout: 20m0s
+    - as: unit-arm
+      cli: latest
+      commands: |
+        oc rsh -n "${MAISTRA_NAMESPACE}" "${MAISTRA_SC_POD}" \
+          sh -c \
+          "export CI=${CI}; \
+           export LOCAL_CPU_RESOURCES=${LOCAL_CPU_RESOURCES}; \
+           export LOCAL_RAM_RESOURCES=${LOCAL_RAM_RESOURCES}; \
+           export LOCAL_JOBS=${LOCAL_JOBS}; \
+          ./ossm/ci/pre-submit.sh"
+        oc cp "${MAISTRA_NAMESPACE}"/"${MAISTRA_SC_POD}":"${ARTIFACT_DIR}"/. "${ARTIFACT_DIR}"
+      env:
+      - name: MAISTRA_NAMESPACE
+      - name: MAISTRA_SC_POD
+      - name: CI
+      - name: LOCAL_CPU_RESOURCES
+      - name: LOCAL_RAM_RESOURCES
+      - name: LOCAL_JOBS
+      from: src
+      resources:
+        requests:
+          cpu: 100m
+          memory: 100Mi
+      timeout: 8h0m0s
+    workflow: servicemesh-proxy-e2e-aws
+- always_run: false
+  as: envoy
+  optional: true
+  steps:
+    cluster_profile: ossm-aws
+    env:
+      CI: "true"
+      COMPUTE_NODE_REPLICAS: "1"
+      COMPUTE_NODE_ROOTVOLUME_SIZE: "300"
+      COMPUTE_NODE_TYPE: m5d.8xlarge
+      LOCAL_CPU_RESOURCES: "30"
+      LOCAL_JOBS: "30"
+      LOCAL_RAM_RESOURCES: "61440"
+      MAISTRA_BUILDER_IMAGE: quay.io/maistra-dev/maistra-builder:3.4
+      MAISTRA_NAMESPACE: maistra-e2e-test
+      MAISTRA_SC_POD: maistra-proxy-test-pod
+    test:
+    - as: copy-src
+      cli: latest
+      commands: |
+        tar cf - . | oc exec -i -n "${MAISTRA_NAMESPACE}" "${MAISTRA_SC_POD}" -- tar xf - -C /work/
+      env:
+      - name: MAISTRA_NAMESPACE
+      - name: MAISTRA_SC_POD
+      from: src
+      resources:
+        requests:
+          cpu: 100m
+          memory: 100Mi
+      timeout: 20m0s
+    - as: envoy
+      cli: latest
+      commands: |
+        oc rsh -n "${MAISTRA_NAMESPACE}" "${MAISTRA_SC_POD}" \
+          sh -c \
+          "export CI=${CI}; \
+           export LOCAL_CPU_RESOURCES=${LOCAL_CPU_RESOURCES}; \
+           export LOCAL_RAM_RESOURCES=${LOCAL_RAM_RESOURCES}; \
+           export LOCAL_JOBS=${LOCAL_JOBS}; \
+          ./ossm/ci/pre-submit-envoy.sh"
+        oc cp "${MAISTRA_NAMESPACE}"/"${MAISTRA_SC_POD}":"${ARTIFACT_DIR}"/. "${ARTIFACT_DIR}"
+      env:
+      - name: MAISTRA_NAMESPACE
+      - name: MAISTRA_SC_POD
+      - name: CI
+      - name: LOCAL_CPU_RESOURCES
+      - name: LOCAL_RAM_RESOURCES
+      - name: LOCAL_JOBS
+      from: src
+      resources:
+        requests:
+          cpu: 100m
+          memory: 100Mi
+      timeout: 8h0m0s
+    workflow: servicemesh-envoy-e2e-aws
+- as: copy-artifacts-gcs
+  postsubmit: true
+  steps:
+    cluster_profile: ossm-aws
+    env:
+      ARTIFACTS_GCS_PATH: gs://maistra-prow-testing/proxy
+      CI: "true"
+      COMPUTE_NODE_REPLICAS: "1"
+      COMPUTE_NODE_TYPE: m5d.8xlarge
+      GCS_PROJECT: maistra-prow-testing
+      LOCAL_CPU_RESOURCES: "30"
+      LOCAL_JOBS: "30"
+      LOCAL_RAM_RESOURCES: "61440"
+      MAISTRA_BUILDER_IMAGE: quay.io/maistra-dev/maistra-builder:3.4
+      MAISTRA_NAMESPACE: maistra-e2e-test
+      MAISTRA_SC_POD: maistra-proxy-test-pod
+    test:
+    - as: copy-src
+      cli: latest
+      commands: |
+        # copy source
+        tar cf - . | oc exec -i -n "${MAISTRA_NAMESPACE}" "${MAISTRA_SC_POD}" -- tar xf - -C /work/
+        # copy gcs service-account
+        TARGET=$(readlink -f /maistra-secrets/service-account.json)
+        oc cp "${TARGET}" "${MAISTRA_NAMESPACE}"/"${MAISTRA_SC_POD}":/work/
+      credentials:
+      - mount_path: /maistra-secrets
+        name: gcs-credentials
+        namespace: test-credentials
+      env:
+      - name: MAISTRA_NAMESPACE
+      - name: MAISTRA_SC_POD
+      from: src
+      resources:
+        requests:
+          cpu: 100m
+          memory: 100Mi
+      timeout: 20m0s
+    - as: copy-artifacts-gcs
+      cli: latest
+      commands: |
+        oc rsh -n "${MAISTRA_NAMESPACE}" "${MAISTRA_SC_POD}" \
+          sh -c \
+          "export CI=${CI}; \
+           export LOCAL_CPU_RESOURCES=${LOCAL_CPU_RESOURCES}; \
+           export LOCAL_RAM_RESOURCES=${LOCAL_RAM_RESOURCES}; \
+           export LOCAL_JOBS=${LOCAL_JOBS}; \
+           export GOOGLE_APPLICATION_CREDENTIALS='/work/service-account.json'; \
+          ./ossm/ci/post-submit.sh"
+      env:
+      - name: MAISTRA_NAMESPACE
+      - name: MAISTRA_SC_POD
+      - name: CI
+      - name: LOCAL_CPU_RESOURCES
+      - name: LOCAL_RAM_RESOURCES
+      - name: LOCAL_JOBS
+      - name: GCS_PROJECT
+      - name: ARTIFACTS_GCS_PATH
+      from: src
+      resources:
+        requests:
+          cpu: 100m
+          memory: 100Mi
+      timeout: 8h0m0s
+    workflow: servicemesh-proxy-e2e-aws
+- as: copy-artifacts-gcs-arm
+  postsubmit: true
+  steps:
+    cluster_profile: ossm-aws
+    env:
+      ARTIFACTS_GCS_PATH: gs://maistra-prow-testing/proxy
+      CI: "true"
+      COMPUTE_NODE_REPLICAS: "1"
+      COMPUTE_NODE_TYPE: m8gd.8xlarge
+      GCS_PROJECT: maistra-prow-testing
+      LOCAL_CPU_RESOURCES: "30"
+      LOCAL_JOBS: "30"
+      LOCAL_RAM_RESOURCES: "61440"
+      MAISTRA_BUILDER_IMAGE: quay.io/maistra-dev/maistra-builder:3.4
+      MAISTRA_NAMESPACE: maistra-e2e-test
+      MAISTRA_SC_POD: maistra-proxy-test-pod
+      OCP_ARCH: arm64
+    test:
+    - as: copy-src
+      cli: latest
+      commands: |
+        # copy source
+        tar cf - . | oc exec -i -n "${MAISTRA_NAMESPACE}" "${MAISTRA_SC_POD}" -- tar xf - -C /work/
+        # copy gcs service-account
+        TARGET=$(readlink -f /maistra-secrets/service-account.json)
+        oc cp "${TARGET}" "${MAISTRA_NAMESPACE}"/"${MAISTRA_SC_POD}":/work/
+      credentials:
+      - mount_path: /maistra-secrets
+        name: gcs-credentials
+        namespace: test-credentials
+      env:
+      - name: MAISTRA_NAMESPACE
+      - name: MAISTRA_SC_POD
+      from: src
+      resources:
+        requests:
+          cpu: 100m
+          memory: 100Mi
+      timeout: 20m0s
+    - as: copy-artifacts-gcs-arm
+      cli: latest
+      commands: |
+        oc rsh -n "${MAISTRA_NAMESPACE}" "${MAISTRA_SC_POD}" \
+          sh -c \
+          "export CI=${CI}; \
+           export LOCAL_CPU_RESOURCES=${LOCAL_CPU_RESOURCES}; \
+           export LOCAL_RAM_RESOURCES=${LOCAL_RAM_RESOURCES}; \
+           export LOCAL_JOBS=${LOCAL_JOBS}; \
+           export GOOGLE_APPLICATION_CREDENTIALS='/work/service-account.json'; \
+          ./ossm/ci/post-submit.sh"
+      env:
+      - name: MAISTRA_NAMESPACE
+      - name: MAISTRA_SC_POD
+      - name: CI
+      - name: LOCAL_CPU_RESOURCES
+      - name: LOCAL_RAM_RESOURCES
+      - name: LOCAL_JOBS
+      - name: GCS_PROJECT
+      - name: ARTIFACTS_GCS_PATH
+      from: src
+      resources:
+        requests:
+          cpu: 100m
+          memory: 100Mi
+      timeout: 8h0m0s
+    workflow: servicemesh-proxy-e2e-aws
+- as: update-istio
+  commands: |
+    # load test-infra automator.sh script
+    export ISTIO_ENVOY_BASE_URL="https://storage.googleapis.com/maistra-prow-testing/proxy"
+    git clone https://github.com/maistra/test-infra.git
+    cd test-infra
+    ./tools/automator.sh \
+      -o openshift-service-mesh \
+      -r istio \
+      -f /creds-github/token \
+      "-c bin/update_proxy.sh ${PULL_BASE_SHA}" \
+      '-t [release-1.30] Automator: Update proxy' \
+      -m bump-proxy-1.30 \
+      -b release-1.30
+  container:
+    from: src
+  postsubmit: true
+  secrets:
+  - mount_path: /creds-github
+    name: ossm-github-simple-job
+zz_generated_metadata:
+  branch: release-1.30
+  org: openshift-service-mesh
+  repo: proxy

--- a/ci-operator/jobs/openshift-service-mesh/proxy/openshift-service-mesh-proxy-release-1.30-postsubmits.yaml
+++ b/ci-operator/jobs/openshift-service-mesh/proxy/openshift-service-mesh-proxy-release-1.30-postsubmits.yaml
@@ -1,0 +1,232 @@
+postsubmits:
+  openshift-service-mesh/proxy:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-1\.30$
+    cluster: build05
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: ossm-aws
+      ci.openshift.io/generator: prowgen
+    max_concurrency: 1
+    name: branch-ci-openshift-service-mesh-proxy-release-1.30-copy-artifacts-gcs
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=copy-artifacts-gcs
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-1\.30$
+    cluster: build05
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: ossm-aws
+      ci.openshift.io/generator: prowgen
+    max_concurrency: 1
+    name: branch-ci-openshift-service-mesh-proxy-release-1.30-copy-artifacts-gcs-arm
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=copy-artifacts-gcs-arm
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-1\.30$
+    cluster: build05
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+    max_concurrency: 1
+    name: branch-ci-openshift-service-mesh-proxy-release-1.30-update-istio
+    reporter_config:
+      slack:
+        channel: '#team-ossm-release-maintenance'
+        job_states_to_report:
+        - failure
+        - error
+        report_template: ':failed: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*.
+          <{{.Status.URL}}|View logs>'
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ossm-github-simple-job
+        - --target=update-istio
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /secrets/ossm-github-simple-job
+          name: ossm-github-simple-job
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: ossm-github-simple-job
+        secret:
+          secretName: ossm-github-simple-job
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator

--- a/ci-operator/jobs/openshift-service-mesh/proxy/openshift-service-mesh-proxy-release-1.30-presubmits.yaml
+++ b/ci-operator/jobs/openshift-service-mesh/proxy/openshift-service-mesh-proxy-release-1.30-presubmits.yaml
@@ -1,0 +1,249 @@
+presubmits:
+  openshift-service-mesh/proxy:
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-1\.30$
+    - ^release-1\.30-
+    cluster: build03
+    context: ci/prow/envoy
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: ossm-aws
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-service-mesh-proxy-release-1.30-envoy
+    optional: true
+    rerun_command: /test envoy
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=envoy
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )envoy,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-1\.30$
+    - ^release-1\.30-
+    cluster: build03
+    context: ci/prow/unit
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: ossm-aws
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-service-mesh-proxy-release-1.30-unit
+    rerun_command: /test unit
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=unit
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )unit,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-1\.30$
+    - ^release-1\.30-
+    cluster: build03
+    context: ci/prow/unit-arm
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: ossm-aws
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-service-mesh-proxy-release-1.30-unit-arm
+    rerun_command: /test unit-arm
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=unit-arm
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )unit-arm,?($|\s.*)

--- a/core-services/image-mirroring/_config.yaml
+++ b/core-services/image-mirroring/_config.yaml
@@ -321,6 +321,8 @@ supplementalCIImages:
     image: quay.io/maistra-dev/maistra-builder:3.2
   ci/maistra-builder:3.3:
     image: quay.io/maistra-dev/maistra-builder:3.3
+  ci/maistra-builder:3.4:
+    image: quay.io/maistra-dev/maistra-builder:3.4
   ci/ods-ci:dev:
     image: quay.io/modh/ods-ci:dev
   ci/yq:3.3.0:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated proxy release 1.30 CI configuration: added multi-architecture test support (AMD64 and ARM), global resource requests, optional additional e2e runs, and post-submit workflows to copy build artifacts to cloud storage.
  * Added image mirroring entry for an updated builder image to ensure the new builder tag is available during CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->