### PR TITLE
Fix Jira env vars in OCM Prow jobs

### DIFF
--- a/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__ocm-fvt-osd-gcp-staging.yaml
+++ b/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__ocm-fvt-osd-gcp-staging.yaml
@@ -26,83 +26,14 @@ tests:
   capabilities:
   - nested-podman
   commands: |
-    JOB_LINK="https://prow.ci.openshift.org/view/gs/test-platform-results/"
-    if [ -n "${PULL_NUMBER:-}" ]; then
-      JOB_LINK="${JOB_LINK}pr-logs/pull/openshift_release/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
-    else
-      JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
-    fi
-
-    env -i bash --norc --noprofile << EOF > /tmp/podman.env
-    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
-    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
-    export ENABLE_JIRA_REPORTING=true
-    export JOB_LINK="${JOB_LINK}"
-    source /usr/local/cs-qe-credentials/ocm-tokens
-    source /usr/local/cs-qe-credentials/jira-cred
-    env | grep -v '^_='
-    EOF
-
-    podman run \
-    --authfile /usr/local/cs-qe-credentials/.dockerconfigjson \
-    --env-file /tmp/podman.env \
-    -v /usr/local/cs-qe-credentials:/credentials:ro,z \
-    -v /usr/local/cs-qe-credentials/osd-ccs-admin.json:/home/ci-user/.gcp/osd-ccs-admin.json:ro,z \
-    --rm \
-    quay.io/redhat-services-prod/ocmci/ocmci:latest \
-    ocmtest test --service cms --job cs-osd-ccs-gcp-ad-staging-main --reportJiraTicket
-  container:
-    from: nested-podman
-    memory_backed_volume:
-      size: 1Gi
-  cron: 0 9 * * *
-  nested_podman: true
-  secrets:
-  - mount_path: /usr/local/cs-qe-credentials
-    name: cs-qe-credentials
-- as: ocm-fvt-periodic-cs-osd-ccs-gcp-marketplace-staging-main
-  capabilities:
-  - nested-podman
-  commands: |
-    JOB_LINK="https://prow.ci.openshift.org/view/gs/test-platform-results/"
-    if [ -n "${PULL_NUMBER:-}" ]; then
-      JOB_LINK="${JOB_LINK}pr-logs/pull/openshift_release/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
-    else
-      JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
-    fi
-
-    env -i bash --norc --noprofile << EOF > /tmp/podman.env
-    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
-    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
-    export ENABLE_JIRA_REPORTING=true
-    export JOB_LINK="${JOB_LINK}"
-    source /usr/local/cs-qe-credentials/ocm-tokens
-    source /usr/local/cs-qe-credentials/jira-cred
-    env | grep -v '^_='
-    EOF
-
-    podman run \
-    --authfile /usr/local/cs-qe-credentials/.dockerconfigjson \
-    --env-file /tmp/podman.env \
-    -v /usr/local/cs-qe-credentials:/credentials:ro,z \
-    -v /usr/local/cs-qe-credentials/osd-ccs-admin.json:/home/ci-user/.gcp/osd-ccs-admin.json:ro,z \
-    --rm \
-    quay.io/redhat-services-prod/ocmci/ocmci:latest \
-    ocmtest test --service cms --job cs-osd-ccs-gcp-marketplace-staging-main --reportJiraTicket
-  container:
-    from: nested-podman
-    memory_backed_volume:
-      size: 1Gi
-  cron: 0 8 * * *
-  nested_podman: true
-  secrets:
-  - mount_path: /usr/local/cs-qe-credentials
-    name: cs-qe-credentials
-- as: ocm-fvt-periodic-cs-osd-gcp-non-cross-proj-wif-staging-main
-  capabilities:
-  - nested-podman
-  commands: |
-    env -i bash --norc --noprofile << 'EOF' > /tmp/podman.env
+    podman_env_file="$(mktemp /tmp/podman.env.XXXXXX)"
+    trap 'rm -f "${podman_env_file}"' EXIT
+    umask 077
+    env -i \
+      PULL_NUMBER="${PULL_NUMBER:-}" \
+      JOB_NAME="${JOB_NAME}" \
+      BUILD_ID="${BUILD_ID}" \
+      bash --norc --noprofile << 'EOF' > "${podman_env_file}"
     export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
     export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
     export ENABLE_JIRA_REPORTING=true
@@ -121,7 +52,97 @@ tests:
 
     podman run \
     --authfile /usr/local/cs-qe-credentials/.dockerconfigjson \
