### PR TITLE
OCPBUGS-84964: telco5g: Update Podman image version and enhance secret retrieval logic

### DIFF
--- a/ci-operator/step-registry/telco5g/ptp/tests/telco5g-ptp-tests-commands.sh
+++ b/ci-operator/step-registry/telco5g/ptp/tests/telco5g-ptp-tests-commands.sh
@@ -172,7 +172,9 @@ spec:
   retry_with_timeout 400 5 oc -n openshift-ptp get sa builder
   dockercgf=""
   for i in $(seq 1 80); do
-    dockercgf=$(oc -n openshift-ptp get secret -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | grep '^builder-dockercfg-' || true)
+    dockercgf=$(oc --request-timeout=10s -n openshift-ptp get secret \
+      -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' \
+      | grep '^builder-dockercfg-' | head -1 || true)
     if [[ -n "${dockercgf}" ]]; then
       break
     fi
@@ -183,7 +185,7 @@ spec:
     echo "[ERROR] builder-dockercfg secret not found after 400s"
     exit 1
   fi
-  jobdefinition=$(sed "s#BUILDER_DOCKERCFG#${dockercgf}#" <<<"$jobdefinition")
+  jobdefinition=${jobdefinition//BUILDER_DOCKERCFG/${dockercgf}}
   echo "$jobdefinition"
   echo "$jobdefinition" | oc apply -f -
 

--- a/ci-operator/step-registry/telco5g/ptp/tests/telco5g-ptp-tests-commands.sh
+++ b/ci-operator/step-registry/telco5g/ptp/tests/telco5g-ptp-tests-commands.sh
@@ -52,7 +52,7 @@ spec:
   serviceAccountName: builder
   containers:
     - name: priv
-      image: quay.io/podman/stable
+      image: quay.io/podman/stable:v4.9.4
       command:
         - /bin/bash
         - -c
@@ -170,7 +170,19 @@ spec:
   #oc label ns openshift-ptp --overwrite pod-security.kubernetes.io/enforce=privileged
 
   retry_with_timeout 400 5 oc -n openshift-ptp get sa builder
-  dockercgf=$(oc -n openshift-ptp get sa builder -oyaml | grep imagePullSecrets -A 1 | grep -o "builder-.*")
+  dockercgf=""
+  for i in $(seq 1 80); do
+    dockercgf=$(oc -n openshift-ptp get secret -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | grep '^builder-dockercfg-' || true)
+    if [[ -n "${dockercgf}" ]]; then
+      break
+    fi
+    echo "Waiting for builder-dockercfg secret (attempt ${i}/80)..."
+    sleep 5
+  done
+  if [[ -z "${dockercgf}" ]]; then
+    echo "[ERROR] builder-dockercfg secret not found after 400s"
+    exit 1
+  fi
   jobdefinition=$(sed "s#BUILDER_DOCKERCFG#${dockercgf}#" <<<"$jobdefinition")
   echo "$jobdefinition"
   echo "$jobdefinition" | oc apply -f -


### PR DESCRIPTION
- Updated Podman image to version v4.9.4 for the builder container to fix incompatibility with openshift-4.12.
- Improved the logic for retrieving the builder-dockercfg secret with retries, including error handling for cases where the secret is not found after multiple attempts. Now getting the secret directly instead of via the service account since this capability is removed in 4.23/5.0
 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stabilized the build job by pinning the container image to a specific, stable version.
  * Improved secret lookup with a retry/polling mechanism and clear timeout to make secret retrieval more reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->