### PR TITLE
chore(cluster-profile): wrap cluster-profiles-config in ClusterProfil…

### DIFF
--- a/ci-operator/step-registry/cluster-profiles/cluster-profiles-config.yaml
+++ b/ci-operator/step-registry/cluster-profiles/cluster-profiles-config.yaml
@@ -1,3 +1,4 @@
+cluster_profiles:
 - owners:
   - org: 3scale
     repos:


### PR DESCRIPTION
Root cause summary:                                                                                                                                         
                                                                                                                                                              
  The ci_ci-operator-checkconfig_latest Docker image was recently updated and changed the Go type api.ClusterProfilesList from a plain slice ([]ClusterProfile) to a struct. 
The cluster-profiles-config.yaml file was still in the old raw YAML array format, which the new tool couldn't unmarshal.    
Fix applied: Added cluster_profiles: as a top-level wrapper key at line 1 of ci-operator/step-registry/cluster-profiles/cluster-profiles-config.yaml. 
This is a one-line change that wraps the existing array under the struct's expected field name.
