### PR TITLE
update ViaQ/vector labels to allow squash merge

### DIFF
--- a/core-services/prow/02_config/_labels.yaml
+++ b/core-services/prow/02_config/_labels.yaml
@@ -1283,3 +1283,10 @@ repos:
         name: run-integration-tests
         target: prs
         addedBy: label
+  ViaQ/vector:
+    labels:
+      - color: ffaa00
+        description: Denotes a PR that should be squashed by tide when it merges.
+        name: tide/merge-method-squash
+        target: prs
+        addedBy: humans


### PR DESCRIPTION
cc @xperimental @vparfonov 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR updates the Prow configuration for the ViaQ/vector repository to enable squash merge for pull requests. It adds a `label` section with the `tide/merge-method-squash` label to the repository's plugin configuration, which instructs Tide (Prow's merge automation service) to squash commits when merging PRs to ViaQ/vector. This change affects the CI/merge automation infrastructure for the ViaQ/vector repository within OpenShift's Prow deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->