### PR TITLE
OSASINFRA-4313: increase timeout for ccpmso jobs

### DIFF
--- a/ci-operator/config/openshift-priv/installer/openshift-priv-installer-main.yaml
+++ b/ci-operator/config/openshift-priv/installer/openshift-priv-installer-main.yaml
@@ -915,7 +915,7 @@ tests:
       resources:
         requests:
           cpu: 100m
-      timeout: 4h0m0s
+      timeout: 7h0m0s
     workflow: openshift-e2e-openstack-ipi
 - as: openstack-manifests
   run_if_changed: openstack

--- a/ci-operator/config/openshift-priv/installer/openshift-priv-installer-release-4.19.yaml
+++ b/ci-operator/config/openshift-priv/installer/openshift-priv-installer-release-4.19.yaml
@@ -703,7 +703,7 @@ tests:
       resources:
         requests:
           cpu: 100m
-      timeout: 4h0m0s
+      timeout: 7h0m0s
     workflow: openshift-e2e-openstack-ipi
 - as: openstack-manifests
   run_if_changed: openstack

--- a/ci-operator/config/openshift-priv/installer/openshift-priv-installer-release-4.20.yaml
+++ b/ci-operator/config/openshift-priv/installer/openshift-priv-installer-release-4.20.yaml
@@ -754,7 +754,7 @@ tests:
       resources:
         requests:
           cpu: 100m
-      timeout: 4h0m0s
+      timeout: 7h0m0s
     workflow: openshift-e2e-openstack-ipi
 - as: openstack-manifests
   run_if_changed: openstack

--- a/ci-operator/config/openshift-priv/installer/openshift-priv-installer-release-4.21.yaml
+++ b/ci-operator/config/openshift-priv/installer/openshift-priv-installer-release-4.21.yaml
@@ -791,7 +791,7 @@ tests:
       resources:
         requests:
           cpu: 100m
-      timeout: 4h0m0s
+      timeout: 7h0m0s
     workflow: openshift-e2e-openstack-ipi
 - as: openstack-manifests
   run_if_changed: openstack

--- a/ci-operator/config/openshift-priv/installer/openshift-priv-installer-release-4.22.yaml
+++ b/ci-operator/config/openshift-priv/installer/openshift-priv-installer-release-4.22.yaml
@@ -915,7 +915,7 @@ tests:
       resources:
         requests:
           cpu: 100m
-      timeout: 4h0m0s
+      timeout: 7h0m0s
     workflow: openshift-e2e-openstack-ipi
 - as: openstack-manifests
   run_if_changed: openstack

--- a/ci-operator/config/openshift-priv/installer/openshift-priv-installer-release-4.23.yaml
+++ b/ci-operator/config/openshift-priv/installer/openshift-priv-installer-release-4.23.yaml
@@ -915,7 +915,7 @@ tests:
       resources:
         requests:
           cpu: 100m
-      timeout: 4h0m0s
+      timeout: 7h0m0s
     workflow: openshift-e2e-openstack-ipi
 - as: openstack-manifests
   run_if_changed: openstack

--- a/ci-operator/config/openshift-priv/installer/openshift-priv-installer-release-5.0.yaml
+++ b/ci-operator/config/openshift-priv/installer/openshift-priv-installer-release-5.0.yaml
@@ -916,7 +916,7 @@ tests:
       resources:
         requests:
           cpu: 100m
-      timeout: 4h0m0s
+      timeout: 7h0m0s
     workflow: openshift-e2e-openstack-ipi
 - as: openstack-manifests
   run_if_changed: openstack

--- a/ci-operator/config/openshift-priv/installer/openshift-priv-installer-release-5.1.yaml
+++ b/ci-operator/config/openshift-priv/installer/openshift-priv-installer-release-5.1.yaml
@@ -915,7 +915,7 @@ tests:
       resources:
         requests:
           cpu: 100m
-      timeout: 4h0m0s
+      timeout: 7h0m0s
     workflow: openshift-e2e-openstack-ipi
 - as: openstack-manifests
   run_if_changed: openstack

