### PR TITLE
ARO-HCP: move e2e lease acquisition into runtime steps

### DIFF
--- a/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main.yaml
+++ b/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main.yaml
@@ -222,13 +222,6 @@ tests:
       ARO_HCP_SUITE_NAME: integration/parallel
       LOCATION: uksouth
       VAULT_SECRET_PROFILE: int
-    leases:
-    - count: 1
-      env: ENV_QUOTA_LEASED_RESOURCE
-      resource_type: aro-hcp-int-quota-slice
-    - count: 20
-      env: LEASED_MSI_CONTAINERS
-      resource_type: aro-hcp-test-msi-containers-int
     workflow: aro-hcp-e2e
 - always_run: false
   as: integration-e2e-parallel-ocp-stable
@@ -242,13 +235,6 @@ tests:
       ARO_HCP_SUITE_NAME: integration/parallel
       LOCATION: uksouth
       VAULT_SECRET_PROFILE: int
-    leases:
-    - count: 1
-      env: ENV_QUOTA_LEASED_RESOURCE
-      resource_type: aro-hcp-int-quota-slice
-    - count: 20
-      env: LEASED_MSI_CONTAINERS
-      resource_type: aro-hcp-test-msi-containers-int
     workflow: aro-hcp-e2e
 - always_run: false
   as: integration-e2e-parallel-ocp-fast
@@ -262,13 +248,6 @@ tests:
       ARO_HCP_SUITE_NAME: integration/parallel
       LOCATION: uksouth
       VAULT_SECRET_PROFILE: int
-    leases:
-    - count: 1
-      env: ENV_QUOTA_LEASED_RESOURCE
-      resource_type: aro-hcp-int-quota-slice
-    - count: 20
-      env: LEASED_MSI_CONTAINERS
-      resource_type: aro-hcp-test-msi-containers-int
     workflow: aro-hcp-e2e
 - always_run: false
   as: integration-e2e-parallel-ocp-nightly
@@ -282,13 +261,6 @@ tests:
       ARO_HCP_SUITE_NAME: integration/parallel
       LOCATION: uksouth
       VAULT_SECRET_PROFILE: int
-    leases:
-    - count: 1
-      env: ENV_QUOTA_LEASED_RESOURCE
-      resource_type: aro-hcp-int-quota-slice
-    - count: 20
-      env: LEASED_MSI_CONTAINERS
-      resource_type: aro-hcp-test-msi-containers-int
     workflow: aro-hcp-e2e
 - always_run: false
   as: stage-e2e-parallel
@@ -300,13 +272,6 @@ tests:
       ARO_HCP_SUITE_NAME: stage/parallel
       LOCATION: uksouth
       VAULT_SECRET_PROFILE: stg
-    leases:
-    - count: 1
-      env: ENV_QUOTA_LEASED_RESOURCE
-      resource_type: aro-hcp-stg-quota-slice
-    - count: 30
-      env: LEASED_MSI_CONTAINERS
-      resource_type: aro-hcp-test-msi-containers-stg
     workflow: aro-hcp-e2e
 - always_run: false
   as: stage-e2e-parallel-ocp-stable
@@ -320,13 +285,6 @@ tests:
       ARO_HCP_SUITE_NAME: stage/parallel
       LOCATION: uksouth
       VAULT_SECRET_PROFILE: stg
-    leases:
-    - count: 1
-      env: ENV_QUOTA_LEASED_RESOURCE
-      resource_type: aro-hcp-stg-quota-slice
-    - count: 30
-      env: LEASED_MSI_CONTAINERS
-      resource_type: aro-hcp-test-msi-containers-stg
     workflow: aro-hcp-e2e
 - always_run: false
   as: stage-e2e-parallel-ocp-fast
@@ -340,13 +298,6 @@ tests:
       ARO_HCP_SUITE_NAME: stage/parallel
       LOCATION: uksouth
       VAULT_SECRET_PROFILE: stg
