### PR TITLE
chore: build with Go1.25

### DIFF
--- a/ci-operator/config/stolostron/cluster-permission/stolostron-cluster-permission-release-2.11.yaml
+++ b/ci-operator/config/stolostron/cluster-permission/stolostron-cluster-permission-release-2.11.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: builder
     namespace: stolostron
-    tag: go1.23-linux
+    tag: go1.25-linux
 images:
   items:
   - dockerfile_path: Dockerfile

--- a/ci-operator/config/stolostron/cluster-proxy-addon/stolostron-cluster-proxy-addon-backplane-2.10.yaml
+++ b/ci-operator/config/stolostron/cluster-proxy-addon/stolostron-cluster-proxy-addon-backplane-2.10.yaml
@@ -3,10 +3,10 @@ base_images:
     name: ubi-minimal
     namespace: ocp
     tag: "9"
-  stolostron_builder_go1.24-linux:
+  stolostron_builder_go1.25-linux:
     name: builder
     namespace: stolostron
-    tag: go1.24-linux
+    tag: go1.25-linux
 binary_build_commands: make build --warn-undefined-variables
 build_root:
   image_stream_tag:

--- a/ci-operator/config/stolostron/cluster-proxy-addon/stolostron-cluster-proxy-addon-backplane-2.6.yaml
+++ b/ci-operator/config/stolostron/cluster-proxy-addon/stolostron-cluster-proxy-addon-backplane-2.6.yaml
@@ -8,7 +8,7 @@ build_root:
   image_stream_tag:
     name: builder
     namespace: stolostron
-    tag: go1.23-linux
+    tag: go1.25-linux
 images:
   items:
   - dockerfile_path: Dockerfile

--- a/ci-operator/config/stolostron/cluster-proxy/stolostron-cluster-proxy-backplane-2.6.yaml
+++ b/ci-operator/config/stolostron/cluster-proxy/stolostron-cluster-proxy-backplane-2.6.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: builder
     namespace: stolostron
-    tag: go1.23-linux
+    tag: go1.25-linux
 images:
   items:
   - dockerfile_path: ./cmd/pure.Dockerfile

--- a/ci-operator/config/stolostron/clusterlifecycle-state-metrics/stolostron-clusterlifecycle-state-metrics-backplane-2.6.yaml
+++ b/ci-operator/config/stolostron/clusterlifecycle-state-metrics/stolostron-clusterlifecycle-state-metrics-backplane-2.6.yaml
@@ -10,7 +10,7 @@ build_root:
   image_stream_tag:
     name: builder
     namespace: stolostron
-    tag: go1.23-linux
+    tag: go1.25-linux
 images:
   items:
   - dockerfile_path: build/Dockerfile.prow

--- a/ci-operator/config/stolostron/klusterlet-addon-controller/stolostron-klusterlet-addon-controller-release-2.11.yaml
+++ b/ci-operator/config/stolostron/klusterlet-addon-controller/stolostron-klusterlet-addon-controller-release-2.11.yaml
@@ -8,7 +8,7 @@ build_root:
   image_stream_tag:
     name: builder
     namespace: stolostron
-    tag: go1.23-linux
+    tag: go1.25-linux
 images:
   items:
   - dockerfile_path: build/Dockerfile

--- a/ci-operator/config/stolostron/klusterlet-addon-controller/stolostron-klusterlet-addon-controller-release-2.15.yaml
+++ b/ci-operator/config/stolostron/klusterlet-addon-controller/stolostron-klusterlet-addon-controller-release-2.15.yaml
@@ -3,10 +3,10 @@ base_images:
     name: ubi-minimal
     namespace: ocp
     tag: "9"
-  stolostron_builder_go1.24-linux:
+  stolostron_builder_go1.25-linux:
     name: builder
     namespace: stolostron
-    tag: go1.24-linux
+    tag: go1.25-linux
 binary_build_commands: go build ./cmd/manager
 build_root:
   image_stream_tag:

--- a/ci-operator/config/stolostron/managed-serviceaccount/stolostron-managed-serviceaccount-backplane-2.6.yaml
+++ b/ci-operator/config/stolostron/managed-serviceaccount/stolostron-managed-serviceaccount-backplane-2.6.yaml
@@ -8,7 +8,7 @@ build_root:
   image_stream_tag:
     name: builder
     namespace: stolostron
-    tag: go1.23-linux
+    tag: go1.25-linux
 images:
   items:
   - dockerfile_path: Dockerfile

--- a/ci-operator/config/stolostron/managedcluster-import-controller/stolostron-managedcluster-import-controller-backplane-2.6.yaml
+++ b/ci-operator/config/stolostron/managedcluster-import-controller/stolostron-managedcluster-import-controller-backplane-2.6.yaml
@@ -3,16 +3,16 @@ base_images:
     name: ubi-minimal
     namespace: ocp
     tag: "9"
-  stolostron_builder_go1.24-linux:
+  stolostron_builder_go1.25-linux:
     name: builder
     namespace: stolostron
