### PR TITLE
OCM-22313 | fix: Change job link ordering to populate job_link envar

### DIFF
--- a/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__ocm-fvt-osd-gcp-staging.yaml
+++ b/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__ocm-fvt-osd-gcp-staging.yaml
@@ -26,18 +26,18 @@ tests:
   capabilities:
   - nested-podman
   commands: |
-    env -i bash --norc --noprofile << 'EOF' > /tmp/podman.env
-    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
-    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
-    export ENABLE_JIRA_REPORTING=true
     JOB_LINK="https://prow.ci.openshift.org/view/gs/test-platform-results/"
     if [ -n "${PULL_NUMBER:-}" ]; then
       JOB_LINK="${JOB_LINK}pr-logs/pull/openshift_release/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
     else
       JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
     fi
-    echo "JOB_LINK=${JOB_LINK}"
-    export JOB_LINK=${JOB_LINK}
+
+    env -i bash --norc --noprofile << EOF > /tmp/podman.env
+    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
+    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
+    export ENABLE_JIRA_REPORTING=true
+    export JOB_LINK="${JOB_LINK}"
     source /usr/local/cs-qe-credentials/ocm-tokens
     source /usr/local/cs-qe-credentials/jira-cred
     env | grep -v '^_='
@@ -64,18 +64,18 @@ tests:
   capabilities:
   - nested-podman
   commands: |
-    env -i bash --norc --noprofile << 'EOF' > /tmp/podman.env
-    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
-    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
-    export ENABLE_JIRA_REPORTING=true
     JOB_LINK="https://prow.ci.openshift.org/view/gs/test-platform-results/"
     if [ -n "${PULL_NUMBER:-}" ]; then
       JOB_LINK="${JOB_LINK}pr-logs/pull/openshift_release/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
     else
       JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
     fi
-    echo "JOB_LINK=${JOB_LINK}"
-    export JOB_LINK=${JOB_LINK}
+
+    env -i bash --norc --noprofile << EOF > /tmp/podman.env
+    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
+    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
+    export ENABLE_JIRA_REPORTING=true
+    export JOB_LINK="${JOB_LINK}"
     source /usr/local/cs-qe-credentials/ocm-tokens
     source /usr/local/cs-qe-credentials/jira-cred
     env | grep -v '^_='

--- a/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__ocm-fvt-rosa-classic-integration.yaml
+++ b/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__ocm-fvt-rosa-classic-integration.yaml
@@ -26,18 +26,18 @@ tests:
   capabilities:
   - nested-podman
   commands: |
-    env -i bash --norc --noprofile << 'EOF' > /tmp/podman.env
-    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
-    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
-    export ENABLE_JIRA_REPORTING=true
     JOB_LINK="https://prow.ci.openshift.org/view/gs/test-platform-results/"
     if [ -n "${PULL_NUMBER:-}" ]; then
       JOB_LINK="${JOB_LINK}pr-logs/pull/openshift_release/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
     else
       JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
     fi
-    echo "JOB_LINK=${JOB_LINK}"
-    export JOB_LINK=${JOB_LINK}
+
+    env -i bash --norc --noprofile << EOF > /tmp/podman.env
+    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
+    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
+    export ENABLE_JIRA_REPORTING=true
+    export JOB_LINK="${JOB_LINK}"
     source /usr/local/cs-qe-credentials/ocm-tokens
     source /usr/local/cs-qe-credentials/jira-cred
     env | grep -v '^_='

--- a/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__ocm-fvt-rosa-classic-staging.yaml
+++ b/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__ocm-fvt-rosa-classic-staging.yaml
@@ -26,18 +26,18 @@ tests:
   capabilities:
   - nested-podman
   commands: |
-    env -i bash --norc --noprofile << 'EOF' > /tmp/podman.env
-    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
-    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
-    export ENABLE_JIRA_REPORTING=true
     JOB_LINK="https://prow.ci.openshift.org/view/gs/test-platform-results/"
     if [ -n "${PULL_NUMBER:-}" ]; then
       JOB_LINK="${JOB_LINK}pr-logs/pull/openshift_release/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
     else
       JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
     fi
