### PR TITLE
remove ranakan19 from codeready-toolchain organization

### DIFF
--- a/ci-operator/config/codeready-toolchain/workload-analyzer/OWNERS
+++ b/ci-operator/config/codeready-toolchain/workload-analyzer/OWNERS
@@ -9,7 +9,6 @@ approvers:
 - matousjobanek
 - mfrancisc
 - rajivnathan
-- ranakan19
 - xcoulon
 - fbm3307
 - metlos
@@ -21,7 +20,6 @@ reviewers:
 - matousjobanek
 - mfrancisc
 - rajivnathan
-- ranakan19
 - xcoulon
 - fbm3307
 - metlos

--- a/ci-operator/jobs/codeready-toolchain/workload-analyzer/OWNERS
+++ b/ci-operator/jobs/codeready-toolchain/workload-analyzer/OWNERS
@@ -9,7 +9,6 @@ approvers:
 - matousjobanek
 - mfrancisc
 - rajivnathan
-- ranakan19
 - xcoulon
 - fbm3307
 - metlos
@@ -21,7 +20,6 @@ reviewers:
 - matousjobanek
 - mfrancisc
 - rajivnathan
-- ranakan19
 - xcoulon
 - fbm3307
 - metlos

--- a/ci-operator/step-registry/codeready-toolchain/OWNERS
+++ b/ci-operator/step-registry/codeready-toolchain/OWNERS
@@ -5,7 +5,6 @@ approvers:
 - metlos
 - mfrancisc
 - rajivnathan
-- ranakan19
 - rsoaresd
 - xcoulon
 - jrosental
@@ -17,7 +16,6 @@ reviewers:
 - metlos
 - mfrancisc
 - rajivnathan
-- ranakan19
 - rsoaresd
 - xcoulon
 - jrosental

--- a/ci-operator/step-registry/codeready-toolchain/aws/OWNERS
+++ b/ci-operator/step-registry/codeready-toolchain/aws/OWNERS
@@ -5,7 +5,6 @@ approvers:
 - metlos
 - mfrancisc
 - rajivnathan
-- ranakan19
 - rsoaresd
 - xcoulon
 - jrosental
@@ -17,7 +16,6 @@ reviewers:
 - metlos
 - mfrancisc
 - rajivnathan
-- ranakan19
 - rsoaresd
 - xcoulon
 - jrosental

--- a/ci-operator/step-registry/codeready-toolchain/aws/codeready-toolchain-aws-workflow.metadata.json
+++ b/ci-operator/step-registry/codeready-toolchain/aws/codeready-toolchain-aws-workflow.metadata.json
@@ -8,7 +8,6 @@
 			"metlos",
 			"mfrancisc",
 			"rajivnathan",
-			"ranakan19",
 			"rsoaresd",
 			"xcoulon",
 			"jrosental"
@@ -20,7 +19,6 @@
 			"metlos",
 			"mfrancisc",
 			"rajivnathan",
-			"ranakan19",
 			"rsoaresd",
 			"xcoulon",
 			"jrosental"

--- a/ci-operator/step-registry/codeready-toolchain/devsandbox-dashboard-prod/OWNERS
+++ b/ci-operator/step-registry/codeready-toolchain/devsandbox-dashboard-prod/OWNERS
@@ -5,7 +5,6 @@ approvers:
 - metlos
 - mfrancisc
 - rajivnathan
-- ranakan19
 - rsoaresd
 - xcoulon
 - jrosental
@@ -17,7 +16,6 @@ reviewers:
 - metlos
 - mfrancisc
 - rajivnathan
-- ranakan19
 - rsoaresd
 - xcoulon
 - jrosental

--- a/ci-operator/step-registry/codeready-toolchain/devsandbox-dashboard-prod/codeready-toolchain-devsandbox-dashboard-prod-ref.metadata.json
+++ b/ci-operator/step-registry/codeready-toolchain/devsandbox-dashboard-prod/codeready-toolchain-devsandbox-dashboard-prod-ref.metadata.json
@@ -8,7 +8,6 @@
 			"metlos",
 			"mfrancisc",
 			"rajivnathan",
-			"ranakan19",
 			"rsoaresd",
 			"xcoulon",
 			"jrosental"
@@ -20,7 +19,6 @@
 			"metlos",
 			"mfrancisc",
 			"rajivnathan",
-			"ranakan19",
 			"rsoaresd",
 			"xcoulon",
 			"jrosental"

