### PR TITLE
neuron-ci: fix install-kserve-deps for ROSA HCP and RHOAI 3.x

### DIFF
--- a/ci-operator/step-registry/aws-neuron-operator/install-kserve-deps/aws-neuron-operator-install-kserve-deps-commands.sh
+++ b/ci-operator/step-registry/aws-neuron-operator/install-kserve-deps/aws-neuron-operator-install-kserve-deps-commands.sh
@@ -21,14 +21,36 @@ else
 fi
 echo "Using KServe deployment mode: ${KSERVE_MODE} (RHOAI channel: ${RHOAI_CHANNEL})"
 
+approve_install_plans() {
+    local ns="${1}"
+    local sub_name="${2}"
+    local csv_name
+    csv_name=$(oc get sub "${sub_name}" -n "${ns}" -o jsonpath='{.status.currentCSV}' 2>/dev/null)
+    if [[ -z "${csv_name}" ]]; then
+        return
+    fi
+    oc get installplan -n "${ns}" -o json 2>/dev/null \
+        | jq -r ".items[] | select(.spec.approved == false)
+                  | select(.spec.clusterServiceVersionNames[]? == \"${csv_name}\")
+                  | .metadata.name" \
+        | while read -r plan; do
+            echo "Auto-approving InstallPlan '${plan}' for ${csv_name} in ${ns}"
+            oc patch installplan "${plan}" -n "${ns}" --type=merge -p '{"spec":{"approved":true}}'
+        done
+}
+
 wait_for_csv() {
     local ns="${1}"
     local name_prefix="${2}"
     local timeout="${3:-600}"
+    local sub_name="${4:-}"
     local elapsed=0
 
     echo "Waiting for CSV starting with '${name_prefix}' in namespace '${ns}' to reach Succeeded..."
     while [[ ${elapsed} -lt ${timeout} ]]; do
+        if [[ -n "${sub_name}" ]]; then
+            approve_install_plans "${ns}" "${sub_name}"
+        fi
         local phase
         phase=$(oc get csv -n "${ns}" -o json 2>/dev/null \
             | jq -r ".items[] | select(.metadata.name | startswith(\"${name_prefix}\")) | .status.phase" \
@@ -145,13 +167,13 @@ fi
 # --- 4. Wait for all CSVs ---
 echo "=== Waiting for operator CSVs ==="
 if [[ "${KSERVE_MODE}" == "Serverless" ]]; then
-    wait_for_csv "openshift-operators" "servicemeshoperator" 600 || exit 1
-    wait_for_csv "openshift-serverless" "serverless-operator" 600 || exit 1
+    wait_for_csv "openshift-operators" "servicemeshoperator" 600 "servicemeshoperator" || exit 1
+    wait_for_csv "openshift-serverless" "serverless-operator" 600 "serverless-operator" || exit 1
 fi
-wait_for_csv "${RHOAI_NAMESPACE}" "rhods-operator" 600 || exit 1
+wait_for_csv "${RHOAI_NAMESPACE}" "rhods-operator" 600 "rhods-operator" || exit 1
 echo "All operator CSVs reached Succeeded"
 
-# --- 5. Configure DSCI for RawDeployment (disable Service Mesh) ---
+# --- 5. Configure DSCI for RawDeployment (disable Service Mesh on RHOAI 2.x) ---
 if [[ "${KSERVE_MODE}" == "RawDeployment" ]]; then
     echo "=== Configuring DSCI for RawDeployment mode ==="
     DSCI_TIMEOUT=300
@@ -159,12 +181,7 @@ if [[ "${KSERVE_MODE}" == "RawDeployment" ]]; then
     while [[ ${DSCI_ELAPSED} -lt ${DSCI_TIMEOUT} ]]; do
         DSCI_NAME=$(oc get dsci -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
         if [[ -n "${DSCI_NAME}" ]]; then
-            if oc patch dsci "${DSCI_NAME}" --type=merge \
-                -p '{"spec":{"serviceMesh":{"managementState":"Removed"}}}'; then
-                echo "DSCI '${DSCI_NAME}' patched: serviceMesh set to Removed"
-                break
-            fi
-            echo "WARNING: DSCI '${DSCI_NAME}' patch failed, retrying..."
+            break
         fi
         sleep 10
         DSCI_ELAPSED=$((DSCI_ELAPSED + 10))
@@ -172,6 +189,16 @@ if [[ "${KSERVE_MODE}" == "RawDeployment" ]]; then
     if [[ ${DSCI_ELAPSED} -ge ${DSCI_TIMEOUT} ]]; then
         echo "ERROR: DSCI not found within ${DSCI_TIMEOUT}s"
         exit 1
+    fi
+    # RHOAI 3.x (DSCI apiVersion v2) removed spec.serviceMesh entirely.
+    # Only patch on RHOAI 2.x where the field still exists.
+    DSCI_API=$(oc get dsci "${DSCI_NAME}" -o jsonpath='{.apiVersion}' 2>/dev/null)
+    if [[ "${DSCI_API}" != *"/v2" ]]; then
+        oc patch dsci "${DSCI_NAME}" --type=merge \
+            -p '{"spec":{"serviceMesh":{"managementState":"Removed"}}}'
+        echo "DSCI '${DSCI_NAME}' patched: serviceMesh set to Removed"
+    else
+        echo "DSCI '${DSCI_NAME}' uses ${DSCI_API} (RHOAI 3.x) -- serviceMesh field not present, skipping patch"
     fi
 fi
 
@@ -320,8 +347,8 @@ spec:
     - --max-num-seqs=${MAX_NUM_SEQS}
     - --max-model-len=${MAX_MODEL_LEN}
     - --disable-frontend-multiprocessing
-    - --enable-chunked-prefill=false
-    - --enable-prefix-caching=false
+    - --no-enable-chunked-prefill
+    - --no-enable-prefix-caching
     env:
     - name: NEURON_COMPILE_CACHE_URL
       value: /mnt/models/neuron-compiled-artifacts


### PR DESCRIPTION
## Summary
- Auto-approve InstallPlans during CSV wait loop: ROSA HCP OperatorGroups enforce Manual approval regardless of Subscription settings, causing operator CSV installs to time out
- Check DSCI API version before patching `serviceMesh`: RHOAI 3.x (`apiVersion v2`) removed `spec.serviceMesh` entirely, so the patch must be skipped
- Fix vLLM boolean flags: newer vLLM versions (`vllm-neuron-rhel9:3`) use `--no-enable-chunked-prefill` / `--no-enable-prefix-caching` instead of `--enable-*=false`

Follow-up to #78753 — these fixes were found during local testing on a ROSA HCP 4.21 cluster.

## Test plan
- [x] Tested end-to-end on ROSA HCP 4.21 cluster with RHOAI 3.x
- [x] Verified InstallPlan auto-approval works (CSV reached Succeeded in 45s)
- [x] Verified DSCI v2 API detection skips serviceMesh patch
- [x] Verified vLLM starts successfully with corrected flags
- [x] KServe InferenceService reached Ready and served inference successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Service Mesh configuration handling to work correctly with different RHOAI versions and API schemas.
  * Updated ServingRuntime container arguments to ensure proper parameter handling for model serving.

* **Improvements**
  * Enhanced operator installation process with automatic approval of installation resources.
  * Improved operator deployment monitoring with subscription-aware waiting mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->