### PR TITLE
add the workflow and jobs for roas classic

### DIFF
--- a/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__periodics.yaml
+++ b/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__periodics.yaml
@@ -41,7 +41,7 @@ tests:
       OCM_LOGIN_ENV: staging
       OPENSHIFT_VERSION: "4.19"
       REPLICAS: "3"
-    workflow: rosa-e2e
+    workflow: rosa-e2e-hcp
 - as: rosa-hcp-e2e-nightly-4-20
   cron: 0 3 * * *
   steps:
@@ -53,7 +53,7 @@ tests:
       OCM_LOGIN_ENV: staging
       OPENSHIFT_VERSION: "4.20"
       REPLICAS: "3"
-    workflow: rosa-e2e
+    workflow: rosa-e2e-hcp
 - as: rosa-hcp-e2e-nightly-4-21
   cron: 30 3 * * *
   steps:
@@ -65,7 +65,7 @@ tests:
       OCM_LOGIN_ENV: staging
       OPENSHIFT_VERSION: "4.21"
       REPLICAS: "3"
-    workflow: rosa-e2e
+    workflow: rosa-e2e-hcp
 - as: rosa-hcp-e2e-nightly-4-22
   cron: 0 4 * * *
   steps:
@@ -77,7 +77,7 @@ tests:
       OCM_LOGIN_ENV: staging
       OPENSHIFT_VERSION: "4.22"
       REPLICAS: "3"
-    workflow: rosa-e2e
+    workflow: rosa-e2e-hcp
 - as: rosa-hcp-e2e-nightly-4-23
   cron: 30 4 * * *
   steps:
@@ -89,7 +89,7 @@ tests:
       OCM_LOGIN_ENV: staging
       OPENSHIFT_VERSION: "4.23"
       REPLICAS: "3"
-    workflow: rosa-e2e
+    workflow: rosa-e2e-hcp
 - as: rosa-hcp-e2e-nightly-5-0
   cron: 0 5 * * *
   steps:
@@ -101,7 +101,31 @@ tests:
       OCM_LOGIN_ENV: staging
       OPENSHIFT_VERSION: "5.0"
       REPLICAS: "3"
-    workflow: rosa-e2e
+    workflow: rosa-e2e-hcp
+- as: rosa-sts-e2e-nightly-4-21
+  cron: 30 5 * * *
+  steps:
+    cluster_profile: rosa-e2e-01
+    env:
+      CHANNEL_GROUP: nightly
+      HOSTED_CP: "false"
+      LABEL_FILTER: Platform:Classic
+      OCM_LOGIN_ENV: staging
+      OPENSHIFT_VERSION: "4.21"
+      REPLICAS: "3"
+    workflow: rosa-e2e-classic
+- as: rosa-sts-e2e-nightly-4-22
+  cron: 0 6 * * *
+  steps:
+    cluster_profile: rosa-e2e-01
+    env:
+      CHANNEL_GROUP: nightly
+      HOSTED_CP: "false"
+      LABEL_FILTER: Platform:Classic
+      OCM_LOGIN_ENV: staging
+      OPENSHIFT_VERSION: "4.22"
+      REPLICAS: "3"
+    workflow: rosa-e2e-classic
 zz_generated_metadata:
   branch: main
   org: openshift-online

--- a/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-periodics.yaml
@@ -1578,6 +1578,172 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
+  cluster: build09
+  cron: 30 5 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-online
+    repo: rosa-e2e
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: rosa-e2e-01
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-online-rosa-e2e-main-periodics-rosa-sts-e2e-nightly-4-21
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=rosa-sts-e2e-nightly-4-21
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build09
+  cron: 0 6 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-online
+    repo: rosa-e2e
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: rosa-e2e-01
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-online-rosa-e2e-main-periodics-rosa-sts-e2e-nightly-4-22
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=rosa-sts-e2e-nightly-4-22
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
   cluster: build06
   cron: 0 14 * * *
   decorate: true

--- a/ci-operator/step-registry/rosa/e2e/classic/OWNERS
+++ b/ci-operator/step-registry/rosa/e2e/classic/OWNERS
@@ -1,0 +1,10 @@
+approvers:
+- tiwillia
+- dustman9000
+- bmeng
+- ravitri
+reviewers:
+- tiwillia
+- dustman9000
+- bmeng
+- ravitri

--- a/ci-operator/step-registry/rosa/e2e/classic/rosa-e2e-classic-workflow.metadata.json
+++ b/ci-operator/step-registry/rosa/e2e/classic/rosa-e2e-classic-workflow.metadata.json
@@ -1,0 +1,17 @@
+{
+	"path": "rosa/e2e/classic/rosa-e2e-classic-workflow.yaml",
+	"owners": {
+		"approvers": [
+			"tiwillia",
+			"dustman9000",
+			"bmeng",
+			"ravitri"
+		],
+		"reviewers": [
+			"tiwillia",
+			"dustman9000",
+			"bmeng",
+			"ravitri"
+		]
+	}
+}