-    --env-file /tmp/podman.env \
+    --env-file "${podman_env_file}" \
+    -v /usr/local/cs-qe-credentials:/credentials:ro,z \
+    -v /usr/local/cs-qe-credentials/osd-ccs-admin.json:/home/ci-user/.gcp/osd-ccs-admin.json:ro,z \
+    --rm \
+    quay.io/redhat-services-prod/ocmci/ocmci:latest \
+    ocmtest test --service cms --job cs-osd-ccs-gcp-ad-staging-main --reportJiraTicket
+  container:
+    from: nested-podman
+    memory_backed_volume:
+      size: 1Gi
+  cron: 0 9 * * *
+  nested_podman: true
+  secrets:
+  - mount_path: /usr/local/cs-qe-credentials
+    name: cs-qe-credentials
+- as: ocm-fvt-periodic-cs-osd-ccs-gcp-marketplace-staging-main
+  capabilities:
+  - nested-podman
+  commands: |
+    podman_env_file="$(mktemp /tmp/podman.env.XXXXXX)"
+    trap 'rm -f "${podman_env_file}"' EXIT
+    umask 077
+    env -i \
+      PULL_NUMBER="${PULL_NUMBER:-}" \
+      JOB_NAME="${JOB_NAME}" \
+      BUILD_ID="${BUILD_ID}" \
+      bash --norc --noprofile << 'EOF' > "${podman_env_file}"
+    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
+    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
+    export ENABLE_JIRA_REPORTING=true
+    JOB_LINK="https://prow.ci.openshift.org/view/gs/test-platform-results/"
+    if [ -n "${PULL_NUMBER:-}" ]; then
+      JOB_LINK="${JOB_LINK}pr-logs/pull/openshift_release/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
+    else
+      JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
+    fi
+    echo "JOB_LINK=${JOB_LINK}"
+    export JOB_LINK=${JOB_LINK}
+    source /usr/local/cs-qe-credentials/ocm-tokens
+    source /usr/local/cs-qe-credentials/jira-cred
+    env | grep -v '^_='
+    EOF
+
+    podman run \
+    --authfile /usr/local/cs-qe-credentials/.dockerconfigjson \
+    --env-file "${podman_env_file}" \
+    -v /usr/local/cs-qe-credentials:/credentials:ro,z \
+    -v /usr/local/cs-qe-credentials/osd-ccs-admin.json:/home/ci-user/.gcp/osd-ccs-admin.json:ro,z \
+    --rm \
+    quay.io/redhat-services-prod/ocmci/ocmci:latest \
+    ocmtest test --service cms --job cs-osd-ccs-gcp-marketplace-staging-main --reportJiraTicket
+  container:
+    from: nested-podman
+    memory_backed_volume:
+      size: 1Gi
+  cron: 0 8 * * *
+  nested_podman: true
+  secrets:
+  - mount_path: /usr/local/cs-qe-credentials
+    name: cs-qe-credentials
+- as: ocm-fvt-periodic-cs-osd-gcp-non-cross-proj-wif-staging-main
+  capabilities:
+  - nested-podman
+  commands: |
+    podman_env_file="$(mktemp /tmp/podman.env.XXXXXX)"
+    trap 'rm -f "${podman_env_file}"' EXIT
+    umask 077
+    env -i \
+      PULL_NUMBER="${PULL_NUMBER:-}" \
+      JOB_NAME="${JOB_NAME}" \
+      BUILD_ID="${BUILD_ID}" \
+      bash --norc --noprofile << 'EOF' > "${podman_env_file}"
+    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
+    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
+    export ENABLE_JIRA_REPORTING=true
+    JOB_LINK="https://prow.ci.openshift.org/view/gs/test-platform-results/"
+    if [ -n "${PULL_NUMBER:-}" ]; then
+      JOB_LINK="${JOB_LINK}pr-logs/pull/openshift_release/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
+    else
+      JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
+    fi
+    echo "JOB_LINK=${JOB_LINK}"
+    export JOB_LINK=${JOB_LINK}
+    source /usr/local/cs-qe-credentials/ocm-tokens
+    source /usr/local/cs-qe-credentials/jira-cred
+    env | grep -v '^_='
+    EOF
+
+    podman run \
+    --authfile /usr/local/cs-qe-credentials/.dockerconfigjson \
+    --env-file "${podman_env_file}" \
     -v /usr/local/cs-qe-credentials:/credentials:ro,z \
     -v /usr/local/cs-qe-credentials/osd-ccs-admin.json:/home/ci-user/.gcp/osd-ccs-admin.json:ro,z \
     --rm \

--- a/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__ocm-fvt-osd-gcp-staging.yaml
+++ b/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__ocm-fvt-osd-gcp-staging.yaml
@@ -33,7 +33,7 @@ tests:
       PULL_NUMBER="${PULL_NUMBER:-}" \
       JOB_NAME="${JOB_NAME}" \
       BUILD_ID="${BUILD_ID}" \
-      bash --norc --noprofile << 'EOF' > "${podman_env_file}"
+      bash --norc --noprofile << EOF > "${podman_env_file}"
     export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
     export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
     export ENABLE_JIRA_REPORTING=true
@@ -78,7 +78,7 @@ tests:
       PULL_NUMBER="${PULL_NUMBER:-}" \
       JOB_NAME="${JOB_NAME}" \
       BUILD_ID="${BUILD_ID}" \
-      bash --norc --noprofile << 'EOF' > "${podman_env_file}"
+      bash --norc --noprofile << EOF > "${podman_env_file}"
     export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
     export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
     export ENABLE_JIRA_REPORTING=true
@@ -123,7 +123,7 @@ tests:
       PULL_NUMBER="${PULL_NUMBER:-}" \
       JOB_NAME="${JOB_NAME}" \
       BUILD_ID="${BUILD_ID}" \
-      bash --norc --noprofile << 'EOF' > "${podman_env_file}"
+      bash --norc --noprofile << EOF > "${podman_env_file}"
     export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
     export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
     export ENABLE_JIRA_REPORTING=true

--- a/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__ocm-fvt-rosa-classic-integration.yaml
+++ b/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__ocm-fvt-rosa-classic-integration.yaml
@@ -33,7 +33,7 @@ tests:
       PULL_NUMBER="${PULL_NUMBER:-}" \
       JOB_NAME="${JOB_NAME}" \
       BUILD_ID="${BUILD_ID}" \
-      bash --norc --noprofile << 'EOF' > "${podman_env_file}"
+      bash --norc --noprofile << EOF > "${podman_env_file}"
     export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
     export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
     export ENABLE_JIRA_REPORTING=true

