### PR TITLE
MPIIT: Refactor mpiit-data-router-reporter step

### DIFF
--- a/ci-operator/config/RedHatQE/interop-testing/RedHatQE-interop-testing-master__cnv-odf-ocp-4.22-lp-interop.yaml
+++ b/ci-operator/config/RedHatQE/interop-testing/RedHatQE-interop-testing-master__cnv-odf-ocp-4.22-lp-interop.yaml
@@ -107,7 +107,6 @@ tests:
       OCP_VERSION: "4.22"
       ODF_OPERATOR_CHANNEL: stable-4.20
       ODF_VERSION_MAJOR_MINOR: "4.20"
-      REPORT_TO_DR: "true"
       REPORTPORTAL_CMP: CNV-lp-interop
       USER_TAGS: |
         scenario cnv

--- a/ci-operator/config/RedHatQE/interop-testing/RedHatQE-interop-testing-master__cnv-odf-ocp-4.23-lp-interop.yaml
+++ b/ci-operator/config/RedHatQE/interop-testing/RedHatQE-interop-testing-master__cnv-odf-ocp-4.23-lp-interop.yaml
@@ -107,7 +107,6 @@ tests:
       OCP_VERSION: "4.23"
       ODF_OPERATOR_CHANNEL: stable-4.20
       ODF_VERSION_MAJOR_MINOR: "4.21"
-      REPORT_TO_DR: "true"
       REPORTPORTAL_CMP: CNV-lp-interop
       USER_TAGS: |
         scenario cnv

--- a/ci-operator/config/RedHatQE/interop-testing/RedHatQE-interop-testing-master__ibm-fusion-access-operator-ocp-4.21-lp-interop-cr.yaml
+++ b/ci-operator/config/RedHatQE/interop-testing/RedHatQE-interop-testing-master__ibm-fusion-access-operator-ocp-4.21-lp-interop-cr.yaml
@@ -50,7 +50,6 @@ tests:
       KMM_REGISTRY_URL: ""
       MAP_TESTS: "true"
       OCP_VERSION: "4.21"
-      REPORT_TO_DR: "true"
       REPORTPORTAL_CMP: Fusion-access-lp-interop
       STORAGE_SCALE_CLIENT_CPU: "2"
       STORAGE_SCALE_CLIENT_MEMORY: 4Gi

--- a/ci-operator/config/RedHatQE/interop-testing/RedHatQE-interop-testing-master__ibm-fusion-access-operator-ocp-4.23-lp-interop.yaml
+++ b/ci-operator/config/RedHatQE/interop-testing/RedHatQE-interop-testing-master__ibm-fusion-access-operator-ocp-4.23-lp-interop.yaml
@@ -50,7 +50,6 @@ tests:
       KMM_REGISTRY_URL: ""
       MAP_TESTS: "true"
       OCP_VERSION: "4.23"
-      REPORT_TO_DR: "true"
       REPORTPORTAL_CMP: Fusion-access-lp-interop
       STORAGE_SCALE_CLIENT_CPU: "2"
       STORAGE_SCALE_CLIENT_MEMORY: 4Gi
@@ -97,7 +96,6 @@ tests:
       KMM_REGISTRY_URL: ""
       MAP_TESTS: "true"
       OCP_VERSION: "4.23"
-      REPORT_TO_DR: "true"
       REPORTPORTAL_CMP: Fusion-access-lp-interop
       STORAGE_SCALE_CLIENT_CPU: "2"
       STORAGE_SCALE_CLIENT_MEMORY: 4Gi

--- a/ci-operator/config/oadp-qe/oadp-qe-automation/oadp-qe-oadp-qe-automation-oadp-1.5__oadp1.5-ocp-4.21-lp-interop-cr.yaml
+++ b/ci-operator/config/oadp-qe/oadp-qe-automation/oadp-qe-oadp-qe-automation-oadp-1.5__oadp1.5-ocp-4.21-lp-interop-cr.yaml
@@ -88,7 +88,6 @@ tests:
           {"name": "redhat-oadp-operator", "source": "redhat-operators", "channel": "stable", "install_namespace": "openshift-adp", "target_namespaces": "openshift-adp", "operator_group":"oadp-operator-group"}
         ]
       RE_TRIGGER_ON_FAILURE: "false"
-      REPORT_TO_DR: "true"
       REPORTPORTAL_CMP: OADP-lp-interop
       STORAGE_CLASS: odf-operator-ceph-rbd-virtualization
       USER_TAGS: |