-    echo "JOB_LINK=${JOB_LINK}"
-    export JOB_LINK=${JOB_LINK}
+
+    env -i bash --norc --noprofile << EOF > /tmp/podman.env
+    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
+    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
+    export ENABLE_JIRA_REPORTING=true
+    export JOB_LINK="${JOB_LINK}"
     source /usr/local/cs-qe-credentials/ocm-tokens
     source /usr/local/cs-qe-credentials/jira-cred
     env | grep -v '^_='
@@ -63,18 +63,18 @@ tests:
   capabilities:
   - nested-podman
   commands: |
-    env -i bash --norc --noprofile << 'EOF' > /tmp/podman.env
-    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
-    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
-    export ENABLE_JIRA_REPORTING=true
     JOB_LINK="https://prow.ci.openshift.org/view/gs/test-platform-results/"
     if [ -n "${PULL_NUMBER:-}" ]; then
       JOB_LINK="${JOB_LINK}pr-logs/pull/openshift_release/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
     else
       JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
     fi
-    echo "JOB_LINK=${JOB_LINK}"
-    export JOB_LINK=${JOB_LINK}
+
+    env -i bash --norc --noprofile << EOF > /tmp/podman.env
+    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
+    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
+    export ENABLE_JIRA_REPORTING=true
+    export JOB_LINK="${JOB_LINK}"
     source /usr/local/cs-qe-credentials/ocm-tokens
     source /usr/local/cs-qe-credentials/jira-cred
     env | grep -v '^_='
@@ -100,18 +100,18 @@ tests:
   capabilities:
   - nested-podman
   commands: |
-    env -i bash --norc --noprofile << 'EOF' > /tmp/podman.env
-    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
-    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
-    export ENABLE_JIRA_REPORTING=true
     JOB_LINK="https://prow.ci.openshift.org/view/gs/test-platform-results/"
     if [ -n "${PULL_NUMBER:-}" ]; then
       JOB_LINK="${JOB_LINK}pr-logs/pull/openshift_release/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
     else
       JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
     fi
-    echo "JOB_LINK=${JOB_LINK}"
-    export JOB_LINK=${JOB_LINK}
+
+    env -i bash --norc --noprofile << EOF > /tmp/podman.env
+    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
+    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
+    export ENABLE_JIRA_REPORTING=true
+    export JOB_LINK="${JOB_LINK}"
     source /usr/local/cs-qe-credentials/ocm-tokens
     source /usr/local/cs-qe-credentials/jira-cred
     env | grep -v '^_='
@@ -137,21 +137,21 @@ tests:
   capabilities:
   - nested-podman
   commands: |
-    podman_env_file="$(mktemp /tmp/podman.env.XXXXXX)"
-    trap 'rm -f "${podman_env_file}"' EXIT
-    umask 077
-    env -i bash --norc --noprofile << 'EOF' > "${podman_env_file}"
-    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
-    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
-    export ENABLE_JIRA_REPORTING=true
     JOB_LINK="https://prow.ci.openshift.org/view/gs/test-platform-results/"
     if [ -n "${PULL_NUMBER:-}" ]; then
       JOB_LINK="${JOB_LINK}pr-logs/pull/openshift_release/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
     else
       JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
     fi
-    echo "JOB_LINK=${JOB_LINK}"
-    export JOB_LINK=${JOB_LINK}
+
+    podman_env_file="$(mktemp /tmp/podman.env.XXXXXX)"
+    trap 'rm -f "${podman_env_file}"' EXIT
+    umask 077
+    env -i bash --norc --noprofile << EOF > "${podman_env_file}"
+    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
+    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
+    export ENABLE_JIRA_REPORTING=true
+    export JOB_LINK="${JOB_LINK}"
     source /usr/local/cs-qe-credentials/ocm-tokens
     source /usr/local/cs-qe-credentials/jira-cred
     env | grep -v '^_='
@@ -177,21 +177,21 @@ tests:
   capabilities:
   - nested-podman
   commands: |
-    podman_env_file="$(mktemp /tmp/podman.env.XXXXXX)"
-    trap 'rm -f "${podman_env_file}"' EXIT
-    umask 077
-    env -i bash --norc --noprofile << 'EOF' > "${podman_env_file}"
-    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
-    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
-    export ENABLE_JIRA_REPORTING=true
     JOB_LINK="https://prow.ci.openshift.org/view/gs/test-platform-results/"
     if [ -n "${PULL_NUMBER:-}" ]; then
       JOB_LINK="${JOB_LINK}pr-logs/pull/openshift_release/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
     else
       JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
     fi