-    leases:
-    - count: 1
-      env: ENV_QUOTA_LEASED_RESOURCE
-      resource_type: aro-hcp-stg-quota-slice
-    - count: 30
-      env: LEASED_MSI_CONTAINERS
-      resource_type: aro-hcp-test-msi-containers-stg
     workflow: aro-hcp-e2e
 - always_run: false
   as: stage-e2e-parallel-ocp-nightly
@@ -360,13 +311,6 @@ tests:
       ARO_HCP_SUITE_NAME: stage/parallel
       LOCATION: uksouth
       VAULT_SECRET_PROFILE: stg
-    leases:
-    - count: 1
-      env: ENV_QUOTA_LEASED_RESOURCE
-      resource_type: aro-hcp-stg-quota-slice
-    - count: 30
-      env: LEASED_MSI_CONTAINERS
-      resource_type: aro-hcp-test-msi-containers-stg
     workflow: aro-hcp-e2e
 - always_run: false
   as: prod-e2e-parallel
@@ -378,13 +322,6 @@ tests:
       ARO_HCP_SUITE_NAME: prod/parallel
       LOCATION: uksouth
       VAULT_SECRET_PROFILE: prod
-    leases:
-    - count: 1
-      env: ENV_QUOTA_LEASED_RESOURCE
-      resource_type: aro-hcp-prod-quota-slice
-    - count: 15
-      env: LEASED_MSI_CONTAINERS
-      resource_type: aro-hcp-test-msi-containers-prod
     workflow: aro-hcp-e2e
 - always_run: false
   as: prod-e2e-parallel-ocp-stable
@@ -398,13 +335,6 @@ tests:
       ARO_HCP_SUITE_NAME: prod/parallel
       LOCATION: uksouth
       VAULT_SECRET_PROFILE: prod
-    leases:
-    - count: 1
-      env: ENV_QUOTA_LEASED_RESOURCE
-      resource_type: aro-hcp-prod-quota-slice
-    - count: 15
-      env: LEASED_MSI_CONTAINERS
-      resource_type: aro-hcp-test-msi-containers-prod
     workflow: aro-hcp-e2e
 - always_run: false
   as: prod-e2e-parallel-ocp-fast
@@ -418,13 +348,6 @@ tests:
       ARO_HCP_SUITE_NAME: prod/parallel
       LOCATION: uksouth
       VAULT_SECRET_PROFILE: prod
-    leases:
-    - count: 1
-      env: ENV_QUOTA_LEASED_RESOURCE
-      resource_type: aro-hcp-prod-quota-slice
-    - count: 15
-      env: LEASED_MSI_CONTAINERS
-      resource_type: aro-hcp-test-msi-containers-prod
     workflow: aro-hcp-e2e
 - always_run: false
   as: prod-e2e-parallel-ocp-nightly
@@ -438,13 +361,6 @@ tests:
       ARO_HCP_SUITE_NAME: prod/parallel
       LOCATION: uksouth
       VAULT_SECRET_PROFILE: prod
-    leases:
-    - count: 1
-      env: ENV_QUOTA_LEASED_RESOURCE
-      resource_type: aro-hcp-prod-quota-slice
-    - count: 15
-      env: LEASED_MSI_CONTAINERS
-      resource_type: aro-hcp-test-msi-containers-prod
     workflow: aro-hcp-e2e
 - always_run: true
   as: e2e-parallel
@@ -454,10 +370,6 @@ tests:
       ARO_HCP_CLOUD: dev
       ARO_HCP_DEPLOY_ENV: prow
       LOCATION: westus3
-    leases:
-    - count: 1
-      env: ENV_QUOTA_LEASED_RESOURCE
-      resource_type: aro-hcp-dev-quota-slice
     workflow: aro-hcp-local-e2e
   timeout: 10h0m0s
 - always_run: false
@@ -468,10 +380,6 @@ tests:
       ARO_HCP_CLOUD: dev
       ARO_HCP_DEPLOY_ENV: ci01
       LOCATION: westus3
-    leases:
-    - count: 1
-      env: ENV_QUOTA_LEASED_RESOURCE
-      resource_type: aro-hcp-dev-quota-slice
     workflow: aro-hcp-local-e2e
   timeout: 10h0m0s
 - as: global-pipeline-postsubmit

