### PR TITLE
OCPBUGS-83580: runc/crun: add allowed_annotation to drop-in runtimes

### DIFF
--- a/ci-operator/step-registry/openshift/manifests/crun-wasm/openshift-manifests-crun-wasm-commands.sh
+++ b/ci-operator/step-registry/openshift/manifests/crun-wasm/openshift-manifests-crun-wasm-commands.sh
@@ -10,6 +10,11 @@ default_runtime = "crun-wasm"
 [crio.runtime.runtimes.crun-wasm]
 runtime_path = "/usr/bin/crun"
 platform_runtime_paths = {"wasi/wasm32" = "/usr/bin/crun-wasm"}
+allowed_annotations = [
+	"io.containers.trace-syscall",
+	"io.kubernetes.cri-o.Devices",
+	"io.kubernetes.cri-o.LinkLogs",
+]
 EOF
 
 cat > "${SHARED_DIR}/manifest_mc-master-crun-wasm.yml" << EOF

--- a/ci-operator/step-registry/openshift/manifests/crun/openshift-manifests-crun-commands.sh
+++ b/ci-operator/step-registry/openshift/manifests/crun/openshift-manifests-crun-commands.sh
@@ -9,6 +9,11 @@ cat > "/tmp/50-crun" << EOF
 default_runtime = "crun"
 [crio.runtime.runtimes.crun]
 runtime_root = "/run/crun"
+allowed_annotations = [
+	"io.containers.trace-syscall",
+	"io.kubernetes.cri-o.Devices",
+	"io.kubernetes.cri-o.LinkLogs",
+]
 EOF
 
 cat > "${SHARED_DIR}/manifest_mc-master-crun.yml" << EOF

--- a/ci-operator/step-registry/openshift/manifests/runc/openshift-manifests-runc-commands.sh
+++ b/ci-operator/step-registry/openshift/manifests/runc/openshift-manifests-runc-commands.sh
@@ -9,6 +9,11 @@ cat > "/tmp/50-runc" << EOF
 default_runtime = "runc"
 [crio.runtime.runtimes.runc]
 runtime_root = "/run/runc"
+allowed_annotations = [
+	"io.containers.trace-syscall",
+	"io.kubernetes.cri-o.Devices",
+	"io.kubernetes.cri-o.LinkLogs",
+]
 EOF
 
 cat > "${SHARED_DIR}/manifest_mc-master-runc.yml" << EOF


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended container runtime annotation support, enabling trace-syscall monitoring, device configuration, and enhanced logging capabilities across crun and runc implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->