### PR TITLE
[OSSM3] Add prepull images for sail e2e

### DIFF
--- a/ci-operator/config/openshift-service-mesh/sail-operator/openshift-service-mesh-sail-operator-lpinterop-3.3__ocp-4.22-lp-interop.yaml
+++ b/ci-operator/config/openshift-service-mesh/sail-operator/openshift-service-mesh-sail-operator-lpinterop-3.3__ocp-4.22-lp-interop.yaml
@@ -11,6 +11,10 @@ base_images:
     name: kiali-int-tests
     namespace: ci
     tag: v2.22
+  kiali-ossm-cypress-tests-runner:
+    name: kiali-ossmc-cypress-tests
+    namespace: ci
+    tag: v2.22
 build_root:
   image_stream_tag:
     name: maistra-builder
@@ -46,7 +50,9 @@ tests:
               {"step": "servicemesh-kiali-int-tests-execute", "failure_type": "pod_failure", "classification": "Kiali Integration Test Execution", "jira_project": "OSSM", "group": {"name": "lp-tests", "priority": 3}, "jira_component": ["!default"], "jira_assignee": "!default", "jira_priority": "!default", "jira_additional_labels": ["!default","interop-tests"]},
               {"step": "servicemesh-kiali-int-tests-execute", "failure_type": "test_failure", "classification": "Kiali Integration Test Failure", "jira_project": "OSSM", "group": {"name": "lp-tests", "priority": 3}, "jira_component": ["!default"], "jira_assignee": "!default", "jira_priority": "!default", "jira_additional_labels": ["!default","interop-tests"]},
               {"step": "servicemesh-kiali-cypress-tests-execute", "failure_type": "pod_failure", "classification": "Kiali Cypress Test Execution", "jira_project": "OSSM", "group": {"name": "lp-tests", "priority": 3}, "jira_component": ["!default"], "jira_assignee": "!default", "jira_priority": "!default", "jira_additional_labels": ["!default","interop-tests"]},
-              {"step": "servicemesh-kiali-cypress-tests-execute", "failure_type": "test_failure", "classification": "Kiali Cypress Test Failure", "jira_project": "OSSM", "group": {"name": "lp-tests", "priority": 3}, "jira_component": ["!default"], "jira_assignee": "!default", "jira_priority": "!default", "jira_additional_labels": ["!default","interop-tests"]}
+              {"step": "servicemesh-kiali-cypress-tests-execute", "failure_type": "test_failure", "classification": "Kiali Cypress Test Failure", "jira_project": "OSSM", "group": {"name": "lp-tests", "priority": 3}, "jira_component": ["!default"], "jira_assignee": "!default", "jira_priority": "!default", "jira_additional_labels": ["!default","interop-tests"]},
+              {"step": "servicemesh-kiali-ossm-cypress-tests-execute", "failure_type": "pod_failure", "classification": "Kiali OSSMC Cypress Test Execution", "jira_project": "OSSM", "group": {"name": "lp-tests", "priority": 3}, "jira_component": ["!default"], "jira_assignee": "!default", "jira_priority": "!default", "jira_additional_labels": ["!default","interop-tests"]},
+              {"step": "servicemesh-kiali-ossm-cypress-tests-execute", "failure_type": "test_failure", "classification": "Kiali OSSMC Cypress Test Failure", "jira_project": "OSSM", "group": {"name": "lp-tests", "priority": 3}, "jira_component": ["!default"], "jira_assignee": "!default", "jira_priority": "!default", "jira_additional_labels": ["!default","interop-tests"]}
             ]
         }
       FIREWATCH_CONFIG_FILE_PATH: https://raw.githubusercontent.com/CSPI-QE/cspi-utils/refs/heads/main/firewatch-base-configs/cr/lp-interop.json
@@ -79,6 +85,7 @@ tests:
     - ref: servicemesh-kiali-int-tests-execute
     - ref: idp-htpasswd
     - ref: servicemesh-kiali-cypress-tests-execute
