### PR TITLE
COS-4080: openshift/os: add RHCOS 10 node image build

### DIFF
--- a/ci-operator/config/openshift/os/openshift-os-master.yaml
+++ b/ci-operator/config/openshift/os/openshift-os-master.yaml
@@ -3,6 +3,10 @@ base_images:
     name: rhel-coreos-base
     namespace: coreos
     tag: "9.8"
+  rhel-coreos-base-10:
+    name: rhel-coreos-base
+    namespace: coreos
+    tag: "10.2"
 build_root:
   image_stream_tag:
     name: coreos-assembler
@@ -33,12 +37,36 @@ images:
         as:
         - registry.ci.openshift.org/rhcos-devel/rhel-coreos:latest
     to: rhel-coreos-extensions
+  - build_args:
+    - name: OPENSHIFT_CI
+      value: "1"
+    - name: IMAGE_NAME
+      value: openshift/ose-rhel-coreos-10
+    - name: IMAGE_CPE
+      value: cpe:/a:redhat:openshift:4.22::el10
+    dockerfile_path: Containerfile
+    inputs:
+      rhel-coreos-base-10:
+        as:
+        - ${IMAGE_FROM}
+    to: rhel-coreos-10
+  - build_args:
+    - name: OPENSHIFT_CI
+      value: "1"
+    dockerfile_path: extensions/Containerfile
+    inputs:
+      rhel-coreos-10:
+        as:
+        - registry.ci.openshift.org/rhcos-devel/rhel-coreos:latest
+    to: rhel-coreos-10-extensions
   skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
 promotion:
   to:
   - excluded_images:
     - rhel-coreos
     - rhel-coreos-extensions
+    - rhel-coreos-10
+    - rhel-coreos-10-extensions
     name: "5.0"
     namespace: ocp
 releases:

--- a/ci-operator/config/openshift/os/openshift-os-release-5.0.yaml
+++ b/ci-operator/config/openshift/os/openshift-os-release-5.0.yaml
@@ -3,6 +3,10 @@ base_images:
     name: rhel-coreos-base
     namespace: coreos
     tag: "9.8"
+  rhel-coreos-base-10:
+    name: rhel-coreos-base
+    namespace: coreos
+    tag: "10.2"
 build_root:
   image_stream_tag:
     name: coreos-assembler
@@ -33,6 +37,28 @@ images:
         as:
         - registry.ci.openshift.org/rhcos-devel/rhel-coreos:latest
     to: rhel-coreos-extensions
+  - build_args:
+    - name: OPENSHIFT_CI
+      value: "1"
+    - name: IMAGE_NAME
+      value: openshift/ose-rhel-coreos-10
+    - name: IMAGE_CPE
+      value: cpe:/a:redhat:openshift:4.22::el10
+    dockerfile_path: Containerfile
+    inputs:
+      rhel-coreos-base-10:
+        as:
+        - ${IMAGE_FROM}
+    to: rhel-coreos-10
+  - build_args:
+    - name: OPENSHIFT_CI
+      value: "1"
+    dockerfile_path: extensions/Containerfile
+    inputs:
+      rhel-coreos-10:
+        as:
+        - registry.ci.openshift.org/rhcos-devel/rhel-coreos:latest
+    to: rhel-coreos-10-extensions
   skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
 promotion:
   to:
@@ -40,6 +66,8 @@ promotion:
     excluded_images:
     - rhel-coreos
     - rhel-coreos-extensions
+    - rhel-coreos-10
+    - rhel-coreos-10-extensions
     name: "5.0"
     namespace: ocp
 releases:

--- a/ci-operator/config/openshift/os/openshift-os-release-5.1.yaml
+++ b/ci-operator/config/openshift/os/openshift-os-release-5.1.yaml
@@ -62,7 +62,8 @@ images:
   skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
 promotion:
   to:
-  - excluded_images:
+  - disabled: true
+    excluded_images:
     - rhel-coreos
     - rhel-coreos-extensions
     - rhel-coreos-10

--- a/ci-operator/config/openshift/os/openshift-os-release-5.1.yaml
+++ b/ci-operator/config/openshift/os/openshift-os-release-5.1.yaml
@@ -3,6 +3,10 @@ base_images:
     name: rhel-coreos-base
     namespace: coreos
     tag: "9.8"
+  rhel-coreos-base-10:
+    name: rhel-coreos-base
+    namespace: coreos
+    tag: "10.2"
 build_root:
   image_stream_tag:
     name: coreos-assembler