--- a/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__ocm-fvt-rosa-classic-integration.yaml
+++ b/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__ocm-fvt-rosa-classic-integration.yaml
@@ -26,18 +26,25 @@ tests:
   capabilities:
   - nested-podman
   commands: |
+    podman_env_file="$(mktemp /tmp/podman.env.XXXXXX)"
+    trap 'rm -f "${podman_env_file}"' EXIT
+    umask 077
+    env -i \
+      PULL_NUMBER="${PULL_NUMBER:-}" \
+      JOB_NAME="${JOB_NAME}" \
+      BUILD_ID="${BUILD_ID}" \
+      bash --norc --noprofile << 'EOF' > "${podman_env_file}"
+    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
+    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
+    export ENABLE_JIRA_REPORTING=true
     JOB_LINK="https://prow.ci.openshift.org/view/gs/test-platform-results/"
     if [ -n "${PULL_NUMBER:-}" ]; then
       JOB_LINK="${JOB_LINK}pr-logs/pull/openshift_release/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
     else
       JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
     fi
-
-    env -i bash --norc --noprofile << EOF > /tmp/podman.env
-    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
-    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
-    export ENABLE_JIRA_REPORTING=true
-    export JOB_LINK="${JOB_LINK}"
+    echo "JOB_LINK=${JOB_LINK}"
+    export JOB_LINK=${JOB_LINK}
     source /usr/local/cs-qe-credentials/ocm-tokens
     source /usr/local/cs-qe-credentials/jira-cred
     env | grep -v '^_='
@@ -45,7 +52,7 @@ tests:
 
     podman run \
     --authfile /usr/local/cs-qe-credentials/.dockerconfigjson \
-    --env-file /tmp/podman.env \
+    --env-file "${podman_env_file}" \
     -v /usr/local/cs-qe-credentials:/credentials:ro,z \
     --rm \
     quay.io/redhat-services-prod/ocmci/ocmci:latest \

--- a/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__ocm-fvt-rosa-classic-staging.yaml
+++ b/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__ocm-fvt-rosa-classic-staging.yaml
@@ -33,7 +33,7 @@ tests:
       PULL_NUMBER="${PULL_NUMBER:-}" \
       JOB_NAME="${JOB_NAME}" \
       BUILD_ID="${BUILD_ID}" \
-      bash --norc --noprofile << 'EOF' > "${podman_env_file}"
+      bash --norc --noprofile << EOF > "${podman_env_file}"
     export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
     export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
     export ENABLE_JIRA_REPORTING=true
@@ -77,7 +77,7 @@ tests:
       PULL_NUMBER="${PULL_NUMBER:-}" \
       JOB_NAME="${JOB_NAME}" \
       BUILD_ID="${BUILD_ID}" \
-      bash --norc --noprofile << 'EOF' > "${podman_env_file}"
+      bash --norc --noprofile << EOF > "${podman_env_file}"
     export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
     export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
     export ENABLE_JIRA_REPORTING=true
@@ -121,7 +121,7 @@ tests:
       PULL_NUMBER="${PULL_NUMBER:-}" \
       JOB_NAME="${JOB_NAME}" \
       BUILD_ID="${BUILD_ID}" \
-      bash --norc --noprofile << 'EOF' > "${podman_env_file}"
+      bash --norc --noprofile << EOF > "${podman_env_file}"
     export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
     export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
     export ENABLE_JIRA_REPORTING=true
@@ -165,7 +165,7 @@ tests:
       PULL_NUMBER="${PULL_NUMBER:-}" \
       JOB_NAME="${JOB_NAME}" \
       BUILD_ID="${BUILD_ID}" \
-      bash --norc --noprofile << 'EOF' > "${podman_env_file}"
+      bash --norc --noprofile << EOF > "${podman_env_file}"
     export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
     export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
     export ENABLE_JIRA_REPORTING=true
@@ -209,7 +209,7 @@ tests:
       PULL_NUMBER="${PULL_NUMBER:-}" \
       JOB_NAME="${JOB_NAME}" \
       BUILD_ID="${BUILD_ID}" \
-      bash --norc --noprofile << 'EOF' > "${podman_env_file}"
+      bash --norc --noprofile << EOF > "${podman_env_file}"
     export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
     export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
     export ENABLE_JIRA_REPORTING=true
@@ -253,7 +253,7 @@ tests:
       PULL_NUMBER="${PULL_NUMBER:-}" \
       JOB_NAME="${JOB_NAME}" \
       BUILD_ID="${BUILD_ID}" \
-      bash --norc --noprofile << 'EOF' > "${podman_env_file}"
+      bash --norc --noprofile << EOF > "${podman_env_file}"
     export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
     export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
     export ENABLE_JIRA_REPORTING=true
@@ -297,7 +297,7 @@ tests:
       PULL_NUMBER="${PULL_NUMBER:-}" \
       JOB_NAME="${JOB_NAME}" \
       BUILD_ID="${BUILD_ID}" \
-      bash --norc --noprofile << 'EOF' > "${podman_env_file}"
+      bash --norc --noprofile << EOF > "${podman_env_file}"
     export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
     export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
     export ENABLE_JIRA_REPORTING=true

--- a/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__ocm-fvt-rosa-classic-staging.yaml
+++ b/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__ocm-fvt-rosa-classic-staging.yaml
@@ -26,18 +26,25 @@ tests:
   capabilities:
   - nested-podman
   commands: |
