### PR TITLE
Disable Argo CD selfHeal for app.ci

### DIFF
--- a/clusters/gitops/apps/app-cluster-appci.yaml
+++ b/clusters/gitops/apps/app-cluster-appci.yaml
@@ -39,7 +39,7 @@ spec:
     automated:
       enabled: true
       prune: false
-      selfHeal: true
+      selfHeal: false
     syncOptions:
       - ApplyOutOfSyncOnly=true
       - CreateNamespace=true


### PR DESCRIPTION
/cc @openshift/test-platform 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

The app.ci Argo CD Application (clusters/gitops/apps/app-cluster-appci.yaml) currently retains an automated sync policy: spec.syncPolicy.automated is present with enabled: true, prune: false and selfHeal: false. The syncOptions (ApplyOutOfSyncOnly, CreateNamespace, PruneLast, RespectIgnoreDifferences, ServerSideApply) remain unchanged.

## Impact

This configuration means the app.ci cluster in the OpenShift CI infrastructure will continue to automatically reconcile changes from the release repository. Because selfHeal is set to false and prune is false, automated syncs will not attempt self-healing or pruning; manual intervention is still required for those actions when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->