### PR TITLE
Add `red-hat-konflux` as trusted app for ALBO and EDO repos

### DIFF
--- a/core-services/prow/02_config/openshift/aws-load-balancer-controller/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/aws-load-balancer-controller/_pluginconfig.yaml
@@ -1,6 +1,5 @@
 approve:
-- commandHelpLink: ""
-  ignore_review_state: true
+- ignore_review_state: true
   repos:
   - openshift/aws-load-balancer-controller
   require_self_approval: true
@@ -11,3 +10,10 @@ plugins:
   openshift/aws-load-balancer-controller:
     plugins:
     - approve
+triggers:
+- org_invite:
+    prominent: {}
+  repos:
+  - openshift/aws-load-balancer-controller
+  trusted_apps:
+  - red-hat-konflux

--- a/core-services/prow/02_config/openshift/aws-load-balancer-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/aws-load-balancer-operator/_pluginconfig.yaml
@@ -1,6 +1,5 @@
 approve:
-- commandHelpLink: ""
-  ignore_review_state: true
+- ignore_review_state: true
   repos:
   - openshift/aws-load-balancer-operator
   require_self_approval: true
@@ -11,3 +10,10 @@ plugins:
   openshift/aws-load-balancer-operator:
     plugins:
     - approve
+triggers:
+- org_invite:
+    prominent: {}
+  repos:
+  - openshift/aws-load-balancer-operator
+  trusted_apps:
+  - red-hat-konflux

--- a/core-services/prow/02_config/openshift/external-dns-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/external-dns-operator/_pluginconfig.yaml
@@ -1,6 +1,5 @@
 approve:
-- commandHelpLink: ""
-  ignore_review_state: true
+- ignore_review_state: true
   repos:
   - openshift/external-dns-operator
   require_self_approval: true
@@ -24,3 +23,10 @@ plugins:
   openshift/external-dns-operator:
     plugins:
     - approve
+triggers:
+- org_invite:
+    prominent: {}
+  repos:
+  - openshift/external-dns-operator
+  trusted_apps:
+  - red-hat-konflux

--- a/core-services/prow/02_config/openshift/external-dns/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/external-dns/_pluginconfig.yaml
@@ -1,6 +1,5 @@
 approve:
-- commandHelpLink: ""
-  ignore_review_state: true
+- ignore_review_state: true
   repos:
   - openshift/external-dns
   require_self_approval: true
@@ -24,3 +23,10 @@ plugins:
   openshift/external-dns:
     plugins:
     - approve
+triggers:
+- org_invite:
+    prominent: {}
+  repos:
+  - openshift/external-dns
+  trusted_apps:
+  - red-hat-konflux


### PR DESCRIPTION
Add trigger configuration with `red-hat-konflux` in `trusted_apps` for `aws-load-balancer-controller`, `aws-load-balancer-operator`, `external-dns-operator`, and `external-dns` so that Konflux-created PRs are `ok-to-test` by default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed an obsolete help link from approval checks across several OpenShift repo plugin configs.
* **New Features**
  * Added repository trigger and org-invite configurations to enable automated repo triggers and trusted-app workflows for multiple OpenShift repositories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->