+    podman_env_file="$(mktemp /tmp/podman.env.XXXXXX)"
+    trap 'rm -f "${podman_env_file}"' EXIT
+    umask 077
+    env -i \
+      PULL_NUMBER="${PULL_NUMBER:-}" \
+      JOB_NAME="${JOB_NAME}" \
+      BUILD_ID="${BUILD_ID}" \
+      bash --norc --noprofile << 'EOF' > "${podman_env_file}"
+    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
+    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
+    export ENABLE_JIRA_REPORTING=true
     JOB_LINK="https://prow.ci.openshift.org/view/gs/test-platform-results/"
     if [ -n "${PULL_NUMBER:-}" ]; then
       JOB_LINK="${JOB_LINK}pr-logs/pull/openshift_release/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
     else
       JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
     fi
-
-    env -i bash --norc --noprofile << EOF > /tmp/podman.env
-    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
-    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
-    export ENABLE_JIRA_REPORTING=true
-    export JOB_LINK="${JOB_LINK}"
+    echo "JOB_LINK=${JOB_LINK}"
+    export JOB_LINK=${JOB_LINK}
     source /usr/local/cs-qe-credentials/ocm-tokens
     source /usr/local/cs-qe-credentials/jira-cred
     env | grep -v '^_='
@@ -45,7 +52,7 @@ tests:
 
     podman run \
     --authfile /usr/local/cs-qe-credentials/.dockerconfigjson \
-    --env-file /tmp/podman.env \
+    --env-file "${podman_env_file}" \
     -v /usr/local/cs-qe-credentials:/credentials:ro,z \
     --rm \
     quay.io/redhat-services-prod/ocmci/ocmci:latest \
@@ -63,18 +70,25 @@ tests:
   capabilities:
   - nested-podman
   commands: |
+    podman_env_file="$(mktemp /tmp/podman.env.XXXXXX)"
+    trap 'rm -f "${podman_env_file}"' EXIT
+    umask 077
+    env -i \
+      PULL_NUMBER="${PULL_NUMBER:-}" \
+      JOB_NAME="${JOB_NAME}" \
+      BUILD_ID="${BUILD_ID}" \
+      bash --norc --noprofile << 'EOF' > "${podman_env_file}"
+    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
+    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
+    export ENABLE_JIRA_REPORTING=true
     JOB_LINK="https://prow.ci.openshift.org/view/gs/test-platform-results/"
     if [ -n "${PULL_NUMBER:-}" ]; then
       JOB_LINK="${JOB_LINK}pr-logs/pull/openshift_release/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
     else
       JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
     fi
-
-    env -i bash --norc --noprofile << EOF > /tmp/podman.env
-    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
-    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
-    export ENABLE_JIRA_REPORTING=true
-    export JOB_LINK="${JOB_LINK}"
+    echo "JOB_LINK=${JOB_LINK}"
+    export JOB_LINK=${JOB_LINK}
     source /usr/local/cs-qe-credentials/ocm-tokens
     source /usr/local/cs-qe-credentials/jira-cred
     env | grep -v '^_='
@@ -82,7 +96,7 @@ tests:
 
     podman run \
     --authfile /usr/local/cs-qe-credentials/.dockerconfigjson \
-    --env-file /tmp/podman.env \
+    --env-file "${podman_env_file}" \
     -v /usr/local/cs-qe-credentials:/credentials:ro,z \
     --rm \
     quay.io/redhat-services-prod/ocmci/ocmci:latest \
@@ -100,18 +114,25 @@ tests:
   capabilities:
   - nested-podman
   commands: |
+    podman_env_file="$(mktemp /tmp/podman.env.XXXXXX)"
+    trap 'rm -f "${podman_env_file}"' EXIT
+    umask 077
+    env -i \
+      PULL_NUMBER="${PULL_NUMBER:-}" \
+      JOB_NAME="${JOB_NAME}" \
+      BUILD_ID="${BUILD_ID}" \
+      bash --norc --noprofile << 'EOF' > "${podman_env_file}"
+    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
+    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
+    export ENABLE_JIRA_REPORTING=true
     JOB_LINK="https://prow.ci.openshift.org/view/gs/test-platform-results/"
     if [ -n "${PULL_NUMBER:-}" ]; then
       JOB_LINK="${JOB_LINK}pr-logs/pull/openshift_release/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
     else
       JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
     fi
-
-    env -i bash --norc --noprofile << EOF > /tmp/podman.env
-    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
-    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
-    export ENABLE_JIRA_REPORTING=true
-    export JOB_LINK="${JOB_LINK}"
+    echo "JOB_LINK=${JOB_LINK}"
+    export JOB_LINK=${JOB_LINK}
     source /usr/local/cs-qe-credentials/ocm-tokens
     source /usr/local/cs-qe-credentials/jira-cred
     env | grep -v '^_='
@@ -119,7 +140,7 @@ tests:
 
     podman run \
     --authfile /usr/local/cs-qe-credentials/.dockerconfigjson \
-    --env-file /tmp/podman.env \
+    --env-file "${podman_env_file}" \
     -v /usr/local/cs-qe-credentials:/credentials:ro,z \
     --rm \
     quay.io/redhat-services-prod/ocmci/ocmci:latest \
@@ -137,21 +158,25 @@ tests:
   capabilities:
   - nested-podman
   commands: |
