### PR TITLE
CLID-618: Download oc-mirror from mirror.openshift.com in install mirror tests

### DIFF
--- a/ci-operator/step-registry/mirror-images/by-oc-mirror/mirror-images-by-oc-mirror-commands.sh
+++ b/ci-operator/step-registry/mirror-images/by-oc-mirror/mirror-images-by-oc-mirror-commands.sh
@@ -141,7 +141,23 @@ oc registry login --to "${new_pull_secret}"
 #    fi
 #done
 
-oc_mirror_bin="oc-mirror"
+# Download oc-mirror from mirror.openshift.com
+echo "Downloading oc-mirror from mirror.openshift.com"
+ARCH=$(uname -m)
+case ${ARCH} in
+    x86_64) ARCH="amd64" ;;
+    aarch64) ARCH="arm64" ;;
+esac
+
+oc_mirror_download_dir=$(mktemp -d)
+pushd "${oc_mirror_download_dir}"
+curl -L --retry 5 --connect-timeout 30 -o oc-mirror.tar.gz \
+    "https://mirror.openshift.com/pub/openshift-v4/${ARCH}/clients/ocp/latest/oc-mirror.tar.gz"
+tar -xzf oc-mirror.tar.gz
+chmod +x oc-mirror
+oc_mirror_bin="${oc_mirror_download_dir}/oc-mirror"
+popd
+
 run_command "'${oc_mirror_bin}' version --output=yaml"
 
 

--- a/ci-operator/step-registry/mirror-images/by-oc-mirror/mirror-images-by-oc-mirror-commands.sh
+++ b/ci-operator/step-registry/mirror-images/by-oc-mirror/mirror-images-by-oc-mirror-commands.sh
@@ -166,15 +166,15 @@ oc_mirror_download_dir=$(mktemp -d)
 pushd "${oc_mirror_download_dir}"
 echo "Downloading oc-mirror from https://mirror.openshift.com/pub/openshift-v4/${ARCH}/clients/ocp/${oc_mirror_version}/"
 # Download version-specific oc-mirror from mirror.openshift.com to match the payload version
-curl -L --retry 5 --connect-timeout 30 -o oc-mirror.tar.gz \
+curl -fL --retry 5 --connect-timeout 30 -o oc-mirror.tar.gz \
     "https://mirror.openshift.com/pub/openshift-v4/${ARCH}/clients/ocp/${oc_mirror_version}/oc-mirror.tar.gz"
 # When oc-mirror is removed from the OCP payload, replace the above curl command with this one to always use the latest version:
-# curl -L --retry 5 --connect-timeout 30 -o oc-mirror.tar.gz \
+# curl -fL --retry 5 --connect-timeout 30 -o oc-mirror.tar.gz \
 #     "https://mirror.openshift.com/pub/openshift-v4/${ARCH}/clients/ocp/latest/oc-mirror.tar.gz"
 
 # Verify the integrity of the downloaded tarball
 echo "Verifying oc-mirror.tar.gz integrity..."
-curl -L --retry 5 --connect-timeout 30 -o sha256sum.txt \
+curl -fL --retry 5 --connect-timeout 30 -o sha256sum.txt \
     "https://mirror.openshift.com/pub/openshift-v4/${ARCH}/clients/ocp/${oc_mirror_version}/sha256sum.txt"
 grep "oc-mirror.tar.gz" sha256sum.txt | sha256sum -c - || {
     echo "ERROR: oc-mirror.tar.gz checksum verification failed"

--- a/ci-operator/step-registry/mirror-images/by-oc-mirror/mirror-images-by-oc-mirror-ref.yaml
+++ b/ci-operator/step-registry/mirror-images/by-oc-mirror/mirror-images-by-oc-mirror-ref.yaml
@@ -1,6 +1,6 @@
 ref:
   as: mirror-images-by-oc-mirror
-  from: oc-mirror
+  from: cli
   cli: latest
   grace_period: 10m
   commands: mirror-images-by-oc-mirror-commands.sh


### PR DESCRIPTION
## Summary
Update mirror-images-by-oc-mirror to download oc-mirror from mirror.openshift.com instead of using oc-mirror container from payload.

## Motivation
oc-mirror is moving to independent releases outside the OCP payload to enable faster iteration and single-version compatibility across multiple OCP versions.

## Changes
- Change from: oc-mirror to from: cli in ref.yaml
- Download oc-mirror binary from mirror.openshift.com
- Support both amd64 and arm64 architectures
- Use latest oc-mirror from mirror.openshift.com

## Testing
- Verified download URL is accessible
- Code follows existing pattern used by other tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Updates OpenShift CI mirror-images-by-oc-mirror test to download oc-mirror at runtime

This PR changes openshift/release CI so the mirror-images-by-oc-mirror install-mirror test downloads an oc-mirror binary from mirror.openshift.com at runtime instead of using the oc-mirror container image bundled in OCP payloads.

Practical changes:
- Step image reference switched from the oc-mirror image to the cli image (ci-operator/step-registry/mirror-images/by-oc-mirror/mirror-images-by-oc-mirror-ref.yaml: from: oc-mirror → from: cli).
- The step script (ci-operator/step-registry/mirror-images/by-oc-mirror/mirror-images-by-oc-mirror-commands.sh) now:
  - Merges the cluster pull-secret with mirror registry credentials early to access mirror.openshift.com and read the target payload version.
  - Detects host architecture (maps uname to amd64/arm64) and downloads the matching oc-mirror binary.
  - Selects oc-mirror release to download:
    - GA payloads: use the exact OCP version.
    - Nightly/CI/RC/EC/pre-release-like payloads: probe a stable-X.Y channel with retries, falling back to latest.
    - Unexpected version formats fall back to latest.
  - Downloads oc-mirror.tar.gz and sha256sum.txt, verifies the tarball checksum, extracts and makes the binary executable, and sets oc_mirror_bin to the downloaded binary for subsequent commands.
  - Adds retry/connect-timeout behavior and uses curl --fail to surface HTTP errors.
  - Removes the previous hardcoded oc-mirror assignment so the downloaded binary is used; existing signing-check and --ignore-release-signature fallback remain unchanged.
- Supports both amd64 and arm64.

Why this matters:
oc-mirror will be released independently of OCP payloads to enable faster iteration and single-version compatibility across OCP versions; downloading oc-mirror at test runtime lets CI use an appropriate/newer oc-mirror release independent of the payload.

Testing and PR discussion:
- Author verified download URL accessibility and checksum verification and followed existing test patterns.
- The author ran many rehearsals; reviewers indicated rehearsal failures looked unrelated and suggested inspecting job artifacts for the mirror-images-by-oc-mirror step.
- openshift-ci-robot flagged the referenced Jira ([CLID-618](https://redhat.atlassian.net/browse/CLID-618)) as missing an expected target version for the target branch.

Commits:
- Main change: download oc-mirror at runtime instead of using the container image.
- Tweak: add --fail to curl invocations to detect HTTP failures immediately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[CLID-618]: https://redhat.atlassian.net/browse/CLID-618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