### PR TITLE
OCPNODE-4437: Add  CI jobs for DRA example driver E2E tests

### DIFF
--- a/ci-operator/config/openshift/origin/openshift-origin-main.yaml
+++ b/ci-operator/config/openshift/origin/openshift-origin-main.yaml
@@ -838,6 +838,21 @@ tests:
   steps:
     cluster_profile: hypershift-aws
     workflow: hypershift-aws-conformance
+- always_run: false
+  as: e2e-aws-ovn-dra-example
+  optional: true
+  steps:
+    cluster_profile: openshift-org-aws
+    env:
+      TEST_ARGS: --run \[Feature:DRA-Example\]
+      TEST_SUITE: all
+    observers:
+      enable:
+      - observers-resource-watch
+    test:
+    - ref: dra-example-driver-install
+    - ref: openshift-e2e-test
+    workflow: openshift-e2e-aws-ovn
 zz_generated_metadata:
   branch: main
   org: openshift

--- a/ci-operator/jobs/openshift/origin/openshift-origin-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/origin/openshift-origin-main-presubmits.yaml
@@ -694,6 +694,92 @@ presubmits:
     - ^main$
     - ^main-
     cluster: build09
+    context: ci/prow/e2e-aws-ovn-dra-example
+    decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - .ci-operator.yaml
+      - images/hello-openshift/Dockerfile.rhel
+      - images/tests/Dockerfile.rhel
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-origin-main-e2e-aws-ovn-dra-example
+    optional: true
+    rerun_command: /test e2e-aws-ovn-dra-example
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-aws-ovn-dra-example
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-aws-ovn-dra-example,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build09
     context: ci/prow/e2e-aws-ovn-edge-zones
     decorate: true
     decoration_config:


### PR DESCRIPTION
Added optional job to `openshift/origin` for testing dra-example driver functionality on OCP.

New jobs:
- `e2e-aws-ovn-dra-example` - trigger: `/test e2e-aws-ovn-dra-example`

Both jobs provision a cluster, deploy the `dra-example-driver` via the existing step-registry ref (merged in #78156), and run the `[Feature:DRA-Example]` E2E tests added in openshift/origin#31064.

Jobs are `always_run: false` + `optional: true` (manual trigger only, does not block PR merges).

JIRA: https://issues.redhat.com/browse/OCPNODE-4437

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds two optional, manually-triggered E2E CI jobs to the OpenShift Origin CI configuration to validate the dra-example driver:

- e2e-aws-ovn-dra-example — provisions an AWS cluster (openshift-org-aws), deploys the dra-example-driver via the existing step-registry ref, and runs the [Feature:DRA-Example] E2E tests using the openshift-e2e-aws-ovn workflow.

The job is configured as optional: true and always_run: false, they run only when explicitly triggered with the corresponding /test prow command and do not block PR merges. Observers-resource-watch is enabled for these runs. The change updates CI pipeline configuration in ci-operator/config/openshift/origin/openshift-origin-main.yaml to add these test entries and wire them into the existing OCP E2E workflows and driver-install step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[OCPNODE-4437]: https://redhat.atlassian.net/browse/OCPNODE-4437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