### PR TITLE
WINC-1916: DEBUG: DO NOT MERGE: Test WMCO 4.22 periodic jobs

### DIFF
--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22__amd64-nightly-4.22-upgrade-from-stable-4.21.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22__amd64-nightly-4.22-upgrade-from-stable-4.21.yaml
@@ -1028,7 +1028,7 @@ tests:
     test:
     - chain: openshift-upgrade-qe-test-canary
     workflow: cucushift-installer-rehearse-vsphere-upi-zones
-- as: aws-ipi-ovn-winc-f7
+- as: aws-ipi-ovn-winc-debug-f7
   cron: 45 2 6,13,20,27 * *
   steps:
     cluster_profile: aws-qe

--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22__amd64-nightly-4.22-upgrade-from-stable-4.21.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22__amd64-nightly-4.22-upgrade-from-stable-4.21.yaml
@@ -1028,7 +1028,7 @@ tests:
     test:
     - chain: openshift-upgrade-qe-test-canary
     workflow: cucushift-installer-rehearse-vsphere-upi-zones
-- as: aws-ipi-ovn-winc-debug-f7
+- as: aws-ipi-ovn-winc-f7
   cron: 45 2 6,13,20,27 * *
   steps:
     cluster_profile: aws-qe
@@ -1041,6 +1041,43 @@ tests:
     test:
     - chain: openshift-upgrade-qe-test-winc
     workflow: cucushift-installer-rehearse-aws-ipi-ovn-winc
+- as: aws-upi-ovn-winc-f7
+  cron: 22 8 3,10,17,24 * *
+  steps:
+    cluster_profile: aws-qe
+    env:
+      BASE_DOMAIN: qe.devcluster.openshift.com
+      TEST_FILTERS_POSTUPG: Smokerun
+      TEST_FILTERS_PREUPG: Smokerun
+      TEST_SCENARIOS_POSTUPG: Windows_Containers
+      TEST_SCENARIOS_PREUPG: Windows_Containers
+    test:
+    - chain: openshift-upgrade-qe-test-winc
+    workflow: cucushift-installer-rehearse-aws-upi-ovn-winc
+- as: vsphere-ipi-ovn-winc-debug-f7
+  cron: 12 4 5,12,19,26 * *
+  steps:
+    cluster_profile: vsphere-connected-2
+    env:
+      TEST_FILTERS_POSTUPG: Smokerun
+      TEST_FILTERS_PREUPG: Smokerun
+      TEST_SCENARIOS_POSTUPG: Windows_Containers
+      TEST_SCENARIOS_PREUPG: Windows_Containers
+    test:
+    - chain: openshift-upgrade-qe-test-winc
+    workflow: cucushift-installer-rehearse-vsphere-ipi-ovn-winc
+- as: vsphere-ipi-proxy-ovn-winc-debug-f28
+  cron: 33 6 18 * *
+  steps:
+    cluster_profile: vsphere-connected-2
+    env:
+      TEST_FILTERS_POSTUPG: Smokerun
+      TEST_FILTERS_PREUPG: Smokerun
+      TEST_SCENARIOS_POSTUPG: Windows_Containers
+      TEST_SCENARIOS_PREUPG: Windows_Containers
+    test:
+    - chain: openshift-upgrade-qe-test-winc
+    workflow: cucushift-installer-rehearse-vsphere-ipi-proxy-ovn-winc
 zz_generated_metadata:
   branch: release-4.22
   org: openshift

--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22__amd64-nightly.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22__amd64-nightly.yaml
@@ -1288,7 +1288,7 @@ tests:
     test:
     - chain: openshift-upgrade-qe-test-heterogeneous
     workflow: cucushift-installer-rehearse-aws-ipi-ovn-ipsec
-- as: aws-ipi-ovn-winc-debug-f7
+- as: aws-ipi-ovn-winc-2025-f7
   cron: 14 11 7,14,21,28 * *
   steps:
     cluster_profile: aws-qe