--- a/ci-operator/config/openshift-knative/serverless-operator/openshift-knative-serverless-operator-release-1.37__ocp-4.22-lp-interop.yaml
+++ b/ci-operator/config/openshift-knative/serverless-operator/openshift-knative-serverless-operator-release-1.37__ocp-4.22-lp-interop.yaml
@@ -157,7 +157,6 @@ tests:
       FIREWATCH_DEFAULT_JIRA_ASSIGNEE: maschmid@redhat.com
       FIREWATCH_DEFAULT_JIRA_PROJECT: SRVCOM
       OCP_VERSION: "4.22"
-      REPORT_TO_DR: "true"
       REPORTPORTAL_CMP: Serverless-lp-interop
       USER_TAGS: |
         scenario serverless
@@ -268,7 +267,6 @@ tests:
       FIREWATCH_DEFAULT_JIRA_ASSIGNEE: maschmid@redhat.com
       FIREWATCH_DEFAULT_JIRA_PROJECT: SRVCOM
       OCP_VERSION: "4.22"
-      REPORT_TO_DR: "true"
       REPORTPORTAL_CMP: Serverless-lp-interop
       USER_TAGS: |
         scenario serverless

--- a/ci-operator/config/quay/quay-tests/quay-quay-tests-master__ocp-4.21-quay-cr.yaml
+++ b/ci-operator/config/quay/quay-tests/quay-quay-tests-master__ocp-4.21-quay-cr.yaml
@@ -57,7 +57,6 @@ tests:
       QBO_CHANNEL: stable-3.14
       QUAY_OPERATOR_CHANNEL: stable-3.14
       QUAY_VERSION: "3.14"
-      REPORT_TO_DR: "true"
       REPORTPORTAL_CMP: Quay-lp-interop
       USER_TAGS: |
         scenario quay

--- a/ci-operator/config/quay/quay-tests/quay-quay-tests-master__ocp-4.22-quay-lp-interop.yaml
+++ b/ci-operator/config/quay/quay-tests/quay-quay-tests-master__ocp-4.22-quay-lp-interop.yaml
@@ -57,7 +57,6 @@ tests:
       QBO_CHANNEL: stable-3.16
       QUAY_OPERATOR_CHANNEL: stable-3.16
       QUAY_VERSION: "3.16"
-      REPORT_TO_DR: "true"
       REPORTPORTAL_CMP: Quay-lp-interop
       USER_TAGS: |
         scenario quay
@@ -96,7 +95,6 @@ tests:
       QBO_CHANNEL: stable-3.16
       QUAY_OPERATOR_CHANNEL: stable-3.16
       QUAY_VERSION: "3.16"
-      REPORT_TO_DR: "true"
       REPORTPORTAL_CMP: Quay-lp-interop
       USER_TAGS: |
         scenario quay

--- a/ci-operator/config/quay/quay-tests/quay-quay-tests-master__ocp-4.23-quay-lp-interop.yaml
+++ b/ci-operator/config/quay/quay-tests/quay-quay-tests-master__ocp-4.23-quay-lp-interop.yaml
@@ -57,7 +57,6 @@ tests:
       QBO_CHANNEL: stable-3.16
       QUAY_OPERATOR_CHANNEL: stable-3.16
       QUAY_VERSION: "3.16"
-      REPORT_TO_DR: "true"
       REPORTPORTAL_CMP: Quay-lp-interop
       USER_TAGS: |
         scenario quay
@@ -96,7 +95,6 @@ tests:
       QBO_CHANNEL: stable-3.16
       QUAY_OPERATOR_CHANNEL: stable-3.16
       QUAY_VERSION: "3.16"
-      REPORT_TO_DR: "true"
       REPORTPORTAL_CMP: Quay-lp-interop
       USER_TAGS: |
         scenario quay

--- a/ci-operator/config/red-hat-storage/ocs-ci/red-hat-storage-ocs-ci-master__ocp-4.22-lp-interop.yaml
+++ b/ci-operator/config/red-hat-storage/ocs-ci/red-hat-storage-ocs-ci-master__ocp-4.22-lp-interop.yaml
@@ -52,7 +52,6 @@ tests:
         [
             {"name": "odf-operator", "install_namespace": "openshift-storage", "channel": "stable-4.21", "target_namespaces": "!install", "operator_group": "openshift-storage-operator-group"}
         ]