-    tag: go1.24-linux
+    tag: go1.25-linux
 binary_build_commands: go build ./cmd/manager
 build_root:
   image_stream_tag:
     name: builder
     namespace: stolostron
-    tag: go1.24-linux
+    tag: go1.25-linux
 images:
   items:
   - dockerfile_path: build/Dockerfile

--- a/ci-operator/config/stolostron/multicloud-operators-foundation/stolostron-multicloud-operators-foundation-backplane-2.11.yaml
+++ b/ci-operator/config/stolostron/multicloud-operators-foundation/stolostron-multicloud-operators-foundation-backplane-2.11.yaml
@@ -3,10 +3,10 @@ base_images:
     name: ubi-minimal
     namespace: ocp
     tag: "9"
-  stolostron_builder_go1.24-linux:
+  stolostron_builder_go1.25-linux:
     name: builder
     namespace: stolostron
-    tag: go1.24-linux
+    tag: go1.25-linux
 binary_build_commands: make build --warn-undefined-variables
 build_root:
   image_stream_tag:

--- a/ci-operator/config/stolostron/multicloud-operators-foundation/stolostron-multicloud-operators-foundation-backplane-2.17.yaml
+++ b/ci-operator/config/stolostron/multicloud-operators-foundation/stolostron-multicloud-operators-foundation-backplane-2.17.yaml
@@ -3,10 +3,10 @@ base_images:
     name: ubi-minimal
     namespace: ocp
     tag: "9"
-  stolostron_builder_go1.24-linux:
+  stolostron_builder_go1.25-linux:
     name: builder
     namespace: stolostron
-    tag: go1.24-linux
+    tag: go1.25-linux
 binary_build_commands: make build --warn-undefined-variables
 build_root:
   image_stream_tag:

--- a/ci-operator/config/stolostron/multicloud-operators-foundation/stolostron-multicloud-operators-foundation-backplane-2.6.yaml
+++ b/ci-operator/config/stolostron/multicloud-operators-foundation/stolostron-multicloud-operators-foundation-backplane-2.6.yaml
@@ -8,7 +8,7 @@ build_root:
   image_stream_tag:
     name: builder
     namespace: stolostron
-    tag: go1.24-linux
+    tag: go1.25-linux
 images:
   items:
   - dockerfile_path: Dockerfile

--- a/ci-operator/config/stolostron/multicloud-operators-foundation/stolostron-multicloud-operators-foundation-backplane-2.7.yaml
+++ b/ci-operator/config/stolostron/multicloud-operators-foundation/stolostron-multicloud-operators-foundation-backplane-2.7.yaml
@@ -3,10 +3,10 @@ base_images:
     name: ubi-minimal
     namespace: ocp
     tag: "9"
-  stolostron_builder_go1.24-linux:
+  stolostron_builder_go1.25-linux:
     name: builder
     namespace: stolostron
-    tag: go1.24-linux
+    tag: go1.25-linux
 binary_build_commands: make build --warn-undefined-variables
 build_root:
   image_stream_tag:

--- a/ci-operator/config/stolostron/multicloud-operators-foundation/stolostron-multicloud-operators-foundation-backplane-5.0.yaml
+++ b/ci-operator/config/stolostron/multicloud-operators-foundation/stolostron-multicloud-operators-foundation-backplane-5.0.yaml
@@ -3,10 +3,10 @@ base_images:
     name: ubi-minimal
     namespace: ocp
     tag: "9"
-  stolostron_builder_go1.24-linux:
+  stolostron_builder_go1.25-linux:
     name: builder
     namespace: stolostron
-    tag: go1.24-linux
+    tag: go1.25-linux
 binary_build_commands: make build --warn-undefined-variables
 build_root:
   image_stream_tag:

--- a/ci-operator/config/stolostron/multicloud-operators-foundation/stolostron-multicloud-operators-foundation-main.yaml
+++ b/ci-operator/config/stolostron/multicloud-operators-foundation/stolostron-multicloud-operators-foundation-main.yaml
@@ -3,10 +3,10 @@ base_images:
     name: ubi-minimal
     namespace: ocp
     tag: "9"
-  stolostron_builder_go1.24-linux:
+  stolostron_builder_go1.25-linux:
     name: builder
     namespace: stolostron
-    tag: go1.24-linux
+    tag: go1.25-linux
 binary_build_commands: make build --warn-undefined-variables
 build_root:
   image_stream_tag:

--- a/ci-operator/config/stolostron/ocm/stolostron-ocm-backplane-2.6.yaml
+++ b/ci-operator/config/stolostron/ocm/stolostron-ocm-backplane-2.6.yaml
@@ -8,7 +8,7 @@ build_root:
   image_stream_tag:
     name: builder
     namespace: stolostron
-    tag: go1.23-linux
+    tag: go1.25-linux
 images:
   items:
   - dockerfile_path: build/Dockerfile.registration-operator


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain version from 1.23/1.24 to 1.25 across multiple CI build configurations to improve build performance and ensure compatibility with the latest Go runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->