### PR TITLE
ART-14615 Update 4.20 repos to track e4s

### DIFF
--- a/core-services/release-controller/_repos/ocp-4.20-rhel9.repo
+++ b/core-services/release-controller/_repos/ocp-4.20-rhel9.repo
@@ -1,6 +1,6 @@
 [rhel-9-baseos]
 name = rhel-9-baseos
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/baseos/os/
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/x86_64/baseos/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -12,7 +12,7 @@ failovermethod = priority
 
 [rhel-9-appstream]
 name = rhel-9-appstream
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/appstream/os/
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/x86_64/appstream/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -72,7 +72,7 @@ failovermethod = priority
 
 [rhel-9-baseos-ppc64le]
 name = rhel-9-baseos-ppc64le
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/ppc64le/baseos/os/
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/ppc64le/baseos/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -84,7 +84,7 @@ failovermethod = priority
 
 [rhel-9-appstream-ppc64le]
 name = rhel-9-appstream-ppc64le
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/ppc64le/appstream/os/
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/ppc64le/appstream/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -132,7 +132,7 @@ failovermethod = priority
 
 [rhel-9-baseos-s390x]
 name = rhel-9-baseos-s390x
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/s390x/baseos/os/
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/s390x/baseos/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -144,7 +144,7 @@ failovermethod = priority
 
 [rhel-9-appstream-s390x]
 name = rhel-9-appstream-s390x
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/s390x/appstream/os/
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/s390x/appstream/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -192,7 +192,7 @@ failovermethod = priority
 
 [rhel-9-baseos-aarch64]
 name = rhel-9-baseos-aarch64
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/aarch64/baseos/os/
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/aarch64/baseos/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -204,7 +204,7 @@ failovermethod = priority
 
 [rhel-9-appstream-aarch64]
 name = rhel-9-appstream-aarch64
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/aarch64/appstream/os/
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/aarch64/appstream/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false

--- a/core-services/release-controller/_repos/ocp-4.20-rhel92.repo
+++ b/core-services/release-controller/_repos/ocp-4.20-rhel92.repo
@@ -1,6 +1,6 @@
 [rhel-9.2-baseos]
 name = rhel-9.2-baseos
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.2/x86_64/baseos/os/
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.2/x86_64/baseos/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -12,7 +12,7 @@ failovermethod = priority
 
 [rhel-9.2-appstream]
 name = rhel-9.2-appstream
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.2/x86_64/appstream/os/
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.2/x86_64/appstream/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false

--- a/core-services/release-controller/_repos/ocp-4.20-rhel94.repo
+++ b/core-services/release-controller/_repos/ocp-4.20-rhel94.repo
@@ -1,6 +1,6 @@
 [rhel-9.4-baseos]
 name = rhel-9.4-baseos
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/baseos/os/
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/x86_64/baseos/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -12,7 +12,7 @@ failovermethod = priority
 
 [rhel-9.4-appstream]
 name = rhel-9.4-appstream
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/appstream/os/
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/x86_64/appstream/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false

--- a/core-services/release-controller/_repos/ocp-4.20-rhel96.repo
+++ b/core-services/release-controller/_repos/ocp-4.20-rhel96.repo
@@ -1,6 +1,6 @@
 [rhel-9.6-baseos]
 name = rhel-9.6-baseos
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.6/x86_64/baseos/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -11,7 +11,7 @@ failovermethod = priority
 
 [rhel-9.6-appstream]
 name = rhel-9.6-appstream
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.6/x86_64/appstream/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -97,7 +97,7 @@ includepkgs = kernel,kernel-*,ose-aws-ecr-image-credential-provider
 
 [rhel-9.6-baseos-ppc64le]
 name = rhel-9.6-baseos-ppc64le
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/os/
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.6/ppc64le/baseos/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -108,7 +108,7 @@ failovermethod = priority
 
 [rhel-9.6-appstream-ppc64le]
 name = rhel-9.6-appstream-ppc64le
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.6/ppc64le/appstream/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -153,7 +153,7 @@ failovermethod = priority
 
 [rhel-9.6-baseos-s390x]
 name = rhel-9.6-baseos-s390x
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/os/
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.6/s390x/baseos/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -164,7 +164,7 @@ failovermethod = priority
 
 [rhel-9.6-appstream-s390x]
 name = rhel-9.6-appstream-s390x
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.6/s390x/appstream/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -209,7 +209,7 @@ failovermethod = priority
 
 [rhel-9.6-baseos-aarch64]
 name = rhel-9.6-baseos-aarch64
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.6/aarch64/baseos/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -220,7 +220,7 @@ failovermethod = priority
 
 [rhel-9.6-appstream-aarch64]
 name = rhel-9.6-appstream-aarch64
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.6/aarch64/appstream/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false


### PR DESCRIPTION
## Summary

Replace EUS (Extended Update Support) with E4S (Extended Update Support for SAP) for baseos and appstream repos across all architectures in OCP 4.20.

This aligns 4.20 with the pattern already established in 4.21 (see commit 0be76186b0b) and ensures the CI repos match the base image requirements after the move to rhel-els-minimal.

## Changes

- Updated 3 repo files: `rhel9`, `rhel92`, `rhel96`
- Changed `cdn.redhat.com/content/eus/` to `cdn.redhat.com/content/e4s/` for **baseos and appstream repos only**
- **codeready-builder repos remain on eus** (e4s not available for this repo)
- Affected architectures: x86_64, ppc64le, s390x, aarch64
- nfv and highavailability repos already used e4s, left unchanged

## Files Modified

- `core-services/release-controller/_repos/ocp-4.20-rhel9.repo` (16 changes)
- `core-services/release-controller/_repos/ocp-4.20-rhel92.repo` (4 changes)
- `core-services/release-controller/_repos/ocp-4.20-rhel94.repo` (4 changes)
- `core-services/release-controller/_repos/ocp-4.20-rhel96.repo` (16 changes)

## Test plan

- Verify repo URLs are accessible and contain expected packages
- Monitor CI builds after merge to ensure no repository access issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Red Hat repository configurations for OCP 4.20 across RHEL 9 variants (9.0, 9.2, 9.4, 9.6) to use the e4s CDN endpoint instead of eus for package delivery. This change applies to base OS and AppStream repos across all supported architectures (x86_64, ppc64le, s390x, aarch64), with all other repo settings unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->