--- a/ci-operator/step-registry/rosa/e2e/classic/rosa-e2e-classic-workflow.yaml
+++ b/ci-operator/step-registry/rosa/e2e/classic/rosa-e2e-classic-workflow.yaml
@@ -1,0 +1,21 @@
+workflow:
+  as: rosa-e2e-classic
+  steps:
+    env:
+      CHANNEL_GROUP: stable
+      HOSTED_CP: "false"
+      MULTI_AZ: "true"
+      REPLICAS: "3"
+    pre:
+      - chain: rosa-aws-sts-provision
+      - ref: rosa-cluster-wait-ready-nodes
+    test:
+      - ref: rosa-e2e-test
+    post:
+      - chain: rosa-cluster-deprovision
+        best_effort: true
+      - ref: rosa-sts-account-roles-delete
+        best_effort: true
+  documentation: |-
+    This workflow provisions a ROSA STS (Classic) cluster and runs the rosa-e2e
+    managed service validation suite, then tears down the cluster.

--- a/ci-operator/step-registry/rosa/e2e/hcp/OWNERS
+++ b/ci-operator/step-registry/rosa/e2e/hcp/OWNERS
@@ -1,0 +1,10 @@
+approvers:
+- tiwillia
+- dustman9000
+- bmeng
+- ravitri
+reviewers:
+- tiwillia
+- dustman9000
+- bmeng
+- ravitri

--- a/ci-operator/step-registry/rosa/e2e/hcp/rosa-e2e-hcp-workflow.metadata.json
+++ b/ci-operator/step-registry/rosa/e2e/hcp/rosa-e2e-hcp-workflow.metadata.json
@@ -1,5 +1,5 @@
 {
-	"path": "rosa/e2e/rosa-e2e-workflow.yaml",
+	"path": "rosa/e2e/hcp/rosa-e2e-hcp-workflow.yaml",
 	"owners": {
 		"approvers": [
 			"tiwillia",

--- a/ci-operator/step-registry/rosa/e2e/hcp/rosa-e2e-hcp-workflow.yaml
+++ b/ci-operator/step-registry/rosa/e2e/hcp/rosa-e2e-hcp-workflow.yaml
@@ -1,5 +1,5 @@
 workflow:
-  as: rosa-e2e
+  as: rosa-e2e-hcp
   steps:
     env:
       CHANNEL_GROUP: stable

--- a/ci-operator/step-registry/rosa/e2e/test/rosa-e2e-test-commands.sh
+++ b/ci-operator/step-registry/rosa/e2e/test/rosa-e2e-test-commands.sh
@@ -45,15 +45,25 @@ export OCM_ENV="${OCM_LOGIN_ENV}"
 export CLUSTER_ID
 export AWS_REGION="${LEASED_RESOURCE}"
 
-# Try to get MC access via backplane
-log "Attempting MC access via backplane..."
-if ocm backplane login "${CLUSTER_ID}" --manager 2>/dev/null; then
-  export MC_KUBECONFIG="${HOME}/.kube/config"
-  MC_SERVER=$(oc whoami --show-server 2>/dev/null || true)
-  if [[ "${MC_SERVER}" == *"backplane"* ]]; then
-    MANAGEMENT_CLUSTER_ID=$(echo "${MC_SERVER}" | sed 's|.*/cluster/||; s|/.*||')
-    export MANAGEMENT_CLUSTER_ID
-    log "MC access established: ${MANAGEMENT_CLUSTER_ID}"
+# Set CLUSTER_TOPOLOGY so the test binary knows the cluster type without an extra OCM API call
+if [[ "${HOSTED_CP:-false}" == "true" ]]; then
+  export CLUSTER_TOPOLOGY="hcp"
+else
+  export CLUSTER_TOPOLOGY="classic"
+fi
+log "Cluster topology: ${CLUSTER_TOPOLOGY}"
+
+# Try to get MC access via backplane (HCP only)
+if [[ "${CLUSTER_TOPOLOGY}" == "hcp" ]]; then
+  log "Attempting MC access via backplane..."
+  if ocm backplane login "${CLUSTER_ID}" --manager 2>/dev/null; then
+    export MC_KUBECONFIG="${HOME}/.kube/config"
+    MC_SERVER=$(oc whoami --show-server 2>/dev/null || true)
+    if [[ "${MC_SERVER}" == *"backplane"* ]]; then
+      MANAGEMENT_CLUSTER_ID=$(echo "${MC_SERVER}" | sed 's|.*/cluster/||; s|/.*||')
+      export MANAGEMENT_CLUSTER_ID
+      log "MC access established: ${MANAGEMENT_CLUSTER_ID}"
+    fi
   fi
 fi
 

--- a/ci-operator/step-registry/rosa/e2e/test/rosa-e2e-test-ref.yaml
+++ b/ci-operator/step-registry/rosa/e2e/test/rosa-e2e-test-ref.yaml
@@ -21,5 +21,6 @@ ref:
   - name: rosa-e2e
     env: ROSA_E2E_IMAGE
   documentation: |-
-    Runs the rosa-e2e test suite against an existing ROSA HCP cluster.
+    Runs the rosa-e2e test suite against an existing ROSA cluster (HCP or Classic).
     Expects CLUSTER_ID in SHARED_DIR/cluster-id and AWS credentials in the cluster profile.
+    Set HOSTED_CP=true for HCP clusters to enable management cluster access via backplane.


### PR DESCRIPTION
Add new workflow and jobs for rosa sts classic cluster testing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated test workflows for ROSA HCP and Classic to run the correct nightly end-to-end tests.

* **Improvements**
  * Test infra now detects cluster topology (HCP vs Classic) and conditionally enables management-cluster backplane access.

* **Documentation**
  * Updated test references and guidance to reflect support for both HCP and Classic ROSA clusters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->