### PR TITLE
CLID-619: Download oc-mirror from mirror.openshift.com in cucushift upgrade tests

### DIFF
--- a/ci-operator/step-registry/cucushift/upgrade/mirror-images/by-oc-mirror/cucushift-upgrade-mirror-images-by-oc-mirror-commands.sh
+++ b/ci-operator/step-registry/cucushift/upgrade/mirror-images/by-oc-mirror/cucushift-upgrade-mirror-images-by-oc-mirror-commands.sh
@@ -103,6 +103,17 @@ curl -L --retry 5 --connect-timeout 30 -o oc-mirror.tar.gz \
 # When oc-mirror is removed from the OCP payload, replace the above curl command with this one to always use the latest version:
 # curl -L --retry 5 --connect-timeout 30 -o oc-mirror.tar.gz \
 #     "https://mirror.openshift.com/pub/openshift-v4/${ARCH}/clients/ocp/latest/oc-mirror.tar.gz"
+
+# Verify the integrity of the downloaded tarball
+echo "Verifying oc-mirror.tar.gz integrity..."
+curl -L --retry 5 --connect-timeout 30 -o sha256sum.txt \
+    "https://mirror.openshift.com/pub/openshift-v4/${ARCH}/clients/ocp/${ocp_full_version}/sha256sum.txt"
+grep "oc-mirror.tar.gz" sha256sum.txt | sha256sum -c - || {
+    echo "ERROR: oc-mirror.tar.gz checksum verification failed"
+    exit 1
+}
+echo "Checksum verification passed"
+
 tar -xzf oc-mirror.tar.gz
 chmod +x oc-mirror
 oc_mirror_bin="${oc_mirror_download_dir}/oc-mirror"

--- a/ci-operator/step-registry/cucushift/upgrade/mirror-images/by-oc-mirror/cucushift-upgrade-mirror-images-by-oc-mirror-commands.sh
+++ b/ci-operator/step-registry/cucushift/upgrade/mirror-images/by-oc-mirror/cucushift-upgrade-mirror-images-by-oc-mirror-commands.sh
@@ -83,8 +83,12 @@ KUBECONFIG="" oc registry login
 run_command "which oc"
 run_command "oc version --client"
 
+# Extract the full OCP version from the target release
+ocp_full_version=$(oc adm release info --registry-config ${CLUSTER_PROFILE_DIR}/pull-secret ${OPENSHIFT_UPGRADE_RELEASE_IMAGE_OVERRIDE} -o jsonpath='{.metadata.version}')
+echo "Target OCP version: ${ocp_full_version}"
+
 # Download oc-mirror from mirror.openshift.com
-echo "Downloading oc-mirror from mirror.openshift.com"
+echo "Downloading oc-mirror version ${ocp_full_version} from mirror.openshift.com"
 ARCH=$(uname -m)
 case ${ARCH} in
     x86_64) ARCH="amd64" ;;
@@ -93,8 +97,12 @@ esac
 
 oc_mirror_download_dir=$(mktemp -d)
 pushd "${oc_mirror_download_dir}"
+# Download version-specific oc-mirror from mirror.openshift.com to match the payload version
 curl -L --retry 5 --connect-timeout 30 -o oc-mirror.tar.gz \
-    "https://mirror.openshift.com/pub/openshift-v4/${ARCH}/clients/ocp/latest/oc-mirror.tar.gz"
+    "https://mirror.openshift.com/pub/openshift-v4/${ARCH}/clients/ocp/${ocp_full_version}/oc-mirror.tar.gz"
+# When oc-mirror is removed from the OCP payload, replace the above curl command with this one to always use the latest version:
+# curl -L --retry 5 --connect-timeout 30 -o oc-mirror.tar.gz \
+#     "https://mirror.openshift.com/pub/openshift-v4/${ARCH}/clients/ocp/latest/oc-mirror.tar.gz"
 tar -xzf oc-mirror.tar.gz
 chmod +x oc-mirror
 oc_mirror_bin="${oc_mirror_download_dir}/oc-mirror"
