### PR TITLE
Remove unused cluster profile secret entries and boskos quota slices

### DIFF
--- a/core-services/ci-secret-bootstrap/_config.yaml
+++ b/core-services/ci-secret-bootstrap/_config.yaml
@@ -983,14 +983,6 @@ secret_configs:
     namespace: ci
   - cluster_groups:
     - non_app_ci
-    name: cluster-secrets-metal-perscale-telco
-    namespace: ci
-  - cluster_groups:
-    - non_app_ci
-    name: cluster-secrets-metal-perscale-selfsched
-    namespace: ci
-  - cluster_groups:
-    - non_app_ci
     name: cluster-secrets-aws-osp-qe
     namespace: ci
   - cluster_groups:
@@ -1012,14 +1004,6 @@ secret_configs:
   - cluster_groups:
     - non_app_ci
     name: cluster-secrets-metal-perfscale-osp
-    namespace: test-credentials
-  - cluster_groups:
-    - non_app_ci
-    name: cluster-secrets-metal-perscale-telco
-    namespace: test-credentials
-  - cluster_groups:
-    - non_app_ci
-    name: cluster-secrets-metal-perscale-selfsched
     namespace: test-credentials
   - cluster_groups:
     - non_app_ci
@@ -1429,78 +1413,6 @@ secret_configs:
   - cluster_groups:
     - non_app_ci
     name: cluster-secrets-gcp-arm64
-    namespace: ci
-- from:
-    pull-secret:
-      dockerconfigJSON:
-      - auth_field: token_image-puller_app.ci_reg_auth_value.txt
-        item: build_farm
-        registry_url: registry.ci.openshift.org
-      - auth_field: auth
-        email_field: email
-        item: cloud.openshift.com-pull-secret
-        registry_url: cloud.openshift.com
-      - auth_field: auth
-        email_field: email
-        item: quay.io-pull-secret
-        registry_url: quay.io
-      - auth_field: auth
-        item: quay.io/multi-arch
-        registry_url: quay.io/multi-arch
-      - auth_field: auth
-        item: quayio-ci-read-only-robot
-        registry_url: quay-proxy.ci.openshift.org
-      - auth_field: auth
-        item: quayio-ci-read-only-robot
-        registry_url: quay.io/openshift/ci
-      - auth_field: auth
-        email_field: email
-        item: registry.connect.redhat.com-pull-secret
-        registry_url: registry.connect.redhat.com
-      - auth_field: auth
-        email_field: email
-        item: registry.redhat.io-pull-secret
-        registry_url: registry.redhat.io
-  to:
-  - cluster_groups:
-    - non_app_ci
-    name: cluster-secrets-aws-outpost
-    namespace: ci
-- from:
-    pull-secret:
-      dockerconfigJSON:
-      - auth_field: token_image-puller_app.ci_reg_auth_value.txt
-        item: build_farm
-        registry_url: registry.ci.openshift.org
-      - auth_field: auth
-        email_field: email
-        item: cloud.openshift.com-pull-secret
-        registry_url: cloud.openshift.com
-      - auth_field: auth
-        email_field: email
-        item: quay.io-pull-secret
-        registry_url: quay.io
-      - auth_field: auth
-        item: quay.io/multi-arch
-        registry_url: quay.io/multi-arch
-      - auth_field: auth
-        item: quayio-ci-read-only-robot
-        registry_url: quay-proxy.ci.openshift.org
-      - auth_field: auth
-        item: quayio-ci-read-only-robot
-        registry_url: quay.io/openshift/ci
-      - auth_field: auth
-        email_field: email
-        item: registry.connect.redhat.com-pull-secret
-        registry_url: registry.connect.redhat.com
-      - auth_field: auth
-        email_field: email
-        item: registry.redhat.io-pull-secret
-        registry_url: registry.redhat.io
-  to:
-  - cluster_groups:
-    - non_app_ci
-    name: cluster-secrets-aws-local-zones
     namespace: ci
 - from:
     pull-secret:
@@ -5559,10 +5471,6 @@ secret_configs:
   - cluster_groups:
     - non_app_ci
     name: cluster-secrets-ibmcloud-qe-2