--- a/ci-operator/config/openshift-priv/openstack-test/openshift-priv-openstack-test-main.yaml
+++ b/ci-operator/config/openshift-priv/openstack-test/openshift-priv-openstack-test-main.yaml
@@ -63,7 +63,7 @@ tests:
       resources:
         requests:
           cpu: 100m
-      timeout: 4h0m0s
+      timeout: 7h0m0s
     - ref: openstack-test-openstack
     workflow: openshift-e2e-openstack-ipi
 - always_run: false

--- a/ci-operator/config/openshift-priv/openstack-test/openshift-priv-openstack-test-release-4.19.yaml
+++ b/ci-operator/config/openshift-priv/openstack-test/openshift-priv-openstack-test-release-4.19.yaml
@@ -63,7 +63,7 @@ tests:
       resources:
         requests:
           cpu: 100m
-      timeout: 4h0m0s
+      timeout: 7h0m0s
     - ref: openstack-test-openstack
     workflow: openshift-e2e-openstack-ipi
 - always_run: false

--- a/ci-operator/config/openshift-priv/openstack-test/openshift-priv-openstack-test-release-4.20.yaml
+++ b/ci-operator/config/openshift-priv/openstack-test/openshift-priv-openstack-test-release-4.20.yaml
@@ -63,7 +63,7 @@ tests:
       resources:
         requests:
           cpu: 100m
-      timeout: 4h0m0s
+      timeout: 7h0m0s
     - ref: openstack-test-openstack
     workflow: openshift-e2e-openstack-ipi
 - always_run: false

--- a/ci-operator/config/openshift-priv/openstack-test/openshift-priv-openstack-test-release-4.21.yaml
+++ b/ci-operator/config/openshift-priv/openstack-test/openshift-priv-openstack-test-release-4.21.yaml
@@ -63,7 +63,7 @@ tests:
       resources:
         requests:
           cpu: 100m
-      timeout: 4h0m0s
+      timeout: 7h0m0s
     - ref: openstack-test-openstack
     workflow: openshift-e2e-openstack-ipi
 - always_run: false

--- a/ci-operator/config/openshift-priv/openstack-test/openshift-priv-openstack-test-release-4.22.yaml
+++ b/ci-operator/config/openshift-priv/openstack-test/openshift-priv-openstack-test-release-4.22.yaml
@@ -63,7 +63,7 @@ tests:
       resources:
         requests:
           cpu: 100m
-      timeout: 4h0m0s
+      timeout: 7h0m0s
     - ref: openstack-test-openstack
     workflow: openshift-e2e-openstack-ipi
 - always_run: false

--- a/ci-operator/config/openshift-priv/openstack-test/openshift-priv-openstack-test-release-4.23.yaml
+++ b/ci-operator/config/openshift-priv/openstack-test/openshift-priv-openstack-test-release-4.23.yaml
@@ -63,7 +63,7 @@ tests:
       resources:
         requests:
           cpu: 100m
-      timeout: 4h0m0s
+      timeout: 7h0m0s
     - ref: openstack-test-openstack
     workflow: openshift-e2e-openstack-ipi
 - always_run: false

--- a/ci-operator/config/openshift-priv/openstack-test/openshift-priv-openstack-test-release-5.0.yaml
+++ b/ci-operator/config/openshift-priv/openstack-test/openshift-priv-openstack-test-release-5.0.yaml
@@ -64,7 +64,7 @@ tests:
       resources:
         requests:
           cpu: 100m
-      timeout: 4h0m0s
+      timeout: 7h0m0s
     - ref: openstack-test-openstack
     workflow: openshift-e2e-openstack-ipi
 - always_run: false

--- a/ci-operator/config/openshift-priv/openstack-test/openshift-priv-openstack-test-release-5.1.yaml
+++ b/ci-operator/config/openshift-priv/openstack-test/openshift-priv-openstack-test-release-5.1.yaml
@@ -63,7 +63,7 @@ tests:
       resources:
         requests:
           cpu: 100m
-      timeout: 4h0m0s
+      timeout: 7h0m0s
     - ref: openstack-test-openstack
     workflow: openshift-e2e-openstack-ipi
 - always_run: false