+    - ref: servicemesh-kiali-ossm-cypress-tests-execute
     workflow: firewatch-ipi-aws-cr
 - as: servicemesh-aws-fips
   cron: 0 23 31 2 *
@@ -97,7 +104,9 @@ tests:
               {"step": "servicemesh-kiali-int-tests-execute", "failure_type": "pod_failure", "classification": "Kiali Integration Test Execution", "jira_project": "OSSM", "group": {"name": "lp-tests", "priority": 3}, "jira_component": ["!default"], "jira_assignee": "!default", "jira_priority": "!default", "jira_additional_labels": ["!default","interop-tests"]},
               {"step": "servicemesh-kiali-int-tests-execute", "failure_type": "test_failure", "classification": "Kiali Integration Test Failure", "jira_project": "OSSM", "group": {"name": "lp-tests", "priority": 3}, "jira_component": ["!default"], "jira_assignee": "!default", "jira_priority": "!default", "jira_additional_labels": ["!default","interop-tests"]},
               {"step": "servicemesh-kiali-cypress-tests-execute", "failure_type": "pod_failure", "classification": "Kiali Cypress Test Execution", "jira_project": "OSSM", "group": {"name": "lp-tests", "priority": 3}, "jira_component": ["!default"], "jira_assignee": "!default", "jira_priority": "!default", "jira_additional_labels": ["!default","interop-tests"]},
-              {"step": "servicemesh-kiali-cypress-tests-execute", "failure_type": "test_failure", "classification": "Kiali Cypress Test Failure", "jira_project": "OSSM", "group": {"name": "lp-tests", "priority": 3}, "jira_component": ["!default"], "jira_assignee": "!default", "jira_priority": "!default", "jira_additional_labels": ["!default","interop-tests"]}
+              {"step": "servicemesh-kiali-cypress-tests-execute", "failure_type": "test_failure", "classification": "Kiali Cypress Test Failure", "jira_project": "OSSM", "group": {"name": "lp-tests", "priority": 3}, "jira_component": ["!default"], "jira_assignee": "!default", "jira_priority": "!default", "jira_additional_labels": ["!default","interop-tests"]},
+              {"step": "servicemesh-kiali-ossm-cypress-tests-execute", "failure_type": "pod_failure", "classification": "Kiali OSSMC Cypress Test Execution", "jira_project": "OSSM", "group": {"name": "lp-tests", "priority": 3}, "jira_component": ["!default"], "jira_assignee": "!default", "jira_priority": "!default", "jira_additional_labels": ["!default","interop-tests"]},
+              {"step": "servicemesh-kiali-ossm-cypress-tests-execute", "failure_type": "test_failure", "classification": "Kiali OSSMC Cypress Test Failure", "jira_project": "OSSM", "group": {"name": "lp-tests", "priority": 3}, "jira_component": ["!default"], "jira_assignee": "!default", "jira_priority": "!default", "jira_additional_labels": ["!default","interop-tests"]}
             ]
         }
       FIREWATCH_CONFIG_FILE_PATH: https://raw.githubusercontent.com/CSPI-QE/cspi-utils/main/firewatch-base-configs/aws-ipi/lp-interop.json
@@ -127,6 +136,7 @@ tests:
     - ref: servicemesh-kiali-int-tests-execute
     - ref: idp-htpasswd
     - ref: servicemesh-kiali-cypress-tests-execute
+    - ref: servicemesh-kiali-ossm-cypress-tests-execute
     workflow: firewatch-ipi-aws
 zz_generated_metadata:
   branch: lpinterop-3.3

--- a/ci-operator/config/openshift-service-mesh/sail-operator/openshift-service-mesh-sail-operator-lpinterop-3.3__ocp-4.22-lp-interop.yaml
+++ b/ci-operator/config/openshift-service-mesh/sail-operator/openshift-service-mesh-sail-operator-lpinterop-3.3__ocp-4.22-lp-interop.yaml
@@ -116,7 +116,7 @@ tests:
       FIREWATCH_DEFAULT_JIRA_PRIORITY: critical
       FIREWATCH_DEFAULT_JIRA_PROJECT: OSSM
       FIREWATCH_FAIL_WITH_TEST_FAILURES: "true"
