### PR TITLE
[INTEROP-9044] [INTEROP-9027] Updating Openshift Pipelines operator v1.22 with other updates

### DIFF
--- a/ci-operator/config/openshift-pipelines/release-tests/openshift-pipelines-release-tests-release-v1.22__ocp-4.22-lp-interop.yaml
+++ b/ci-operator/config/openshift-pipelines/release-tests/openshift-pipelines-release-tests-release-v1.22__ocp-4.22-lp-interop.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: rhel-9-release-golang-1.24-openshift-4.22
+    tag: rhel-9-release-golang-1.25-openshift-4.22
 images:
   items:
   - context_dir: .

--- a/ci-operator/config/openshift-pipelines/release-tests/openshift-pipelines-release-tests-release-v1.22__ocp-4.22-lp-interop.yaml
+++ b/ci-operator/config/openshift-pipelines/release-tests/openshift-pipelines-release-tests-release-v1.22__ocp-4.22-lp-interop.yaml
@@ -1,0 +1,89 @@
+base_images:
+  cli:
+    name: "4.22"
+    namespace: ocp
+    tag: cli
+build_root:
+  image_stream_tag:
+    name: release
+    namespace: openshift
+    tag: rhel-9-release-golang-1.24-openshift-4.22
+images:
+  items:
+  - context_dir: .
+    dockerfile_path: Dockerfile
+    to: openshift-pipelines-runner
+releases:
+  latest:
+    candidate:
+      product: ocp
+      stream: nightly
+      version: "4.22"
+resources:
+  '*':
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: cr-openshift-pipelines-aws
+  cron: 0 3,15 * * *
+  steps:
+    cluster_profile: aws-cspi-qe
+    env:
+      BASE_DOMAIN: cspilp.interop.ccitredhat.com
+      FIREWATCH_CONFIG: |
+        {
+          "failure_rules":
+            [
+              {"step": "openshift-pipelines-install", "failure_type": "all", "classification": "Operator Installation Failure", "group": {"name": "lp-tests", "priority": 1}, "jira_project": "SRVKP", "jira_assignee": "!default", "jira_component": ["QA"], "jira_priority": "major", "jira_additional_labels": ["!default","interop-tests"]},
+              {"step": "openshift-pipelines-tests", "failure_type": "all", "classification": "Test Failure", "group": {"name": "lp-tests", "priority": 1}, "jira_project": "SRVKP", "jira_assignee": "!default", "jira_component": ["QA"], "jira_priority": "major", "jira_additional_labels": ["!default","interop-tests"]}
+            ]
+        }
+      FIREWATCH_CONFIG_FILE_PATH: https://raw.githubusercontent.com/CSPI-QE/cspi-utils/refs/heads/main/firewatch-base-configs/cr/lp-interop.json
+      FIREWATCH_DEFAULT_JIRA_ADDITIONAL_LABELS: '["4.22-lp","self-managed-lp","pipelines-lp"]'
+      FIREWATCH_DEFAULT_JIRA_ASSIGNEE: sselvan@redhat.com
+      FIREWATCH_DEFAULT_JIRA_PROJECT: SRVKP
+      FIREWATCH_FAIL_WITH_TEST_FAILURES: "true"
+      MAP_TESTS: "true"
+      OCP_VERSION: "4.22"
+      REPORTPORTAL_CMP: lp-interop-OpenshiftPipelines
+      USER_TAGS: |
+        scenario pipelines
+    test:
+    - ref: openshift-pipelines-tests
+    workflow: firewatch-ipi-aws-cr
+  timeout: 2h0m0s
+- as: openshift-pipelines-aws-fips
+  cron: 0 23 31 2 *
+  steps:
+    cluster_profile: aws-cspi-qe
+    env:
+      BASE_DOMAIN: cspilp.interop.ccitredhat.com
+      FIREWATCH_CONFIG: |
+        {
+          "failure_rules":
+            [
+              {"step": "openshift-pipelines-install", "failure_type": "all", "classification": "Operator Installation Failure", "group": {"name": "lp-tests", "priority": 1}, "jira_project": "SRVKP", "jira_assignee": "!default", "jira_component": ["QA"], "jira_priority": "major", "jira_additional_labels": ["!default","interop-tests"]},
+              {"step": "openshift-pipelines-tests", "failure_type": "all", "classification": "Test Failure", "group": {"name": "lp-tests", "priority": 1}, "jira_project": "SRVKP", "jira_assignee": "!default", "jira_component": ["QA"], "jira_priority": "major", "jira_additional_labels": ["!default","interop-tests"]}
+            ]
+        }
+      FIREWATCH_CONFIG_FILE_PATH: https://raw.githubusercontent.com/CSPI-QE/cspi-utils/refs/heads/main/firewatch-base-configs/aws-ipi/lp-interop.json
+      FIREWATCH_DEFAULT_JIRA_ADDITIONAL_LABELS: '["4.22-lp","self-managed-lp","pipelines-lp","fips"]'
+      FIREWATCH_DEFAULT_JIRA_ASSIGNEE: sselvan@redhat.com
+      FIREWATCH_DEFAULT_JIRA_PROJECT: LPINTEROP
+      FIREWATCH_FAIL_WITH_TEST_FAILURES: "true"
+      MAP_TESTS: "true"
+      REPORTPORTAL_CMP: lp-interop-OpenshiftPipelines
+      USER_TAGS: |
+        scenario pipelines
+    test:
+    - ref: openshift-pipelines-tests
+    workflow: firewatch-ipi-aws
+  timeout: 2h0m0s
+zz_generated_metadata:
+  branch: release-v1.22
+  org: openshift-pipelines
+  repo: release-tests
+  variant: ocp-4.22-lp-interop

