### PR TITLE
AROSLSRE-780: Onboard Azure/ARO-Tools to Prow

### DIFF
--- a/core-services/prow/02_config/Azure/ARO-Tools/_pluginconfig.yaml
+++ b/core-services/prow/02_config/Azure/ARO-Tools/_pluginconfig.yaml
@@ -1,0 +1,37 @@
+external_plugins:
+  Azure/ARO-Tools:
+  - endpoint: http://refresh
+    events:
+    - issue_comment
+    name: refresh
+  - endpoint: http://needs-rebase
+    events:
+    - issue_comment
+    - pull_request
+    name: needs-rebase
+plugins:
+  Azure/ARO-Tools:
+    plugins:
+    - assign
+    - approve
+    - blunderbuss
+    - help
+    - hold
+    - label
+    - lgtm
+    - lifecycle
+    - override
+    - retitle
+    - shrug
+    - skip
+    - trigger
+    - verify-owners
+    - owners-label
+    - wip
+triggers:
+- org_invite:
+    prominent: {}
+  repos:
+  - Azure/ARO-Tools
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/Azure/ARO-Tools/_pluginconfig.yaml
+++ b/core-services/prow/02_config/Azure/ARO-Tools/_pluginconfig.yaml
@@ -29,9 +29,7 @@ plugins:
     - owners-label
     - wip
 triggers:
-- org_invite:
-    prominent: {}
-  repos:
+- repos:
   - Azure/ARO-Tools
   trusted_apps:
   - openshift-merge-bot

--- a/core-services/prow/02_config/Azure/ARO-Tools/_prowconfig.yaml
+++ b/core-services/prow/02_config/Azure/ARO-Tools/_prowconfig.yaml
@@ -1,0 +1,20 @@
+branch-protection:
+  orgs:
+    Azure:
+      repos:
+        ARO-Tools:
+          unmanaged: true
+tide:
+  queries:
+  - includedBranches:
+    - main
+    labels:
+    - approved
+    - lgtm
+    missingLabels:
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - needs-rebase
+    repos:
+    - Azure/ARO-Tools


### PR DESCRIPTION
## Summary
- Onboard [Azure/ARO-Tools](https://github.com/Azure/ARO-Tools) to Prow
- Add plugin config with `approve`, `lgtm`, `blunderbuss`, `verify-owners`, `owners-label` and other standard plugins
- Add tide config for merge automation on `main` branch

## JIRA
[AROSLSRE-780](https://redhat.atlassian.net/browse/AROSLSRE-780)

## Prerequisites
- [ARO-Tools#231](https://github.com/Azure/ARO-Tools/pull/231) — OWNERS file ([AROSLSRE-779](https://redhat.atlassian.net/browse/AROSLSRE-779))

## Test plan
- [ ] Prow config validation passes CI
- [ ] After merge, verify Prow responds to `/lgtm` and `/approve` on ARO-Tools PRs

[AROSLSRE-780]: https://redhat.atlassian.net/browse/AROSLSRE-780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AROSLSRE-779]: https://redhat.atlassian.net/browse/AROSLSRE-779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores / CI infrastructure**
  * Onboards `Azure/ARO-Tools` to Prow.
  * Enables standard Prow commands and automation, including `/lgtm` and `/approve`.
  * Configures the `refresh` and `needs-rebase` external plugins.
  * Trusts `openshift-merge-bot` for repository automation.
  * Configures Tide to merge compliant pull requests targeting `main` when they have `approved` and `lgtm` labels and no blocking labels.
  * Removes the stale `org_invite` trigger so the checked-in configuration matches `make prow-config` output.
  * Requires an `OWNERS` file from ARO-Tools PR `#231` before owner-based automation can function.
  * The `openshift-merge-bot` GitHub App must be installed for `Azure/ARO-Tools`, with the required collaborators and permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->