### PR TITLE
mco: add ocl jobs to pipeline

### DIFF
--- a/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-main.yaml
+++ b/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-main.yaml
@@ -274,8 +274,9 @@ tests:
       timeout: 1h40m0s
     workflow: ipi-gcp
   timeout: 4h0m0s
-- as: e2e-gcp-op-ocl-part1
-  skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|OWNERS_ALIASES|LICENSE)$
+- always_run: false
+  as: e2e-gcp-op-ocl-part1
+  pipeline_skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|OWNERS_ALIASES|LICENSE)$
   steps:
     cluster_profile: openshift-org-gcp
     test:
@@ -288,8 +289,9 @@ tests:
           cpu: 100m
       timeout: 2h30m0s
     workflow: ipi-gcp
-- as: e2e-gcp-op-ocl-part2
-  skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|OWNERS_ALIASES|LICENSE)$
+- always_run: false
+  as: e2e-gcp-op-ocl-part2
+  pipeline_skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|OWNERS_ALIASES|LICENSE)$
   steps:
     cluster_profile: openshift-org-gcp
     test:

--- a/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-main-presubmits.yaml
@@ -2271,6 +2271,8 @@ presubmits:
     trigger: (?m)^/test( | .* )e2e-gcp-op,?($|\s.*)
   - agent: kubernetes
     always_run: false
+    annotations:
+      pipeline_skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|OWNERS_ALIASES|LICENSE)$
     branches:
     - ^main$
     - ^main-
@@ -2284,7 +2286,6 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-machine-config-operator-main-e2e-gcp-op-ocl-part1
     rerun_command: /test e2e-gcp-op-ocl-part1
-    skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|OWNERS_ALIASES|LICENSE)$
     spec:
       containers:
       - args:
@@ -2352,6 +2353,8 @@ presubmits:
     trigger: (?m)^/test( | .* )e2e-gcp-op-ocl-part1,?($|\s.*)
   - agent: kubernetes
     always_run: false
+    annotations:
+      pipeline_skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|OWNERS_ALIASES|LICENSE)$
     branches:
     - ^main$
     - ^main-
@@ -2365,7 +2368,6 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-machine-config-operator-main-e2e-gcp-op-ocl-part2
     rerun_command: /test e2e-gcp-op-ocl-part2
-    skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|OWNERS_ALIASES|LICENSE)$
     spec:
       containers:
       - args:


### PR DESCRIPTION
These jobs were made required in https://github.com/openshift/release/pull/78253, let's have them run in the 2nd stage of the pipeline. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD test pipeline configuration to improve efficiency by streamlining test execution when only documentation, metadata files, and license information are modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->