### PR TITLE
OPCT-398: Update opct v0.6.4 and refresh current supported jobs

### DIFF
--- a/ci-operator/config/openshift/release/.config.prowgen
+++ b/ci-operator/config/openshift/release/.config.prowgen
@@ -850,6 +850,8 @@ slack_reporter:
   - e2e-external-aws
   - e2e-external-aws-ccm
   - opct-external-aws-ccm
+  - opct-platform-external-aws
+  - opct-platform-external-aws-ccm
   excluded_variants:
   - ci-4.10
   - ci-4.10-upgrade-from-stable-4.9

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22.yaml
@@ -2219,12 +2219,18 @@ tests:
     env:
       PLATFORM_EXTERNAL_CCM_ENABLED: "yes"
     workflow: openshift-e2e-external-aws
-- as: opct-external-aws-ccm
+- as: opct-platform-external-aws-ccm
   cron: '@weekly'
   steps:
     cluster_profile: openshift-org-aws
     env:
       PLATFORM_EXTERNAL_CCM_ENABLED: "yes"
+    workflow: opct-conformance-external-aws
+  timeout: 6h0m0s
+- as: opct-platform-external-aws
+  cron: "@weekly"
+  steps:
+    cluster_profile: openshift-org-aws
     workflow: opct-conformance-external-aws
   timeout: 6h0m0s
 - as: e2e-aws-ovn-kube-apiserver-rollout

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22.yaml
@@ -2228,7 +2228,7 @@ tests:
     workflow: opct-conformance-external-aws
   timeout: 6h0m0s
 - as: opct-platform-external-aws
-  cron: "@weekly"
+  cron: '@weekly'
   steps:
     cluster_profile: openshift-org-aws
     workflow: opct-conformance-external-aws

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.23.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.23.yaml
@@ -2180,7 +2180,7 @@ tests:
       PLATFORM_EXTERNAL_CCM_ENABLED: "yes"
     workflow: openshift-e2e-external-aws
 - as: opct-platform-external-aws-ccm
-  cron: "@monthly"
+  cron: '@monthly'
   steps:
     cluster_profile: openshift-org-aws
     env:
@@ -2188,7 +2188,7 @@ tests:
     workflow: opct-conformance-external-aws
   timeout: 6h0m0s
 - as: opct-platform-external-aws
-  cron: "@monthly"
+  cron: '@monthly'
   steps:
     cluster_profile: openshift-org-aws
     workflow: opct-conformance-external-aws

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.23.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.23.yaml
@@ -2179,12 +2179,18 @@ tests:
     env:
       PLATFORM_EXTERNAL_CCM_ENABLED: "yes"
     workflow: openshift-e2e-external-aws
-- as: opct-external-aws-ccm
-  cron: '@weekly'
+- as: opct-platform-external-aws-ccm
+  cron: "@monthly"
   steps:
     cluster_profile: openshift-org-aws
     env:
       PLATFORM_EXTERNAL_CCM_ENABLED: "yes"
+    workflow: opct-conformance-external-aws
+  timeout: 6h0m0s
+- as: opct-platform-external-aws
+  cron: "@monthly"
+  steps:
+    cluster_profile: openshift-org-aws
     workflow: opct-conformance-external-aws
   timeout: 6h0m0s
 - as: e2e-aws-ovn-kube-apiserver-rollout

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
@@ -2371,12 +2371,18 @@ tests:
     env:
       PLATFORM_EXTERNAL_CCM_ENABLED: "yes"
     workflow: openshift-e2e-external-aws
-- as: opct-external-aws-ccm
-  cron: '@weekly'
+- as: opct-platform-external-aws-ccm
+  cron: '@monthly'
   steps:
     cluster_profile: openshift-org-aws
     env:
       PLATFORM_EXTERNAL_CCM_ENABLED: "yes"
+    workflow: opct-conformance-external-aws
+  timeout: 6h0m0s
+- as: opct-platform-external-aws
+  cron: '@monthly'
+  steps:
+    cluster_profile: openshift-org-aws
     workflow: opct-conformance-external-aws
   timeout: 6h0m0s
 - as: e2e-aws-ovn-kube-apiserver-rollout

--- a/ci-operator/step-registry/opct/conformance/external-aws/opct-conformance-external-aws-workflow.yaml
+++ b/ci-operator/step-registry/opct/conformance/external-aws/opct-conformance-external-aws-workflow.yaml
@@ -17,7 +17,7 @@ workflow:
     env:
       PROVIDER_NAME: aws
       PLATFORM_EXTERNAL_CCM_ENABLED: no
