### PR TITLE
red-hat-storage: tag AWS CI clusters with USER_TAGS

### DIFF
--- a/ci-operator/config/red-hat-storage/ocs-operator/red-hat-storage-ocs-operator-cephx.yaml
+++ b/ci-operator/config/red-hat-storage/ocs-operator/red-hat-storage-ocs-operator-cephx.yaml
@@ -45,6 +45,8 @@ tests:
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
       COMPUTE_NODE_TYPE: m5.2xlarge
+      USER_TAGS: |
+        createdBy gh-openshift-ci
       ZONES_COUNT: "3"
     test:
     - as: e2e-test

--- a/ci-operator/config/red-hat-storage/ocs-operator/red-hat-storage-ocs-operator-main.yaml
+++ b/ci-operator/config/red-hat-storage/ocs-operator/red-hat-storage-ocs-operator-main.yaml
@@ -44,6 +44,8 @@ tests:
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
       COMPUTE_NODE_TYPE: m5.2xlarge
+      USER_TAGS: |
+        createdBy gh-openshift-ci
       ZONES_COUNT: "3"
     test:
     - as: e2e-test

--- a/ci-operator/config/red-hat-storage/ocs-operator/red-hat-storage-ocs-operator-release-4.10.yaml
+++ b/ci-operator/config/red-hat-storage/ocs-operator/red-hat-storage-ocs-operator-release-4.10.yaml
@@ -99,6 +99,8 @@ tests:
       OO_INSTALL_NAMESPACE: openshift-storage
       OO_PACKAGE: ocs-operator
       OO_TARGET_NAMESPACES: '!install'
+      USER_TAGS: |
+        createdBy gh-openshift-ci
     post:
     - as: ocs-must-gather
       cli: latest
@@ -137,6 +139,8 @@ tests:
     cluster_profile: odf-aws
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
+      USER_TAGS: |
+        createdBy gh-openshift-ci
     test:
     - as: test
       cli: latest

--- a/ci-operator/config/red-hat-storage/ocs-operator/red-hat-storage-ocs-operator-release-4.11.yaml
+++ b/ci-operator/config/red-hat-storage/ocs-operator/red-hat-storage-ocs-operator-release-4.11.yaml
@@ -95,6 +95,8 @@ tests:
       OO_INSTALL_NAMESPACE: openshift-storage
       OO_PACKAGE: ocs-operator
       OO_TARGET_NAMESPACES: '!install'
+      USER_TAGS: |
+        createdBy gh-openshift-ci
     post:
     - as: ocs-must-gather
       cli: latest
@@ -133,6 +135,8 @@ tests:
     cluster_profile: odf-aws
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
+      USER_TAGS: |
+        createdBy gh-openshift-ci
     test:
     - as: test
       cli: latest

--- a/ci-operator/config/red-hat-storage/ocs-operator/red-hat-storage-ocs-operator-release-4.12.yaml
+++ b/ci-operator/config/red-hat-storage/ocs-operator/red-hat-storage-ocs-operator-release-4.12.yaml
@@ -91,6 +91,8 @@ tests:
       OO_INSTALL_NAMESPACE: openshift-storage
       OO_PACKAGE: ocs-operator
       OO_TARGET_NAMESPACES: '!install'
+      USER_TAGS: |
+        createdBy gh-openshift-ci
       ZONES_COUNT: "3"
     post:
     - as: ocs-must-gather

--- a/ci-operator/config/red-hat-storage/ocs-operator/red-hat-storage-ocs-operator-release-4.13.yaml
+++ b/ci-operator/config/red-hat-storage/ocs-operator/red-hat-storage-ocs-operator-release-4.13.yaml
@@ -82,6 +82,8 @@ tests:
       OO_INSTALL_NAMESPACE: openshift-storage
       OO_PACKAGE: ocs-operator
       OO_TARGET_NAMESPACES: '!install'
+      USER_TAGS: |
+        createdBy gh-openshift-ci
       ZONES_COUNT: "3"
     post:
     - as: ocs-must-gather

--- a/ci-operator/config/red-hat-storage/ocs-operator/red-hat-storage-ocs-operator-release-4.14.yaml
+++ b/ci-operator/config/red-hat-storage/ocs-operator/red-hat-storage-ocs-operator-release-4.14.yaml
@@ -47,6 +47,8 @@ tests:
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
       COMPUTE_NODE_TYPE: m5.2xlarge
