### PR TITLE
MPIIT: Remove ocs tests from CNV scenario

### DIFF
--- a/ci-operator/config/RedHatQE/interop-testing/RedHatQE-interop-testing-master__cnv-odf-ocp-4.22-lp-interop.yaml
+++ b/ci-operator/config/RedHatQE/interop-testing/RedHatQE-interop-testing-master__cnv-odf-ocp-4.22-lp-interop.yaml
@@ -72,7 +72,6 @@ tests:
     test:
     - chain: cucushift-installer-check-cluster-health
     - ref: interop-tests-deploy-odf
-    - ref: interop-tests-ocs-tests
     - ref: interop-tests-cnv-tests-e2e-deploy
     - ref: interop-tests-openshift-virtualization-tests
     workflow: firewatch-ipi-aws-cr
@@ -115,7 +114,6 @@ tests:
     test:
     - chain: cucushift-installer-check-cluster-health
     - ref: interop-tests-deploy-odf
-    - ref: interop-tests-ocs-tests
     - ref: interop-tests-cnv-tests-e2e-deploy
     - ref: interop-tests-openshift-virtualization-tests
     workflow: firewatch-ipi-aws-cr

--- a/ci-operator/config/RedHatQE/interop-testing/RedHatQE-interop-testing-master__cnv-odf-ocp-4.23-lp-interop.yaml
+++ b/ci-operator/config/RedHatQE/interop-testing/RedHatQE-interop-testing-master__cnv-odf-ocp-4.23-lp-interop.yaml
@@ -72,7 +72,6 @@ tests:
     test:
     - chain: cucushift-installer-check-cluster-health
     - ref: interop-tests-deploy-odf
-    - ref: interop-tests-ocs-tests
     - ref: interop-tests-cnv-tests-e2e-deploy
     - ref: interop-tests-openshift-virtualization-tests
     workflow: firewatch-ipi-aws-cr
@@ -115,7 +114,6 @@ tests:
     test:
     - chain: cucushift-installer-check-cluster-health
     - ref: interop-tests-deploy-odf
-    - ref: interop-tests-ocs-tests
     - ref: interop-tests-cnv-tests-e2e-deploy
     - ref: interop-tests-openshift-virtualization-tests
     workflow: firewatch-ipi-aws-cr


### PR DESCRIPTION
Per the CNV scenario improvement work, we remove post-deployment ODF tests to reduce runtime. 
Single-product ODF test coverage is not required for this CNV testing job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed OCS tests from CNV-ODF interop testing workflows for OCP versions 4.22 and 4.23, streamlining the test execution sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->