@@ -1297,15 +1297,17 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: Windows_Server-2025-English-Core-Base
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-aws-ipi-ovn-winc
-- as: aws-upi-ovn-winc-debug-f7
+- as: aws-upi-ovn-winc-2025-f7
   cron: 0 23 4,11,18,27 * *
   steps:
     cluster_profile: aws-qe
     env:
       BASE_DOMAIN: qe.devcluster.openshift.com
+      BYOH_WINDOWS_VERSION: "2025"
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
@@ -3479,7 +3481,7 @@ tests:
     test:
     - chain: openshift-e2e-test-qe-destructive
     workflow: cucushift-installer-rehearse-gcp-ipi-ovn-ipsec
-- as: gcp-ipi-ovn-winc-debug-f7
+- as: gcp-ipi-ovn-winc-2025-f7
   cron: 23 14 3,10,17,26 * *
   steps:
     cluster_profile: gcp-qe
@@ -3487,10 +3489,11 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: projects/windows-cloud/global/images/family/windows-2025-core
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-gcp-ipi-ovn-winc
-- as: azure-ipi-ovn-winc-debug-f7
+- as: azure-ipi-ovn-winc-2025-f7
   cron: 23 15 3,12,19,26 * *
   steps:
     cluster_profile: azure-qe
@@ -3499,6 +3502,7 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WIN_SKU: 2025-datacenter
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-azure-ipi-ovn-winc

--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22__amd64-nightly.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22__amd64-nightly.yaml
@@ -1288,7 +1288,7 @@ tests:
     test:
     - chain: openshift-upgrade-qe-test-heterogeneous
     workflow: cucushift-installer-rehearse-aws-ipi-ovn-ipsec
-- as: aws-ipi-ovn-winc-f7
+- as: aws-ipi-ovn-winc-debug-f7
   cron: 14 11 7,14,21,28 * *
   steps:
     cluster_profile: aws-qe
@@ -1300,7 +1300,7 @@ tests:
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-aws-ipi-ovn-winc
-- as: aws-upi-ovn-winc-f7
+- as: aws-upi-ovn-winc-debug-f7
   cron: 0 23 4,11,18,27 * *
   steps:
     cluster_profile: aws-qe
@@ -1312,7 +1312,7 @@ tests:
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-aws-upi-ovn-winc
-- as: vsphere-ipi-proxy-ovn-winc-f28
+- as: vsphere-ipi-proxy-ovn-winc-debug-f28
   cron: 57 15 14 * *
   steps:
     cluster_profile: vsphere-connected-2
@@ -3479,7 +3479,7 @@ tests:
     test:
     - chain: openshift-e2e-test-qe-destructive
     workflow: cucushift-installer-rehearse-gcp-ipi-ovn-ipsec
-- as: gcp-ipi-ovn-winc-f7
+- as: gcp-ipi-ovn-winc-debug-f7
   cron: 23 14 3,10,17,26 * *
   steps:
     cluster_profile: gcp-qe
@@ -3490,7 +3490,7 @@ tests:
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-gcp-ipi-ovn-winc
-- as: azure-ipi-ovn-winc-f7
+- as: azure-ipi-ovn-winc-debug-f7
   cron: 23 15 3,12,19,26 * *
   steps:
     cluster_profile: azure-qe
@@ -3502,7 +3502,7 @@ tests:
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-azure-ipi-ovn-winc
-- as: vsphere-ipi-disconnected-ovn-winc-f28
+- as: vsphere-ipi-disconnected-ovn-winc-debug-f28
   cron: 0 18 15 * *
   steps:
     cluster_profile: vsphere-dis-2
@@ -3516,7 +3516,7 @@ tests:
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-vsphere-ipi-disconnected-ovn-winc
-- as: vsphere-ipi-ovn-winc-f7
+- as: vsphere-ipi-ovn-winc-debug-f7
   cron: 23 2 5,12,19,26 * *
   steps:
     cluster_profile: vsphere-connected-2
@@ -3527,7 +3527,7 @@ tests:
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-vsphere-ipi-ovn-winc
-- as: nutanix-ipi-ovn-winc-f7
+- as: nutanix-ipi-ovn-winc-debug-f7
   cron: 1 15 9,16,23,30 * *
   steps:
     cluster_profile: nutanix-qe