+      USER_TAGS: |
+        createdBy gh-openshift-ci
       ZONES_COUNT: "3"
     test:
     - as: e2e-test

--- a/ci-operator/config/red-hat-storage/ocs-operator/red-hat-storage-ocs-operator-release-4.15.yaml
+++ b/ci-operator/config/red-hat-storage/ocs-operator/red-hat-storage-ocs-operator-release-4.15.yaml
@@ -42,6 +42,8 @@ tests:
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
       COMPUTE_NODE_TYPE: m5.2xlarge
+      USER_TAGS: |
+        createdBy gh-openshift-ci
       ZONES_COUNT: "3"
     test:
     - as: e2e-test

--- a/ci-operator/config/red-hat-storage/ocs-operator/red-hat-storage-ocs-operator-release-4.16.yaml
+++ b/ci-operator/config/red-hat-storage/ocs-operator/red-hat-storage-ocs-operator-release-4.16.yaml
@@ -42,6 +42,8 @@ tests:
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
       COMPUTE_NODE_TYPE: m5.2xlarge
+      USER_TAGS: |
+        createdBy gh-openshift-ci
       ZONES_COUNT: "3"
     test:
     - as: e2e-test

--- a/ci-operator/config/red-hat-storage/ocs-operator/red-hat-storage-ocs-operator-release-4.17.yaml
+++ b/ci-operator/config/red-hat-storage/ocs-operator/red-hat-storage-ocs-operator-release-4.17.yaml
@@ -42,6 +42,8 @@ tests:
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
       COMPUTE_NODE_TYPE: m5.2xlarge
+      USER_TAGS: |
+        createdBy gh-openshift-ci
       ZONES_COUNT: "3"
     test:
     - as: e2e-test

--- a/ci-operator/config/red-hat-storage/ocs-operator/red-hat-storage-ocs-operator-release-4.18.yaml
+++ b/ci-operator/config/red-hat-storage/ocs-operator/red-hat-storage-ocs-operator-release-4.18.yaml
@@ -42,6 +42,8 @@ tests:
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
       COMPUTE_NODE_TYPE: m5.2xlarge
+      USER_TAGS: |
+        createdBy gh-openshift-ci
       ZONES_COUNT: "3"
     test:
     - as: e2e-test

--- a/ci-operator/config/red-hat-storage/ocs-operator/red-hat-storage-ocs-operator-release-4.19.yaml
+++ b/ci-operator/config/red-hat-storage/ocs-operator/red-hat-storage-ocs-operator-release-4.19.yaml
@@ -43,6 +43,8 @@ tests:
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
       COMPUTE_NODE_TYPE: m5.2xlarge
+      USER_TAGS: |
+        createdBy gh-openshift-ci
       ZONES_COUNT: "3"
     test:
     - as: e2e-test

--- a/ci-operator/config/red-hat-storage/ocs-operator/red-hat-storage-ocs-operator-release-4.2.yaml
+++ b/ci-operator/config/red-hat-storage/ocs-operator/red-hat-storage-ocs-operator-release-4.2.yaml
@@ -95,6 +95,8 @@ tests:
     cluster_profile: odf-aws
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
+      USER_TAGS: |
+        createdBy gh-openshift-ci
     test:
     - as: test
       cli: latest
@@ -110,6 +112,8 @@ tests:
     cluster_profile: odf-aws
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
+      USER_TAGS: |
+        createdBy gh-openshift-ci
     test:
     - as: test
       cli: latest

--- a/ci-operator/config/red-hat-storage/ocs-operator/red-hat-storage-ocs-operator-release-4.20.yaml
+++ b/ci-operator/config/red-hat-storage/ocs-operator/red-hat-storage-ocs-operator-release-4.20.yaml
@@ -43,6 +43,8 @@ tests:
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
       COMPUTE_NODE_TYPE: m5.2xlarge
+      USER_TAGS: |
+        createdBy gh-openshift-ci
       ZONES_COUNT: "3"
     test:
     - as: e2e-test

--- a/ci-operator/config/red-hat-storage/ocs-operator/red-hat-storage-ocs-operator-release-4.21.yaml
+++ b/ci-operator/config/red-hat-storage/ocs-operator/red-hat-storage-ocs-operator-release-4.21.yaml
@@ -42,6 +42,8 @@ tests:
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
       COMPUTE_NODE_TYPE: m5.2xlarge
