### PR TITLE
Ovn techpreview serial timeouts 2

### DIFF
--- a/ci-operator/config/openshift/release/openshift-release-main__ci-4.22.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__ci-4.22.yaml
@@ -130,6 +130,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-aws-ovn-serial
+  timeout: 5h0m0s
 - as: e2e-aws-ovn-techpreview-serial
   interval: 168h
   shard_count: 3
@@ -141,6 +142,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-aws-ovn-serial
+  timeout: 5h0m0s
 - as: e2e-aws-ovn-rhcos10-techpreview-serial
   interval: 12h
   shard_count: 3
@@ -154,6 +156,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-aws-ovn-serial
+  timeout: 5h0m0s
 - as: e2e-aws-ovn-upgrade
   interval: 168h
   steps:

--- a/ci-operator/config/openshift/release/openshift-release-main__ci-4.23.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__ci-4.23.yaml
@@ -102,6 +102,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-aws-ovn-serial
+  timeout: 5h0m0s
 - as: e2e-aws-ovn-techpreview-serial
   interval: 168h
   shard_count: 3
@@ -113,6 +114,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-aws-ovn-serial
+  timeout: 5h0m0s
 - as: e2e-aws-ovn-rhcos10-techpreview-serial
   interval: 168h
   shard_count: 3
@@ -126,6 +128,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-aws-ovn-serial
+  timeout: 5h0m0s
 - as: e2e-aws-ovn-upgrade
   interval: 168h
   steps:

--- a/ci-operator/config/openshift/release/openshift-release-main__ci-5.0.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__ci-5.0.yaml
@@ -125,6 +125,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-aws-ovn-serial
+  timeout: 5h0m0s
 - as: e2e-aws-ovn-techpreview-serial
   interval: 168h
   shard_count: 3
@@ -136,6 +137,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-aws-ovn-serial
+  timeout: 5h0m0s
 - as: e2e-aws-ovn-rhcos9-techpreview-serial
   interval: 12h
   shard_count: 3
@@ -148,6 +150,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-aws-ovn-serial
+  timeout: 5h0m0s
 - as: e2e-aws-ovn-rhcos9-10-techpreview-serial
   interval: 12h
   shard_count: 3
@@ -161,6 +164,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-aws-ovn-serial
+  timeout: 5h0m0s
 - as: e2e-aws-ovn-rhcos10-techpreview-serial
   interval: 168h
   shard_count: 3
@@ -174,6 +178,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-aws-ovn-serial
+  timeout: 5h0m0s
 - as: e2e-aws-ovn-upgrade
   interval: 168h
   steps:
@@ -248,6 +253,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-azure-serial
+  timeout: 5h0m0s
 - as: e2e-azure-ovn-serial-rhcos9-10-techpreview
   interval: 12h
   steps:
@@ -260,6 +266,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-azure-serial
+  timeout: 5h0m0s
 - as: e2e-azure-ovn-techpreview-serial
   interval: 168h
   steps:

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22.yaml
@@ -175,6 +175,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-aws-single-node
+  timeout: 5h0m0s
 - as: e2e-aws-ccm-techpreview
   interval: 168h
   steps:
@@ -201,6 +202,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-aws-single-node
+  timeout: 5h0m0s
 - as: e2e-aws-ovn-single-node-rhcos10-techpreview-serial
   interval: 12h
   steps:
@@ -214,6 +216,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-aws-single-node
+  timeout: 5h0m0s
 - as: e2e-metal-ovn-single-node-live-iso
   interval: 168h
   steps:
@@ -258,6 +261,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: baremetalds-e2e-serial-ovn-ipv6-runc
+  timeout: 5h0m0s
 - as: e2e-metal-ipi-ovn-serial-ipv4
   capabilities:
   - intranet
@@ -285,6 +289,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: baremetalds-e2e-serial-ovn-ipv4
+  timeout: 5h0m0s
 - as: e2e-metal-ipi-serial-ovn-ipv6
   capabilities:
   - intranet
@@ -316,6 +321,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: baremetalds-e2e-serial-ovn-dualstack
+  timeout: 5h0m0s
 - as: e2e-metal-ipi-ovn-upgrade
   capabilities:
   - intranet
