### PR TITLE
cnf ran: added schedule-job to two-sno lane

### DIFF
--- a/ci-operator/config/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main__cnf-ran-two-sno-4.14.yaml
+++ b/ci-operator/config/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main__cnf-ran-two-sno-4.14.yaml
@@ -20,7 +20,7 @@ tests:
 - as: cnf-ran-ztp-tests
   capabilities:
   - intranet
-  cron: 0 23 31 2 *
+  cron: 0 22 * * 5
   steps:
     env:
       CLUSTER_NAME: fthub-01
@@ -28,8 +28,8 @@ tests:
         [
           {"name":"local-storage-operator","catalog":"redhat-operators","nsname":"openshift-local-storage","channel":"stable","og_name":"local-operator-group","subscription_name":"local-storage-operator","deploy_default_config":false,"ns_annotations":{"workload.openshift.io/allowed":"management"}},
           {"name":"openshift-gitops-operator","catalog":"redhat-operators","nsname":"openshift-gitops-operator","channel":"latest","og_name":"openshift-gitops-operator","subscription_name":"openshift-gitops-operator","deploy_default_config":false,"og_spec":{"targetNamespaces":[]}},
-          {"name":"advanced-cluster-management","catalog":"redhat-operators","nsname":"open-cluster-management","channel":"release-2.11","default_channel":"release-2.12","og_name":"open-cluster-management","subscription_name":"acm-operator-subscription","deploy_default_config":false,"og_spec":{"targetNamespaces":["open-cluster-management"]}},
-          {"name":"multicluster-engine","catalog":"redhat-operators","nsname":"multicluster-engine","channel":"stable-2.6","default_channel":"stable-2.7","og_name":"multicluster-engine","subscription_name":"multicluster-engine","deploy_default_config":true,"og_spec":{}},
+          {"name":"advanced-cluster-management","catalog":"redhat-operators","nsname":"open-cluster-management","channel":"release-2.11","og_name":"open-cluster-management","subscription_name":"acm-operator-subscription","deploy_default_config":false,"og_spec":{"targetNamespaces":["open-cluster-management"]}},
+          {"name":"multicluster-engine","catalog":"redhat-operators","nsname":"multicluster-engine","channel":"stable-2.6","og_name":"multicluster-engine","subscription_name":"multicluster-engine","deploy_default_config":true,"og_spec":{}},
           {"name":"topology-aware-lifecycle-manager","catalog":"topology-aware-lifecycle-manager-fbc","og_name":"global-operators","nsname":"openshift-operators","fbc_iib_repo":"latest","channel":"stable","deploy_default_config":false,"ocp_operator_mirror_fbc_image_base":"quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-fbc-4-14"}
         ]
       JOB_NAME: periodic-ci-openshift-kni-eco-ci-cd-main-cnf-ran-two-sno-4.16-cnf-ran-ztp-tests
@@ -45,7 +45,7 @@ tests:
           {"name":"sriov-fec","catalog":"certified-operators","nsname":"vran-acceleration-operators","channel":"stable"},
           {"name":"ptp-operator","catalog":"redhat-operators-ptp-art","fbc_iib_repo":"ose-ptp-operator","nsname":"openshift-ptp","channel":"stable","ns_labels":{"workload.openshift.io/allowed":"management","name":"openshift-ptp"}},
           {"name":"sriov-network-operator","catalog":"redhat-operators-sriov-art","fbc_iib_repo":"ose-sriov-network-operator","nsname":"openshift-sriov-network-operator","channel":"stable","og_name":"sriov-network-operators","subscription_name":"sriov-network-operator-subscription"},
-          {"name":"cluster-logging","catalog":"redhat-operators","nsname":"openshift-logging","channel":"stable-5.8","default_channel":"stable-6.0","og_name":"cluster-logging","subscription_name":"cluster-logging","og_spec":{"targetNamespaces":[]}},
+          {"name":"cluster-logging","catalog":"redhat-operators","nsname":"openshift-logging","channel":"stable-5.8","og_name":"cluster-logging","subscription_name":"cluster-logging","og_spec":{"targetNamespaces":[]}},
           {"name":"local-storage-operator","fbc_iib_repo":"ose-local-storage-rhel9-operator","catalog":"redhat-operators-storage-art","nsname":"openshift-local-storage","channel":"stable","og_name":"local-operator-group","subscription_name":"local-storage-operator","deploy_default_config":false,"ns_labels":{"workload.openshift.io/allowed":"management"}}
         ]
       VERSION: "4.14"
