### PR TITLE
ART-18321: whitelist openshift/block-copyfail

### DIFF
--- a/core-services/openshift-priv/_whitelist.yaml
+++ b/core-services/openshift-priv/_whitelist.yaml
@@ -7,6 +7,7 @@ whitelist:
   openshift-eng:
     - ocp-build-data
   openshift:
+    - block-copyfail
     - cert-manager-istio-csr
     - cert-manager-operator
     - cert-manager-trust-manager


### PR DESCRIPTION
Signed-off-by: Rayford Johnson <rayfordj@users.noreply.github.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration whitelist settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->