-    namespace: ci
-  - cluster_groups:
-    - non_app_ci
-    name: cluster-secrets-ibmcloud-gpu
     namespace: ci
 - from:
     pull-secret:

--- a/core-services/prow/02_config/_boskos.yaml
+++ b/core-services/prow/02_config/_boskos.yaml
@@ -2190,19 +2190,6 @@ resources:
   state: free
   type: aws-outpost-qe-quota-slice
 - names:
-  - us-east-1--aws-outpost-quota-slice-0
-  - us-east-1--aws-outpost-quota-slice-1
-  - us-east-1--aws-outpost-quota-slice-2
-  - us-east-1--aws-outpost-quota-slice-3
-  - us-east-1--aws-outpost-quota-slice-4
-  - us-east-1--aws-outpost-quota-slice-5
-  - us-east-1--aws-outpost-quota-slice-6
-  - us-east-1--aws-outpost-quota-slice-7
-  - us-east-1--aws-outpost-quota-slice-8
-  - us-east-1--aws-outpost-quota-slice-9
-  state: free
-  type: aws-outpost-quota-slice
-- names:
   - us-east-1--aws-ovn-perfscale-quota-slice-0
   - us-east-1--aws-ovn-perfscale-quota-slice-1
   - us-east-1--aws-ovn-perfscale-quota-slice-2
@@ -4739,19 +4726,6 @@ resources:
   - us-east--ibmcloud-cspi-qe-quota-slice-39
   state: free
   type: ibmcloud-cspi-qe-quota-slice
-- names:
-  - us-east--ibmcloud-gpu-quota-slice-0
-  - us-east--ibmcloud-gpu-quota-slice-1
-  - us-east--ibmcloud-gpu-quota-slice-2
-  - us-east--ibmcloud-gpu-quota-slice-3
-  - us-east--ibmcloud-gpu-quota-slice-4
-  - us-east--ibmcloud-gpu-quota-slice-5
-  - us-east--ibmcloud-gpu-quota-slice-6
-  - us-east--ibmcloud-gpu-quota-slice-7
-  - us-east--ibmcloud-gpu-quota-slice-8
-  - us-east--ibmcloud-gpu-quota-slice-9
-  state: free
-  type: ibmcloud-gpu-quota-slice
 - names:
   - lon04--ibmcloud-multi-ppc64le-quota-slice-0
   - lon04--ibmcloud-multi-ppc64le-quota-slice-1

--- a/core-services/prow/02_config/generate-boskos.py
+++ b/core-services/prow/02_config/generate-boskos.py
@@ -66,9 +66,6 @@ CONFIG = {
     'aws-sd-qe-quota-slice': {
         'us-west-2': 10,
     },
-    'aws-outpost-quota-slice': {
-        'us-east-1': 10,
-    },
     'aws-outpost-qe-quota-slice': {
         'us-east-1': 5,
     },
@@ -489,9 +486,6 @@ CONFIG = {
         'jp-tok': 20,
     },
     'ibmcloud-qe-2-quota-slice': {
-        'us-east': 10,
-    },
-    'ibmcloud-gpu-quota-slice': {
         'us-east': 10,
     },
     'ibmcloud-multi-ppc64le-quota-slice': {


### PR DESCRIPTION
## Summary
- Remove 5 dead `cluster-secrets-*` entries from `_config.yaml` that are not referenced by any ci-operator config or step-registry file, and do not correspond to any known cluster profile in `api.ClusterProfiles()`:
  - `cluster-secrets-metal-perscale-telco` (ci + test-credentials namespaces)
  - `cluster-secrets-metal-perscale-selfsched` (ci + test-credentials namespaces)
  - `cluster-secrets-aws-outpost` (entire from block, sole target)
  - `cluster-secrets-aws-local-zones` (entire from block, sole target)
  - `cluster-secrets-ibmcloud-gpu` (to entry in shared from block)
- Remove corresponding boskos quota slices for `aws-outpost` and `ibmcloud-gpu` from `generate-boskos.py` and `_boskos.yaml`

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added support for new AWS, GCP, and IBM Cloud environments
  * Introduced quality assurance testing resource allocations across multiple cloud platforms and regions
  * Enhanced secret provisioning configuration for improved infrastructure management
  * Consolidated and restructured cloud provider resource mappings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->