--- a/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__e2e.yaml
+++ b/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__e2e.yaml
@@ -32,13 +32,6 @@ tests:
       ARO_HCP_SUITE_NAME: integration/parallel
       LOCATION: uksouth
       VAULT_SECRET_PROFILE: int
-    leases:
-    - count: 1
-      env: ENV_QUOTA_LEASED_RESOURCE
-      resource_type: aro-hcp-int-quota-slice
-    - count: 20
-      env: LEASED_MSI_CONTAINERS
-      resource_type: aro-hcp-test-msi-containers-int
     workflow: aro-hcp-e2e
 - as: stage-e2e-parallel
   max_concurrency: 4
@@ -51,13 +44,6 @@ tests:
       ARO_HCP_SUITE_NAME: stage/parallel
       LOCATION: uksouth
       VAULT_SECRET_PROFILE: stg
-    leases:
-    - count: 1
-      env: ENV_QUOTA_LEASED_RESOURCE
-      resource_type: aro-hcp-stg-quota-slice
-    - count: 30
-      env: LEASED_MSI_CONTAINERS
-      resource_type: aro-hcp-test-msi-containers-stg
     workflow: aro-hcp-e2e
 - as: prod-e2e-parallel
   max_concurrency: 4
@@ -70,13 +56,6 @@ tests:
       ARO_HCP_SUITE_NAME: prod/parallel
       LOCATION: uksouth
       VAULT_SECRET_PROFILE: prod
-    leases:
-    - count: 1
-      env: ENV_QUOTA_LEASED_RESOURCE
-      resource_type: aro-hcp-prod-quota-slice
-    - count: 15
-      env: LEASED_MSI_CONTAINERS
-      resource_type: aro-hcp-test-msi-containers-prod
     workflow: aro-hcp-e2e
 zz_generated_metadata:
   branch: main

--- a/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__periodic.yaml
+++ b/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__periodic.yaml
@@ -22,13 +22,6 @@ tests:
       ARO_HCP_SUITE_NAME: integration/parallel
       LOCATION: uksouth
       VAULT_SECRET_PROFILE: int
-    leases:
-    - count: 1
-      env: ENV_QUOTA_LEASED_RESOURCE
-      resource_type: aro-hcp-int-quota-slice
-    - count: 20
-      env: LEASED_MSI_CONTAINERS
-      resource_type: aro-hcp-test-msi-containers-int
     workflow: aro-hcp-e2e
   timeout: 4h0m0s
 - as: stage-e2e-parallel
@@ -40,13 +33,6 @@ tests:
       ARO_HCP_SUITE_NAME: stage/parallel
       LOCATION: uksouth
       VAULT_SECRET_PROFILE: stg
-    leases:
-    - count: 1
-      env: ENV_QUOTA_LEASED_RESOURCE
-      resource_type: aro-hcp-stg-quota-slice
-    - count: 30
-      env: LEASED_MSI_CONTAINERS
-      resource_type: aro-hcp-test-msi-containers-stg
     workflow: aro-hcp-e2e
   timeout: 4h0m0s
 - as: stage-e2e-parallel-ocp-nightly
@@ -60,13 +46,6 @@ tests:
       ARO_HCP_SUITE_NAME: stage/parallel
       LOCATION: uksouth
       VAULT_SECRET_PROFILE: stg
-    leases:
-    - count: 1
-      env: ENV_QUOTA_LEASED_RESOURCE
-      resource_type: aro-hcp-stg-quota-slice
-    - count: 30
-      env: LEASED_MSI_CONTAINERS
-      resource_type: aro-hcp-test-msi-containers-stg
     workflow: aro-hcp-e2e
 - as: prod-e2e-parallel
   cron: 0 2 * * *
@@ -77,13 +56,6 @@ tests:
       ARO_HCP_SUITE_NAME: prod/parallel
       LOCATION: uksouth
       VAULT_SECRET_PROFILE: prod
