### PR TITLE
Fix test-infra jobs for OSSM 3.4

### DIFF
--- a/ci-operator/config/maistra/test-infra/maistra-test-infra-main.yaml
+++ b/ci-operator/config/maistra/test-infra/maistra-test-infra-main.yaml
@@ -847,7 +847,7 @@ tests:
     dependencies:
       RELEASE_IMAGE_LATEST: release:latest
     env:
-      MAISTRA_BUILDER_IMAGE: quay.io/maistra-dev/maistra-builder:3.4
+      MAISTRA_BUILDER_IMAGE: quay.io/maistra-dev/maistra-builder:3.3
       MAISTRA_NAMESPACE: maistra-e2e-test
       MAISTRA_SC_POD: maistra-e2e-test-sc-pod
     test:
@@ -890,7 +890,7 @@ tests:
       RELEASE_IMAGE_LATEST: release:latest
     env:
       HUB: quay.io/maistra-dev
-      MAISTRA_BUILDER_IMAGE: quay.io/maistra-dev/maistra-builder:3.4
+      MAISTRA_BUILDER_IMAGE: quay.io/maistra-dev/maistra-builder:3.3
       MAISTRA_NAMESPACE: maistra-e2e-test
       MAISTRA_SC_POD: maistra-e2e-test-sc-pod
     test:


### PR DESCRIPTION
Build images must be one version prior, as the current version (3.4) doesn't exist yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD builder configuration to ensure consistent tooling across build environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->