+    podman_env_file="$(mktemp /tmp/podman.env.XXXXXX)"
+    trap 'rm -f "${podman_env_file}"' EXIT
+    umask 077
+    env -i \
+      PULL_NUMBER="${PULL_NUMBER:-}" \
+      JOB_NAME="${JOB_NAME}" \
+      BUILD_ID="${BUILD_ID}" \
+      bash --norc --noprofile << 'EOF' > "${podman_env_file}"
+    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
+    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
+    export ENABLE_JIRA_REPORTING=true
     JOB_LINK="https://prow.ci.openshift.org/view/gs/test-platform-results/"
     if [ -n "${PULL_NUMBER:-}" ]; then
       JOB_LINK="${JOB_LINK}pr-logs/pull/openshift_release/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
     else
       JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
     fi
-
-    podman_env_file="$(mktemp /tmp/podman.env.XXXXXX)"
-    trap 'rm -f "${podman_env_file}"' EXIT
-    umask 077
-    env -i bash --norc --noprofile << EOF > "${podman_env_file}"
-    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
-    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
-    export ENABLE_JIRA_REPORTING=true
-    export JOB_LINK="${JOB_LINK}"
+    echo "JOB_LINK=${JOB_LINK}"
+    export JOB_LINK=${JOB_LINK}
     source /usr/local/cs-qe-credentials/ocm-tokens
     source /usr/local/cs-qe-credentials/jira-cred
     env | grep -v '^_='
@@ -177,21 +202,25 @@ tests:
   capabilities:
   - nested-podman
   commands: |
+    podman_env_file="$(mktemp /tmp/podman.env.XXXXXX)"
+    trap 'rm -f "${podman_env_file}"' EXIT
+    umask 077
+    env -i \
+      PULL_NUMBER="${PULL_NUMBER:-}" \
+      JOB_NAME="${JOB_NAME}" \
+      BUILD_ID="${BUILD_ID}" \
+      bash --norc --noprofile << 'EOF' > "${podman_env_file}"
+    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
+    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
+    export ENABLE_JIRA_REPORTING=true
     JOB_LINK="https://prow.ci.openshift.org/view/gs/test-platform-results/"
     if [ -n "${PULL_NUMBER:-}" ]; then
       JOB_LINK="${JOB_LINK}pr-logs/pull/openshift_release/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
     else
       JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
     fi
-
-    podman_env_file="$(mktemp /tmp/podman.env.XXXXXX)"
-    trap 'rm -f "${podman_env_file}"' EXIT
-    umask 077
-    env -i bash --norc --noprofile << EOF > "${podman_env_file}"
-    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
-    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
-    export ENABLE_JIRA_REPORTING=true
-    export JOB_LINK="${JOB_LINK}"
+    echo "JOB_LINK=${JOB_LINK}"
+    export JOB_LINK=${JOB_LINK}
     source /usr/local/cs-qe-credentials/ocm-tokens
     source /usr/local/cs-qe-credentials/jira-cred
     env | grep -v '^_='
@@ -217,18 +246,25 @@ tests:
   capabilities:
   - nested-podman
   commands: |
+    podman_env_file="$(mktemp /tmp/podman.env.XXXXXX)"
+    trap 'rm -f "${podman_env_file}"' EXIT
+    umask 077
+    env -i \
+      PULL_NUMBER="${PULL_NUMBER:-}" \
+      JOB_NAME="${JOB_NAME}" \
+      BUILD_ID="${BUILD_ID}" \
+      bash --norc --noprofile << 'EOF' > "${podman_env_file}"
+    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
+    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
+    export ENABLE_JIRA_REPORTING=true
     JOB_LINK="https://prow.ci.openshift.org/view/gs/test-platform-results/"
     if [ -n "${PULL_NUMBER:-}" ]; then
       JOB_LINK="${JOB_LINK}pr-logs/pull/openshift_release/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
     else
       JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
     fi
-
-    env -i bash --norc --noprofile << EOF > /tmp/podman.env
-    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
-    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
-    export ENABLE_JIRA_REPORTING=true
-    export JOB_LINK="${JOB_LINK}"
+    echo "JOB_LINK=${JOB_LINK}"
+    export JOB_LINK=${JOB_LINK}
     source /usr/local/cs-qe-credentials/ocm-tokens
     source /usr/local/cs-qe-credentials/jira-cred
     env | grep -v '^_='
@@ -236,7 +272,7 @@ tests:
 
     podman run \
     --authfile /usr/local/cs-qe-credentials/.dockerconfigjson \
-    --env-file /tmp/podman.env \
+    --env-file "${podman_env_file}" \
     -v /usr/local/cs-qe-credentials:/credentials:ro,z \
     --rm \
     quay.io/redhat-services-prod/ocmci/ocmci:latest \
@@ -254,21 +290,25 @@ tests:
   capabilities:
   - nested-podman
   commands: |
+    podman_env_file="$(mktemp /tmp/podman.env.XXXXXX)"
+    trap 'rm -f "${podman_env_file}"' EXIT
+    umask 077
+    env -i \
+      PULL_NUMBER="${PULL_NUMBER:-}" \
+      JOB_NAME="${JOB_NAME}" \
+      BUILD_ID="${BUILD_ID}" \
+      bash --norc --noprofile << 'EOF' > "${podman_env_file}"
+    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
+    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
+    export ENABLE_JIRA_REPORTING=true
     JOB_LINK="https://prow.ci.openshift.org/view/gs/test-platform-results/"
     if [ -n "${PULL_NUMBER:-}" ]; then
       JOB_LINK="${JOB_LINK}pr-logs/pull/openshift_release/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
     else
       JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
     fi
