### PR TITLE
Replace t2a-standard-4 with n4a-standard-4 MTO

### DIFF
--- a/ci-operator/config/openshift-priv/multiarch-tuning-operator/openshift-priv-multiarch-tuning-operator-v0.0.1.yaml
+++ b/ci-operator/config/openshift-priv/multiarch-tuning-operator/openshift-priv-multiarch-tuning-operator-v0.0.1.yaml
@@ -125,6 +125,7 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      CONTROL_PLANE_NODE_TYPE: n4a-standard-4
       GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
     post:
@@ -132,7 +133,10 @@ tests:
     - ref: send-results-to-reportportal
     pre:
     - ref: storage-conf-storageclass-pre-set-default-gcp
-    - chain: ipi-gcp-pre
+    - chain: ipi-conf-gcp
+    - ref: ipi-conf-gcp-patch-controlplane-disk
+    - ref: rhcos-conf-osstream
+    - chain: ipi-install
     test:
     - ref: ipi-install-heterogeneous
     - as: test
@@ -162,6 +166,7 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      CONTROL_PLANE_NODE_TYPE: n4a-standard-4
       GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
     post:
@@ -169,7 +174,10 @@ tests:
     - ref: send-results-to-reportportal
     pre:
     - ref: storage-conf-storageclass-pre-set-default-gcp
-    - chain: ipi-gcp-pre
+    - chain: ipi-conf-gcp
+    - ref: ipi-conf-gcp-patch-controlplane-disk
+    - ref: rhcos-conf-osstream
+    - chain: ipi-install
     test:
     - ref: ipi-install-heterogeneous
     - as: test

--- a/ci-operator/config/openshift-priv/multiarch-tuning-operator/openshift-priv-multiarch-tuning-operator-v0.0.1.yaml
+++ b/ci-operator/config/openshift-priv/multiarch-tuning-operator/openshift-priv-multiarch-tuning-operator-v0.0.1.yaml
@@ -125,7 +125,14 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
+    post:
+    - chain: ipi-gcp-post
+    - ref: send-results-to-reportportal
+    pre:
+    - ref: storage-conf-storageclass-pre-set-default-gcp
+    - chain: ipi-gcp-pre
     test:
     - ref: ipi-install-heterogeneous
     - as: test
@@ -141,7 +148,6 @@ tests:
         requests:
           cpu: 100m
           memory: 200Mi
-    workflow: ipi-gcp
 - always_run: false
   as: e2e-gcp-multi-operator
   optional: true
@@ -156,7 +162,14 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
+    post:
+    - chain: ipi-gcp-post
+    - ref: send-results-to-reportportal
+    pre:
+    - ref: storage-conf-storageclass-pre-set-default-gcp
+    - chain: ipi-gcp-pre
     test:
     - ref: ipi-install-heterogeneous
     - as: test
@@ -170,7 +183,6 @@ tests:
         requests:
           cpu: 100m
           memory: 200Mi
-    workflow: ipi-gcp
 - as: security
   optional: true
   steps:

--- a/ci-operator/config/openshift-priv/multiarch-tuning-operator/openshift-priv-multiarch-tuning-operator-v0.0.1.yaml
+++ b/ci-operator/config/openshift-priv/multiarch-tuning-operator/openshift-priv-multiarch-tuning-operator-v0.0.1.yaml
@@ -124,7 +124,7 @@ tests:
       ADDITIONAL_WORKER_VM_TYPE: n2-standard-4
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
-      COMPUTE_NODE_TYPE: t2a-standard-4
+      COMPUTE_NODE_TYPE: n4a-standard-4
       OCP_ARCH: arm64
     test:
     - ref: ipi-install-heterogeneous
@@ -155,7 +155,7 @@ tests:
       ADDITIONAL_WORKER_VM_TYPE: n2-standard-4
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
-      COMPUTE_NODE_TYPE: t2a-standard-4
+      COMPUTE_NODE_TYPE: n4a-standard-4
       OCP_ARCH: arm64
     test:
     - ref: ipi-install-heterogeneous

--- a/ci-operator/config/openshift-priv/multiarch-tuning-operator/openshift-priv-multiarch-tuning-operator-v0.9.yaml
+++ b/ci-operator/config/openshift-priv/multiarch-tuning-operator/openshift-priv-multiarch-tuning-operator-v0.9.yaml
@@ -160,7 +160,14 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
+    post:
+    - chain: ipi-gcp-post
+    - ref: send-results-to-reportportal
+    pre:
+    - ref: storage-conf-storageclass-pre-set-default-gcp
+    - chain: ipi-gcp-pre
     test:
     - ref: ipi-install-heterogeneous
     - as: test
@@ -176,7 +183,6 @@ tests:
         requests:
           cpu: 100m
           memory: 200Mi
-    workflow: ipi-gcp
 - as: e2e-gcp-multi-operator
   capabilities:
   - arm64
@@ -193,7 +199,14 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
+    post:
+    - chain: ipi-gcp-post
+    - ref: send-results-to-reportportal
+    pre:
+    - ref: storage-conf-storageclass-pre-set-default-gcp
+    - chain: ipi-gcp-pre
     test:
     - ref: ipi-install-heterogeneous
     - as: test
@@ -207,7 +220,6 @@ tests:
         requests:
           cpu: 100m
           memory: 200Mi
-    workflow: ipi-gcp
 - as: security
   capabilities:
   - arm64

--- a/ci-operator/config/openshift-priv/multiarch-tuning-operator/openshift-priv-multiarch-tuning-operator-v0.9.yaml
+++ b/ci-operator/config/openshift-priv/multiarch-tuning-operator/openshift-priv-multiarch-tuning-operator-v0.9.yaml
@@ -159,7 +159,7 @@ tests:
       ADDITIONAL_WORKER_VM_TYPE: n2-standard-4
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
-      COMPUTE_NODE_TYPE: t2a-standard-4
+      COMPUTE_NODE_TYPE: n4a-standard-4
       OCP_ARCH: arm64
     test:
     - ref: ipi-install-heterogeneous
@@ -192,7 +192,7 @@ tests:
       ADDITIONAL_WORKER_VM_TYPE: n2-standard-4
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
-      COMPUTE_NODE_TYPE: t2a-standard-4
+      COMPUTE_NODE_TYPE: n4a-standard-4
       OCP_ARCH: arm64
     test:
     - ref: ipi-install-heterogeneous

--- a/ci-operator/config/openshift-priv/multiarch-tuning-operator/openshift-priv-multiarch-tuning-operator-v0.9.yaml
+++ b/ci-operator/config/openshift-priv/multiarch-tuning-operator/openshift-priv-multiarch-tuning-operator-v0.9.yaml
@@ -160,6 +160,7 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      CONTROL_PLANE_NODE_TYPE: n4a-standard-4
       GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
     post:
@@ -167,7 +168,10 @@ tests:
     - ref: send-results-to-reportportal
     pre:
     - ref: storage-conf-storageclass-pre-set-default-gcp
-    - chain: ipi-gcp-pre
+    - chain: ipi-conf-gcp
+    - ref: ipi-conf-gcp-patch-controlplane-disk
+    - ref: rhcos-conf-osstream
+    - chain: ipi-install
     test:
     - ref: ipi-install-heterogeneous
     - as: test
@@ -199,6 +203,7 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      CONTROL_PLANE_NODE_TYPE: n4a-standard-4
       GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
     post:
@@ -206,7 +211,10 @@ tests:
     - ref: send-results-to-reportportal
     pre:
     - ref: storage-conf-storageclass-pre-set-default-gcp
-    - chain: ipi-gcp-pre
+    - chain: ipi-conf-gcp
+    - ref: ipi-conf-gcp-patch-controlplane-disk
+    - ref: rhcos-conf-osstream
+    - chain: ipi-install
     test:
     - ref: ipi-install-heterogeneous
     - as: test

--- a/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-main__ocp416.yaml
+++ b/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-main__ocp416.yaml
@@ -89,7 +89,7 @@ tests:
       ADDITIONAL_WORKER_VM_TYPE: n2-standard-4
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
-      COMPUTE_NODE_TYPE: t2a-standard-4
+      COMPUTE_NODE_TYPE: n4a-standard-4
       OCP_ARCH: arm64
     test:
     - ref: ipi-install-heterogeneous

--- a/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-main__ocp416.yaml
+++ b/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-main__ocp416.yaml
@@ -90,11 +90,17 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
+    post:
+    - chain: ipi-gcp-post
+    - ref: send-results-to-reportportal
+    pre:
+    - ref: storage-conf-storageclass-pre-set-default-gcp
+    - chain: ipi-gcp-pre
     test:
     - ref: ipi-install-heterogeneous
     - ref: multiarch-tuning-operator-e2e-olm-kustomize