--- a/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22-periodics.yaml
+++ b/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22-periodics.yaml
@@ -3137,7 +3137,7 @@ periodics:
     ci-operator.openshift.io/variant: amd64-nightly-4.22-upgrade-from-stable-4.21
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-openshift-tests-private-release-4.22-amd64-nightly-4.22-upgrade-from-stable-4.21-aws-ipi-ovn-winc-f7
+  name: periodic-ci-openshift-openshift-tests-private-release-4.22-amd64-nightly-4.22-upgrade-from-stable-4.21-aws-ipi-ovn-winc-debug-f7
   spec:
     containers:
     - args:
@@ -3147,7 +3147,7 @@ periodics:
       - --oauth-token-path=/usr/local/github-credentials/oauth
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=aws-ipi-ovn-winc-f7
+      - --target=aws-ipi-ovn-winc-debug-f7
       - --variant=amd64-nightly-4.22-upgrade-from-stable-4.21
       command:
       - ci-operator
@@ -25552,7 +25552,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-openshift-tests-private-release-4.22-amd64-nightly-aws-ipi-ovn-winc-f7
+  name: periodic-ci-openshift-openshift-tests-private-release-4.22-amd64-nightly-aws-ipi-ovn-winc-debug-f7
   spec:
     containers:
     - args:
@@ -25562,7 +25562,7 @@ periodics:
       - --oauth-token-path=/usr/local/github-credentials/oauth
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=aws-ipi-ovn-winc-f7
+      - --target=aws-ipi-ovn-winc-debug-f7
       - --variant=amd64-nightly
       command:
       - ci-operator
@@ -29968,7 +29968,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-openshift-tests-private-release-4.22-amd64-nightly-aws-upi-ovn-winc-f7
+  name: periodic-ci-openshift-openshift-tests-private-release-4.22-amd64-nightly-aws-upi-ovn-winc-debug-f7
   spec:
     containers:
     - args:
@@ -29978,7 +29978,7 @@ periodics:
       - --oauth-token-path=/usr/local/github-credentials/oauth
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=aws-upi-ovn-winc-f7
+      - --target=aws-upi-ovn-winc-debug-f7
       - --variant=amd64-nightly
       command:
       - ci-operator
@@ -35002,7 +35002,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-openshift-tests-private-release-4.22-amd64-nightly-azure-ipi-ovn-winc-f7
+  name: periodic-ci-openshift-openshift-tests-private-release-4.22-amd64-nightly-azure-ipi-ovn-winc-debug-f7
   spec:
     containers:
     - args:
@@ -35012,7 +35012,7 @@ periodics:
       - --oauth-token-path=/usr/local/github-credentials/oauth
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=azure-ipi-ovn-winc-f7
+      - --target=azure-ipi-ovn-winc-debug-f7
       - --variant=amd64-nightly
       command:
       - ci-operator
@@ -39800,7 +39800,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-openshift-tests-private-release-4.22-amd64-nightly-gcp-ipi-ovn-winc-f7
+  name: periodic-ci-openshift-openshift-tests-private-release-4.22-amd64-nightly-gcp-ipi-ovn-winc-debug-f7
   spec:
     containers:
     - args:
@@ -39810,7 +39810,7 @@ periodics:
       - --oauth-token-path=/usr/local/github-credentials/oauth
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=gcp-ipi-ovn-winc-f7
+      - --target=gcp-ipi-ovn-winc-debug-f7
       - --variant=amd64-nightly
       command:
       - ci-operator
@@ -48351,7 +48351,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-openshift-tests-private-release-4.22-amd64-nightly-nutanix-ipi-ovn-winc-f7
+  name: periodic-ci-openshift-openshift-tests-private-release-4.22-amd64-nightly-nutanix-ipi-ovn-winc-debug-f7
   spec:
     containers:
     - args:
@@ -48361,7 +48361,7 @@ periodics:
       - --oauth-token-path=/usr/local/github-credentials/oauth
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=nutanix-ipi-ovn-winc-f7
+      - --target=nutanix-ipi-ovn-winc-debug-f7
       - --variant=amd64-nightly
       command:
       - ci-operator
