### PR TITLE
KFLUXINFRA-3633 - upgrade the version of the OC cluster that dr-tests uses

### DIFF
--- a/ci-operator/config/redhat-appstudio/infra-deployments/redhat-appstudio-infra-deployments-main.yaml
+++ b/ci-operator/config/redhat-appstudio/infra-deployments/redhat-appstudio-infra-deployments-main.yaml
@@ -127,7 +127,7 @@ tests:
     owner: konflux
     product: ocp
     timeout: 3h0m0s
-    version: "4.17"
+    version: "4.18"
   optional: true
   run_if_changed: ^components/disaster-recovery/.*
   steps:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test environment cluster configuration to support the latest infrastructure version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->