-    workflow: ipi-gcp
 - always_run: false
   as: e2e-aws-ovn-proxy-mto-origin
   capabilities:

--- a/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-main__ocp416.yaml
+++ b/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-main__ocp416.yaml
@@ -90,6 +90,7 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      CONTROL_PLANE_NODE_TYPE: n4a-standard-4
       GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
     post:
@@ -97,7 +98,10 @@ tests:
     - ref: send-results-to-reportportal
     pre:
     - ref: storage-conf-storageclass-pre-set-default-gcp
-    - chain: ipi-gcp-pre
+    - chain: ipi-conf-gcp
+    - ref: ipi-conf-gcp-patch-controlplane-disk
+    - ref: rhcos-conf-osstream
+    - chain: ipi-install
     test:
     - ref: ipi-install-heterogeneous
     - ref: multiarch-tuning-operator-e2e-olm-kustomize

--- a/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-main__ocp417.yaml
+++ b/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-main__ocp417.yaml
@@ -89,7 +89,7 @@ tests:
       ADDITIONAL_WORKER_VM_TYPE: n2-standard-4
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
-      COMPUTE_NODE_TYPE: t2a-standard-4
+      COMPUTE_NODE_TYPE: n4a-standard-4
       OCP_ARCH: arm64
     test:
     - ref: ipi-install-heterogeneous

--- a/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-main__ocp417.yaml
+++ b/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-main__ocp417.yaml
@@ -90,11 +90,17 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
+    post:
+    - chain: ipi-gcp-post
+    - ref: send-results-to-reportportal
+    pre:
+    - ref: storage-conf-storageclass-pre-set-default-gcp
+    - chain: ipi-gcp-pre
     test:
     - ref: ipi-install-heterogeneous
     - ref: multiarch-tuning-operator-e2e-olm-kustomize
-    workflow: ipi-gcp
 - always_run: false
   as: e2e-aws-ovn-proxy-mto-origin
   capabilities:

--- a/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-main__ocp417.yaml
+++ b/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-main__ocp417.yaml
@@ -90,6 +90,7 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      CONTROL_PLANE_NODE_TYPE: n4a-standard-4
       GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
     post:
@@ -97,7 +98,10 @@ tests:
     - ref: send-results-to-reportportal
     pre:
     - ref: storage-conf-storageclass-pre-set-default-gcp
-    - chain: ipi-gcp-pre
+    - chain: ipi-conf-gcp
+    - ref: ipi-conf-gcp-patch-controlplane-disk
+    - ref: rhcos-conf-osstream
+    - chain: ipi-install
     test:
     - ref: ipi-install-heterogeneous
     - ref: multiarch-tuning-operator-e2e-olm-kustomize

--- a/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-main__ocp420.yaml
+++ b/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-main__ocp420.yaml
@@ -90,7 +90,7 @@ tests:
       ADDITIONAL_WORKER_VM_TYPE: n2-standard-4
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
-      COMPUTE_NODE_TYPE: t2a-standard-4
+      COMPUTE_NODE_TYPE: n4a-standard-4
       OCP_ARCH: arm64
     test:
     - ref: ipi-install-heterogeneous

--- a/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-main__ocp420.yaml
+++ b/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-main__ocp420.yaml
@@ -91,11 +91,17 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
+    post:
+    - chain: ipi-gcp-post
+    - ref: send-results-to-reportportal
+    pre:
+    - ref: storage-conf-storageclass-pre-set-default-gcp
+    - chain: ipi-gcp-pre
     test:
     - ref: ipi-install-heterogeneous
     - ref: multiarch-tuning-operator-e2e-olm-kustomize
-    workflow: ipi-gcp
 - always_run: false
   as: e2e-aws-ovn-proxy-mto-origin
   capabilities:

--- a/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-main__ocp420.yaml
+++ b/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-main__ocp420.yaml
@@ -91,6 +91,7 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      CONTROL_PLANE_NODE_TYPE: n4a-standard-4
       GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
     post:
@@ -98,7 +99,10 @@ tests:
     - ref: send-results-to-reportportal
     pre:
     - ref: storage-conf-storageclass-pre-set-default-gcp
-    - chain: ipi-gcp-pre
+    - chain: ipi-conf-gcp
+    - ref: ipi-conf-gcp-patch-controlplane-disk
+    - ref: rhcos-conf-osstream
+    - chain: ipi-install
     test:
     - ref: ipi-install-heterogeneous
     - ref: multiarch-tuning-operator-e2e-olm-kustomize

--- a/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-main__ocp421.yaml
+++ b/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-main__ocp421.yaml
@@ -90,7 +90,7 @@ tests:
       ADDITIONAL_WORKER_VM_TYPE: n2-standard-4
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
-      COMPUTE_NODE_TYPE: t2a-standard-4
+      COMPUTE_NODE_TYPE: n4a-standard-4
       OCP_ARCH: arm64
     test:
     - ref: ipi-install-heterogeneous

--- a/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-main__ocp421.yaml
+++ b/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-main__ocp421.yaml
@@ -91,11 +91,17 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
+    post:
+    - chain: ipi-gcp-post
+    - ref: send-results-to-reportportal
+    pre:
+    - ref: storage-conf-storageclass-pre-set-default-gcp
+    - chain: ipi-gcp-pre
     test:
     - ref: ipi-install-heterogeneous
     - ref: multiarch-tuning-operator-e2e-olm-kustomize
-    workflow: ipi-gcp
 - always_run: false
   as: e2e-aws-ovn-proxy-mto-origin
   capabilities:

--- a/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-main__ocp421.yaml
+++ b/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-main__ocp421.yaml
@@ -91,6 +91,7 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      CONTROL_PLANE_NODE_TYPE: n4a-standard-4
       GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
     post:
@@ -98,7 +99,10 @@ tests:
     - ref: send-results-to-reportportal
     pre:
     - ref: storage-conf-storageclass-pre-set-default-gcp
-    - chain: ipi-gcp-pre
+    - chain: ipi-conf-gcp
+    - ref: ipi-conf-gcp-patch-controlplane-disk
+    - ref: rhcos-conf-osstream
+    - chain: ipi-install
     test:
     - ref: ipi-install-heterogeneous
     - ref: multiarch-tuning-operator-e2e-olm-kustomize

--- a/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-main__ocp422.yaml
+++ b/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-main__ocp422.yaml
@@ -90,7 +90,7 @@ tests:
       ADDITIONAL_WORKER_VM_TYPE: n2-standard-4
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
-      COMPUTE_NODE_TYPE: t2a-standard-4
+      COMPUTE_NODE_TYPE: n4a-standard-4
       OCP_ARCH: arm64
     test:
     - ref: ipi-install-heterogeneous

--- a/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-main__ocp422.yaml
+++ b/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-main__ocp422.yaml
@@ -91,11 +91,17 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
+    post:
+    - chain: ipi-gcp-post
+    - ref: send-results-to-reportportal
+    pre:
+    - ref: storage-conf-storageclass-pre-set-default-gcp
+    - chain: ipi-gcp-pre
     test:
     - ref: ipi-install-heterogeneous
     - ref: multiarch-tuning-operator-e2e-olm-kustomize
-    workflow: ipi-gcp
 - always_run: false
   as: e2e-aws-ovn-proxy-mto-origin
   capabilities:

--- a/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-main__ocp422.yaml
+++ b/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-main__ocp422.yaml
@@ -91,6 +91,7 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      CONTROL_PLANE_NODE_TYPE: n4a-standard-4
       GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
     post:
@@ -98,7 +99,10 @@ tests:
     - ref: send-results-to-reportportal
     pre:
     - ref: storage-conf-storageclass-pre-set-default-gcp
-    - chain: ipi-gcp-pre
+    - chain: ipi-conf-gcp
+    - ref: ipi-conf-gcp-patch-controlplane-disk
+    - ref: rhcos-conf-osstream
+    - chain: ipi-install
     test:
     - ref: ipi-install-heterogeneous
     - ref: multiarch-tuning-operator-e2e-olm-kustomize

--- a/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-main__ocp422.yaml
+++ b/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-main__ocp422.yaml
@@ -81,7 +81,7 @@ tests:
   - arm64
   skip_if_only_changed: (^docs/)|((^|/)OWNERS(_ALIASES)?$)|((^|/)[A-Za-z]+\.md$)|((^|/)\.github/)|((^|/)\.tekton/)|((^|/).*konflux\.Dockerfile$)
   steps:
-    cluster_profile: openshift-org-gcp
+    cluster_profile: gcp-sustaining-autorelease-412
     dependencies:
       OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: release:multi-initial
       OPERATOR_IMAGE: pipeline:multiarch-tuning-operator

