### PR TITLE
rosa-e2e: Add Classic STS nightly jobs and !Access:MC label filter (4.19-4.22, HCP 5.0)

### DIFF
--- a/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__periodics.yaml
+++ b/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__periodics.yaml
@@ -38,6 +38,7 @@ tests:
       CHANNEL_GROUP: nightly
       ENABLE_BILLING_ACCOUNT: "yes"
       HOSTED_CP: "true"
+      LABEL_FILTER: '!Access:MC'
       OCM_LOGIN_ENV: staging
       OPENSHIFT_VERSION: "4.19"
       REPLICAS: "3"
@@ -50,6 +51,7 @@ tests:
       CHANNEL_GROUP: nightly
       ENABLE_BILLING_ACCOUNT: "yes"
       HOSTED_CP: "true"
+      LABEL_FILTER: '!Access:MC'
       OCM_LOGIN_ENV: staging
       OPENSHIFT_VERSION: "4.20"
       REPLICAS: "3"
@@ -62,6 +64,7 @@ tests:
       CHANNEL_GROUP: nightly
       ENABLE_BILLING_ACCOUNT: "yes"
       HOSTED_CP: "true"
+      LABEL_FILTER: '!Access:MC'
       OCM_LOGIN_ENV: staging
       OPENSHIFT_VERSION: "4.21"
       REPLICAS: "3"
@@ -74,6 +77,7 @@ tests:
       CHANNEL_GROUP: nightly
       ENABLE_BILLING_ACCOUNT: "yes"
       HOSTED_CP: "true"
+      LABEL_FILTER: '!Access:MC'
       OCM_LOGIN_ENV: staging
       OPENSHIFT_VERSION: "4.22"
       REPLICAS: "3"
@@ -86,33 +90,38 @@ tests:
       CHANNEL_GROUP: nightly
       ENABLE_BILLING_ACCOUNT: "yes"
       HOSTED_CP: "true"
+      LABEL_FILTER: '!Access:MC'
       OCM_LOGIN_ENV: staging
       OPENSHIFT_VERSION: "5.0"
       REPLICAS: "3"
     workflow: rosa-e2e-hcp
-- as: rosa-sts-e2e-nightly-4-21
+- as: rosa-classic-sts-e2e-nightly-4-19
   cron: 30 5 * * *
   steps:
     cluster_profile: rosa-e2e-01
     env:
       CHANNEL_GROUP: nightly
+      CLUSTER_TOPOLOGY: classic
       HOSTED_CP: "false"
-      LABEL_FILTER: Platform:Classic
+      LABEL_FILTER: Platform:Classic && !Access:MC
       OCM_LOGIN_ENV: staging
-      OPENSHIFT_VERSION: "4.21"
-      REPLICAS: "3"
+      OPENSHIFT_VERSION: "4.19"
+      REPLICAS: "2"
+      STS: "true"
     workflow: rosa-e2e-classic
-- as: rosa-sts-e2e-nightly-4-22
+- as: rosa-classic-sts-e2e-nightly-4-23
   cron: 0 6 * * *
   steps:
     cluster_profile: rosa-e2e-01
     env:
       CHANNEL_GROUP: nightly
+      CLUSTER_TOPOLOGY: classic
       HOSTED_CP: "false"
-      LABEL_FILTER: Platform:Classic
+      LABEL_FILTER: Platform:Classic && !Access:MC
       OCM_LOGIN_ENV: staging
-      OPENSHIFT_VERSION: "4.22"
-      REPLICAS: "3"
+      OPENSHIFT_VERSION: "4.23"
+      REPLICAS: "2"
+      STS: "true"
     workflow: rosa-e2e-classic
 zz_generated_metadata:
   branch: main

--- a/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__periodics.yaml
+++ b/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__periodics.yaml
@@ -82,19 +82,6 @@ tests:
       OPENSHIFT_VERSION: "4.22"
       REPLICAS: "3"
     workflow: rosa-e2e-hcp
