### PR TITLE
OCM-23542 | chore: bump prow image

### DIFF
--- a/ci-operator/config/openshift-online/ocm-cli/openshift-online-ocm-cli-main__images.yaml
+++ b/ci-operator/config/openshift-online/ocm-cli/openshift-online-ocm-cli-main__images.yaml
@@ -2,17 +2,17 @@ build_root:
   image_stream_tag:
     name: builder
     namespace: ocp
-    tag: rhel-9-golang-1.24-openshift-4.21
+    tag: rhel-9-golang-1.25-openshift-4.22
 images:
   items:
   - dockerfile_literal: |
-      FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.21 AS builder
+      FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS builder
       WORKDIR /go/src/github.com/openshift-online/ocm-cli
       COPY . .
       ENV GOFLAGS=-buildvcs=false
       RUN make install
 
-      FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.21
+      FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22
       COPY --from=builder /go/bin/ocm /usr/bin/
       RUN yum -y install --setopt=skip_missing_names_on_install=False \
       jq \


### PR DESCRIPTION
Update image to 4.22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure to use Go 1.25 and OpenShift 4.22 builder images for improved compatibility and access to latest toolchain enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->