### PR TITLE
fleetshift: split fleetshift-server into fast amd64-only config

### DIFF
--- a/ci-operator/config/fleetshift/fleetshift-poc/fleetshift-fleetshift-poc-main.yaml
+++ b/ci-operator/config/fleetshift/fleetshift-poc/fleetshift-fleetshift-poc-main.yaml
@@ -5,15 +5,8 @@ build_root:
     tag: go1.25-linux
 images:
   items:
-  - additional_architectures:
-    - arm64
-    dockerfile_path: Dockerfile
+  - dockerfile_path: Dockerfile
     to: fleetshift-server
-  - additional_architectures:
-    - arm64
-    dockerfile_path: Dockerfile.local
-    from: fleetshift-server
-    to: fleetshift-server-local
 resources:
   '*':
     requests:
@@ -21,8 +14,6 @@ resources:
       memory: 200Mi
 tests:
 - as: pr-image-mirror
-  capabilities:
-  - arm64
   steps:
     dependencies:
       SOURCE_IMAGE_REF: fleetshift-server
@@ -31,8 +22,6 @@ tests:
       REGISTRY_ORG: stolostron
     workflow: fleetshift-ci-image-mirror
 - as: pr-merge-image-mirror-latest
-  capabilities:
-  - arm64
   postsubmit: true
   steps:
     dependencies:
@@ -43,47 +32,12 @@ tests:
       REGISTRY_ORG: stolostron
     workflow: fleetshift-ci-image-mirror
 - as: pr-merge-image-mirror-sha
-  capabilities:
-  - arm64
   postsubmit: true
   steps:
     dependencies:
       SOURCE_IMAGE_REF: fleetshift-server
     env:
       IMAGE_REPO: fleetshift-server
-      REGISTRY_ORG: stolostron
-    workflow: fleetshift-ci-image-mirror
-- as: pr-image-mirror-local
-  capabilities:
-  - arm64
-  steps:
-    dependencies:
-      SOURCE_IMAGE_REF: fleetshift-server-local
-    env:
-      IMAGE_REPO: fleetshift-server-local
-      REGISTRY_ORG: stolostron
-    workflow: fleetshift-ci-image-mirror
-- as: pr-merge-image-mirror-local-latest
-  capabilities:
-  - arm64
-  postsubmit: true
-  steps:
-    dependencies:
-      SOURCE_IMAGE_REF: fleetshift-server-local
-    env:
-      IMAGE_REPO: fleetshift-server-local
-      IMAGE_TAG: latest
-      REGISTRY_ORG: stolostron
-    workflow: fleetshift-ci-image-mirror
-- as: pr-merge-image-mirror-local-sha
-  capabilities:
-  - arm64
-  postsubmit: true
-  steps:
-    dependencies:
-      SOURCE_IMAGE_REF: fleetshift-server-local
-    env:
-      IMAGE_REPO: fleetshift-server-local
       REGISTRY_ORG: stolostron
     workflow: fleetshift-ci-image-mirror
 zz_generated_metadata:

--- a/ci-operator/config/fleetshift/fleetshift-poc/fleetshift-fleetshift-poc-main__multiarch.yaml
+++ b/ci-operator/config/fleetshift/fleetshift-poc/fleetshift-fleetshift-poc-main__multiarch.yaml
@@ -1,0 +1,60 @@
+build_root:
+  image_stream_tag:
+    name: builder
+    namespace: stolostron
+    tag: go1.25-linux
+images:
+  items:
+  - additional_architectures:
+    - arm64
+    dockerfile_path: Dockerfile
+    to: fleetshift-server
+  - additional_architectures:
+    - arm64
+    dockerfile_path: Dockerfile.local
+    from: fleetshift-server
+    to: fleetshift-server-local
+resources:
+  '*':
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: pr-image-mirror-local
+  capabilities:
+  - arm64
+  steps:
+    dependencies:
+      SOURCE_IMAGE_REF: fleetshift-server-local
+    env:
+      IMAGE_REPO: fleetshift-server-local
+      REGISTRY_ORG: stolostron
+    workflow: fleetshift-ci-image-mirror
+- as: pr-merge-image-mirror-local-latest
+  capabilities:
+  - arm64
+  postsubmit: true
+  steps:
+    dependencies:
+      SOURCE_IMAGE_REF: fleetshift-server-local
+    env:
+      IMAGE_REPO: fleetshift-server-local
+      IMAGE_TAG: latest
+      REGISTRY_ORG: stolostron
+    workflow: fleetshift-ci-image-mirror
+- as: pr-merge-image-mirror-local-sha
+  capabilities:
+  - arm64
+  postsubmit: true
+  steps:
+    dependencies:
+      SOURCE_IMAGE_REF: fleetshift-server-local
+    env:
+      IMAGE_REPO: fleetshift-server-local
+      REGISTRY_ORG: stolostron
+    workflow: fleetshift-ci-image-mirror
+zz_generated_metadata:
+  branch: main
+  org: fleetshift
+  repo: fleetshift-poc
+  variant: multiarch

--- a/ci-operator/jobs/fleetshift/fleetshift-poc/fleetshift-fleetshift-poc-main-postsubmits.yaml
+++ b/ci-operator/jobs/fleetshift/fleetshift-poc/fleetshift-fleetshift-poc-main-postsubmits.yaml
@@ -10,6 +10,149 @@ postsubmits:
       skip_cloning: true
     labels:
       capability/arm64: arm64