@@ -400,6 +406,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: baremetalds-e2e-serial-ovn-ipv6
+  timeout: 5h0m0s
 - as: e2e-metal-ipi-ovn-ipv6-runc-techpreview
   capabilities:
   - intranet
@@ -461,6 +468,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: baremetalds-e2e-serial-ovn-dualstack
+  timeout: 5h0m0s
 - as: e2e-metal-ipi-ovn-ipv6
   capabilities:
   - intranet
@@ -1030,6 +1038,7 @@ tests:
       TEST_SKIPS: provisioning should mount multiple PV pointing to the same storage
         on the same node
     workflow: openshift-e2e-vsphere-upi-serial
+  timeout: 5h0m0s
 - as: e2e-vsphere-csi-operator-test
   cron: 52 15 * * *
   steps:
@@ -1139,6 +1148,7 @@ tests:
         Operators low level operators
       TEST_SUITE: openshift/conformance/serial
     workflow: openshift-e2e-vsphere-hybrid-env
+  timeout: 5h0m0s
 - as: e2e-vsphere-ovn-upi-hybrid-env-techpreview
   cron: 55 7 * * *
   steps:
@@ -1273,6 +1283,7 @@ tests:
     - chain: ipi-aws-pre
     - ref: fips-check
     workflow: openshift-e2e-aws
+  timeout: 5h0m0s
 - as: console-aws
   interval: 168h
   steps:
@@ -1318,6 +1329,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-aws-ovn-serial
+  timeout: 5h0m0s
 - as: e2e-aws-ovn-tls-13
   interval: 168h
   steps:
@@ -1644,6 +1656,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-gcp-ovn-serial
+  timeout: 5h0m0s
 - as: e2e-aws-ovn-etcd-scaling
   interval: 168h
   steps:
@@ -2308,6 +2321,7 @@ tests:
       TEST_SKIPS: provisioning should mount multiple PV pointing to the same storage
         on the same node
     workflow: openshift-e2e-vsphere-serial-runc
+  timeout: 5h0m0s
 - as: e2e-azure-ovn-serial-runc
   cron: '@daily'
   steps:
@@ -2316,6 +2330,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-azure-serial-runc
+  timeout: 5h0m0s
 - as: e2e-gcp-ovn-serial-runc
   cron: '@daily'
   steps:
@@ -2324,6 +2339,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-gcp-serial-runc
+  timeout: 5h0m0s
 - as: e2e-aws-serial-runc
   cron: '@daily'
   steps:
@@ -2431,6 +2447,7 @@ tests:
     env:
       EXTRA_MG_ARGS: --host-network
     workflow: openshift-e2e-aws-ovn-serial-ipsec
+  timeout: 5h0m0s
 - as: e2e-short-cert-rotation
   cron: 0 8 * * Sun
   steps:

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.23.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.23.yaml
@@ -175,6 +175,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-aws-single-node
+  timeout: 5h0m0s
 - as: e2e-aws-ccm-techpreview
   interval: 168h
   steps:
@@ -201,6 +202,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-aws-single-node
+  timeout: 5h0m0s
 - as: e2e-aws-ovn-single-node-rhcos10-techpreview-serial
   interval: 168h
   steps:
@@ -214,6 +216,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-aws-single-node
+  timeout: 5h0m0s
 - as: e2e-metal-ovn-single-node-live-iso
   interval: 168h
   steps:
@@ -258,6 +261,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: baremetalds-e2e-serial-ovn-ipv6-runc
+  timeout: 5h0m0s
 - as: e2e-metal-ipi-ovn-serial-ipv4
   capabilities:
   - intranet
@@ -285,6 +289,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: baremetalds-e2e-serial-ovn-ipv4
+  timeout: 5h0m0s
 - as: e2e-metal-ipi-serial-ovn-ipv6
   capabilities:
   - intranet
@@ -316,6 +321,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: baremetalds-e2e-serial-ovn-dualstack
+  timeout: 5h0m0s
 - as: e2e-metal-ipi-ovn-upgrade
   capabilities:
   - intranet
@@ -400,6 +406,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: baremetalds-e2e-serial-ovn-ipv6
+  timeout: 5h0m0s
 - as: e2e-metal-ipi-ovn-ipv6-runc-techpreview
   capabilities:
   - intranet
