### PR TITLE
no-jira: Fix registry authentication in ipi-conf-gcp-oidc-creds-deprovision step

### DIFF
--- a/ci-operator/step-registry/ipi/conf/gcp/oidc-creds-deprovision/ipi-conf-gcp-oidc-creds-deprovision-commands.sh
+++ b/ci-operator/step-registry/ipi/conf/gcp/oidc-creds-deprovision/ipi-conf-gcp-oidc-creds-deprovision-commands.sh
@@ -16,7 +16,7 @@ export GOOGLE_APPLICATION_CREDENTIALS="${GCP_SHARED_CREDENTIALS_FILE}"
 PROJECT="$(< ${CLUSTER_PROFILE_DIR}/openshift_gcp_project)"
 
 echo "RELEASE_IMAGE_LATEST: ${RELEASE_IMAGE_LATEST}"
-# RELEASE_IMAGE_LATEST_FROM_BUILD_FARM is pointed to the same image as RELEASE_IMAGE_LATEST, 
+# RELEASE_IMAGE_LATEST_FROM_BUILD_FARM is pointed to the same image as RELEASE_IMAGE_LATEST,
 # but for some ci jobs triggerred by remote api, RELEASE_IMAGE_LATEST might be overridden with tag name, to avoid auth error
 # when accessing it, always use build farm registry pullspec.
 echo "RELEASE_IMAGE_LATEST_FROM_BUILD_FARM: ${RELEASE_IMAGE_LATEST_FROM_BUILD_FARM}"
@@ -27,7 +27,21 @@ echo "RELEASE_IMAGE_LATEST_FROM_BUILD_FARM: ${RELEASE_IMAGE_LATEST_FROM_BUILD_FA
 # for deprovision.
 # https://docs.ci.openshift.org/docs/architecture/step-registry/#sharing-data-between-steps
 echo "> Extract gcp credentials requests from the release image"
-oc adm release extract --credentials-requests --cloud=gcp --to="/tmp/credrequests" "${RELEASE_IMAGE_LATEST_FROM_BUILD_FARM}"
+dir="$(mktemp -d)"
+pushd "${dir}" >/dev/null
+cleanup() {
+  rm -f pull-secret
+  popd >/dev/null || true
+  rm -rf "${dir}"
+}
+trap cleanup EXIT
+
+cp "${CLUSTER_PROFILE_DIR}/pull-secret" pull-secret
+# After cluster is set up, ci-operator make KUBECONFIG pointing to the installed cluster,
+# to make "oc registry login" interact with the build farm, set KUBECONFIG to empty,
+# so that the credentials of the build farm registry can be saved in docker client config file.
+KUBECONFIG="" oc registry login --to pull-secret
+oc adm release extract --registry-config pull-secret --credentials-requests --cloud=gcp --to="/tmp/credrequests" "${RELEASE_IMAGE_LATEST_FROM_BUILD_FARM}"
 
 echo "> Output gcp credentials requests to directory: /tmp/credrequests"
 ls "/tmp/credrequests"

--- a/ci-operator/step-registry/ipi/conf/gcp/oidc-creds-deprovision/ipi-conf-gcp-oidc-creds-deprovision-ref.yaml
+++ b/ci-operator/step-registry/ipi/conf/gcp/oidc-creds-deprovision/ipi-conf-gcp-oidc-creds-deprovision-ref.yaml
@@ -3,6 +3,7 @@ ref:
   from: cloud-credential-operator
   cli: latest
   commands: ipi-conf-gcp-oidc-creds-deprovision-commands.sh
+  grace_period: 10m
   resources:
     requests:
       cpu: 10m


### PR DESCRIPTION
The step was failing with "unauthorized: authentication required" when extracting credentials requests from the CI registry. Added the standard authentication pattern (copy pull-secret, oc registry login, use --registry-config) that all other credential provision/deprovision steps use to authenticate to the registry before extracting release images.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of pull secrets during credential extraction to make the process more robust.
  * Added automatic cleanup of temporary pull-secret copies (ensures removal of sensitive temporary data).
* **Chores**
  * Increased the deprovision step grace period to 10 minutes to reduce premature termination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->