@@ -134,7 +142,8 @@ check_signed "${OPENSHIFT_UPGRADE_RELEASE_IMAGE_OVERRIDE}" || payload_signed="fa
 mirrorCmd="'${oc_mirror_bin}' -c ${image_set_config} docker://${target_release_image_repo} --dest-tls-verify=false --v2 --workspace file://${oc_mirror_dir}"
 
 # ref OCPBUGS-56009
-ocp_version=$(oc adm release info --registry-config ${CLUSTER_PROFILE_DIR}/pull-secret ${OPENSHIFT_UPGRADE_RELEASE_IMAGE_OVERRIDE} -o jsonpath='{.metadata.version}' | cut -d. -f 1,2)
+# Extract major.minor version for comparison (already extracted full version earlier)
+ocp_version=$(echo "${ocp_full_version}" | cut -d. -f 1,2)
 if ! isPreVersion "${ocp_version}" "4.19" && [[ "${payload_signed}" == "false" ]] ; then
     mirrorCmd="${mirrorCmd} --ignore-release-signature"
 fi

--- a/ci-operator/step-registry/cucushift/upgrade/mirror-images/by-oc-mirror/cucushift-upgrade-mirror-images-by-oc-mirror-commands.sh
+++ b/ci-operator/step-registry/cucushift/upgrade/mirror-images/by-oc-mirror/cucushift-upgrade-mirror-images-by-oc-mirror-commands.sh
@@ -87,8 +87,26 @@ run_command "oc version --client"
 ocp_full_version=$(oc adm release info --registry-config ${CLUSTER_PROFILE_DIR}/pull-secret ${OPENSHIFT_UPGRADE_RELEASE_IMAGE_OVERRIDE} -o jsonpath='{.metadata.version}')
 echo "Target OCP version: ${ocp_full_version}"
 
+# Determine which oc-mirror version to download
+# Nightly/CI builds aren't published to mirror.openshift.com, so use stable-X.Y channel for them
+if [[ "${ocp_full_version}" =~ ^([0-9]+\.[0-9]+)\. ]]; then
+    ocp_minor_version="${BASH_REMATCH[1]}"
+    if [[ "${ocp_full_version}" =~ (nightly|ci|rc) ]]; then
+        # For nightly/CI/RC builds, use stable-X.Y channel
+        oc_mirror_version="stable-${ocp_minor_version}"
+        echo "Using oc-mirror from stable-${ocp_minor_version} channel (target is nightly/CI build)"
+    else
+        # For GA releases, use the exact version
+        oc_mirror_version="${ocp_full_version}"
+        echo "Using oc-mirror version ${ocp_full_version} (target is GA release)"
+    fi
+else
+    # Fallback to latest if version format is unexpected
+    oc_mirror_version="latest"
+    echo "Warning: Unexpected version format '${ocp_full_version}', using latest oc-mirror"
+fi
+
 # Download oc-mirror from mirror.openshift.com
-echo "Downloading oc-mirror version ${ocp_full_version} from mirror.openshift.com"
 ARCH=$(uname -m)
 case ${ARCH} in
     x86_64) ARCH="amd64" ;;
@@ -97,9 +115,10 @@ esac
 
 oc_mirror_download_dir=$(mktemp -d)
 pushd "${oc_mirror_download_dir}"
+echo "Downloading oc-mirror from https://mirror.openshift.com/pub/openshift-v4/${ARCH}/clients/ocp/${oc_mirror_version}/"
 # Download version-specific oc-mirror from mirror.openshift.com to match the payload version
 curl -L --retry 5 --connect-timeout 30 -o oc-mirror.tar.gz \
-    "https://mirror.openshift.com/pub/openshift-v4/${ARCH}/clients/ocp/${ocp_full_version}/oc-mirror.tar.gz"
+    "https://mirror.openshift.com/pub/openshift-v4/${ARCH}/clients/ocp/${oc_mirror_version}/oc-mirror.tar.gz"
 # When oc-mirror is removed from the OCP payload, replace the above curl command with this one to always use the latest version:
 # curl -L --retry 5 --connect-timeout 30 -o oc-mirror.tar.gz \
 #     "https://mirror.openshift.com/pub/openshift-v4/${ARCH}/clients/ocp/latest/oc-mirror.tar.gz"
