### PR TITLE
WINC: Add cucushift-installer-wait to winc workflow test sections

### DIFF
--- a/ci-operator/step-registry/cucushift/installer/rehearse/aws/ipi/ovn/winc/cucushift-installer-rehearse-aws-ipi-ovn-winc-workflow.yaml
+++ b/ci-operator/step-registry/cucushift/installer/rehearse/aws/ipi/ovn/winc/cucushift-installer-rehearse-aws-ipi-ovn-winc-workflow.yaml
@@ -11,6 +11,8 @@ workflow:
     pre:
       - chain: cucushift-installer-rehearse-aws-ipi-ovn-winc-provision
       - ref: cucushift-installer-reportportal-marker
+    test:
+      - ref: cucushift-installer-wait
     post:
       - chain: cucushift-installer-rehearse-aws-ipi-deprovision
       - ref: send-results-to-reportportal

--- a/ci-operator/step-registry/cucushift/installer/rehearse/aws/upi/ovn/winc/cucushift-installer-rehearse-aws-upi-ovn-winc-workflow.yaml
+++ b/ci-operator/step-registry/cucushift/installer/rehearse/aws/upi/ovn/winc/cucushift-installer-rehearse-aws-upi-ovn-winc-workflow.yaml
@@ -10,6 +10,8 @@ workflow:
     pre:
       - chain: cucushift-installer-rehearse-aws-upi-ovn-winc-provision
       - ref: cucushift-installer-reportportal-marker
+    test:
+      - ref: cucushift-installer-wait
     post:
       - chain: cucushift-installer-rehearse-aws-upi-ovn-winc-deprovision
       - ref: send-results-to-reportportal

--- a/ci-operator/step-registry/cucushift/installer/rehearse/azure/ipi/ovn/winc/cucushift-installer-rehearse-azure-ipi-ovn-winc-workflow.yaml
+++ b/ci-operator/step-registry/cucushift/installer/rehearse/azure/ipi/ovn/winc/cucushift-installer-rehearse-azure-ipi-ovn-winc-workflow.yaml
@@ -11,6 +11,8 @@ workflow:
     pre:
       - chain: cucushift-installer-rehearse-azure-ipi-ovn-winc-provision
       - ref: cucushift-installer-reportportal-marker
+    test:
+      - ref: cucushift-installer-wait
     post:
       - chain: cucushift-installer-rehearse-azure-ipi-ovn-winc-deprovision
       - ref: send-results-to-reportportal

--- a/ci-operator/step-registry/cucushift/installer/rehearse/gcp/ipi/ovn/winc/cucushift-installer-rehearse-gcp-ipi-ovn-winc-workflow.yaml
+++ b/ci-operator/step-registry/cucushift/installer/rehearse/gcp/ipi/ovn/winc/cucushift-installer-rehearse-gcp-ipi-ovn-winc-workflow.yaml
@@ -11,6 +11,8 @@ workflow:
     pre:
       - chain: cucushift-installer-rehearse-gcp-ipi-ovn-winc-provision
       - ref: cucushift-installer-reportportal-marker
+    test:
+      - ref: cucushift-installer-wait
     post:
       - chain: cucushift-installer-rehearse-gcp-ipi-deprovision
       - ref: send-results-to-reportportal

--- a/ci-operator/step-registry/cucushift/installer/rehearse/nutanix/ipi/ovn/winc/cucushift-installer-rehearse-nutanix-ipi-ovn-winc-workflow.yaml
+++ b/ci-operator/step-registry/cucushift/installer/rehearse/nutanix/ipi/ovn/winc/cucushift-installer-rehearse-nutanix-ipi-ovn-winc-workflow.yaml
@@ -12,6 +12,8 @@ workflow:
     pre:
       - chain: cucushift-installer-rehearse-nutanix-ipi-ovn-winc-provision
       - ref: cucushift-installer-reportportal-marker
+    test:
+      - ref: cucushift-installer-wait
     post:
       - chain: cucushift-installer-rehearse-nutanix-ipi-ovn-winc-deprovision
       - ref: send-results-to-reportportal

