### PR TITLE
Move hypershift-workload-credentials and insights-live secrets into GSM config

### DIFF
--- a/core-services/ci-secret-bootstrap/_config.yaml
+++ b/core-services/ci-secret-bootstrap/_config.yaml
@@ -3275,22 +3275,6 @@ secret_configs:
     name: clusterpool-manager-credentials
     namespace: ci
 - from:
-    kubeconfig:
-      field: sa.hypershift-workload.hosted-mgmt.config
-      item: build_farm
-    sa.hypershift-workload.hosted-mgmt.token.txt:
-      field: sa.hypershift-workload.hosted-mgmt.token.txt
-      item: build_farm
-  to:
-  - cluster_groups:
-    - build_farm
-    name: hypershift-workload-credentials
-    namespace: test-credentials
-  - cluster_groups:
-    - build_farm
-    name: hypershift-workload-credentials
-    namespace: ci
-- from:
     ci.htpasswd:
       field: ci.htpasswd
       item: boskos-oauth-proxy
@@ -4602,15 +4586,6 @@ secret_configs:
     name: registry-push-credentials-ci-images-mirror
     namespace: ci
     type: kubernetes.io/dockerconfigjson
-- from:
-    insights-live.yaml:
-      field: insights-live.yaml
-      item: insights-ci-account
-  to:
-  - cluster_groups:
-    - non_app_ci
-    name: insights-live
-    namespace: test-credentials
 - from:
     .dockerconfigjson:
       dockerconfigJSON:

--- a/core-services/ci-secret-bootstrap/gsm-config.yaml
+++ b/core-services/ci-secret-bootstrap/gsm-config.yaml
@@ -1673,3 +1673,29 @@ bundles:
     targets:
       - cluster: build01  # todo: change to cluster_groups: [non_app_ci]
         namespace: ci
+
+  - name: hypershift-workload-credentials
+    gsm_secrets:
+      - collection: test-platform-infra
+        group: build_farm
+        fields:
+          - name: sa--dot--hypershift-workload--dot--hosted-mgmt--dot--config
+            as: kubeconfig
+          - name: sa--dot--hypershift-workload--dot--hosted-mgmt--dot--token--dot--txt
+    sync_to_cluster: true
+    targets:
+      - cluster_groups: [build_farm]
+        namespace: test-credentials
+      - cluster_groups: [build_farm]
+        namespace: ci
+
+  - name: insights-live
+    gsm_secrets:
+      - collection: test-platform-infra
+        group: insights-ci-account
+        fields:
+          - name: insights-live--dot--yaml
+    sync_to_cluster: true
+    targets:
+      - cluster_groups: [non_app_ci]
+        namespace: test-credentials


### PR DESCRIPTION
These secrets have already been created in GSM, so no point keeping them in the old config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized secret bootstrap configurations to optimize credential placement and secure management across test and CI cluster environments
  * Introduced new configuration bundles for workload credential management and authentication across cluster infrastructure
  * Enhanced secret targeting and assignment for monitoring and insights data collection systems across multiple cluster deployments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->