### PR TITLE
[OSSM] Increase memory for AWS ARM instance

### DIFF
--- a/ci-operator/config/openshift-service-mesh/sail-operator/openshift-service-mesh-sail-operator-main__ocp-4.20.yaml
+++ b/ci-operator/config/openshift-service-mesh/sail-operator/openshift-service-mesh-sail-operator-main__ocp-4.20.yaml
@@ -94,8 +94,8 @@ tests:
   steps:
     cluster_profile: ossm-aws
     env:
-      COMPUTE_NODE_TYPE: m6g.xlarge
-      CONTROL_PLANE_INSTANCE_TYPE: m6g.xlarge
+      COMPUTE_NODE_TYPE: r6g.xlarge
+      CONTROL_PLANE_INSTANCE_TYPE: r6g.xlarge
       HUB: quay.io/sail-dev
       INSTALLATION_METHOD: helm
       MAISTRA_BUILDER_IMAGE: registry.istio.io/testing/build-tools:master-63fd6eec6f3df5a3ed4e190e60153ef3425f66b4


### PR DESCRIPTION
This instance is just 25% expensive than `m6g.xlarge` and it has the same specs but larger memory. This aims to avoid this error during e2e test execution:
```
[1777880359] Operator Installation Test Suite - 7/7 specs •••••command terminated with exit code 137
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated AWS instance types for ARM-based end-to-end testing in the Sail Operator test infrastructure configuration to optimize performance and resource allocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->