### PR TITLE
Mark gather-network and gather-core-dump as best_effort

### DIFF
--- a/ci-operator/step-registry/gather/core-dump/gather-core-dump-ref.yaml
+++ b/ci-operator/step-registry/gather/core-dump/gather-core-dump-ref.yaml
@@ -1,5 +1,6 @@
 ref:
   as: gather-core-dump
+  best_effort: true
   optional_on_success: true
   from: cli
   commands: gather-core-dump-commands.sh

--- a/ci-operator/step-registry/gather/network/gather-network-ref.yaml
+++ b/ci-operator/step-registry/gather/network/gather-network-ref.yaml
@@ -1,8 +1,10 @@
 ref:
   as: gather-network
+  best_effort: true
   optional_on_success: true
   from: cli
   commands: gather-network-commands.sh
+  timeout: 20m
   resources:
     requests:
       cpu: 300m


### PR DESCRIPTION
Other gather steps (gather-must-gather, gather-extra, gather-audit-logs) already have best_effort: true. Align gather-network and gather-core-dump for consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD resilience: data-gathering steps (network and core-dump collection) are now best-effort, so transient failures in these diagnostics won’t abort pipelines.
  * Pipelines will continue running when gather operations encounter issues, while still attempting to collect available diagnostic information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->