@@ -33,12 +37,36 @@ images:
         as:
         - registry.ci.openshift.org/rhcos-devel/rhel-coreos:latest
     to: rhel-coreos-extensions
+  - build_args:
+    - name: OPENSHIFT_CI
+      value: "1"
+    - name: IMAGE_NAME
+      value: openshift/ose-rhel-coreos-10
+    - name: IMAGE_CPE
+      value: cpe:/a:redhat:openshift:4.22::el10
+    dockerfile_path: Containerfile
+    inputs:
+      rhel-coreos-base-10:
+        as:
+        - ${IMAGE_FROM}
+    to: rhel-coreos-10
+  - build_args:
+    - name: OPENSHIFT_CI
+      value: "1"
+    dockerfile_path: extensions/Containerfile
+    inputs:
+      rhel-coreos-10:
+        as:
+        - registry.ci.openshift.org/rhcos-devel/rhel-coreos:latest
+    to: rhel-coreos-10-extensions
   skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
 promotion:
   to:
   - excluded_images:
     - rhel-coreos
     - rhel-coreos-extensions
+    - rhel-coreos-10
+    - rhel-coreos-10-extensions
     name: "5.1"
     namespace: ocp
 releases:

--- a/ci-operator/jobs/openshift/os/openshift-os-release-5.1-presubmits.yaml
+++ b/ci-operator/jobs/openshift/os/openshift-os-release-5.1-presubmits.yaml
@@ -106,7 +106,6 @@ presubmits:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --report-credentials-file=/etc/report/credentials
         - --target=[images]
-        - --target=[release:latest]
         command:
         - ci-operator
         image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest

--- a/core-services/image-mirroring/_config.yaml
+++ b/core-services/image-mirroring/_config.yaml
@@ -823,6 +823,10 @@ supplementalCIImages:
     namespace: coreos
     name: rhel-coreos-base
     tag: "10.1"
+  coreos/rhel-coreos-base:10.2:
+    namespace: coreos
+    name: rhel-coreos-base
+    tag: "10.2"
   coreos/rhel-coreos-base:9.6:
     namespace: coreos
     name: rhel-coreos-base


### PR DESCRIPTION
Add RHEL 10.2 node image build alongside the existing RHEL 9.8 in the openshift/os CI configs. Currently only the RHEL 9.8 node image is built.

Adds a second base_images entry (rhel-coreos-base:10.2) and a second images entry to build rhel-coreos-10 in:
- openshift-os-master.yaml
- openshift-os-release-5.0.yaml                                                                                                                                                               
- openshift-os-release-5.1.yaml

Aditionally disabling 5.1 in the second commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR updates OpenShift CI configs in the openshift/os area to add RHEL CoreOS (RHCOS) / RHEL 10.2 node image builds so CI will validate el10 node images alongside the existing el9 builds.

## Practical changes
- Adds a new base_images entry rhel-coreos-base-10 (tag 10.2) and wires it into image builds.
- Introduces image build pipelines:
  - rhel-coreos-10 (Containerfile; IMAGE_NAME openshift/ose-rhel-coreos-10; IMAGE_CPE set for el10)
  - rhel-coreos-10-extensions (extensions/Containerfile consuming rhel-coreos-10)
- Updates promotion settings to exclude the new images from automatic promotion. For release branches (release-5.0 and release-5.1) promotion for the coreos images is disabled.
- Adds the new coreos/rhel-coreos-base:10.2 entry to core-services/image-mirroring/_config.yaml so CI can mirror the base image.

Files changed (CI/config + mirroring):
- ci-operator/config/openshift/os/openshift-os-master.yaml
- ci-operator/config/openshift/os/openshift-os-release-5.0.yaml
- ci-operator/config/openshift/os/openshift-os-release-5.1.yaml
- core-services/image-mirroring/_config.yaml

## Impact / notes for reviewers
- CI will now build and test RHEL CoreOS 10.2 node images and their extensions in addition to RHEL 9.8, closing the previous el10 testing gap.
- pj-rehearse runs failed for the author due to an import timeout for quay.io/openshift/ci:coreos_rhel-coreos-base_10.2 in the CI imagestream (missing tag), and the author could not inspect the coreos imagestream due to permission errors. Reviewers should verify the mirrored base image is available and that mirroring/import is succeeding for the new 10.2 tag before merging.
- The author indicated intent to squash commits; travier suggested ensuring the image-mirroring config is updated (the mirroring entry for coreos/rhel-coreos-base:10.2 is present in this PR).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->