-- as: rosa-hcp-e2e-nightly-5-0
-  cron: 0 5 * * *
-  steps:
-    cluster_profile: rosa-e2e-01
-    env:
-      CHANNEL_GROUP: nightly
-      ENABLE_BILLING_ACCOUNT: "yes"
-      HOSTED_CP: "true"
-      LABEL_FILTER: '!Access:MC'
-      OCM_LOGIN_ENV: staging
-      OPENSHIFT_VERSION: "5.0"
-      REPLICAS: "3"
-    workflow: rosa-e2e-hcp
 - as: rosa-classic-sts-e2e-nightly-4-19
   cron: 30 5 * * *
   steps:
@@ -109,7 +96,7 @@ tests:
       REPLICAS: "2"
       STS: "true"
     workflow: rosa-e2e-classic
-- as: rosa-classic-sts-e2e-nightly-4-23
+- as: rosa-classic-sts-e2e-nightly-4-20
   cron: 0 6 * * *
   steps:
     cluster_profile: rosa-e2e-01
@@ -119,7 +106,35 @@ tests:
       HOSTED_CP: "false"
       LABEL_FILTER: Platform:Classic && !Access:MC
       OCM_LOGIN_ENV: staging
-      OPENSHIFT_VERSION: "4.23"
+      OPENSHIFT_VERSION: "4.20"
+      REPLICAS: "2"
+      STS: "true"
+    workflow: rosa-e2e-classic
+- as: rosa-classic-sts-e2e-nightly-4-21
+  cron: 30 6 * * *
+  steps:
+    cluster_profile: rosa-e2e-01
+    env:
+      CHANNEL_GROUP: nightly
+      CLUSTER_TOPOLOGY: classic
+      HOSTED_CP: "false"
+      LABEL_FILTER: Platform:Classic && !Access:MC
+      OCM_LOGIN_ENV: staging
+      OPENSHIFT_VERSION: "4.21"
+      REPLICAS: "2"
+      STS: "true"
+    workflow: rosa-e2e-classic
+- as: rosa-classic-sts-e2e-nightly-4-22
+  cron: 0 7 * * *
+  steps:
+    cluster_profile: rosa-e2e-01
+    env:
+      CHANNEL_GROUP: nightly
+      CLUSTER_TOPOLOGY: classic
+      HOSTED_CP: "false"
+      LABEL_FILTER: Platform:Classic && !Access:MC
+      OCM_LOGIN_ENV: staging
+      OPENSHIFT_VERSION: "4.22"
       REPLICAS: "2"
       STS: "true"
     workflow: rosa-e2e-classic

--- a/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__periodics.yaml
+++ b/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__periodics.yaml
@@ -82,6 +82,19 @@ tests:
       OPENSHIFT_VERSION: "4.22"
       REPLICAS: "3"
     workflow: rosa-e2e-hcp
+- as: rosa-hcp-e2e-nightly-5-0
+  cron: 30 4 * * *
+  steps:
+    cluster_profile: rosa-e2e-01
+    env:
+      CHANNEL_GROUP: nightly
+      ENABLE_BILLING_ACCOUNT: "yes"
+      HOSTED_CP: "true"
+      LABEL_FILTER: '!Access:MC'
+      OCM_LOGIN_ENV: staging
+      OPENSHIFT_VERSION: "5.0"
+      REPLICAS: "3"
+    workflow: rosa-e2e-hcp
 - as: rosa-classic-sts-e2e-nightly-4-19
   cron: 30 5 * * *
   steps:

--- a/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-periodics.yaml
@@ -2248,6 +2248,89 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
+  cluster: build09
+  cron: 30 4 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-online
+    repo: rosa-e2e
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: rosa-e2e-01
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-online-rosa-e2e-main-periodics-rosa-hcp-e2e-nightly-5-0
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=rosa-hcp-e2e-nightly-5-0
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
   cluster: build06
   cron: 0 14 * * *
   decorate: true

--- a/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-periodics.yaml
@@ -1683,7 +1683,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-online-rosa-e2e-main-periodics-rosa-classic-sts-e2e-nightly-4-23
+  name: periodic-ci-openshift-online-rosa-e2e-main-periodics-rosa-classic-sts-e2e-nightly-4-20
   spec:
     containers:
     - args:
@@ -1692,7 +1692,173 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=rosa-classic-sts-e2e-nightly-4-23
+      - --target=rosa-classic-sts-e2e-nightly-4-20
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build09
+  cron: 30 6 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-online
+    repo: rosa-e2e
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: rosa-e2e-01
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-online-rosa-e2e-main-periodics-rosa-classic-sts-e2e-nightly-4-21
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=rosa-classic-sts-e2e-nightly-4-21
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build09
+  cron: 0 7 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-online
+    repo: rosa-e2e
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: rosa-e2e-01
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-online-rosa-e2e-main-periodics-rosa-classic-sts-e2e-nightly-4-22
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=rosa-classic-sts-e2e-nightly-4-22
       - --variant=periodics
       command:
       - ci-operator
@@ -2025,255 +2191,6 @@ periodics:
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
       - --target=rosa-hcp-e2e-nightly-4-22
-      - --variant=periodics
-      command:
-      - ci-operator
-      env:
-      - name: HTTP_SERVER_IP
-        valueFrom:
-          fieldRef:
-            fieldPath: status.podIP
-      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-      imagePullPolicy: Always
-      name: ""
-      ports:
-      - containerPort: 8080
-        name: http
-      resources:
-        requests:
-          cpu: 10m
-      volumeMounts:
-      - mountPath: /etc/boskos
-        name: boskos
-        readOnly: true
-      - mountPath: /secrets/ci-pull-credentials
-        name: ci-pull-credentials
-        readOnly: true
-      - mountPath: /secrets/gcs
-        name: gcs-credentials
-        readOnly: true
-      - mountPath: /secrets/manifest-tool
-        name: manifest-tool-local-pusher
-        readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
-      - mountPath: /etc/report
-        name: result-aggregator
-        readOnly: true
-    serviceAccountName: ci-operator
-    volumes:
-    - name: boskos
-      secret:
-        items:
-        - key: credentials
-          path: credentials
-        secretName: boskos-credentials
-    - name: ci-pull-credentials
-      secret:
-        secretName: ci-pull-credentials
-    - name: manifest-tool-local-pusher
-      secret:
-        secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
-    - name: result-aggregator
-      secret:
-        secretName: result-aggregator
-- agent: kubernetes
-  cluster: build09
-  cron: 0 5 * * *
-  decorate: true
-  decoration_config:
-    skip_cloning: true
-  extra_refs:
-  - base_ref: main
-    org: openshift-online
-    repo: rosa-e2e
-  labels:
-    ci-operator.openshift.io/cloud: aws
-    ci-operator.openshift.io/cloud-cluster-profile: rosa-e2e-01
-    ci-operator.openshift.io/variant: periodics
-    ci.openshift.io/generator: prowgen
-    job-release: "4.22"
-    pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-online-rosa-e2e-main-periodics-rosa-hcp-e2e-nightly-5-0
-  spec:
-    containers:
-    - args:
-      - --gcs-upload-secret=/secrets/gcs/service-account.json
-      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-      - --lease-server-credentials-file=/etc/boskos/credentials
-      - --report-credentials-file=/etc/report/credentials
-      - --secret-dir=/secrets/ci-pull-credentials
-      - --target=rosa-hcp-e2e-nightly-5-0
-      - --variant=periodics
-      command:
-      - ci-operator
-      env:
-      - name: HTTP_SERVER_IP
-        valueFrom:
-          fieldRef:
-            fieldPath: status.podIP
-      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-      imagePullPolicy: Always
-      name: ""
-      ports:
-      - containerPort: 8080
-        name: http
-      resources:
-        requests:
-          cpu: 10m
-      volumeMounts:
-      - mountPath: /etc/boskos
-        name: boskos
-        readOnly: true
-      - mountPath: /secrets/ci-pull-credentials
-        name: ci-pull-credentials
-        readOnly: true
-      - mountPath: /secrets/gcs
-        name: gcs-credentials
-        readOnly: true
-      - mountPath: /secrets/manifest-tool
-        name: manifest-tool-local-pusher
-        readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
-      - mountPath: /etc/report
-        name: result-aggregator
-        readOnly: true
-    serviceAccountName: ci-operator
-    volumes:
-    - name: boskos
-      secret:
-        items:
-        - key: credentials
-          path: credentials
-        secretName: boskos-credentials
-    - name: ci-pull-credentials
-      secret:
-        secretName: ci-pull-credentials
-    - name: manifest-tool-local-pusher
-      secret:
-        secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
-    - name: result-aggregator
-      secret:
-        secretName: result-aggregator
-- agent: kubernetes
-  cluster: build09
-  cron: 30 5 * * *
-  decorate: true
-  decoration_config:
-    skip_cloning: true
-  extra_refs:
-  - base_ref: main
-    org: openshift-online
-    repo: rosa-e2e
-  labels:
-    ci-operator.openshift.io/cloud: aws
-    ci-operator.openshift.io/cloud-cluster-profile: rosa-e2e-01
-    ci-operator.openshift.io/variant: periodics
-    ci.openshift.io/generator: prowgen
-    job-release: "4.22"
-    pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-online-rosa-e2e-main-periodics-rosa-sts-e2e-nightly-4-21
-  spec:
-    containers:
-    - args:
-      - --gcs-upload-secret=/secrets/gcs/service-account.json
-      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-      - --lease-server-credentials-file=/etc/boskos/credentials
-      - --report-credentials-file=/etc/report/credentials
-      - --secret-dir=/secrets/ci-pull-credentials
-      - --target=rosa-sts-e2e-nightly-4-21
-      - --variant=periodics
-      command:
-      - ci-operator
-      env:
-      - name: HTTP_SERVER_IP
-        valueFrom:
-          fieldRef:
-            fieldPath: status.podIP
-      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-      imagePullPolicy: Always
-      name: ""
-      ports:
-      - containerPort: 8080
-        name: http
-      resources:
-        requests:
-          cpu: 10m
-      volumeMounts:
-      - mountPath: /etc/boskos
-        name: boskos
-        readOnly: true
-      - mountPath: /secrets/ci-pull-credentials
-        name: ci-pull-credentials
-        readOnly: true
-      - mountPath: /secrets/gcs
-        name: gcs-credentials
-        readOnly: true
-      - mountPath: /secrets/manifest-tool
-        name: manifest-tool-local-pusher
-        readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
-      - mountPath: /etc/report
-        name: result-aggregator
-        readOnly: true
-    serviceAccountName: ci-operator
-    volumes:
-    - name: boskos
-      secret:
-        items:
-        - key: credentials
-          path: credentials
-        secretName: boskos-credentials
-    - name: ci-pull-credentials
-      secret:
-        secretName: ci-pull-credentials
-    - name: manifest-tool-local-pusher
-      secret:
-        secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
-    - name: result-aggregator
-      secret:
-        secretName: result-aggregator
-- agent: kubernetes
-  cluster: build09
-  cron: 0 6 * * *
-  decorate: true
-  decoration_config:
-    skip_cloning: true
-  extra_refs:
-  - base_ref: main
-    org: openshift-online
-    repo: rosa-e2e
-  labels:
-    ci-operator.openshift.io/cloud: aws
-    ci-operator.openshift.io/cloud-cluster-profile: rosa-e2e-01
-    ci-operator.openshift.io/variant: periodics
-    ci.openshift.io/generator: prowgen
-    job-release: "4.22"
-    pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-online-rosa-e2e-main-periodics-rosa-sts-e2e-nightly-4-22
-  spec:
-    containers:
-    - args:
-      - --gcs-upload-secret=/secrets/gcs/service-account.json
-      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-      - --lease-server-credentials-file=/etc/boskos/credentials
-      - --report-credentials-file=/etc/report/credentials
-      - --secret-dir=/secrets/ci-pull-credentials
-      - --target=rosa-sts-e2e-nightly-4-22
       - --variant=periodics
       command:
       - ci-operator

