### PR TITLE
ART-14615 Update 4.20 repos to RHEL 9.6 to match ART base image

### DIFF
--- a/core-services/release-controller/_repos/ocp-4.20-rhel9.repo
+++ b/core-services/release-controller/_repos/ocp-4.20-rhel9.repo
@@ -1,6 +1,6 @@
 [rhel-9-baseos]
 name = rhel-9-baseos
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/x86_64/baseos/os/
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.6/x86_64/baseos/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -12,7 +12,7 @@ failovermethod = priority
 
 [rhel-9-appstream]
 name = rhel-9-appstream
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/x86_64/appstream/os/
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.6/x86_64/appstream/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -36,7 +36,7 @@ failovermethod = priority
 
 [rhel-9-nfv]
 name = rhel-9-nfv
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/x86_64/nfv/os/
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.6/x86_64/nfv/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -60,7 +60,7 @@ skip_if_unavailable = true
 
 [rhel-9-codeready-builder-rpms]
 name = rhel-9-codeready-builder-rpms
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/codeready-builder/os/
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/codeready-builder/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -72,7 +72,7 @@ failovermethod = priority
 
 [rhel-9-baseos-ppc64le]
 name = rhel-9-baseos-ppc64le
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/ppc64le/baseos/os/
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.6/ppc64le/baseos/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -84,7 +84,7 @@ failovermethod = priority
 
 [rhel-9-appstream-ppc64le]
 name = rhel-9-appstream-ppc64le
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/ppc64le/appstream/os/
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.6/ppc64le/appstream/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -120,7 +120,7 @@ skip_if_unavailable = true
 
 [rhel-9-codeready-builder-rpms-ppc64le]
 name = rhel-9-codeready-builder-rpms-ppc64le
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/ppc64le/codeready-builder/os/
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/codeready-builder/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -132,7 +132,7 @@ failovermethod = priority
 
 [rhel-9-baseos-s390x]
 name = rhel-9-baseos-s390x
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/s390x/baseos/os/
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.6/s390x/baseos/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -144,7 +144,7 @@ failovermethod = priority
 
 [rhel-9-appstream-s390x]
 name = rhel-9-appstream-s390x
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/s390x/appstream/os/
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.6/s390x/appstream/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -180,7 +180,7 @@ skip_if_unavailable = true
 
 [rhel-9-codeready-builder-rpms-s390x]
 name = rhel-9-codeready-builder-rpms-s390x
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/s390x/codeready-builder/os/
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/codeready-builder/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -192,7 +192,7 @@ failovermethod = priority
 
 [rhel-9-baseos-aarch64]
 name = rhel-9-baseos-aarch64
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/aarch64/baseos/os/
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.6/aarch64/baseos/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -204,7 +204,7 @@ failovermethod = priority
 
 [rhel-9-appstream-aarch64]
 name = rhel-9-appstream-aarch64
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/aarch64/appstream/os/
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.6/aarch64/appstream/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
@@ -240,7 +240,7 @@ skip_if_unavailable = true
 
 [rhel-9-codeready-builder-rpms-aarch64]
 name = rhel-9-codeready-builder-rpms-aarch64
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/aarch64/codeready-builder/os/
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/codeready-builder/os/
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false


### PR DESCRIPTION
## Summary
Update `ocp-4.20-rhel9.repo` to use RHEL 9.6 (from 9.4) to align with the `base-rhel9` image built by ART, which uses RHEL 9.6 repos.

## Problem
CI build failures in ovn-kubernetes and other components where the base image contains packages from RHEL 9.6 (e.g., `iproute-6.11.0-1.el9`) but CI repo files only provide RHEL 9.4 packages (e.g., `iproute-6.2.0-6.el9_4`), causing DNF dependency conflicts.

## Evidence
- Base image: `Red Hat Enterprise Linux release 9.6 (Plow)`
- Base image has: `iproute-6.11.0-1.el9`
- RHEL 9.4 repos: latest is `iproute-6.2.0-6.el9_4` (no 6.11.0)
- RHEL 9.6 repos: has `iproute-6.11.0-1.el9` ✓

When Dockerfile runs `dnf install iproute-tc` with 9.4 repos, it tries to install `iproute-tc-6.2.0` which requires exact match `iproute = 6.2.0`, but base has `6.11.0` → conflict.

## Solution
Update `ocp-4.20-rhel9.repo` to use RHEL 9.6 repos to match the base image.

The version-specific repo files (`ocp-4.20-rhel92.repo`, `ocp-4.20-rhel94.repo`, `ocp-4.20-rhel96.repo`) remain unchanged at their respective versions.

## Changes
- 13 lines changed in `core-services/release-controller/_repos/ocp-4.20-rhel9.repo`
- All architectures: x86_64, ppc64le, s390x, aarch64
- Changed from: `https://cdn.redhat.com/content/e4s/rhel9/9.4/...`
- Changed to: `https://cdn.redhat.com/content/e4s/rhel9/9.6/...`

## Related
- Supersedes: #78810
- Failure logs: https://storage.googleapis.com/test-platform-results/pr-logs/pull/openshift_ovn-kubernetes/3070/pull-ci-openshift-ovn-kubernetes-release-4.20-images/2051655787121479680/build-log.txt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated system repository configuration to reference the latest RHEL 9 content paths across all supported architectures (x86_64, ppc64le, s390x, aarch64) for base OS, application stream, NFV, and development tools repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->