@@ -461,6 +468,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: baremetalds-e2e-serial-ovn-dualstack
+  timeout: 5h0m0s
 - as: e2e-metal-ipi-ovn-ipv6
   capabilities:
   - intranet
@@ -993,6 +1001,7 @@ tests:
       TEST_SKIPS: provisioning should mount multiple PV pointing to the same storage
         on the same node
     workflow: openshift-e2e-vsphere-upi-serial
+  timeout: 5h0m0s
 - as: e2e-vsphere-csi-operator-test
   cron: 52 15 * * *
   steps:
@@ -1102,6 +1111,7 @@ tests:
         Operators low level operators
       TEST_SUITE: openshift/conformance/serial
     workflow: openshift-e2e-vsphere-hybrid-env
+  timeout: 5h0m0s
 - as: e2e-vsphere-ovn-upi-hybrid-env-techpreview
   cron: 40 18 * * 1
   steps:
@@ -1236,6 +1246,7 @@ tests:
     - chain: ipi-aws-pre
     - ref: fips-check
     workflow: openshift-e2e-aws
+  timeout: 5h0m0s
 - as: console-aws
   interval: 168h
   steps:
@@ -1280,6 +1291,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-aws-ovn-serial
+  timeout: 5h0m0s
 - as: e2e-aws-ovn-tls-13
   interval: 168h
   steps:
@@ -1606,6 +1618,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-gcp-ovn-serial
+  timeout: 5h0m0s
 - as: e2e-aws-ovn-etcd-scaling
   interval: 168h
   steps:
@@ -2268,6 +2281,7 @@ tests:
       TEST_SKIPS: provisioning should mount multiple PV pointing to the same storage
         on the same node
     workflow: openshift-e2e-vsphere-serial-runc
+  timeout: 5h0m0s
 - as: e2e-azure-ovn-serial-runc
   cron: '@daily'
   steps:
@@ -2276,6 +2290,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-azure-serial-runc
+  timeout: 5h0m0s
 - as: e2e-gcp-ovn-serial-runc
   cron: '@daily'
   steps:
@@ -2284,6 +2299,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-gcp-serial-runc
+  timeout: 5h0m0s
 - as: e2e-aws-serial-runc
   cron: '@daily'
   steps:
@@ -2391,6 +2407,7 @@ tests:
     env:
       EXTRA_MG_ARGS: --host-network
     workflow: openshift-e2e-aws-ovn-serial-ipsec
+  timeout: 5h0m0s
 - as: e2e-short-cert-rotation
   cron: 0 8 * * Sun
   steps:

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
@@ -175,6 +175,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-aws-single-node
+  timeout: 5h0m0s
 - as: e2e-aws-ccm-techpreview
   interval: 168h
   steps:
@@ -201,6 +202,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-aws-single-node
+  timeout: 5h0m0s
 - as: e2e-aws-ovn-single-node-rhcos10-techpreview-serial
   interval: 168h
   steps:
@@ -214,6 +216,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-aws-single-node
+  timeout: 5h0m0s
 - as: e2e-metal-ovn-single-node-live-iso
   interval: 168h
   steps:
@@ -258,6 +261,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: baremetalds-e2e-serial-ovn-ipv6-runc
+  timeout: 5h0m0s
 - as: e2e-metal-ipi-ovn-serial-ipv4
   capabilities:
   - intranet
@@ -285,6 +289,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: baremetalds-e2e-serial-ovn-ipv4
+  timeout: 5h0m0s
 - as: e2e-metal-ipi-serial-ovn-ipv6
   capabilities:
   - intranet
@@ -316,6 +321,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: baremetalds-e2e-serial-ovn-dualstack
+  timeout: 5h0m0s
 - as: e2e-metal-ipi-ovn-upgrade
   capabilities:
   - intranet
@@ -431,6 +437,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: baremetalds-e2e-serial-ovn-ipv6
+  timeout: 5h0m0s
 - as: e2e-metal-ipi-ovn-ipv6-runc-techpreview
   capabilities:
   - intranet
@@ -492,6 +499,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: baremetalds-e2e-serial-ovn-dualstack
+  timeout: 5h0m0s
 - as: e2e-metal-ipi-ovn-ipv6
   capabilities:
   - intranet