@@ -56,6 +56,7 @@ tests:
     - ref: telcov10n-functional-cnf-network-trigger-job
     - ref: telcov10n-verify-junit-reports
     pre:
+    - ref: telcov10n-functional-cnf-network-schedule-job
     - ref: telcov10n-functional-cnf-ran-hub-deploy
     - ref: telcov10n-functional-cnf-ran-hub-config
     - ref: telcov10n-functional-cnf-ran-mirror-spoke-operators

--- a/ci-operator/config/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main__cnf-ran-two-sno-4.16.yaml
+++ b/ci-operator/config/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main__cnf-ran-two-sno-4.16.yaml
@@ -28,8 +28,8 @@ tests:
         [
           {"name":"local-storage-operator","catalog":"redhat-operators","nsname":"openshift-local-storage","channel":"stable","og_name":"local-operator-group","subscription_name":"local-storage-operator","deploy_default_config":false,"ns_annotations":{"workload.openshift.io/allowed":"management"}},
           {"name":"openshift-gitops-operator","catalog":"redhat-operators","nsname":"openshift-gitops-operator","channel":"latest","og_name":"openshift-gitops-operator","subscription_name":"openshift-gitops-operator","deploy_default_config":false,"og_spec":{"targetNamespaces":[]}},
-          {"name":"advanced-cluster-management","catalog":"redhat-operators","nsname":"open-cluster-management","channel":"release-2.13","default_channel":"release-2.14","og_name":"open-cluster-management","subscription_name":"acm-operator-subscription","deploy_default_config":false,"og_spec":{"targetNamespaces":["open-cluster-management"]}},
-          {"name":"multicluster-engine","catalog":"redhat-operators","nsname":"multicluster-engine","channel":"stable-2.8","default_channel":"stable-2.9","og_name":"multicluster-engine","subscription_name":"multicluster-engine","deploy_default_config":true,"og_spec":{}},
+          {"name":"advanced-cluster-management","catalog":"redhat-operators","nsname":"open-cluster-management","channel":"release-2.13","og_name":"open-cluster-management","subscription_name":"acm-operator-subscription","deploy_default_config":false,"og_spec":{"targetNamespaces":["open-cluster-management"]}},
+          {"name":"multicluster-engine","catalog":"redhat-operators","nsname":"multicluster-engine","channel":"stable-2.8","og_name":"multicluster-engine","subscription_name":"multicluster-engine","deploy_default_config":true,"og_spec":{}},
           {"name":"topology-aware-lifecycle-manager","catalog":"topology-aware-lifecycle-manager-fbc","og_name":"global-operators","nsname":"openshift-operators","fbc_iib_repo":"latest","channel":"stable","deploy_default_config":false,"ocp_operator_mirror_fbc_image_base":"quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-fbc-4-16"}
         ]
       JOB_NAME: periodic-ci-openshift-kni-eco-ci-cd-main-cnf-ran-two-sno-4.18-cnf-ran-ztp-tests
@@ -45,7 +45,7 @@ tests:
           {"name":"sriov-fec","catalog":"certified-operators","nsname":"vran-acceleration-operators","channel":"stable"},
           {"name":"ptp-operator","catalog":"redhat-operators-ptp-art","fbc_iib_repo":"ose-ptp-rhel9-operator","nsname":"openshift-ptp","channel":"stable","ns_labels":{"workload.openshift.io/allowed":"management","name":"openshift-ptp"}},
           {"name":"sriov-network-operator","catalog":"redhat-operators-sriov-art","fbc_iib_repo":"ose-sriov-network-rhel9-operator","nsname":"openshift-sriov-network-operator","channel":"stable","og_name":"sriov-network-operators","subscription_name":"sriov-network-operator-subscription"},
-          {"name":"cluster-logging","catalog":"redhat-operators","nsname":"openshift-logging","channel":"stable-6.0","default_channel":"stable-6.2","og_name":"cluster-logging","subscription_name":"cluster-logging","og_spec":{"targetNamespaces":[]}},
+          {"name":"cluster-logging","catalog":"redhat-operators","nsname":"openshift-logging","channel":"stable-6.0","og_name":"cluster-logging","subscription_name":"cluster-logging","og_spec":{"targetNamespaces":[]}},
           {"name":"local-storage-operator","fbc_iib_repo":"ose-local-storage-rhel9-operator","catalog":"redhat-operators-storage-art","nsname":"openshift-local-storage","channel":"stable","og_name":"local-operator-group","subscription_name":"local-storage-operator","deploy_default_config":false,"ns_labels":{"workload.openshift.io/allowed":"management"}}
         ]
       VERSION: "4.16"