--- a/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-v0.0.1.yaml
+++ b/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-v0.0.1.yaml
@@ -121,7 +121,7 @@ tests:
       ADDITIONAL_WORKER_VM_TYPE: n2-standard-4
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
-      COMPUTE_NODE_TYPE: t2a-standard-4
+      COMPUTE_NODE_TYPE: n4a-standard-4
       OCP_ARCH: arm64
     test:
     - ref: ipi-install-heterogeneous
@@ -152,7 +152,7 @@ tests:
       ADDITIONAL_WORKER_VM_TYPE: n2-standard-4
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
-      COMPUTE_NODE_TYPE: t2a-standard-4
+      COMPUTE_NODE_TYPE: n4a-standard-4
       OCP_ARCH: arm64
     test:
     - ref: ipi-install-heterogeneous

--- a/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-v0.0.1.yaml
+++ b/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-v0.0.1.yaml
@@ -122,7 +122,14 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
+    post:
+    - chain: ipi-gcp-post
+    - ref: send-results-to-reportportal
+    pre:
+    - ref: storage-conf-storageclass-pre-set-default-gcp
+    - chain: ipi-gcp-pre
     test:
     - ref: ipi-install-heterogeneous
     - as: test
@@ -138,7 +145,6 @@ tests:
         requests:
           cpu: 100m
           memory: 200Mi
-    workflow: ipi-gcp
 - always_run: false
   as: e2e-gcp-multi-operator
   optional: true
@@ -153,7 +159,14 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
+    post:
+    - chain: ipi-gcp-post
+    - ref: send-results-to-reportportal
+    pre:
+    - ref: storage-conf-storageclass-pre-set-default-gcp
+    - chain: ipi-gcp-pre
     test:
     - ref: ipi-install-heterogeneous
     - as: test
@@ -167,7 +180,6 @@ tests:
         requests:
           cpu: 100m
           memory: 200Mi
-    workflow: ipi-gcp
 - as: security
   optional: true
   steps:

--- a/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-v0.0.1.yaml
+++ b/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-v0.0.1.yaml
@@ -122,6 +122,7 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      CONTROL_PLANE_NODE_TYPE: n4a-standard-4
       GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
     post:
@@ -129,7 +130,10 @@ tests:
     - ref: send-results-to-reportportal
     pre:
     - ref: storage-conf-storageclass-pre-set-default-gcp
-    - chain: ipi-gcp-pre
+    - chain: ipi-conf-gcp
+    - ref: ipi-conf-gcp-patch-controlplane-disk
+    - ref: rhcos-conf-osstream
+    - chain: ipi-install
     test:
     - ref: ipi-install-heterogeneous
     - as: test
@@ -159,6 +163,7 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      CONTROL_PLANE_NODE_TYPE: n4a-standard-4
       GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
     post:
@@ -166,7 +171,10 @@ tests:
     - ref: send-results-to-reportportal
     pre:
     - ref: storage-conf-storageclass-pre-set-default-gcp
-    - chain: ipi-gcp-pre
+    - chain: ipi-conf-gcp
+    - ref: ipi-conf-gcp-patch-controlplane-disk
+    - ref: rhcos-conf-osstream
+    - chain: ipi-install
     test:
     - ref: ipi-install-heterogeneous
     - as: test

--- a/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-v0.9.yaml
+++ b/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-v0.9.yaml
@@ -157,6 +157,7 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      CONTROL_PLANE_NODE_TYPE: n4a-standard-4
       GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
     post:
@@ -164,7 +165,10 @@ tests:
     - ref: send-results-to-reportportal
     pre:
     - ref: storage-conf-storageclass-pre-set-default-gcp
-    - chain: ipi-gcp-pre
+    - chain: ipi-conf-gcp
+    - ref: ipi-conf-gcp-patch-controlplane-disk
+    - ref: rhcos-conf-osstream
+    - chain: ipi-install
     test:
     - ref: ipi-install-heterogeneous
     - as: test
@@ -196,6 +200,7 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      CONTROL_PLANE_NODE_TYPE: n4a-standard-4
       GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
     post:
@@ -203,7 +208,10 @@ tests:
     - ref: send-results-to-reportportal
     pre:
     - ref: storage-conf-storageclass-pre-set-default-gcp
-    - chain: ipi-gcp-pre
+    - chain: ipi-conf-gcp
+    - ref: ipi-conf-gcp-patch-controlplane-disk
+    - ref: rhcos-conf-osstream
+    - chain: ipi-install
     test:
     - ref: ipi-install-heterogeneous
     - as: test

--- a/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-v0.9.yaml
+++ b/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-v0.9.yaml
@@ -157,7 +157,14 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
+    post:
+    - chain: ipi-gcp-post
+    - ref: send-results-to-reportportal
+    pre:
+    - ref: storage-conf-storageclass-pre-set-default-gcp
+    - chain: ipi-gcp-pre
     test:
     - ref: ipi-install-heterogeneous
     - as: test
@@ -173,7 +180,6 @@ tests:
         requests:
           cpu: 100m
           memory: 200Mi
-    workflow: ipi-gcp
 - as: e2e-gcp-multi-operator
   capabilities:
   - arm64
@@ -190,7 +196,14 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
+    post:
+    - chain: ipi-gcp-post
+    - ref: send-results-to-reportportal
+    pre:
+    - ref: storage-conf-storageclass-pre-set-default-gcp
+    - chain: ipi-gcp-pre
     test:
     - ref: ipi-install-heterogeneous
     - as: test
@@ -204,7 +217,6 @@ tests:
         requests:
           cpu: 100m
           memory: 200Mi
-    workflow: ipi-gcp
 - as: e2e-aws-post-multi-operator-olm
   cluster: build01
   postsubmit: true

--- a/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-v0.9.yaml
+++ b/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-v0.9.yaml
@@ -156,7 +156,7 @@ tests:
       ADDITIONAL_WORKER_VM_TYPE: n2-standard-4
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
-      COMPUTE_NODE_TYPE: t2a-standard-4
+      COMPUTE_NODE_TYPE: n4a-standard-4
       OCP_ARCH: arm64
     test:
     - ref: ipi-install-heterogeneous
@@ -189,7 +189,7 @@ tests:
       ADDITIONAL_WORKER_VM_TYPE: n2-standard-4
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
-      COMPUTE_NODE_TYPE: t2a-standard-4
+      COMPUTE_NODE_TYPE: n4a-standard-4
       OCP_ARCH: arm64
     test:
     - ref: ipi-install-heterogeneous

--- a/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-v1.x__ocp416.yaml
+++ b/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-v1.x__ocp416.yaml
@@ -89,7 +89,7 @@ tests:
       ADDITIONAL_WORKER_VM_TYPE: n2-standard-4
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
-      COMPUTE_NODE_TYPE: t2a-standard-4
+      COMPUTE_NODE_TYPE: n4a-standard-4
       OCP_ARCH: arm64
     test:
     - ref: ipi-install-heterogeneous

--- a/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-v1.x__ocp416.yaml
+++ b/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-v1.x__ocp416.yaml
@@ -90,11 +90,17 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
+    post:
+    - chain: ipi-gcp-post
+    - ref: send-results-to-reportportal
+    pre:
+    - ref: storage-conf-storageclass-pre-set-default-gcp
+    - chain: ipi-gcp-pre
     test:
     - ref: ipi-install-heterogeneous
     - ref: multiarch-tuning-operator-e2e-olm-kustomize
-    workflow: ipi-gcp
 - always_run: false
   as: e2e-aws-ovn-proxy-mto-origin
   capabilities:

--- a/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-v1.x__ocp416.yaml
+++ b/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-v1.x__ocp416.yaml
@@ -90,6 +90,7 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      CONTROL_PLANE_NODE_TYPE: n4a-standard-4
       GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
     post:
@@ -97,7 +98,10 @@ tests:
     - ref: send-results-to-reportportal
     pre:
     - ref: storage-conf-storageclass-pre-set-default-gcp
-    - chain: ipi-gcp-pre
+    - chain: ipi-conf-gcp
+    - ref: ipi-conf-gcp-patch-controlplane-disk
+    - ref: rhcos-conf-osstream
+    - chain: ipi-install
     test:
     - ref: ipi-install-heterogeneous
     - ref: multiarch-tuning-operator-e2e-olm-kustomize

--- a/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-v1.x__ocp417.yaml
+++ b/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-v1.x__ocp417.yaml
@@ -89,7 +89,7 @@ tests:
       ADDITIONAL_WORKER_VM_TYPE: n2-standard-4
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
-      COMPUTE_NODE_TYPE: t2a-standard-4
+      COMPUTE_NODE_TYPE: n4a-standard-4
       OCP_ARCH: arm64
     test:
     - ref: ipi-install-heterogeneous

