### PR TITLE
KFLUXVNGD-899: grant dptp-controller-manager finalizers permission on ephemeralclusters

### DIFF
--- a/clusters/app.ci/assets/dptp-controller-manager.yaml
+++ b/clusters/app.ci/assets/dptp-controller-manager.yaml
@@ -13,6 +13,12 @@ rules:
   - watch
   - update
 - apiGroups:
+  - ci.openshift.io
+  resources:
+  - ephemeralclusters/finalizers
+  verbs:
+  - update
+- apiGroups:
   - prow.k8s.io
   resources:
   - prowjobs


### PR DESCRIPTION
The EphemeralCluster credentials Secret uses SetControllerReference which sets blockOwnerDeletion=true on the ownerReference. Kubernetes requires the controller to have update permission on the owner's finalizers subresource for this to succeed.

Assisted-by: Claude claude-opus-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated cluster controller manager permissions to support additional resource management operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->