-
-    podman_env_file="$(mktemp /tmp/podman.env.XXXXXX)"
-    trap 'rm -f "${podman_env_file}"' EXIT
-    umask 077
-    env -i bash --norc --noprofile << EOF > "${podman_env_file}"
-    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
-    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
-    export ENABLE_JIRA_REPORTING=true
-    export JOB_LINK="${JOB_LINK}"
+    echo "JOB_LINK=${JOB_LINK}"
+    export JOB_LINK=${JOB_LINK}
     source /usr/local/cs-qe-credentials/ocm-tokens
     source /usr/local/cs-qe-credentials/jira-cred
     env | grep -v '^_='

--- a/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__ocm-fvt-rosa-hcp-staging.yaml
+++ b/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__ocm-fvt-rosa-hcp-staging.yaml
@@ -26,18 +26,25 @@ tests:
   capabilities:
   - nested-podman
   commands: |
+    podman_env_file="$(mktemp /tmp/podman.env.XXXXXX)"
+    trap 'rm -f "${podman_env_file}"' EXIT
+    umask 077
+    env -i \
+      PULL_NUMBER="${PULL_NUMBER:-}" \
+      JOB_NAME="${JOB_NAME}" \
+      BUILD_ID="${BUILD_ID}" \
+      bash --norc --noprofile << 'EOF' > "${podman_env_file}"
+    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
+    export AWS_SHARED_VPC_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
+    export ENABLE_JIRA_REPORTING=true
     JOB_LINK="https://prow.ci.openshift.org/view/gs/test-platform-results/"
     if [ -n "${PULL_NUMBER:-}" ]; then
       JOB_LINK="${JOB_LINK}pr-logs/pull/openshift_release/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
     else
       JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
     fi
-
-    env -i bash --norc --noprofile << EOF > /tmp/podman.env
-    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
-    export AWS_SHARED_VPC_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
-    export ENABLE_JIRA_REPORTING=true
-    export JOB_LINK="${JOB_LINK}"
+    echo "JOB_LINK=${JOB_LINK}"
+    export JOB_LINK=${JOB_LINK}
     source /usr/local/cs-qe-credentials/ocm-tokens
     source /usr/local/cs-qe-credentials/jira-cred
     env | grep -v '^_='
@@ -45,7 +52,7 @@ tests:
 
     podman run \
     --authfile /usr/local/cs-qe-credentials/.dockerconfigjson \
-    --env-file /tmp/podman.env \
+    --env-file "${podman_env_file}" \
     -v /usr/local/cs-qe-credentials:/credentials:ro,z \
     --rm \
     quay.io/redhat-services-prod/ocmci/ocmci:latest \
@@ -63,18 +70,25 @@ tests:
   capabilities:
   - nested-podman
   commands: |
+    podman_env_file="$(mktemp /tmp/podman.env.XXXXXX)"
+    trap 'rm -f "${podman_env_file}"' EXIT
+    umask 077
+    env -i \
+      PULL_NUMBER="${PULL_NUMBER:-}" \
+      JOB_NAME="${JOB_NAME}" \
+      BUILD_ID="${BUILD_ID}" \
+      bash --norc --noprofile << 'EOF' > "${podman_env_file}"
+    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
+    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
+    export ENABLE_JIRA_REPORTING=true
     JOB_LINK="https://prow.ci.openshift.org/view/gs/test-platform-results/"
     if [ -n "${PULL_NUMBER:-}" ]; then
       JOB_LINK="${JOB_LINK}pr-logs/pull/openshift_release/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
     else
       JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
     fi
-
-    env -i bash --norc --noprofile << EOF > /tmp/podman.env
-    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
-    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
-    export ENABLE_JIRA_REPORTING=true
-    export JOB_LINK="${JOB_LINK}"
+    echo "JOB_LINK=${JOB_LINK}"
+    export JOB_LINK=${JOB_LINK}
     source /usr/local/cs-qe-credentials/ocm-tokens
     source /usr/local/cs-qe-credentials/jira-cred
     env | grep -v '^_='
@@ -82,7 +96,7 @@ tests:
 
     podman run \
     --authfile /usr/local/cs-qe-credentials/.dockerconfigjson \
-    --env-file /tmp/podman.env \
+    --env-file "${podman_env_file}" \
     -v /usr/local/cs-qe-credentials:/credentials:ro,z \
     --rm \
     quay.io/redhat-services-prod/ocmci/ocmci:latest \
@@ -100,18 +114,25 @@ tests:
   capabilities:
   - nested-podman
   commands: |
+    podman_env_file="$(mktemp /tmp/podman.env.XXXXXX)"
+    trap 'rm -f "${podman_env_file}"' EXIT
+    umask 077
+    env -i \
+      PULL_NUMBER="${PULL_NUMBER:-}" \
+      JOB_NAME="${JOB_NAME}" \
+      BUILD_ID="${BUILD_ID}" \
+      bash --norc --noprofile << 'EOF' > "${podman_env_file}"
+    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
+    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
+    export ENABLE_JIRA_REPORTING=true
     JOB_LINK="https://prow.ci.openshift.org/view/gs/test-platform-results/"
     if [ -n "${PULL_NUMBER:-}" ]; then
       JOB_LINK="${JOB_LINK}pr-logs/pull/openshift_release/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
     else
       JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
     fi
-
-    env -i bash --norc --noprofile << EOF > /tmp/podman.env
-    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
-    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
-    export ENABLE_JIRA_REPORTING=true
-    export JOB_LINK="${JOB_LINK}"
+    echo "JOB_LINK=${JOB_LINK}"
+    export JOB_LINK=${JOB_LINK}
     source /usr/local/cs-qe-credentials/ocm-tokens
     source /usr/local/cs-qe-credentials/jira-cred
     env | grep -v '^_='