-      OPCT_CLI_IMAGE: "quay.io/opct/opct:v0.6.2"
+      OPCT_CLI_IMAGE: "quay.io/opct/opct:v0.6.4"
   documentation: |-
     The OPCT Conformance External E2E workflow executes the common end-to-end test suite using
     OPCT tool.

--- a/ci-operator/step-registry/opct/conformance/test/results/opct-conformance-test-results-commands.sh
+++ b/ci-operator/step-registry/opct/conformance/test/results/opct-conformance-test-results-commands.sh
@@ -59,12 +59,13 @@ collect_inspect || true
 retrieve_artifact || true
 show_results || true
 
-# Check if job is running in OPCT repo to skip upload results to
+# Check if job is running in OPCT workflow in allowed job ref to skip upload results to
 # OPCT storage.
 show_reader "Consolidating artifacts as Baseline Results"
 INVALID_OPCT_REPO="true"
 VALID_REPOS=("redhat-openshift-ecosystem-provider-certification-tool")
 VALID_REPOS+=("redhat-openshift-ecosystem-opct")
+VALID_REPOS+=("periodic-ci-openshift-release-main")
 show_msg "Checking if JOB name is allowed to upload results: ${JOB_NAME}"
 for VR in "${VALID_REPOS[@]}"; do
   if [[ $JOB_NAME == *"$VR"* ]]; then
@@ -72,7 +73,7 @@ for VR in "${VALID_REPOS[@]}"; do
   fi
 done
 
-# Ignore persisting data in non OPCT/repo jobs
+# Ignore persisting data from unexpected jobs
 if [[ "${INVALID_OPCT_REPO}" == "true" ]]; then
   show_msg "# WARNING: Job $JOB_NAME is not allowed to persist baseline results, ignoring it."
   exit 0

--- a/ci-operator/step-registry/opct/test/platform-external-vsphere/opct-test-platform-external-vsphere-workflow.yaml
+++ b/ci-operator/step-registry/opct/test/platform-external-vsphere/opct-test-platform-external-vsphere-workflow.yaml
@@ -14,7 +14,7 @@ workflow:
       - ref: upi-deprovision-vsphere-dns
       - ref: ipi-deprovision-vsphere-lease
     env:
-      OPCT_CLI_IMAGE: "quay.io/opct/opct:v0.6.2"
+      OPCT_CLI_IMAGE: "quay.io/opct/opct:v0.6.4"
       DEFAULT_NETWORK_TYPE: "single-tenant"
       OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY: true
   documentation: |-

--- a/ci-operator/step-registry/opct/test/platform-none-vsphere/opct-test-platform-none-vsphere-workflow.yaml
+++ b/ci-operator/step-registry/opct/test/platform-none-vsphere/opct-test-platform-none-vsphere-workflow.yaml
@@ -14,7 +14,7 @@ workflow:
       - ref: upi-deprovision-vsphere-dns
       - ref: ipi-deprovision-vsphere-lease
     env:
-      OPCT_CLI_IMAGE: "quay.io/opct/opct:v0.6.2"
+      OPCT_CLI_IMAGE: "quay.io/opct/opct:v0.6.4"
       DEFAULT_NETWORK_TYPE: "single-tenant"
       OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY: true
   documentation: |-


### PR DESCRIPTION
Update periodic jobs for platform external (with and without CCM), on
OPCT workflow, to test new OCP versions accordingly.

We want to test often in stable OCP relases, as OPCT workflows are used
by partners which is validating/certified under stable OCP versions.

The job without CCM is added to 4.22+ versions as platform type None
installations will be deprecation soon, and this is a valid workflow for
partners, we need to get signals on that variant too.

This PR is a subset of changes added in wider work to refresh CI jobs for platform external and VCSP program's workflow with opct: https://github.com/openshift/release/pull/78511

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated OPCT CLI/tool to v0.6.4 across test workflows.
  * Renamed and added platform-external AWS test jobs; added separate CCM and non-CCM jobs for 4.22, 4.23 and 5.0 with adjusted schedules.
  * Adjusted test scheduling to include monthly cadences.
  * Expanded alerting configuration to include the new jobs and widened baseline-artifact allowlist for result persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->