+      USER_TAGS: |
+        createdBy gh-openshift-ci
       ZONES_COUNT: "3"
     test:
     - as: e2e-test

--- a/ci-operator/config/red-hat-storage/ocs-operator/red-hat-storage-ocs-operator-release-4.22.yaml
+++ b/ci-operator/config/red-hat-storage/ocs-operator/red-hat-storage-ocs-operator-release-4.22.yaml
@@ -42,6 +42,8 @@ tests:
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
       COMPUTE_NODE_TYPE: m5.2xlarge
+      USER_TAGS: |
+        createdBy gh-openshift-ci
       ZONES_COUNT: "3"
     test:
     - as: e2e-test

--- a/ci-operator/config/red-hat-storage/ocs-operator/red-hat-storage-ocs-operator-release-4.3.yaml
+++ b/ci-operator/config/red-hat-storage/ocs-operator/red-hat-storage-ocs-operator-release-4.3.yaml
@@ -96,6 +96,8 @@ tests:
     cluster_profile: odf-aws
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
+      USER_TAGS: |
+        createdBy gh-openshift-ci
     test:
     - as: test
       cli: latest
@@ -111,6 +113,8 @@ tests:
     cluster_profile: odf-aws
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
+      USER_TAGS: |
+        createdBy gh-openshift-ci
     test:
     - as: test
       cli: latest

--- a/ci-operator/config/red-hat-storage/ocs-operator/red-hat-storage-ocs-operator-release-4.4.yaml
+++ b/ci-operator/config/red-hat-storage/ocs-operator/red-hat-storage-ocs-operator-release-4.4.yaml
@@ -95,6 +95,8 @@ tests:
     cluster_profile: odf-aws
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
+      USER_TAGS: |
+        createdBy gh-openshift-ci
     test:
     - as: test
       cli: latest
@@ -110,6 +112,8 @@ tests:
     cluster_profile: odf-aws
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
+      USER_TAGS: |
+        createdBy gh-openshift-ci
     test:
     - as: test
       cli: latest

--- a/ci-operator/config/red-hat-storage/ocs-operator/red-hat-storage-ocs-operator-release-4.5.yaml
+++ b/ci-operator/config/red-hat-storage/ocs-operator/red-hat-storage-ocs-operator-release-4.5.yaml
@@ -90,6 +90,8 @@ tests:
     cluster_profile: odf-aws
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
+      USER_TAGS: |
+        createdBy gh-openshift-ci
     test:
     - as: test
       cli: latest
@@ -105,6 +107,8 @@ tests:
     cluster_profile: odf-aws
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
+      USER_TAGS: |
+        createdBy gh-openshift-ci
     test:
     - as: test
       cli: latest

--- a/ci-operator/config/red-hat-storage/ocs-operator/red-hat-storage-ocs-operator-release-4.6.yaml
+++ b/ci-operator/config/red-hat-storage/ocs-operator/red-hat-storage-ocs-operator-release-4.6.yaml
@@ -115,6 +115,8 @@ tests:
       OO_INSTALL_NAMESPACE: openshift-storage
       OO_PACKAGE: ocs-operator
       OO_TARGET_NAMESPACES: '!install'
+      USER_TAGS: |
+        createdBy gh-openshift-ci
     test:
     - as: tests
       commands: |
@@ -130,6 +132,8 @@ tests:
     cluster_profile: odf-aws
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
+      USER_TAGS: |
+        createdBy gh-openshift-ci
     test:
     - as: test
       cli: latest

--- a/ci-operator/config/red-hat-storage/ocs-operator/red-hat-storage-ocs-operator-release-4.7.yaml
+++ b/ci-operator/config/red-hat-storage/ocs-operator/red-hat-storage-ocs-operator-release-4.7.yaml
@@ -114,6 +114,8 @@ tests:
       OO_INSTALL_NAMESPACE: openshift-storage
       OO_PACKAGE: ocs-operator
       OO_TARGET_NAMESPACES: '!install'
+      USER_TAGS: |
+        createdBy gh-openshift-ci
     test:
     - as: tests
       commands: |
@@ -129,6 +131,8 @@ tests:
     cluster_profile: odf-aws
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
+      USER_TAGS: |
+        createdBy gh-openshift-ci
     test:
     - as: test
       cli: latest