--- a/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-v1.x__ocp417.yaml
+++ b/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-v1.x__ocp417.yaml
@@ -90,11 +90,17 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
+    post:
+    - chain: ipi-gcp-post
+    - ref: send-results-to-reportportal
+    pre:
+    - ref: storage-conf-storageclass-pre-set-default-gcp
+    - chain: ipi-gcp-pre
     test:
     - ref: ipi-install-heterogeneous
     - ref: multiarch-tuning-operator-e2e-olm-kustomize
-    workflow: ipi-gcp
 - always_run: false
   as: e2e-aws-ovn-proxy-mto-origin
   capabilities:

--- a/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-v1.x__ocp417.yaml
+++ b/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-v1.x__ocp417.yaml
@@ -90,6 +90,7 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      CONTROL_PLANE_NODE_TYPE: n4a-standard-4
       GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
     post:
@@ -97,7 +98,10 @@ tests:
     - ref: send-results-to-reportportal
     pre:
     - ref: storage-conf-storageclass-pre-set-default-gcp
-    - chain: ipi-gcp-pre
+    - chain: ipi-conf-gcp
+    - ref: ipi-conf-gcp-patch-controlplane-disk
+    - ref: rhcos-conf-osstream
+    - chain: ipi-install
     test:
     - ref: ipi-install-heterogeneous
     - ref: multiarch-tuning-operator-e2e-olm-kustomize

--- a/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-v1.x__ocp420.yaml
+++ b/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-v1.x__ocp420.yaml
@@ -90,7 +90,7 @@ tests:
       ADDITIONAL_WORKER_VM_TYPE: n2-standard-4
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
-      COMPUTE_NODE_TYPE: t2a-standard-4
+      COMPUTE_NODE_TYPE: n4a-standard-4
       OCP_ARCH: arm64
     test:
     - ref: ipi-install-heterogeneous

--- a/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-v1.x__ocp420.yaml
+++ b/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-v1.x__ocp420.yaml
@@ -91,11 +91,17 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
+    post:
+    - chain: ipi-gcp-post
+    - ref: send-results-to-reportportal
+    pre:
+    - ref: storage-conf-storageclass-pre-set-default-gcp
+    - chain: ipi-gcp-pre
     test:
     - ref: ipi-install-heterogeneous
     - ref: multiarch-tuning-operator-e2e-olm-kustomize
-    workflow: ipi-gcp
 - always_run: false
   as: e2e-aws-ovn-proxy-mto-origin
   capabilities:

--- a/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-v1.x__ocp420.yaml
+++ b/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-v1.x__ocp420.yaml
@@ -91,6 +91,7 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      CONTROL_PLANE_NODE_TYPE: n4a-standard-4
       GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
     post:
@@ -98,7 +99,10 @@ tests:
     - ref: send-results-to-reportportal
     pre:
     - ref: storage-conf-storageclass-pre-set-default-gcp
-    - chain: ipi-gcp-pre
+    - chain: ipi-conf-gcp
+    - ref: ipi-conf-gcp-patch-controlplane-disk
+    - ref: rhcos-conf-osstream
+    - chain: ipi-install
     test:
     - ref: ipi-install-heterogeneous
     - ref: multiarch-tuning-operator-e2e-olm-kustomize

--- a/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-v1.x__ocp421.yaml
+++ b/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-v1.x__ocp421.yaml
@@ -90,7 +90,7 @@ tests:
       ADDITIONAL_WORKER_VM_TYPE: n2-standard-4
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
-      COMPUTE_NODE_TYPE: t2a-standard-4
+      COMPUTE_NODE_TYPE: n4a-standard-4
       OCP_ARCH: arm64
     test:
     - ref: ipi-install-heterogeneous

--- a/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-v1.x__ocp421.yaml
+++ b/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-v1.x__ocp421.yaml
@@ -91,11 +91,17 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
+    post:
+    - chain: ipi-gcp-post
+    - ref: send-results-to-reportportal
+    pre:
+    - ref: storage-conf-storageclass-pre-set-default-gcp
+    - chain: ipi-gcp-pre
     test:
     - ref: ipi-install-heterogeneous
     - ref: multiarch-tuning-operator-e2e-olm-kustomize
-    workflow: ipi-gcp
 - always_run: false
   as: e2e-aws-ovn-proxy-mto-origin
   capabilities:

--- a/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-v1.x__ocp421.yaml
+++ b/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-v1.x__ocp421.yaml
@@ -91,6 +91,7 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      CONTROL_PLANE_NODE_TYPE: n4a-standard-4
       GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
     post:
@@ -98,7 +99,10 @@ tests:
     - ref: send-results-to-reportportal
     pre:
     - ref: storage-conf-storageclass-pre-set-default-gcp
-    - chain: ipi-gcp-pre
+    - chain: ipi-conf-gcp
+    - ref: ipi-conf-gcp-patch-controlplane-disk
+    - ref: rhcos-conf-osstream
+    - chain: ipi-install
     test:
     - ref: ipi-install-heterogeneous
     - ref: multiarch-tuning-operator-e2e-olm-kustomize

--- a/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-v1.x__ocp422.yaml
+++ b/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-v1.x__ocp422.yaml
@@ -90,7 +90,7 @@ tests:
       ADDITIONAL_WORKER_VM_TYPE: n2-standard-4
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
-      COMPUTE_NODE_TYPE: t2a-standard-4
+      COMPUTE_NODE_TYPE: n4a-standard-4
       OCP_ARCH: arm64
     test:
     - ref: ipi-install-heterogeneous

--- a/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-v1.x__ocp422.yaml
+++ b/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-v1.x__ocp422.yaml
@@ -91,11 +91,17 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
+    post:
+    - chain: ipi-gcp-post
+    - ref: send-results-to-reportportal
+    pre:
+    - ref: storage-conf-storageclass-pre-set-default-gcp
+    - chain: ipi-gcp-pre
     test:
     - ref: ipi-install-heterogeneous
     - ref: multiarch-tuning-operator-e2e-olm-kustomize
-    workflow: ipi-gcp
 - always_run: false
   as: e2e-aws-ovn-proxy-mto-origin
   capabilities:

--- a/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-v1.x__ocp422.yaml
+++ b/ci-operator/config/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-v1.x__ocp422.yaml
@@ -91,6 +91,7 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      CONTROL_PLANE_NODE_TYPE: n4a-standard-4
       GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
     post:
@@ -98,7 +99,10 @@ tests:
     - ref: send-results-to-reportportal
     pre:
     - ref: storage-conf-storageclass-pre-set-default-gcp
-    - chain: ipi-gcp-pre
+    - chain: ipi-conf-gcp
+    - ref: ipi-conf-gcp-patch-controlplane-disk
+    - ref: rhcos-conf-osstream
+    - chain: ipi-install
     test:
     - ref: ipi-install-heterogeneous
     - ref: multiarch-tuning-operator-e2e-olm-kustomize

--- a/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-main__ocp416.yaml
+++ b/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-main__ocp416.yaml
@@ -89,7 +89,7 @@ tests:
       ADDITIONAL_WORKER_VM_TYPE: n2-standard-4
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
-      COMPUTE_NODE_TYPE: t2a-standard-4
+      COMPUTE_NODE_TYPE: n4a-standard-4
       OCP_ARCH: arm64
     test:
     - ref: ipi-install-heterogeneous

--- a/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-main__ocp416.yaml
+++ b/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-main__ocp416.yaml
@@ -90,11 +90,17 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
+    post:
+    - chain: ipi-gcp-post
+    - ref: send-results-to-reportportal
+    pre:
+    - ref: storage-conf-storageclass-pre-set-default-gcp
+    - chain: ipi-gcp-pre
     test:
     - ref: ipi-install-heterogeneous
     - ref: multiarch-tuning-operator-e2e-olm-kustomize
-    workflow: ipi-gcp
 - always_run: false
   as: e2e-aws-ovn-proxy-mto-origin
   capabilities:

--- a/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-main__ocp416.yaml
+++ b/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-main__ocp416.yaml
@@ -90,6 +90,7 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      CONTROL_PLANE_NODE_TYPE: n4a-standard-4
       GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
     post:
@@ -97,7 +98,10 @@ tests:
     - ref: send-results-to-reportportal
     pre:
     - ref: storage-conf-storageclass-pre-set-default-gcp
-    - chain: ipi-gcp-pre
+    - chain: ipi-conf-gcp
+    - ref: ipi-conf-gcp-patch-controlplane-disk
+    - ref: rhcos-conf-osstream
+    - chain: ipi-install
     test:
     - ref: ipi-install-heterogeneous
     - ref: multiarch-tuning-operator-e2e-olm-kustomize

