### PR TITLE
Add secret-manager image

### DIFF
--- a/core-services/image-mirroring/openshift/mapping_origin_ci-operator-4.17
+++ b/core-services/image-mirroring/openshift/mapping_origin_ci-operator-4.17
@@ -18,3 +18,4 @@ quay-proxy.ci.openshift.org/openshift/ci:ci_prow-job-dispatcher_latest quay.io/o
 quay-proxy.ci.openshift.org/openshift/ci:ci_auto-config-brancher_latest quay.io/openshift/ci-public:ci_auto-config-brancher_latest
 quay-proxy.ci.openshift.org/openshift/ci:ci_golangci-lint_latest quay.io/openshift/ci-public:ci_golangci-lint_latest
 quay-proxy.ci.openshift.org/openshift/ci:ci_check-cluster-profiles-config_latest quay.io/openshift/ci-public:ci_check-cluster-profiles-config_latest
+quay-proxy.ci.openshift.org/openshift/ci:ci_secret-manager_latest quay.io/openshift/ci-public:ci_secret-manager_latest


### PR DESCRIPTION
Add the missing secret-manager image to the ci-public image mirroring mapping file so it gets mirrored from `quay-proxy.ci.openshift.org/openshift/ci` to `quay.io/openshift/ci-public`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI infrastructure configuration mappings to extend the existing operator image mapping set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->