--- a/ci-operator/config/openshift-pipelines/release-tests/openshift-pipelines-release-tests-release-v1.22__ocp-4.22-lp-interop.yaml
+++ b/ci-operator/config/openshift-pipelines/release-tests/openshift-pipelines-release-tests-release-v1.22__ocp-4.22-lp-interop.yaml
@@ -56,7 +56,7 @@ tests:
     - ref: openshift-pipelines-tests
     workflow: firewatch-ipi-aws-cr
   timeout: 3h0m0s
-- as: openshift-pipelines-aws-fips
+- as: aws-fips
   cron: 0 23 31 2 *
   steps:
     cluster_profile: aws-cspi-qe

--- a/ci-operator/config/openshift-pipelines/release-tests/openshift-pipelines-release-tests-release-v1.22__ocp-4.22-lp-interop.yaml
+++ b/ci-operator/config/openshift-pipelines/release-tests/openshift-pipelines-release-tests-release-v1.22__ocp-4.22-lp-interop.yaml
@@ -52,6 +52,7 @@ tests:
       USER_TAGS: |
         scenario pipelines
     test:
+    - ref: openshift-pipelines-install
     - ref: openshift-pipelines-tests
     workflow: firewatch-ipi-aws-cr
   timeout: 2h0m0s
@@ -79,6 +80,7 @@ tests:
       USER_TAGS: |
         scenario pipelines
     test:
+    - ref: openshift-pipelines-install
     - ref: openshift-pipelines-tests
     workflow: firewatch-ipi-aws
   timeout: 2h0m0s

--- a/ci-operator/config/openshift-pipelines/release-tests/openshift-pipelines-release-tests-release-v1.22__ocp-4.22-lp-interop.yaml
+++ b/ci-operator/config/openshift-pipelines/release-tests/openshift-pipelines-release-tests-release-v1.22__ocp-4.22-lp-interop.yaml
@@ -33,6 +33,7 @@ tests:
     cluster_profile: aws-cspi-qe
     env:
       BASE_DOMAIN: cspilp.interop.ccitredhat.com