--- a/ci-operator/config/openshift/installer/openshift-installer-main.yaml
+++ b/ci-operator/config/openshift/installer/openshift-installer-main.yaml
@@ -912,7 +912,7 @@ tests:
       resources:
         requests:
           cpu: 100m
-      timeout: 4h0m0s
+      timeout: 7h0m0s
     workflow: openshift-e2e-openstack-ipi
 - as: openstack-manifests
   run_if_changed: openstack

--- a/ci-operator/config/openshift/installer/openshift-installer-release-4.19.yaml
+++ b/ci-operator/config/openshift/installer/openshift-installer-release-4.19.yaml
@@ -700,7 +700,7 @@ tests:
       resources:
         requests:
           cpu: 100m
-      timeout: 4h0m0s
+      timeout: 7h0m0s
     workflow: openshift-e2e-openstack-ipi
 - as: openstack-manifests
   run_if_changed: openstack

--- a/ci-operator/config/openshift/installer/openshift-installer-release-4.20.yaml
+++ b/ci-operator/config/openshift/installer/openshift-installer-release-4.20.yaml
@@ -751,7 +751,7 @@ tests:
       resources:
         requests:
           cpu: 100m
-      timeout: 4h0m0s
+      timeout: 7h0m0s
     workflow: openshift-e2e-openstack-ipi
 - as: openstack-manifests
   run_if_changed: openstack

--- a/ci-operator/config/openshift/installer/openshift-installer-release-4.21.yaml
+++ b/ci-operator/config/openshift/installer/openshift-installer-release-4.21.yaml
@@ -788,7 +788,7 @@ tests:
       resources:
         requests:
           cpu: 100m
-      timeout: 4h0m0s
+      timeout: 7h0m0s
     workflow: openshift-e2e-openstack-ipi
 - as: openstack-manifests
   run_if_changed: openstack

--- a/ci-operator/config/openshift/installer/openshift-installer-release-4.22.yaml
+++ b/ci-operator/config/openshift/installer/openshift-installer-release-4.22.yaml
@@ -912,7 +912,7 @@ tests:
       resources:
         requests:
           cpu: 100m
-      timeout: 4h0m0s
+      timeout: 7h0m0s
     workflow: openshift-e2e-openstack-ipi
 - as: openstack-manifests
   run_if_changed: openstack

--- a/ci-operator/config/openshift/installer/openshift-installer-release-4.23.yaml
+++ b/ci-operator/config/openshift/installer/openshift-installer-release-4.23.yaml
@@ -912,7 +912,7 @@ tests:
       resources:
         requests:
           cpu: 100m
-      timeout: 4h0m0s
+      timeout: 7h0m0s
     workflow: openshift-e2e-openstack-ipi
 - as: openstack-manifests
   run_if_changed: openstack

--- a/ci-operator/config/openshift/installer/openshift-installer-release-5.0.yaml
+++ b/ci-operator/config/openshift/installer/openshift-installer-release-5.0.yaml
@@ -913,7 +913,7 @@ tests:
       resources:
         requests:
           cpu: 100m
-      timeout: 4h0m0s
+      timeout: 7h0m0s
     workflow: openshift-e2e-openstack-ipi
 - as: openstack-manifests
   run_if_changed: openstack

--- a/ci-operator/config/openshift/installer/openshift-installer-release-5.1.yaml
+++ b/ci-operator/config/openshift/installer/openshift-installer-release-5.1.yaml
@@ -912,7 +912,7 @@ tests:
       resources:
         requests:
           cpu: 100m
-      timeout: 4h0m0s
+      timeout: 7h0m0s
     workflow: openshift-e2e-openstack-ipi
 - as: openstack-manifests
   run_if_changed: openstack

--- a/ci-operator/config/openshift/openstack-test/openshift-openstack-test-main.yaml
+++ b/ci-operator/config/openshift/openstack-test/openshift-openstack-test-main.yaml
@@ -60,7 +60,7 @@ tests:
       resources:
         requests:
           cpu: 100m
