### PR TITLE
OCM-23817 Migrate cs-rosa-hcp-amd64-staging-main OCM FVT job to Prow periodic

### DIFF
--- a/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__ocm-fvt-rosa-hcp-staging.yaml
+++ b/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__ocm-fvt-rosa-hcp-staging.yaml
@@ -284,6 +284,46 @@ tests:
   secrets:
   - mount_path: /usr/local/cs-qe-credentials
     name: cs-qe-credentials
+- as: ocm-fvt-periodic-cs-rosa-hcp-amd64-staging-main
+  capabilities:
+  - nested-podman
+  commands: |
+    JOB_LINK="https://prow.ci.openshift.org/view/gs/test-platform-results/"
+    if [ -n "${PULL_NUMBER:-}" ]; then
+      JOB_LINK="${JOB_LINK}pr-logs/pull/openshift_release/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
+    else
+      JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
+    fi
+
+    podman_env_file="$(mktemp /tmp/podman.env.XXXXXX)"
+    trap 'rm -f "${podman_env_file}"' EXIT
+    umask 077
+    env -i bash --norc --noprofile << EOF > "${podman_env_file}"
+    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
+    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
+    export ENABLE_JIRA_REPORTING=true
+    export JOB_LINK="${JOB_LINK}"
+    source /usr/local/cs-qe-credentials/ocm-tokens
+    source /usr/local/cs-qe-credentials/jira-cred
+    env | grep -v '^_='
+    EOF
+
+    podman run \
+    --authfile /usr/local/cs-qe-credentials/.dockerconfigjson \
+    --env-file "${podman_env_file}" \
+    -v /usr/local/cs-qe-credentials:/credentials:ro,z \
+    --rm \
+    quay.io/redhat-services-prod/ocmci/ocmci:latest \
+    ocmtest test --service cms --job cs-rosa-hcp-amd64-staging-main --reportJiraTicket
+  container:
+    from: nested-podman
+    memory_backed_volume:
+      size: 1Gi
+  cron: 0 9 * * *
+  nested_podman: true
+  secrets:
+  - mount_path: /usr/local/cs-qe-credentials
+    name: cs-qe-credentials
 zz_generated_metadata:
   branch: main
   org: openshift-online

--- a/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-periodics.yaml
@@ -1023,6 +1023,78 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-online-rosa-e2e-main-ocm-fvt-rosa-hcp-staging-ocm-fvt-periodic-cs-rosa-hcp-amd64-staging-main
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/cs-qe-credentials
+      - --target=ocm-fvt-periodic-cs-rosa-hcp-amd64-staging-main
+      - --variant=ocm-fvt-rosa-hcp-staging
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /secrets/cs-qe-credentials
+        name: cs-qe-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: cs-qe-credentials
+      secret:
+        secretName: cs-qe-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build06
+  cron: 0 9 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-online
+    repo: rosa-e2e
+  labels:
+    capability/nested-podman: nested-podman
+    ci-operator.openshift.io/variant: ocm-fvt-rosa-hcp-staging
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-online-rosa-e2e-main-ocm-fvt-rosa-hcp-staging-ocm-fvt-periodic-cs-rosa-hcp-arm-staging-main
   spec:
     containers:


### PR DESCRIPTION
  ## Summary                                                                                                                                                  
                                                                                                                                                              
  - Add Prow periodic for `cs-rosa-hcp-amd64-staging-main` OCM FVT job                                                                                      
  - Migrates from Tekton/Konflux to Prow using nested-podman + ocmci container pattern                                                                        
  - Runs CMS API gating tests against staging OCM environment using the rosa-hcp-ad cluster profile (ROSA HCP amd64-only, multiarch disabled)               
  - Test scopes: Day1Post, Day2Pre, Day2CH (Critical/High)                                                                                                    
                                                                                                                                                              
  ## Details                                                                                                                                                  
                                                                                                                                                              
  - Cron: `0 8 * * *` (08:00 UTC daily)                                                                                                                       
  - Workflow: `cms-gating-test`                                                                                                                               
  - Jira: https://redhat.atlassian.net/browse/OCM-23817
  - Epic: https://redhat.atlassian.net/browse/ROSAENG-391            

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR adds a new Prow periodic job to the OpenShift CI infrastructure for testing ROSA HCP deployments. Specifically, it configures a daily OCM (OpenShift Cloud Management) CMS API gating test that will run against the staging environment using a ROSA HCP amd64-only configuration (the `cs-rosa-hcp-ad` cluster profile).

The change adds the test definition `ocm-fvt-periodic-cs-rosa-hcp-amd64-staging-main` to the CI operator configuration for the `openshift-online/rosa-e2e` repository. The test follows an established pattern already used by other ROSA HCP periodic jobs in the same configuration file:

- **Execution**: Uses nested-podman with the `ocmci` container image to execute the test
- **Schedule**: Runs daily at 08:00 UTC via cron
- **Credentials**: Mounts CS-QE credentials and AWS credentials for test environment access
- **Reporting**: Enables JIRA ticket reporting for test results and includes job links in reports
- **Resources**: Allocates 1GB memory-backed volume for the container

This is part of the broader migration effort to move OCM FVT jobs from the Tekton/Konflux platform to Prow's periodic job execution model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->