### PR TITLE
Onboard openshift-eng/ship-hook

### DIFF
--- a/ci-operator/config/openshift-eng/ship-hook/OWNERS
+++ b/ci-operator/config/openshift-eng/ship-hook/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+- petr-muller

--- a/ci-operator/config/openshift-eng/ship-hook/openshift-eng-ship-hook-main.yaml
+++ b/ci-operator/config/openshift-eng/ship-hook/openshift-eng-ship-hook-main.yaml
@@ -1,0 +1,41 @@
+binary_build_commands: make
+build_root:
+  project_image:
+    dockerfile_path: Dockerfile.buildroot
+images:
+  items:
+  - dockerfile_path: images/ship-hook/Dockerfile
+    inputs:
+      bin:
+        paths:
+        - destination_dir: _output
+          source_path: /go/src/github.com/openshift-eng/ship-hook/_output/ship-hook
+    to: ship-hook
+promotion:
+  to:
+  - namespace: ci
+    tag: latest
+resources:
+  '*':
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: verify
+  commands: make verify
+  container:
+    from: src
+- as: unit
+  commands: make test
+  container:
+    from: src
+- as: integration
+  commands: make integration-test
+  container:
+    from: src
+zz_generated_metadata:
+  branch: main
+  org: openshift-eng
+  repo: ship-hook

--- a/ci-operator/jobs/openshift-eng/ship-hook/OWNERS
+++ b/ci-operator/jobs/openshift-eng/ship-hook/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+- petr-muller

--- a/ci-operator/jobs/openshift-eng/ship-hook/openshift-eng-ship-hook-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift-eng/ship-hook/openshift-eng-ship-hook-main-postsubmits.yaml
@@ -1,0 +1,62 @@
+postsubmits:
+  openshift-eng/ship-hook:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    cluster: build01
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/is-promotion: "true"
+      ci.openshift.io/generator: prowgen
+    max_concurrency: 1
+    name: branch-ci-openshift-eng-ship-hook-main-images
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --image-mirror-push-secret=/etc/push-secret/.dockerconfigjson
+        - --promote
+        - --report-credentials-file=/etc/report/credentials
+        - --target=[images]
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/push-secret
+          name: push-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: push-secret
+        secret:
+          secretName: registry-push-credentials-ci-central
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator

--- a/ci-operator/jobs/openshift-eng/ship-hook/openshift-eng-ship-hook-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-eng/ship-hook/openshift-eng-ship-hook-main-presubmits.yaml
@@ -1,0 +1,246 @@
+presubmits:
+  openshift-eng/ship-hook:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build01
+    context: ci/prow/images
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-eng-ship-hook-main-images
+    rerun_command: /test images
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=[images]
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )images,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build01
+    context: ci/prow/integration
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-eng-ship-hook-main-integration
+    rerun_command: /test integration
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=integration
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )integration,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build01
+    context: ci/prow/unit
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-eng-ship-hook-main-unit
+    rerun_command: /test unit
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=unit
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )unit,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build01
+    context: ci/prow/verify
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-eng-ship-hook-main-verify
+    rerun_command: /test verify
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=verify
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify,?($|\s.*)

--- a/core-services/prow/02_config/openshift-eng/ship-hook/OWNERS
+++ b/core-services/prow/02_config/openshift-eng/ship-hook/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+- petr-muller

