### PR TITLE
WIP: test resource-agents etcd-predrain-hook-fixes branch

### DIFF
--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22.yaml
@@ -806,6 +806,8 @@ tests:
       CUSTOM_OS_IMAGE_REPO: rh-edge-enablement/tnf-custom-rhcos
       CUSTOM_OS_MIRROR_REGISTRY: quay.io
       RESOURCE_AGENT_SOURCE: REPO
+      RESOURCE_AGENTS_REPO: https://github.com/vimauro/resource-agents
+      RESOURCE_AGENTS_REF: etcd-predrain-hook-fixes
     workflow: baremetalds-two-node-fencing-recovery
 - as: e2e-metal-ovn-two-node-fencing-ipv6-recovery
   capabilities:

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
@@ -876,6 +876,8 @@ tests:
       CUSTOM_OS_IMAGE_REPO: rh-edge-enablement/tnf-custom-rhcos
       CUSTOM_OS_MIRROR_REGISTRY: quay.io
       RESOURCE_AGENT_SOURCE: REPO
+      RESOURCE_AGENTS_REPO: https://github.com/vimauro/resource-agents
+      RESOURCE_AGENTS_REF: etcd-predrain-hook-fixes
     workflow: baremetalds-two-node-fencing-recovery
 - as: e2e-metal-ovn-two-node-fencing-ipv6-recovery
   capabilities:


### PR DESCRIPTION
## Summary
- Point `e2e-metal-ovn-two-node-fencing-recovery-repo-ra` jobs (4.22 and 5.0) at `vimauro/resource-agents@etcd-predrain-hook-fixes`
- Testing fix for etcd learner deadlock during Machine deletion flows

**Do not merge** — this is a temporary config change for CI rehearsal only.

## Test plan
- [ ] `/pj-rehearse periodic-ci-openshift-release-main-nightly-4.22-e2e-metal-ovn-two-node-fencing-recovery-repo-ra`
- [ ] `/pj-rehearse periodic-ci-openshift-release-main-nightly-5.0-e2e-metal-ovn-two-node-fencing-recovery-repo-ra`
- [ ] Verify build logs show `git fetch origin etcd-predrain-hook-fixes`
- [ ] Verify disruptive two-node e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR makes a temporary, rehearsal-only change to OpenShift CI so the nightly 4.22 and 5.0 disruptive two-node e2e jobs use a contributor fork of resource-agents to validate a proposed fix for an etcd learner deadlock that can occur during Machine deletion flows.

Concretely, the e2e-metal-ovn-two-node-fencing-recovery-repo-ra jobs in the openshift-release nightly ci-operator configs are updated to set two env vars:
- RESOURCE_AGENTS_REPO → https://github.com/vimauro/resource-agents
- RESOURCE_AGENTS_REF  → etcd-predrain-hook-fixes

Effect: those periodic CI jobs will fetch and build the specified branch from vimauro/resource-agents instead of the upstream resource-agents code, allowing the disruptive two-node tests to exercise the fix before any upstream merge.

Notes:
- This is a Do Not Merge / WIP change for rehearsals only.
- Expected verification: rehearsals of the two periodic jobs (4.22 and 5.0) show git fetch of the etcd-predrain-hook-fixes ref and the disruptive two-node e2e tests complete successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->