-    leases:
-    - count: 1
-      env: ENV_QUOTA_LEASED_RESOURCE
-      resource_type: aro-hcp-prod-quota-slice
-    - count: 15
-      env: LEASED_MSI_CONTAINERS
-      resource_type: aro-hcp-test-msi-containers-prod
     workflow: aro-hcp-e2e
   timeout: 4h0m0s
 - as: prod-e2e-parallel-ocp-nightly
@@ -97,13 +69,6 @@ tests:
       ARO_HCP_SUITE_NAME: prod/parallel
       LOCATION: uksouth
       VAULT_SECRET_PROFILE: prod
-    leases:
-    - count: 1
-      env: ENV_QUOTA_LEASED_RESOURCE
-      resource_type: aro-hcp-prod-quota-slice
-    - count: 15
-      env: LEASED_MSI_CONTAINERS
-      resource_type: aro-hcp-test-msi-containers-prod
     workflow: aro-hcp-e2e
 zz_generated_metadata:
   branch: main

--- a/ci-operator/step-registry/aro-hcp/e2e/aro-hcp-e2e-workflow.yaml
+++ b/ci-operator/step-registry/aro-hcp/e2e/aro-hcp-e2e-workflow.yaml
@@ -4,10 +4,12 @@ workflow:
     allow_best_effort_post_steps: true
     pre:
       - ref: aro-hcp-write-config
+      - ref: aro-hcp-lease-acquire
     test:
       - ref: aro-hcp-test-persistent
     post:
       - ref: aro-hcp-gather-test-visualization
       - ref: aro-hcp-gather-custom-link-tools
+      - ref: aro-hcp-lease-release
   documentation: |-
     The ARO HCP e2e workflow runs the full end-to-end suite against an existing environment.

--- a/ci-operator/step-registry/aro-hcp/lease/acquire/OWNERS
+++ b/ci-operator/step-registry/aro-hcp/lease/acquire/OWNERS
@@ -1,0 +1,16 @@
+approvers:
+- geoberle
+- jharrington22
+- mmazur
+- raelga
+- roivaz
+- venkateshsredhat
+- deads2k
+reviewers:
+- geoberle
+- jharrington22
+- mmazur
+- raelga
+- roivaz
+- venkateshsredhat
+- deads2k

--- a/ci-operator/step-registry/aro-hcp/lease/acquire/aro-hcp-lease-acquire-commands.sh
+++ b/ci-operator/step-registry/aro-hcp/lease/acquire/aro-hcp-lease-acquire-commands.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# shellcheck disable=SC1091
+source "$LEASE_PROXY_CLIENT_SH"
+source ci-operator/step-registry/aro-hcp/lease/common/aro-hcp-lease-common-commands.sh
+
+function on_exit() {
+    local exit_code="$1"
+    if [[ "$exit_code" -ne 0 ]]; then
+        aro_hcp_lease::release_all || true
+    fi
+}
+
+trap 'on_exit $?' EXIT
+
+aro_hcp_lease::prepare_state
+
+case "${ARO_HCP_DEPLOY_ENV}" in
+    prow|ci01)
+        aro_hcp_lease::acquire_role "env-quota" "aro-hcp-dev-quota-slice" "1"
+        aro_hcp_lease::acquire_role "msi-containers" "aro-hcp-test-msi-containers-dev" "20"
+        aro_hcp_lease::acquire_role "msi-mock-sp" "aro-hcp-msi-mock-cs-sp-dev" "1"
+        ;;
+    int)
+        aro_hcp_lease::acquire_role "env-quota" "aro-hcp-int-quota-slice" "1"
+        aro_hcp_lease::acquire_role "msi-containers" "aro-hcp-test-msi-containers-int" "20"
+        ;;
+    stg)
+        aro_hcp_lease::acquire_role "env-quota" "aro-hcp-stg-quota-slice" "1"
+        aro_hcp_lease::acquire_role "msi-containers" "aro-hcp-test-msi-containers-stg" "30"
+        ;;
+    prod)
+        aro_hcp_lease::acquire_role "env-quota" "aro-hcp-prod-quota-slice" "1"
+        aro_hcp_lease::acquire_role "msi-containers" "aro-hcp-test-msi-containers-prod" "15"
+        ;;
+    *)
+        printf 'Unsupported ARO_HCP_DEPLOY_ENV: %s\n' "${ARO_HCP_DEPLOY_ENV}" >&2
+        exit 1
+        ;;
+esac
+
+aro_hcp_lease::write_env_exports
+printf 'Prepared ARO HCP runtime lease exports in %s\n' "$(aro_hcp_lease::env_file)"
+
+trap - EXIT