@@ -107,7 +126,7 @@ curl -L --retry 5 --connect-timeout 30 -o oc-mirror.tar.gz \
 # Verify the integrity of the downloaded tarball
 echo "Verifying oc-mirror.tar.gz integrity..."
 curl -L --retry 5 --connect-timeout 30 -o sha256sum.txt \
-    "https://mirror.openshift.com/pub/openshift-v4/${ARCH}/clients/ocp/${ocp_full_version}/sha256sum.txt"
+    "https://mirror.openshift.com/pub/openshift-v4/${ARCH}/clients/ocp/${oc_mirror_version}/sha256sum.txt"
 grep "oc-mirror.tar.gz" sha256sum.txt | sha256sum -c - || {
     echo "ERROR: oc-mirror.tar.gz checksum verification failed"
     exit 1

--- a/ci-operator/step-registry/cucushift/upgrade/mirror-images/by-oc-mirror/cucushift-upgrade-mirror-images-by-oc-mirror-commands.sh
+++ b/ci-operator/step-registry/cucushift/upgrade/mirror-images/by-oc-mirror/cucushift-upgrade-mirror-images-by-oc-mirror-commands.sh
@@ -82,6 +82,24 @@ KUBECONFIG="" oc registry login
 
 run_command "which oc"
 run_command "oc version --client"
+
+# Download oc-mirror from mirror.openshift.com
+echo "Downloading oc-mirror from mirror.openshift.com"
+ARCH=$(uname -m)
+case ${ARCH} in
+    x86_64) ARCH="amd64" ;;
+    aarch64) ARCH="arm64" ;;
+esac
+
+oc_mirror_download_dir=$(mktemp -d)
+pushd "${oc_mirror_download_dir}"
+curl -L --retry 5 --connect-timeout 30 -o oc-mirror.tar.gz \
+    "https://mirror.openshift.com/pub/openshift-v4/${ARCH}/clients/ocp/latest/oc-mirror.tar.gz"
+tar -xzf oc-mirror.tar.gz
+chmod +x oc-mirror
+oc_mirror_bin="${oc_mirror_download_dir}/oc-mirror"
+popd
+
 oc_mirror_dir=$(mktemp -d)
 pushd "${oc_mirror_dir}"
 new_pull_secret="${oc_mirror_dir}/new_pull_secret"
@@ -90,7 +108,6 @@ new_pull_secret="${oc_mirror_dir}/new_pull_secret"
 registry_cred=$(head -n 1 "/var/run/vault/mirror-registry/registry_creds" | base64 -w 0)
 cat "${CLUSTER_PROFILE_DIR}/pull-secret" | python3 -c 'import json,sys;j=json.load(sys.stdin);a=j["auths"];a["'${MIRROR_REGISTRY_HOST}'"]={"auth":"'${registry_cred}'"};j["auths"]=a;print(json.dumps(j))' > "${new_pull_secret}"
 
-oc_mirror_bin="oc-mirror"
 run_command "'${oc_mirror_bin}' version --output=yaml"
 
 # set the imagesetconfigure

