### PR TITLE
OCPBUGS-84940: [release-4.22] remove ReportPortal integration

### DIFF
--- a/ci-operator/config/openshift/insights-operator/openshift-insights-operator-release-4.22.yaml
+++ b/ci-operator/config/openshift/insights-operator/openshift-insights-operator-release-4.22.yaml
@@ -94,7 +94,7 @@ tests:
     - as: test
       cli: latest
       commands: |
-        pytest.sh -k "not serial and not periodic_only and not slow" --junitxml=$(pwd)/test-report.xml --rp_enabled --rp_name=Insights_operator_e2e_tests_pr_checks
+        pytest.sh -k "not serial and not periodic_only and not slow" --junitxml=$(pwd)/test-report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -120,9 +120,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -136,8 +133,6 @@ tests:
         name: SLACK_BOT_TOKEN
       - default: /secret/slack-webhook-url/slack-webhook-url
         name: SLACK_WEBHOOK_URL
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:
@@ -156,7 +151,7 @@ tests:
     - as: test
       cli: latest
       commands: |
-        pytest.sh -k "serial and not periodic_only and not slow" --junitxml=$(pwd)/test-report.xml --rp_enabled --rp_name=Insights_operator_serial_tests_pr_checks
+        pytest.sh -k "serial and not periodic_only and not slow" --junitxml=$(pwd)/test-report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -182,9 +177,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -198,8 +190,6 @@ tests:
         name: SLACK_BOT_TOKEN
       - default: /secret/slack-webhook-url/slack-webhook-url
         name: SLACK_WEBHOOK_URL
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:
@@ -218,7 +208,7 @@ tests:
     - as: test
       cli: latest
       commands: |
-        pytest.sh -k "not periodic_only and slow" --junitxml=$(pwd)/test-report.xml --rp_enabled --rp_name=Insights_operator_slow_tests_pr_checks
+        pytest.sh -k "not periodic_only and slow" --junitxml=$(pwd)/test-report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -244,9 +234,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -260,8 +247,6 @@ tests:
         name: SLACK_BOT_TOKEN
       - default: /secret/slack-webhook-url/slack-webhook-url
         name: SLACK_WEBHOOK_URL
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:

--- a/ci-operator/config/openshift/insights-operator/openshift-insights-operator-release-4.22__periodics.yaml
+++ b/ci-operator/config/openshift/insights-operator/openshift-insights-operator-release-4.22__periodics.yaml
@@ -37,7 +37,7 @@ tests:
     - as: test
       cli: latest
       commands: |
-        pytest.sh -k "not techpreview and periodic_only" --junitxml=$(pwd)/test-report.xml --rp_enabled --rp_name=Insights_operator_e2e_tests_periodic
+        pytest.sh -k "not techpreview and periodic_only" --junitxml=$(pwd)/test-report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -57,9 +57,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -69,8 +66,6 @@ tests:
         name: AWS_REGION_PATH
       - default: /secret/aws/aws-secret-access-key/aws-secret-access-key
         name: AWS_SECRET_ACCESS_KEY_PATH
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:
@@ -91,7 +86,6 @@ tests:
     - as: test
       cli: latest
       commands: pytest.sh -m "techpreview and not periodic_only" --junitxml=$(pwd)/test-report.xml
-        --rp_enabled --rp_name=Insights_operator_e2e_tests_techpreview
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -117,9 +111,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -133,8 +124,6 @@ tests:
         name: SLACK_BOT_TOKEN
       - default: /secret/slack-webhook-url/slack-webhook-url
         name: SLACK_WEBHOOK_URL
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       resources:
         requests:
@@ -154,7 +143,7 @@ tests:
     - as: api-insights-tests
       cli: latest
       commands: |
-        pytest.sh -m 'insights_data_gather or data_gather' --junitxml=$(pwd)/junit_report.xml --rp_enabled --rp_name=Insights_operator_e2e_tests_techpreview_4.21
+        pytest.sh -m 'insights_data_gather or data_gather' --junitxml=$(pwd)/junit_report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -174,9 +163,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -186,8 +172,6 @@ tests:
         name: AWS_REGION_PATH
       - default: /secret/aws/aws-secret-access-key/aws-secret-access-key
         name: AWS_SECRET_ACCESS_KEY_PATH
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:
@@ -208,7 +192,7 @@ tests:
     - as: api-insights-tests
       cli: latest
       commands: |
