### PR TITLE
secret-manager: add arm64 support and fix login on host

### DIFF
--- a/ci-operator/config/openshift/ci-tools-standalone/openshift-ci-tools-standalone-main.yaml
+++ b/ci-operator/config/openshift/ci-tools-standalone/openshift-ci-tools-standalone-main.yaml
@@ -109,7 +109,9 @@ images:
         - destination_dir: .
           source_path: /go/bin/retester
     to: retester
-  - dockerfile_literal: |-
+  - additional_architectures:
+    - arm64
+    dockerfile_literal: |-
       FROM ubi-python
       COPY . /workspace/
       WORKDIR /workspace/ci-tools-standalone/cmd/secret-manager

--- a/hack/secret-manager.sh
+++ b/hack/secret-manager.sh
@@ -15,12 +15,23 @@ if [ "${1:-}" = "clean" ]; then
 fi
 
 mkdir -p "$GCLOUD_CONFIG_PATH"
+
+if [ "${1:-}" = "login" ]; then
+    if ! command -v gcloud &>/dev/null; then
+        echo "Error: 'gcloud' is not installed. Install it with: brew install google-cloud-sdk" >&2
+        exit 1
+    fi
+    CLOUDSDK_CONFIG="$GCLOUD_CONFIG_PATH" exec gcloud auth application-default login --verbosity=error
+fi
+
 tty_flags=()
 if [ -t 0 ] && [ -t 1 ]; then
     tty_flags=(-it)
 fi
 
-"$CONTAINER_ENGINE" pull "$IMAGE" >/dev/null
+if ! "$CONTAINER_ENGINE" image exists "$IMAGE" 2>/dev/null; then
+    "$CONTAINER_ENGINE" pull "$IMAGE" >/dev/null
+fi
 exec "$CONTAINER_ENGINE" run --rm "${tty_flags[@]}" \
     -v "$GCLOUD_CONFIG_PATH:/gcloud:z" \
     -e CLOUDSDK_CONFIG=/gcloud \


### PR DESCRIPTION
## Summary
- Build the `secret-manager` container image for both amd64 and arm64 so it runs natively on Apple Silicon
- Handle the `login` subcommand on the host using the local `gcloud` CLI, since `gcloud` is not bundled in the container image
- Skip pulling when the image is already cached locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes to secret-manager CI infrastructure

This PR adds ARM64 (Apple Silicon) support for the secret-manager tool used in the OpenShift CI infrastructure and improves the local authentication workflow.

### Multi-architecture container image support
Added a new `secret-manager` container image to the CI operator configuration for `openshift-ci-tools-standalone`. The image is built as a multi-architecture image supporting both amd64 and arm64 architectures, enabling the secret-manager tool to run natively on ARM64 machines, particularly useful for developers using Apple Silicon Macs.

The image is constructed from the `ubi-python` base image and includes:
- The secret-manager Python source code from the ci-tools-standalone repository
- Python dependencies installed via pip
- Entrypoint configured to run the secret-manager's main Python script

### Improved local authentication handling
Modified the secret-manager wrapper script (`hack/secret-manager.sh`) to handle the `login` subcommand differently:
- The login operation now uses the locally installed `gcloud` CLI instead of relying on `gcloud` being available inside the container
- Introduces dedicated credential storage via a local gcloud configuration directory
- Validates that `gcloud` is installed on the host before attempting login, providing clear error messaging if missing

### Image caching optimization
Changed the container image pulling behavior to check if the image is already cached locally before attempting to pull. This reduces unnecessary network requests and improves performance for repeated executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->