### PR TITLE
gcp-project-operator: Add prek validation to PROW CI

### DIFF
--- a/ci-operator/config/openshift/gcp-project-operator/openshift-gcp-project-operator-master.yaml
+++ b/ci-operator/config/openshift/gcp-project-operator/openshift-gcp-project-operator-master.yaml
@@ -4,6 +4,14 @@ images:
   items:
   - dockerfile_path: build/Dockerfile
     to: unused
+  - dockerfile_literal: |
+      FROM src
+      RUN PREK_VERSION="$(tr -d '[:space:]' < .prek-version 2>/dev/null || true)" \
+        && PREK_VERSION="${PREK_VERSION:-v0.3.9}" \
+        && curl -fsSL "https://github.com/j178/prek/releases/download/${PREK_VERSION}/prek-x86_64-unknown-linux-gnu.tar.gz" \
+        | tar xzf - --strip-components=1 -C /usr/local/bin/ prek-x86_64-unknown-linux-gnu/prek
+    from: src
+    to: prek-runner
 resources:
   '*':
     limits:
@@ -46,6 +54,20 @@ tests:
   commands: make validate
   container:
     from: src
+  skip_if_only_changed: ^(?:\.tekton|\.github)|\.md$|^(?:\.gitignore|OWNERS|LICENSE)$
+- as: prek
+  commands: |
+    export PREK_HOME=/tmp/prek
+    cd /go/src/github.com/openshift/gcp-project-operator
+    git init
+    git add -A
+    if [ -x hack/ci.sh ]; then
+      ./hack/ci.sh
+    else
+      prek run --all-files
+    fi
+  container:
+    from: prek-runner
   skip_if_only_changed: ^(?:\.tekton|\.github)|\.md$|^(?:\.gitignore|OWNERS|LICENSE)$
 zz_generated_metadata:
   branch: master

--- a/ci-operator/jobs/openshift/gcp-project-operator/openshift-gcp-project-operator-master-presubmits.yaml
+++ b/ci-operator/jobs/openshift/gcp-project-operator/openshift-gcp-project-operator-master-presubmits.yaml
@@ -190,6 +190,68 @@ presubmits:
     - ^master$
     - ^master-
     cluster: build03
+    context: ci/prow/prek
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-gcp-project-operator-master-prek
+    rerun_command: /test prek
+    skip_if_only_changed: ^(?:\.tekton|\.github)|\.md$|^(?:\.gitignore|OWNERS|LICENSE)$
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=prek
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )prek,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^master$
+    - ^master-
+    cluster: build03
     context: ci/prow/test
     decorate: true
     labels:


### PR DESCRIPTION
## Summary

Add prek validation to PROW CI for gcp-project-operator to validate code hygiene and linting in presubmit checks.

## Background

The gcp-project-operator repository merged prek-based development workflow in https://github.com/openshift/gcp-project-operator/pull/296, which added:
- Pre-commit hooks for file hygiene + golangci-lint
- Claude Code stop hook integration
- Developer documentation in CONTRIBUTING.md

This PR integrates prek validation into PROW CI to enforce the same checks in presubmit jobs.

## Changes

### CI Configuration
- Add `prek-runner` image built FROM `src` (includes Go toolchain, make, golangci-lint)
- Add `prek` presubmit test that validates code via `hack/ci.sh`
- Skip validation for documentation-only changes

### Technical Details
- **Image build**: FROM `src` ensures all build tools are available (make, golangci-lint, Go)
- **Test command**: Includes `cd /go/src/github.com/openshift/gcp-project-operator` to set proper working directory
- **Git setup**: Initializes git repo and stages all files for prek to validate
- **Conditional execution**: Uses `hack/ci.sh` if present, falls back to `prek run --all-files`

### Pattern
Follows the same pattern as aws-account-operator (https://github.com/openshift/release/pull/78697) and rosa-claude-plugins for Go projects using the boilerplate framework.

## Testing

CI rehearsal jobs will validate:
- prek-runner image builds successfully
- prek validation runs without errors
- Skip patterns work correctly

/cc @openshift/openshift-team-srep

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
* **Scope / impact**
  * Adds PREK-based presubmit validation to the OpenShift CI configuration for the openshift/gcp-project-operator repository (ci-operator config and generated presubmit job).

* **Tests**
  * Adds a new PRESUBMIT test "prek" that runs repository file-hygiene and lint validation. The job:
    * Runs in a new prek-runner container and sets PREK_HOME=/tmp/prek.
    * Ensures working directory is /go/src/github.com/openshift/gcp-project-operator, initializes a git repo and stages files (git init; git add -A) so PREK can validate.
    * Executes hack/ci.sh if present, otherwise falls back to `prek run --all-files`.
    * Is skipped for documentation-only changes using the repository’s existing skip_if_only_changed pattern.

* **CI image / build**
  * Adds a dedicated prek-runner image built FROM src via a dockerfile_literal (installs prek from a tarball whose version is read from .prek-version with default v0.3.9). The image provides the Go toolchain, make and golangci-lint required by prek validation and is referenced by the new test.

* **Behavior & compatibility**
  * Implements the same prek/boilerplate pattern used for other Go projects (e.g., aws-account-operator, rosa-claude-plugins) so the repo’s PREK workflow is enforced in PROW presubmits.

* **Activity / rehearsals**
  * Author repeatedly ran CI rehearsals (/pj-rehearse and variants). One optional infra-related test initially failed but subsequent runs (including coverage) passed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->