--- a/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-main__ocp417.yaml
+++ b/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-main__ocp417.yaml
@@ -89,7 +89,7 @@ tests:
       ADDITIONAL_WORKER_VM_TYPE: n2-standard-4
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
-      COMPUTE_NODE_TYPE: t2a-standard-4
+      COMPUTE_NODE_TYPE: n4a-standard-4
       OCP_ARCH: arm64
     test:
     - ref: ipi-install-heterogeneous

--- a/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-main__ocp417.yaml
+++ b/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-main__ocp417.yaml
@@ -90,11 +90,17 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
+    post:
+    - chain: ipi-gcp-post
+    - ref: send-results-to-reportportal
+    pre:
+    - ref: storage-conf-storageclass-pre-set-default-gcp
+    - chain: ipi-gcp-pre
     test:
     - ref: ipi-install-heterogeneous
     - ref: multiarch-tuning-operator-e2e-olm-kustomize
-    workflow: ipi-gcp
 - always_run: false
   as: e2e-aws-ovn-proxy-mto-origin
   capabilities:

--- a/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-main__ocp417.yaml
+++ b/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-main__ocp417.yaml
@@ -90,6 +90,7 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      CONTROL_PLANE_NODE_TYPE: n4a-standard-4
       GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
     post:
@@ -97,7 +98,10 @@ tests:
     - ref: send-results-to-reportportal
     pre:
     - ref: storage-conf-storageclass-pre-set-default-gcp
-    - chain: ipi-gcp-pre
+    - chain: ipi-conf-gcp
+    - ref: ipi-conf-gcp-patch-controlplane-disk
+    - ref: rhcos-conf-osstream
+    - chain: ipi-install
     test:
     - ref: ipi-install-heterogeneous
     - ref: multiarch-tuning-operator-e2e-olm-kustomize

--- a/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-main__ocp420.yaml
+++ b/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-main__ocp420.yaml
@@ -90,7 +90,7 @@ tests:
       ADDITIONAL_WORKER_VM_TYPE: n2-standard-4
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
-      COMPUTE_NODE_TYPE: t2a-standard-4
+      COMPUTE_NODE_TYPE: n4a-standard-4
       OCP_ARCH: arm64
     test:
     - ref: ipi-install-heterogeneous

--- a/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-main__ocp420.yaml
+++ b/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-main__ocp420.yaml
@@ -91,11 +91,17 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
+    post:
+    - chain: ipi-gcp-post
+    - ref: send-results-to-reportportal
+    pre:
+    - ref: storage-conf-storageclass-pre-set-default-gcp
+    - chain: ipi-gcp-pre
     test:
     - ref: ipi-install-heterogeneous
     - ref: multiarch-tuning-operator-e2e-olm-kustomize
-    workflow: ipi-gcp
 - always_run: false
   as: e2e-aws-ovn-proxy-mto-origin
   capabilities:

--- a/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-main__ocp420.yaml
+++ b/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-main__ocp420.yaml
@@ -91,6 +91,7 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      CONTROL_PLANE_NODE_TYPE: n4a-standard-4
       GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
     post:
@@ -98,7 +99,10 @@ tests:
     - ref: send-results-to-reportportal
     pre:
     - ref: storage-conf-storageclass-pre-set-default-gcp
-    - chain: ipi-gcp-pre
+    - chain: ipi-conf-gcp
+    - ref: ipi-conf-gcp-patch-controlplane-disk
+    - ref: rhcos-conf-osstream
+    - chain: ipi-install
     test:
     - ref: ipi-install-heterogeneous
     - ref: multiarch-tuning-operator-e2e-olm-kustomize

--- a/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-main__ocp421.yaml
+++ b/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-main__ocp421.yaml
@@ -90,7 +90,7 @@ tests:
       ADDITIONAL_WORKER_VM_TYPE: n2-standard-4
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
-      COMPUTE_NODE_TYPE: t2a-standard-4
+      COMPUTE_NODE_TYPE: n4a-standard-4
       OCP_ARCH: arm64
     test:
     - ref: ipi-install-heterogeneous

--- a/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-main__ocp421.yaml
+++ b/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-main__ocp421.yaml
@@ -91,11 +91,17 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
+    post:
+    - chain: ipi-gcp-post
+    - ref: send-results-to-reportportal
+    pre:
+    - ref: storage-conf-storageclass-pre-set-default-gcp
+    - chain: ipi-gcp-pre
     test:
     - ref: ipi-install-heterogeneous
     - ref: multiarch-tuning-operator-e2e-olm-kustomize
-    workflow: ipi-gcp
 - always_run: false
   as: e2e-aws-ovn-proxy-mto-origin
   capabilities:

--- a/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-main__ocp421.yaml
+++ b/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-main__ocp421.yaml
@@ -91,6 +91,7 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      CONTROL_PLANE_NODE_TYPE: n4a-standard-4
       GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
     post:
@@ -98,7 +99,10 @@ tests:
     - ref: send-results-to-reportportal
     pre:
     - ref: storage-conf-storageclass-pre-set-default-gcp
-    - chain: ipi-gcp-pre
+    - chain: ipi-conf-gcp
+    - ref: ipi-conf-gcp-patch-controlplane-disk
+    - ref: rhcos-conf-osstream
+    - chain: ipi-install
     test:
     - ref: ipi-install-heterogeneous
     - ref: multiarch-tuning-operator-e2e-olm-kustomize

--- a/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-main__ocp422.yaml
+++ b/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-main__ocp422.yaml
@@ -90,7 +90,7 @@ tests:
       ADDITIONAL_WORKER_VM_TYPE: n2-standard-4
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
-      COMPUTE_NODE_TYPE: t2a-standard-4
+      COMPUTE_NODE_TYPE: n4a-standard-4
       OCP_ARCH: arm64
     test:
     - ref: ipi-install-heterogeneous

--- a/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-main__ocp422.yaml
+++ b/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-main__ocp422.yaml
@@ -91,11 +91,17 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
+    post:
+    - chain: ipi-gcp-post
+    - ref: send-results-to-reportportal
+    pre:
+    - ref: storage-conf-storageclass-pre-set-default-gcp
+    - chain: ipi-gcp-pre
     test:
     - ref: ipi-install-heterogeneous
     - ref: multiarch-tuning-operator-e2e-olm-kustomize
-    workflow: ipi-gcp
 - always_run: false
   as: e2e-aws-ovn-proxy-mto-origin
   capabilities:

--- a/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-main__ocp422.yaml
+++ b/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-main__ocp422.yaml
@@ -91,6 +91,7 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      CONTROL_PLANE_NODE_TYPE: n4a-standard-4
       GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
     post:
@@ -98,7 +99,10 @@ tests:
     - ref: send-results-to-reportportal
     pre:
     - ref: storage-conf-storageclass-pre-set-default-gcp
-    - chain: ipi-gcp-pre
+    - chain: ipi-conf-gcp
+    - ref: ipi-conf-gcp-patch-controlplane-disk
+    - ref: rhcos-conf-osstream
+    - chain: ipi-install
     test:
     - ref: ipi-install-heterogeneous
     - ref: multiarch-tuning-operator-e2e-olm-kustomize

--- a/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-v0.0.1.yaml
+++ b/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-v0.0.1.yaml
@@ -121,7 +121,7 @@ tests:
       ADDITIONAL_WORKER_VM_TYPE: n2-standard-4
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
-      COMPUTE_NODE_TYPE: t2a-standard-4
+      COMPUTE_NODE_TYPE: n4a-standard-4
       OCP_ARCH: arm64
     test:
     - ref: ipi-install-heterogeneous
@@ -152,7 +152,7 @@ tests:
       ADDITIONAL_WORKER_VM_TYPE: n2-standard-4
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
-      COMPUTE_NODE_TYPE: t2a-standard-4
+      COMPUTE_NODE_TYPE: n4a-standard-4
       OCP_ARCH: arm64
     test:
     - ref: ipi-install-heterogeneous

--- a/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-v0.0.1.yaml
+++ b/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-v0.0.1.yaml
@@ -122,7 +122,14 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
+    post:
+    - chain: ipi-gcp-post
+    - ref: send-results-to-reportportal
+    pre:
+    - ref: storage-conf-storageclass-pre-set-default-gcp
+    - chain: ipi-gcp-pre
     test:
     - ref: ipi-install-heterogeneous
     - as: test
@@ -138,7 +145,6 @@ tests:
         requests:
           cpu: 100m
           memory: 200Mi
-    workflow: ipi-gcp
 - always_run: false
   as: e2e-gcp-multi-operator
   optional: true
@@ -153,7 +159,14 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
+    post:
+    - chain: ipi-gcp-post
+    - ref: send-results-to-reportportal
+    pre:
+    - ref: storage-conf-storageclass-pre-set-default-gcp
+    - chain: ipi-gcp-pre
     test:
     - ref: ipi-install-heterogeneous
     - as: test