-      REPORT_TO_DR: "true"
       REPORTPORTAL_CMP: ODF-lp-interop
       USER_TAGS: |
         scenario odf
@@ -92,7 +91,6 @@ tests:
         [
             {"name": "odf-operator", "install_namespace": "openshift-storage", "channel": "stable-4.21","target_namespaces": "!install", "operator_group": "openshift-storage-operator-group"}
         ]
-      REPORT_TO_DR: "true"
       REPORTPORTAL_CMP: ODF-lp-interop
       USER_TAGS: |
         scenario odf

--- a/ci-operator/config/redhat-developer/gitops-operator/redhat-developer-gitops-operator-v1.20__gitops-ocp-4.22-lp-interop.yaml
+++ b/ci-operator/config/redhat-developer/gitops-operator/redhat-developer-gitops-operator-v1.20__gitops-ocp-4.22-lp-interop.yaml
@@ -86,7 +86,6 @@ tests:
         [
             {"name": "openshift-gitops-operator", "source": "redhat-operators", "channel": "latest", "install_namespace": "openshift-gitops-operator", "target_namespaces": "", "operator_group": "global-operators"}
         ]
-      REPORT_TO_DR: "true"
       REPORTPORTAL_CMP: Gitops-lp-interop
       USER_TAGS: |
         scenario gitops

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4.22-lp-interop-acs-latest.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4.22-lp-interop-acs-latest.yaml
@@ -72,7 +72,6 @@ tests:
       FIREWATCH_FAIL_WITH_TEST_FAILURES: "true"
       MAP_TESTS: "true"
       OCP_VERSION: "4.22"
-      REPORT_TO_DR: "true"
       REPORTPORTAL_CMP: ACSLatest-lp-interop
       USER_TAGS: |
         scenario acs

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-4.10__ocp-4-22-lp-interop.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-4.10__ocp-4-22-lp-interop.yaml
@@ -43,7 +43,6 @@ tests:
       FIREWATCH_FAIL_WITH_TEST_FAILURES: "true"
       MAP_TESTS: "true"
       OCP_VERSION: "4.22"
-      REPORT_TO_DR: "true"
       REPORTPORTAL_CMP: ACS-lp-interop
       TEST_SUITE: ocp-compliance-e2e-tests
       USER_TAGS: |

--- a/ci-operator/step-registry/firewatch/ipi/aws/cr/firewatch-ipi-aws-cr-workflow.yaml
+++ b/ci-operator/step-registry/firewatch/ipi/aws/cr/firewatch-ipi-aws-cr-workflow.yaml
@@ -1,8 +1,6 @@
 workflow:
   as: firewatch-ipi-aws-cr
   steps:
-    env:
-        REPORT_TO_DR: "true"
     pre:
       - chain: ipi-aws-pre
     post:

--- a/ci-operator/step-registry/mpiit/data-router-reporter/mpiit-data-router-reporter-commands.sh
+++ b/ci-operator/step-registry/mpiit/data-router-reporter/mpiit-data-router-reporter-commands.sh
@@ -1,59 +1,37 @@
 #!/bin/bash
-set -o nounset
-set -o errexit
-set -o pipefail
+set -euxo pipefail; shopt -s inherit_errexit
 
+# Legacy backward compatibility. TODO: To be removed once all caller are migrated.
+: "${DR__RP__CR_COMP_NAME:=${REPORTPORTAL_CMP}}"
 
-function reportToDataRouter() {
-    if [[ $REPORT_TO_DR == "true" ]]; then
-        if [[ $REPORTPORTAL_CMP == "" ]]; then
-            echo "Required variable 'REPORTPORTAL_CMP' is missing!"
-            exit 1
-        fi
-      datarouter-openshift-ci
+[ -n "${DR__RP__CR_COMP_NAME}" ]
+
+# If `OCP_VERSION` is not set, try to extract it form `JOB_NAME`.
+if [ -z "${OCP_VERSION}" ]; then
+    if [[ "${JOB_NAME}" =~ ocp-([0-9]+\.[0-9]+) ]]; then
+        OCP_VERSION="${BASH_REMATCH[1]}"
+    else
+        OCP_VERSION="unknown"
     fi
-}
+fi
 
