### PR TITLE
check-cluster-profiles make target use quay.io/openshift/ci-public

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,8 @@ check-labels: python-help
 	@echo "Labels config check: PASS"
 
 check-cluster-profiles:
-	$(SKIP_PULL) || $(CONTAINER_ENGINE) pull $(CONTAINER_ENGINE_OPTS) quay.io/openshift/ci:ci_check-cluster-profiles-config_latest
-	$(CONTAINER_ENGINE) run $(CONTAINER_ENGINE_OPTS) $(CONTAINER_USER) --rm -v "$(CURDIR):/release$(VOLUME_MOUNT_FLAGS)" quay.io/openshift/ci:ci_check-cluster-profiles-config_latest --normalize --config-path=/release/ci-operator/step-registry/cluster-profiles/cluster-profiles-config.yaml
+	$(SKIP_PULL) || $(CONTAINER_ENGINE) pull $(CONTAINER_ENGINE_OPTS) quay.io/openshift/ci-public:ci_check-cluster-profiles-config_latest
+	$(CONTAINER_ENGINE) run $(CONTAINER_ENGINE_OPTS) $(CONTAINER_USER) --rm -v "$(CURDIR):/release$(VOLUME_MOUNT_FLAGS)" quay.io/openshift/ci-public:ci_check-cluster-profiles-config_latest --normalize --config-path=/release/ci-operator/step-registry/cluster-profiles/cluster-profiles-config.yaml
 	@echo "Cluster profiles config check: PASS"
 
 check-yaml-indentation: python-help


### PR DESCRIPTION
As per title.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated container registry reference for cluster profile checks in the build pipeline to use an alternative public registry while maintaining all existing configuration parameters and runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->