### PR TITLE
Add boilerplate image-v8.3.6 to Prow mirroring

### DIFF
--- a/core-services/image-mirroring/_config.yaml
+++ b/core-services/image-mirroring/_config.yaml
@@ -27,6 +27,8 @@ supplementalCIImages:
     image: quay.io/redhat-services-prod/openshift/boilerplate:image-v8.3.4
   openshift/boilerplate:image-v8.3.5:
     image: quay.io/redhat-services-prod/openshift/boilerplate:image-v8.3.5
+  openshift/boilerplate:image-v8.3.6:
+    image: quay.io/redhat-services-prod/openshift/boilerplate:image-v8.3.6
   azure/plugin-base:latest:
     image: registry.access.redhat.com/rhel7:latest
   chaos/krkn:latest:


### PR DESCRIPTION
**What type of PR is this?**

/kind misc

**What this PR does / why we need it:**

Adds `boilerplate:image-v8.3.6` to supplementalCIImages for Prow mirroring.

This image includes:
- UBI9:9.7-1778044007 with Go 1.25.9
- Fixes for critical stdlib CVEs (CVE-2026-27143 and 11 others)

**Which issue(s) this PR fixes:**

Required for downstream projects (aws-account-operator and others) to pass CI coverage tests after upgrading to Go 1.25.9 for security fixes.

Without this mirroring, coverage tests fail with:
```
compile: version "go1.25.9" does not match go tool version "go1.25.7 (Red Hat 1.25.7-1.el9_7)"
```

**Related:**
- https://github.com/openshift/boilerplate/pull/727 (UBI9 update)
- https://github.com/openshift/aws-account-operator/pull/979 (downstream security fixes)
- Konflux release: image-v8.3.6 (completed successfully)

**Special notes for your reviewer:**

Please review with #forum-ocp-testplatform team.

The image has been built and released through Konflux and is available at:
`quay.io/redhat-services-prod/openshift/boilerplate:image-v8.3.6`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR updates the OpenShift CI infrastructure's image mirroring configuration to register the `boilerplate:image-v8.3.6` image as a supplemental CI image for Prow.

**What changed:**
Added the `openshift/boilerplate:image-v8.3.6` image entry to `core-services/image-mirroring/_config.yaml`, making it available as a mirrored supplemental image for CI jobs. The image is hosted at `quay.io/redhat-services-prod/openshift/boilerplate:image-v8.3.6`.

**Why it matters:**
This image enables downstream projects (such as aws-account-operator) to run their CI tests with Go 1.25.9, which includes critical standard library CVE fixes. Without this change, projects that upgrade to Go 1.25.9 experience compilation failures in coverage tests due to Go version mismatches between the build environment and the test execution environment. By registering this image in the mirroring configuration, downstream projects can now reliably provision CI environments that match their required Go version, unblocking their CI coverage test execution.

**Affected infrastructure:**
Prow CI job image mirroring for OpenShift projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->