### PR TITLE
[Debug] Add wait step to e2e-aws-mno-qe-integration-tests for OCP 4.22

### DIFF
--- a/ci-operator/config/openshift/lvm-operator/openshift-lvm-operator-main.yaml
+++ b/ci-operator/config/openshift/lvm-operator/openshift-lvm-operator-main.yaml
@@ -343,7 +343,9 @@ tests:
     env:
       LVM_OPERATOR_SUB_INSTALL_NAMESPACE: openshift-lvm-storage
       LVM_OPERATOR_SUB_SOURCE: lvm-catalogsource
+      TIMEOUT: +8 hours
     test:
+    - ref: wait
     - as: lvms-mno-integration-test
       cli: latest
       commands: |


### PR DESCRIPTION
This adds a wait step to enable debugging of test failures in OCP 4.22.

The wait step pauses the workflow before tests run, allowing QE to:
- SSH into the test environment
- Inspect system state and logs
- Debug configuration issues
- Investigate test failures

OCP Version: 4.22
Job: e2e-aws-mno-qe-integration-tests
Timeout: 8 hours

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted test timeout to 8 hours for integration test job.
  * Added preparatory step to test execution sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->