### PR TITLE
Revert "Add check-cluster-profiles-config to ci-public image mirroring"

### DIFF
--- a/core-services/image-mirroring/openshift/mapping_origin_ci-operator-4.17
+++ b/core-services/image-mirroring/openshift/mapping_origin_ci-operator-4.17
@@ -16,6 +16,5 @@ quay-proxy.ci.openshift.org/openshift/ci:ci_applyconfig_latest quay.io/openshift
 quay-proxy.ci.openshift.org/openshift/ci:ci_github-ldap-user-group-creator_latest quay.io/openshift/ci-public:ci_github-ldap-user-group-creator_latest
 quay-proxy.ci.openshift.org/openshift/ci:ci_prow-job-dispatcher_latest quay.io/openshift/ci-public:ci_prow-job-dispatcher_latest
 quay-proxy.ci.openshift.org/openshift/ci:ci_auto-config-brancher_latest quay.io/openshift/ci-public:ci_auto-config-brancher_latest
-quay-proxy.ci.openshift.org/openshift/ci:ci_check-cluster-profiles-config_latest quay.io/openshift/ci-public:ci_check-cluster-profiles-config_latest
 quay-proxy.ci.openshift.org/openshift/ci:ci_golangci-lint_latest quay.io/openshift/ci-public:ci_golangci-lint_latest
 quay-proxy.ci.openshift.org/openshift/ci:ci_check-cluster-profiles-config_latest quay.io/openshift/ci-public:ci_check-cluster-profiles-config_latest


### PR DESCRIPTION
Reverts openshift/release#78830

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated image-mirroring mapping configuration for OpenShift infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->