### PR TITLE
telco5g/ptp: fail fast when cluster nodes are not Ready

### DIFF
--- a/ci-operator/step-registry/telco5g/ptp/tests/telco5g-ptp-tests-commands.sh
+++ b/ci-operator/step-registry/telco5g/ptp/tests/telco5g-ptp-tests-commands.sh
@@ -285,6 +285,24 @@ export IMG_VERSION="release-${T5CI_VERSION}"
 
 export KUBECONFIG=$SHARED_DIR/kubeconfig
 
+# Fail fast if any node is not Ready
+echo "************ Checking node readiness ************"
+oc get nodes -owide
+NOT_READY_NODES=$(oc get nodes -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' | grep -v "True$" || true)
+if [[ -n "${NOT_READY_NODES}" ]]; then
+  echo "[ERROR] The following nodes are not Ready:"
+  echo "${NOT_READY_NODES}"
+  echo "[ERROR] All nodes must be Ready before starting PTP tests. Aborting."
+  exit 1
+fi
+TOTAL_NODES=$(oc get nodes --no-headers | wc -l)
+if [[ "${TOTAL_NODES}" -eq 0 ]]; then
+  echo "[ERROR] No nodes found in the cluster. Aborting."
+  exit 1
+fi
+echo "[INFO] All ${TOTAL_NODES} nodes are Ready."
+echo "***************************************************"
+
 # Set go version
 if [[ "$T5CI_VERSION" =~ 4.1[2-5]+ ]]; then
   source "$HOME"/golang-1.20


### PR DESCRIPTION
## Summary
- Adds a node readiness check at the start of the `telco5g-ptp-tests` step, right after `KUBECONFIG` is set and before the expensive image build
- If any node is missing or not in `Ready` state, the job aborts immediately with a clear error message listing the problematic nodes
- Prevents wasting ~15+ minutes on image builds and operator deployment when the cluster is already broken

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds an early node readiness check to the telco5g PTP operator tests CI workflow to fail-fast when cluster infrastructure is unhealthy.

## Changes

**Affected component:** Telco5G PTP operator CI tests (`ci-operator/step-registry/telco5g/ptp/tests/telco5g-ptp-tests-commands.sh`)

**What changed:** A node readiness verification block (18 lines) was inserted at the start of the test execution, immediately after the KUBECONFIG is set and before any image builds or operator deployments begin. The check:

- Queries the cluster for all node Ready status conditions
- Fails immediately with a clear error message if any nodes are missing or not in Ready state
- Fails if the cluster has zero nodes  
- Logs the total count of ready nodes if the cluster is healthy

**Rationale:** Previously, if a cluster was already in a broken state (nodes not ready), the test job would waste 15+ minutes building PTP operator images and deploying the operator before eventually failing. This change shifts failure detection to the earliest possible point, saving significant CI resources and providing faster feedback to developers.

The implementation uses `oc get nodes` with JSON path filtering to cleanly identify non-ready nodes and reports them explicitly in the error output for debugging purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->