### PR TITLE
MULTIARCH-6023: move leases to lon04

### DIFF
--- a/core-services/prow/02_config/_boskos.yaml
+++ b/core-services/prow/02_config/_boskos.yaml
@@ -4753,9 +4753,9 @@ resources:
   state: free
   type: ibmcloud-gpu-quota-slice
 - names:
-  - us-east--ibmcloud-multi-ppc64le-quota-slice-0
-  - us-east--ibmcloud-multi-ppc64le-quota-slice-1
-  - us-east--ibmcloud-multi-ppc64le-quota-slice-2
+  - lon04--ibmcloud-multi-ppc64le-quota-slice-0
+  - lon04--ibmcloud-multi-ppc64le-quota-slice-1
+  - lon04--ibmcloud-multi-ppc64le-quota-slice-2
   state: free
   type: ibmcloud-multi-ppc64le-quota-slice
 - names:
@@ -5437,8 +5437,8 @@ resources:
   state: free
   type: powervs-9-quota-slice
 - names:
-  - wdc06--powervs-multi-1-quota-slice-0
-  - wdc06--powervs-multi-1-quota-slice-1
+  - lon04--powervs-multi-1-quota-slice-0
+  - lon04--powervs-multi-1-quota-slice-1
   state: free
   type: powervs-multi-1-quota-slice
 - names:

--- a/core-services/prow/02_config/generate-boskos.py
+++ b/core-services/prow/02_config/generate-boskos.py
@@ -477,7 +477,7 @@ CONFIG = {
     'powervs-8-quota-slice': {},
     'powervs-9-quota-slice': {},
     'powervs-multi-1-quota-slice': {
-        'wdc06': 2,
+        'lon04': 2,
     },
     'ibmcloud-cspi-qe-quota-slice': {
         'us-east': 40,
@@ -495,7 +495,7 @@ CONFIG = {
         'us-east': 10,
     },
     'ibmcloud-multi-ppc64le-quota-slice': {
-        'us-east': 3,
+        'lon04': 3,
     },
     'ibmcloud-multi-s390x-quota-slice': {
         'ca-tor': 3,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Boskos resource quota configuration for IBM Cloud and PowerVS services. Adjusted availability-zone assignments for multi-instance quota resources while maintaining total resource capacity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->