@@ -50750,7 +50750,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-openshift-tests-private-release-4.22-amd64-nightly-vsphere-ipi-disconnected-ovn-winc-f28
+  name: periodic-ci-openshift-openshift-tests-private-release-4.22-amd64-nightly-vsphere-ipi-disconnected-ovn-winc-debug-f28
   spec:
     containers:
     - args:
@@ -50760,7 +50760,7 @@ periodics:
       - --oauth-token-path=/usr/local/github-credentials/oauth
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=vsphere-ipi-disconnected-ovn-winc-f28
+      - --target=vsphere-ipi-disconnected-ovn-winc-debug-f28
       - --variant=amd64-nightly
       command:
       - ci-operator
@@ -53954,7 +53954,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-openshift-tests-private-release-4.22-amd64-nightly-vsphere-ipi-ovn-winc-f7
+  name: periodic-ci-openshift-openshift-tests-private-release-4.22-amd64-nightly-vsphere-ipi-ovn-winc-debug-f7
   spec:
     containers:
     - args:
@@ -53964,7 +53964,7 @@ periodics:
       - --oauth-token-path=/usr/local/github-credentials/oauth
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=vsphere-ipi-ovn-winc-f7
+      - --target=vsphere-ipi-ovn-winc-debug-f7
       - --variant=amd64-nightly
       command:
       - ci-operator
@@ -54674,7 +54674,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-openshift-tests-private-release-4.22-amd64-nightly-vsphere-ipi-proxy-ovn-winc-f28
+  name: periodic-ci-openshift-openshift-tests-private-release-4.22-amd64-nightly-vsphere-ipi-proxy-ovn-winc-debug-f28
   spec:
     containers:
     - args:
@@ -54684,7 +54684,7 @@ periodics:
       - --oauth-token-path=/usr/local/github-credentials/oauth
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=vsphere-ipi-proxy-ovn-winc-f28
+      - --target=vsphere-ipi-proxy-ovn-winc-debug-f28
       - --variant=amd64-nightly
       command:
       - ci-operator

--- a/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22-periodics.yaml
+++ b/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22-periodics.yaml
@@ -3137,7 +3137,7 @@ periodics:
     ci-operator.openshift.io/variant: amd64-nightly-4.22-upgrade-from-stable-4.21
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-openshift-tests-private-release-4.22-amd64-nightly-4.22-upgrade-from-stable-4.21-aws-ipi-ovn-winc-debug-f7
+  name: periodic-ci-openshift-openshift-tests-private-release-4.22-amd64-nightly-4.22-upgrade-from-stable-4.21-aws-ipi-ovn-winc-f7
   spec:
     containers:
     - args:
@@ -3147,7 +3147,7 @@ periodics:
       - --oauth-token-path=/usr/local/github-credentials/oauth
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=aws-ipi-ovn-winc-debug-f7
+      - --target=aws-ipi-ovn-winc-f7
       - --variant=amd64-nightly-4.22-upgrade-from-stable-4.21
       command:
       - ci-operator
@@ -3860,6 +3860,95 @@ periodics:
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
       - --target=aws-sc2s-ipi-disc-priv-fips-f28
+      - --variant=amd64-nightly-4.22-upgrade-from-stable-4.21
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /usr/local/github-credentials
+        name: github-credentials-openshift-ci-robot-private-git-cloner
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: github-credentials-openshift-ci-robot-private-git-cloner
+      secret:
+        secretName: github-credentials-openshift-ci-robot-private-git-cloner
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build09
+  cron: 22 8 3,10,17,24 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: release-4.22
+    org: openshift
+    repo: openshift-tests-private
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-qe
+    ci-operator.openshift.io/variant: amd64-nightly-4.22-upgrade-from-stable-4.21
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-openshift-tests-private-release-4.22-amd64-nightly-4.22-upgrade-from-stable-4.21-aws-upi-ovn-winc-f7
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --oauth-token-path=/usr/local/github-credentials/oauth
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=aws-upi-ovn-winc-f7
       - --variant=amd64-nightly-4.22-upgrade-from-stable-4.21
       command:
       - ci-operator
