### PR TITLE
Remove reporting of openshift-test-private to lvms channel

### DIFF
--- a/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.16-periodics.yaml
+++ b/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.16-periodics.yaml
@@ -51515,17 +51515,6 @@ periodics:
     job-release: "4.16"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.16-multi-nightly-aws-ipi-sno-lvms-arm-f14
-  reporter_config:
-    slack:
-      channel: '#lvms-release-coordination'
-      job_states_to_report:
-      - error
-      - failure
-      - success
-      report_template: '{{if eq .Status.State "success"}} :rainbow: Job *{{.Spec.Job}}*
-        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :rainbow: {{else}}
-        :volcano: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
-        logs> :volcano: {{end}}'
   spec:
     containers:
     - args:

--- a/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.17-periodics.yaml
+++ b/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.17-periodics.yaml
@@ -63809,17 +63809,6 @@ periodics:
     job-release: "4.17"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.17-multi-nightly-aws-ipi-sno-lvms-arm-f14
-  reporter_config:
-    slack:
-      channel: '#lvms-release-coordination'
-      job_states_to_report:
-      - error
-      - failure
-      - success
-      report_template: '{{if eq .Status.State "success"}} :rainbow: Job *{{.Spec.Job}}*
-        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :rainbow: {{else}}
-        :volcano: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
-        logs> :volcano: {{end}}'
   spec:
     containers:
     - args:

--- a/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.18-periodics.yaml
+++ b/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.18-periodics.yaml
@@ -71601,17 +71601,6 @@ periodics:
     job-release: "4.18"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.18-multi-nightly-aws-ipi-sno-lvms-arm-f14
-  reporter_config:
-    slack:
-      channel: '#lvms-release-coordination'
-      job_states_to_report:
-      - error
-      - failure
-      - success
-      report_template: '{{if eq .Status.State "success"}} :rainbow: Job *{{.Spec.Job}}*
-        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :rainbow: {{else}}
-        :volcano: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
-        logs> :volcano: {{end}}'
   spec:
     containers:
     - args:

--- a/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.19-periodics.yaml
+++ b/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.19-periodics.yaml
@@ -76146,17 +76146,6 @@ periodics:
     job-release: "4.19"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.19-multi-nightly-aws-ipi-sno-lvms-arm-f14
-  reporter_config:
-    slack:
-      channel: '#lvms-release-coordination'
-      job_states_to_report:
-      - error
-      - failure
-      - success
-      report_template: '{{if eq .Status.State "success"}} :rainbow: Job *{{.Spec.Job}}*
-        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :rainbow: {{else}}
-        :volcano: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
-        logs> :volcano: {{end}}'
   spec:
     containers:
     - args:

--- a/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.20-periodics.yaml
+++ b/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.20-periodics.yaml
@@ -78178,17 +78178,6 @@ periodics:
     job-release: "4.20"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.20-multi-nightly-aws-ipi-sno-lvms-arm-f14
-  reporter_config:
-    slack:
-      channel: '#lvms-release-coordination'
-      job_states_to_report:
-      - error
-      - failure
-      - success
-      report_template: '{{if eq .Status.State "success"}} :rainbow: Job *{{.Spec.Job}}*
-        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :rainbow: {{else}}
-        :volcano: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
-        logs> :volcano: {{end}}'
   spec:
     containers:
     - args:

--- a/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.21-periodics.yaml
+++ b/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.21-periodics.yaml
@@ -85092,17 +85092,6 @@ periodics:
     job-release: "4.21"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-4.21-multi-nightly-aws-ipi-sno-lvms-arm-f14
-  reporter_config:
-    slack:
-      channel: '#lvms-release-coordination'
-      job_states_to_report:
-      - error
-      - failure
-      - success
-      report_template: '{{if eq .Status.State "success"}} :rainbow: Job *{{.Spec.Job}}*
-        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :rainbow: {{else}}
-        :volcano: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
-        logs> :volcano: {{end}}'
   spec:
     containers:
     - args:

--- a/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-5.0-periodics.yaml
+++ b/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-5.0-periodics.yaml
@@ -42781,17 +42781,6 @@ periodics:
     job-release: "5.0"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-openshift-tests-private-release-5.0-multi-nightly-aws-ipi-sno-lvms-arm-f7
-  reporter_config:
-    slack:
-      channel: '#lvms-release-coordination'
-      job_states_to_report:
-      - error
-      - failure
-      - success
-      report_template: '{{if eq .Status.State "success"}} :rainbow: Job *{{.Spec.Job}}*
-        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :rainbow: {{else}}
-        :volcano: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
-        logs> :volcano: {{end}}'
   spec:
     containers:
     - args:


### PR DESCRIPTION
Tests are being run from lvm operator repo and we would not want tests running from openshift-test-private to report in the lvms-release-coordination channel, so disabling the same