--- a/ci-operator/config/red-hat-storage/ocs-operator/red-hat-storage-ocs-operator-release-4.8.yaml
+++ b/ci-operator/config/red-hat-storage/ocs-operator/red-hat-storage-ocs-operator-release-4.8.yaml
@@ -112,6 +112,8 @@ tests:
       OO_INSTALL_NAMESPACE: openshift-storage
       OO_PACKAGE: ocs-operator
       OO_TARGET_NAMESPACES: '!install'
+      USER_TAGS: |
+        createdBy gh-openshift-ci
     post:
     - as: ocs-must-gather
       cli: latest
@@ -146,6 +148,8 @@ tests:
       OO_INSTALL_NAMESPACE: openshift-storage
       OO_PACKAGE: ocs-operator
       OO_TARGET_NAMESPACES: '!install'
+      USER_TAGS: |
+        createdBy gh-openshift-ci
     post:
     - as: ocs-must-gather
       cli: latest
@@ -173,6 +177,8 @@ tests:
     cluster_profile: odf-aws
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
+      USER_TAGS: |
+        createdBy gh-openshift-ci
     test:
     - as: test
       cli: latest

--- a/ci-operator/config/red-hat-storage/ocs-operator/red-hat-storage-ocs-operator-release-4.9.yaml
+++ b/ci-operator/config/red-hat-storage/ocs-operator/red-hat-storage-ocs-operator-release-4.9.yaml
@@ -102,6 +102,8 @@ tests:
       OO_INSTALL_NAMESPACE: openshift-storage
       OO_PACKAGE: ocs-operator
       OO_TARGET_NAMESPACES: '!install'
+      USER_TAGS: |
+        createdBy gh-openshift-ci
     post:
     - as: ocs-must-gather
       cli: latest
@@ -146,6 +148,8 @@ tests:
       OO_INSTALL_NAMESPACE: openshift-storage
       OO_PACKAGE: ocs-operator
       OO_TARGET_NAMESPACES: '!install'
+      USER_TAGS: |
+        createdBy gh-openshift-ci
     post:
     - as: ocs-must-gather
       cli: latest
@@ -173,6 +177,8 @@ tests:
     cluster_profile: odf-aws
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
+      USER_TAGS: |
+        createdBy gh-openshift-ci
     test:
     - as: test
       cli: latest

--- a/ci-operator/config/red-hat-storage/odf-console/red-hat-storage-odf-console-master.yaml
+++ b/ci-operator/config/red-hat-storage/odf-console/red-hat-storage-odf-console-master.yaml
@@ -36,6 +36,8 @@ tests:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
       COMPUTE_NODE_REPLICAS: "4"
       COMPUTE_NODE_TYPE: m4.2xlarge
+      USER_TAGS: |
+        createdBy gh-openshift-ci
       ZONES_COUNT: "3"
     test:
     - as: tests

--- a/ci-operator/config/red-hat-storage/odf-console/red-hat-storage-odf-console-release-4.11.yaml
+++ b/ci-operator/config/red-hat-storage/odf-console/red-hat-storage-odf-console-release-4.11.yaml
@@ -52,6 +52,8 @@ tests:
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
       COMPUTE_NODE_TYPE: m4.2xlarge
+      USER_TAGS: |
+        createdBy gh-openshift-ci
       ZONES_COUNT: "1"
     test:
     - as: tests

--- a/ci-operator/config/red-hat-storage/odf-console/red-hat-storage-odf-console-release-4.12.yaml
+++ b/ci-operator/config/red-hat-storage/odf-console/red-hat-storage-odf-console-release-4.12.yaml
@@ -52,6 +52,8 @@ tests:
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
       COMPUTE_NODE_TYPE: m5.2xlarge
+      USER_TAGS: |
+        createdBy gh-openshift-ci
       ZONES_COUNT: "3"
     test:
     - as: tests

--- a/ci-operator/config/red-hat-storage/odf-console/red-hat-storage-odf-console-release-4.13.yaml
+++ b/ci-operator/config/red-hat-storage/odf-console/red-hat-storage-odf-console-release-4.13.yaml
@@ -35,6 +35,8 @@ tests:
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
       COMPUTE_NODE_TYPE: m5.2xlarge
