### PR TITLE
fix(tls-scanner): presubmit fast smoke tests

### DIFF
--- a/ci-operator/config/openshift/tls-scanner/.config.prowgen
+++ b/ci-operator/config/openshift/tls-scanner/.config.prowgen
@@ -1,0 +1,14 @@
+slack_reporter:
+- channel: '#forum-case'
+  job_states_to_report:
+  - success
+  - failure
+  - error
+  report_template: '{{if eq .Status.State "success"}} :white_check_mark: Job *{{.Spec.Job}}*
+    ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> {{else}} :warning:
+    Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs>
+    {{end}}'
+  job_names:
+  - periodic-default-tls
+  - periodic-pqc-readiness
+  - periodic-tls13-adherence

--- a/ci-operator/config/openshift/tls-scanner/openshift-tls-scanner-main.yaml
+++ b/ci-operator/config/openshift/tls-scanner/openshift-tls-scanner-main.yaml
@@ -50,41 +50,24 @@ tests:
   commands: make test
   container:
     from: src
-- as: default-tls
+- as: smoke-tls
   cluster_claim:
     architecture: amd64
     cloud: aws
     owner: openshift-ci
     product: ocp
-    timeout: 5h0m0s
+    timeout: 1h0m0s
     version: "4.22"
   optional: true
   steps:
+    env:
+      PQC_CHECK: "true"
+      SCAN_LIMIT_IPS: "10"
+      SCANNER_CPU: "1"
+      SCANNER_MEMORY: 1Gi
     test:
     - ref: tls-scanner-run
     workflow: generic-claim
-- as: default-pqc-readiness
-  optional: true
-  steps:
-    cluster_profile: openshift-org-aws
-    env:
-      COMPUTE_NODE_TYPE: m5.4xlarge
-      PQC_CHECK: "true"
-    test:
-    - ref: tls-scanner-run
-    workflow: ipi-aws
-- as: tls13-adherence
-  optional: true
-  steps:
-    cluster_profile: openshift-org-aws
-    env:
-      COMPUTE_NODE_TYPE: m5.4xlarge
-      PQC_CHECK: "false"
-      TLS_13_ENABLE_TLS_ADHERENCE: "true"
-      TLS_13_TLS_ADHERENCE_POLICY: StrictAllComponents
-    test:
-    - ref: tls-scanner-run
-    workflow: openshift-e2e-aws-ovn-tls-13
 - as: periodic-default-tls
   interval: 72h
   steps:
@@ -113,16 +96,6 @@ tests:
       PQC_CHECK: "false"
       TLS_13_ENABLE_TLS_ADHERENCE: "true"
       TLS_13_TLS_ADHERENCE_POLICY: StrictAllComponents
-    test:
-    - ref: tls-scanner-run
-    workflow: openshift-e2e-aws-ovn-tls-13
-- as: tls13-pqc-readiness
-  optional: true
-  steps:
-    cluster_profile: openshift-org-aws
-    env:
-      COMPUTE_NODE_TYPE: m5.4xlarge
-      PQC_CHECK: "true"
     test:
     - ref: tls-scanner-run
     workflow: openshift-e2e-aws-ovn-tls-13

--- a/ci-operator/jobs/openshift/tls-scanner/openshift-tls-scanner-main-periodics.yaml
+++ b/ci-operator/jobs/openshift/tls-scanner/openshift-tls-scanner-main-periodics.yaml
@@ -15,6 +15,17 @@ periodics:
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-tls-scanner-main-periodic-default-tls
+  reporter_config:
+    slack:
+      channel: '#forum-case'
+      job_states_to_report:
+      - success
+      - failure
+      - error
+      report_template: '{{if eq .Status.State "success"}} :white_check_mark: Job *{{.Spec.Job}}*
+        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> {{else}} :warning:
+        Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+        logs> {{end}}'
   spec:
     containers:
     - args:
@@ -95,6 +106,17 @@ periodics:
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-tls-scanner-main-periodic-pqc-readiness
+  reporter_config:
+    slack:
+      channel: '#forum-case'
+      job_states_to_report:
+      - success
+      - failure
+      - error
+      report_template: '{{if eq .Status.State "success"}} :white_check_mark: Job *{{.Spec.Job}}*
+        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> {{else}} :warning:
+        Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+        logs> {{end}}'
   spec:
     containers:
     - args:
