### PR TITLE
fix(console-plugin-template): run Jest in CI

### DIFF
--- a/ci-operator/config/openshift/console-plugin-template/openshift-console-plugin-template-main.yaml
+++ b/ci-operator/config/openshift/console-plugin-template/openshift-console-plugin-template-main.yaml
@@ -26,16 +26,12 @@ resources:
       cpu: 100m
       memory: 200Mi
 tests:
-- as: lint-aws-plugin-template
-  steps:
-    test:
-    - as: lint
-      commands: yarn install && yarn run lint
-      from: src
-      resources:
-        requests:
-          cpu: 100m
-          memory: 200Mi
+- as: frontend
+  commands: |
+    git config --global --add safe.directory /go/src/github.com/openshift/console-plugin-template
+    ./test-frontend.sh
+  container:
+    from: src
 - as: e2e-aws-plugin-template
   steps:
     cluster_profile: openshift-org-aws
@@ -44,7 +40,7 @@ tests:
       cli: latest
       commands: ./test-prow-e2e.sh
       dependencies:
-      - env: CYPRESS_PLUGIN_TEMPLATE_PULL_SPEC
+      - env: PLUGIN_TEMPLATE_PULL_SPEC
         name: console-plugin-template
       from: src
       grace_period: 30m0s

--- a/ci-operator/config/openshift/console-plugin-template/openshift-console-plugin-template-release-4.22.yaml
+++ b/ci-operator/config/openshift/console-plugin-template/openshift-console-plugin-template-release-4.22.yaml
@@ -26,16 +26,12 @@ resources:
       cpu: 100m
       memory: 200Mi
 tests:
-- as: lint-aws-plugin-template
-  steps:
-    test:
-    - as: lint
-      commands: yarn install && yarn run lint
-      from: src
-      resources:
-        requests:
-          cpu: 100m
-          memory: 200Mi
+- as: frontend
+  commands: |
+    git config --global --add safe.directory /go/src/github.com/openshift/console-plugin-template
+    ./test-frontend.sh
+  container:
+    from: src
 - as: e2e-aws-plugin-template
   steps:
     cluster_profile: openshift-org-aws
@@ -44,7 +40,7 @@ tests:
       cli: latest
       commands: ./test-prow-e2e.sh
       dependencies:
-      - env: CYPRESS_PLUGIN_TEMPLATE_PULL_SPEC
+      - env: PLUGIN_TEMPLATE_PULL_SPEC
         name: console-plugin-template
       from: src
       grace_period: 30m0s

--- a/ci-operator/config/openshift/console-plugin-template/openshift-console-plugin-template-release-4.23.yaml
+++ b/ci-operator/config/openshift/console-plugin-template/openshift-console-plugin-template-release-4.23.yaml
@@ -26,16 +26,12 @@ resources:
       cpu: 100m
       memory: 200Mi
 tests:
-- as: lint-aws-plugin-template
-  steps:
-    test:
-    - as: lint
-      commands: yarn install && yarn run lint
-      from: src
-      resources:
-        requests:
-          cpu: 100m
-          memory: 200Mi
+- as: frontend
+  commands: |
+    git config --global --add safe.directory /go/src/github.com/openshift/console-plugin-template
+    ./test-frontend.sh
+  container:
+    from: src
 - as: e2e-aws-plugin-template
   steps:
     cluster_profile: openshift-org-aws
@@ -44,7 +40,7 @@ tests:
       cli: latest
       commands: ./test-prow-e2e.sh
       dependencies:
-      - env: CYPRESS_PLUGIN_TEMPLATE_PULL_SPEC
+      - env: PLUGIN_TEMPLATE_PULL_SPEC
         name: console-plugin-template
       from: src
       grace_period: 30m0s

--- a/ci-operator/config/openshift/console-plugin-template/openshift-console-plugin-template-release-5.0.yaml
+++ b/ci-operator/config/openshift/console-plugin-template/openshift-console-plugin-template-release-5.0.yaml
@@ -27,16 +27,12 @@ resources:
       cpu: 100m
       memory: 200Mi
 tests:
-- as: lint-aws-plugin-template
-  steps:
-    test:
-    - as: lint
-      commands: yarn install && yarn run lint
-      from: src
-      resources:
-        requests:
-          cpu: 100m
-          memory: 200Mi
+- as: frontend
+  commands: |
+    git config --global --add safe.directory /go/src/github.com/openshift/console-plugin-template
+    ./test-frontend.sh
+  container:
+    from: src
 - as: e2e-aws-plugin-template
   steps:
     cluster_profile: openshift-org-aws
@@ -45,7 +41,7 @@ tests:
       cli: latest
       commands: ./test-prow-e2e.sh
       dependencies:
-      - env: CYPRESS_PLUGIN_TEMPLATE_PULL_SPEC
+      - env: PLUGIN_TEMPLATE_PULL_SPEC
         name: console-plugin-template
       from: src
       grace_period: 30m0s

--- a/ci-operator/config/openshift/console-plugin-template/openshift-console-plugin-template-release-5.1.yaml
+++ b/ci-operator/config/openshift/console-plugin-template/openshift-console-plugin-template-release-5.1.yaml
@@ -26,16 +26,12 @@ resources:
       cpu: 100m
       memory: 200Mi
 tests:
-- as: lint-aws-plugin-template
-  steps:
-    test:
-    - as: lint
-      commands: yarn install && yarn run lint
-      from: src
-      resources:
-        requests:
-          cpu: 100m
-          memory: 200Mi
+- as: frontend
+  commands: |
+    git config --global --add safe.directory /go/src/github.com/openshift/console-plugin-template
+    ./test-frontend.sh
+  container:
+    from: src
 - as: e2e-aws-plugin-template
   steps:
     cluster_profile: openshift-org-aws
@@ -44,7 +40,7 @@ tests:
       cli: latest
       commands: ./test-prow-e2e.sh
       dependencies:
-      - env: CYPRESS_PLUGIN_TEMPLATE_PULL_SPEC
+      - env: PLUGIN_TEMPLATE_PULL_SPEC
         name: console-plugin-template
       from: src
       grace_period: 30m0s

--- a/ci-operator/jobs/openshift/console-plugin-template/openshift-console-plugin-template-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/console-plugin-template/openshift-console-plugin-template-main-presubmits.yaml
@@ -86,6 +86,67 @@ presubmits:
     - ^main$
     - ^main-
     cluster: build05
+    context: ci/prow/frontend
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-console-plugin-template-main-frontend
+    rerun_command: /test frontend
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=frontend
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )frontend,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build05
     context: ci/prow/images
     decorate: true
     labels:
@@ -134,81 +195,3 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )images,?($|\s.*)
-  - agent: kubernetes
-    always_run: true
-    branches:
-    - ^main$
-    - ^main-
-    cluster: build05
-    context: ci/prow/lint-aws-plugin-template
-    decorate: true
-    labels:
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-console-plugin-template-main-lint-aws-plugin-template
-    rerun_command: /test lint-aws-plugin-template
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=lint-aws-plugin-template
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )lint-aws-plugin-template,?($|\s.*)

--- a/ci-operator/jobs/openshift/console-plugin-template/openshift-console-plugin-template-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift/console-plugin-template/openshift-console-plugin-template-release-4.22-presubmits.yaml
@@ -86,6 +86,67 @@ presubmits:
     - ^release-4\.22$
     - ^release-4\.22-
     cluster: build05
+    context: ci/prow/frontend
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-console-plugin-template-release-4.22-frontend
+    rerun_command: /test frontend
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=frontend
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )frontend,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.22$
+    - ^release-4\.22-
+    cluster: build05
     context: ci/prow/images
     decorate: true
     labels:
@@ -134,81 +195,3 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )images,?($|\s.*)
-  - agent: kubernetes
-    always_run: true
-    branches:
-    - ^release-4\.22$
-    - ^release-4\.22-
-    cluster: build05
-    context: ci/prow/lint-aws-plugin-template
-    decorate: true
-    labels:
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-console-plugin-template-release-4.22-lint-aws-plugin-template
-    rerun_command: /test lint-aws-plugin-template
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=lint-aws-plugin-template
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )lint-aws-plugin-template,?($|\s.*)

