### PR TITLE
trusted-execution-clusters: No package installation for provisioning

### DIFF
--- a/ci-operator/step-registry/trusted-execution-clusters/ref/operator/beaker-kind-provision/trusted-execution-clusters-ref-operator-beaker-kind-provision-commands.sh
+++ b/ci-operator/step-registry/trusted-execution-clusters/ref/operator/beaker-kind-provision/trusted-execution-clusters-ref-operator-beaker-kind-provision-commands.sh
@@ -524,21 +524,6 @@ mkdir -p /tmp/kind-deployment-logs
 exec > >(tee -a /tmp/kind-deployment-logs/deployment.log)
 exec 2>&1
 
-# Install Dependencies
-echo "[INFO] Installing dependencies..."
-
-if command -v dnf &> /dev/null; then
-  PKG_MGR="dnf"
-elif command -v yum &> /dev/null; then
-  PKG_MGR="yum"
-else
-  echo "[ERROR] Neither dnf nor yum package manager found"
-  exit 1
-fi
-
-echo "[INFO] Installing basic prerequisites..."
-${SUDO} ${PKG_MGR} install -y curl gcc make dnf-plugins-core wget tar git jq file
-
 # Install Rust
 echo "[INFO] Installing Rust via rustup..."
 if ! command -v rustc &> /dev/null; then
@@ -558,34 +543,6 @@ rustc --version
 cargo --version
 
 echo "[SUCCESS] Rust installed successfully"
-
-# Install Docker CE
-echo "[INFO] Installing Docker CE..."
-
-if command -v docker &> /dev/null && systemctl is-active --quiet docker; then
-    DOCKER_VERSION=$(docker --version | awk '{print $3}' | sed 's/,//')
-    echo "[INFO] Docker is already installed and running: ${DOCKER_VERSION}"
-    echo "[INFO] Skipping Docker installation"
-else
-    echo "[INFO] Docker not found or not running, installing..."
-
-    ${SUDO} tee /etc/yum.repos.d/docker-ce.repo > /dev/null <<'DOCKERREPO'
-[docker-ce-stable]
-name=Docker CE Stable - $basearch
-baseurl=https://download.docker.com/linux/fedora/$releasever/$basearch/stable
-enabled=1
-gpgcheck=1
-gpgkey=https://download.docker.com/linux/fedora/gpg
-DOCKERREPO
-
-    ${SUDO} ${PKG_MGR} install -y docker-ce docker-ce-cli containerd.io
-    echo "[SUCCESS] Docker CE installed"
-fi
-
-echo "[INFO] Installing additional dependencies..."
-${SUDO} ${PKG_MGR} install -y conntrack golang || echo "[WARN] Some packages may already be installed"
-
-echo "[SUCCESS] Additional dependencies installed"
 
 # Start Container Runtime Service
 echo "[INFO] Starting Docker service..."


### PR DESCRIPTION
Remove package installations from provision step for trusted-execution-clusters CI. They're being moved to Ansible, and were also Fedora-specific. cc @alicefr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR modifies the trusted-execution-clusters CI infrastructure to remove Fedora-specific package installations from the provisioning step. Package installations are being moved to Ansible playbooks for better separation of concerns and platform independence.

## Changes

**Modified:** CI provisioning step for trusted-execution-clusters operator on Beaker bare metal machines

The `beaker-kind-provision` step now skips distro-specific package management (dnf/yum/rpm) and instead:
- Downloads pre-built binaries for tools like kubectl, kind, and Go from upstream sources
- Installs Rust via rustup (language-agnostic curl-based installer)
- Starts and manages systemd services for Docker rather than relying on package manager installation

The infrastructure now expects Ansible to handle base OS package dependencies separately, while this provisioning script focuses on:
1. Establishing SSH connectivity to Beaker machines
2. Installing development tools via their upstream installers
3. Preparing the Beaker environment for Kind cluster deployment
4. Cloning the operator repository and configuring the Kind cluster setup

This approach improves portability across different Linux distributions and versions while maintaining clearer separation between base OS setup (Ansible) and application-specific tooling (this provisioning script).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->