@@ -175,6 +197,17 @@ periodics:
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-tls-scanner-main-periodic-tls13-adherence
+  reporter_config:
+    slack:
+      channel: '#forum-case'
+      job_states_to_report:
+      - success
+      - failure
+      - error
+      report_template: '{{if eq .Status.State "success"}} :white_check_mark: Job *{{.Spec.Job}}*
+        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> {{else}} :warning:
+        Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+        logs> {{end}}'
   spec:
     containers:
     - args:

--- a/ci-operator/jobs/openshift/tls-scanner/openshift-tls-scanner-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/tls-scanner/openshift-tls-scanner-main-presubmits.yaml
@@ -6,50 +6,32 @@ presubmits:
     - ^main$
     - ^main-
     cluster: build05
-    context: ci/prow/default-pqc-readiness
+    context: ci/prow/images
     decorate: true
     decoration_config:
       skip_cloning: true
     labels:
-      ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-tls-scanner-main-default-pqc-readiness
-    optional: true
-    rerun_command: /test default-pqc-readiness
+    name: pull-ci-openshift-tls-scanner-main-images
+    rerun_command: /test images
     spec:
       containers:
       - args:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=default-pqc-readiness
+        - --target=[images]
+        - --target=[release:latest]
         command:
         - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
         image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
         imagePullPolicy: Always
         name: ""
-        ports:
-        - containerPort: 8080
-          name: http
         resources:
           requests:
             cpu: 10m
         volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
@@ -64,15 +46,6 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
@@ -82,23 +55,23 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )default-pqc-readiness,?($|\s.*)
+    trigger: (?m)^/test( | .* )images,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:
     - ^main$
     - ^main-
     cluster: build05
-    context: ci/prow/default-tls
+    context: ci/prow/smoke-tls
     decorate: true
     decoration_config:
       skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-tls-scanner-main-default-tls
+    name: pull-ci-openshift-tls-scanner-main-smoke-tls
     optional: true
-    rerun_command: /test default-tls
+    rerun_command: /test smoke-tls
     spec:
       containers:
       - args:
@@ -108,7 +81,7 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=default-tls
+        - --target=smoke-tls
         command:
         - ci-operator
         env:
@@ -170,229 +143,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )default-tls,?($|\s.*)
-  - agent: kubernetes
-    always_run: true
-    branches:
-    - ^main$
-    - ^main-
-    cluster: build05
-    context: ci/prow/images
-    decorate: true
-    decoration_config:
-      skip_cloning: true
-    labels:
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-tls-scanner-main-images
-    rerun_command: /test images
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --report-credentials-file=/etc/report/credentials
-        - --target=[images]
-        - --target=[release:latest]
-        command:
-        - ci-operator
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )images,?($|\s.*)
-  - agent: kubernetes
-    always_run: true
-    branches:
-    - ^main$
-    - ^main-
-    cluster: build05
-    context: ci/prow/tls13-adherence
-    decorate: true
-    decoration_config:
-      skip_cloning: true
-    labels:
-      ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-tls-scanner-main-tls13-adherence
-    optional: true
-    rerun_command: /test tls13-adherence
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=tls13-adherence
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )tls13-adherence,?($|\s.*)
-  - agent: kubernetes
-    always_run: true
-    branches:
-    - ^main$
-    - ^main-
-    cluster: build05
-    context: ci/prow/tls13-pqc-readiness
-    decorate: true
-    decoration_config:
-      skip_cloning: true
-    labels:
-      ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-tls-scanner-main-tls13-pqc-readiness
-    optional: true
-    rerun_command: /test tls13-pqc-readiness
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=tls13-pqc-readiness
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )tls13-pqc-readiness,?($|\s.*)
+    trigger: (?m)^/test( | .* )smoke-tls,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:

--- a/ci-operator/jobs/openshift/tls-scanner/openshift-tls-scanner-release-4.22-periodics.yaml
+++ b/ci-operator/jobs/openshift/tls-scanner/openshift-tls-scanner-release-4.22-periodics.yaml
@@ -15,6 +15,17 @@ periodics:
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-openshift-tls-scanner-release-4.22-periodic-default-tls
+  reporter_config:
+    slack:
+      channel: '#forum-case'
+      job_states_to_report:
+      - success
+      - failure
+      - error
+      report_template: '{{if eq .Status.State "success"}} :white_check_mark: Job *{{.Spec.Job}}*
+        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> {{else}} :warning:
+        Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+        logs> {{end}}'
   spec:
     containers:
     - args:

--- a/ci-operator/step-registry/tls/scanner/run/tls-scanner-run-commands.sh
+++ b/ci-operator/step-registry/tls/scanner/run/tls-scanner-run-commands.sh
@@ -22,6 +22,11 @@ if [[ "${PQC_CHECK:-false}" == "true" ]]; then
     echo "PQC readiness mode enabled: checks TLS 1.3 support and mlkem or mlkem25519 support per target."
 fi
 
