### PR TITLE
NO-JIRA: tls-scanner: Fix exit code handling, lingering failed pods, and clarify docs

### DIFF
--- a/ci-operator/step-registry/tls/scanner/run/tls-scanner-run-commands.sh
+++ b/ci-operator/step-registry/tls/scanner/run/tls-scanner-run-commands.sh
@@ -69,7 +69,7 @@ spec:
   - name: scanner
     image: ${SCANNER_IMAGE}
     command:
-    - /bin/sh
+    - /bin/bash
     - -c
     - |
       mkdir -p /results
@@ -78,9 +78,12 @@ spec:
         --csv-file /results/results.csv \
         --junit-file /results/junit_tls_scan.xml \
         --log-file /results/scan.log 2>&1 | tee /results/output.log
-      echo "Scan complete. Exit code: \$?" | tee -a /results/output.log
+      SCAN_EXIT_CODE=\${PIPESTATUS[0]}
+      echo "Scan complete. Exit code: \${SCAN_EXIT_CODE}" | tee -a /results/output.log
       # Keep pod alive for artifact collection
       sleep 120
+      # We are intentionally ignoring the scanner exit code for the moment
+      # exit \${SCAN_EXIT_CODE}
     resources:
       requests:
         cpu: "${SCANNER_CPU}"

--- a/ci-operator/step-registry/tls/scanner/run/tls-scanner-run-commands.sh
+++ b/ci-operator/step-registry/tls/scanner/run/tls-scanner-run-commands.sh
@@ -148,8 +148,8 @@ if [[ "$(oc get pod/tls-scanner -n "${NAMESPACE}" -o jsonpath='{.status.phase}' 
     exit 1
 fi
 
-oc wait --for=jsonpath='{.status.phase}'=Succeeded pod/tls-scanner -n "${NAMESPACE}" --timeout=4h || {
-    echo "Scanner did not complete successfully"
+oc wait --for=jsonpath='{.status.phase}'=Succeeded pod/tls-scanner -n "${NAMESPACE}" --timeout=10m || {
+    echo "Scanner did not complete successfully - timeout exceeded"
     oc describe pod/tls-scanner -n "${NAMESPACE}"
     exit 1
 }

--- a/ci-operator/step-registry/tls/scanner/run/tls-scanner-run-commands.sh
+++ b/ci-operator/step-registry/tls/scanner/run/tls-scanner-run-commands.sh
@@ -80,6 +80,7 @@ spec:
         --log-file /results/scan.log 2>&1 | tee /results/output.log
       SCAN_EXIT_CODE=\${PIPESTATUS[0]}
       echo "Scan complete. Exit code: \${SCAN_EXIT_CODE}" | tee -a /results/output.log
+      touch /results/scan.done
       # Keep pod alive for artifact collection
       sleep 120
       # We are intentionally ignoring the scanner exit code for the moment
@@ -118,9 +119,9 @@ echo "Waiting for scan to finish (pod stays alive 120s after scan for artifact c
 while true; do
     phase=$(oc get pod/tls-scanner -n "${NAMESPACE}" -o jsonpath='{.status.phase}' 2>/dev/null || echo "Unknown")
     echo "Poll: phase=${phase}"
-    # Sentinel check first — must copy artifacts while pod is still running.
-    if oc exec pod/tls-scanner -n "${NAMESPACE}" -- grep -q "Scan complete" /results/output.log 2>/dev/null; then
-        echo "Sentinel found in /results/output.log — proceeding to copy artifacts"
+    # Scanner completion check first — must copy artifacts while pod is still running.
+    if oc exec pod/tls-scanner -n "${NAMESPACE}" -- test -f /results/scan.done 2>/dev/null; then
+        echo "/results/scan.done found — proceeding to copy artifacts"
         break
     fi
     # Fallback: pod already exited (sleep window expired or crash).

--- a/ci-operator/step-registry/tls/scanner/run/tls-scanner-run-ref.yaml
+++ b/ci-operator/step-registry/tls/scanner/run/tls-scanner-run-ref.yaml
@@ -9,7 +9,7 @@ ref:
     documentation: "Comma-separated list of namespaces to scan. Empty means scan all namespaces."
   - name: PQC_CHECK
     default: "false"
-    documentation: "Set to 'true' to enable post-quantum cryptography readiness checks (TLS 1.3 and mlkem/mlkem25519 support)."
+    documentation: "Set to 'true' to check post-quantum cryptography readiness (scanner will only check TLS 1.3 and mlkem/mlkem25519 support)."
   - name: SCAN_LIMIT_IPS
     default: ""
     documentation: "Max IPs to scan (empty/0 = no limit). Bounds actual TLS scans after full endpoint discovery."
@@ -37,4 +37,4 @@ ref:
   documentation: |-
     Runs the TLS scanner against all pods in the target cluster.
     The scanner runs with cluster-admin privileges and full host access.
-    Set PQC_CHECK=true to enable post-quantum cryptography readiness checks.
+    Set PQC_CHECK=true to check post-quantum cryptography readiness (scanner will only check TLS 1.3 and mlkem/mlkem25519 support).


### PR DESCRIPTION
The PR aims to fix exit code handling, lingering failed pods, and clarify documentation.

A few things I have found during integrating the steps into our component's CI. I am happy to address any feedback. Happy to drop any commits.