### PR TITLE
remove the ignore differences configuration for that app.ci cluster in ArgoCD

### DIFF
--- a/clusters/gitops/apps/app-cluster-appci.yaml
+++ b/clusters/gitops/apps/app-cluster-appci.yaml
@@ -9,23 +9,6 @@ spec:
   destination:
     name: app.ci
     namespace: openshift-gitops
-  ignoreDifferences:
-    - group: apps
-      kind: DaemonSet
-      name: webhook-server
-      namespace: crt-admission-webhooks
-      jqPathExpressions:
-        - '.spec.template.spec.containers[].image'
-    - group: apps
-      kind: Deployment
-      jqPathExpressions:
-        - '.spec.template.spec.containers[].image'
-    - group: apps
-      kind: StatefulSet
-      name: vault
-      namespace: vault
-      jqPathExpressions:
-        - '.spec.template.spec.containers[].image'
   project: default
   source:
     directory:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR removes the `ignoreDifferences` configuration from the ArgoCD Application manifest for the app.ci cluster. 

Previously, the manifest was configured to ignore image differences in three types of resources:
- The `webhook-server` DaemonSet (in the `crt-admission-webhooks` namespace)
- All Deployments
- The `vault` StatefulSet (in the `vault` namespace)

By removing this configuration, ArgoCD will now detect and enforce synchronization of image updates for these resources, rather than allowing them to drift from the desired state. This makes the app.ci cluster's deployment configuration stricter, ensuring that container images are kept in sync with what is defined in the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->