### PR TITLE
CRC: use Intel Cascade Lake as cpu platform for n2-standard-16 type

### DIFF
--- a/ci-operator/step-registry/code-ready/crc/e2e/code-ready-crc-e2e-workflow.yaml
+++ b/ci-operator/step-registry/code-ready/crc/e2e/code-ready-crc-e2e-workflow.yaml
@@ -3,7 +3,7 @@ workflow:
   steps:
     env:
       MACHINE_TYPE: n2-standard-16
-      CPU_PLATFORM: "Intel Haswell"
+      CPU_PLATFORM: "Intel Cascade Lake"
     pre:
       - chain: upi-gcp-nested-pre
     test:

--- a/ci-operator/step-registry/code-ready/crc/integration/code-ready-crc-integration-workflow.yaml
+++ b/ci-operator/step-registry/code-ready/crc/integration/code-ready-crc-integration-workflow.yaml
@@ -3,7 +3,7 @@ workflow:
   steps:
     env:
       MACHINE_TYPE: n2-standard-16
-      CPU_PLATFORM: "Intel Haswell"
+      CPU_PLATFORM: "Intel Cascade Lake"
     pre:
       - chain: upi-gcp-nested-pre
     test:

--- a/ci-operator/step-registry/code-ready/crc/microshift/code-ready-crc-microshift-workflow.yaml
+++ b/ci-operator/step-registry/code-ready/crc/microshift/code-ready-crc-microshift-workflow.yaml
@@ -3,7 +3,7 @@ workflow:
   steps:
     env:
       MACHINE_TYPE: n2-standard-16
-      CPU_PLATFORM: "Intel Haswell"
+      CPU_PLATFORM: "Intel Cascade Lake"
     pre:
       - chain: upi-gcp-nested-pre
     test:

--- a/ci-operator/step-registry/code-ready/snc/e2e/code-ready-snc-e2e-workflow.yaml
+++ b/ci-operator/step-registry/code-ready/snc/e2e/code-ready-snc-e2e-workflow.yaml
@@ -3,7 +3,7 @@ workflow:
   steps:
     env:
       MACHINE_TYPE: n2-standard-16
-      CPU_PLATFORM: "Intel Haswell"
+      CPU_PLATFORM: "Intel Cascade Lake"
     pre:
       - chain: upi-gcp-nested-pre
     test:

--- a/ci-operator/step-registry/code-ready/snc/microshift/code-ready-snc-microshift-workflow.yaml
+++ b/ci-operator/step-registry/code-ready/snc/microshift/code-ready-snc-microshift-workflow.yaml
@@ -3,7 +3,7 @@ workflow:
   steps:
     env:
       MACHINE_TYPE: n2-standard-16
-      CPU_PLATFORM: "Intel Haswell"
+      CPU_PLATFORM: "Intel Cascade Lake"
     pre:
       - chain: upi-gcp-nested-pre
       - ref: code-ready-snc-subscription


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR updates the Google Cloud Platform (GCP) CPU platform specification for Code-Ready Containers (CRC) and Simplified Nested Cluster (SNC) CI workflows in OpenShift's test infrastructure.

## Changes

The PR modifies five workflow definitions used in the OpenShift CI step-registry to update the `CPU_PLATFORM` environment variable from "Intel Haswell" to "Intel Cascade Lake" for the `n2-standard-16` GCP machine type:

- **code-ready-crc-e2e-workflow.yaml** - CRC end-to-end testing workflow
- **code-ready-crc-integration-workflow.yaml** - CRC integration testing workflow
- **code-ready-crc-microshift-workflow.yaml** - CRC MicroShift testing workflow
- **code-ready-snc-e2e-workflow.yaml** - SNC end-to-end testing workflow
- **code-ready-snc-microshift-workflow.yaml** - SNC MicroShift testing workflow

## Impact

These workflows define how Code-Ready Containers and Simplified Nested Cluster tests execute on GCP nested clusters. The CPU platform specification controls the minimum CPU generation used when provisioning the GCP instances. This update to Intel Cascade Lake (a newer processor generation) affects the test infrastructure used for validating CRC functionality in the OpenShift CI pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->