--- a/core-services/prow/02_config/openshift-eng/ship-hook/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-eng/ship-hook/_pluginconfig.yaml
@@ -1,0 +1,56 @@
+approve:
+- lgtm_acts_as_approve: true
+  repos:
+  - openshift-eng/ship-hook
+  require_self_approval: false
+external_plugins:
+  openshift-eng/ship-hook:
+  - endpoint: http://refresh
+    events:
+    - issue_comment
+    name: refresh
+  - endpoint: http://needs-rebase
+    events:
+    - issue_comment
+    - pull_request
+    name: needs-rebase
+  - endpoint: http://pipeline-controller
+    events:
+    - pull_request
+    - issue_comment
+    name: pipeline-controller
+lgtm:
+- repos:
+  - openshift-eng/ship-hook
+  review_acts_as_lgtm: true
+plugins:
+  openshift-eng/ship-hook:
+    plugins:
+    - assign
+    - cat
+    - dog
+    - heart
+    - help
+    - hold
+    - jira
+    - label
+    - lgtm
+    - lifecycle
+    - override
+    - pony
+    - retitle
+    - shrug
+    - skip
+    - trigger
+    - verify-owners
+    - owners-label
+    - wip
+    - yuks
+    - approve
+triggers:
+- org_invite:
+    prominent: {}
+  repos:
+  - openshift-eng/ship-hook
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-eng/ship-hook/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift-eng/ship-hook/_prowconfig.yaml
@@ -1,0 +1,14 @@
+tide:
+  queries:
+  - labels:
+    - approved
+    - lgtm
+    missingLabels:
+    - backports/unvalidated-commits
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - jira/invalid-bug
+    - needs-rebase
+    repos:
+    - openshift-eng/ship-hook


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR onboards the openshift-eng/ship-hook repository into OpenShift CI and Prow by adding ci-operator configuration, repo-level Prow configuration, and OWNERS entries.

- What changed and practical effect:
  - CI (ci-operator):
    - Adds ci-operator config for openshift-eng/ship-hook (openshift-eng-ship-hook-main.yaml) that:
      - Builds the ship-hook binary using a buildroot (Dockerfile.buildroot) and builds the ship-hook image from images/ship-hook/Dockerfile.
      - Promotes the built image to the ci namespace with the latest tag.
      - Declares global resource requests (100m CPU / 200Mi memory) and a memory limit (4Gi) for components selected by '*'.
      - Adds test suites: verify (make verify), unit (make test), and integration (make integration-test) running in the src working container.
      - Includes zz_generated_metadata (branch=main, org=openshift-eng, repo=ship-hook).
    - Practical effect: enables automated builds, tests, and image promotion for the ship-hook repo within OpenShift CI.

  - Prow / core-services:
    - Adds repo-level OWNERS entries (ci-operator and prow paths) adding petr-muller as an approver, granting repo approver rights.
    - Adds a repo-specific _pluginconfig.yaml that:
      - Enables approve behavior with lgtm acting as approve (lgtm_acts_as_approve: true) and does not require self-approval.
      - Enables review_acts_as_lgtm and provides an explicit allowlist of external plugins (including approve and common maintenance plugins).
      - Configures external plugin forwarding endpoints for refresh/needs-rebase/pipeline-controller on issue_comment and pull_request events.
      - Restricts trusted triggers for the repo to openshift-merge-bot.
    - Adds a repo-specific _prowconfig.yaml that:
      - Adds a Tide query for openshift-eng/ship-hook requiring both approved and lgtm labels for merge readiness.
      - Configures missingLabels to block merges for various do-not-merge/backport/needs-rebase labels and jira/invalid-bug.
    - Practical effect: establishes review/LGTM/approve semantics, external plugin integrations, merge gating requiring approved+LGTM, and trusts the merge bot for triggering.

- Files of note added/modified:
  - ci-operator/config/openshift-eng/ship-hook/openshift-eng-ship-hook-main.yaml (new CI config)
  - ci-operator/config/openshift-eng/ship-hook/OWNERS (adds approver)
  - core-services/prow/02_config/openshift-eng/ship-hook/_pluginconfig.yaml (new)
  - core-services/prow/02_config/openshift-eng/ship-hook/_prowconfig.yaml (new)
  - core-services/prow/02_config/openshift-eng/ship-hook/OWNERS (adds approver)

- Review effort: Low–Medium overall. CI config is straightforward; review the _pluginconfig.yaml and external endpoints for security and expected plugin behavior.

- Comments: PR discussion consists of repeated "/pj-rehearse" invocations by the author and an automated "Reviews resumed" reply from coderabbitai; no reviewer feedback is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->