-      timeout: 4h0m0s
+      timeout: 7h0m0s
     - ref: openstack-test-openstack
     workflow: openshift-e2e-openstack-ipi
 - always_run: false

--- a/ci-operator/config/openshift/openstack-test/openshift-openstack-test-release-4.19.yaml
+++ b/ci-operator/config/openshift/openstack-test/openshift-openstack-test-release-4.19.yaml
@@ -60,7 +60,7 @@ tests:
       resources:
         requests:
           cpu: 100m
-      timeout: 4h0m0s
+      timeout: 7h0m0s
     - ref: openstack-test-openstack
     workflow: openshift-e2e-openstack-ipi
 - always_run: false

--- a/ci-operator/config/openshift/openstack-test/openshift-openstack-test-release-4.20.yaml
+++ b/ci-operator/config/openshift/openstack-test/openshift-openstack-test-release-4.20.yaml
@@ -60,7 +60,7 @@ tests:
       resources:
         requests:
           cpu: 100m
-      timeout: 4h0m0s
+      timeout: 7h0m0s
     - ref: openstack-test-openstack
     workflow: openshift-e2e-openstack-ipi
 - always_run: false

--- a/ci-operator/config/openshift/openstack-test/openshift-openstack-test-release-4.21.yaml
+++ b/ci-operator/config/openshift/openstack-test/openshift-openstack-test-release-4.21.yaml
@@ -60,7 +60,7 @@ tests:
       resources:
         requests:
           cpu: 100m
-      timeout: 4h0m0s
+      timeout: 7h0m0s
     - ref: openstack-test-openstack
     workflow: openshift-e2e-openstack-ipi
 - always_run: false

--- a/ci-operator/config/openshift/openstack-test/openshift-openstack-test-release-4.22.yaml
+++ b/ci-operator/config/openshift/openstack-test/openshift-openstack-test-release-4.22.yaml
@@ -60,7 +60,7 @@ tests:
       resources:
         requests:
           cpu: 100m
-      timeout: 4h0m0s
+      timeout: 7h0m0s
     - ref: openstack-test-openstack
     workflow: openshift-e2e-openstack-ipi
 - always_run: false

--- a/ci-operator/config/openshift/openstack-test/openshift-openstack-test-release-4.23.yaml
+++ b/ci-operator/config/openshift/openstack-test/openshift-openstack-test-release-4.23.yaml
@@ -60,7 +60,7 @@ tests:
       resources:
         requests:
           cpu: 100m
-      timeout: 4h0m0s
+      timeout: 7h0m0s
     - ref: openstack-test-openstack
     workflow: openshift-e2e-openstack-ipi
 - always_run: false

--- a/ci-operator/config/openshift/openstack-test/openshift-openstack-test-release-5.0.yaml
+++ b/ci-operator/config/openshift/openstack-test/openshift-openstack-test-release-5.0.yaml
@@ -61,7 +61,7 @@ tests:
       resources:
         requests:
           cpu: 100m
-      timeout: 4h0m0s
+      timeout: 7h0m0s
     - ref: openstack-test-openstack
     workflow: openshift-e2e-openstack-ipi
 - always_run: false

--- a/ci-operator/config/openshift/openstack-test/openshift-openstack-test-release-5.1.yaml
+++ b/ci-operator/config/openshift/openstack-test/openshift-openstack-test-release-5.1.yaml
@@ -60,7 +60,7 @@ tests:
       resources:
         requests:
           cpu: 100m
-      timeout: 4h0m0s
+      timeout: 7h0m0s
     - ref: openstack-test-openstack
     workflow: openshift-e2e-openstack-ipi
 - always_run: false

--- a/ci-operator/config/shiftstack/ci/shiftstack-ci-release-4.19.yaml
+++ b/ci-operator/config/shiftstack/ci/shiftstack-ci-release-4.19.yaml
@@ -177,7 +177,7 @@ tests:
       resources:
         requests:
           cpu: 100m
-      timeout: 4h0m0s
+      timeout: 7h0m0s
     - ref: openshift-e2e-test
     - ref: openstack-test-openstack
     workflow: openshift-e2e-openstack-ipi
