### PR TITLE
Add new pause image for k8s 1.36

### DIFF
--- a/ci-operator/step-registry/baremetalds/e2e/test/baremetalds-e2e-test-commands.sh
+++ b/ci-operator/step-registry/baremetalds/e2e/test/baremetalds-e2e-test-commands.sh
@@ -57,6 +57,8 @@ declare -a MIRRORED_IMAGES=(
   "registry.k8s.io/pause:3.10.1 $DEVSCRIPTS_TEST_IMAGE_REPO:e2e-25-registry-k8s-io-pause-3-10-1-a6__nK-VRxiifU0Z"
   # new image coming in k8s 1.35
   "registry.k8s.io/pause:3.10.1 $DEVSCRIPTS_TEST_IMAGE_REPO:e2e-22-registry-k8s-io-pause-3-10-1-a6__nK-VRxiifU0Z"
+  # new image coming in k8s 1.36
+  "registry.k8s.io/pause:3.10.2 $DEVSCRIPTS_TEST_IMAGE_REPO:e2e-22-registry-k8s-io-pause-3-10-2-Xnr_kb1i4Z5Tu7vt"
   # new image coming in k8s 1.29.11. This should be removed once k8s is bumped in openshift/origin too (or https://issues.redhat.com/browse/TRT-1942 is fixed)
   "registry.k8s.io/etcd:3.5.16-0 $DEVSCRIPTS_TEST_IMAGE_REPO:e2e-11-registry-k8s-io-etcd-3-5-16-0-ExW1ETJqOZa6gx2F"
   # new image coming in k8s 1.30.5. This should be removed once k8s is bumped in openshift/origin too (or https://issues.redhat.com/browse/TRT-1942 is fixed)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR adds support for a new pause container image in the baremetal e2e test infrastructure. Specifically, it updates the `baremetalds-e2e-test-commands.sh` script used by OpenShift CI to mirror container images needed for testing.

The change adds an entry for `registry.k8s.io/pause:3.10.2` to the `MIRRORED_IMAGES` array, which is the pause image that will be included in Kubernetes 1.36. This ensures that when baremetal e2e tests run against Kubernetes 1.36 environments, the correct pause image is available for mirroring to the test cluster.

The pause image is a minimal container used by Kubernetes as the parent for pods, and adding this entry ensures compatibility testing for the upcoming Kubernetes release without requiring manual updates when the test infrastructure encounters this new image version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->