-function extractOCPVersion() {
-    # If OCP_VERSION is not set, we don't want to fail the entire launch report process
-    # The version attribute is not essentially required, so extract it from the JOB_NAME
-    if [[ -z "${OCP_VERSION}" ]]; then
-        if [[ "${JOB_NAME}" =~ ocp-([0-9]+\.[0-9]+) ]]; then
-            export OCP_VERSION="${BASH_REMATCH[1]}"
-        else
-            export OCP_VERSION="unknown"
-        fi
-    fi
-    true
-}
+DATAROUTER_RESULTS="${SHARED_DIR}/*.xml" \
+    REPORTPORTAL_LAUNCH_NAME="${DR__RP__CR_COMP_NAME}" \
+    REPORTPORTAL_LAUNCH_ATTRIBUTES="$(
+        jq -nc \
+            --arg jobName "${JOB_NAME}" \
+            --arg buildID "${BUILD_ID}" \
+            --arg ocpVer "${OCP_VERSION}" \
+            --arg crCompName "${DR__RP__CR_COMP_NAME}" \
+            --arg fipsEnabled "${FIPS_ENABLED}" \
+            '[
+                {key: "job_name", value: $jobName},
+                {key: "build_id", value: $buildID},
+                {key: "ocp_release", value: $ocpVer},
+                {key: "ComponentReadiness_ComponentName", value: $crCompName},
+                {key: "fips_enabled", value: $fipsEnabled}
+            ]'
+    )" \
+    datarouter-openshift-ci
 
-export DATAROUTER_RESULTS="${SHARED_DIR}/*.xml"
-export REPORTPORTAL_APPLY_TFA="${APPLY_TFA}"
-export REPORTPORTAL_CMP
-export REPORTPORTAL_HOSTNAME
-export REPORTPORTAL_PROJECT="lp-interop-dr_personal"
-export REPORTPORTAL_LAUNCH_NAME="${REPORTPORTAL_CMP}"
-
-extractOCPVersion
-
-typeset version="${OCP_VERSION}"
-typeset fips="${FIPS_ENABLED}"
-
-REPORTPORTAL_LAUNCH_ATTRIBUTES="$(
-    jq -nc \
-        --arg jobName "${JOB_NAME}" \
-        --arg buildID "${BUILD_ID}" \
-        --arg ocpVer "${version}" \
-        --arg rpCompName "${REPORTPORTAL_CMP}" \
-        --arg fipsEnabled "${fips}" \
-        '[
-            {key: "job_name", value: $jobName},
-            {key: "build_id", value: $buildID},
-            {key: "ocp_release", value: $ocpVer},
-            {key: "component_name", value: $rpCompName},
-            {key: "fips_enabled", value: $fipsEnabled}
-        ]'
-)"
-export REPORTPORTAL_LAUNCH_ATTRIBUTES
-
-reportToDataRouter
+true

--- a/ci-operator/step-registry/mpiit/data-router-reporter/mpiit-data-router-reporter-ref.yaml
+++ b/ci-operator/step-registry/mpiit/data-router-reporter/mpiit-data-router-reporter-ref.yaml
@@ -19,21 +19,27 @@ ref:
       name: mpiit-dr-creds
       mount_path: /datarouter/secrets
   env:
-  - name: REPORT_TO_DR
-    default: "false"
-  - name: APPLY_TFA
+  - name: REPORTPORTAL_APPLY_TFA
     default: "true"
-    documentation: Whether to apply TFA (Test Failure Analysis)
+    documentation: Instructs the Report Portal whether to perform Test Failure Analysis (TFA).
   - name: REPORTPORTAL_HOSTNAME
     default: "reportportal-lp-interop.apps.dno.ocp-hub.prod.psi.redhat.com"
-  - name: OCP_VERSION
-    default: ""
-    documentation: If exists, will be injected as an attribute
+    documentation: Hostname of the Report Portal instance that the Data Router client uses when publishing results.
+  - name: REPORTPORTAL_PROJECT
+    default: "lp-interop-dr_personal"
+    documentation: Report Portal project that receives the uploads produced by this step.
   - name: REPORTPORTAL_CMP
     default: ""
-    documentation: Component (Layered Product) mention for metadata attributes
+    documentation: Deprecated component or launch identifier. See DR__RP__CR_COMP_NAME instead.
+  - name: DR__RP__CR_COMP_NAME
+    default: ""
+    documentation: Layered Product name for Component Readiness (CR), injected into Report Portal launch attributes, and sets launch name.
   - name: FIPS_ENABLED
     default: "false"
