### PR TITLE
qci-pruner: fix BuildConfig to fetch script from main not master

### DIFF
--- a/clusters/app.ci/supplemental-ci-images/qci-pruner.yaml
+++ b/clusters/app.ci/supplemental-ci-images/qci-pruner.yaml
@@ -18,7 +18,7 @@ spec:
       RUN mkdir /tmp/bin && curl -L --fail -v https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable-4.20/openshift-client-linux.tar.gz | tar xvzf - -C /tmp/bin/ oc && \
         chmod ug+x /tmp/bin/oc
       ENV PATH="/tmp/bin:${PATH}"
-      RUN wget https://raw.githubusercontent.com/openshift/release/refs/heads/master/hack/qci_registry_pruner.py && chmod +x ./qci_registry_pruner.py
+      RUN wget https://raw.githubusercontent.com/openshift/release/refs/heads/main/hack/qci_registry_pruner.py && chmod +x ./qci_registry_pruner.py
     type: Dockerfile
   strategy:
     type: Docker


### PR DESCRIPTION
/cc @openshift/test-platform 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD build configuration to retrieve scripts from the latest branch reference instead of a legacy one.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->