--- a/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-periodics.yaml
@@ -1585,6 +1585,172 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build09
+  cron: 30 5 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-online
+    repo: rosa-e2e
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: rosa-e2e-01
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-online-rosa-e2e-main-periodics-rosa-classic-sts-e2e-nightly-4-19
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=rosa-classic-sts-e2e-nightly-4-19
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build09
+  cron: 0 6 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-online
+    repo: rosa-e2e
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: rosa-e2e-01
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-online-rosa-e2e-main-periodics-rosa-classic-sts-e2e-nightly-4-23
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=rosa-classic-sts-e2e-nightly-4-23
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build09
   cron: 30 2 * * *
   decorate: true
   decoration_config:

--- a/ci-operator/step-registry/rosa/e2e/classic/rosa-e2e-classic-workflow.yaml
+++ b/ci-operator/step-registry/rosa/e2e/classic/rosa-e2e-classic-workflow.yaml
@@ -4,8 +4,10 @@ workflow:
     env:
       CHANNEL_GROUP: stable
       HOSTED_CP: "false"
-      MULTI_AZ: "true"
-      REPLICAS: "3"
+      STS: "true"
+      REPLICAS: "2"
+      CLUSTER_TOPOLOGY: classic
+      LABEL_FILTER: "Platform:Classic"
     pre:
       - chain: rosa-aws-sts-provision
       - ref: rosa-cluster-wait-ready-nodes