@@ -56,6 +56,7 @@ tests:
     - ref: telcov10n-functional-cnf-network-trigger-job
     - ref: telcov10n-verify-junit-reports
     pre:
+    - ref: telcov10n-functional-cnf-network-schedule-job
     - ref: telcov10n-functional-cnf-ran-hub-deploy
     - ref: telcov10n-functional-cnf-ran-hub-config
     - ref: telcov10n-functional-cnf-ran-mirror-spoke-operators

--- a/ci-operator/config/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main__cnf-ran-two-sno-4.18.yaml
+++ b/ci-operator/config/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main__cnf-ran-two-sno-4.18.yaml
@@ -28,8 +28,8 @@ tests:
         [
           {"name":"local-storage-operator","catalog":"redhat-operators","nsname":"openshift-local-storage","channel":"stable","og_name":"local-operator-group","subscription_name":"local-storage-operator","deploy_default_config":false,"ns_annotations":{"workload.openshift.io/allowed":"management"}},
           {"name":"openshift-gitops-operator","catalog":"redhat-operators","nsname":"openshift-gitops-operator","channel":"latest","og_name":"openshift-gitops-operator","subscription_name":"openshift-gitops-operator","deploy_default_config":false,"og_spec":{"targetNamespaces":[]}},
-          {"name":"advanced-cluster-management","catalog":"redhat-operators","nsname":"open-cluster-management","channel":"release-2.13","default_channel":"release-2.16","og_name":"open-cluster-management","subscription_name":"acm-operator-subscription","deploy_default_config":false,"og_spec":{"targetNamespaces":["open-cluster-management"]}},
-          {"name":"multicluster-engine","catalog":"redhat-operators","nsname":"multicluster-engine","channel":"stable-2.8","default_channel":"stable-2.11","og_name":"multicluster-engine","subscription_name":"multicluster-engine","deploy_default_config":true,"og_spec":{}},
+          {"name":"advanced-cluster-management","catalog":"redhat-operators","nsname":"open-cluster-management","channel":"release-2.13","og_name":"open-cluster-management","subscription_name":"acm-operator-subscription","deploy_default_config":false,"og_spec":{"targetNamespaces":["open-cluster-management"]}},
+          {"name":"multicluster-engine","catalog":"redhat-operators","nsname":"multicluster-engine","channel":"stable-2.8","og_name":"multicluster-engine","subscription_name":"multicluster-engine","deploy_default_config":true,"og_spec":{}},
           {"name":"topology-aware-lifecycle-manager","catalog":"topology-aware-lifecycle-manager-fbc","og_name":"global-operators","nsname":"openshift-operators","fbc_iib_repo":"latest","channel":"stable","deploy_default_config":false,"ocp_operator_mirror_fbc_image_base":"quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-fbc-4-18"}
         ]
       JOB_NAME: periodic-ci-openshift-kni-eco-ci-cd-main-cnf-ran-two-sno-4.20-cnf-ran-ztp-tests
@@ -45,7 +45,7 @@ tests:
           {"name":"sriov-fec","catalog":"certified-operators","nsname":"vran-acceleration-operators","channel":"stable"},
           {"name":"ptp-operator","catalog":"redhat-operators-ptp-art","fbc_iib_repo":"ose-ptp-rhel9-operator","nsname":"openshift-ptp","channel":"stable","ns_labels":{"workload.openshift.io/allowed":"management","name":"openshift-ptp"}},
           {"name":"sriov-network-operator","catalog":"redhat-operators-sriov-art","fbc_iib_repo":"ose-sriov-network-rhel9-operator","nsname":"openshift-sriov-network-operator","channel":"stable","og_name":"sriov-network-operators","subscription_name":"sriov-network-operator-subscription"},
-          {"name":"cluster-logging","catalog":"redhat-operators","nsname":"openshift-logging","channel":"stable-6.1","default_channel":"stable-6.3","og_name":"cluster-logging","subscription_name":"cluster-logging","og_spec":{"targetNamespaces":[]}},
+          {"name":"cluster-logging","catalog":"redhat-operators","nsname":"openshift-logging","channel":"stable-6.1","og_name":"cluster-logging","subscription_name":"cluster-logging","og_spec":{"targetNamespaces":[]}},
           {"name":"local-storage-operator","fbc_iib_repo":"ose-local-storage-rhel9-operator","catalog":"redhat-operators-storage-art","nsname":"openshift-local-storage","channel":"stable","og_name":"local-operator-group","subscription_name":"local-storage-operator","deploy_default_config":false,"ns_labels":{"workload.openshift.io/allowed":"management"}}
         ]
       VERSION: "4.18"
