### PR TITLE
add promrule-check to managed-cluster-config pre-merge test

### DIFF
--- a/ci-operator/config/openshift/managed-cluster-config/openshift-managed-cluster-config-master.yaml
+++ b/ci-operator/config/openshift/managed-cluster-config/openshift-managed-cluster-config-master.yaml
@@ -16,6 +16,11 @@ tests:
   container:
     from: src
   optional: true
+- as: promrule-check
+  commands: make promrule-check
+  container:
+    from: src
+  run_if_changed: ^deploy/
 - as: checklinks-weekly
   commands: make checklinks
   container:

--- a/ci-operator/jobs/openshift/managed-cluster-config/openshift-managed-cluster-config-master-presubmits.yaml
+++ b/ci-operator/jobs/openshift/managed-cluster-config/openshift-managed-cluster-config-master-presubmits.yaml
@@ -127,3 +127,67 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )pr-check,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^master$
+    - ^master-
+    cluster: build04
+    context: ci/prow/promrule-check
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-managed-cluster-config-master-promrule-check
+    rerun_command: /test promrule-check
+    run_if_changed: ^deploy/
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=promrule-check
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )promrule-check,?($|\s.*)


### PR DESCRIPTION
Check in MCC added via managed-cluster-config#2738

Check the prometheusrules in MCC before it failed in conformance testing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated validation for deployment configuration files in the continuous integration pipeline. This validation runs automatically when deployment configurations are modified, improving reliability of the deployment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->