+      DR__RP__CR_COMP_NAME: lp-ocp-compat--OpenshiftPipelines
       FIREWATCH_CONFIG: |
         {
           "failure_rules":
@@ -48,20 +49,20 @@ tests:
       FIREWATCH_FAIL_WITH_TEST_FAILURES: "true"
       MAP_TESTS: "true"
       OCP_VERSION: "4.22"
-      REPORTPORTAL_CMP: lp-interop-OpenshiftPipelines
       USER_TAGS: |
         scenario pipelines
     test:
     - ref: openshift-pipelines-install
     - ref: openshift-pipelines-tests
     workflow: firewatch-ipi-aws-cr
-  timeout: 2h0m0s
+  timeout: 3h0m0s
 - as: openshift-pipelines-aws-fips
   cron: 0 23 31 2 *
   steps:
     cluster_profile: aws-cspi-qe
     env:
       BASE_DOMAIN: cspilp.interop.ccitredhat.com
+      DR__RP__CR_COMP_NAME: lp-ocp-compat--OpenshiftPipelines
       FIREWATCH_CONFIG: |
         {
           "failure_rules":
@@ -76,14 +77,13 @@ tests:
       FIREWATCH_DEFAULT_JIRA_PROJECT: LPINTEROP
       FIREWATCH_FAIL_WITH_TEST_FAILURES: "true"
       MAP_TESTS: "true"
-      REPORTPORTAL_CMP: lp-interop-OpenshiftPipelines
       USER_TAGS: |
         scenario pipelines
     test:
     - ref: openshift-pipelines-install
     - ref: openshift-pipelines-tests
     workflow: firewatch-ipi-aws
-  timeout: 2h0m0s
+  timeout: 3h0m0s
 zz_generated_metadata:
   branch: release-v1.22
   org: openshift-pipelines

--- a/ci-operator/config/openshift-pipelines/release-tests/openshift-pipelines-release-tests-release-v1.22__openshift-pipelines-ocp4.21-lp-rosa-hypershift.yaml
+++ b/ci-operator/config/openshift-pipelines/release-tests/openshift-pipelines-release-tests-release-v1.22__openshift-pipelines-ocp4.21-lp-rosa-hypershift.yaml
@@ -1,0 +1,78 @@
+base_images:
+  cli:
+    name: "4.21"
+    namespace: ocp
+    tag: cli
+  ocm-cli:
+    name: ocm-cli
+    namespace: ci
+    tag: latest
+  rosa-aws-cli:
+    name: rosa-aws-cli
+    namespace: ci
+    tag: latest
+  upi-installer:
+    name: "4.21"
+    namespace: ocp
+    tag: upi-installer
+build_root:
+  image_stream_tag:
+    name: release
+    namespace: openshift
+    tag: rhel-9-release-golang-1.24-openshift-4.21
+images:
+  items:
+  - context_dir: .
+    dockerfile_path: Dockerfile
+    to: openshift-pipelines-runner
+releases:
+  latest:
+    candidate:
+      product: ocp
+      stream: nightly
+      version: "4.21"
+resources:
+  '*':
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: openshift-pipelines-aws-rosa-hypershift
+  cron: 0 23 31 2 *
+  steps:
+    cluster_profile: aws-sd-qe
+    env:
+      CHANNEL_GROUP: candidate
+      FIREWATCH_CONFIG: |
+        {
+          "failure_rules":
+              [
+                {"step": "openshift-pipelines-install", "failure_type": "all", "classification": "Operator Installation Failure", "group": {"name": "lp-tests", "priority": 1}, "jira_project": "SRVKP", "jira_assignee": "!default", "jira_component": ["QA"], "jira_priority": "major", "jira_additional_labels": ["!default","interop-tests"]},
+                {"step": "openshift-pipelines-tests", "failure_type": "all", "classification": "Test Failure", "group": {"name": "lp-tests", "priority": 1}, "jira_project": "SRVKP", "jira_assignee": "!default", "jira_component": ["QA"], "jira_priority": "major", "jira_additional_labels": ["!default","interop-tests"]}
+              ]
+        }
+      FIREWATCH_CONFIG_FILE_PATH: https://raw.githubusercontent.com/CSPI-QE/cspi-utils/main/firewatch-base-configs/rosa/lp-interop.json
+      FIREWATCH_DEFAULT_JIRA_ADDITIONAL_LABELS: '["4.21-lp","rosa-hypershift-lp","pipelines-lp"]'
+      FIREWATCH_DEFAULT_JIRA_ASSIGNEE: sselvan@redhat.com
+      FIREWATCH_DEFAULT_JIRA_PROJECT: LPINTEROP
+      FIREWATCH_FAIL_WITH_TEST_FAILURES: "true"
+      FIREWATCH_JIRA_SERVER: https://issues.redhat.com
+      NAME_PREFIX: ocpe2e
+      OCM_LOGIN_ENV: staging
+      ROSACLI_BUILD: latest
+      TEST_PROFILE: ocpe2e-rosa-hcp-shared-vpc-advanced
+      VERSION: "4.21"
+    test:
+    - ref: ipi-install-rbac
+    - ref: cucushift-hypershift-extended-health-check
+    - ref: openshift-pipelines-install
+    - ref: openshift-pipelines-tests
+    - ref: firewatch-report-issues
+    workflow: rosa-lifecycle-advanced
+zz_generated_metadata:
+  branch: release-v1.22
+  org: openshift-pipelines
+  repo: release-tests
+  variant: openshift-pipelines-ocp4.21-lp-rosa-hypershift

--- a/ci-operator/config/openshift-pipelines/release-tests/openshift-pipelines-release-tests-release-v1.22__openshift-pipelines-ocp4.21-lp-rosa-hypershift.yaml
+++ b/ci-operator/config/openshift-pipelines/release-tests/openshift-pipelines-release-tests-release-v1.22__openshift-pipelines-ocp4.21-lp-rosa-hypershift.yaml
@@ -39,7 +39,7 @@ resources:
       cpu: 100m
       memory: 200Mi
 tests:
-- as: openshift-pipelines-aws-rosa-hypershift
+- as: aws-rosa-hypershift
   cron: 0 23 31 2 *
   steps:
     cluster_profile: aws-sd-qe

--- a/ci-operator/config/openshift-pipelines/release-tests/openshift-pipelines-release-tests-release-v1.22__openshift-pipelines-ocp4.21-lp-rosa-hypershift.yaml
+++ b/ci-operator/config/openshift-pipelines/release-tests/openshift-pipelines-release-tests-release-v1.22__openshift-pipelines-ocp4.21-lp-rosa-hypershift.yaml
@@ -19,7 +19,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: rhel-9-release-golang-1.24-openshift-4.21
+    tag: rhel-9-release-golang-1.25-openshift-4.21
 images:
   items:
   - context_dir: .
@@ -67,7 +67,6 @@ tests:
     test:
     - ref: ipi-install-rbac
     - ref: cucushift-hypershift-extended-health-check
-    - ref: openshift-pipelines-install
     - ref: openshift-pipelines-tests
     - ref: firewatch-report-issues
     workflow: rosa-lifecycle-advanced

--- a/ci-operator/config/openshift-pipelines/release-tests/openshift-pipelines-release-tests-release-v1.22__openshift-pipelines-ocp4.21-lp-rosa-hypershift.yaml
+++ b/ci-operator/config/openshift-pipelines/release-tests/openshift-pipelines-release-tests-release-v1.22__openshift-pipelines-ocp4.21-lp-rosa-hypershift.yaml
@@ -71,6 +71,7 @@ tests:
     - ref: openshift-pipelines-tests
     - ref: firewatch-report-issues
     workflow: rosa-lifecycle-advanced
+  timeout: 2h0m0s
 zz_generated_metadata:
   branch: release-v1.22
   org: openshift-pipelines

--- a/ci-operator/config/openshift-pipelines/release-tests/openshift-pipelines-release-tests-release-v1.22__openshift-pipelines-ocp4.21-lp-rosa-hypershift.yaml
+++ b/ci-operator/config/openshift-pipelines/release-tests/openshift-pipelines-release-tests-release-v1.22__openshift-pipelines-ocp4.21-lp-rosa-hypershift.yaml
@@ -67,6 +67,7 @@ tests:
     test:
     - ref: ipi-install-rbac
     - ref: cucushift-hypershift-extended-health-check
+    - ref: openshift-pipelines-install
     - ref: openshift-pipelines-tests
     - ref: firewatch-report-issues
     workflow: rosa-lifecycle-advanced

--- a/ci-operator/config/openshift-pipelines/release-tests/openshift-pipelines-release-tests-release-v1.22__openshift-pipelines-ocp4.21-lp-rosa-hypershift.yaml
+++ b/ci-operator/config/openshift-pipelines/release-tests/openshift-pipelines-release-tests-release-v1.22__openshift-pipelines-ocp4.21-lp-rosa-hypershift.yaml
@@ -71,7 +71,6 @@ tests:
     - ref: openshift-pipelines-tests
     - ref: firewatch-report-issues
     workflow: rosa-lifecycle-advanced
-  timeout: 2h0m0s
 zz_generated_metadata:
   branch: release-v1.22
   org: openshift-pipelines

--- a/ci-operator/jobs/openshift-pipelines/release-tests/openshift-pipelines-release-tests-release-v1.22-periodics.yaml
+++ b/ci-operator/jobs/openshift-pipelines/release-tests/openshift-pipelines-release-tests-release-v1.22-periodics.yaml
@@ -1,15 +1,105 @@
 periodics:
 - agent: kubernetes
   cluster: build10
-  cron: 0 3,15 * * *
+  cron: 0 23 31 2 *
   decorate: true
   decoration_config:
-    skip_cloning: true
+    sparse_checkout_files:
+    - Dockerfile
     timeout: 3h0m0s
   extra_refs:
   - base_ref: release-v1.22
     org: openshift-pipelines
     repo: release-tests
+    sparse_checkout_files:
+    - Dockerfile
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-cspi-qe
+    ci-operator.openshift.io/variant: ocp-4.22-lp-interop
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-pipelines-release-tests-release-v1.22-ocp-4.22-lp-interop-aws-fips
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=aws-fips
+      - --variant=ocp-4.22-lp-interop
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build10
+  cron: 0 3,15 * * *
+  decorate: true
+  decoration_config:
+    sparse_checkout_files:
+    - Dockerfile
+    timeout: 3h0m0s
+  extra_refs:
+  - base_ref: release-v1.22
+    org: openshift-pipelines
+    repo: release-tests
+    sparse_checkout_files:
+    - Dockerfile
   labels:
     ci-operator.openshift.io/cloud: aws
     ci-operator.openshift.io/cloud-cluster-profile: aws-cspi-qe
@@ -99,106 +189,14 @@ periodics:
   cron: 0 23 31 2 *
   decorate: true
   decoration_config:
-    skip_cloning: true
-    timeout: 3h0m0s
+    sparse_checkout_files:
+    - Dockerfile
   extra_refs:
   - base_ref: release-v1.22
     org: openshift-pipelines
     repo: release-tests
-  labels:
-    ci-operator.openshift.io/cloud: aws
-    ci-operator.openshift.io/cloud-cluster-profile: aws-cspi-qe
-    ci-operator.openshift.io/variant: ocp-4.22-lp-interop
-    ci.openshift.io/generator: prowgen
-    job-release: "4.22"
-    pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-pipelines-release-tests-release-v1.22-ocp-4.22-lp-interop-openshift-pipelines-aws-fips
-  reporter_config:
-    slack:
-      channel: '#tektoncd-pipeline-ci'
-      job_states_to_report:
-      - success
-      - failure
-      - error
-      report_template: '{{if eq .Status.State "success"}} :slack-green: Job *{{.Spec.Job}}*
-        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> {{else}} :failed:
-        Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
-        logs> {{end}}'
-  spec:
-    containers:
-    - args:
-      - --gcs-upload-secret=/secrets/gcs/service-account.json
-      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-      - --lease-server-credentials-file=/etc/boskos/credentials
-      - --report-credentials-file=/etc/report/credentials
-      - --secret-dir=/secrets/ci-pull-credentials
-      - --target=openshift-pipelines-aws-fips
-      - --variant=ocp-4.22-lp-interop
-      command:
-      - ci-operator
-      env:
-      - name: HTTP_SERVER_IP
-        valueFrom:
-          fieldRef:
-            fieldPath: status.podIP
-      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-      imagePullPolicy: Always
-      name: ""
-      ports:
-      - containerPort: 8080
-        name: http
-      resources:
-        requests:
-          cpu: 10m
-      volumeMounts:
-      - mountPath: /etc/boskos
-        name: boskos
-        readOnly: true
-      - mountPath: /secrets/ci-pull-credentials
-        name: ci-pull-credentials
-        readOnly: true
-      - mountPath: /secrets/gcs
-        name: gcs-credentials
-        readOnly: true
-      - mountPath: /secrets/manifest-tool
-        name: manifest-tool-local-pusher
-        readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
-      - mountPath: /etc/report
-        name: result-aggregator
-        readOnly: true
-    serviceAccountName: ci-operator
-    volumes:
-    - name: boskos
-      secret:
-        items:
-        - key: credentials
-          path: credentials
-        secretName: boskos-credentials
-    - name: ci-pull-credentials
-      secret:
-        secretName: ci-pull-credentials
-    - name: manifest-tool-local-pusher
-      secret:
-        secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
-    - name: result-aggregator
-      secret:
-        secretName: result-aggregator
-- agent: kubernetes
-  cluster: build10
-  cron: 0 23 31 2 *
-  decorate: true
-  decoration_config:
-    skip_cloning: true
-  extra_refs:
-  - base_ref: release-v1.22
-    org: openshift-pipelines
-    repo: release-tests
+    sparse_checkout_files:
+    - Dockerfile
   labels:
     ci-operator.openshift.io/cloud: aws
     ci-operator.openshift.io/cloud-cluster-profile: aws-sd-qe
@@ -206,18 +204,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.21"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-pipelines-release-tests-release-v1.22-openshift-pipelines-ocp4.21-lp-rosa-hypershift-openshift-pipelines-aws-rosa-hypershift
-  reporter_config:
-    slack:
-      channel: '#tektoncd-pipeline-ci'
-      job_states_to_report:
-      - success
-      - failure
-      - error
-      report_template: '{{if eq .Status.State "success"}} :slack-green: Job *{{.Spec.Job}}*
-        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> {{else}} :failed:
-        Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
-        logs> {{end}}'
+  name: periodic-ci-openshift-pipelines-release-tests-release-v1.22-openshift-pipelines-ocp4.21-lp-rosa-hypershift-aws-rosa-hypershift
   spec:
     containers:
     - args:
@@ -226,7 +213,7 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=openshift-pipelines-aws-rosa-hypershift
+      - --target=aws-rosa-hypershift
       - --variant=openshift-pipelines-ocp4.21-lp-rosa-hypershift
       command:
       - ci-operator

--- a/ci-operator/jobs/openshift-pipelines/release-tests/openshift-pipelines-release-tests-release-v1.22-periodics.yaml
+++ b/ci-operator/jobs/openshift-pipelines/release-tests/openshift-pipelines-release-tests-release-v1.22-periodics.yaml
@@ -1,0 +1,285 @@
+periodics:
+- agent: kubernetes
+  cluster: build10
+  cron: 0 3,15 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+    timeout: 2h0m0s
+  extra_refs:
+  - base_ref: release-v1.22
+    org: openshift-pipelines
+    repo: release-tests
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-cspi-qe
+    ci-operator.openshift.io/variant: ocp-4.22-lp-interop
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-pipelines-release-tests-release-v1.22-ocp-4.22-lp-interop-cr-openshift-pipelines-aws
+  reporter_config:
+    slack:
+      channel: '#tektoncd-pipeline-ci'
+      job_states_to_report:
+      - success
+      - failure
+      - error
+      report_template: '{{if eq .Status.State "success"}} :slack-green: Job *{{.Spec.Job}}*
+        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> {{else}} :failed:
+        Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+        logs> {{end}}'
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=cr-openshift-pipelines-aws
+      - --variant=ocp-4.22-lp-interop
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build10
+  cron: 0 23 31 2 *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+    timeout: 2h0m0s
+  extra_refs:
+  - base_ref: release-v1.22
+    org: openshift-pipelines
+    repo: release-tests
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-cspi-qe
+    ci-operator.openshift.io/variant: ocp-4.22-lp-interop
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-pipelines-release-tests-release-v1.22-ocp-4.22-lp-interop-openshift-pipelines-aws-fips
+  reporter_config:
+    slack:
+      channel: '#tektoncd-pipeline-ci'
+      job_states_to_report:
+      - success
+      - failure
+      - error
+      report_template: '{{if eq .Status.State "success"}} :slack-green: Job *{{.Spec.Job}}*
+        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> {{else}} :failed:
+        Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+        logs> {{end}}'
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=openshift-pipelines-aws-fips
+      - --variant=ocp-4.22-lp-interop
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build10
+  cron: 0 23 31 2 *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: release-v1.22
+    org: openshift-pipelines
+    repo: release-tests
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-sd-qe
+    ci-operator.openshift.io/variant: openshift-pipelines-ocp4.21-lp-rosa-hypershift
+    ci.openshift.io/generator: prowgen
+    job-release: "4.21"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-pipelines-release-tests-release-v1.22-openshift-pipelines-ocp4.21-lp-rosa-hypershift-openshift-pipelines-aws-rosa-hypershift
+  reporter_config:
+    slack:
+      channel: '#tektoncd-pipeline-ci'
+      job_states_to_report:
+      - success
+      - failure
+      - error
+      report_template: '{{if eq .Status.State "success"}} :slack-green: Job *{{.Spec.Job}}*
+        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> {{else}} :failed:
+        Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+        logs> {{end}}'
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=openshift-pipelines-aws-rosa-hypershift
+      - --variant=openshift-pipelines-ocp4.21-lp-rosa-hypershift
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator

--- a/ci-operator/jobs/openshift-pipelines/release-tests/openshift-pipelines-release-tests-release-v1.22-periodics.yaml
+++ b/ci-operator/jobs/openshift-pipelines/release-tests/openshift-pipelines-release-tests-release-v1.22-periodics.yaml
@@ -195,7 +195,6 @@ periodics:
   decorate: true
   decoration_config:
     skip_cloning: true
-    timeout: 2h0m0s
   extra_refs:
   - base_ref: release-v1.22
     org: openshift-pipelines

--- a/ci-operator/jobs/openshift-pipelines/release-tests/openshift-pipelines-release-tests-release-v1.22-periodics.yaml
+++ b/ci-operator/jobs/openshift-pipelines/release-tests/openshift-pipelines-release-tests-release-v1.22-periodics.yaml
@@ -21,6 +21,17 @@ periodics:
     job-release: "4.22"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-pipelines-release-tests-release-v1.22-ocp-4.22-lp-interop-aws-fips
+  reporter_config:
+    slack:
+      channel: '#tektoncd-pipeline-ci'
+      job_states_to_report:
+      - success
+      - failure
+      - error
+      report_template: '{{if eq .Status.State "success"}} :slack-green: Job *{{.Spec.Job}}*
+        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> {{else}} :failed:
+        Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+        logs> {{end}}'
   spec:
     containers:
     - args:
@@ -205,6 +216,17 @@ periodics:
     job-release: "4.21"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-pipelines-release-tests-release-v1.22-openshift-pipelines-ocp4.21-lp-rosa-hypershift-aws-rosa-hypershift
+  reporter_config:
+    slack:
+      channel: '#tektoncd-pipeline-ci'
+      job_states_to_report:
+      - success
+      - failure
+      - error
+      report_template: '{{if eq .Status.State "success"}} :slack-green: Job *{{.Spec.Job}}*
+        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> {{else}} :failed:
+        Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+        logs> {{end}}'
   spec:
     containers:
     - args:

--- a/ci-operator/jobs/openshift-pipelines/release-tests/openshift-pipelines-release-tests-release-v1.22-periodics.yaml
+++ b/ci-operator/jobs/openshift-pipelines/release-tests/openshift-pipelines-release-tests-release-v1.22-periodics.yaml
@@ -5,7 +5,7 @@ periodics:
   decorate: true
   decoration_config:
     skip_cloning: true
-    timeout: 2h0m0s
+    timeout: 3h0m0s
   extra_refs:
   - base_ref: release-v1.22
     org: openshift-pipelines
@@ -100,7 +100,7 @@ periodics:
   decorate: true
   decoration_config:
     skip_cloning: true
-    timeout: 2h0m0s
+    timeout: 3h0m0s
   extra_refs:
   - base_ref: release-v1.22
     org: openshift-pipelines
@@ -195,6 +195,7 @@ periodics:
   decorate: true
   decoration_config:
     skip_cloning: true
+    timeout: 2h0m0s
   extra_refs:
   - base_ref: release-v1.22
     org: openshift-pipelines

--- a/ci-operator/jobs/openshift-pipelines/release-tests/openshift-pipelines-release-tests-release-v1.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift-pipelines/release-tests/openshift-pipelines-release-tests-release-v1.22-presubmits.yaml
@@ -9,7 +9,8 @@ presubmits:
     context: ci/prow/ocp-4.22-lp-interop-images
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci-operator.openshift.io/variant: ocp-4.22-lp-interop
       ci.openshift.io/generator: prowgen
@@ -67,7 +68,8 @@ presubmits:
     context: ci/prow/openshift-pipelines-ocp4.21-lp-rosa-hypershift-images
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci-operator.openshift.io/variant: openshift-pipelines-ocp4.21-lp-rosa-hypershift
       ci.openshift.io/generator: prowgen

--- a/ci-operator/jobs/openshift-pipelines/release-tests/openshift-pipelines-release-tests-release-v1.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift-pipelines/release-tests/openshift-pipelines-release-tests-release-v1.22-presubmits.yaml
@@ -1,0 +1,118 @@
+presubmits:
+  openshift-pipelines/release-tests:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-v1\.22$
+    - ^release-v1\.22-
+    cluster: build01
+    context: ci/prow/ocp-4.22-lp-interop-images
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/variant: ocp-4.22-lp-interop
+      ci.openshift.io/generator: prowgen
+      job-release: "4.22"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-pipelines-release-tests-release-v1.22-ocp-4.22-lp-interop-images
+    rerun_command: /test ocp-4.22-lp-interop-images
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=[images]
+        - --variant=ocp-4.22-lp-interop
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )ocp-4.22-lp-interop-images,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-v1\.22$
+    - ^release-v1\.22-
+    cluster: build01
+    context: ci/prow/openshift-pipelines-ocp4.21-lp-rosa-hypershift-images
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/variant: openshift-pipelines-ocp4.21-lp-rosa-hypershift
+      ci.openshift.io/generator: prowgen
+      job-release: "4.21"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-pipelines-release-tests-release-v1.22-openshift-pipelines-ocp4.21-lp-rosa-hypershift-images
+    rerun_command: /test openshift-pipelines-ocp4.21-lp-rosa-hypershift-images
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=[images]
+        - --variant=openshift-pipelines-ocp4.21-lp-rosa-hypershift
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )openshift-pipelines-ocp4.21-lp-rosa-hypershift-images,?($|\s.*)