--- a/ci-operator/jobs/openshift/console-plugin-template/openshift-console-plugin-template-release-4.23-presubmits.yaml
+++ b/ci-operator/jobs/openshift/console-plugin-template/openshift-console-plugin-template-release-4.23-presubmits.yaml
@@ -86,6 +86,67 @@ presubmits:
     - ^release-4\.23$
     - ^release-4\.23-
     cluster: build05
+    context: ci/prow/frontend
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-console-plugin-template-release-4.23-frontend
+    rerun_command: /test frontend
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=frontend
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )frontend,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.23$
+    - ^release-4\.23-
+    cluster: build05
     context: ci/prow/images
     decorate: true
     labels:
@@ -134,81 +195,3 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )images,?($|\s.*)
-  - agent: kubernetes
-    always_run: true
-    branches:
-    - ^release-4\.23$
-    - ^release-4\.23-
-    cluster: build05
-    context: ci/prow/lint-aws-plugin-template
-    decorate: true
-    labels:
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-console-plugin-template-release-4.23-lint-aws-plugin-template
-    rerun_command: /test lint-aws-plugin-template
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=lint-aws-plugin-template
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )lint-aws-plugin-template,?($|\s.*)

--- a/ci-operator/jobs/openshift/console-plugin-template/openshift-console-plugin-template-release-5.0-presubmits.yaml
+++ b/ci-operator/jobs/openshift/console-plugin-template/openshift-console-plugin-template-release-5.0-presubmits.yaml
@@ -86,6 +86,67 @@ presubmits:
     - ^release-5\.0$
     - ^release-5\.0-
     cluster: build05
+    context: ci/prow/frontend
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-console-plugin-template-release-5.0-frontend
+    rerun_command: /test frontend
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=frontend
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )frontend,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-5\.0$
+    - ^release-5\.0-
+    cluster: build05
     context: ci/prow/images
     decorate: true
     labels:
@@ -133,81 +194,3 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )images,?($|\s.*)
-  - agent: kubernetes
-    always_run: true
-    branches:
-    - ^release-5\.0$
-    - ^release-5\.0-
-    cluster: build05
-    context: ci/prow/lint-aws-plugin-template
-    decorate: true
-    labels:
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-console-plugin-template-release-5.0-lint-aws-plugin-template
-    rerun_command: /test lint-aws-plugin-template
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=lint-aws-plugin-template
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )lint-aws-plugin-template,?($|\s.*)

--- a/ci-operator/jobs/openshift/console-plugin-template/openshift-console-plugin-template-release-5.1-presubmits.yaml
+++ b/ci-operator/jobs/openshift/console-plugin-template/openshift-console-plugin-template-release-5.1-presubmits.yaml
@@ -86,6 +86,67 @@ presubmits:
     - ^release-5\.1$
     - ^release-5\.1-
     cluster: build05
+    context: ci/prow/frontend
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-console-plugin-template-release-5.1-frontend
+    rerun_command: /test frontend
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=frontend
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )frontend,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-5\.1$
+    - ^release-5\.1-
+    cluster: build05
     context: ci/prow/images
     decorate: true
     labels:
@@ -134,81 +195,3 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )images,?($|\s.*)
-  - agent: kubernetes
-    always_run: true
-    branches:
-    - ^release-5\.1$
-    - ^release-5\.1-
-    cluster: build05
-    context: ci/prow/lint-aws-plugin-template
-    decorate: true
-    labels:
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-console-plugin-template-release-5.1-lint-aws-plugin-template
-    rerun_command: /test lint-aws-plugin-template
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=lint-aws-plugin-template
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )lint-aws-plugin-template,?($|\s.*)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Affects OpenShift CI configuration for the console-plugin-template repository (ci-operator job definitions under ci-operator/config/openshift/console-plugin-template for main and multiple release branches).
- Replaces the prior lint-only job (lint-aws-plugin-template) with a new frontend test job that configures git safe.directory for the repo and runs the repository's frontend test script (./test-frontend.sh) inside the src-built container. Practically, this enables running the plugin's frontend tests (e.g., Jest) in CI rather than only linting.
- Updates the AWS e2e workflow dependency to rename the pull-spec environment variable from CYPRESS_PLUGIN_TEMPLATE_PULL_SPEC to PLUGIN_TEMPLATE_PULL_SPEC, standardizing how the plugin image pull-spec is referenced downstream.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->