--- a/ci-operator/step-registry/aro-hcp/lease/acquire/aro-hcp-lease-acquire-ref.metadata.json
+++ b/ci-operator/step-registry/aro-hcp/lease/acquire/aro-hcp-lease-acquire-ref.metadata.json
@@ -1,0 +1,23 @@
+{
+	"path": "aro-hcp/lease/acquire/aro-hcp-lease-acquire-ref.yaml",
+	"owners": {
+		"approvers": [
+			"geoberle",
+			"jharrington22",
+			"mmazur",
+			"raelga",
+			"roivaz",
+			"venkateshsredhat",
+			"deads2k"
+		],
+		"reviewers": [
+			"geoberle",
+			"jharrington22",
+			"mmazur",
+			"raelga",
+			"roivaz",
+			"venkateshsredhat",
+			"deads2k"
+		]
+	}
+}

--- a/ci-operator/step-registry/aro-hcp/lease/acquire/aro-hcp-lease-acquire-ref.yaml
+++ b/ci-operator/step-registry/aro-hcp/lease/acquire/aro-hcp-lease-acquire-ref.yaml
@@ -1,0 +1,16 @@
+ref:
+  as: aro-hcp-lease-acquire
+  from: aro-hcp-e2e-tests
+  commands: aro-hcp-lease-acquire-commands.sh
+  grace_period: 15s
+  resources:
+    requests:
+      cpu: 10m
+      memory: 100Mi
+  env:
+    - name: ARO_HCP_DEPLOY_ENV
+      default: ""
+      documentation: Config environment name (prow, ci01, int, stg, prod).
+  documentation: |-
+    Acquire the runtime Boskos leases required by ARO HCP E2E workflows and
+    persist the current lease env vars into SHARED_DIR for later steps.

--- a/ci-operator/step-registry/aro-hcp/lease/common/OWNERS
+++ b/ci-operator/step-registry/aro-hcp/lease/common/OWNERS
@@ -1,0 +1,16 @@
+approvers:
+- geoberle
+- jharrington22
+- mmazur
+- raelga
+- roivaz
+- venkateshsredhat
+- deads2k
+reviewers:
+- geoberle
+- jharrington22
+- mmazur
+- raelga
+- roivaz
+- venkateshsredhat
+- deads2k