--- a/ci-operator/step-registry/cucushift/upgrade/mirror-images/by-oc-mirror/cucushift-upgrade-mirror-images-by-oc-mirror-commands.sh
+++ b/ci-operator/step-registry/cucushift/upgrade/mirror-images/by-oc-mirror/cucushift-upgrade-mirror-images-by-oc-mirror-commands.sh
@@ -88,15 +88,21 @@ ocp_full_version=$(oc adm release info --registry-config ${CLUSTER_PROFILE_DIR}/
 echo "Target OCP version: ${ocp_full_version}"
 
 # Determine which oc-mirror version to download
-# Nightly/CI builds aren't published to mirror.openshift.com, so use stable-X.Y channel for them
+# Nightly/CI/pre-release builds aren't published to mirror.openshift.com
 if [[ "${ocp_full_version}" =~ ^([0-9]+\.[0-9]+)\. ]]; then
     ocp_minor_version="${BASH_REMATCH[1]}"
-    if [[ "${ocp_full_version}" =~ (nightly|ci|rc) ]]; then
-        # For nightly/CI/RC builds, use stable-X.Y channel
-        oc_mirror_version="stable-${ocp_minor_version}"
-        echo "Using oc-mirror from stable-${ocp_minor_version} channel (target is nightly/CI build)"
+    if [[ "${ocp_full_version}" =~ (nightly|ci|rc|ec) ]]; then
+        # For nightly/CI/RC/EC builds, try stable-X.Y channel, fall back to latest if it doesn't exist
+        # Check if stable channel exists (released versions only)
+        if curl -sf --head "https://mirror.openshift.com/pub/openshift-v4/amd64/clients/ocp/stable-${ocp_minor_version}/" >/dev/null 2>&1; then
+            oc_mirror_version="stable-${ocp_minor_version}"
+            echo "Using oc-mirror from stable-${ocp_minor_version} channel (target is pre-release build)"
+        else
+            oc_mirror_version="latest"
+            echo "Using oc-mirror from latest channel (stable-${ocp_minor_version} not yet available)"
+        fi
     else
-        # For GA releases, use the exact version
+        # For what looks like GA releases, use exact version
         oc_mirror_version="${ocp_full_version}"
         echo "Using oc-mirror version ${ocp_full_version} (target is GA release)"
     fi

--- a/ci-operator/step-registry/cucushift/upgrade/mirror-images/by-oc-mirror/cucushift-upgrade-mirror-images-by-oc-mirror-commands.sh
+++ b/ci-operator/step-registry/cucushift/upgrade/mirror-images/by-oc-mirror/cucushift-upgrade-mirror-images-by-oc-mirror-commands.sh
@@ -87,6 +87,13 @@ run_command "oc version --client"
 ocp_full_version=$(oc adm release info --registry-config ${CLUSTER_PROFILE_DIR}/pull-secret ${OPENSHIFT_UPGRADE_RELEASE_IMAGE_OVERRIDE} -o jsonpath='{.metadata.version}')
 echo "Target OCP version: ${ocp_full_version}"
 
+# Detect architecture for oc-mirror download
+ARCH=$(uname -m)
+case ${ARCH} in
+    x86_64) ARCH="amd64" ;;
+    aarch64) ARCH="arm64" ;;
+esac
+
 # Determine which oc-mirror version to download
 # Nightly/CI/pre-release builds aren't published to mirror.openshift.com
 if [[ "${ocp_full_version}" =~ ^([0-9]+\.[0-9]+)\. ]]; then
@@ -94,7 +101,7 @@ if [[ "${ocp_full_version}" =~ ^([0-9]+\.[0-9]+)\. ]]; then
     if [[ "${ocp_full_version}" =~ (nightly|ci|rc|ec) ]]; then
         # For nightly/CI/RC/EC builds, try stable-X.Y channel, fall back to latest if it doesn't exist
         # Check if stable channel exists (released versions only)
-        if curl -sf --head "https://mirror.openshift.com/pub/openshift-v4/amd64/clients/ocp/stable-${ocp_minor_version}/" >/dev/null 2>&1; then
+        if curl -sf --head "https://mirror.openshift.com/pub/openshift-v4/${ARCH}/clients/ocp/stable-${ocp_minor_version}/" >/dev/null 2>&1; then
             oc_mirror_version="stable-${ocp_minor_version}"
             echo "Using oc-mirror from stable-${ocp_minor_version} channel (target is pre-release build)"
         else
@@ -113,11 +120,6 @@ else
 fi
 
 # Download oc-mirror from mirror.openshift.com
-ARCH=$(uname -m)
-case ${ARCH} in
-    x86_64) ARCH="amd64" ;;
-    aarch64) ARCH="arm64" ;;
-esac
 
 oc_mirror_download_dir=$(mktemp -d)
 pushd "${oc_mirror_download_dir}"

