### PR TITLE
just for testing

### DIFF
--- a/ci-operator/config/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main__compute-nto.yaml
+++ b/ci-operator/config/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main__compute-nto.yaml
@@ -11,7 +11,7 @@ resources:
       cpu: 100m
       memory: 200Mi
 tests:
-- as: e2e-telcov10n-nto-tests-v2-t0-crun-bm-4-21
+- as: e2e-telcov10n-nto-tests-v2-t0-crun-bm-4-22-0-rc-2
   capabilities:
   - intranet
   cron: 59 23 * * 0
@@ -23,10 +23,9 @@ tests:
       FEATURES: compute
       HUGEPAGES_DEFAULT_SIZE: 1G
       HUGEPAGES_PAGES: '[{"count": 1, "size": "1G"}, {"count": 128, "size": "2M"}]'
-      LABEL_FILTER: tier-0
       LABELS: nto
       RT_KERNEL: "true"
-      VERSION: "4.21"
+      VERSION: 4.22.0-rc.2
     test:
     - ref: telcov10n-functional-compute-nto-eco-gotests
     workflow: telcov10n-functional-compute-nto-ocp-setup

--- a/ci-operator/jobs/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main-periodics.yaml
@@ -5659,19 +5659,7 @@ periodics:
     ci-operator.openshift.io/variant: compute-nto
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-kni-eco-ci-cd-main-compute-nto-e2e-telcov10n-nto-tests-v2-t0-crun-bm-4-21
-  reporter_config:
-    slack:
-      channel: '#eco-ci-cd-notifications'
-      job_states_to_report:
-      - failure
-      - error
-      - success
-      - aborted
-      report_template: '{{if eq .Status.State "success"}} :slack-green: Job *{{.Spec.Job}}*
-        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> {{else}} :failed:
-        Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
-        logs> {{end}}'
+  name: periodic-ci-openshift-kni-eco-ci-cd-main-compute-nto-e2e-telcov10n-nto-tests-v2-t0-crun-bm-4-22-0-rc-2
   spec:
     containers:
     - args:
@@ -5679,7 +5667,7 @@ periodics:
       - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
-      - --target=e2e-telcov10n-nto-tests-v2-t0-crun-bm-4-21
+      - --target=e2e-telcov10n-nto-tests-v2-t0-crun-bm-4-22-0-rc-2
       - --variant=compute-nto
       command:
       - ci-operator

--- a/ci-operator/step-registry/telcov10n/functional/compute-nto/ocp-deploy/telcov10n-functional-compute-nto-ocp-deploy-commands.sh
+++ b/ci-operator/step-registry/telcov10n/functional/compute-nto/ocp-deploy/telcov10n-functional-compute-nto-ocp-deploy-commands.sh
@@ -77,10 +77,10 @@ main() {
     echo "Deploy OCP for compute-nto testing"
     ansible-playbook ./playbooks/deploy-ocp-hybrid-multinode.yml \
         -i ./inventories/ocp-deployment/build-inventory.py \
-        --extra-vars "release=${VERSION}" \
+        --extra-vars "release=quay.io/openshift-release-dev/ocp-release:4.22.0-rc.2-x86_64" \
         --extra-vars "cluster_name=${CLUSTER_NAME}" \
         --extra-vars "kubeconfig=/home/telcov10n/project/generated/${CLUSTER_NAME}/auth/kubeconfig" \
-        --extra-vars "ocp_version_facts_release_type=${OCP_VERSION_RELEASE_TYPE}" \
+        --extra-vars "ocp_version_facts_release_type=quay.io/openshift-release-dev/ocp-release:4.22.0-rc.2-x86_64" \
         --extra-vars "ocp_version_release_age_max_days=${OCP_VERSION_RELEASE_AGE_MAX_DAYS}"
 
     echo "Store inventory in SHARED_DIR"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI job to target the OpenShift 4.22.0-rc.2 variant and set VERSION to 4.22.0-rc.2; removed a tier-0 label filter from that job.
  * Updated deployment invocation used in e2e runs to use the OpenShift 4.22.0-rc.2 release image/tag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->