### PR TITLE
Update Go builder from 1.24 to 1.25 for cluster-logging-operator release 6.5

### DIFF
--- a/ci-operator/config/openshift/cluster-logging-operator/openshift-cluster-logging-operator-release-6.5.yaml
+++ b/ci-operator/config/openshift/cluster-logging-operator/openshift-cluster-logging-operator-release-6.5.yaml
@@ -2,7 +2,7 @@ base_images:
   go_builder:
     name: builder
     namespace: ocp
-    tag: rhel-9-golang-1.24-openshift-4.21
+    tag: rhel-9-golang-1.25-openshift-4.21
   log-file-metric-exporter:
     name: 6.y
     namespace: logging
@@ -31,7 +31,7 @@ build_root:
   image_stream_tag:
     name: builder
     namespace: ocp
-    tag: rhel-9-golang-1.24-openshift-4.21
+    tag: rhel-9-golang-1.25-openshift-4.21
 images:
   items:
   - from: ubi9-minimal


### PR DESCRIPTION
 Update Go builder from 1.24 to 1.25 for cluster-logging-operator release 6.5

releted to: 
- https://github.com/openshift/cluster-logging-operator/pull/3266
- https://redhat.atlassian.net/browse/LOG-9379

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI build environment to use Go 1.25 instead of Go 1.24.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->