### PR TITLE
CLID-620: Download oc-mirror from mirror.openshift.com in longduration tests

### DIFF
--- a/ci-operator/step-registry/openshift-extended/test/longduration/openshift-extended-test-longduration-commands.sh
+++ b/ci-operator/step-registry/openshift-extended/test/longduration/openshift-extended-test-longduration-commands.sh
@@ -265,22 +265,31 @@ if [[ $IS_ACTIVE_CLUSTER_OPENSHIFT != "false" ]]; then
     ocpVersion=$(oc get clusterversion -o json | jq -r '.items[0].status.desired.version')
 fi
 
-#if OVERWRITE_OC_MIRROR then overwrite the oc-mirror from the payload
+#if OVERRIDE_OC_MIRROR then download oc-mirror from mirror.openshift.com
 if [[ $OVERRIDE_OC_MIRROR == "true" ]]; then
     echo "OCP Version: ${ocpVersion}"
     if [[ "$ocpVersion" == *arm* ]] || [[ "${OCP_ARCH:-}" != "amd64" ]]; then
-        echo "[WARN]OCP_ARCH is not amd64, or OCP is not for amd64, currently do not support to overwrite the oc-mirror from the OCP release image"
+        echo "[WARN]OCP_ARCH is not amd64, or OCP is not for amd64, currently do not support arm64 oc-mirror download"
     fi
     if [[ -n "${ocpVersion:-}" ]]; then
         tmpDir=$(mktemp -d)
         cd ${tmpDir}
-        echo "Extracting oc-mirror from ${ocpVersion}, OCP_ARCH: ${OCP_ARCH}"
+        echo "Downloading oc-mirror from mirror.openshift.com for OCP version ${ocpVersion}, OCP_ARCH: ${OCP_ARCH}"
         set -x
-        filter="linux/amd64"      
-        tag=$(oc adm release info "${ocpVersion}" -a "${CLUSTER_PROFILE_DIR}/pull-secret" --filter-by-os="${filter}" -o json | jq -r '.references.spec.tags[] | select(.name=="oc-mirror") | .from.name')
-        which oc
-        uname -m
-        oc image extract "${tag}" --path=/usr/bin/oc-mirror:. -a "${CLUSTER_PROFILE_DIR}/pull-secret" --filter-by-os="${filter}" --confirm
+
+        # Determine architecture
+        ARCH=$(uname -m)
+        case ${ARCH} in
+            x86_64) ARCH="amd64" ;;
+            aarch64) ARCH="arm64" ;;
+        esac
+
+        # Download oc-mirror from mirror.openshift.com
+        echo "Downloading oc-mirror for architecture: ${ARCH}"
+        curl -L --retry 5 --connect-timeout 30 -o oc-mirror.tar.gz \
+            "https://mirror.openshift.com/pub/openshift-v4/${ARCH}/clients/ocp/latest/oc-mirror.tar.gz"
+
+        tar -xzf oc-mirror.tar.gz
         ls -la ./oc-mirror
         md5sum ./oc-mirror
         chmod +x ./oc-mirror

--- a/ci-operator/step-registry/openshift-extended/test/longduration/openshift-extended-test-longduration-commands.sh
+++ b/ci-operator/step-registry/openshift-extended/test/longduration/openshift-extended-test-longduration-commands.sh
@@ -266,12 +266,12 @@ if [[ $IS_ACTIVE_CLUSTER_OPENSHIFT != "false" ]]; then
 fi
 
 #if OVERRIDE_OC_MIRROR then download oc-mirror from mirror.openshift.com
-if [[ $OVERRIDE_OC_MIRROR == "true" ]]; then
-    echo "OCP Version: ${ocpVersion}"
+if [[ "${OVERRIDE_OC_MIRROR:-}" == "true" ]]; then
+    echo "OCP Version: ${ocpVersion:-}"
     if [[ -n "${ocpVersion:-}" ]]; then
         tmpDir=$(mktemp -d)
-        cd ${tmpDir}
-        echo "Downloading oc-mirror from mirror.openshift.com for OCP version ${ocpVersion}, OCP_ARCH: ${OCP_ARCH}"
+        cd "${tmpDir}"
+        echo "Downloading oc-mirror from mirror.openshift.com for OCP version ${ocpVersion}, OCP_ARCH: ${OCP_ARCH:-}"
         set -x
 
         # Detect architecture for oc-mirror download


### PR DESCRIPTION
## Summary
Update openshift-extended-test-longduration to download oc-mirror from mirror.openshift.com instead of extracting from OCP payload.

## Motivation
oc-mirror is moving to independent releases outside the OCP payload to enable faster iteration and single-version compatibility across multiple OCP versions.

## Changes
- Replace oc image extract with curl download
- Support both amd64 and arm64 architectures
- Use latest oc-mirror from mirror.openshift.com

## Testing
- Verified download URL is accessible
- Code follows existing pattern used by other tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## openshift-extended-test-longduration CI step: Download oc-mirror from mirror.openshift.com

This PR updates the OpenShift CI step used by the extended long-duration tests in the openshift/release repository (ci-operator step in the step-registry) so the test obtains oc-mirror by downloading it from mirror.openshift.com instead of extracting it from the OCP release payload.

What changed (practical effect)
- The step script ci-operator/step-registry/openshift-extended/test/longduration/openshift-extended-test-longduration-commands.sh now, when OVERRIDE_OC_MIRROR="true", downloads oc-mirror.tar.gz from https://mirror.openshift.com/pub/openshift-v4/{ARCH}/clients/ocp/latest/oc-mirror.tar.gz rather than using `oc adm release info` + `oc image extract`.
- Adds host architecture detection and mapping (uname -m → amd64 for x86_64, arm64 for aarch64).
- Selects oc-mirror directory based on the OCP version string: probes for stable-X.Y for pre-release-style identifiers (nightly|ci|rc|ec) with curl retry logic, uses the exact X.Y.* path for GA-style versions, and falls back to latest when needed.
- Downloads the tarball and checksum (sha256sum.txt), verifies the tarball via `sha256sum -c`, extracts oc-mirror into a temporary directory, validates the binary, and adds it to PATH.
- Removes the previous payload-extraction flow and related variables/warnings.

Why
- oc-mirror is being released independently of OCP payloads to allow faster iteration and to provide a single oc-mirror release usable across multiple OCP versions; CI must fetch oc-mirror from the new distribution location.

Scope / Impact
- Affects OpenShift CI configuration in the openshift/release repository: the long-duration extended tests' ci-operator step implementation.
- Supports both amd64 and arm64 test hosts.
- Implementation-only change to test step behavior; no public APIs or exported interfaces were modified.

Testing & PR activity
- Download URL accessibility and checksum verification logic were checked; implementation follows existing CI patterns (architecture mapping, curl retry/probing, checksum validation).
- PR author ran repeated rehearsals; reviewers approved (/lgtm, /approve) and automation confirmed the JIRA reference. The author noted some flaky rehearsals while iterating.

Files changed
- ci-operator/step-registry/openshift-extended/test/longduration/openshift-extended-test-longduration-commands.sh (replace payload extraction with direct mirror download, version selection probing, architecture mapping, checksum validation, and extraction)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->