-    echo "JOB_LINK=${JOB_LINK}"
-    export JOB_LINK=${JOB_LINK}
+
+    podman_env_file="$(mktemp /tmp/podman.env.XXXXXX)"
+    trap 'rm -f "${podman_env_file}"' EXIT
+    umask 077
+    env -i bash --norc --noprofile << EOF > "${podman_env_file}"
+    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
+    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
+    export ENABLE_JIRA_REPORTING=true
+    export JOB_LINK="${JOB_LINK}"
     source /usr/local/cs-qe-credentials/ocm-tokens
     source /usr/local/cs-qe-credentials/jira-cred
     env | grep -v '^_='
@@ -217,18 +217,18 @@ tests:
   capabilities:
   - nested-podman
   commands: |
-    env -i bash --norc --noprofile << 'EOF' > /tmp/podman.env
-    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
-    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
-    export ENABLE_JIRA_REPORTING=true
     JOB_LINK="https://prow.ci.openshift.org/view/gs/test-platform-results/"
     if [ -n "${PULL_NUMBER:-}" ]; then
       JOB_LINK="${JOB_LINK}pr-logs/pull/openshift_release/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
     else
       JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
     fi
-    echo "JOB_LINK=${JOB_LINK}"
-    export JOB_LINK=${JOB_LINK}
+
+    env -i bash --norc --noprofile << EOF > /tmp/podman.env
+    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
+    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
+    export ENABLE_JIRA_REPORTING=true
+    export JOB_LINK="${JOB_LINK}"
     source /usr/local/cs-qe-credentials/ocm-tokens
     source /usr/local/cs-qe-credentials/jira-cred
     env | grep -v '^_='
@@ -254,21 +254,21 @@ tests:
   capabilities:
   - nested-podman
   commands: |
-    podman_env_file="$(mktemp /tmp/podman.env.XXXXXX)"
-    trap 'rm -f "${podman_env_file}"' EXIT
-    umask 077
-    env -i bash --norc --noprofile << 'EOF' > "${podman_env_file}"
-    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
-    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
-    export ENABLE_JIRA_REPORTING=true
     JOB_LINK="https://prow.ci.openshift.org/view/gs/test-platform-results/"
     if [ -n "${PULL_NUMBER:-}" ]; then
       JOB_LINK="${JOB_LINK}pr-logs/pull/openshift_release/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
     else
       JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
     fi
-    echo "JOB_LINK=${JOB_LINK}"
-    export JOB_LINK=${JOB_LINK}
+
+    podman_env_file="$(mktemp /tmp/podman.env.XXXXXX)"
+    trap 'rm -f "${podman_env_file}"' EXIT
+    umask 077
+    env -i bash --norc --noprofile << EOF > "${podman_env_file}"
+    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
+    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
+    export ENABLE_JIRA_REPORTING=true
+    export JOB_LINK="${JOB_LINK}"
     source /usr/local/cs-qe-credentials/ocm-tokens
     source /usr/local/cs-qe-credentials/jira-cred
     env | grep -v '^_='

--- a/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__ocm-fvt-rosa-hcp-staging.yaml
+++ b/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__ocm-fvt-rosa-hcp-staging.yaml
@@ -26,18 +26,18 @@ tests:
   capabilities:
   - nested-podman
   commands: |
-    env -i bash --norc --noprofile << 'EOF' > /tmp/podman.env
-    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
-    export AWS_SHARED_VPC_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
-    export ENABLE_JIRA_REPORTING=true
     JOB_LINK="https://prow.ci.openshift.org/view/gs/test-platform-results/"
     if [ -n "${PULL_NUMBER:-}" ]; then
       JOB_LINK="${JOB_LINK}pr-logs/pull/openshift_release/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
     else
       JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
     fi
-    echo "JOB_LINK=${JOB_LINK}"
-    export JOB_LINK=${JOB_LINK}
+
+    env -i bash --norc --noprofile << EOF > /tmp/podman.env
+    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
+    export AWS_SHARED_VPC_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
+    export ENABLE_JIRA_REPORTING=true
+    export JOB_LINK="${JOB_LINK}"
     source /usr/local/cs-qe-credentials/ocm-tokens
     source /usr/local/cs-qe-credentials/jira-cred
     env | grep -v '^_='