### PR DESCRIPTION
Update:

- Fixed the timeout issue.
- Enhanced and consolidated the same test steps ref (`openshift-pipelines-install` and `openshift-pipelines-tests`)
- Fixed the FIPS job by correcting the workflow to `firewatch-ipi-aws`
- Updated Openshift Pipelines workflow to use the latest operator version (v1.22) across all platforms - FIPS, Non-FIPS/w CR, ROSA HCP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds ci-operator release-test configurations and workflow updates to enable CI for the OpenShift Pipelines operator v1.22 across LP interop and ROSA HyperShift, consolidating test step references, standardizing FIREWATCH settings, and correcting the FIPS workflow reference.

## Practical impact

- Enables periodic and rehearsed CI for OpenShift Pipelines v1.22 on:
  - OCP 4.22 LP interop (standard and FIPS variants)
  - OCP 4.21 ROSA HyperShift (ROSA HCP)
- Reduces the timeout for the new jobs from 3 hours to 2 hours to limit long-running/stalled runs.
- Ensures rehearsals and scheduled runs exercise the intended v1.22 operator workflows by standardizing operator version and test references.
- The PR author validated changes via ci-operator/registry checks and multiple /pj-rehearse invocations for the new periodic jobs.

## Key edits and fixes

- Added new ci-operator release-tests configs for OpenShift Pipelines v1.22 (LP interop and ROSA HyperShift).
- Consolidated identical test step references for openshift-pipelines-install and openshift-pipelines-tests to reuse refs across jobs.
- Fixed the FIPS job to reference the correct firewatch-ipi-aws workflow so FIREWATCH reporting functions for the FIPS configuration.
- Standardized FIREWATCH configuration (failure rules, Jira/project defaults, assignees and labels) across workflows.
- Adjusted timeout settings: reduced from 3h to 2h for the new jobs (note: ROSA HCP timeout behavior was adjusted across commits).

## Files added/updated

- ci-operator/config/openshift-pipelines/release-tests/openshift-pipelines-release-tests-release-v1.22__ocp-4.22-lp-interop.yaml — new LP interop release-tests config (includes CR and FIPS jobs, FIREWATCH, timeout and test refs).
- ci-operator/config/openshift-pipelines/release-tests/openshift-pipelines-release-tests-release-v1.22__openshift-pipelines-ocp4.21-lp-rosa-hypershift.yaml — new ROSA HyperShift release-tests config (ROSA HCP workflow, FIREWATCH and test refs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->