### PR TITLE
OCPBUGS-85081: OpenStack: fix rhcos name/content mismatch in upgrade jobs

### DIFF
--- a/ci-operator/step-registry/openstack/conf/rhcosimage/openstack-conf-rhcosimage-commands.sh
+++ b/ci-operator/step-registry/openstack/conf/rhcosimage/openstack-conf-rhcosimage-commands.sh
@@ -4,13 +4,16 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
-# Get OCP version from the release image metadata.
-# Must run before proxy setup: the build farm registry needs a direct connection.
-export HOME="${HOME:-/tmp/home}"
-export XDG_RUNTIME_DIR="${HOME}/run"
-mkdir -p "${XDG_RUNTIME_DIR}"
-KUBECONFIG="" oc registry login
-OCP_VERSION="$(oc adm release info "${RELEASE_IMAGE_LATEST}" --output=json | jq -r '.metadata.version' | cut -d. -f1,2)"
+# Get OCP version from the installer binary itself.
+# This ensures the Glance image name matches the RHCOS content that the
+# installer embeds, which is important for upgrade jobs where the installer
+# version can differ from the release under test.
+OCP_VERSION="$(openshift-install version 2>/dev/null | sed -n 's/^release image\s\+.*:\([0-9]\+\.[0-9]\+\).*/\1/p')"
+if [[ ! "${OCP_VERSION}" =~ ^[0-9]+\.[0-9]+$ ]]; then
+	echo "ERROR: Failed to extract OCP version from openshift-install:" >&2
+	openshift-install version >&2
+	exit 1
+fi
 
 export OS_CLIENT_CONFIG_FILE="${SHARED_DIR}/clouds.yaml"
 

--- a/ci-operator/step-registry/openstack/conf/rhcosimage/openstack-conf-rhcosimage-ref.yaml
+++ b/ci-operator/step-registry/openstack/conf/rhcosimage/openstack-conf-rhcosimage-ref.yaml
@@ -2,9 +2,6 @@ ref:
   as: openstack-conf-rhcosimage
   from: openstack-installer
   commands: openstack-conf-rhcosimage-commands.sh
-  dependencies:
-  - name: "release:latest"
-    env: RELEASE_IMAGE_LATEST
   resources:
     requests:
       cpu: 10m
@@ -17,11 +14,14 @@ ref:
     default: "rhcos"
     documentation: |-
       Prefix for the RHCOS image name in OpenStack Glance. The OCP minor
-      version is appended automatically (e.g. "rhcos" becomes "rhcos-4.18").
-      The step will create or update this image to match the version embedded
-      in openshift-install.
+      version from the openshift-install binary is appended automatically
+      (e.g. "rhcos" becomes "rhcos-4.18"). The step will create or update
+      this image to match the version embedded in openshift-install.
   documentation: |-
     Pre-uploads the RHCOS image to OpenStack Glance when it is not already
     at the version expected by the installer, then patches install-config.yaml
-    to reference that image via platform.openstack.clusterOSImage. This
-    avoids redundant image downloads during every cluster installation.
+    to reference that image via platform.openstack.clusterOSImage. Both the
+    image name and its content are derived from the openshift-install binary
+    to ensure consistency, which is important for upgrade jobs where the
+    installer version can differ from the release under test. This avoids
+    redundant image downloads during every cluster installation.


### PR DESCRIPTION
Derive OCP_VERSION from the openshift-install binary instead of from RELEASE_IMAGE_LATEST. This ensures the Glance image name always matches the RHCOS content that the installer embeds.

Previously, upgrade jobs (e.g. 4.20->4.21) used the 4.20 installer binary but named the image 'rhcos-4.21' based on release:latest. This caused a constant back-and-forth with regular 4.21 jobs: the upgrade job would upload the 4.20 RHCOS as 'rhcos-4.21', then a regular job would overwrite it with the actual 4.21 RHCOS, triggering a ~2.3GB download and upload on every cycle.

With this fix, upgrade jobs will correctly name their image 'rhcos-4.20', avoiding the collision entirely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Image naming now appends the OpenShift minor version derived from the installer binary so image names match the installer.
  * Added validation to reject invalid major.minor version values and show installer output on failure.
  * If image and installer versions differ, images are pre-uploaded to Glance to ensure availability.

* **Documentation**
  * Clarified image naming, pre-upload behavior, and how the installer-derived image is referenced during deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->