### PR TITLE
Add CI for telco-reference 4.22 branch

### DIFF
--- a/ci-operator/config/openshift-kni/telco-reference/openshift-kni-telco-reference-release-4.22.yaml
+++ b/ci-operator/config/openshift-kni/telco-reference/openshift-kni-telco-reference-release-4.22.yaml
@@ -35,6 +35,6 @@ tests:
   container:
     from: src
 zz_generated_metadata:
-  branch: main
+  branch: release-4.22
   org: openshift-kni
   repo: telco-reference

--- a/ci-operator/jobs/openshift-kni/telco-reference/openshift-kni-telco-reference-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift-kni/telco-reference/openshift-kni-telco-reference-release-4.22-presubmits.yaml
@@ -1,0 +1,65 @@
+presubmits:
+  openshift-kni/telco-reference:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.22$
+    - ^release-4\.22-
+    cluster: build05
+    context: ci/prow/lintcheck
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-kni-telco-reference-release-4.22-lintcheck
+    rerun_command: /test lintcheck
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=lintcheck
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )lintcheck,?($|\s.*)


### PR DESCRIPTION
Add checksum verification for external binaries (kube-compare v0.12.0, helm v3.16.1, and kustomize v5.8.1) to strengthen supply chain security posture.

Also update main branch config with the same security improvements.

Added kustomize to the container for hub configuration verification.

Assisted by claude