### PR TITLE
neuron-ci: use KServe RawDeployment mode on OCP >= 4.21

### DIFF
--- a/ci-operator/config/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main__4.21-stable.yaml
+++ b/ci-operator/config/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main__4.21-stable.yaml
@@ -106,7 +106,7 @@ tests:
       OCM_LOGIN_ENV: production
       OPENSHIFT_VERSION: "4.21"
       REGION: us-west-2
-      RHOAI_CHANNEL: stable
+      RHOAI_CHANNEL: stable-3.x
       VLLM_NEURON_IMAGE: registry.redhat.io/rhaiis/vllm-neuron-rhel9:3
     workflow: aws-neuron-operator-kserve-e2e-rosa
 - as: aws-neuron-operator-kserve-e2e-weekly
@@ -126,7 +126,7 @@ tests:
       OCM_LOGIN_ENV: production
       OPENSHIFT_VERSION: "4.21"
       REGION: us-west-2
-      RHOAI_CHANNEL: stable
+      RHOAI_CHANNEL: stable-3.x
       VLLM_NEURON_IMAGE: registry.redhat.io/rhaiis/vllm-neuron-rhel9:3
     workflow: aws-neuron-operator-kserve-e2e-rosa
 zz_generated_metadata:

--- a/ci-operator/step-registry/aws-neuron-operator/install-kserve-deps/aws-neuron-operator-install-kserve-deps-commands.sh
+++ b/ci-operator/step-registry/aws-neuron-operator/install-kserve-deps/aws-neuron-operator-install-kserve-deps-commands.sh
@@ -7,6 +7,20 @@ echo "Installing KServe inference stack dependencies"
 
 export KUBECONFIG="${SHARED_DIR}/kubeconfig"
 
