### PR TITLE
Increase rh-ecosystem-edge ocp-4-17-0 clusterpool runningCount to 6

### DIFF
--- a/clusters/hosted-mgmt/hive/pools/rh-ecosystem-edge/ocp-4-17-0_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/rh-ecosystem-edge/ocp-4-17-0_clusterpool.yaml
@@ -29,7 +29,7 @@ spec:
       region: us-east-1
   pullSecretRef:
     name: pull-secret
-  runningCount: 1
+  runningCount: 6
   size: 6
   skipMachinePools: true
 status:


### PR DESCRIPTION
/cc @ybettan 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure Updates**
  * Increased available cluster instances from 1 to 6, expanding capacity and resource availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->