### PR TITLE
NO-JIRA: revert: retry stanza breaks our diff compare during config-change-trigger job

### DIFF
--- a/ci-operator/config/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main.yaml
+++ b/ci-operator/config/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main.yaml
@@ -113,17 +113,11 @@ tests:
   run_if_changed: .sh$
 - as: ocp-ci-monitor
   cron: 0 7 * * *
-  retry:
-    attempts: 2
-    interval: 30m
   steps:
     workflow: openshift-edge-tooling-ci-monitor
 - as: pr-notifier
   cron: 0 7 * * 0-5
   restrict_network_access: false
-  retry:
-    attempts: 2
-    interval: 30m
   steps:
     env:
       FORBIDDEN_LABELS: jira/invalid-bug

--- a/ci-operator/jobs/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main-periodics.yaml
@@ -21,9 +21,6 @@ periodics:
       - error
       report_template: |
         :warning: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs>
-  retry:
-    attempts: 2
-    interval: 30m
   spec:
     containers:
     - args:
@@ -103,9 +100,6 @@ periodics:
       - error
       report_template: |
         :warning: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs>
-  retry:
-    attempts: 2
-    interval: 30m
   spec:
     containers:
     - args:


### PR DESCRIPTION
reverting the use of retry in our lane, this stanza breaks config-change-trigger when the job runs due to the deep equal compare failing with the internal property of the upstream retry struct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed automatic retry mechanisms from scheduled CI tests. Tests will now fail immediately without retry attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->