### PR TITLE
Grant secrets access to the ephemeral-cluster service account

### DIFF
--- a/clusters/app.ci/ephemeral-cluster/00_admin.yaml
+++ b/clusters/app.ci/ephemeral-cluster/00_admin.yaml
@@ -22,6 +22,14 @@ rules:
   - ephemeralclusters
   verbs:
   - "*"
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - watch
+  - list
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
The crossplane composition for TestPlatformCluster now observes credential Secrets created by the EphemeralCluster controller instead of reading credentials directly from EphemeralCluster status. The ephemeral-cluster service account needs get/watch/list on secrets in the ephemeral-cluster namespace for provider-kubernetes to observe these resources.

Assisted-by: Claude claude-opus-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR grants the `ephemeral-cluster` service account permission to read Secrets in the ephemeral-cluster namespace. The change adds a new policy rule to the `ephemeral-cluster-admin` ClusterRole, permitting `get`, `watch`, and `list` verbs on core Secrets.

## Context

The ephemeral-cluster controller has been updated to create credential Secrets rather than storing credentials in EphemeralCluster status. To enable the crossplane composition for TestPlatformCluster to observe these credential Secrets through provider-kubernetes, the ephemeral-cluster service account needs explicit permissions to read those Secrets.

## Changes

**clusters/app.ci/ephemeral-cluster/00_admin.yaml**
- Added a new RBAC rule to the `ephemeral-cluster-admin` ClusterRole granting `get`, `watch`, and `list` permissions on core Secrets, enabling the service account to observe credential Secrets created by the controller.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->