### PR TITLE
OCPBUGS-84702: Skip snapshot tests in vSphere clusters with host groups

### DIFF
--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.19.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.19.yaml
@@ -576,6 +576,7 @@ tests:
     cluster_profile: vsphere-elastic
     env:
       FEATURE_SET: TechPreviewNoUpgrade
+      TEST_SKIPS: Feature:VolumeSnapshotDataSource
     workflow: openshift-e2e-vsphere-host-groups-csi
 - as: e2e-vsphere-ovn-multi-vcenter-csi
   cron: 26 8 * * 1

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.20.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.20.yaml
@@ -672,6 +672,7 @@ tests:
     cluster_profile: vsphere-elastic
     env:
       FEATURE_SET: TechPreviewNoUpgrade
+      TEST_SKIPS: Feature:VolumeSnapshotDataSource
     workflow: openshift-e2e-vsphere-host-groups-csi
 - as: e2e-vsphere-ovn-zones
   cron: 12 1 * * 4

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.21.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.21.yaml
@@ -716,6 +716,7 @@ tests:
     cluster_profile: vsphere-elastic
     env:
       FEATURE_SET: TechPreviewNoUpgrade
+      TEST_SKIPS: Feature:VolumeSnapshotDataSource
     workflow: openshift-e2e-vsphere-host-groups-csi
 - as: e2e-vsphere-ovn-zones
   cron: 22 16 * * 0

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22.yaml
@@ -1074,6 +1074,8 @@ tests:
   cron: 36 3 * * 0
   steps:
     cluster_profile: vsphere-elastic
+    env:
+      TEST_SKIPS: Feature:VolumeSnapshotDataSource
     workflow: openshift-e2e-vsphere-host-groups-csi
 - as: e2e-vsphere-ovn-zones
   cron: 16 0 * * 5

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.23.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.23.yaml
@@ -1037,6 +1037,8 @@ tests:
   cron: 36 3 * * 0
   steps:
     cluster_profile: vsphere-elastic
+    env:
+      TEST_SKIPS: Feature:VolumeSnapshotDataSource
     workflow: openshift-e2e-vsphere-host-groups-csi
 - as: e2e-vsphere-ovn-zones
   cron: 16 0 * * 5

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
@@ -1180,6 +1180,8 @@ tests:
   cron: 42 0 * * 5
   steps:
     cluster_profile: vsphere-elastic
+    env:
+      TEST_SKIPS: Feature:VolumeSnapshotDataSource
     workflow: openshift-e2e-vsphere-host-groups-csi
 - as: e2e-vsphere-ovn-zones
   cron: 44 16 * * 5


### PR DESCRIPTION
Our CI sets up vSphere with host groups in a way that each topology (host group) has its own datastore and there is no shared datastore among all hosts.

A snapshot of a volume can then be used only in the host group with the original volume. Kubernetes does not track topology of snapshots (only of PVs) and thus may try to restore the snapshot in a host group where the snapshot is not accessible. Snapshot tests then randomly fail.

See https://github.com/kubernetes/enhancements/issues/5943 for an upstream feature. We need to disable the snapshot tests until it's implemented upstream.

Only modification of host-groups-csi jobs is needed, only these jobs run snapshot tests with the real vSphere storage. Regular, non-csi e2e jobs run snapshot tests with a mock CSI driver that is not affected by topology.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated nightly test configs (OpenShift 4.19–5.0) to skip the VolumeSnapshotDataSource feature test in the vSphere OVN host-groups CSI tech-preview e2e jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->