### PR TITLE
Use ubi-python-312 image

### DIFF
--- a/ci-operator/config/openshift/ci-tools-standalone/openshift-ci-tools-standalone-main.yaml
+++ b/ci-operator/config/openshift/ci-tools-standalone/openshift-ci-tools-standalone-main.yaml
@@ -8,7 +8,7 @@ base_images:
     namespace: ocp
     tag: "9"
   ubi-python:
-    name: python-312
+    name: ubi-python-312
     namespace: ocp
     tag: "9"
 binary_build_commands: make production-install
@@ -110,7 +110,7 @@ images:
           source_path: /go/bin/retester
     to: retester
   - dockerfile_literal: |-
-      FROM registry.access.redhat.com/ubi9/python-312:latest
+      FROM ubi-python
       WORKDIR /app
       COPY cmd/secret-manager/requirements.txt .
       RUN pip install --no-cache-dir -r requirements.txt


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI base image configuration for enhanced compatibility and consistency across build processes. These internal infrastructure adjustments maintain system stability without affecting user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->