### PR TITLE
aro-hcp: fix custom-link-tools subscription-id lookup broken by #78619 for INT/STG/PROD

### DIFF
--- a/ci-operator/step-registry/aro-hcp/gather/custom-link-tools/aro-hcp-gather-custom-link-tools-commands.sh
+++ b/ci-operator/step-registry/aro-hcp/gather/custom-link-tools/aro-hcp-gather-custom-link-tools-commands.sh
@@ -7,16 +7,12 @@ set -o xtrace
 export CLUSTER_PROFILE_DIR="/var/run/aro-hcp-${VAULT_SECRET_PROFILE}"
 
 export AZURE_TOKEN_CREDENTIALS=prod
-INFRA_SUB_FILE="${CLUSTER_PROFILE_DIR}/infra-${ARO_HCP_DEPLOY_ENV}-subscription-id"
-FALLBACK_SUB_FILE="${CLUSTER_PROFILE_DIR}/subscription-id"
-if [[ -s "${INFRA_SUB_FILE}" ]]; then
-  SUBSCRIPTION_ID=$(cat "${INFRA_SUB_FILE}")
-elif [[ -s "${FALLBACK_SUB_FILE}" ]]; then
-  SUBSCRIPTION_ID=$(cat "${FALLBACK_SUB_FILE}")
-else
-  echo "No subscription-id file found in ${CLUSTER_PROFILE_DIR}"
+SUB_FILE="${CLUSTER_PROFILE_DIR}/subscription-id"
+if [[ ! -s "${SUB_FILE}" ]]; then
+  echo "No subscription-id file found at ${SUB_FILE}"
   exit 1
 fi
+SUBSCRIPTION_ID=$(cat "${SUB_FILE}")
 
 START_TIME_FALLBACK_ARGS=""
 if [[ -f "${SHARED_DIR}/write-config-timestamp-rfc3339" ]]; then

--- a/ci-operator/step-registry/aro-hcp/gather/custom-link-tools/aro-hcp-gather-custom-link-tools-commands.sh
+++ b/ci-operator/step-registry/aro-hcp/gather/custom-link-tools/aro-hcp-gather-custom-link-tools-commands.sh
@@ -7,7 +7,16 @@ set -o xtrace
 export CLUSTER_PROFILE_DIR="/var/run/aro-hcp-${VAULT_SECRET_PROFILE}"
 
 export AZURE_TOKEN_CREDENTIALS=prod
-SUBSCRIPTION_ID=$(cat "${CLUSTER_PROFILE_DIR}/infra-${ARO_HCP_DEPLOY_ENV}-subscription-id")
+INFRA_SUB_FILE="${CLUSTER_PROFILE_DIR}/infra-${ARO_HCP_DEPLOY_ENV}-subscription-id"
+FALLBACK_SUB_FILE="${CLUSTER_PROFILE_DIR}/subscription-id"
+if [[ -s "${INFRA_SUB_FILE}" ]]; then
+  SUBSCRIPTION_ID=$(cat "${INFRA_SUB_FILE}")
+elif [[ -s "${FALLBACK_SUB_FILE}" ]]; then
+  SUBSCRIPTION_ID=$(cat "${FALLBACK_SUB_FILE}")
+else
+  echo "No subscription-id file found in ${CLUSTER_PROFILE_DIR}"
+  exit 1
+fi
 
 START_TIME_FALLBACK_ARGS=""
 if [[ -f "${SHARED_DIR}/write-config-timestamp-rfc3339" ]]; then


### PR DESCRIPTION
### What

Fix the `aro-hcp-gather-custom-link-tools` step to fall back to `subscription-id` when `infra-{env}-subscription-id` doesn't exist in the cluster profile.

### Why

PR #78619 ("ARO-HCP: Use ARO_HCP_DEPLOY_ENV to determine env", merged May 4) changed the script to read `infra-${ARO_HCP_DEPLOY_ENV}-subscription-id`. But the INT, STG, and PROD cluster profiles don't have this file — they have `subscription-id` instead. The script fails silently (best_effort step) and produces no HTML artifacts, causing the Prow Spyglass dashboard to be missing the Commands, Test Logs, and Component logs sections.

**All three environments are broken:**
- INT: `cat /var/run/aro-hcp-int/infra-int-subscription-id: No such file or directory` — [2051512173166858240](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/branch-ci-Azure-ARO-HCP-main-e2e-integration-e2e-parallel/2051512173166858240)
- STG: `cat /var/run/aro-hcp-stg/infra-stg-subscription-id: No such file or directory` — [2051482060391976960](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-Azure-ARO-HCP-main-periodic-stage-e2e-parallel/2051482060391976960)
- PROD: `cat /var/run/aro-hcp-prod/infra-prod-subscription-id: No such file or directory` — [2051571821928517632](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/branch-ci-Azure-ARO-HCP-main-e2e-prod-e2e-parallel/2051571821928517632)

**Last working run** (before #78619): [2051119706273746944](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-Azure-ARO-HCP-main-periodic-stage-e2e-parallel/2051119706273746944) — used old script with `subscription-id`, has all HTML artifacts.

### Fix

Try `infra-{env}-subscription-id` first (works for dev where infra subscriptions are sharded), fall back to `subscription-id` (works for int/stg/prod profiles with a single subscription file).

### JIRA

[ARO-26757](https://redhat.atlassian.net/browse/ARO-26757)

[ARO-26757]: https://redhat.atlassian.net/browse/ARO-26757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