+      ci-operator.openshift.io/variant: multiarch
+      ci.openshift.io/generator: prowgen
+    max_concurrency: 1
+    name: branch-ci-fleetshift-fleetshift-poc-main-multiarch-pr-merge-image-mirror-local-latest
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --target=pr-merge-image-mirror-local-latest
+        - --variant=multiarch
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    cluster: build05
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      capability/arm64: arm64
+      ci-operator.openshift.io/variant: multiarch
+      ci.openshift.io/generator: prowgen
+    max_concurrency: 1
+    name: branch-ci-fleetshift-fleetshift-poc-main-multiarch-pr-merge-image-mirror-local-sha
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --target=pr-merge-image-mirror-local-sha
+        - --variant=multiarch
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    cluster: build05
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
     name: branch-ci-fleetshift-fleetshift-poc-main-pr-merge-image-mirror-latest
@@ -79,147 +222,6 @@ postsubmits:
     decoration_config:
       skip_cloning: true
     labels:
-      capability/arm64: arm64
-      ci.openshift.io/generator: prowgen
-    max_concurrency: 1
-    name: branch-ci-fleetshift-fleetshift-poc-main-pr-merge-image-mirror-local-latest
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --report-credentials-file=/etc/report/credentials
-        - --target=pr-merge-image-mirror-local-latest
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-  - agent: kubernetes
-    always_run: true
-    branches:
-    - ^main$
-    cluster: build05
-    decorate: true
-    decoration_config:
-      skip_cloning: true
-    labels:
-      capability/arm64: arm64
-      ci.openshift.io/generator: prowgen
-    max_concurrency: 1
-    name: branch-ci-fleetshift-fleetshift-poc-main-pr-merge-image-mirror-local-sha
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --report-credentials-file=/etc/report/credentials
-        - --target=pr-merge-image-mirror-local-sha
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-  - agent: kubernetes
-    always_run: true
-    branches:
-    - ^main$
-    cluster: build05
-    decorate: true
-    decoration_config:
-      skip_cloning: true
-    labels:
-      capability/arm64: arm64
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
     name: branch-ci-fleetshift-fleetshift-poc-main-pr-merge-image-mirror-sha

--- a/ci-operator/jobs/fleetshift/fleetshift-poc/fleetshift-fleetshift-poc-main-presubmits.yaml
+++ b/ci-operator/jobs/fleetshift/fleetshift-poc/fleetshift-fleetshift-poc-main-presubmits.yaml
@@ -11,7 +11,6 @@ presubmits:
     decoration_config:
       skip_cloning: true
     labels:
-      capability/arm64: arm64
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-fleetshift-fleetshift-poc-main-images
@@ -62,12 +61,145 @@ presubmits:
     - ^main$
     - ^main-
     cluster: build03
-    context: ci/prow/pr-image-mirror
+    context: ci/prow/multiarch-images
     decorate: true
     decoration_config:
       skip_cloning: true
     labels:
       capability/arm64: arm64
+      ci-operator.openshift.io/variant: multiarch
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-fleetshift-fleetshift-poc-main-multiarch-images
+    rerun_command: /test multiarch-images
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=[images]
+        - --variant=multiarch
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )multiarch-images,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build03
+    context: ci/prow/multiarch-pr-image-mirror-local
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      capability/arm64: arm64
+      ci-operator.openshift.io/variant: multiarch
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-fleetshift-fleetshift-poc-main-multiarch-pr-image-mirror-local
+    rerun_command: /test multiarch-pr-image-mirror-local
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --target=pr-image-mirror-local
+        - --variant=multiarch
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )multiarch-pr-image-mirror-local,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build03
+    context: ci/prow/pr-image-mirror
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-fleetshift-fleetshift-poc-main-pr-image-mirror
@@ -130,77 +262,3 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )pr-image-mirror,?($|\s.*)
-  - agent: kubernetes
-    always_run: true
-    branches:
-    - ^main$
-    - ^main-
-    cluster: build03
-    context: ci/prow/pr-image-mirror-local
-    decorate: true
-    decoration_config:
-      skip_cloning: true
-    labels:
-      capability/arm64: arm64
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-fleetshift-fleetshift-poc-main-pr-image-mirror-local
-    rerun_command: /test pr-image-mirror-local
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --report-credentials-file=/etc/report/credentials
-        - --target=pr-image-mirror-local
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )pr-image-mirror-local,?($|\s.*)


### PR DESCRIPTION
## Summary
This is an attempt to make image mirroring faster after merges to main by removing slower arm64 build from fleetshift-server image. fleetshift-server is only needed on hosted k8s (x86), while fleetshift-server-local is the main dev image and still builds with multiarch in a separate job.

- Split fleetshift-poc CI config into a main config (amd64-only) and a `__multiarch` variant
- `fleetshift-server` only needs x86 (deployed to k8s cluster), so the main config builds and mirrors it without arm64 — fast `latest` and SHA tags on merge
- `fleetshift-server-local` needs both architectures (local dev on ARM Macs), so the multiarch variant handles its builds and mirrors separately
- No changes to `fleetshift-user-interface` — `fleetshift-web` needs both architectures and has no x86-only image to decouple

## Test plan
- [x] Verify `make update` generates correct Prow jobs
- [x] Verify main config postsubmits produce amd64-only images for fleetshift-server
- [x] Verify multiarch variant postsubmits produce multi-arch manifest lists for fleetshift-server-local
- [x] Verify multiarch variant presubmits validate arm64 builds on PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Streamlined CI configuration for FleetShift POC builds and image mirroring workflows, consolidating build targets and test processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->