### PR TITLE
HPNEX-5: Consolidate PR lifecycle jobs and add openshift-eng/ai-helpers

### DIFF
--- a/ci-operator/jobs/infra-periodics.yaml
+++ b/ci-operator/jobs/infra-periodics.yaml
@@ -650,12 +650,13 @@ periodics:
   decorate: true
   labels:
     ci.openshift.io/role: infra
-  name: periodic-hypershift-pr-stale
+  name: periodic-pr-stale
   spec:
     containers:
     - args:
       - |-
         --query=repo:openshift/hypershift
+        repo:openshift-eng/ai-helpers
         is:pr
         is:open
         comments:<2500
@@ -699,12 +700,13 @@ periodics:
   decorate: true
   labels:
     ci.openshift.io/role: infra
-  name: periodic-hypershift-pr-rotten
+  name: periodic-pr-rotten
   spec:
     containers:
     - args:
       - |-
         --query=repo:openshift/hypershift
+        repo:openshift-eng/ai-helpers
         is:pr
         is:open
         comments:<2500
@@ -749,12 +751,13 @@ periodics:
   decorate: true
   labels:
     ci.openshift.io/role: infra
-  name: periodic-hypershift-pr-close
+  name: periodic-pr-close
   spec:
     containers:
     - args:
       - |-
         --query=repo:openshift/hypershift
+        repo:openshift-eng/ai-helpers
         is:pr
         is:open
         comments:<2500


### PR DESCRIPTION
## Summary
- Rename `periodic-hypershift-pr-{stale,rotten,close}` to `periodic-pr-{stale,rotten,close}` since they're no longer hypershift-specific
- Add `repo:openshift-eng/ai-helpers` to automatically manage stale PRs (30d stale → 14d rotten → 7d close)