@@ -119,7 +140,7 @@ tests:
 
     podman run \
     --authfile /usr/local/cs-qe-credentials/.dockerconfigjson \
-    --env-file /tmp/podman.env \
+    --env-file "${podman_env_file}" \
     -v /usr/local/cs-qe-credentials:/credentials:ro,z \
     --rm \
     quay.io/redhat-services-prod/ocmci/ocmci:latest \
@@ -137,18 +158,25 @@ tests:
   capabilities:
   - nested-podman
   commands: |
+    podman_env_file="$(mktemp /tmp/podman.env.XXXXXX)"
+    trap 'rm -f "${podman_env_file}"' EXIT
+    umask 077
+    env -i \
+      PULL_NUMBER="${PULL_NUMBER:-}" \
+      JOB_NAME="${JOB_NAME}" \
+      BUILD_ID="${BUILD_ID}" \
+      bash --norc --noprofile << 'EOF' > "${podman_env_file}"
+    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
+    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
+    export ENABLE_JIRA_REPORTING=true
     JOB_LINK="https://prow.ci.openshift.org/view/gs/test-platform-results/"
     if [ -n "${PULL_NUMBER:-}" ]; then
       JOB_LINK="${JOB_LINK}pr-logs/pull/openshift_release/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
     else
       JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
     fi
-
-    env -i bash --norc --noprofile << EOF > /tmp/podman.env
-    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
-    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
-    export ENABLE_JIRA_REPORTING=true
-    export JOB_LINK="${JOB_LINK}"
+    echo "JOB_LINK=${JOB_LINK}"
+    export JOB_LINK=${JOB_LINK}
     source /usr/local/cs-qe-credentials/ocm-tokens
     source /usr/local/cs-qe-credentials/jira-cred
     env | grep -v '^_='
@@ -156,7 +184,7 @@ tests:
 
     podman run \
     --authfile /usr/local/cs-qe-credentials/.dockerconfigjson \
-    --env-file /tmp/podman.env \
+    --env-file "${podman_env_file}" \
     -v /usr/local/cs-qe-credentials:/credentials:ro,z \
     --rm \
     quay.io/redhat-services-prod/ocmci/ocmci:latest \
@@ -174,18 +202,25 @@ tests:
   capabilities:
   - nested-podman
   commands: |
+    podman_env_file="$(mktemp /tmp/podman.env.XXXXXX)"
+    trap 'rm -f "${podman_env_file}"' EXIT
+    umask 077
+    env -i \
+      PULL_NUMBER="${PULL_NUMBER:-}" \
+      JOB_NAME="${JOB_NAME}" \
+      BUILD_ID="${BUILD_ID}" \
+      bash --norc --noprofile << 'EOF' > "${podman_env_file}"
+    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
+    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
+    export ENABLE_JIRA_REPORTING=true
     JOB_LINK="https://prow.ci.openshift.org/view/gs/test-platform-results/"
     if [ -n "${PULL_NUMBER:-}" ]; then
       JOB_LINK="${JOB_LINK}pr-logs/pull/openshift_release/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
     else
       JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
     fi
-
-    env -i bash --norc --noprofile << EOF > /tmp/podman.env
-    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
-    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
-    export ENABLE_JIRA_REPORTING=true
-    export JOB_LINK="${JOB_LINK}"
+    echo "JOB_LINK=${JOB_LINK}"
+    export JOB_LINK=${JOB_LINK}
     source /usr/local/cs-qe-credentials/ocm-tokens
     source /usr/local/cs-qe-credentials/jira-cred
     env | grep -v '^_='
@@ -193,7 +228,7 @@ tests:
 
     podman run \
     --authfile /usr/local/cs-qe-credentials/.dockerconfigjson \
-    --env-file /tmp/podman.env \
+    --env-file "${podman_env_file}" \
     -v /usr/local/cs-qe-credentials:/credentials:ro,z \
     --rm \
     quay.io/redhat-services-prod/ocmci/ocmci:latest \
@@ -211,18 +246,25 @@ tests:
   capabilities:
   - nested-podman
   commands: |
+    podman_env_file="$(mktemp /tmp/podman.env.XXXXXX)"
+    trap 'rm -f "${podman_env_file}"' EXIT
+    umask 077
+    env -i \
+      PULL_NUMBER="${PULL_NUMBER:-}" \
+      JOB_NAME="${JOB_NAME}" \
+      BUILD_ID="${BUILD_ID}" \
+      bash --norc --noprofile << 'EOF' > "${podman_env_file}"
+    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
+    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
+    export ENABLE_JIRA_REPORTING=true
     JOB_LINK="https://prow.ci.openshift.org/view/gs/test-platform-results/"
     if [ -n "${PULL_NUMBER:-}" ]; then
       JOB_LINK="${JOB_LINK}pr-logs/pull/openshift_release/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
     else
       JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
     fi
-
-    env -i bash --norc --noprofile << EOF > /tmp/podman.env
-    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
-    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
-    export ENABLE_JIRA_REPORTING=true
-    export JOB_LINK="${JOB_LINK}"
+    echo "JOB_LINK=${JOB_LINK}"
+    export JOB_LINK=${JOB_LINK}
     source /usr/local/cs-qe-credentials/ocm-tokens
     source /usr/local/cs-qe-credentials/jira-cred
     env | grep -v '^_='
