### PR TITLE
OCM-23816 Migrate cs-rosa-hcp-arm-staging-main OCM FVT job to Prow periodic

### DIFF
--- a/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__ocm-fvt-rosa-hcp-staging.yaml
+++ b/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__ocm-fvt-rosa-hcp-staging.yaml
@@ -244,6 +244,46 @@ tests:
   secrets:
   - mount_path: /usr/local/cs-qe-credentials
     name: cs-qe-credentials
+- as: ocm-fvt-periodic-cs-rosa-hcp-arm-staging-main
+  capabilities:
+  - nested-podman
+  commands: |
+    JOB_LINK="https://prow.ci.openshift.org/view/gs/test-platform-results/"
+    if [ -n "${PULL_NUMBER:-}" ]; then
+      JOB_LINK="${JOB_LINK}pr-logs/pull/openshift_release/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
+    else
+      JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
+    fi
+
+    podman_env_file="$(mktemp /tmp/podman.env.XXXXXX)"
+    trap 'rm -f "${podman_env_file}"' EXIT
+    umask 077
+    env -i bash --norc --noprofile << EOF > "${podman_env_file}"
+    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
+    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
+    export ENABLE_JIRA_REPORTING=true
+    export JOB_LINK="${JOB_LINK}"
+    source /usr/local/cs-qe-credentials/ocm-tokens
+    source /usr/local/cs-qe-credentials/jira-cred
+    env | grep -v '^_='
+    EOF
+
+    podman run \
+    --authfile /usr/local/cs-qe-credentials/.dockerconfigjson \
+    --env-file "${podman_env_file}" \
+    -v /usr/local/cs-qe-credentials:/credentials:ro,z \
+    --rm \
+    quay.io/redhat-services-prod/ocmci/ocmci:latest \
+    ocmtest test --service cms --job cs-rosa-hcp-arm-staging-main --reportJiraTicket
+  container:
+    from: nested-podman
+    memory_backed_volume:
+      size: 1Gi
+  cron: 0 9 * * *
+  nested_podman: true
+  secrets:
+  - mount_path: /usr/local/cs-qe-credentials
+    name: cs-qe-credentials
 zz_generated_metadata:
   branch: main
   org: openshift-online

--- a/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-periodics.yaml
@@ -1009,6 +1009,78 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build06
+  cron: 0 9 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-online
+    repo: rosa-e2e
+  labels:
+    capability/nested-podman: nested-podman
+    ci-operator.openshift.io/variant: ocm-fvt-rosa-hcp-staging
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-online-rosa-e2e-main-ocm-fvt-rosa-hcp-staging-ocm-fvt-periodic-cs-rosa-hcp-arm-staging-main
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/cs-qe-credentials
+      - --target=ocm-fvt-periodic-cs-rosa-hcp-arm-staging-main
+      - --variant=ocm-fvt-rosa-hcp-staging
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /secrets/cs-qe-credentials
+        name: cs-qe-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: cs-qe-credentials
+      secret:
+        secretName: cs-qe-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build06
   cron: 0 8 * * *
   decorate: true
   decoration_config:


### PR DESCRIPTION
  ## Summary                                                                                                                                                  
                                                                                                                                                              
  - Add Prow periodic for `cs-rosa-hcp-arm-staging-main` OCM FVT job                                                                                        
  - Migrates from Tekton/Konflux to Prow using nested-podman + ocmci container pattern                                                                        
  - Runs CMS API gating tests against staging OCM environment using the rosa-hcp-arm cluster profile (ROSA HCP ARM/aarch64)
  - Test scopes: Day1Post, Day2Pre, Day2CH (Critical/High)                                                                                                    
                                                                                                                                                              
  ## Details                                                                                                                                                  
                                                                                                                                                              
  - Cron: `0 8 * * *` (08:00 UTC daily)                                                                                                                       
  - Workflow: `cms-gating-test`                                                                                                                               
  - Jira: https://redhat.atlassian.net/browse/OCM-23816
  - Epic: https://redhat.atlassian.net/browse/ROSAENG-391              

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Migration of OCM FVT Job to Prow Periodic

This PR migrates the `cs-rosa-hcp-arm-staging-main` OCM (OpenShift Container Management) FVT (Functional Verification Test) job from Tekton/Konflux to Prow periodic job configuration.

### Changes

Adds a new periodic test job named `ocm-fvt-periodic-cs-rosa-hcp-arm-staging-main` to the Rosa E2E CI configuration. The job is configured to:

- **Run schedule**: Daily at 08:00 UTC via cron `0 8 * * *`
- **Container pattern**: Uses nested-podman with the `ocmci:latest` container image to execute CMS API gating tests
- **Test environment**: Targets the staging OCM environment using the `rosa-hcp-arm` cluster profile (ARM/aarch64 architecture)
- **Test scopes**: Covers Day1Post, Day2Pre, and Day2CH (Critical/High priority) scenarios
- **Workflow**: Uses the `cms-gating-test` workflow for execution
- **Credentials**: Mounts CS QE credentials and references Jira ticket [OCM-23816](https://redhat.atlassian.net/browse/OCM-23816) with Epic [ROSAENG-391](https://redhat.atlassian.net/browse/ROSAENG-391)

The job is configured with standard resource requests and includes proper secret mounting and environment variable setup for Jira reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[OCM-23816]: https://redhat.atlassian.net/browse/OCM-23816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