@@ -56,6 +56,7 @@ tests:
     - ref: telcov10n-functional-cnf-network-trigger-job
     - ref: telcov10n-verify-junit-reports
     pre:
+    - ref: telcov10n-functional-cnf-network-schedule-job
     - ref: telcov10n-functional-cnf-ran-hub-deploy
     - ref: telcov10n-functional-cnf-ran-hub-config
     - ref: telcov10n-functional-cnf-ran-mirror-spoke-operators

--- a/ci-operator/config/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main__cnf-ran-two-sno-4.20.yaml
+++ b/ci-operator/config/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main__cnf-ran-two-sno-4.20.yaml
@@ -28,8 +28,8 @@ tests:
         [
           {"name":"local-storage-operator","catalog":"redhat-operators","nsname":"openshift-local-storage","channel":"stable","og_name":"local-operator-group","subscription_name":"local-storage-operator","deploy_default_config":false,"ns_annotations":{"workload.openshift.io/allowed":"management"}},
           {"name":"openshift-gitops-operator","catalog":"redhat-operators","nsname":"openshift-gitops-operator","channel":"latest","og_name":"openshift-gitops-operator","subscription_name":"openshift-gitops-operator","deploy_default_config":false,"og_spec":{"targetNamespaces":[]}},
-          {"name":"advanced-cluster-management","catalog":"redhat-operators","nsname":"open-cluster-management","channel":"release-2.15","default_channel":"release-2.16","og_name":"open-cluster-management","subscription_name":"acm-operator-subscription","deploy_default_config":false,"og_spec":{"targetNamespaces":["open-cluster-management"]}},
-          {"name":"multicluster-engine","catalog":"redhat-operators","nsname":"multicluster-engine","channel":"stable-2.10","default_channel":"stable-2.11","og_name":"multicluster-engine","subscription_name":"multicluster-engine","deploy_default_config":true,"og_spec":{}},
+          {"name":"advanced-cluster-management","catalog":"redhat-operators","nsname":"open-cluster-management","channel":"release-2.15","og_name":"open-cluster-management","subscription_name":"acm-operator-subscription","deploy_default_config":false,"og_spec":{"targetNamespaces":["open-cluster-management"]}},
+          {"name":"multicluster-engine","catalog":"redhat-operators","nsname":"multicluster-engine","channel":"stable-2.10","og_name":"multicluster-engine","subscription_name":"multicluster-engine","deploy_default_config":true,"og_spec":{}},
           {"name":"topology-aware-lifecycle-manager","catalog":"topology-aware-lifecycle-manager-fbc","og_name":"global-operators","nsname":"openshift-operators","fbc_iib_repo":"latest","channel":"stable","deploy_default_config":false,"ocp_operator_mirror_fbc_image_base":"quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-fbc-${VERSION_TAG}"}
         ]
       JOB_NAME: periodic-ci-openshift-kni-eco-ci-cd-main-cnf-ran-two-sno-4.21-cnf-ran-ztp-tests
@@ -45,7 +45,7 @@ tests:
           {"name":"sriov-fec","catalog":"certified-operators","nsname":"vran-acceleration-operators","channel":"stable"},
           {"name":"ptp-operator","catalog":"redhat-operators-ptp-art","fbc_iib_repo":"ose-ptp-rhel9-operator","nsname":"openshift-ptp","channel":"stable","ns_labels":{"workload.openshift.io/allowed":"management","name":"openshift-ptp"}},
           {"name":"sriov-network-operator","catalog":"redhat-operators-sriov-art","fbc_iib_repo":"ose-sriov-network-rhel9-operator","nsname":"openshift-sriov-network-operator","channel":"stable","og_name":"sriov-network-operators","subscription_name":"sriov-network-operator-subscription"},