@@ -16,6 +18,11 @@ workflow:
         best_effort: true
       - ref: rosa-sts-account-roles-delete
         best_effort: true
+      - ref: rosa-e2e-cleanup-vpc
+        best_effort: true
+      - ref: aws-deprovision-stacks
+        best_effort: true
   documentation: |-
-    This workflow provisions a ROSA STS (Classic) cluster and runs the rosa-e2e
-    managed service validation suite, then tears down the cluster.
+    This workflow provisions a ROSA Classic STS cluster and runs the
+    rosa-e2e managed service validation suite filtered to Classic-compatible
+    tests, then tears down the cluster.

--- a/ci-operator/step-registry/rosa/e2e/test/rosa-e2e-test-commands.sh
+++ b/ci-operator/step-registry/rosa/e2e/test/rosa-e2e-test-commands.sh
@@ -45,33 +45,28 @@ export OCM_ENV="${OCM_LOGIN_ENV}"
 export CLUSTER_ID
 export AWS_REGION="${LEASED_RESOURCE}"
 
-# Set CLUSTER_TOPOLOGY so the test binary knows the cluster type without an extra OCM API call
-if [[ "${HOSTED_CP:-false}" == "true" ]]; then
-  export CLUSTER_TOPOLOGY="hcp"
-else
-  export CLUSTER_TOPOLOGY="classic"
-fi
-log "Cluster topology: ${CLUSTER_TOPOLOGY}"
-
-# Try to get MC access via backplane (HCP only)
-if [[ "${CLUSTER_TOPOLOGY}" == "hcp" ]]; then
-  log "Attempting MC access via backplane..."
-  if ocm backplane login "${CLUSTER_ID}" --manager 2>/dev/null; then
-    export MC_KUBECONFIG="${HOME}/.kube/config"
-    MC_SERVER=$(oc whoami --show-server 2>/dev/null || true)
-    if [[ "${MC_SERVER}" == *"backplane"* ]]; then
-      MANAGEMENT_CLUSTER_ID=$(echo "${MC_SERVER}" | sed 's|.*/cluster/||; s|/.*||')
-      export MANAGEMENT_CLUSTER_ID
-      log "MC access established: ${MANAGEMENT_CLUSTER_ID}"
-    fi
+# Try to get manager cluster access via backplane
+# HCP: --manager accesses the Management Cluster (HyperShift operator, HCP namespaces)
+# Classic: --manager accesses the Hive cluster (ClusterDeployment)
+log "Attempting manager cluster access via backplane..."
+if ocm backplane login "${CLUSTER_ID}" --manager 2>/dev/null; then
+  export MC_KUBECONFIG="${HOME}/.kube/config"
+  MC_SERVER=$(oc whoami --show-server 2>/dev/null || true)
+  if [[ "${MC_SERVER}" == *"backplane"* ]]; then
+    MANAGEMENT_CLUSTER_ID=$(echo "${MC_SERVER}" | sed 's|.*/cluster/||; s|/.*||')
+    export MANAGEMENT_CLUSTER_ID
+    log "Manager cluster access established: ${MANAGEMENT_CLUSTER_ID}"
   fi
 fi
 
 # Run tests