+      USER_TAGS: |
+        createdBy gh-openshift-ci
       ZONES_COUNT: "3"
     test:
     - as: tests

--- a/ci-operator/config/red-hat-storage/odf-console/red-hat-storage-odf-console-release-4.14.yaml
+++ b/ci-operator/config/red-hat-storage/odf-console/red-hat-storage-odf-console-release-4.14.yaml
@@ -35,6 +35,8 @@ tests:
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
       COMPUTE_NODE_TYPE: m5.2xlarge
+      USER_TAGS: |
+        createdBy gh-openshift-ci
       ZONES_COUNT: "3"
     test:
     - as: tests

--- a/ci-operator/config/red-hat-storage/odf-console/red-hat-storage-odf-console-release-4.15.yaml
+++ b/ci-operator/config/red-hat-storage/odf-console/red-hat-storage-odf-console-release-4.15.yaml
@@ -35,6 +35,8 @@ tests:
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
       COMPUTE_NODE_TYPE: m5.2xlarge
+      USER_TAGS: |
+        createdBy gh-openshift-ci
       ZONES_COUNT: "3"
     test:
     - as: tests

--- a/ci-operator/config/red-hat-storage/odf-console/red-hat-storage-odf-console-release-4.16.yaml
+++ b/ci-operator/config/red-hat-storage/odf-console/red-hat-storage-odf-console-release-4.16.yaml
@@ -35,6 +35,8 @@ tests:
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
       COMPUTE_NODE_TYPE: m5.2xlarge
+      USER_TAGS: |
+        createdBy gh-openshift-ci
       ZONES_COUNT: "3"
     test:
     - as: tests

--- a/ci-operator/config/red-hat-storage/odf-console/red-hat-storage-odf-console-release-4.17.yaml
+++ b/ci-operator/config/red-hat-storage/odf-console/red-hat-storage-odf-console-release-4.17.yaml
@@ -35,6 +35,8 @@ tests:
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
       COMPUTE_NODE_TYPE: m5.2xlarge
+      USER_TAGS: |
+        createdBy gh-openshift-ci
       ZONES_COUNT: "3"
     test:
     - as: tests

--- a/ci-operator/config/red-hat-storage/odf-console/red-hat-storage-odf-console-release-4.18.yaml
+++ b/ci-operator/config/red-hat-storage/odf-console/red-hat-storage-odf-console-release-4.18.yaml
@@ -35,6 +35,8 @@ tests:
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
       COMPUTE_NODE_TYPE: m5.2xlarge
+      USER_TAGS: |
+        createdBy gh-openshift-ci
       ZONES_COUNT: "3"
     test:
     - as: tests

--- a/ci-operator/config/red-hat-storage/odf-console/red-hat-storage-odf-console-release-4.19.yaml
+++ b/ci-operator/config/red-hat-storage/odf-console/red-hat-storage-odf-console-release-4.19.yaml
@@ -36,6 +36,8 @@ tests:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
       COMPUTE_NODE_REPLICAS: "4"
       COMPUTE_NODE_TYPE: m4.2xlarge
+      USER_TAGS: |
+        createdBy gh-openshift-ci
       ZONES_COUNT: "3"
     test:
     - as: tests

--- a/ci-operator/config/red-hat-storage/odf-multicluster-orchestrator/red-hat-storage-odf-multicluster-orchestrator-release-4.10.yaml
+++ b/ci-operator/config/red-hat-storage/odf-multicluster-orchestrator/red-hat-storage-odf-multicluster-orchestrator-release-4.10.yaml
@@ -35,6 +35,8 @@ tests:
     cluster_profile: odf-aws
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
+      USER_TAGS: |
+        createdBy gh-openshift-ci
     test:
     - as: integration-test-aws
       commands: USE_EXISTING_CLUSTER=true make test

--- a/ci-operator/config/red-hat-storage/odf-multicluster-orchestrator/red-hat-storage-odf-multicluster-orchestrator-release-4.11.yaml
+++ b/ci-operator/config/red-hat-storage/odf-multicluster-orchestrator/red-hat-storage-odf-multicluster-orchestrator-release-4.11.yaml
@@ -36,6 +36,8 @@ tests:
     cluster_profile: odf-aws
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
+      USER_TAGS: |
+        createdBy gh-openshift-ci
     test:
     - as: integration-test-aws
       commands: USE_EXISTING_CLUSTER=true make test