-          {"name":"cluster-logging","catalog":"redhat-operators","nsname":"openshift-logging","channel":"stable-6.2","default_channel":"stable-6.5","og_name":"cluster-logging","subscription_name":"cluster-logging","og_spec":{"targetNamespaces":[]}},
+          {"name":"cluster-logging","catalog":"redhat-operators","nsname":"openshift-logging","channel":"stable-6.2","og_name":"cluster-logging","subscription_name":"cluster-logging","og_spec":{"targetNamespaces":[]}},
           {"name":"local-storage-operator","fbc_iib_repo":"ose-local-storage-rhel9-operator","catalog":"redhat-operators-storage-art","nsname":"openshift-local-storage","channel":"stable","og_name":"local-operator-group","subscription_name":"local-storage-operator","deploy_default_config":false,"ns_labels":{"workload.openshift.io/allowed":"management"}}
         ]
       VERSION: "4.20"
@@ -56,6 +56,7 @@ tests:
     - ref: telcov10n-functional-cnf-network-trigger-job
     - ref: telcov10n-verify-junit-reports
     pre:
+    - ref: telcov10n-functional-cnf-network-schedule-job
     - ref: telcov10n-functional-cnf-ran-hub-deploy
     - ref: telcov10n-functional-cnf-ran-hub-config
     - ref: telcov10n-functional-cnf-ran-mirror-spoke-operators

--- a/ci-operator/config/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main__cnf-ran-two-sno-4.21.yaml
+++ b/ci-operator/config/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main__cnf-ran-two-sno-4.21.yaml
@@ -45,7 +45,7 @@ tests:
           {"name":"sriov-fec","catalog":"certified-operators","nsname":"vran-acceleration-operators","channel":"stable"},
           {"name":"ptp-operator","catalog":"redhat-operators-ptp-art","fbc_iib_repo":"ose-ptp-rhel9-operator","nsname":"openshift-ptp","channel":"stable","ns_labels":{"workload.openshift.io/allowed":"management","name":"openshift-ptp"}},
           {"name":"sriov-network-operator","catalog":"redhat-operators-sriov-art","fbc_iib_repo":"ose-sriov-network-rhel9-operator","nsname":"openshift-sriov-network-operator","channel":"stable","og_name":"sriov-network-operators","subscription_name":"sriov-network-operator-subscription"},
-          {"name":"cluster-logging","catalog":"redhat-operators","nsname":"openshift-logging","channel":"stable-6.4","default_channel":"stable-6.5","og_name":"cluster-logging","subscription_name":"cluster-logging","og_spec":{"targetNamespaces":[]}},
+          {"name":"cluster-logging","catalog":"redhat-operators","nsname":"openshift-logging","channel":"stable-6.4","og_name":"cluster-logging","subscription_name":"cluster-logging","og_spec":{"targetNamespaces":[]}},
           {"name":"local-storage-operator","fbc_iib_repo":"ose-local-storage-rhel9-operator","catalog":"redhat-operators-storage-art","nsname":"openshift-local-storage","channel":"stable","og_name":"local-operator-group","subscription_name":"local-storage-operator","deploy_default_config":false,"ns_labels":{"workload.openshift.io/allowed":"management"}}
         ]
       VERSION: "4.21"
@@ -56,6 +56,7 @@ tests:
     - ref: telcov10n-functional-cnf-network-trigger-job
     - ref: telcov10n-verify-junit-reports
     pre:
+    - ref: telcov10n-functional-cnf-network-schedule-job
     - ref: telcov10n-functional-cnf-ran-hub-deploy
     - ref: telcov10n-functional-cnf-ran-hub-config
     - ref: telcov10n-functional-cnf-ran-mirror-spoke-operators

--- a/ci-operator/config/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main__cnf-ran-two-sno-4.22.yaml
+++ b/ci-operator/config/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main__cnf-ran-two-sno-4.22.yaml
@@ -54,6 +54,7 @@ tests:
     - ref: telcov10n-functional-cnf-network-trigger-job
     - ref: telcov10n-verify-junit-reports
     pre:
+    - ref: telcov10n-functional-cnf-network-schedule-job
     - ref: telcov10n-functional-cnf-ran-hub-deploy
     - ref: telcov10n-functional-cnf-ran-hub-config
     - ref: telcov10n-functional-cnf-ran-mirror-spoke-operators

--- a/ci-operator/jobs/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-kni/eco-ci-cd/openshift-kni-eco-ci-cd-main-periodics.yaml
@@ -3578,7 +3578,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build07
-  cron: 0 23 31 2 *
+  cron: 0 22 * * 5
   decorate: true
   decoration_config:
     skip_cloning: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated CI/CD pipeline configurations for CNF RAN two-SNO testing across OpenShift versions 4.14 through 4.22 with new validation steps integrated into automated test workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->