### PR TITLE
fix: manually sync OWNERS file until bug is fixed in autoowners

### DIFF
--- a/ci-operator/config/openshift/osde2e/OWNERS
+++ b/ci-operator/config/openshift/osde2e/OWNERS
@@ -4,15 +4,30 @@
 # Logins who are not members of 'openshift' organization were filtered out
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
-approvers:
-- christophermancini
-- ritmun
-- varunraokadaparthi
-- yiqinzhang
-options: {}
 reviewers:
-- christophermancini
-- minlei98
-- ritmun
-- varunraokadaparthi
-- yiqinzhang
+  - ritmun
+  - yiqinzhang
+  - varunraokadaparthi
+  - christophermancini
+  - minlei98
+approvers:
+  - ritmun
+  - yiqinzhang
+  - varunraokadaparthi
+  - christophermancini
+
+filters:
+  # Nightly job YAML files in openshift/release repo - ROSA engineers can approve
+  # Pattern: openshift-osde2e-main__nightly-*.yaml
+  # These files don't exist in osde2e repo, so this filter has no effect here
+  # Other files (openshift-osde2e-main.yaml, .config.prowgen, OWNERS) fall back to top-level approvers
+  "^openshift-osde2e-main__nightly-.*\\.yaml$":
+    approvers:
+      - bmeng
+      - dustman9000
+      - smarthall
+      - ravitri
+      - ritmun
+      - yiqinzhang
+      - varunraokadaparthi
+      - christophermancini


### PR DESCRIPTION
Manually syncing the OWNERS file till this bug is fixed in ci-tools repo: https://github.com/openshift/ci-tools/pull/5128

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code ownership and approval configuration to reorganize reviewer and approver assignments with enhanced file-matching rules for specific build configurations.

---

**Note:** This change is internal operational configuration with no impact on product functionality or end-user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->