### PR TITLE
DNM: debug broken c2s environment

### DIFF
--- a/ci-operator/step-registry/cucushift/installer/rehearse/aws/c2s/ipi/disconnected/private/provision/cucushift-installer-rehearse-aws-c2s-ipi-disconnected-private-provision-chain.yaml
+++ b/ci-operator/step-registry/cucushift/installer/rehearse/aws/c2s/ipi/disconnected/private/provision/cucushift-installer-rehearse-aws-c2s-ipi-disconnected-private-provision-chain.yaml
@@ -17,6 +17,7 @@ chain:
     - ref: ipi-conf-aws
     - ref: ipi-conf-mirror
     - ref: ipi-install-monitoringpvc
+    - ref: cucushift-installer-wait
     - ref: aws-c2s-init-token-service
     - ref: ipi-conf-manual-creds-remove-unnecessary-creds
     - ref: ipi-install-install-aws


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted CI pipeline orchestration to add an additional wait step in the installer rehearsal chain for AWS disconnected/private flows.

* **Improvements**
  * Refined RHCOS AMI selection for AWS C2S/SC2S: introduced explicit handling for OpenShift 4.22+ to select the correct image, with prior fallback narrowed to 4.10–4.21.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->