@@ -202,7 +202,7 @@ tests:
       resources:
         requests:
           cpu: 100m
-      timeout: 4h0m0s
+      timeout: 7h0m0s
     - ref: openshift-e2e-test
     - ref: openstack-test-openstack
     workflow: openshift-e2e-openstack-ipi

--- a/ci-operator/config/shiftstack/ci/shiftstack-ci-release-4.20.yaml
+++ b/ci-operator/config/shiftstack/ci/shiftstack-ci-release-4.20.yaml
@@ -173,7 +173,7 @@ tests:
       resources:
         requests:
           cpu: 100m
-      timeout: 4h0m0s
+      timeout: 7h0m0s
     - ref: openshift-e2e-test
     - ref: openstack-test-openstack
     workflow: openshift-e2e-openstack-ipi
@@ -197,7 +197,7 @@ tests:
       resources:
         requests:
           cpu: 100m
-      timeout: 4h0m0s
+      timeout: 7h0m0s
     - ref: openshift-e2e-test
     - ref: openstack-test-openstack
     workflow: openshift-e2e-openstack-ipi

--- a/ci-operator/config/shiftstack/ci/shiftstack-ci-release-4.21.yaml
+++ b/ci-operator/config/shiftstack/ci/shiftstack-ci-release-4.21.yaml
@@ -173,7 +173,7 @@ tests:
       resources:
         requests:
           cpu: 100m
-      timeout: 4h0m0s
+      timeout: 7h0m0s
     - ref: openshift-e2e-test
     - ref: openstack-test-openstack
     workflow: openshift-e2e-openstack-ipi
@@ -197,7 +197,7 @@ tests:
       resources:
         requests:
           cpu: 100m
-      timeout: 4h0m0s
+      timeout: 7h0m0s
     - ref: openshift-e2e-test
     - ref: openstack-test-openstack
     workflow: openshift-e2e-openstack-ipi

--- a/ci-operator/config/shiftstack/ci/shiftstack-ci-release-4.22.yaml
+++ b/ci-operator/config/shiftstack/ci/shiftstack-ci-release-4.22.yaml
@@ -173,7 +173,7 @@ tests:
       resources:
         requests:
           cpu: 100m
-      timeout: 4h0m0s
+      timeout: 7h0m0s
     - ref: openshift-e2e-test
     - ref: openstack-test-openstack
     workflow: openshift-e2e-openstack-ipi
@@ -197,7 +197,7 @@ tests:
       resources:
         requests:
           cpu: 100m
-      timeout: 4h0m0s
+      timeout: 7h0m0s
     - ref: openshift-e2e-test
     - ref: openstack-test-openstack
     workflow: openshift-e2e-openstack-ipi


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chore — CI configuration**
  * Increase e2e-openstack-ccpmso test timeouts from 4h0m0s to 7h0m0s across CI job definitions. Affects ci-operator/Prow job YAMLs in multiple places including:
    - ci-operator/config/openshift/* (installer, openstack-test) for main and release-4.19 → release-5.1
    - ci-operator/config/openshift-priv/* (installer, openstack-test) for main and release-4.19 → release-5.1
    - ci-operator/config/shiftstack/ci/* (shiftstack CI for release-4.19 → release-4.22)
    - e2e step impacted: openstack-test-cpms (used by e2e-openstack-ccpmso and e2e-openstack-ccpmso-zone)
  * Practical effect: longer allowed execution time for OpenStack CCPMSO E2E tests to reduce spurious timeouts and rehearse failures.

Additional PR metadata:
* Author: gryf
* Jira: [OSASINFRA-4313](https://redhat.atlassian.net/browse/OSASINFRA-4313) (openshift-ci-robot marked the Jira reference valid but warned the Jira target version was missing/invalid)
* The author ran "/pj-rehearse periodic-ci-shiftstack-ci-release-4.22-e2e-openstack-ccpmso" multiple times.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[OSASINFRA-4313]: https://redhat.atlassian.net/browse/OSASINFRA-4313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