### PR TITLE
NO-JIRA: Move IPI PowerVS to dal10 and lon04

### DIFF
--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.16.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.16.yaml
@@ -541,7 +541,7 @@ tests:
   - sshd-bastion
   cron: 0 0 25 1 *
   steps:
-    cluster_profile: powervs-4
+    cluster_profile: powervs-6
     dependencies:
       OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: release:multi-latest
     env:

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.18.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.18.yaml
@@ -605,7 +605,7 @@ tests:
   - sshd-bastion
   cron: 0 7 * * *
   steps:
-    cluster_profile: powervs-7
+    cluster_profile: powervs-6
     env:
       ARCH: ppc64le
       BRANCH: "4.18"

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.19.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.19.yaml
@@ -603,9 +603,9 @@ tests:
 - as: ocp-e2e-ovn-powervs-capi-multi-p-p
   capabilities:
   - sshd-bastion
-  cron: 0 23 * * *
+  cron: 0 15 * * *
   steps:
-    cluster_profile: powervs-7
+    cluster_profile: powervs-6
     env:
       ARCH: ppc64le
       BRANCH: "4.19"

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.20.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.20.yaml
@@ -609,7 +609,7 @@ tests:
   - sshd-bastion
   cron: 0 1,13 * * *
   steps:
-    cluster_profile: powervs-9
+    cluster_profile: powervs-3
     env:
       ARCH: ppc64le
       BRANCH: "4.20"

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.21.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.21.yaml
@@ -642,7 +642,7 @@ tests:
   - sshd-bastion
   cron: 0 7,19 * * *
   steps:
-    cluster_profile: powervs-8
+    cluster_profile: powervs-3
     env:
       ARCH: ppc64le
       BRANCH: "4.21"

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.22.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.22.yaml
@@ -715,7 +715,7 @@ tests:
   - sshd-bastion
   cron: 0 4,16 * * *
   steps:
-    cluster_profile: powervs-8
+    cluster_profile: powervs-3
     env:
       ARCH: ppc64le
       BRANCH: "4.22"

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.23.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.23.yaml
@@ -684,7 +684,7 @@ tests:
   - sshd-bastion
   cron: 0 10 * * 0,2,4,6
   steps:
-    cluster_profile: powervs-8
+    cluster_profile: powervs-3
     env:
       ARCH: ppc64le
       BRANCH: "4.23"

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-5.0.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-5.0.yaml
@@ -653,9 +653,9 @@ tests:
 - as: ocp-e2e-ovn-powervs-capi-multi-p-p
   capabilities:
   - sshd-bastion
-  cron: 0 22 * * 1,3,5
+  cron: 0 19 * * 1,3,5
   steps:
-    cluster_profile: powervs-9
+    cluster_profile: powervs-6
     env:
       ARCH: ppc64le
       BRANCH: "5.0"

--- a/ci-operator/jobs/openshift/multiarch/openshift-multiarch-main-periodics.yaml
+++ b/ci-operator/jobs/openshift/multiarch/openshift-multiarch-main-periodics.yaml
@@ -18840,8 +18840,8 @@ periodics:
     repo: multiarch
   labels:
     capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: powervs-4
-    ci-operator.openshift.io/cloud-cluster-profile: powervs-4
+    ci-operator.openshift.io/cloud: powervs-6
+    ci-operator.openshift.io/cloud-cluster-profile: powervs-6
     ci-operator.openshift.io/variant: nightly-4.16
     ci.openshift.io/generator: prowgen
     job-release: "4.16"
@@ -27920,8 +27920,8 @@ periodics:
     repo: multiarch
   labels:
     capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: powervs-7
-    ci-operator.openshift.io/cloud-cluster-profile: powervs-7
+    ci-operator.openshift.io/cloud: powervs-6
+    ci-operator.openshift.io/cloud-cluster-profile: powervs-6
     ci-operator.openshift.io/variant: nightly-4.18
     ci.openshift.io/generator: prowgen
     job-release: "4.18"
@@ -32658,7 +32658,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build01
-  cron: 0 23 * * *
+  cron: 0 15 * * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -32668,8 +32668,8 @@ periodics:
     repo: multiarch
   labels:
     capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: powervs-7
-    ci-operator.openshift.io/cloud-cluster-profile: powervs-7
+    ci-operator.openshift.io/cloud: powervs-6
+    ci-operator.openshift.io/cloud-cluster-profile: powervs-6
     ci-operator.openshift.io/variant: nightly-4.19
     ci.openshift.io/generator: prowgen
     job-release: "4.19"
@@ -37834,8 +37834,8 @@ periodics:
     repo: multiarch
   labels:
     capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: powervs-9
-    ci-operator.openshift.io/cloud-cluster-profile: powervs-9
+    ci-operator.openshift.io/cloud: powervs-3
+    ci-operator.openshift.io/cloud-cluster-profile: powervs-3
     ci-operator.openshift.io/variant: nightly-4.20
     ci.openshift.io/generator: prowgen
     job-release: "4.20"
@@ -43253,8 +43253,8 @@ periodics:
     repo: multiarch
   labels:
     capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: powervs-8
-    ci-operator.openshift.io/cloud-cluster-profile: powervs-8
+    ci-operator.openshift.io/cloud: powervs-3
+    ci-operator.openshift.io/cloud-cluster-profile: powervs-3
     ci-operator.openshift.io/variant: nightly-4.21
     ci.openshift.io/generator: prowgen
     job-release: "4.21"
@@ -48672,8 +48672,8 @@ periodics:
     repo: multiarch
   labels:
     capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: powervs-8
-    ci-operator.openshift.io/cloud-cluster-profile: powervs-8
+    ci-operator.openshift.io/cloud: powervs-3
+    ci-operator.openshift.io/cloud-cluster-profile: powervs-3
     ci-operator.openshift.io/variant: nightly-4.22
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
@@ -54511,8 +54511,8 @@ periodics:
     repo: multiarch
   labels:
     capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: powervs-8
-    ci-operator.openshift.io/cloud-cluster-profile: powervs-8
+    ci-operator.openshift.io/cloud: powervs-3
+    ci-operator.openshift.io/cloud-cluster-profile: powervs-3
     ci-operator.openshift.io/variant: nightly-4.23
     ci.openshift.io/generator: prowgen
     job-release: "4.23"
@@ -61682,7 +61682,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build01
-  cron: 0 22 * * 1,3,5
+  cron: 0 19 * * 1,3,5
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -61692,8 +61692,8 @@ periodics:
     repo: multiarch
   labels:
     capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: powervs-9
-    ci-operator.openshift.io/cloud-cluster-profile: powervs-9
+    ci-operator.openshift.io/cloud: powervs-6
+    ci-operator.openshift.io/cloud-cluster-profile: powervs-6
     ci-operator.openshift.io/variant: nightly-5.0
     ci.openshift.io/generator: prowgen
     job-release: "5.0"


### PR DESCRIPTION
This PR:

1. Changes the PowerVS CI we are monitoring to dal10 and lon04 regions
lon04 (powervs-6) - Daily/less frequent jobs:
• 4.16, 4.18, 4.19, 5.0
dal10 (powervs-3) - High-frequency jobs:
• 4.20, 4.21, 4.22, 4.23

2. Adjusted the timing for 4.19 and 5.0 to maintain at least 3-hour gaps between all jobs in each region.

3. Move 4.16 from wdc06 to lon04

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI test infrastructure configurations across multiple OpenShift nightly build versions to optimize cluster profile assignments for PowerVS test environments.
  * Adjusted test scheduling for specific build versions to improve test execution timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->