@@ -230,7 +272,7 @@ tests:
 
     podman run \
     --authfile /usr/local/cs-qe-credentials/.dockerconfigjson \
-    --env-file /tmp/podman.env \
+    --env-file "${podman_env_file}" \
     -v /usr/local/cs-qe-credentials:/credentials:ro,z \
     --rm \
     quay.io/redhat-services-prod/ocmci/ocmci:latest \

--- a/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__ocm-fvt-rosa-hcp-staging.yaml
+++ b/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__ocm-fvt-rosa-hcp-staging.yaml
@@ -33,7 +33,7 @@ tests:
       PULL_NUMBER="${PULL_NUMBER:-}" \
       JOB_NAME="${JOB_NAME}" \
       BUILD_ID="${BUILD_ID}" \
-      bash --norc --noprofile << 'EOF' > "${podman_env_file}"
+      bash --norc --noprofile << EOF > "${podman_env_file}"
     export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
     export AWS_SHARED_VPC_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
     export ENABLE_JIRA_REPORTING=true
@@ -77,7 +77,7 @@ tests:
       PULL_NUMBER="${PULL_NUMBER:-}" \
       JOB_NAME="${JOB_NAME}" \
       BUILD_ID="${BUILD_ID}" \
-      bash --norc --noprofile << 'EOF' > "${podman_env_file}"
+      bash --norc --noprofile << EOF > "${podman_env_file}"
     export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
     export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
     export ENABLE_JIRA_REPORTING=true
@@ -121,7 +121,7 @@ tests:
       PULL_NUMBER="${PULL_NUMBER:-}" \
       JOB_NAME="${JOB_NAME}" \
       BUILD_ID="${BUILD_ID}" \
-      bash --norc --noprofile << 'EOF' > "${podman_env_file}"
+      bash --norc --noprofile << EOF > "${podman_env_file}"
     export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
     export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
     export ENABLE_JIRA_REPORTING=true
@@ -165,7 +165,7 @@ tests:
       PULL_NUMBER="${PULL_NUMBER:-}" \
       JOB_NAME="${JOB_NAME}" \
       BUILD_ID="${BUILD_ID}" \
-      bash --norc --noprofile << 'EOF' > "${podman_env_file}"
+      bash --norc --noprofile << EOF > "${podman_env_file}"
     export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
     export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
     export ENABLE_JIRA_REPORTING=true
@@ -209,7 +209,7 @@ tests:
       PULL_NUMBER="${PULL_NUMBER:-}" \
       JOB_NAME="${JOB_NAME}" \
       BUILD_ID="${BUILD_ID}" \
-      bash --norc --noprofile << 'EOF' > "${podman_env_file}"
+      bash --norc --noprofile << EOF > "${podman_env_file}"
     export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
     export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
     export ENABLE_JIRA_REPORTING=true
@@ -253,7 +253,7 @@ tests:
       PULL_NUMBER="${PULL_NUMBER:-}" \
       JOB_NAME="${JOB_NAME}" \
       BUILD_ID="${BUILD_ID}" \
-      bash --norc --noprofile << 'EOF' > "${podman_env_file}"
+      bash --norc --noprofile << EOF > "${podman_env_file}"
     export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
     export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
     export ENABLE_JIRA_REPORTING=true


### PR DESCRIPTION
* Fixes broken Jira related environment variables in all OCM periodic jobs. The env -i command was clearing Prow variables (`PULL_NUMBER`, `JOB_NAME`, `BUILD_ID`), causing `JOB_LINK` to be empty.
* Applies mktemp+trap+umask security pattern to all jobs for safe temp file handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR (openshift/release) fixes Jira environment variable handling and improves temporary file security in OCM (openshift-online) periodic Prow jobs used for ROSA E2E testing.

## What changed, in practical terms

- Affected CI job definitions under ci-operator/config/openshift-online/rosa-e2e were updated so each periodic OCM FVT job:
  - Creates a per-run Podman env file instead of using a shared /tmp/podman.env (mktemp).
  - Tightens permissions with umask 077 and registers an EXIT trap to remove the temp file on exit.
  - Writes the environment into the temp file via a bash heredoc and passes it to podman with --env-file "${podman_env_file}".
- Fixed Jira reporting by ensuring Prow-provided variables (PULL_NUMBER, JOB_NAME, BUILD_ID) are preserved when building the env file: JOB_LINK is computed and emitted/exported inside the heredoc so it appears in the env-file passed to the container (previous use of env -i cleared those variables and left JOB_LINK empty).
- Applied the mktemp+trap+umask security pattern across the updated jobs for safer temporary-file handling.
- Adjusted heredoc quoting/placement where needed so variable expansion happens where intended (most heredocs are unquoted; one job used a quoted delimiter).

## Scope / affected jobs

Changes touch multiple OCM FVT periodic jobs under openshift-online/rosa-e2e, including (examples from the change set):
- cs-osd-ccs-gcp-ad-staging-main
- cs-osd-ccs-gcp-marketplace-staging-main
- cs-osd-gcp-non-cross-proj-wif-staging-main
- rosa-classic integration/staging jobs
- rosa-hcp staging jobs across various test scenarios

Each job now sets ENABLE_JIRA_REPORTING=true, constructs and exports JOB_LINK into the env-file, sources OCM/Jira credential files, filters the environment, and passes the secure per-run env file into podman.

## Notes for reviewers

- Changes are YAML job-config only; no exported/public code entities were altered.
- Commit message highlights fixing heredoc quoting so JOB_LINK is expanded/exported into the env file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->