### PR TITLE
Jf envar test

### DIFF
--- a/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__job-link-test.yaml
+++ b/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__job-link-test.yaml
@@ -1,0 +1,82 @@
+base_images:
+  nested-podman:
+    name: nested-podman
+    namespace: ci
+    tag: latest
+build_root:
+  image_stream_tag:
+    name: builder
+    namespace: ocp
+    tag: rhel-9-golang-1.24-openshift-4.22
+releases:
+  latest:
+    candidate:
+      product: ocp
+      stream: nightly
+      version: "4.22"
+resources:
+  '*':
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: job-link-envar-test
+  capabilities:
+  - nested-podman
+  commands: |
+    echo "========================================="
+    echo "Testing JOB_LINK environment variable"
+    echo "========================================="
+    echo ""
+    echo "Step 1: Displaying Prow environment variables"
+    echo "JOB_NAME: ${JOB_NAME}"
+    echo "BUILD_ID: ${BUILD_ID}"
+    echo "PULL_NUMBER: ${PULL_NUMBER:-<not set>}"
+    echo ""
+
+    echo "Step 2: Constructing JOB_LINK outside env -i"
+    JOB_LINK="https://prow.ci.openshift.org/view/gs/test-platform-results/"
+    if [ -n "${PULL_NUMBER:-}" ]; then
+      JOB_LINK="${JOB_LINK}pr-logs/pull/openshift_release/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
+    else
+      JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
+    fi
+    echo "JOB_LINK constructed: ${JOB_LINK}"
+    echo ""
+
+    echo "Step 3: Creating podman env file with variable substitution"
+    env -i bash --norc --noprofile << EOF > /tmp/podman.env
+    export TEST_VAR="hello from env file"
+    export JOB_LINK="${JOB_LINK}"
+    env | grep -v '^_='
+    EOF
+
+    echo ""
+    echo "Step 4: Contents of /tmp/podman.env:"
+    cat /tmp/podman.env
+    echo ""
+
+    echo "Step 5: Running podman container with env file"
+    podman run \
+    --env-file /tmp/podman.env \
+    --rm \
+    quay.io/openshift/origin-cli:latest \
+    bash -c 'echo ""; echo "=== Inside Podman Container ==="; echo "JOB_LINK value: ${JOB_LINK}"; echo "TEST_VAR value: ${TEST_VAR}"; echo ""; echo "All environment variables:"; env | sort; echo ""'
+
+    echo ""
+    echo "========================================="
+    echo "Test completed successfully"
+    echo "========================================="
+  container:
+    from: nested-podman
+    memory_backed_volume:
+      size: 1Gi
+  interval: 24h
+  nested_podman: true
+zz_generated_metadata:
+  branch: main
+  org: openshift-online
+  repo: rosa-e2e
+  variant: job-link-test

--- a/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-periodics.yaml
@@ -1,6 +1,71 @@
 periodics:
 - agent: kubernetes
   cluster: build06
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-online
+    repo: rosa-e2e
+  interval: 24h
+  labels:
+    capability/nested-podman: nested-podman
+    ci-operator.openshift.io/variant: job-link-test
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-online-rosa-e2e-main-job-link-test-job-link-envar-test
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --report-credentials-file=/etc/report/credentials
+      - --target=job-link-envar-test
+      - --variant=job-link-test
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build06
   cron: 0 9 * * *
   decorate: true
   decoration_config:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds a new periodic CI job to the OpenShift CI configuration for the openshift-online/rosa-e2e repo: a variant job-link-test that registers the periodic job periodic-ci-openshift-online-rosa-e2e-main-job-link-test and the presubmit-style job job-link-envar-test.

Practically:
- Registers a new periodic CI job under ci-operator for openshift-online/rosa-e2e (targets branch main, org openshift-online, repo rosa-e2e) that runs on a 24h interval and targets the OCP nightly 4.22 stream.
- Uses a nested-podman base image (rhel-9-golang-1.24-openshift-4.22) with nested_podman enabled and a 1Gi memory-backed volume so the job can run podman-in-podman.
- Adds a lightweight validation script that:
  - Prints Prow environment variables,
  - Constructs JOB_LINK (uses PULL_NUMBER when present),
  - Writes TEST_VAR and the constructed JOB_LINK into /tmp/podman.env using an env -i heredoc,
  - Displays the created env file,
  - Runs a nested podman container with --env-file to echo JOB_LINK and TEST_VAR and list environment variables inside the container.
- Declares resource requests and limits (requests: 100m CPU, 200Mi memory; default limits include 4Gi memory) appropriate for nested-podman runs.

Effect: introduces a small, targeted validation job to ensure JOB_LINK construction and env-file propagation work correctly for nested-podman CI runs in the ROSA E2E configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->