+OCP_MINOR=$(oc get clusterversion version -o jsonpath='{.status.desired.version}' | cut -d. -f2)
+echo "Detected OCP minor version: 4.${OCP_MINOR}"
+
+if [[ "${OCP_MINOR}" -ge 21 ]]; then
+    KSERVE_MODE="RawDeployment"
+    if [[ "${RHOAI_CHANNEL}" != stable-3.* ]]; then
+        echo "OCP >= 4.21 requires RHOAI 3.x; overriding RHOAI_CHANNEL from '${RHOAI_CHANNEL}' to 'stable-3.x'"
+        RHOAI_CHANNEL="stable-3.x"
+    fi
+else
+    KSERVE_MODE="Serverless"
+fi
+echo "Using KServe deployment mode: ${KSERVE_MODE} (RHOAI channel: ${RHOAI_CHANNEL})"
+
 wait_for_csv() {
     local ns="${1}"
     local name_prefix="${2}"
@@ -31,9 +45,12 @@ wait_for_csv() {
     return 1
 }
 
-# --- 1. Install Service Mesh operator ---
-echo "=== Installing Service Mesh operator ==="
-oc apply -f - <<'EOF'
+# Service Mesh and Serverless are only needed for Serverless mode (OCP < 4.21).
+# OCP 4.21+ deprecates Service Mesh 2.x; KServe uses RawDeployment instead.
+if [[ "${KSERVE_MODE}" == "Serverless" ]]; then
+    # --- 1. Install Service Mesh operator ---
+    echo "=== Installing Service Mesh operator ==="
+    oc apply -f - <<'EOF'
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
@@ -47,9 +64,9 @@ spec:
   sourceNamespace: openshift-marketplace
 EOF
 
-# --- 2. Install Serverless operator ---
-echo "=== Installing Serverless operator ==="
-oc apply -f - <<'EOF'
+    # --- 2. Install Serverless operator ---
+    echo "=== Installing Serverless operator ==="
+    oc apply -f - <<'EOF'
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -74,27 +91,21 @@ spec:
   source: redhat-operators
   sourceNamespace: openshift-marketplace
 EOF
+fi
 
 # --- 3. Install RHOAI operator ---
+# RHOAI 3.x only supports AllNamespaces install mode, so it must be installed
+# in openshift-operators (which has a global OperatorGroup). RHOAI 2.x supports
+# OwnNamespace and can use a dedicated namespace.
 echo "=== Installing OpenShift AI (RHOAI) operator ==="
-oc apply -f - <<EOF
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: redhat-ods-operator
----
-apiVersion: operators.coreos.com/v1
-kind: OperatorGroup
-metadata:
-  name: rhods-operator
-  namespace: redhat-ods-operator
-spec: {}
----
+if [[ "${KSERVE_MODE}" == "RawDeployment" ]]; then
+    RHOAI_NAMESPACE="openshift-operators"
+    oc apply -f - <<EOF
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: rhods-operator
-  namespace: redhat-ods-operator
+  namespace: ${RHOAI_NAMESPACE}
 spec:
   channel: ${RHOAI_CHANNEL}
   installPlanApproval: Automatic
@@ -102,17 +113,72 @@ spec:
   source: redhat-operators
   sourceNamespace: openshift-marketplace
 EOF
+else
+    RHOAI_NAMESPACE="redhat-ods-operator"
+    oc apply -f - <<EOF
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${RHOAI_NAMESPACE}
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: rhods-operator
+  namespace: ${RHOAI_NAMESPACE}
+spec: {}
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: rhods-operator
+  namespace: ${RHOAI_NAMESPACE}
+spec:
+  channel: ${RHOAI_CHANNEL}
+  installPlanApproval: Automatic
+  name: rhods-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+EOF
+fi
 
 # --- 4. Wait for all CSVs ---
 echo "=== Waiting for operator CSVs ==="
-wait_for_csv "openshift-operators" "servicemeshoperator" 600 || exit 1
-wait_for_csv "openshift-serverless" "serverless-operator" 600 || exit 1
-wait_for_csv "redhat-ods-operator" "rhods-operator" 600 || exit 1
+if [[ "${KSERVE_MODE}" == "Serverless" ]]; then
+    wait_for_csv "openshift-operators" "servicemeshoperator" 600 || exit 1
+    wait_for_csv "openshift-serverless" "serverless-operator" 600 || exit 1
+fi
+wait_for_csv "${RHOAI_NAMESPACE}" "rhods-operator" 600 || exit 1
 echo "All operator CSVs reached Succeeded"
 
-# --- 5. Create DataScienceCluster ---
+# --- 5. Configure DSCI for RawDeployment (disable Service Mesh) ---
+if [[ "${KSERVE_MODE}" == "RawDeployment" ]]; then
+    echo "=== Configuring DSCI for RawDeployment mode ==="
+    DSCI_TIMEOUT=300
+    DSCI_ELAPSED=0
+    while [[ ${DSCI_ELAPSED} -lt ${DSCI_TIMEOUT} ]]; do
+        DSCI_NAME=$(oc get dsci -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+        if [[ -n "${DSCI_NAME}" ]]; then
+            if oc patch dsci "${DSCI_NAME}" --type=merge \
+                -p '{"spec":{"serviceMesh":{"managementState":"Removed"}}}'; then
+                echo "DSCI '${DSCI_NAME}' patched: serviceMesh set to Removed"
+                break
+            fi
+            echo "WARNING: DSCI '${DSCI_NAME}' patch failed, retrying..."
+        fi
+        sleep 10
+        DSCI_ELAPSED=$((DSCI_ELAPSED + 10))
+    done
+    if [[ ${DSCI_ELAPSED} -ge ${DSCI_TIMEOUT} ]]; then
+        echo "ERROR: DSCI not found within ${DSCI_TIMEOUT}s"
+        exit 1
+    fi
+fi
+
+# --- 6. Create DataScienceCluster ---
 echo "=== Creating DataScienceCluster ==="
-oc apply -f - <<'EOF'
+if [[ "${KSERVE_MODE}" == "Serverless" ]]; then
+    oc apply -f - <<'EOF'
 apiVersion: datasciencecluster.opendatahub.io/v1
 kind: DataScienceCluster
 metadata:
@@ -147,6 +213,40 @@ spec:
     workbenches:
       managementState: Removed
 EOF
+else
+    oc apply -f - <<'EOF'
+apiVersion: datasciencecluster.opendatahub.io/v1
+kind: DataScienceCluster
+metadata:
+  name: default-dsc
+spec:
+  components:
+    codeflare:
+      managementState: Removed
+    dashboard:
+      managementState: Managed
+    datasciencepipelines:
+      managementState: Removed
+    kserve:
+      managementState: Managed
+      serving:
+        managementState: Removed
+    kueue:
+      managementState: Removed
+    modelmeshserving:
+      managementState: Removed
+    modelregistry:
+      managementState: Removed
+    ray:
+      managementState: Removed
+    trainingoperator:
+      managementState: Removed
+    trustyai:
+      managementState: Removed
+    workbenches:
+      managementState: Removed
+EOF
+fi
 
 echo "Waiting for DataScienceCluster to reach Ready..."
 oc wait --for=jsonpath='{.status.phase}'=Ready datasciencecluster/default-dsc --timeout=600s || {
@@ -156,32 +256,36 @@ oc wait --for=jsonpath='{.status.phase}'=Ready datasciencecluster/default-dsc --
 }
 echo "DataScienceCluster is Ready"
 
-# --- 6. Configure inference namespace ---
+# --- 7. Configure inference namespace ---
 echo "=== Configuring inference namespace ==="
 oc create namespace "${KSERVE_INFERENCE_NAMESPACE}" 2>/dev/null || true
-oc label namespace "${KSERVE_INFERENCE_NAMESPACE}" istio-injection=enabled --overwrite
-
-# --- 7. Patch Knative Serving config ---
-echo "=== Patching Knative Serving config ==="
-KNATIVE_TIMEOUT=300
-KNATIVE_ELAPSED=0
-while [[ ${KNATIVE_ELAPSED} -lt ${KNATIVE_TIMEOUT} ]]; do
-    if oc get configmap config-deployment -n knative-serving &>/dev/null; then
-        if oc patch configmap config-deployment -n knative-serving --type=merge \
-            -p '{"data":{"registries-skipping-tag-resolving":"kind.local,ko.local,dev.local,registry.redhat.io"}}'; then
-            echo "Knative Serving config-deployment patched"
-            break
-        fi
-    fi
-    sleep 10
-    KNATIVE_ELAPSED=$((KNATIVE_ELAPSED + 10))
-done
-if [[ ${KNATIVE_ELAPSED} -ge ${KNATIVE_TIMEOUT} ]]; then
-    echo "ERROR: knative-serving/config-deployment configmap could not be patched within ${KNATIVE_TIMEOUT}s"
-    exit 1
+if [[ "${KSERVE_MODE}" == "Serverless" ]]; then
+    oc label namespace "${KSERVE_INFERENCE_NAMESPACE}" istio-injection=enabled --overwrite
 fi
 
-# --- 8. Create ServingRuntime ---
+# --- 8. Patch Knative Serving config (Serverless mode only) ---
+if [[ "${KSERVE_MODE}" == "Serverless" ]]; then
+    echo "=== Patching Knative Serving config ==="
+    KNATIVE_TIMEOUT=300
+    KNATIVE_ELAPSED=0
+    while [[ ${KNATIVE_ELAPSED} -lt ${KNATIVE_TIMEOUT} ]]; do
+        if oc get configmap config-deployment -n knative-serving &>/dev/null; then
+            if oc patch configmap config-deployment -n knative-serving --type=merge \
+                -p '{"data":{"registries-skipping-tag-resolving":"kind.local,ko.local,dev.local,registry.redhat.io"}}'; then
+                echo "Knative Serving config-deployment patched"
+                break
+            fi
+        fi
+        sleep 10
+        KNATIVE_ELAPSED=$((KNATIVE_ELAPSED + 10))
+    done
+    if [[ ${KNATIVE_ELAPSED} -ge ${KNATIVE_TIMEOUT} ]]; then
+        echo "ERROR: knative-serving/config-deployment configmap could not be patched within ${KNATIVE_TIMEOUT}s"
+        exit 1
+    fi
+fi
+
+# --- 9. Create ServingRuntime ---
 echo "=== Creating vllm-neuron ServingRuntime ==="
 oc apply -f - <<EOF
 apiVersion: serving.kserve.io/v1alpha1
@@ -192,8 +296,10 @@ metadata:
   annotations:
     openshift.io/display-name: "vLLM for AWS Neuron"
     opendatahub.io/recommended-accelerators: '["neuron.amazonaws.com"]'
-    sidecar.istio.io/inject: "true"
-    serving.knative.openshift.io/enablePassthrough: "true"
+$(if [[ "${KSERVE_MODE}" == "Serverless" ]]; then
+    echo '    sidecar.istio.io/inject: "true"'
+    echo '    serving.knative.openshift.io/enablePassthrough: "true"'
+fi)
 spec:
   multiModel: false
   supportedModelFormats:
@@ -248,7 +354,7 @@ spec:
     emptyDir: {}
 EOF
 
-# --- 9. Create HF token secret and ServiceAccount ---
+# --- 10. Create HF token secret and ServiceAccount ---
 echo "=== Setting up model access credentials ==="
 if [[ -f "${CLUSTER_PROFILE_DIR}/hf-token" ]]; then
     HF_TOKEN=$(cat "${CLUSTER_PROFILE_DIR}/hf-token")
@@ -277,4 +383,4 @@ secrets:
 - name: hf-token
 EOF
 
-echo "KServe inference stack installation complete"
+echo "KServe inference stack installation complete (mode: ${KSERVE_MODE})"

--- a/ci-operator/step-registry/aws-neuron-operator/install-kserve-deps/aws-neuron-operator-install-kserve-deps-ref.yaml
+++ b/ci-operator/step-registry/aws-neuron-operator/install-kserve-deps/aws-neuron-operator-install-kserve-deps-ref.yaml
@@ -32,7 +32,9 @@ ref:
     documentation: Max model context length for the vLLM Neuron serving runtime.
   documentation: |-
     Installs the KServe inference stack on an already-provisioned ROSA HCP
-    cluster with Neuron operators. Deploys Service Mesh, Serverless, and
-    OpenShift AI (RHOAI) operators via OLM, creates a DataScienceCluster
-    with KServe enabled, configures the inference namespace, and deploys
+    cluster with Neuron operators. On OCP < 4.21, deploys Service Mesh 2.x,
+    Serverless, and RHOAI via OLM with KServe in Serverless mode. On
+    OCP >= 4.21, skips Service Mesh and Serverless (SM 2.x is deprecated)
+    and configures KServe in RawDeployment mode instead. Creates a
+    DataScienceCluster, configures the inference namespace, and deploys
     the vllm-neuron ServingRuntime.

--- a/ci-operator/step-registry/aws-neuron-operator/kserve-e2e-rosa/aws-neuron-operator-kserve-e2e-rosa-workflow.yaml
+++ b/ci-operator/step-registry/aws-neuron-operator/kserve-e2e-rosa/aws-neuron-operator-kserve-e2e-rosa-workflow.yaml
@@ -43,6 +43,7 @@ workflow:
       timeout: 30m
   documentation: |-
     Provisions a ROSA HCP cluster with AWS Inferentia (inf2.8xlarge) nodes,
-    installs the Neuron operator stack and KServe inference stack (Service Mesh,
-    Serverless, OpenShift AI), then runs KServe inference tests using the
-    vllm-neuron ServingRuntime with eco-gotests.
+    installs the Neuron operator stack and KServe inference stack. On OCP < 4.21,
+    uses Serverless mode (Service Mesh 2.x + Serverless + RHOAI). On OCP >= 4.21,
+    uses RawDeployment mode (RHOAI only, no Service Mesh or Serverless). Runs
+    KServe inference tests using the vllm-neuron ServingRuntime with eco-gotests.


### PR DESCRIPTION
## Summary

- Detect OCP version at runtime in the `install-kserve-deps` step and switch between **Serverless mode** (Service Mesh 2.x + Serverless + RHOAI 2.x) for OCP < 4.21 and **RawDeployment mode** (RHOAI 3.x only) for OCP >= 4.21.
- Service Mesh 2.x is deprecated on OCP 4.21+, so the script now skips SM and Serverless operator installation, auto-overrides `RHOAI_CHANNEL` to `stable-3.x`, installs RHOAI in `openshift-operators` (AllNamespaces mode), patches DSCI to disable serviceMesh, and creates a DataScienceCluster with `serving.managementState: Removed`.
- Update 4.21 CI config to set `RHOAI_CHANNEL: stable-3.x` explicitly.

## Test plan

- [x] Manually tested on a ROSA HCP cluster with OCP 4.21 — RHOAI 3.x installs successfully, DataScienceCluster reaches Ready, ServingRuntime is created without Istio/Knative annotations.
- [ ] CI jobs for OCP < 4.21 (4.19, 4.20) should continue using Serverless mode unchanged.
- [ ] CI jobs for OCP 4.21 should use RawDeployment mode.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated CI workflow configuration to specify `RHOAI_CHANNEL` as `stable-3.x` for AWS Neuron Operator KServe tests.
  * Added version-specific deployment mode support: Serverless mode for OpenShift < 4.21, RawDeployment mode for OpenShift >= 4.21.

* **Documentation**
  * Clarified KServe deployment behavior and dependencies based on OpenShift platform version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->