@@ -167,7 +180,6 @@ tests:
         requests:
           cpu: 100m
           memory: 200Mi
-    workflow: ipi-gcp
 - as: security
   optional: true
   steps:

--- a/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-v0.0.1.yaml
+++ b/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-v0.0.1.yaml
@@ -122,6 +122,7 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      CONTROL_PLANE_NODE_TYPE: n4a-standard-4
       GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
     post:
@@ -129,7 +130,10 @@ tests:
     - ref: send-results-to-reportportal
     pre:
     - ref: storage-conf-storageclass-pre-set-default-gcp
-    - chain: ipi-gcp-pre
+    - chain: ipi-conf-gcp
+    - ref: ipi-conf-gcp-patch-controlplane-disk
+    - ref: rhcos-conf-osstream
+    - chain: ipi-install
     test:
     - ref: ipi-install-heterogeneous
     - as: test
@@ -159,6 +163,7 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      CONTROL_PLANE_NODE_TYPE: n4a-standard-4
       GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
     post:
@@ -166,7 +171,10 @@ tests:
     - ref: send-results-to-reportportal
     pre:
     - ref: storage-conf-storageclass-pre-set-default-gcp
-    - chain: ipi-gcp-pre
+    - chain: ipi-conf-gcp
+    - ref: ipi-conf-gcp-patch-controlplane-disk
+    - ref: rhcos-conf-osstream
+    - chain: ipi-install
     test:
     - ref: ipi-install-heterogeneous
     - as: test

--- a/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-v0.9.yaml
+++ b/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-v0.9.yaml
@@ -157,6 +157,7 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      CONTROL_PLANE_NODE_TYPE: n4a-standard-4
       GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
     post:
@@ -164,7 +165,10 @@ tests:
     - ref: send-results-to-reportportal
     pre:
     - ref: storage-conf-storageclass-pre-set-default-gcp
-    - chain: ipi-gcp-pre
+    - chain: ipi-conf-gcp
+    - ref: ipi-conf-gcp-patch-controlplane-disk
+    - ref: rhcos-conf-osstream
+    - chain: ipi-install
     test:
     - ref: ipi-install-heterogeneous
     - as: test
@@ -196,6 +200,7 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      CONTROL_PLANE_NODE_TYPE: n4a-standard-4
       GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
     post:
@@ -203,7 +208,10 @@ tests:
     - ref: send-results-to-reportportal
     pre:
     - ref: storage-conf-storageclass-pre-set-default-gcp
-    - chain: ipi-gcp-pre
+    - chain: ipi-conf-gcp
+    - ref: ipi-conf-gcp-patch-controlplane-disk
+    - ref: rhcos-conf-osstream
+    - chain: ipi-install
     test:
     - ref: ipi-install-heterogeneous
     - as: test

--- a/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-v0.9.yaml
+++ b/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-v0.9.yaml
@@ -157,7 +157,14 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
+    post:
+    - chain: ipi-gcp-post
+    - ref: send-results-to-reportportal
+    pre:
+    - ref: storage-conf-storageclass-pre-set-default-gcp
+    - chain: ipi-gcp-pre
     test:
     - ref: ipi-install-heterogeneous
     - as: test
@@ -173,7 +180,6 @@ tests:
         requests:
           cpu: 100m
           memory: 200Mi
-    workflow: ipi-gcp
 - as: e2e-gcp-multi-operator
   capabilities:
   - arm64
@@ -190,7 +196,14 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
+    post:
+    - chain: ipi-gcp-post
+    - ref: send-results-to-reportportal
+    pre:
+    - ref: storage-conf-storageclass-pre-set-default-gcp
+    - chain: ipi-gcp-pre
     test:
     - ref: ipi-install-heterogeneous
     - as: test
@@ -204,7 +217,6 @@ tests:
         requests:
           cpu: 100m
           memory: 200Mi
-    workflow: ipi-gcp
 - as: e2e-aws-post-multi-operator-olm
   cluster: build01
   postsubmit: true

--- a/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-v0.9.yaml
+++ b/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-v0.9.yaml
@@ -156,7 +156,7 @@ tests:
       ADDITIONAL_WORKER_VM_TYPE: n2-standard-4
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
-      COMPUTE_NODE_TYPE: t2a-standard-4
+      COMPUTE_NODE_TYPE: n4a-standard-4
       OCP_ARCH: arm64
     test:
     - ref: ipi-install-heterogeneous
@@ -189,7 +189,7 @@ tests:
       ADDITIONAL_WORKER_VM_TYPE: n2-standard-4
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
-      COMPUTE_NODE_TYPE: t2a-standard-4
+      COMPUTE_NODE_TYPE: n4a-standard-4
       OCP_ARCH: arm64
     test:
     - ref: ipi-install-heterogeneous

--- a/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-v1.x__ocp416.yaml
+++ b/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-v1.x__ocp416.yaml
@@ -89,7 +89,7 @@ tests:
       ADDITIONAL_WORKER_VM_TYPE: n2-standard-4
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
-      COMPUTE_NODE_TYPE: t2a-standard-4
+      COMPUTE_NODE_TYPE: n4a-standard-4
       OCP_ARCH: arm64
     test:
     - ref: ipi-install-heterogeneous

--- a/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-v1.x__ocp416.yaml
+++ b/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-v1.x__ocp416.yaml
@@ -90,11 +90,17 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
+    post:
+    - chain: ipi-gcp-post
+    - ref: send-results-to-reportportal
+    pre:
+    - ref: storage-conf-storageclass-pre-set-default-gcp
+    - chain: ipi-gcp-pre
     test:
     - ref: ipi-install-heterogeneous
     - ref: multiarch-tuning-operator-e2e-olm-kustomize
-    workflow: ipi-gcp
 - always_run: false
   as: e2e-aws-ovn-proxy-mto-origin
   capabilities:

--- a/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-v1.x__ocp416.yaml
+++ b/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-v1.x__ocp416.yaml
@@ -90,6 +90,7 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      CONTROL_PLANE_NODE_TYPE: n4a-standard-4
       GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
     post:
@@ -97,7 +98,10 @@ tests:
     - ref: send-results-to-reportportal
     pre:
     - ref: storage-conf-storageclass-pre-set-default-gcp
-    - chain: ipi-gcp-pre
+    - chain: ipi-conf-gcp
+    - ref: ipi-conf-gcp-patch-controlplane-disk
+    - ref: rhcos-conf-osstream
+    - chain: ipi-install
     test:
     - ref: ipi-install-heterogeneous
     - ref: multiarch-tuning-operator-e2e-olm-kustomize

--- a/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-v1.x__ocp417.yaml
+++ b/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-v1.x__ocp417.yaml
@@ -89,7 +89,7 @@ tests:
       ADDITIONAL_WORKER_VM_TYPE: n2-standard-4
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
-      COMPUTE_NODE_TYPE: t2a-standard-4
+      COMPUTE_NODE_TYPE: n4a-standard-4
       OCP_ARCH: arm64
     test:
     - ref: ipi-install-heterogeneous

--- a/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-v1.x__ocp417.yaml
+++ b/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-v1.x__ocp417.yaml
@@ -90,11 +90,17 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
+    post:
+    - chain: ipi-gcp-post
+    - ref: send-results-to-reportportal
+    pre:
+    - ref: storage-conf-storageclass-pre-set-default-gcp
+    - chain: ipi-gcp-pre
     test:
     - ref: ipi-install-heterogeneous
     - ref: multiarch-tuning-operator-e2e-olm-kustomize
-    workflow: ipi-gcp
 - always_run: false
   as: e2e-aws-ovn-proxy-mto-origin
   capabilities:

--- a/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-v1.x__ocp417.yaml
+++ b/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-v1.x__ocp417.yaml
@@ -90,6 +90,7 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      CONTROL_PLANE_NODE_TYPE: n4a-standard-4
       GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
     post:
@@ -97,7 +98,10 @@ tests:
     - ref: send-results-to-reportportal
     pre:
     - ref: storage-conf-storageclass-pre-set-default-gcp
-    - chain: ipi-gcp-pre
+    - chain: ipi-conf-gcp
+    - ref: ipi-conf-gcp-patch-controlplane-disk
+    - ref: rhcos-conf-osstream
+    - chain: ipi-install
     test:
     - ref: ipi-install-heterogeneous
     - ref: multiarch-tuning-operator-e2e-olm-kustomize

--- a/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-v1.x__ocp420.yaml
+++ b/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-v1.x__ocp420.yaml
@@ -90,7 +90,7 @@ tests:
       ADDITIONAL_WORKER_VM_TYPE: n2-standard-4
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
-      COMPUTE_NODE_TYPE: t2a-standard-4
+      COMPUTE_NODE_TYPE: n4a-standard-4
       OCP_ARCH: arm64
     test:
     - ref: ipi-install-heterogeneous