-        pytest.sh -m 'insights_data_gather or data_gather' --junitxml=$(pwd)/junit_report.xml --rp_enabled --rp_name=Insights_operator_e2e_tests_techpreview_4.21
+        pytest.sh -m 'insights_data_gather or data_gather' --junitxml=$(pwd)/junit_report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -228,9 +212,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -240,8 +221,6 @@ tests:
         name: AWS_REGION_PATH
       - default: /secret/aws/aws-secret-access-key/aws-secret-access-key
         name: AWS_SECRET_ACCESS_KEY_PATH
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:
@@ -262,7 +241,7 @@ tests:
     - as: api-insights-tests
       cli: latest
       commands: |
-        pytest.sh -m 'insights_data_gather or data_gather' --junitxml=$(pwd)/junit_report.xml --rp_enabled --rp_name=Insights_operator_e2e_tests_techpreview_4.21
+        pytest.sh -m 'insights_data_gather or data_gather' --junitxml=$(pwd)/junit_report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -282,9 +261,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -294,8 +270,6 @@ tests:
         name: AWS_REGION_PATH
       - default: /secret/aws/aws-secret-access-key/aws-secret-access-key
         name: AWS_SECRET_ACCESS_KEY_PATH
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:
@@ -316,7 +290,7 @@ tests:
     - as: api-insights-tests
       cli: latest
       commands: |
-        pytest.sh -m 'insights_data_gather or data_gather' --junitxml=$(pwd)/junit_report.xml --rp_enabled --rp_name=Insights_operator_e2e_tests_techpreview_4.21
+        pytest.sh -m 'insights_data_gather or data_gather' --junitxml=$(pwd)/junit_report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -336,9 +310,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -348,8 +319,6 @@ tests:
         name: AWS_REGION_PATH
       - default: /secret/aws/aws-secret-access-key/aws-secret-access-key
         name: AWS_SECRET_ACCESS_KEY_PATH
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:
@@ -375,7 +344,7 @@ tests:
     - as: api-insights-tests
       cli: latest
       commands: |
-        pytest.sh -m 'insights_data_gather or data_gather' --junitxml=$(pwd)/junit_report.xml --rp_enabled --rp_name=Insights_operator_e2e_tests_techpreview_4.22
+        pytest.sh -m 'insights_data_gather or data_gather' --junitxml=$(pwd)/junit_report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -395,9 +364,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -407,8 +373,6 @@ tests:
         name: AWS_REGION_PATH
       - default: /secret/aws/aws-secret-access-key/aws-secret-access-key
         name: AWS_SECRET_ACCESS_KEY_PATH
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:
@@ -427,7 +391,7 @@ tests:
     - as: api-insights-tests
       cli: latest
       commands: |
-        pytest.sh -m 'insights_data_gather or data_gather' --junitxml=$(pwd)/junit_report.xml --rp_enabled --rp_name=Insights_operator_e2e_tests_techpreview_4.21
+        pytest.sh -m 'insights_data_gather or data_gather' --junitxml=$(pwd)/junit_report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -447,9 +411,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -459,8 +420,6 @@ tests:
         name: AWS_REGION_PATH
       - default: /secret/aws/aws-secret-access-key/aws-secret-access-key
         name: AWS_SECRET_ACCESS_KEY_PATH
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:
@@ -479,7 +438,7 @@ tests:
     - as: api-insights-tests
       cli: latest
       commands: |
-        pytest.sh -m 'insights_runtime_extractor' --junitxml=$(pwd)/junit_report.xml --rp_enabled --rp_name=Insights_operator_tests_insights_runtime_extractor_4.21
+        pytest.sh -m 'insights_runtime_extractor' --junitxml=$(pwd)/junit_report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -499,9 +458,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -511,8 +467,6 @@ tests:
         name: AWS_REGION_PATH
       - default: /secret/aws/aws-secret-access-key/aws-secret-access-key
         name: AWS_SECRET_ACCESS_KEY_PATH
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:
@@ -531,7 +485,7 @@ tests:
     - as: api-insights-tests
       cli: latest
       commands: |