+if [[ -n "${SCAN_LIMIT_IPS:-}" && "${SCAN_LIMIT_IPS}" != "0" ]]; then
+    SCANNER_ARGS="${SCANNER_ARGS} --limit-ips ${SCAN_LIMIT_IPS}"
+    echo "Limiting scan to ${SCAN_LIMIT_IPS} IPs (smoke testing)."
+fi
+
 mkdir -p "${SCANNER_ARTIFACT_DIR}"
 
 echo "=== TLS Scanner ==="
@@ -78,11 +83,11 @@ spec:
       sleep 120
     resources:
       requests:
-        cpu: "4"
-        memory: 4Gi
+        cpu: "${SCANNER_CPU}"
+        memory: ${SCANNER_MEMORY}
       limits:
-        cpu: "4"
-        memory: 4Gi
+        cpu: "${SCANNER_CPU}"
+        memory: ${SCANNER_MEMORY}
     securityContext:
       privileged: true
       runAsUser: 0

--- a/ci-operator/step-registry/tls/scanner/run/tls-scanner-run-ref.yaml
+++ b/ci-operator/step-registry/tls/scanner/run/tls-scanner-run-ref.yaml
@@ -10,6 +10,15 @@ ref:
   - name: PQC_CHECK
     default: "false"
     documentation: "Set to 'true' to enable post-quantum cryptography readiness checks (TLS 1.3 and mlkem/mlkem25519 support)."
+  - name: SCAN_LIMIT_IPS
+    default: ""
+    documentation: "Max IPs to scan (empty/0 = no limit). Bounds actual TLS scans after full endpoint discovery."
+  - name: SCANNER_CPU
+    default: "4"
+    documentation: "CPU request/limit for the scanner pod."
+  - name: SCANNER_MEMORY
+    default: "4Gi"
+    documentation: "Memory request/limit for the scanner pod."
   dependencies:
   - env: RELEASE_IMAGE_LATEST
     name: release:latest


### PR DESCRIPTION
Adds the following:
1. fast smoke tests to help with faster iterations
2. periodic jobs run as norma
3. slack notifications from periodic jobs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR updates OpenShift CI configuration for the openshift/tls-scanner repository to add a fast, bounded presubmit smoke test, preserve full periodic scans, and add Slack notifications for periodic job results.

What changed (practical impact)
- Added an optional presubmit "smoke-tls" ci-operator test that runs via the generic-claim workflow with a 1h timeout and OpenShift 4.22. It sets PQC_CHECK=true and SCAN_LIMIT_IPS=10 so presubmits perform a bounded (smoke) scan for much faster feedback to PR authors. The smoke test requests a smaller scanner footprint (SCANNER_CPU/SCANNER_MEMORY).
- Periodic, full scans remain configured (periodic-default-tls, periodic-pqc-readiness, periodic-tls13-adherence) with their existing larger compute profile and workflows; these continue to run as before.
- Periodic jobs now send Slack notifications: a slack_reporter block posts success/failure/error messages for the three periodic jobs to channel #forum-case with a templated message linking to job logs.
- Step/ref and run script support for bounded (smoke) scans:
  - ci-operator/step-registry/tls/scanner/run/tls-scanner-run-ref.yaml: adds SCAN_LIMIT_IPS env var (default ""), documented to treat empty/0 as no limit.
  - ci-operator/step-registry/tls/scanner/run/tls-scanner-run-commands.sh: when SCAN_LIMIT_IPS is set and non-zero, appends --limit-ips <n> to the scanner invocation and echoes a message indicating the scan is limited.

Files changed (high level)
- ci-operator/config/openshift/tls-scanner/.config.prowgen — add slack_reporter block for periodic jobs
- ci-operator/config/openshift/tls-scanner/openshift-tls-scanner-main.yaml — add optional smoke-tls test (presubmit), keep periodic tests
- ci-operator/step-registry/tls/scanner/run/tls-scanner-run-ref.yaml — add SCAN_LIMIT_IPS env/documentation
- ci-operator/step-registry/tls/scanner/run/tls-scanner-run-commands.sh — implement SCAN_LIMIT_IPS handling and echo smoke-test message

Impact
- Faster presubmit feedback via bounded smoke scans (SCAn_LIMIT_IPS) while preserving full periodic scans for comprehensive coverage.
- Increased visibility of periodic job outcomes via Slack notifications.
- Changes are CI/test configuration and test-step logic only; no application code changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->