### PR TITLE
hypershift/gcp: enable ImageRegistry capability for GCP hosted clusters

### DIFF
--- a/ci-operator/step-registry/hypershift/dump/azure/diagnostics/hypershift-dump-azure-diagnostics-commands.sh
+++ b/ci-operator/step-registry/hypershift/dump/azure/diagnostics/hypershift-dump-azure-diagnostics-commands.sh
@@ -44,7 +44,11 @@ if [[ -f "${SHARED_DIR}/mgmt_kubeconfig" ]]; then
     export KUBECONFIG="${SHARED_DIR}/mgmt_kubeconfig"
 fi
 
-CLUSTER_NAME="$(echo -n "$PROW_JOB_ID" | sha256sum | cut -c -20)"
+if [[ -f "${SHARED_DIR}/cluster-name" ]]; then
+  CLUSTER_NAME="$(<"${SHARED_DIR}/cluster-name")"
+else
+  CLUSTER_NAME="$(echo -n "$PROW_JOB_ID" | sha256sum | cut -c -20)"
+fi
 RESOURCE_GROUP=$(oc get hc -n clusters "$CLUSTER_NAME" -o jsonpath='{.spec.platform.azure.resourceGroup}')
 NODES=$(KUBECONFIG="${SHARED_DIR}"/nested_kubeconfig oc get node -o jsonpath='{.items[*].metadata.name}')
 for NODE in $NODES; do

--- a/ci-operator/step-registry/hypershift/dump/hypershift-dump-chain.yaml
+++ b/ci-operator/step-registry/hypershift/dump/hypershift-dump-chain.yaml
@@ -15,7 +15,11 @@ chain:
         export MANAGED_SERVICE="$HYPERSHIFT_MANAGED_SERVICE"
       fi
       
-      CLUSTER_NAME="$(echo -n $PROW_JOB_ID|sha256sum|cut -c-20)"
+      if [[ -f "${SHARED_DIR}/cluster-name" ]]; then
+        CLUSTER_NAME="$(<"${SHARED_DIR}/cluster-name")"
+      else
+        CLUSTER_NAME="$(echo -n $PROW_JOB_ID|sha256sum|cut -c-20)"
+      fi
       bin/hypershift dump cluster --artifact-dir=$ARTIFACT_DIR \
       --dump-guest-cluster=true \
       --name="${CLUSTER_NAME}"

--- a/ci-operator/step-registry/hypershift/gcp/create/hypershift-gcp-create-chain.yaml
+++ b/ci-operator/step-registry/hypershift/gcp/create/hypershift-gcp-create-chain.yaml
@@ -79,7 +79,6 @@ chain:
         --boot-image "${GCP_BOOT_IMAGE}" \
         --annotations "hypershift.openshift.io/capi-provider-gcp-image=${CAPG_IMAGE}" \
         --annotations "hypershift.openshift.io/pod-security-admission-label-override=baseline" \
-        --disable-cluster-capabilities ImageRegistry \
         --disable-cluster-capabilities Console \
         --disable-cluster-capabilities Ingress \
         --feature-set TechPreviewNoUpgrade

--- a/ci-operator/step-registry/hypershift/gcp/gke/provision/hypershift-gcp-gke-provision-commands.sh
+++ b/ci-operator/step-registry/hypershift/gcp/gke/provision/hypershift-gcp-gke-provision-commands.sh
@@ -76,6 +76,7 @@ gcloud services enable \
     iam.googleapis.com \
     iamcredentials.googleapis.com \
     cloudresourcemanager.googleapis.com \
+    storage.googleapis.com \
     --project="${HC_PROJECT_ID}"
 
 # GCP API enablement is eventually consistent: gcloud services enable returns

--- a/ci-operator/step-registry/hypershift/k8sgpt/hypershift-k8sgpt-commands.sh
+++ b/ci-operator/step-registry/hypershift/k8sgpt/hypershift-k8sgpt-commands.sh
@@ -63,7 +63,11 @@ common_params=(--output json --anonymize --with-doc "$explain_arg" --filter "$ac
 
 mkdir -p "${ARTIFACT_DIR}/namespaces" "${ARTIFACT_DIR}/hostedcluster"
 
-CLUSTER_NAME="$(echo -n $PROW_JOB_ID|sha256sum|cut -c-20)"
+if [[ -f "${SHARED_DIR}/cluster-name" ]]; then
+  CLUSTER_NAME="$(<"${SHARED_DIR}/cluster-name")"
+else
+  CLUSTER_NAME="$(echo -n $PROW_JOB_ID|sha256sum|cut -c-20)"
+fi
 HOSTED_CLUSTER_NS=$(oc get hostedcluster -A -ojsonpath='{.items[0].metadata.namespace}' --ignore-not-found)
 
 mgmt_namespaces=(hypershift)

--- a/ci-operator/step-registry/hypershift/mce/dump/hypershift-mce-dump-commands.sh
+++ b/ci-operator/step-registry/hypershift/mce/dump/hypershift-mce-dump-commands.sh
@@ -6,7 +6,11 @@ if [ -f "${SHARED_DIR}/proxy-conf.sh" ] ; then
   source "${SHARED_DIR}/proxy-conf.sh"
 fi
 
-CLUSTER_NAME="$(echo -n $PROW_JOB_ID|sha256sum|cut -c-20)"
+if [[ -f "${SHARED_DIR}/cluster-name" ]]; then
+  CLUSTER_NAME="$(<"${SHARED_DIR}/cluster-name")"
+else
+  CLUSTER_NAME="$(echo -n $PROW_JOB_ID|sha256sum|cut -c-20)"
+fi
 HOSTED_CLUSTER_NS=$(oc get hostedcluster -A -ojsonpath='{.items[0].metadata.namespace}')
 EXTRA_ARGS=""
 PLATFORM_TYPE=$(oc get hostedclusters -n ${HOSTED_CLUSTER_NS} ${CLUSTER_NAME} -ojsonpath="{.spec.platform.type}")


### PR DESCRIPTION
## Summary

- Remove `--disable-cluster-capabilities ImageRegistry` from `hypershift-gcp-create` chain so GCP hosted clusters get a functional image registry (Console and Ingress remain disabled)
- Enable `storage.googleapis.com` in the HC project API list so the image registry operator can create its GCS bucket on startup
- Fix `hypershift-dump` chain and related scripts to read `SHARED_DIR/cluster-name` when available rather than recomputing from `sha256(PROW_JOB_ID)[:20]`. GCP uses a different HC CR naming scheme (`gcp-hc-<hash8>`), so the hardcoded AWS formula caused dump to fail with `hostedclusters ... not found`. The GCP destroy chain already did this correctly; dump now matches.

## Test plan
- [x] Verify `e2e-v2-gke` job completes with image registry operator in `Available` state
- [x] Confirm GCS bucket is created in the HC project during cluster setup
- [x] Confirm HC project deletion in deprovision cleans up the bucket automatically
- [x] Confirm dump step succeeds on GCP jobs (no longer fails with `hostedclusters ... not found`)