@@ -9148,6 +9237,95 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: vsphere02
+  cron: 12 4 5,12,19,26 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: release-4.22
+    org: openshift
+    repo: openshift-tests-private
+  labels:
+    ci-operator.openshift.io/cloud: vsphere
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-connected-2
+    ci-operator.openshift.io/variant: amd64-nightly-4.22-upgrade-from-stable-4.21
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-openshift-tests-private-release-4.22-amd64-nightly-4.22-upgrade-from-stable-4.21-vsphere-ipi-ovn-winc-debug-f7
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --oauth-token-path=/usr/local/github-credentials/oauth
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=vsphere-ipi-ovn-winc-debug-f7
+      - --variant=amd64-nightly-4.22-upgrade-from-stable-4.21
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /usr/local/github-credentials
+        name: github-credentials-openshift-ci-robot-private-git-cloner
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: github-credentials-openshift-ci-robot-private-git-cloner
+      secret:
+        secretName: github-credentials-openshift-ci-robot-private-git-cloner
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: vsphere02
   cron: 2 20 11 * *
   decorate: true
   decoration_config:
@@ -9173,6 +9351,95 @@ periodics:
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
       - --target=vsphere-ipi-proxy-fips-f28
+      - --variant=amd64-nightly-4.22-upgrade-from-stable-4.21
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /usr/local/github-credentials
+        name: github-credentials-openshift-ci-robot-private-git-cloner
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: github-credentials-openshift-ci-robot-private-git-cloner
+      secret:
+        secretName: github-credentials-openshift-ci-robot-private-git-cloner
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: vsphere02
+  cron: 33 6 18 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: release-4.22
+    org: openshift
+    repo: openshift-tests-private
+  labels:
+    ci-operator.openshift.io/cloud: vsphere
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-connected-2
+    ci-operator.openshift.io/variant: amd64-nightly-4.22-upgrade-from-stable-4.21
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-openshift-tests-private-release-4.22-amd64-nightly-4.22-upgrade-from-stable-4.21-vsphere-ipi-proxy-ovn-winc-debug-f28
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --oauth-token-path=/usr/local/github-credentials/oauth
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=vsphere-ipi-proxy-ovn-winc-debug-f28
       - --variant=amd64-nightly-4.22-upgrade-from-stable-4.21
       command:
       - ci-operator
@@ -25552,7 +25819,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-openshift-tests-private-release-4.22-amd64-nightly-aws-ipi-ovn-winc-debug-f7
+  name: periodic-ci-openshift-openshift-tests-private-release-4.22-amd64-nightly-aws-ipi-ovn-winc-2025-f7
   spec:
     containers:
     - args:
@@ -25562,7 +25829,7 @@ periodics:
       - --oauth-token-path=/usr/local/github-credentials/oauth
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=aws-ipi-ovn-winc-debug-f7
+      - --target=aws-ipi-ovn-winc-2025-f7
       - --variant=amd64-nightly
       command:
       - ci-operator
@@ -29968,7 +30235,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-openshift-tests-private-release-4.22-amd64-nightly-aws-upi-ovn-winc-debug-f7
+  name: periodic-ci-openshift-openshift-tests-private-release-4.22-amd64-nightly-aws-upi-ovn-winc-2025-f7
   spec:
     containers:
     - args:
@@ -29978,7 +30245,7 @@ periodics:
       - --oauth-token-path=/usr/local/github-credentials/oauth
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=aws-upi-ovn-winc-debug-f7
+      - --target=aws-upi-ovn-winc-2025-f7
       - --variant=amd64-nightly
       command:
       - ci-operator
@@ -35002,7 +35269,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-openshift-tests-private-release-4.22-amd64-nightly-azure-ipi-ovn-winc-debug-f7
+  name: periodic-ci-openshift-openshift-tests-private-release-4.22-amd64-nightly-azure-ipi-ovn-winc-2025-f7
   spec:
     containers:
     - args:
@@ -35012,7 +35279,7 @@ periodics:
       - --oauth-token-path=/usr/local/github-credentials/oauth
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=azure-ipi-ovn-winc-debug-f7
+      - --target=azure-ipi-ovn-winc-2025-f7
       - --variant=amd64-nightly
       command:
       - ci-operator