--- a/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-v1.x__ocp420.yaml
+++ b/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-v1.x__ocp420.yaml
@@ -91,11 +91,17 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
+    post:
+    - chain: ipi-gcp-post
+    - ref: send-results-to-reportportal
+    pre:
+    - ref: storage-conf-storageclass-pre-set-default-gcp
+    - chain: ipi-gcp-pre
     test:
     - ref: ipi-install-heterogeneous
     - ref: multiarch-tuning-operator-e2e-olm-kustomize
-    workflow: ipi-gcp
 - always_run: false
   as: e2e-aws-ovn-proxy-mto-origin
   capabilities:

--- a/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-v1.x__ocp420.yaml
+++ b/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-v1.x__ocp420.yaml
@@ -91,6 +91,7 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      CONTROL_PLANE_NODE_TYPE: n4a-standard-4
       GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
     post:
@@ -98,7 +99,10 @@ tests:
     - ref: send-results-to-reportportal
     pre:
     - ref: storage-conf-storageclass-pre-set-default-gcp
-    - chain: ipi-gcp-pre
+    - chain: ipi-conf-gcp
+    - ref: ipi-conf-gcp-patch-controlplane-disk
+    - ref: rhcos-conf-osstream
+    - chain: ipi-install
     test:
     - ref: ipi-install-heterogeneous
     - ref: multiarch-tuning-operator-e2e-olm-kustomize

--- a/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-v1.x__ocp421.yaml
+++ b/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-v1.x__ocp421.yaml
@@ -90,7 +90,7 @@ tests:
       ADDITIONAL_WORKER_VM_TYPE: n2-standard-4
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
-      COMPUTE_NODE_TYPE: t2a-standard-4
+      COMPUTE_NODE_TYPE: n4a-standard-4
       OCP_ARCH: arm64
     test:
     - ref: ipi-install-heterogeneous

--- a/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-v1.x__ocp421.yaml
+++ b/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-v1.x__ocp421.yaml
@@ -91,11 +91,17 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
+    post:
+    - chain: ipi-gcp-post
+    - ref: send-results-to-reportportal
+    pre:
+    - ref: storage-conf-storageclass-pre-set-default-gcp
+    - chain: ipi-gcp-pre
     test:
     - ref: ipi-install-heterogeneous
     - ref: multiarch-tuning-operator-e2e-olm-kustomize
-    workflow: ipi-gcp
 - always_run: false
   as: e2e-aws-ovn-proxy-mto-origin
   capabilities:

--- a/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-v1.x__ocp421.yaml
+++ b/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-v1.x__ocp421.yaml
@@ -91,6 +91,7 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      CONTROL_PLANE_NODE_TYPE: n4a-standard-4
       GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
     post:
@@ -98,7 +99,10 @@ tests:
     - ref: send-results-to-reportportal
     pre:
     - ref: storage-conf-storageclass-pre-set-default-gcp
-    - chain: ipi-gcp-pre
+    - chain: ipi-conf-gcp
+    - ref: ipi-conf-gcp-patch-controlplane-disk
+    - ref: rhcos-conf-osstream
+    - chain: ipi-install
     test:
     - ref: ipi-install-heterogeneous
     - ref: multiarch-tuning-operator-e2e-olm-kustomize

--- a/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-v1.x__ocp422.yaml
+++ b/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-v1.x__ocp422.yaml
@@ -90,7 +90,7 @@ tests:
       ADDITIONAL_WORKER_VM_TYPE: n2-standard-4
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
-      COMPUTE_NODE_TYPE: t2a-standard-4
+      COMPUTE_NODE_TYPE: n4a-standard-4
       OCP_ARCH: arm64
     test:
     - ref: ipi-install-heterogeneous

--- a/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-v1.x__ocp422.yaml
+++ b/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-v1.x__ocp422.yaml
@@ -91,11 +91,17 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
+    post:
+    - chain: ipi-gcp-post
+    - ref: send-results-to-reportportal
+    pre:
+    - ref: storage-conf-storageclass-pre-set-default-gcp
+    - chain: ipi-gcp-pre
     test:
     - ref: ipi-install-heterogeneous
     - ref: multiarch-tuning-operator-e2e-olm-kustomize
-    workflow: ipi-gcp
 - always_run: false
   as: e2e-aws-ovn-proxy-mto-origin
   capabilities:

--- a/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-v1.x__ocp422.yaml
+++ b/ci-operator/config/outrigger-project/multiarch-tuning-operator/outrigger-project-multiarch-tuning-operator-v1.x__ocp422.yaml
@@ -91,6 +91,7 @@ tests:
       ADDITIONAL_WORKERS: "1"
       COMPUTE_NODE_REPLICAS: "2"
       COMPUTE_NODE_TYPE: n4a-standard-4
+      CONTROL_PLANE_NODE_TYPE: n4a-standard-4
       GCP_SC_DISK_TYPE: hyperdisk-balanced
       OCP_ARCH: arm64
     post:
@@ -98,7 +99,10 @@ tests:
     - ref: send-results-to-reportportal
     pre:
     - ref: storage-conf-storageclass-pre-set-default-gcp
-    - chain: ipi-gcp-pre
+    - chain: ipi-conf-gcp
+    - ref: ipi-conf-gcp-patch-controlplane-disk
+    - ref: rhcos-conf-osstream
+    - chain: ipi-install
     test:
     - ref: ipi-install-heterogeneous
     - ref: multiarch-tuning-operator-e2e-olm-kustomize

--- a/ci-operator/jobs/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/multiarch-tuning-operator/openshift-multiarch-tuning-operator-main-presubmits.yaml
@@ -1956,7 +1956,7 @@ presubmits:
     labels:
       capability/arm64: arm64
       ci-operator.openshift.io/cloud: gcp
-      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+      ci-operator.openshift.io/cloud-cluster-profile: gcp-sustaining-autorelease-412
       ci-operator.openshift.io/variant: ocp422
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"

--- a/ci-operator/step-registry/ipi/conf/gcp/patch-controlplane-disk/OWNERS
+++ b/ci-operator/step-registry/ipi/conf/gcp/patch-controlplane-disk/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- openshift-ci-robot
+reviewers:
+- openshift-ci-robot

--- a/ci-operator/step-registry/ipi/conf/gcp/patch-controlplane-disk/ipi-conf-gcp-patch-controlplane-disk-commands.sh
+++ b/ci-operator/step-registry/ipi/conf/gcp/patch-controlplane-disk/ipi-conf-gcp-patch-controlplane-disk-commands.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+CONFIG="${SHARED_DIR}/install-config.yaml"
+
+# Patch control plane and compute disk type to hyperdisk-balanced for n4a instances
+# n4a-standard-4 (ARM Axion) only supports hyperdisk-balanced, not pd-ssd
+echo "Patching control plane and compute disk type to hyperdisk-balanced"
+
+# Create a patch file
+cat > "${SHARED_DIR}/install-config-disk.yaml.patch" << EOF
+controlPlane:
+  platform:
+    gcp:
+      osDisk:
+        diskType: hyperdisk-balanced
+compute:
+- name: worker
+  platform:
+    gcp:
+      osDisk:
+        diskType: hyperdisk-balanced
+EOF
+
+# Merge the patch with the existing install-config
+yq-go m -x -i "${CONFIG}" "${SHARED_DIR}/install-config-disk.yaml.patch"
+
+echo "Control plane and compute disk type updated to hyperdisk-balanced"

--- a/ci-operator/step-registry/ipi/conf/gcp/patch-controlplane-disk/ipi-conf-gcp-patch-controlplane-disk-ref.metadata.json
+++ b/ci-operator/step-registry/ipi/conf/gcp/patch-controlplane-disk/ipi-conf-gcp-patch-controlplane-disk-ref.metadata.json
@@ -1,0 +1,11 @@
+{
+	"path": "ipi/conf/gcp/patch-controlplane-disk/ipi-conf-gcp-patch-controlplane-disk-ref.yaml",
+	"owners": {
+		"approvers": [
+			"openshift-ci-robot"
+		],
+		"reviewers": [
+			"openshift-ci-robot"
+		]
+	}
+}