@@ -63,18 +63,18 @@ tests:
   capabilities:
   - nested-podman
   commands: |
-    env -i bash --norc --noprofile << 'EOF' > /tmp/podman.env
-    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
-    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
-    export ENABLE_JIRA_REPORTING=true
     JOB_LINK="https://prow.ci.openshift.org/view/gs/test-platform-results/"
     if [ -n "${PULL_NUMBER:-}" ]; then
       JOB_LINK="${JOB_LINK}pr-logs/pull/openshift_release/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
     else
       JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
     fi
-    echo "JOB_LINK=${JOB_LINK}"
-    export JOB_LINK=${JOB_LINK}
+
+    env -i bash --norc --noprofile << EOF > /tmp/podman.env
+    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
+    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
+    export ENABLE_JIRA_REPORTING=true
+    export JOB_LINK="${JOB_LINK}"
     source /usr/local/cs-qe-credentials/ocm-tokens
     source /usr/local/cs-qe-credentials/jira-cred
     env | grep -v '^_='
@@ -100,18 +100,18 @@ tests:
   capabilities:
   - nested-podman
   commands: |
-    env -i bash --norc --noprofile << 'EOF' > /tmp/podman.env
-    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
-    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
-    export ENABLE_JIRA_REPORTING=true
     JOB_LINK="https://prow.ci.openshift.org/view/gs/test-platform-results/"
     if [ -n "${PULL_NUMBER:-}" ]; then
       JOB_LINK="${JOB_LINK}pr-logs/pull/openshift_release/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
     else
       JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
     fi
-    echo "JOB_LINK=${JOB_LINK}"
-    export JOB_LINK=${JOB_LINK}
+
+    env -i bash --norc --noprofile << EOF > /tmp/podman.env
+    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
+    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
+    export ENABLE_JIRA_REPORTING=true
+    export JOB_LINK="${JOB_LINK}"
     source /usr/local/cs-qe-credentials/ocm-tokens
     source /usr/local/cs-qe-credentials/jira-cred
     env | grep -v '^_='
@@ -137,18 +137,18 @@ tests:
   capabilities:
   - nested-podman
   commands: |
-    env -i bash --norc --noprofile << 'EOF' > /tmp/podman.env
-    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
-    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
-    export ENABLE_JIRA_REPORTING=true
     JOB_LINK="https://prow.ci.openshift.org/view/gs/test-platform-results/"
     if [ -n "${PULL_NUMBER:-}" ]; then
       JOB_LINK="${JOB_LINK}pr-logs/pull/openshift_release/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
     else
       JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
     fi
-    echo "JOB_LINK=${JOB_LINK}"
-    export JOB_LINK=${JOB_LINK}
+
+    env -i bash --norc --noprofile << EOF > /tmp/podman.env
+    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
+    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
+    export ENABLE_JIRA_REPORTING=true
+    export JOB_LINK="${JOB_LINK}"
     source /usr/local/cs-qe-credentials/ocm-tokens
     source /usr/local/cs-qe-credentials/jira-cred
     env | grep -v '^_='
@@ -174,18 +174,18 @@ tests:
   capabilities:
   - nested-podman
   commands: |
-    env -i bash --norc --noprofile << 'EOF' > /tmp/podman.env
-    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
-    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
-    export ENABLE_JIRA_REPORTING=true
     JOB_LINK="https://prow.ci.openshift.org/view/gs/test-platform-results/"
     if [ -n "${PULL_NUMBER:-}" ]; then
       JOB_LINK="${JOB_LINK}pr-logs/pull/openshift_release/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
     else
       JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
     fi
-    echo "JOB_LINK=${JOB_LINK}"
-    export JOB_LINK=${JOB_LINK}
+
+    env -i bash --norc --noprofile << EOF > /tmp/podman.env
+    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
+    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
+    export ENABLE_JIRA_REPORTING=true
+    export JOB_LINK="${JOB_LINK}"
     source /usr/local/cs-qe-credentials/ocm-tokens
     source /usr/local/cs-qe-credentials/jira-cred
     env | grep -v '^_='


### PR DESCRIPTION
The joblink was being wiped out by being in the wrong order of execution. This will allow it to be populated and consumed by ocmtest to generate the right link to the prow job.