@@ -39800,7 +40067,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-openshift-tests-private-release-4.22-amd64-nightly-gcp-ipi-ovn-winc-debug-f7
+  name: periodic-ci-openshift-openshift-tests-private-release-4.22-amd64-nightly-gcp-ipi-ovn-winc-2025-f7
   spec:
     containers:
     - args:
@@ -39810,7 +40077,7 @@ periodics:
       - --oauth-token-path=/usr/local/github-credentials/oauth
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=gcp-ipi-ovn-winc-debug-f7
+      - --target=gcp-ipi-ovn-winc-2025-f7
       - --variant=amd64-nightly
       command:
       - ci-operator


### PR DESCRIPTION
Konflux: https://github.com/openshift/windows-machine-config-operator-fbc/pull/211

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Scope: Changes to OpenShift CI configuration (ci-operator configs under ci-operator/config/openshift/openshift-tests-private) that affect the 4.22 nightly and 4.22 upgrade-from-stable-4.21 Windows test job sets. These edits change which Prow jobs are generated for Windows-container and Windows-upgrade testing.

- Practical changes:
  - ci-operator config for the 4.22 upgrade-from-stable workflow:
    - Replaced an existing AWS upgrade test entry `aws-ipi-ovn-winc-f7` with `aws-upi-ovn-winc-f7` (workflow updated from cucushift-installer-rehearse-aws-ipi-ovn-winc → cucushift-installer-rehearse-aws-upi-ovn-winc) and adjusted its cron.
    - Added two vSphere Windows "debug" periodic tests: `vsphere-ipi-ovn-winc-debug-f7` and `vsphere-ipi-proxy-ovn-winc-debug-f28` with their own schedules and the same Windows test filters/workflow wiring.
  - ci-operator config for the 4.22 nightly set:
    - Renamed multiple Windows test jobs to 2025-image variants: aws-ipi-ovn-winc-f7 → aws-ipi-ovn-winc-2025-f7, aws-upi-ovn-winc-f7 → aws-upi-ovn-winc-2025-f7, gcp-ipi-ovn-winc-f7 → gcp-ipi-ovn-winc-2025-f7, azure-ipi-ovn-winc-f7 → azure-ipi-ovn-winc-2025-f7.
    - Several vSphere and Nutanix jobs switched to debug-suffixed keys (e.g., vsphere-ipi-ovn-winc-f7 → vsphere-ipi-ovn-winc-debug-f7, vsphere-ipi-proxy-ovn-winc-f28 → vsphere-ipi-proxy-ovn-winc-debug-f28, nutanix-ipi-ovn-winc-f7 → nutanix-ipi-ovn-winc-debug-f7) without changing schedules/filters/workflows.
    - Updated Windows image selection env vars to use 2025 variants:
      - AWS IPI: WINDOWS_OS_ID set to Windows_Server-2025-English-Core-Base
      - AWS UPI BYOH: BYOH_WINDOWS_VERSION set to "2025"
      - GCP: WINDOWS_OS_ID points to projects/windows-cloud/global/images/family/windows-2025-core
      - Azure: WIN_SKU set to 2025-datacenter
    - Test filters, cron schedules and workflow wiring are preserved where noted; primarily job keys and image/version env vars changed.

- Impact: This changes the set of Prow jobs produced for 4.22 Windows testing (some jobs now target 2025 images, others are exposed as debug variants or swapped between IPI/UPI identifiers). CI consumers and test monitoring dashboards should see different job names and updated image/version selection for Windows nodes.

- Process / metadata notes:
  - The author repeatedly ran prow rehearsal commands to test the new debug/2025 periodic jobs across providers (GCP, Nutanix, Azure, vSphere, AWS) and placed the PR on hold.
  - The repo bot confirmed the PR references JIRA [WINC-1916](https://redhat.atlassian.net/browse/WINC-1916) but flagged the Jira issue for not having the expected target version for the PR's target branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[WINC-1916]: https://redhat.atlassian.net/browse/WINC-1916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