--- a/ci-operator/config/red-hat-storage/odf-multicluster-orchestrator/red-hat-storage-odf-multicluster-orchestrator-release-4.12.yaml
+++ b/ci-operator/config/red-hat-storage/odf-multicluster-orchestrator/red-hat-storage-odf-multicluster-orchestrator-release-4.12.yaml
@@ -35,6 +35,8 @@ tests:
     cluster_profile: odf-aws
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
+      USER_TAGS: |
+        createdBy gh-openshift-ci
     test:
     - as: integration-test-aws
       commands: USE_EXISTING_CLUSTER=true make test

--- a/ci-operator/config/red-hat-storage/odf-multicluster-orchestrator/red-hat-storage-odf-multicluster-orchestrator-release-4.13.yaml
+++ b/ci-operator/config/red-hat-storage/odf-multicluster-orchestrator/red-hat-storage-odf-multicluster-orchestrator-release-4.13.yaml
@@ -35,6 +35,8 @@ tests:
     cluster_profile: odf-aws
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
+      USER_TAGS: |
+        createdBy gh-openshift-ci
     test:
     - as: integration-test-aws
       commands: USE_EXISTING_CLUSTER=true make test

--- a/ci-operator/config/red-hat-storage/odf-multicluster-orchestrator/red-hat-storage-odf-multicluster-orchestrator-release-4.14.yaml
+++ b/ci-operator/config/red-hat-storage/odf-multicluster-orchestrator/red-hat-storage-odf-multicluster-orchestrator-release-4.14.yaml
@@ -35,6 +35,8 @@ tests:
     cluster_profile: odf-aws
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
+      USER_TAGS: |
+        createdBy gh-openshift-ci
     test:
     - as: integration-test-aws
       commands: USE_EXISTING_CLUSTER=true make test

--- a/ci-operator/config/red-hat-storage/odf-multicluster-orchestrator/red-hat-storage-odf-multicluster-orchestrator-release-4.15.yaml
+++ b/ci-operator/config/red-hat-storage/odf-multicluster-orchestrator/red-hat-storage-odf-multicluster-orchestrator-release-4.15.yaml
@@ -35,6 +35,8 @@ tests:
     cluster_profile: odf-aws
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
+      USER_TAGS: |
+        createdBy gh-openshift-ci
     test:
     - as: integration-test-aws
       commands: USE_EXISTING_CLUSTER=true make test

--- a/ci-operator/config/red-hat-storage/odf-multicluster-orchestrator/red-hat-storage-odf-multicluster-orchestrator-release-4.16.yaml
+++ b/ci-operator/config/red-hat-storage/odf-multicluster-orchestrator/red-hat-storage-odf-multicluster-orchestrator-release-4.16.yaml
@@ -35,6 +35,8 @@ tests:
     cluster_profile: odf-aws
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
+      USER_TAGS: |
+        createdBy gh-openshift-ci
     test:
     - as: integration-test-aws
       commands: USE_EXISTING_CLUSTER=true make test

--- a/ci-operator/config/red-hat-storage/odf-multicluster-orchestrator/red-hat-storage-odf-multicluster-orchestrator-release-4.17.yaml
+++ b/ci-operator/config/red-hat-storage/odf-multicluster-orchestrator/red-hat-storage-odf-multicluster-orchestrator-release-4.17.yaml
@@ -35,6 +35,8 @@ tests:
     cluster_profile: odf-aws
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
+      USER_TAGS: |
+        createdBy gh-openshift-ci
     test:
     - as: integration-test-aws
       commands: USE_EXISTING_CLUSTER=true make test

--- a/ci-operator/config/red-hat-storage/odf-multicluster-orchestrator/red-hat-storage-odf-multicluster-orchestrator-release-4.9.yaml
+++ b/ci-operator/config/red-hat-storage/odf-multicluster-orchestrator/red-hat-storage-odf-multicluster-orchestrator-release-4.9.yaml
@@ -35,6 +35,8 @@ tests:
     cluster_profile: odf-aws
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
+      USER_TAGS: |
+        createdBy gh-openshift-ci
     test:
     - as: integration-test-aws
       commands: USE_EXISTING_CLUSTER=true make test