--- a/ci-operator/step-registry/codeready-toolchain/devsandbox-dashboard-prod/codeready-toolchain-devsandbox-dashboard-prod-workflow.metadata.json
+++ b/ci-operator/step-registry/codeready-toolchain/devsandbox-dashboard-prod/codeready-toolchain-devsandbox-dashboard-prod-workflow.metadata.json
@@ -8,7 +8,6 @@
 			"metlos",
 			"mfrancisc",
 			"rajivnathan",
-			"ranakan19",
 			"rsoaresd",
 			"xcoulon",
 			"jrosental"
@@ -20,7 +19,6 @@
 			"metlos",
 			"mfrancisc",
 			"rajivnathan",
-			"ranakan19",
 			"rsoaresd",
 			"xcoulon",
 			"jrosental"

--- a/ci-operator/step-registry/codeready-toolchain/gather/OWNERS
+++ b/ci-operator/step-registry/codeready-toolchain/gather/OWNERS
@@ -5,7 +5,6 @@ approvers:
 - metlos
 - mfrancisc
 - rajivnathan
-- ranakan19
 - rsoaresd
 - xcoulon
 - jrosental
@@ -17,7 +16,6 @@ reviewers:
 - metlos
 - mfrancisc
 - rajivnathan
-- ranakan19
 - rsoaresd
 - xcoulon
 - jrosental

--- a/ci-operator/step-registry/codeready-toolchain/gather/codeready-toolchain-gather-ref.metadata.json
+++ b/ci-operator/step-registry/codeready-toolchain/gather/codeready-toolchain-gather-ref.metadata.json
@@ -8,7 +8,6 @@
 			"metlos",
 			"mfrancisc",
 			"rajivnathan",
-			"ranakan19",
 			"rsoaresd",
 			"xcoulon",
 			"jrosental"
@@ -20,7 +19,6 @@
 			"metlos",
 			"mfrancisc",
 			"rajivnathan",
-			"ranakan19",
 			"rsoaresd",
 			"xcoulon",
 			"jrosental"

--- a/core-services/prow/02_config/codeready-toolchain/api/OWNERS
+++ b/core-services/prow/02_config/codeready-toolchain/api/OWNERS
@@ -13,8 +13,6 @@ approvers:
 - fbm3307
 - metlos
 - rsoaresd
-- ranakan19
-
 options: {}
 reviewers:
 - alexeykazakov
@@ -25,4 +23,3 @@ reviewers:
 - fbm3307
 - metlos
 - rsoaresd
-- ranakan19

--- a/core-services/prow/02_config/codeready-toolchain/sandbox-sre/OWNERS
+++ b/core-services/prow/02_config/codeready-toolchain/sandbox-sre/OWNERS
@@ -13,8 +13,6 @@ approvers:
 - fbm3307
 - metlos
 - rsoaresd
-- ranakan19
-
 options: {}
 reviewers:
 - alexeykazakov
@@ -25,4 +23,3 @@ reviewers:
 - fbm3307
 - metlos
 - rsoaresd
-- ranakan19

--- a/core-services/prow/02_config/codeready-toolchain/toolchain-cicd/OWNERS
+++ b/core-services/prow/02_config/codeready-toolchain/toolchain-cicd/OWNERS
@@ -13,8 +13,6 @@ approvers:
 - fbm3307
 - metlos
 - rsoaresd
-- ranakan19
-
 options: {}
 reviewers:
 - alexeykazakov
@@ -25,4 +23,3 @@ reviewers:
 - fbm3307
 - metlos
 - rsoaresd
-- ranakan19

--- a/core-services/prow/02_config/codeready-toolchain/toolchain-common/OWNERS
+++ b/core-services/prow/02_config/codeready-toolchain/toolchain-common/OWNERS
@@ -13,8 +13,6 @@ approvers:
 - fbm3307
 - metlos
 - rsoaresd
-- ranakan19
-
 options: {}
 reviewers:
 - alexeykazakov
@@ -25,4 +23,3 @@ reviewers:
 - fbm3307
 - metlos
 - rsoaresd
-- ranakan19

--- a/core-services/prow/02_config/codeready-toolchain/workload-analyzer/OWNERS
+++ b/core-services/prow/02_config/codeready-toolchain/workload-analyzer/OWNERS
@@ -9,7 +9,6 @@ approvers:
 - matousjobanek
 - mfrancisc
 - rajivnathan
-- ranakan19
 - xcoulon
 - fbm3307
 - metlos
@@ -21,7 +20,6 @@ reviewers:
 - matousjobanek
 - mfrancisc
 - rajivnathan
-- ranakan19
 - xcoulon
 - fbm3307
 - metlos


### PR DESCRIPTION
# Description
Kanika is no longer a member of Developer Sandbox team, so we need to clean her ownership in codeready-toolchain organization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code ownership configurations and reviewer assignments across multiple build pipeline and project directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->