### PR TITLE
NO_ISSUE: add osac-project-gather to component workflow

### DIFF
--- a/ci-operator/step-registry/osac-project/ofcir/baremetal/component/osac-project-ofcir-baremetal-component-workflow.yaml
+++ b/ci-operator/step-registry/osac-project/ofcir/baremetal/component/osac-project-ofcir-baremetal-component-workflow.yaml
@@ -12,6 +12,7 @@ workflow:
     test:
       - ref: osac-project-baremetal-test
     post:
+      - ref: osac-project-gather
       - ref: ofcir-gather
       - ref: ofcir-release
     env:


### PR DESCRIPTION
## Summary
- Adds the missing `osac-project-gather` step to the `osac-project-ofcir-baremetal-component` workflow's post steps
- The base workflow (`osac-project-ofcir-baremetal`) already has this step, but it was omitted when the component variant was created in #78715
- Without this step, OSAC-specific debug artifacts (logs, CRs) are not collected on test failures in component presubmit jobs

## Test plan
- [ ] CI validation passes (step registry, config semantics)
- [ ] Verify post steps match base workflow ordering: `osac-project-gather` → `ofcir-gather` → `ofcir-release`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow configuration with an additional post-test processing step to improve build and release procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->