--- a/ci-operator/step-registry/ipi/conf/gcp/patch-controlplane-disk/ipi-conf-gcp-patch-controlplane-disk-ref.yaml
+++ b/ci-operator/step-registry/ipi/conf/gcp/patch-controlplane-disk/ipi-conf-gcp-patch-controlplane-disk-ref.yaml
@@ -1,0 +1,14 @@
+ref:
+  as: ipi-conf-gcp-patch-controlplane-disk
+  from_image:
+    namespace: ocp
+    name: "4.18"
+    tag: upi-installer
+  commands: ipi-conf-gcp-patch-controlplane-disk-commands.sh
+  resources:
+    requests:
+      cpu: 10m
+      memory: 100Mi
+  documentation: |-
+    Patches the install-config.yaml to set the control plane and compute disk type to hyperdisk-balanced.
+    This is required for n4a-standard-4 (ARM Axion) instances which only support hyperdisk-balanced disks.

--- a/ci-operator/step-registry/storage/conf/storageclass/pre-set-default-gcp/OWNERS
+++ b/ci-operator/step-registry/storage/conf/storageclass/pre-set-default-gcp/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+- storage-approvers
+- duanwei33
+- Phaow
+reviewers:
+- storage-reviewers
+- duanwei33
+- Phaow

--- a/ci-operator/step-registry/storage/conf/storageclass/pre-set-default-gcp/OWNERS
+++ b/ci-operator/step-registry/storage/conf/storageclass/pre-set-default-gcp/OWNERS
@@ -1,8 +1,4 @@
 approvers:
 - storage-approvers
-- duanwei33
-- Phaow
 reviewers:
 - storage-reviewers
-- duanwei33
-- Phaow

--- a/ci-operator/step-registry/storage/conf/storageclass/pre-set-default-gcp/storage-conf-storageclass-pre-set-default-gcp-commands.sh
+++ b/ci-operator/step-registry/storage/conf/storageclass/pre-set-default-gcp/storage-conf-storageclass-pre-set-default-gcp-commands.sh
@@ -3,7 +3,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-cat << EOF > ${SHARED_DIR}/manifest_storageclass.yaml
+cat << EOF > "${SHARED_DIR}/manifest_storageclass.yaml"
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -19,7 +19,7 @@ allowVolumeExpansion: true
 reclaimPolicy: Delete
 EOF
 
-cat << EOF > ${SHARED_DIR}/manifest_cluster_csi_driver.yaml
+cat << EOF > "${SHARED_DIR}/manifest_cluster_csi_driver.yaml"
 apiVersion: operator.openshift.io/v1
 kind: "ClusterCSIDriver"
 metadata:

--- a/ci-operator/step-registry/storage/conf/storageclass/pre-set-default-gcp/storage-conf-storageclass-pre-set-default-gcp-commands.sh
+++ b/ci-operator/step-registry/storage/conf/storageclass/pre-set-default-gcp/storage-conf-storageclass-pre-set-default-gcp-commands.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+cat << EOF > ${SHARED_DIR}/manifest_storageclass.yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ${GCP_SC_DISK_TYPE}
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: pd.csi.storage.gke.io
+parameters:
+  type: ${GCP_SC_DISK_TYPE}
+  replication-type: none
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+EOF
+
+cat << EOF > ${SHARED_DIR}/manifest_cluster_csi_driver.yaml
+apiVersion: operator.openshift.io/v1
+kind: "ClusterCSIDriver"
+metadata:
+  name: "pd.csi.storage.gke.io"
+spec:
+  logLevel: Normal
+  managementState: Managed
+  operatorLogLevel: Normal
+  storageClassState: Unmanaged
+EOF

--- a/ci-operator/step-registry/storage/conf/storageclass/pre-set-default-gcp/storage-conf-storageclass-pre-set-default-gcp-ref.metadata.json
+++ b/ci-operator/step-registry/storage/conf/storageclass/pre-set-default-gcp/storage-conf-storageclass-pre-set-default-gcp-ref.metadata.json
@@ -1,0 +1,15 @@
+{
+	"path": "storage/conf/storageclass/pre-set-default-gcp/storage-conf-storageclass-pre-set-default-gcp-ref.yaml",
+	"owners": {
+		"approvers": [
+			"storage-approvers",
+			"duanwei33",
+			"Phaow"
+		],
+		"reviewers": [
+			"storage-reviewers",
+			"duanwei33",
+			"Phaow"
+		]
+	}
+}

--- a/ci-operator/step-registry/storage/conf/storageclass/pre-set-default-gcp/storage-conf-storageclass-pre-set-default-gcp-ref.metadata.json
+++ b/ci-operator/step-registry/storage/conf/storageclass/pre-set-default-gcp/storage-conf-storageclass-pre-set-default-gcp-ref.metadata.json
@@ -2,14 +2,10 @@
 	"path": "storage/conf/storageclass/pre-set-default-gcp/storage-conf-storageclass-pre-set-default-gcp-ref.yaml",
 	"owners": {
 		"approvers": [
-			"storage-approvers",
-			"duanwei33",
-			"Phaow"
+			"storage-approvers"
 		],
 		"reviewers": [
-			"storage-reviewers",
-			"duanwei33",
-			"Phaow"
+			"storage-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/storage/conf/storageclass/pre-set-default-gcp/storage-conf-storageclass-pre-set-default-gcp-ref.yaml
+++ b/ci-operator/step-registry/storage/conf/storageclass/pre-set-default-gcp/storage-conf-storageclass-pre-set-default-gcp-ref.yaml
@@ -1,5 +1,6 @@
 ref:
   as: storage-conf-storageclass-pre-set-default-gcp
+  from: cli
   commands: storage-conf-storageclass-pre-set-default-gcp-commands.sh
   resources:
     requests:

--- a/ci-operator/step-registry/storage/conf/storageclass/pre-set-default-gcp/storage-conf-storageclass-pre-set-default-gcp-ref.yaml
+++ b/ci-operator/step-registry/storage/conf/storageclass/pre-set-default-gcp/storage-conf-storageclass-pre-set-default-gcp-ref.yaml
@@ -1,0 +1,18 @@
+ref:
+  as: storage-conf-storageclass-pre-set-default-gcp
+  commands: storage-conf-storageclass-pre-set-default-gcp-commands.sh
+  resources:
+    requests:
+      cpu: 10m
+      memory: 100Mi
+  env:
+  - name: GCP_SC_DISK_TYPE
+    default: "pd-balanced"
+    documentation: |-
+      The GCP persistent disk type to use for the default StorageClass.
+      Valid values are "pd-balanced", "pd-ssd", "pd-standard", and "hyperdisk-balanced".
+  documentation: |-
+    The `storage-conf-storageclass-pre-set-default-gcp` step creates a default
+    StorageClass with a configurable GCP disk type and sets the ClusterCSIDriver
+    storageClassState to Unmanaged. Manifests are written to ${SHARED_DIR} for
+    injection at install time.


### PR DESCRIPTION
Replace t2a-standard-4 with n4a-standard-4 in multiarch-tuning-operator configs

Updates COMPUTE_NODE_TYPE from t2a-standard-4 to n4a-standard-4 for ARM64 test configurations across openshift, openshift-priv, and outrigger-project multiarch-tuning-operator variants.

 t2a-standard-4 is old and starting to be phased out.

```
level=error msg=A t2a-standard-4 VM instance is currently unavailable in the us-central1-a zone. Consider trying your request in the us-central1-f, us-central1-b zone(s), which currently has capacity to accommodate your request. Alternatively, you can try your request again with a different VM hardware configuration or at a later time. For more information, see the troubleshooting documentation.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR updates ARM64 test infrastructure configuration for the multiarch-tuning-operator project by replacing an obsolete Google Cloud Platform (GCP) VM instance type with a newer alternative.

### Core Changes

**Compute Instance Type Update**: Across 22 CI operator configuration files in the `openshift`, `openshift-priv`, and `outrigger-project` organizations, the `COMPUTE_NODE_TYPE` environment variable for GCP-based end-to-end tests is being changed from `t2a-standard-4` (an older ARM64 instance type) to `n4a-standard-4` (a newer ARM64 instance type). This change applies to multiple multiarch-tuning-operator configuration variants including:
- Main branch variants with OCP versions 4.16 through 4.22
- Release variants (v0.0.1, v0.9, v1.x series)
- Multi-operator test configurations (e2e-gcp-multi-operator and e2e-gcp-multi-operator-olm steps)

The rationale is that t2a-standard-4 is being phased out, as evidenced by the PR description noting GCP VM instance availability issues in the us-central1-a zone and recommending alternatives.

### Additional Infrastructure Changes

Four new files were added to the storage step registry for GCP-based storage class configuration:
- OWNERS file defining approval groups (storage-approvers/storage-reviewers)
- Bash script (`storage-conf-storageclass-pre-set-default-gcp-commands.sh`) that generates Kubernetes manifests for creating a default GCP StorageClass with configurable disk types and an OpenShift ClusterCSIDriver
- Metadata and YAML reference files documenting the new step with resource requests and environment configuration

### Testing Status

CI rehearsal runs have been initiated and retested by multiple reviewers to validate the configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->