-GINKGO_ARGS=(--ginkgo.junit-report="${ARTIFACT_DIR}/junit-rosa-e2e.xml" --ginkgo.v)
+GINKGO_FLAGS="--ginkgo.junit-report=${ARTIFACT_DIR}/junit-rosa-e2e.xml --ginkgo.v"
 if [[ -n "${LABEL_FILTER}" ]]; then
-  log "Label filter: ${LABEL_FILTER}"
-  GINKGO_ARGS+=(--ginkgo.label-filter="${LABEL_FILTER}")
+  GINKGO_FLAGS="${GINKGO_FLAGS} --ginkgo.label-filter=${LABEL_FILTER}"
+fi
+
+if [[ -n "${CLUSTER_TOPOLOGY:-}" ]]; then
+  export CLUSTER_TOPOLOGY
 fi
 
 if [[ -n "${EXCLUDE_CLUSTER_OPERATORS}" ]]; then
@@ -79,6 +74,6 @@ if [[ -n "${EXCLUDE_CLUSTER_OPERATORS}" ]]; then
 fi
 
 log "Running rosa-e2e tests..."
-/usr/local/bin/e2e.test "${GINKGO_ARGS[@]}"
+/usr/local/bin/e2e.test ${GINKGO_FLAGS}
 
 log "Tests complete. Results at ${ARTIFACT_DIR}/junit-rosa-e2e.xml"

--- a/ci-operator/step-registry/rosa/e2e/test/rosa-e2e-test-ref.yaml
+++ b/ci-operator/step-registry/rosa/e2e/test/rosa-e2e-test-ref.yaml
@@ -16,10 +16,10 @@ ref:
     documentation: Whether the cluster is HCP (true) or Classic (false). Controls topology detection and MC access.
   - name: LABEL_FILTER
     default: ""
-    documentation: Ginkgo label filter for test selection (e.g. "Area:ManagedService").
-  - name: HOSTED_CP
-    default: "false"
-    documentation: Set to 'true' for HCP clusters to enable management cluster access via backplane and set CLUSTER_TOPOLOGY=hcp.
+    documentation: Ginkgo label filter for test selection (e.g. "Platform:Classic", "Area:ManagedService").
+  - name: CLUSTER_TOPOLOGY
+    default: ""
+    documentation: Override topology detection (hcp, classic, osd-gcp). Auto-detected from OCM if empty.
   - name: EXCLUDE_CLUSTER_OPERATORS
     default: ""
     documentation: Comma-separated list of ClusterOperators to exclude from health checks.
@@ -27,6 +27,6 @@ ref:
   - name: rosa-e2e
     env: ROSA_E2E_IMAGE
   documentation: |-
-    Runs the rosa-e2e test suite against an existing ROSA cluster (HCP or Classic).
+    Runs the rosa-e2e test suite against an existing ROSA cluster (HCP or Classic STS).
     Expects CLUSTER_ID in SHARED_DIR/cluster-id and AWS credentials in the cluster profile.
     Set HOSTED_CP=true for HCP clusters to enable management cluster access via backplane.


### PR DESCRIPTION
## Summary

- Add ROSA Classic STS nightly periodic jobs for 4.19, 4.20, 4.21, 4.22
- Add `rosa-e2e-classic` workflow for Classic STS cluster testing
- Add `!Access:MC` label filter to all HCP and Classic nightly jobs
- Add `CLUSTER_TOPOLOGY` env var to the `rosa-e2e-test` step for explicit topology override
- Scope all jobs to 4.19-4.22 (5.0 and 4.23 not yet supported)

### Jobs added/modified