--- a/ci-operator/step-registry/cucushift/upgrade/mirror-images/by-oc-mirror/cucushift-upgrade-mirror-images-by-oc-mirror-ref.yaml
+++ b/ci-operator/step-registry/cucushift/upgrade/mirror-images/by-oc-mirror/cucushift-upgrade-mirror-images-by-oc-mirror-ref.yaml
@@ -1,6 +1,6 @@
 ref:
   as: cucushift-upgrade-mirror-images-by-oc-mirror
-  from: oc-mirror
+  from: cli
   cli: target
   grace_period: 10m
   commands: cucushift-upgrade-mirror-images-by-oc-mirror-commands.sh


### PR DESCRIPTION
## Summary
Update cucushift-upgrade-mirror-images-by-oc-mirror to download oc-mirror from mirror.openshift.com instead of using oc-mirror container from payload.

## Motivation
oc-mirror is moving to independent releases outside the OCP payload to enable faster iteration and single-version compatibility across multiple OCP versions.

## Changes
- Change from: oc-mirror to from: cli in ref.yaml
- Download oc-mirror binary from mirror.openshift.com
- Support both amd64 and arm64 architectures
- Use latest oc-mirror from mirror.openshift.com
  
## Testing
- Verified download URL is accessible
- Code follows existing pattern used by other tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR updates OpenShift CI in the openshift/release repository to change how the cucushift upgrade mirror-images step obtains oc-mirror: the cucushift-upgrade-mirror-images-by-oc-mirror step now downloads the oc-mirror CLI binary from mirror.openshift.com (selecting a release channel/version that matches the target payload when possible and matching the host CPU architecture) instead of using an oc-mirror container image bundled in the OCP payload.

Practical impact
- Affected CI step: ci-operator/step-registry/cucushift/upgrade/mirror-images/by-oc-mirror — used by cucushift upgrade mirror-image jobs in OpenShift CI.
- Runtime behavior changes:
  - The step extracts the full OCP version from OPENSHIFT_UPGRADE_RELEASE_IMAGE_OVERRIDE via oc adm release info (ocp_full_version) and computes ocp_version (major.minor) from that for signature/version logic.
  - It selects an oc-mirror release: for GA-like versions it uses the exact ocp_full_version; for nightly/CI/RC/EC builds it prefers stable-X.Y (if available on mirror.openshift.com) and falls back to latest.
  - It detects host CPU (x86_64→amd64, aarch64→arm64), downloads the matching oc-mirror.tar.gz and sha256sum from https://mirror.openshift.com/pub/openshift-v4/${ARCH}/clients/ocp/${oc_mirror_version}/, verifies the tarball checksum, extracts the oc-mirror binary, makes it executable, and sets oc_mirror_bin to that binary.
  - Existing workflows remain: ImageSetConfiguration generation, merging registry credentials into ${XDG_RUNTIME_DIR}/containers/auth.json, workspace/output and graph-data handling, execution of oc-mirror to produce idms/itms/updateService, and image signature verification (with conditional --ignore-release-signature for older/unsigned payloads) are preserved.
  - ref.yaml now uses cli: target (ref.from changed from "oc-mirror" to "cli") so the step pulls a CLI artifact rather than an oc-mirror image from the payload.

Changes
- ci-operator/step-registry/cucushift/upgrade/mirror-images/by-oc-mirror/cucushift-upgrade-mirror-images-by-oc-mirror-commands.sh:
  - Compute ocp_full_version once and derive ocp_version from it.
  - Add oc-mirror channel/version selection logic, architecture detection, download, checksum verification, extraction, and oc_mirror_bin setup.
  - Preserve existing registry auth handling, ImageSetConfiguration generation, signature verification logic, and downstream behavior.
- ci-operator/step-registry/cucushift/upgrade/mirror-images/by-oc-mirror/cucushift-upgrade-mirror-images-by-oc-mirror-ref.yaml:
  - Change ref.from/ref.cli to fetch CLI artifacts (from: cli) instead of relying on an oc-mirror payload image.

Rationale
- oc-mirror is being released independently of OCP payloads to enable faster iteration and maintain a single oc-mirror binary compatible across multiple OCP versions; this change aligns cucushift upgrade tests with that distribution model while keeping existing authentication and signature verification workflows intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->