### PR TITLE
shiftstack/merge-bot: Bump ORC, CPO upstream release branches

### DIFF
--- a/ci-operator/config/shiftstack/merge-bot/shiftstack-merge-bot-main.yaml
+++ b/ci-operator/config/shiftstack/merge-bot/shiftstack-merge-bot-main.yaml
@@ -276,7 +276,7 @@ tests:
     test:
     - as: cloud-provider-openstack-main
       commands: |
-        merge-bot --source https://github.com/kubernetes/cloud-provider-openstack:release-1.35 \
+        merge-bot --source https://github.com/kubernetes/cloud-provider-openstack:release-1.36 \
                   --dest openshift/cloud-provider-openstack:main \
                   --merge shiftstack/cloud-provider-openstack:merge-bot-main \
                   --update-go-modules \

--- a/ci-operator/config/shiftstack/merge-bot/shiftstack-merge-bot-main.yaml
+++ b/ci-operator/config/shiftstack/merge-bot/shiftstack-merge-bot-main.yaml
@@ -538,7 +538,7 @@ tests:
     test:
     - as: openstack-resource-controller-main
       commands: |
-        merge-bot --source https://github.com/k-orc/openstack-resource-controller:release-1.0 \
+        merge-bot --source https://github.com/k-orc/openstack-resource-controller:release-2.0 \
                   --dest openshift/openstack-resource-controller:main \
                   --merge shiftstack/openstack-resource-controller:merge-bot-main \
                   --update-go-modules \


### PR DESCRIPTION
- **shiftstack/merge-bot: Sync ORC with release-2.0 branch**
- **shiftstack/merge-bot: Sync CPO with release-1.36**

/hold

We need https://github.com/kubernetes/cloud-provider-openstack/pull/3104 first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI configuration for scheduled merge-bot jobs to pull newer upstream releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->