--- a/ci-operator/config/red-hat-storage/odf-operator/red-hat-storage-odf-operator-main.yaml
+++ b/ci-operator/config/red-hat-storage/odf-operator/red-hat-storage-odf-operator-main.yaml
@@ -40,6 +40,8 @@ tests:
     cluster_profile: odf-aws
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
+      USER_TAGS: |
+        createdBy gh-openshift-ci
     test:
     - as: unit-tests
       cli: latest

--- a/ci-operator/config/red-hat-storage/odf-operator/red-hat-storage-odf-operator-release-4.10.yaml
+++ b/ci-operator/config/red-hat-storage/odf-operator/red-hat-storage-odf-operator-release-4.10.yaml
@@ -93,6 +93,8 @@ tests:
       OO_INSTALL_NAMESPACE: openshift-storage
       OO_PACKAGE: odf-operator
       OO_TARGET_NAMESPACES: '!install'
+      USER_TAGS: |
+        createdBy gh-openshift-ci
     test:
     - as: tests
       commands: |

--- a/ci-operator/config/red-hat-storage/odf-operator/red-hat-storage-odf-operator-release-4.11.yaml
+++ b/ci-operator/config/red-hat-storage/odf-operator/red-hat-storage-odf-operator-release-4.11.yaml
@@ -89,6 +89,8 @@ tests:
       OO_INSTALL_NAMESPACE: openshift-storage
       OO_PACKAGE: odf-operator
       OO_TARGET_NAMESPACES: '!install'
+      USER_TAGS: |
+        createdBy gh-openshift-ci
     test:
     - as: tests
       commands: |

--- a/ci-operator/config/red-hat-storage/odf-operator/red-hat-storage-odf-operator-release-4.12.yaml
+++ b/ci-operator/config/red-hat-storage/odf-operator/red-hat-storage-odf-operator-release-4.12.yaml
@@ -39,6 +39,8 @@ tests:
     cluster_profile: odf-aws
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
+      USER_TAGS: |
+        createdBy gh-openshift-ci
     test:
     - as: unit-tests
       cli: latest

--- a/ci-operator/config/red-hat-storage/odf-operator/red-hat-storage-odf-operator-release-4.13.yaml
+++ b/ci-operator/config/red-hat-storage/odf-operator/red-hat-storage-odf-operator-release-4.13.yaml
@@ -39,6 +39,8 @@ tests:
     cluster_profile: odf-aws
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
+      USER_TAGS: |
+        createdBy gh-openshift-ci
     test:
     - as: unit-tests
       cli: latest

--- a/ci-operator/config/red-hat-storage/odf-operator/red-hat-storage-odf-operator-release-4.14.yaml
+++ b/ci-operator/config/red-hat-storage/odf-operator/red-hat-storage-odf-operator-release-4.14.yaml
@@ -39,6 +39,8 @@ tests:
     cluster_profile: odf-aws
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
+      USER_TAGS: |
+        createdBy gh-openshift-ci
     test:
     - as: unit-tests
       cli: latest

--- a/ci-operator/config/red-hat-storage/odf-operator/red-hat-storage-odf-operator-release-4.15.yaml
+++ b/ci-operator/config/red-hat-storage/odf-operator/red-hat-storage-odf-operator-release-4.15.yaml
@@ -39,6 +39,8 @@ tests:
     cluster_profile: odf-aws
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
+      USER_TAGS: |
+        createdBy gh-openshift-ci
     test:
     - as: unit-tests
       cli: latest

--- a/ci-operator/config/red-hat-storage/odf-operator/red-hat-storage-odf-operator-release-4.16.yaml
+++ b/ci-operator/config/red-hat-storage/odf-operator/red-hat-storage-odf-operator-release-4.16.yaml
@@ -39,6 +39,8 @@ tests:
     cluster_profile: odf-aws
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
+      USER_TAGS: |
+        createdBy gh-openshift-ci
     test:
     - as: unit-tests
       cli: latest

--- a/ci-operator/config/red-hat-storage/odf-operator/red-hat-storage-odf-operator-release-4.17.yaml
+++ b/ci-operator/config/red-hat-storage/odf-operator/red-hat-storage-odf-operator-release-4.17.yaml
@@ -39,6 +39,8 @@ tests:
     cluster_profile: odf-aws
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
+      USER_TAGS: |
+        createdBy gh-openshift-ci
     test:
     - as: unit-tests
       cli: latest