-    documentation: Whether FIPS is enabled (true/false); will be injected as an attribute
+    documentation: This information is set as a metadata attribute of the report.
+  - name: OCP_VERSION
+    default: ""
+    documentation: If this is set to an empty string, the Step will attempt to determine the OCP version by parsing the job name (`ocp-*.*`). This information is set as a metadata attribute of the report.
   documentation: |-
-    The step analysis the tests and upload the results to ReportPortal
+    This step uploads the results to [Data Router-Report Portal](https://redhat.atlassian.net/wiki/spaces/CentralCI/pages/133962446/D+O+Data+Router).
+    It supplies Report Portal launch metadata, including the launch name and attributes derived from the job context and from the environment variables documented above.

--- a/ci-operator/step-registry/mpiit/data-router-reporter/mpiit-data-router-reporter-ref.yaml
+++ b/ci-operator/step-registry/mpiit/data-router-reporter/mpiit-data-router-reporter-ref.yaml
@@ -41,5 +41,5 @@ ref:
     default: ""
     documentation: If this is set to an empty string, the Step will attempt to determine the OCP version by parsing the job name (`ocp-*.*`). This information is set as a metadata attribute of the report.
   documentation: |-
-    This step uploads the results to [Data Router-Report Portal](https://redhat.atlassian.net/wiki/spaces/CentralCI/pages/133962446/D+O+Data+Router).
+    This step uploads the results to [Data Router Report Portal](https://redhat.atlassian.net/wiki/display/CentralCI/D%26O+Data+Router).
     It supplies Report Portal launch metadata, including the launch name and attributes derived from the job context and from the environment variables documented above.


### PR DESCRIPTION
Main changes:

- Refactor `mpiit-data-router-reporter` step to be cleaner and simpler, use better practices, and be name consistent with env vars.
- Remove `REPORT_TO_DR` variable. As long as this ref is mentioned in any job, it does not need additional activation logic.

**Update**:
Verified run [(logs)](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/78819/rehearse-78819-periodic-ci-openshift-pipelines-release-tests-release-v1.21-ocp-4.22-lp-interop-cr-openshift-pipelines-aws/2052303880150061056) successfully reports results to DR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
* Affects OpenShift CI configuration and the mpiit step-registry used by many component job definitions (ci-operator/* and ci-operator/step-registry/*).
* Behavior changes
  * The mpiit data-router reporter step was refactored to be simpler and more robust:
    - Script hardened with strict bash flags (set -euxo pipefail; inherit_errexit).
    - The reporter now runs unconditionally (removed conditional REPORT_TO_DR gating).
    - OCP_VERSION is derived from JOB_NAME when not provided (falls back to "unknown").
    - Introduces a backward-compatible alias DR__RP__CR_COMP_NAME (falls back to REPORTPORTAL_CMP) and requires it to be non-empty.
    - The datarouter invocation is inlined (removed helper functions and exported vars) and supplies REPORTPORTAL_LAUNCH_NAME and REPORTPORTAL_LAUNCH_ATTRIBUTES directly.
    - Launch attributes payload now uses key ComponentReadiness_ComponentName instead of component_name and still includes job_name, build_id, ocp_release, and fips_enabled.
  * The step reference metadata (mpiit-data-router-reporter-ref.yaml) was updated:
    - Adds/renames environment variables and documentation: REPORTPORTAL_APPLY_TFA, REPORTPORTAL_HOSTNAME, REPORTPORTAL_PROJECT, DR__RP__CR_COMP_NAME (and documents OCP_VERSION and FIPS_ENABLED behavior).
* CI job configuration updates
  * Many ci-operator job env blocks had REPORT_TO_DR: "true" removed (no runtime activation key needed anymore). Jobs instead keep explicit OCP/ODF/other version and FIREWATCH/REPORTPORTAL settings as appropriate.
  * One ci-operator config adds a redhat-oadp-operator entry to an OPERATORS list for the oadp-interop-aws job.
* Impact summary for reviewers
  * Runtime: reporters will publish to Data Router for jobs that reference the step without requiring REPORT_TO_DR; ensure callers set DR__RP__CR_COMP_NAME / REPORTPORTAL_CMP and other Report Portal envs as needed.
  * Backwards compatibility: DR__RP__CR_COMP_NAME bridges existing REPORTPORTAL_CMP usage, but callers should migrate to the new names and defaults documented in the ref.
  * No public code/APIs changed — only CI step scripts and CI YAML configuration were modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->