-        pytest.sh -m 'insights_runtime_extractor' --junitxml=$(pwd)/junit_report.xml --rp_enabled --rp_name=Insights_operator_tests_insights_runtime_extractor_4.21
+        pytest.sh -m 'insights_runtime_extractor' --junitxml=$(pwd)/junit_report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -551,9 +505,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -563,8 +514,6 @@ tests:
         name: AWS_REGION_PATH
       - default: /secret/aws/aws-secret-access-key/aws-secret-access-key
         name: AWS_SECRET_ACCESS_KEY_PATH
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:
@@ -583,7 +532,7 @@ tests:
     - as: api-insights-tests
       cli: latest
       commands: |
-        pytest.sh -m 'insights_runtime_extractor' --junitxml=$(pwd)/junit_report.xml --rp_enabled --rp_name=Insights_operator_tests_insights_runtime_extractor_4.21
+        pytest.sh -m 'insights_runtime_extractor' --junitxml=$(pwd)/junit_report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -603,9 +552,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -615,8 +561,6 @@ tests:
         name: AWS_REGION_PATH
       - default: /secret/aws/aws-secret-access-key/aws-secret-access-key
         name: AWS_SECRET_ACCESS_KEY_PATH
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:
@@ -635,7 +579,7 @@ tests:
     - as: api-insights-tests
       cli: latest
       commands: |
-        pytest.sh -m 'insights_runtime_extractor' --junitxml=$(pwd)/junit_report.xml --rp_enabled --rp_name=Insights_operator_tests_insights_runtime_extractor_4.21
+        pytest.sh -m 'insights_runtime_extractor' --junitxml=$(pwd)/junit_report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -655,9 +599,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -667,8 +608,6 @@ tests:
         name: AWS_REGION_PATH
       - default: /secret/aws/aws-secret-access-key/aws-secret-access-key
         name: AWS_SECRET_ACCESS_KEY_PATH
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:
@@ -685,7 +624,7 @@ tests:
     - as: api-insights-tests
       cli: latest
       commands: |
-        pytest.sh -m 'insights_runtime_extractor' --junitxml=$(pwd)/junit_report.xml --rp_enabled --rp_name=Insights_operator_e2e_tests_techpreview_4.21
+        pytest.sh -m 'insights_runtime_extractor' --junitxml=$(pwd)/junit_report.xml
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -705,9 +644,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -717,8 +653,6 @@ tests:
         name: AWS_REGION_PATH
       - default: /secret/aws/aws-secret-access-key/aws-secret-access-key
         name: AWS_SECRET_ACCESS_KEY_PATH
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:
@@ -746,7 +680,6 @@ tests:
     - as: test
       cli: latest
       commands: pytest.sh -k "not tp_only and not slow and not UI" --junitxml=$(pwd)/test-report.xml
-        --rp_enabled --rp_name=hosted-hypershift-insights-operator-e2e-tests
       credentials:
       - mount_path: /secrets
         name: insights-qa
@@ -766,9 +699,6 @@ tests:
       - mount_path: /secret/ocm-access/
         name: insights-ocm-token
         namespace: test-credentials
-      - mount_path: /secret/insights-rp-access/
-        name: insights-rp-token
-        namespace: test-credentials
       env:
       - default: /secret/aws/aws-access-key-id/aws-access-key-id
         name: AWS_ACCESS_KEY_ID_PATH
@@ -778,8 +708,6 @@ tests:
         name: AWS_REGION_PATH
       - default: /secret/aws/aws-secret-access-key/aws-secret-access-key
         name: AWS_SECRET_ACCESS_KEY_PATH
-      - default: /secret/insights-rp-access/insights-rp-token
-        name: RP_API_KEY
       from: insights-operator-tests
       grace_period: 30s
       resources:


### PR DESCRIPTION
ReportPortal is no longer used and maintained. The upload of data has been failing for a long time and the errors are logged into test results, which makes it hard to read and find real errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI test infrastructure configuration to modify test reporting mechanisms across E2E and platform-specific test jobs. Test execution and output validation workflows remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->