@@ -1083,6 +1091,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-vsphere-serial
+  timeout: 5h0m0s
 - as: e2e-vsphere-ovn-techpreview-serial
   cron: 40,55 2,9,10 * * *
   steps:
@@ -1102,6 +1111,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-vsphere-serial
+  timeout: 5h0m0s
 - as: e2e-vsphere-ovn-rhcos10-techpreview-serial
   cron: 3 4 * * 4
   steps:
@@ -1136,6 +1146,7 @@ tests:
       TEST_SKIPS: provisioning should mount multiple PV pointing to the same storage
         on the same node
     workflow: openshift-e2e-vsphere-upi-serial
+  timeout: 5h0m0s
 - as: e2e-vsphere-csi-operator-test
   cron: 18 3 * * *
   steps:
@@ -1245,6 +1256,7 @@ tests:
         Operators low level operators
       TEST_SUITE: openshift/conformance/serial
     workflow: openshift-e2e-vsphere-hybrid-env
+  timeout: 5h0m0s
 - as: e2e-vsphere-ovn-upi-hybrid-env-techpreview
   cron: 50 1 * * *
   steps:
@@ -1416,6 +1428,7 @@ tests:
     - chain: ipi-aws-pre
     - ref: fips-check
     workflow: openshift-e2e-aws
+  timeout: 5h0m0s
 - as: console-aws
   interval: 168h
   steps:
@@ -1460,6 +1473,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-aws-ovn-serial
+  timeout: 5h0m0s
 - as: e2e-aws-ovn-serial-rhcos9-techpreview
   interval: 12h
   shard_count: 2
@@ -1472,6 +1486,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-aws-ovn-serial
+  timeout: 5h0m0s
 - as: e2e-aws-ovn-serial-rhcos9-10-techpreview
   interval: 12h
   shard_count: 2
@@ -1485,6 +1500,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-aws-ovn-serial
+  timeout: 5h0m0s
 - as: e2e-aws-ovn-tls-13
   interval: 168h
   steps:
@@ -1811,6 +1827,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-gcp-ovn-serial
+  timeout: 5h0m0s
 - as: e2e-aws-ovn-etcd-scaling
   interval: 168h
   steps:
@@ -2460,6 +2477,7 @@ tests:
       TEST_SKIPS: provisioning should mount multiple PV pointing to the same storage
         on the same node
     workflow: openshift-e2e-vsphere-serial-runc
+  timeout: 5h0m0s
 - as: e2e-azure-ovn-serial-runc
   cron: '@daily'
   steps:
@@ -2468,6 +2486,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-azure-serial-runc
+  timeout: 5h0m0s
 - as: e2e-gcp-ovn-serial-runc
   cron: '@daily'
   steps:
@@ -2476,6 +2495,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-gcp-serial-runc
+  timeout: 5h0m0s
 - as: e2e-aws-serial-runc
   cron: '@daily'
   steps:
@@ -2575,6 +2595,7 @@ tests:
     env:
       EXTRA_MG_ARGS: --host-network
     workflow: openshift-e2e-aws-ovn-serial-ipsec
+  timeout: 5h0m0s
 - as: e2e-short-cert-rotation
   cron: 0 8 * * Sun
   steps:


### PR DESCRIPTION
Continue to see many serial jobs timing out.  Bumping the default timeout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR increases job timeout limits for long-running serial test jobs across multiple OpenShift release branches (4.22, 4.23, and 5.0). The changes add a 5-hour timeout (`5h0m0s`) to various e2e test configurations that have been experiencing timeout failures.

## Changes

The modifications apply to OpenShift CI operator configuration files across three release versions:

**OpenShift 4.22 & 4.23:**
- Added 5-hour timeout to OVN serial tests (e2e-aws-ovn-serial, e2e-aws-ovn-techpreview-serial)

**OpenShift 5.0:**
- Added 5-hour timeout to multiple OVN-based test variants, including serial, techpreview, and RHCOS-specific variants across AWS and Azure environments

**Nightly job configurations (4.22, 4.23, 5.0):**
- Extended timeout to numerous nightly e2e test entries across multiple infrastructure platforms (AWS, Azure, GCP, VMware vSphere, Bare Metal, etc.)

These are purely configuration changes that adjust timeout parameters in the ci-operator job definitions—no test logic or job structure is altered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->