--- a/ci-operator/step-registry/cucushift/installer/rehearse/vsphere/ipi/disconnected/ovn/winc/cucushift-installer-rehearse-vsphere-ipi-disconnected-ovn-winc-workflow.yaml
+++ b/ci-operator/step-registry/cucushift/installer/rehearse/vsphere/ipi/disconnected/ovn/winc/cucushift-installer-rehearse-vsphere-ipi-disconnected-ovn-winc-workflow.yaml
@@ -5,6 +5,8 @@ workflow:
       WINDOWS_NODE_REPLICAS: "2"
     pre:
     - chain: cucushift-installer-rehearse-vsphere-ipi-disconnected-ovn-winc-provision
+    test:
+    - ref: cucushift-installer-wait
     post:
     - chain: cucushift-installer-rehearse-vsphere-ipi-disconnected-ovn-winc-deprovision
   documentation: |-

--- a/ci-operator/step-registry/cucushift/installer/rehearse/vsphere/ipi/ovn/winc/cucushift-installer-rehearse-vsphere-ipi-ovn-winc-workflow.yaml
+++ b/ci-operator/step-registry/cucushift/installer/rehearse/vsphere/ipi/ovn/winc/cucushift-installer-rehearse-vsphere-ipi-ovn-winc-workflow.yaml
@@ -13,6 +13,8 @@ workflow:
     pre:
       - chain: cucushift-installer-rehearse-vsphere-ipi-ovn-winc-provision
       - ref: cucushift-installer-reportportal-marker
+    test:
+      - ref: cucushift-installer-wait
     post:
       - chain: cucushift-installer-rehearse-vsphere-ipi-ovn-winc-deprovision
       - ref: send-results-to-reportportal

--- a/ci-operator/step-registry/cucushift/installer/rehearse/vsphere/ipi/proxy/ovn/winc/cucushift-installer-rehearse-vsphere-ipi-proxy-ovn-winc-workflow.yaml
+++ b/ci-operator/step-registry/cucushift/installer/rehearse/vsphere/ipi/proxy/ovn/winc/cucushift-installer-rehearse-vsphere-ipi-proxy-ovn-winc-workflow.yaml
@@ -11,6 +11,8 @@ workflow:
     pre:
       - chain: cucushift-installer-rehearse-vsphere-ipi-proxy-ovn-winc-provision
       - ref: cucushift-installer-reportportal-marker
+    test:
+      - ref: cucushift-installer-wait
     post:
       - chain: cucushift-installer-rehearse-vsphere-ipi-proxy-deprovision
       - ref: send-results-to-reportportal


### PR DESCRIPTION
## Summary
- Adds the `cucushift-installer-wait` ref to the test section of all 8 winc workflows:
  - `cucushift-installer-rehearse-aws-ipi-ovn-winc`
  - `cucushift-installer-rehearse-aws-upi-ovn-winc`
  - `cucushift-installer-rehearse-gcp-ipi-ovn-winc`
  - `cucushift-installer-rehearse-azure-ipi-ovn-winc`
  - `cucushift-installer-rehearse-nutanix-ipi-ovn-winc`
  - `cucushift-installer-rehearse-vsphere-ipi-ovn-winc`
  - `cucushift-installer-rehearse-vsphere-ipi-proxy-ovn-winc`
  - `cucushift-installer-rehearse-vsphere-ipi-disconnected-ovn-winc`
- Enables controlling cluster duration via `SLEEP_DURATION` when using cluster-bot `workflow-test`
- Existing CI jobs are unaffected since they define their own test sections (with `openshift-extended-test`) which override the workflow test section

## Problem
Winc workflows had no test section, preventing cluster-bot from accepting `SLEEP_DURATION` as an override parameter (config resolution failed).

## Usage
Use `workflow-test` (not `workflow-launch`) to control cluster duration. Do not use quotes around the parameter (Slack smart quotes break config resolution):
```
workflow-test cucushift-installer-rehearse-vsphere-ipi-proxy-ovn-winc 4.22 SLEEP_DURATION=5h
```

Note: `workflow-launch` always replaces the test section with its own `clusterbot-wait` step (which uses `CLUSTER_DURATION`, capped at 4h by the step timeout). Use `workflow-test` to preserve the workflow's `cucushift-installer-wait` ref. The practical limit is ~7h (the 8h ProwJob decoration timeout minus cluster provisioning time).