### PR TITLE
qci-pruner set REGISTRY_AUTH_FILE for oc adm release info pulls

### DIFF
--- a/hack/qci_registry_pruner.py
+++ b/hack/qci_registry_pruner.py
@@ -256,7 +256,18 @@ def get_release_component_images(payload_pullspec: str) -> List[Dict[str, str]]:
         # For that, we would need to get image info for all architectures.
         # Here, we assume a single manifest.
         cmd = ["oc", "adm", "release", "info", "--output=json", payload_pullspec]
-        result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=300)
+        dockerconfig_json = os.getenv(QUAY_DOCKERCONFIGJSON_PATH_ENV_NAME)
+        run_env = os.environ.copy()
+        if dockerconfig_json:
+            run_env["REGISTRY_AUTH_FILE"] = dockerconfig_json
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=300,
+            env=run_env,
+        )
 
         data = json.loads(result.stdout)
         tags = data.get("references", {}).get("spec", {}).get("tags", [])


### PR DESCRIPTION
Fixing https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-openshift-release-qci-pruner/2051451952310521856#1:build-log.txt%3A3121 

/cc @openshift/test-platform 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced authentication credential handling in registry pruning infrastructure tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->