| Job | Version | Type | Schedule |
|-----|---------|------|----------|
| rosa-hcp-e2e-nightly-4-19 | 4.19 | HCP | 02:30 UTC |
| rosa-hcp-e2e-nightly-4-20 | 4.20 | HCP | 03:00 UTC |
| rosa-hcp-e2e-nightly-4-21 | 4.21 | HCP | 03:30 UTC |
| rosa-hcp-e2e-nightly-4-22 | 4.22 | HCP | 04:00 UTC |
| rosa-classic-sts-e2e-nightly-4-19 | 4.19 | Classic STS | 05:30 UTC |
| rosa-classic-sts-e2e-nightly-4-20 | 4.20 | Classic STS | 06:00 UTC |
| rosa-classic-sts-e2e-nightly-4-21 | 4.21 | Classic STS | 06:30 UTC |
| rosa-classic-sts-e2e-nightly-4-22 | 4.22 | Classic STS | 07:00 UTC |

### MC test exclusion

MC-dependent tests (labeled `Access:MC` in [rosa-e2e#40](https://github.com/openshift-online/rosa-e2e/pull/40)) are excluded via label filter until a dedicated e2e sector with bastion access is provisioned ([ROSAENG-1082](https://redhat.atlassian.net/browse/ROSAENG-1082)).

## Test plan

- [ ] pj-rehearse representative HCP and Classic jobs
- [ ] Verify Classic workflow provisions STS cluster correctly
- [ ] Verify label filter excludes MC tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR updates OpenShift CI configs to add nightly ROSA Classic STS e2e testing alongside existing HCP testing. It introduces a dedicated rosa-e2e-classic workflow, exposes CLUSTER_TOPOLOGY to the test step, updates the test runner to handle manager-cluster access for both HCP and Classic topologies, and adds periodic jobs to run Classic STS nightlies. It also scopes existing HCP nightlies to exclude manager-cluster-only tests.

## What changed (practical impact)

- CI repo impacted: OpenShift CI configuration for the rosa-e2e jobset (generated periodic job configs and step-registry workflow/steps).
- New workflow: Adds ci-operator/step-registry/rosa/e2e/classic/rosa-e2e-classic-workflow.yaml and an OWNERS file. This workflow provisions Classic STS clusters, runs rosa-e2e with Classic-specific filters, and tears down resources.
- Test-step API: Exposes CLUSTER_TOPOLOGY (and EXCLUDE_CLUSTER_OPERATORS) in ci-operator/step-registry/rosa/e2e/test/rosa-e2e-test-ref.yaml so the test step can be explicitly told which topology to target.
- Runtime behavior: Updates ci-operator/step-registry/rosa/e2e/test/rosa-e2e-test-commands.sh to export CLUSTER_TOPOLOGY when provided and to establish manager-cluster/backplane access appropriately for both HCP and Classic targets.
- Periodics: Adds Classic STS nightly periodic jobs (OpenShift 4.19–4.22) using the new rosa-e2e-classic workflow and updates the generated periodic job manifests (ci-operator/config/...__periodics.yaml and ci-operator/jobs/...) to include them with specific cron schedules and envs (Platform:Classic, STS:false/true flags, REPLICAS, and !Access:MC label filter).
- HCP isolation: Adds LABEL_FILTER: '!Access:MC' to existing HCP nightly jobs (4.19–4.22) to exclude tests that require manager-cluster access until a dedicated e2e sector for MC is provisioned. The commit history also narrows/nightly scope by removing some older/unsupported nightly entries (e.g., HCP 5.0 and Classic 4.23).

## Test plan / status

- make jobs generated the expected periodic definitions (checked).
- make registry-metadata passed (checked).
- Rehearsal for the new Classic nightly (rosa-classic-sts-e2e-nightly) is pending and will be run after merge-bot posts the rehearsal notifier.

## Notes / rationale

- CLUSTER_TOPOLOGY enables explicit multi-topology testing (HCP vs Classic) without conflating test selection.
- Label filtering (!Access:MC) prevents manager-cluster-only tests from running against HCP nightlies until MC test infrastructure is available (tracks [ROSAENG-1082](https://redhat.atlassian.net/browse/ROSAENG-1082)).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->