### PR TITLE
NO-JIRA: add new externaloidc tpnu presubmit jobs for hypershift that are triggered manually

### DIFF
--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-main.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-main.yaml
@@ -548,6 +548,27 @@ tests:
       GKE_REGION: us-central1
       GKE_RELEASE_CHANNEL: stable
     workflow: hypershift-gcp-gke-e2e-v2
+- always_run: false
+  as: e2e-aws-external-oidc-techpreview
+  optional: true
+  steps:
+    cluster_profile: hypershift-aws
+    env:
+      CI_TESTS_RUN: TestExternalOIDC
+      OAUTH_EXTERNAL_OIDC_PROVIDER: keycloak
+      TECH_PREVIEW_NO_UPGRADE: "true"
+    workflow: hypershift-aws-e2e-external-oidc
+- always_run: false
+  as: e2e-azure-aks-external-oidc-techpreview
+  optional: true
+  steps:
+    cluster_profile: hypershift-aks
+    env:
+      AUTH_THROUGH_CERTS: "true"
+      CI_TESTS_RUN: TestExternalOIDC
+      ENABLE_HYPERSHIFT_CERT_ROTATION_SCALE: "true"
+      TECH_PREVIEW_NO_UPGRADE: "true"
+    workflow: hypershift-azure-aks-external-oidc
 zz_generated_metadata:
   branch: main
   org: openshift

--- a/ci-operator/jobs/openshift/hypershift/openshift-hypershift-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/hypershift/openshift-hypershift-main-presubmits.yaml
@@ -659,6 +659,87 @@ presubmits:
     - ^main$
     - ^main-
     cluster: build01
+    context: ci/prow/e2e-aws-external-oidc-techpreview
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: hypershift-aws
+      ci-operator.openshift.io/cloud-cluster-profile: hypershift-aws
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-hypershift-main-e2e-aws-external-oidc-techpreview
+    optional: true
+    rerun_command: /test e2e-aws-external-oidc-techpreview
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-aws-external-oidc-techpreview
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-aws-external-oidc-techpreview,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build01
     context: ci/prow/e2e-aws-metrics
     decorate: true
     labels:
@@ -1061,6 +1142,87 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-aws-upgrade-hypershift-operator,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build01
+    context: ci/prow/e2e-azure-aks-external-oidc-techpreview
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: hypershift-aks
+      ci-operator.openshift.io/cloud-cluster-profile: hypershift-aks
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-hypershift-main-e2e-azure-aks-external-oidc-techpreview
+    optional: true
+    rerun_command: /test e2e-azure-aks-external-oidc-techpreview
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-azure-aks-external-oidc-techpreview
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-azure-aks-external-oidc-techpreview,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:


### PR DESCRIPTION
This PR adds new presubmit jobs for hypershift repo that allow externaloidc feature gates to be tested. This will help to unblock https://github.com/openshift/hypershift/pull/8287 by providing a clear path forward with testing. 

This is required as periodic jobs do not build images per test run in HyperShift. Rather, they use the latest HyperShift image found, which does not include PR changes for feature gate testing. 

These tests only run if triggered manually.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR updates OpenShift CI configuration in the openshift/release repository to add two new HyperShift presubmit ci-operator entries that let reviewers manually run e2e tests exercising HyperShift’s external OIDC tech-preview behavior so test runs build images that include PR changes.

What changed, practically
- Affects: ci-operator configuration for the openshift/hypershift project (ci-operator/config/openshift/hypershift/openshift-hypershift-main.yaml).
- Adds two new tech-preview e2e presubmit entries (manual-trigger intent) that target external OIDC tests and build images per run:
  - e2e-aws-external-oidc-techpreview — cluster_profile: hypershift-aws; env: CI_TESTS_RUN=TestExternalOIDC, OAUTH_EXTERNAL_OIDC_PROVIDER=keycloak, TECH_PREVIEW_NO_UPGRADE="true"; workflow: hypershift-aws-e2e-external-oidc.
  - e2e-azure-aks-external-oidc-techpreview — cluster_profile: hypershift-aks; env: AUTH_THROUGH_CERTS="true", CI_TESTS_RUN=TestExternalOIDC, ENABLE_HYPERSHIFT_CERT_ROTATION_SCALE="true", TECH_PREVIEW_NO_UPGRADE="true"; workflow: hypershift-azure-aks-external-oidc.
- Additions only in the inspected ci-operator file; no other logic or exported/public API changes.

Rationale
- Periodic HyperShift tests reuse previously built images and therefore would not validate PR changes that introduce or toggle feature gates. These presubmits are intended to be triggered manually so each run builds images including the PR under test and can validate external OIDC feature-gate changes (e.g., files like auth.go / external_oidc.go and their tests).

Other notes
- Script and cluster-profiles-config.yaml changes were removed from this PR and are tracked separately (previously included changes moved to PR #78739).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->