-      GINKGO_FLAGS: -v --keep-going --label-filter=smoke&&!ambient&&!cert-manager
+      GINKGO_FLAGS: -v --keep-going --label-filter=smoke&&!cert-manager
       ISTIO_SAMPLE_APP_VERSION: v1.28.4
       ISTIO_VERSION: v1.28-latest
       KIALI_VERSION: v2.22

--- a/ci-operator/step-registry/servicemesh/sail-operator/e2e-lpinterop/servicemesh-sail-operator-e2e-lpinterop-commands.sh
+++ b/ci-operator/step-registry/servicemesh/sail-operator/e2e-lpinterop/servicemesh-sail-operator-e2e-lpinterop-commands.sh
@@ -30,6 +30,158 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
+# Function to pre-pull container images on all OCP nodes
+# Usage: prepull_image_on_nodes <image-name>
+# Example: prepull_image_on_nodes "ztunnel"
+prepull_image_on_nodes() {
+    local IMAGE_NAME="$1"
+    local CSV_PATTERN="servicemeshoperator3"
+
+    # Validate input
+    if [ -z "$IMAGE_NAME" ]; then
+        echo -e "Error: Image name is required"
+        echo "Usage: prepull_image_on_nodes <image-name>"
+        return 1
+    fi
+
+    # Auto-detect CSV
+    echo -e "Auto-detecting latest servicemeshoperator3 CSV..."
+    oc get csv
+    local CSV_NAME
+    CSV_NAME=$(oc get csv -o json | jq -r --arg pattern "$CSV_PATTERN" '
+      .items[] |
+      select(.metadata.name | startswith($pattern)) |
+      {name: .metadata.name, version: (.metadata.name | capture($pattern + "\\.v(?<v>.*)").v // "0")}
+    ' | jq -rs 'sort_by(.version | split(".") | map(tonumber)) | last | .name')
+
+    if [ -z "$CSV_NAME" ] || [ "$CSV_NAME" = "null" ]; then
+        echo -e "Error: Could not auto-detect CSV matching pattern '${CSV_PATTERN}'"
+        echo "Available CSVs:"
+        oc get csv -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | grep "$CSV_PATTERN" || echo "None found"
+        return 1
+    fi
+    echo -e "Detected CSV: ${CSV_NAME}"
+
+    echo -e "=== Pre-pulling ${IMAGE_NAME} image on all OCP nodes ==="
+
+    # Step 1: Extract the latest patch version for each minor version from CSV
+    echo -e "\nStep 1: Extracting latest ${IMAGE_NAME} images for each minor version from CSV ${CSV_NAME}..."
+
+    local TARGET_IMAGES
+    TARGET_IMAGES=$(oc get csv "$CSV_NAME" -o json | jq -r --arg img "$IMAGE_NAME" '
+      [.spec.relatedImages[] |
+      select(.name | contains($img)) |
+      {
+        name: .name,
+        image: .image,
+        version: (.name | capture("images_v(?<v>.*?)_" + $img).v // "0"),
+        minor: (.name | capture("images_v(?<maj>\\d+)_(?<min>\\d+)_.*?_" + $img) | "\(.maj).\(.min)")
+      }] |
+      group_by(.minor) |
+      map(sort_by(.version | split("_") | map(tonumber)) | last) |
+      sort_by(.minor | split(".") | map(tonumber)) |
+      reverse |
+      .[] |
+      "\(.minor): \(.image)"
+    ')
+
+    if [ -z "$TARGET_IMAGES" ]; then
+        echo -e "Error: Could not find ${IMAGE_NAME} images in CSV"
+        echo "Available images with '${IMAGE_NAME}' in name:"
+        oc get csv "$CSV_NAME" -o json | jq -r --arg img "$IMAGE_NAME" '.spec.relatedImages[] | select(.name | contains($img)) | "\(.name): \(.image)"'
+        return 1
+    fi
+
+    echo -e "Found latest ${IMAGE_NAME} images for each minor version:"
+    echo "$TARGET_IMAGES" | while IFS= read -r line; do
+        echo -e "  $line"
+    done
+
+    # Step 2: Get all nodes
+    echo -e "\nStep 2: Getting all OCP nodes..."
+    local NODES
+    NODES=$(oc get nodes -o jsonpath='{.items[*].metadata.name}')
+
+    if [ -z "$NODES" ]; then
+        echo -e "Error: No nodes found"
+        return 1
+    fi
+
+    local NODE_COUNT
+    NODE_COUNT=$(echo $NODES | wc -w)
+    echo -e "Found $NODE_COUNT nodes"
+
+    # Step 3: Pre-pull all images on each node
+    echo -e "\nStep 3: Pre-pulling images on all nodes..."
+
+    local TOTAL_PULLS=0
+    local SUCCESSFUL_PULLS=0
+    local FAILED_PULLS=0
+    local FAILED_DETAILS=()
+
+    # Extract just the image URLs (remove the "minor: " prefix)
+    local IMAGE_URLS
+    IMAGE_URLS=$(echo "$TARGET_IMAGES" | cut -d' ' -f2)
+
+    for NODE in $NODES; do
+        echo -e "\nProcessing node: $NODE"
+
+        while IFS= read -r IMAGE_URL; do
+            [ -z "$IMAGE_URL" ] && continue
+
+            local IMAGE_VERSION
+            IMAGE_VERSION=$(echo "$TARGET_IMAGES" | grep "$IMAGE_URL" | cut -d':' -f1)
+
+            echo -e "  Pulling ${IMAGE_VERSION}..."
+            TOTAL_PULLS=$((TOTAL_PULLS + 1))
+
+            local OUTPUT
+            local PULL_EXIT_CODE
+
+            # Use oc debug to access the node and pull the image
+            set +e
+            OUTPUT=$(oc debug node/$NODE -- chroot /host sh -c "crictl pull \"$IMAGE_URL\"" 2>&1)
+            PULL_EXIT_CODE=$?
+            set -e
+            echo "$OUTPUT" | grep -E "(Image is up to date|Image is updated|Downloaded|Pulling|error|Error)" || true
+
+            # Check if the pull was successful
+            local GREP_RESULT
+            set +e
+            echo "$OUTPUT" | grep -qE "(Image is up to date|Image is updated|Downloaded|Pulling)"
+            GREP_RESULT=$?
+            set -e
+
+            if [ $GREP_RESULT -eq 0 ] || [ $PULL_EXIT_CODE -eq 0 ]; then
+                echo -e "  ✓ Successfully pulled ${IMAGE_VERSION} on node $NODE"
+                SUCCESSFUL_PULLS=$((SUCCESSFUL_PULLS + 1))
+            else
+                echo -e "  ✗ Failed to pull ${IMAGE_VERSION} on node $NODE"
+                FAILED_PULLS=$((FAILED_PULLS + 1))
+                FAILED_DETAILS+=("$NODE: $IMAGE_VERSION")
+            fi
+        done <<< "$IMAGE_URLS"
+    done
+
+    # Summary
+    echo -e "\n=== Summary ==="
+    echo -e "Total nodes: $NODE_COUNT"
+    echo -e "Total pull attempts: $TOTAL_PULLS"
+    echo -e "Successful pulls: $SUCCESSFUL_PULLS"
+
+    if [ $FAILED_PULLS -gt 0 ]; then
+        echo -e "Failed pulls: $FAILED_PULLS"
+        echo -e "Failed details:"
+        for DETAIL in "${FAILED_DETAILS[@]}"; do
+            echo -e "  - $DETAIL"
+        done
+        return 1
+    else
+        echo -e "All nodes successfully pulled all ${IMAGE_NAME} images!"
+        return 0
+    fi
+}
+
 function install_yq_if_not_exists() {
     # Install yq manually if not found in image
     echo "Checking if yq exists"
@@ -72,6 +224,10 @@ ret_code=0
 mkdir ./test_artifacts
 ARTIFACTS="$(pwd)/test_artifacts"
 export ARTIFACTS
+
+# workaround for node instability, for now, ztunnel image only
+prepull_image_on_nodes "ztunnel"
+
 #execute test, do not terminate when there is some failure since we want to archive junit files
 make test.e2e.ocp || ret_code=$?
 

--- a/ci-operator/step-registry/servicemesh/sail-operator/e2e-lpinterop/servicemesh-sail-operator-e2e-lpinterop-commands.sh
+++ b/ci-operator/step-registry/servicemesh/sail-operator/e2e-lpinterop/servicemesh-sail-operator-e2e-lpinterop-commands.sh
@@ -228,6 +228,15 @@ export ARTIFACTS
 # workaround for node instability, for now, ztunnel image only
 prepull_image_on_nodes "ztunnel"
 
+FIPS_CLUSTER=false
+# If fips cluster, patch network config to be able to run ambient tests
+if [[ $(oc get machineconfigs | grep fips) ]]; then
+    echo "Patching network config to be able to run ambient tests on fips cluster"
+    oc patch networks.operator.openshift.io cluster --type=merge -p '{"spec":{"defaultNetwork":{"ovnKubernetesConfig":{"gatewayConfig":{"routingViaHost": true}}}}}'
+    FIPS_CLUSTER=true
+fi
+export FIPS_CLUSTER
+
 #execute test, do not terminate when there is some failure since we want to archive junit files
 make test.e2e.ocp || ret_code=$?
 


### PR DESCRIPTION
**Part of this PR:**

- [OSSM3] Add prepull images for sail e2e to workaround cluster network instability
- Enable ambient on FIPS (supported now)
- Re-enabled OSSMC job

**=======================================================================**
auto-generated comment: release notes by coderabbit.ai
**=======================================================================**
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Scope: CI configuration and e2e step for the openshift-service-mesh sail-operator periodic CI (ocp-4.22 lp-interop flows).

- Practical changes:
  - Adds a node-level image pre-pull helper and invocation to improve Sail operator e2e stability:
    - New prepull_image_on_nodes(image-name) shell function added to the sail-operator e2e step script; it detects CSV images, enumerates nodes, and runs crictl pulls on each node.
    - Calls prepull_image_on_nodes "ztunnel" before running make test.e2e.ocp to mitigate cluster network instability during tests.
  - CI/test flow updates:
    - Adjusts Firewatch failure tracking and test refs for the cr-servicemesh-aws and servicemesh-aws-fips flows: removes several ancillary steps (servicemesh-istio-install, servicemesh-kiali-int-tests-execute, idp-htpasswd) and replaces servicemesh-kiali-cypress-tests-execute with servicemesh-kiali-ossm-cypress-tests-execute.
    - Adds a new base_images entry for kiali-ossm-cypress-tests-runner.
    - Modifies GINKGO_FLAGS for the FIPS flow to allow ambient tests (removed the "!ambient" filter).
  - Operational:
    - Re-enables the OSSMC job (kiali-ossm cypress coverage).
    - Marks the PR as draft/work-in-progress; author is mkralik3 (branch ossm3_fix → main).

- Rationale: Mitigate transient cluster network failures by pre-pulling critical images, enable ambient mode under FIPS where now supported, and restore OSSM Kiali Cypress coverage with an updated runner image and failure tracking.

- Impact: CI/integration behavior changes only (ci-operator config and step-registry script). Review focus: correctness and robustness of the prepull logic, node execution safety (oc debug usage), and correctness of updated test refs/failure tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->