--- a/ci-operator/config/red-hat-storage/odf-operator/red-hat-storage-odf-operator-release-4.18.yaml
+++ b/ci-operator/config/red-hat-storage/odf-operator/red-hat-storage-odf-operator-release-4.18.yaml
@@ -38,6 +38,8 @@ tests:
     cluster_profile: odf-aws
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
+      USER_TAGS: |
+        createdBy gh-openshift-ci
     test:
     - as: unit-tests
       cli: latest

--- a/ci-operator/config/red-hat-storage/odf-operator/red-hat-storage-odf-operator-release-4.19.yaml
+++ b/ci-operator/config/red-hat-storage/odf-operator/red-hat-storage-odf-operator-release-4.19.yaml
@@ -38,6 +38,8 @@ tests:
     cluster_profile: odf-aws
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
+      USER_TAGS: |
+        createdBy gh-openshift-ci
     test:
     - as: unit-tests
       cli: latest

--- a/ci-operator/config/red-hat-storage/odf-operator/red-hat-storage-odf-operator-release-4.20.yaml
+++ b/ci-operator/config/red-hat-storage/odf-operator/red-hat-storage-odf-operator-release-4.20.yaml
@@ -38,6 +38,8 @@ tests:
     cluster_profile: odf-aws
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
+      USER_TAGS: |
+        createdBy gh-openshift-ci
     test:
     - as: unit-tests
       cli: latest

--- a/ci-operator/config/red-hat-storage/odf-operator/red-hat-storage-odf-operator-release-4.21.yaml
+++ b/ci-operator/config/red-hat-storage/odf-operator/red-hat-storage-odf-operator-release-4.21.yaml
@@ -38,6 +38,8 @@ tests:
     cluster_profile: odf-aws
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
+      USER_TAGS: |
+        createdBy gh-openshift-ci
     test:
     - as: unit-tests
       cli: latest

--- a/ci-operator/config/red-hat-storage/odf-operator/red-hat-storage-odf-operator-release-4.22.yaml
+++ b/ci-operator/config/red-hat-storage/odf-operator/red-hat-storage-odf-operator-release-4.22.yaml
@@ -40,6 +40,8 @@ tests:
     cluster_profile: odf-aws
     env:
       BASE_DOMAIN: ocs.syseng.devcluster.openshift.com
+      USER_TAGS: |
+        createdBy gh-openshift-ci
     test:
     - as: unit-tests
       cli: latest

--- a/ci-operator/config/red-hat-storage/odf-operator/red-hat-storage-odf-operator-release-4.9.yaml
+++ b/ci-operator/config/red-hat-storage/odf-operator/red-hat-storage-odf-operator-release-4.9.yaml
@@ -89,6 +89,8 @@ tests:
       OO_INSTALL_NAMESPACE: openshift-storage
       OO_PACKAGE: odf-operator
       OO_TARGET_NAMESPACES: '!install'
+      USER_TAGS: |
+        createdBy gh-openshift-ci
     test:
     - as: tests
       commands: |


### PR DESCRIPTION
Set USER_TAGS (createdBy gh-openshift-ci) in every odf-aws test env that uses BASE_DOMAIN ocs.syseng.devcluster.openshift.com, so ipi-conf-aws applies consistent EC2 user tags for cost tracking and ownership across ocs-operator, odf-operator, odf-console, and odf-multicluster-orchestrator jobs.

Ref-https://steps.ci.openshift.org/workflow/ipi-aws

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
* **Chore — OpenShift CI configs (red-hat-storage)**
  * Adds a USER_TAGS environment variable (block scalar with "createdBy gh-openshift-ci") to many ci-operator job configs across the red-hat-storage repository.
  * Affects ci-operator configs for ocs-operator, odf-operator, odf-console, and odf-multicluster-orchestrator (multiple release files and main branches). Changes are limited to test steps that run AWS IPI e2e jobs.
  * Practical effect: sets USER_TAGS so ipi-conf-aws will apply consistent EC2 user tags for clusters that use BASE_DOMAIN ocs.syseng.devcluster.openshift.com. This enables consistent cost-tracking and ownership metadata across ODF/OCS AWS CI clusters.
  * Scope/impact: purely CI configuration additions (environment variables); no code or exported API changes. Low-risk; repeated, small insertions across many YAML job files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->