--- a/ci-operator/step-registry/aro-hcp/lease/common/aro-hcp-lease-common-commands.sh
+++ b/ci-operator/step-registry/aro-hcp/lease/common/aro-hcp-lease-common-commands.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+
+function aro_hcp_lease::state_dir() {
+    if [[ -z "${SHARED_DIR:-}" ]]; then
+        printf '$SHARED_DIR is empty\n' >&2
+        return 1
+    fi
+
+    printf '%s/aro-hcp-leases' "$SHARED_DIR"
+}
+
+function aro_hcp_lease::env_file() {
+    local state_dir
+    state_dir=$(aro_hcp_lease::state_dir) || return 1
+    printf '%s/env.sh' "$state_dir"
+}
+
+function aro_hcp_lease::handle_file() {
+    local role="$1"
+    local state_dir
+    state_dir=$(aro_hcp_lease::state_dir) || return 1
+    printf '%s/%s.handle' "$state_dir" "$role"
+}
+
+function aro_hcp_lease::proxy_available() {
+    [[ -n "${LEASE_PROXY_SERVER_URL:-}" ]]
+}
+
+function aro_hcp_lease::prepare_state() {
+    local state_dir env_file
+    state_dir=$(aro_hcp_lease::state_dir) || return 1
+    env_file=$(aro_hcp_lease::env_file) || return 1
+
+    rm -rf "$state_dir"
+    mkdir -p "$state_dir"
+    : > "$env_file"
+}
+
+function aro_hcp_lease::persist_temp_handle() {
+    local role="$1"
+    local temp_handle="$2"
+    local handle_file
+    handle_file=$(aro_hcp_lease::handle_file "$role") || return 1
+
+    if ! cp "$temp_handle" "$handle_file"; then
+        printf 'Failed to persist lease handle for role "%s"\n' "$role" >&2
+        lease__release --handle="$temp_handle" || true
+        return 1
+    fi
+
+    if ! touch "${handle_file}.lock"; then
+        printf 'Failed to create lock file for role "%s"\n' "$role" >&2
+        rm -f "$handle_file"
+        lease__release --handle="$temp_handle" || true
+        return 1
+    fi
+
+    rm -f "$temp_handle" "${temp_handle}.lock"
+}
+
+function aro_hcp_lease::acquire_role() {
+    local role="$1"
+    local type="$2"
+    local count="${3:-1}"
+    local temp_handle handle_file
+
+    if ! aro_hcp_lease::proxy_available; then
+        printf 'LEASE_PROXY_SERVER_URL not set, skipping acquire for role "%s"\n' "$role"
+        return 0
+    fi
+
+    temp_handle=$(lease__acquire --type="$type" --count="$count" --scope=step)
+    aro_hcp_lease::persist_temp_handle "$role" "$temp_handle"
+
+    handle_file=$(aro_hcp_lease::handle_file "$role") || return 1
+    printf 'Acquired role "%s" from "%s": %s\n' \
+        "$role" \
+        "$type" \
+        "$(lease__cat --handle="$handle_file" --format=csv)"
+}
+
+function aro_hcp_lease::read_handle_values() {
+    local role="$1"
+    local handle_file
+    handle_file=$(aro_hcp_lease::handle_file "$role") || return 1
+
+    if [[ ! -f "$handle_file" ]]; then
+        return 0
+    fi
+
+    mapfile -t values < "$handle_file"
+    if [[ "${#values[@]}" -eq 0 ]]; then
+        return 0
+    fi
+
+    local joined="${values[0]}"
+    local i
+    for ((i = 1; i < ${#values[@]}; i++)); do
+        joined+=" ${values[i]}"
+    done
+
+    printf '%s' "$joined"
+}
+
+function aro_hcp_lease::write_export() {
+    local name="$1"
+    local value="$2"
+    local env_file
+    env_file=$(aro_hcp_lease::env_file) || return 1
+
+    printf 'export %s=%q\n' "$name" "$value" >> "$env_file"
+}
+
+function aro_hcp_lease::write_env_exports() {
+    local env_file
+    env_file=$(aro_hcp_lease::env_file) || return 1
+    : > "$env_file"
+
+    local value
+
+    value=$(aro_hcp_lease::read_handle_values "env-quota")
+    if [[ -n "$value" ]]; then
+        aro_hcp_lease::write_export "ENV_QUOTA_LEASED_RESOURCE" "$value"
+    fi
+
+    value=$(aro_hcp_lease::read_handle_values "msi-containers")
+    if [[ -n "$value" ]]; then
+        aro_hcp_lease::write_export "LEASED_MSI_CONTAINERS" "$value"
+    fi
+
+    value=$(aro_hcp_lease::read_handle_values "msi-mock-sp")
+    if [[ -n "$value" ]]; then
+        aro_hcp_lease::write_export "LEASED_MSI_MOCK_SP" "$value"
+    fi
+}
+
+function aro_hcp_lease::source_env_exports() {
+    local env_file
+    env_file=$(aro_hcp_lease::env_file) || return 1
+
+    if [[ ! -f "$env_file" ]]; then
+        return 0
+    fi
+
+    # shellcheck disable=SC1090
+    source "$env_file"
+}
+
+function aro_hcp_lease::release_all() {
+    local state_dir
+    state_dir=$(aro_hcp_lease::state_dir) || return 1
+
+    if [[ ! -d "$state_dir" ]]; then
+        return 0
+    fi
+
+    local result=0
+    local handle_file
+    shopt -s nullglob
+    for handle_file in "$state_dir"/*.handle; do
+        lease__release --handle="$handle_file" || result=$?
+    done
+    shopt -u nullglob
+
+    if [[ "$result" -eq 0 ]]; then
+        rm -rf "$state_dir"
+    fi
+
+    return "$result"
+}

--- a/ci-operator/step-registry/aro-hcp/lease/common/aro-hcp-lease-common-ref.metadata.json
+++ b/ci-operator/step-registry/aro-hcp/lease/common/aro-hcp-lease-common-ref.metadata.json
@@ -1,0 +1,23 @@
+{
+	"path": "aro-hcp/lease/common/aro-hcp-lease-common-ref.yaml",
+	"owners": {
+		"approvers": [
+			"geoberle",
+			"jharrington22",
+			"mmazur",
+			"raelga",
+			"roivaz",
+			"venkateshsredhat",
+			"deads2k"
+		],
+		"reviewers": [
+			"geoberle",
+			"jharrington22",
+			"mmazur",
+			"raelga",
+			"roivaz",
+			"venkateshsredhat",
+			"deads2k"
+		]
+	}
+}

--- a/ci-operator/step-registry/aro-hcp/lease/common/aro-hcp-lease-common-ref.yaml
+++ b/ci-operator/step-registry/aro-hcp/lease/common/aro-hcp-lease-common-ref.yaml
@@ -1,0 +1,10 @@
+ref:
+  as: aro-hcp-lease-common
+  from: aro-hcp-e2e-tests
+  commands: aro-hcp-lease-common-commands.sh
+  resources:
+    requests:
+      cpu: 10m
+      memory: 100Mi
+  documentation: |-
+    Shared shell helpers for ARO HCP runtime lease acquisition and release.

--- a/ci-operator/step-registry/aro-hcp/lease/release/OWNERS
+++ b/ci-operator/step-registry/aro-hcp/lease/release/OWNERS
@@ -1,0 +1,16 @@
+approvers:
+- geoberle
+- jharrington22
+- mmazur
+- raelga
+- roivaz
+- venkateshsredhat
+- deads2k
+reviewers:
+- geoberle
+- jharrington22
+- mmazur
+- raelga
+- roivaz
+- venkateshsredhat
+- deads2k

--- a/ci-operator/step-registry/aro-hcp/lease/release/aro-hcp-lease-release-commands.sh
+++ b/ci-operator/step-registry/aro-hcp/lease/release/aro-hcp-lease-release-commands.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# shellcheck disable=SC1091
+source "$LEASE_PROXY_CLIENT_SH"
+source ci-operator/step-registry/aro-hcp/lease/common/aro-hcp-lease-common-commands.sh
+
+aro_hcp_lease::release_all

--- a/ci-operator/step-registry/aro-hcp/lease/release/aro-hcp-lease-release-ref.metadata.json
+++ b/ci-operator/step-registry/aro-hcp/lease/release/aro-hcp-lease-release-ref.metadata.json
@@ -1,0 +1,23 @@
+{
+	"path": "aro-hcp/lease/release/aro-hcp-lease-release-ref.yaml",
+	"owners": {
+		"approvers": [
+			"geoberle",
+			"jharrington22",
+			"mmazur",
+			"raelga",
+			"roivaz",
+			"venkateshsredhat",
+			"deads2k"
+		],
+		"reviewers": [
+			"geoberle",
+			"jharrington22",
+			"mmazur",
+			"raelga",
+			"roivaz",
+			"venkateshsredhat",
+			"deads2k"
+		]
+	}
+}

--- a/ci-operator/step-registry/aro-hcp/lease/release/aro-hcp-lease-release-ref.yaml
+++ b/ci-operator/step-registry/aro-hcp/lease/release/aro-hcp-lease-release-ref.yaml
@@ -1,0 +1,10 @@
+ref:
+  as: aro-hcp-lease-release
+  from: aro-hcp-e2e-tests
+  commands: aro-hcp-lease-release-commands.sh
+  resources:
+    requests:
+      cpu: 10m
+      memory: 100Mi
+  documentation: |-
+    Release the runtime Boskos leases acquired for an ARO HCP E2E workflow.

--- a/ci-operator/step-registry/aro-hcp/local-e2e/aro-hcp-local-e2e-workflow.yaml
+++ b/ci-operator/step-registry/aro-hcp/local-e2e/aro-hcp-local-e2e-workflow.yaml
@@ -2,15 +2,9 @@ workflow:
   as: aro-hcp-local-e2e
   steps:
     allow_best_effort_post_steps: true
-    leases:
-    - resource_type: aro-hcp-test-msi-containers-dev
-      env: LEASED_MSI_CONTAINERS
-      count: 20
-    - resource_type: aro-hcp-msi-mock-cs-sp-dev
-      env: LEASED_MSI_MOCK_SP
-      count: 1
     pre:
       - ref: aro-hcp-write-config
+      - ref: aro-hcp-lease-acquire
       - ref: aro-hcp-provision-environment
     test:
       - ref: aro-hcp-test-local
@@ -21,5 +15,6 @@ workflow:
       - ref: aro-hcp-gather-custom-link-tools
       - ref: aro-hcp-gather-observability
       - ref: aro-hcp-deprovision-environment
+      - ref: aro-hcp-lease-release
   documentation: |-
     The local ARO HCP e2e workflow starts an ARO HCP environment and runs the full end-to-end suite against it.

--- a/ci-operator/step-registry/aro-hcp/provision/environment/aro-hcp-provision-environment-commands.sh
+++ b/ci-operator/step-registry/aro-hcp/provision/environment/aro-hcp-provision-environment-commands.sh
@@ -3,6 +3,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+source ci-operator/step-registry/aro-hcp/lease/common/aro-hcp-lease-common-commands.sh
+aro_hcp_lease::source_env_exports
+
 export CLUSTER_PROFILE_DIR="/var/run/aro-hcp-${VAULT_SECRET_PROFILE}"
 
 export AZURE_CLIENT_ID; AZURE_CLIENT_ID=$(cat "${CLUSTER_PROFILE_DIR}/client-id")

--- a/ci-operator/step-registry/aro-hcp/test/local/aro-hcp-test-local-commands.sh
+++ b/ci-operator/step-registry/aro-hcp/test/local/aro-hcp-test-local-commands.sh
@@ -3,6 +3,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+source ci-operator/step-registry/aro-hcp/lease/common/aro-hcp-lease-common-commands.sh
+aro_hcp_lease::source_env_exports
+
 export CLUSTER_PROFILE_DIR="/var/run/aro-hcp-${VAULT_SECRET_PROFILE}"
 
 export AZURE_CLIENT_ID; AZURE_CLIENT_ID=$(cat "${CLUSTER_PROFILE_DIR}/client-id")

--- a/ci-operator/step-registry/aro-hcp/test/persistent/aro-hcp-test-persistent-commands.sh
+++ b/ci-operator/step-registry/aro-hcp/test/persistent/aro-hcp-test-persistent-commands.sh
@@ -4,6 +4,9 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
+source ci-operator/step-registry/aro-hcp/lease/common/aro-hcp-lease-common-commands.sh
+aro_hcp_lease::source_env_exports
+
 export CLUSTER_PROFILE_DIR="/var/run/aro-hcp-${VAULT_SECRET_PROFILE}"
 
 export AZURE_CLIENT_ID; AZURE_CLIENT_ID=$(cat "${CLUSTER_PROFILE_DIR}/client-id")


### PR DESCRIPTION
Preserve the current lease env-var contracts while shifting ARO-HCP E2E jobs to runtime lease proxy steps so later slot and pool selection changes stay localized to step-registry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Removed inline lease resource configurations from test definitions across integration, staging, and production environments.

* **Refactor**
  * Centralized lease resource management by introducing dedicated lease acquisition and release workflow steps.
  * Updated E2E and local E2E workflows to use explicit lease lifecycle management phases.
  * Added supporting infrastructure for streamlined lease handling across test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->