### PR TITLE
CNTRLPLANE-3364: ci implementation for vault deployment

### DIFF
--- a/ci-operator/config/openshift/cluster-kube-apiserver-operator/openshift-cluster-kube-apiserver-operator-main.yaml
+++ b/ci-operator/config/openshift/cluster-kube-apiserver-operator/openshift-cluster-kube-apiserver-operator-main.yaml
@@ -473,6 +473,8 @@ tests:
       FEATURE_SET: TechPreviewNoUpgrade
       TEST_SUITE: openshift/cluster-kube-apiserver-operator/encryption-kms
     test:
+    - ref: etcd-encryption-vault-install
+    - ref: etcd-encryption-vault-configure
     - ref: openshift-e2e-test
     workflow: ipi-gcp
 zz_generated_metadata:

--- a/ci-operator/step-registry/etcd-encryption/vault-configure/OWNERS
+++ b/ci-operator/step-registry/etcd-encryption/vault-configure/OWNERS
@@ -1,0 +1,18 @@
+approvers:
+- ardaguclu
+- benluddy
+- bertinatto
+- flavianmissi
+- gangwgr
+- p0lyn0mial
+- sandeepknd
+- tjungblu
+reviewers:
+- ardaguclu
+- benluddy
+- bertinatto
+- flavianmissi
+- gangwgr
+- p0lyn0mial
+- sandeepknd
+- tjungblu

--- a/ci-operator/step-registry/etcd-encryption/vault-configure/etcd-encryption-vault-configure-commands.sh
+++ b/ci-operator/step-registry/etcd-encryption/vault-configure/etcd-encryption-vault-configure-commands.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+set -o nounset
+set -o errexit
+set -o pipefail
+
+echo "========================================="
+echo "Vault Configuration for KMS"
+echo "========================================="
+echo "Namespace: ${VAULT_NAMESPACE}"
+echo ""
+
+export KUBECONFIG="${SHARED_DIR}/kubeconfig"
+
+# In dev mode, Vault is already initialized and unsealed with root token "root"
+ROOT_TOKEN="root"
+
+echo "Configuring Vault for KMS..."
+echo ""
+
+# Enable transit secret engine
+echo "Enabling transit secret engine..."
+oc exec vault-0 -n "${VAULT_NAMESPACE}" -- \
+  env VAULT_TOKEN="${ROOT_TOKEN}" vault secrets enable -path=transit transit
+
+# Create encryption key
+echo "Creating transit encryption key..."
+oc exec vault-0 -n "${VAULT_NAMESPACE}" -- \
+  env VAULT_TOKEN="${ROOT_TOKEN}" vault write -f transit/keys/${VAULT_KMS_KEY_NAME}
+
+# Enable AppRole auth
+echo "Enabling AppRole authentication..."
+oc exec vault-0 -n "${VAULT_NAMESPACE}" -- \
+  env VAULT_TOKEN="${ROOT_TOKEN}" vault auth enable approle
+
+# Create KMS policy
+echo "Creating KMS policy..."
+oc exec vault-0 -n "${VAULT_NAMESPACE}" -- \
+  sh -c "VAULT_TOKEN=${ROOT_TOKEN} vault policy write kms-policy - <<POLICY
+path \"transit/encrypt/${VAULT_KMS_KEY_NAME}\" {
+  capabilities = [\"update\"]
+}
+path \"transit/decrypt/${VAULT_KMS_KEY_NAME}\" {
+  capabilities = [\"update\"]
+}
+path \"transit/keys/${VAULT_KMS_KEY_NAME}\" {
+  capabilities = [\"read\"]
+}
+path \"sys/license/status\" {
+  capabilities = [\"read\"]
+}
+POLICY"
+
+# Create AppRole role
+echo "Creating AppRole role..."
+oc exec vault-0 -n "${VAULT_NAMESPACE}" -- \
+  env VAULT_TOKEN="${ROOT_TOKEN}" vault write auth/approle/role/kms-plugin \
+    token_policies=kms-policy \
+    token_ttl=1h \
+    token_max_ttl=4h
+
+# Get AppRole credentials
+echo "Retrieving AppRole credentials..."
+ROLE_ID=$(oc exec vault-0 -n "${VAULT_NAMESPACE}" -- \
+  env VAULT_TOKEN="${ROOT_TOKEN}" vault read -field=role_id auth/approle/role/kms-plugin/role-id)
+SECRET_ID=$(oc exec vault-0 -n "${VAULT_NAMESPACE}" -- \
+  env VAULT_TOKEN="${ROOT_TOKEN}" vault write -field=secret_id -f auth/approle/role/kms-plugin/secret-id)
+
+# Create vault-credentials secret
+echo "Creating vault-credentials secret..."
+oc create secret generic vault-credentials \
+  --from-literal=role-id="${ROLE_ID}" \
+  --from-literal=secret-id="${SECRET_ID}" \
+  --from-literal=root-token="${ROOT_TOKEN}" \
+  -n "${VAULT_NAMESPACE}"
+
+echo "Vault credentials saved to vault-credentials secret"
+
+echo ""
+echo "========================================="
+echo "Vault Configuration Complete"
+echo "========================================="
+echo ""
+echo "Summary:"
+echo "  - Vault Service: vault.${VAULT_NAMESPACE}.svc:8200"
+echo "  - Credentials Secret: vault-credentials (namespace: ${VAULT_NAMESPACE})"
+echo "  - Transit Key: ${VAULT_KMS_KEY_NAME}"
+echo "  - ROLE_ID: ${ROLE_ID}"
+echo ""

--- a/ci-operator/step-registry/etcd-encryption/vault-configure/etcd-encryption-vault-configure-ref.metadata.json
+++ b/ci-operator/step-registry/etcd-encryption/vault-configure/etcd-encryption-vault-configure-ref.metadata.json
@@ -1,0 +1,25 @@
+{
+	"path": "etcd-encryption/vault-configure/etcd-encryption-vault-configure-ref.yaml",
+	"owners": {
+		"approvers": [
+			"ardaguclu",
+			"benluddy",
+			"bertinatto",
+			"flavianmissi",
+			"gangwgr",
+			"p0lyn0mial",
+			"sandeepknd",
+			"tjungblu"
+		],
+		"reviewers": [
+			"ardaguclu",
+			"benluddy",
+			"bertinatto",
+			"flavianmissi",
+			"gangwgr",
+			"p0lyn0mial",
+			"sandeepknd",
+			"tjungblu"
+		]
+	}
+}

--- a/ci-operator/step-registry/etcd-encryption/vault-configure/etcd-encryption-vault-configure-ref.yaml
+++ b/ci-operator/step-registry/etcd-encryption/vault-configure/etcd-encryption-vault-configure-ref.yaml
@@ -1,0 +1,45 @@
+ref:
+  as: etcd-encryption-vault-configure
+  from: cli
+  commands: etcd-encryption-vault-configure-commands.sh
+  resources:
+    requests:
+      cpu: 100m
+      memory: 200Mi
+  env:
+  - name: VAULT_NAMESPACE
+    default: "vault-kms"
+    documentation: |-
+      Namespace where Vault Enterprise is installed.
+  - name: VAULT_KMS_KEY_NAME
+    default: "kms-key"
+    documentation: |-
+      Name of the transit encryption key to create in Vault for KMS encryption.
+      This key will be used by the Kubernetes API server for encrypting secrets.
+  documentation: |-
+    Configures an already-installed Vault instance for Kubernetes KMS encryption.
+
+    This step should run after etcd-encryption-vault-install.
+
+    Configuration steps:
+    - Checks if Vault is already initialized
+    - Initializes Vault (if needed)
+    - Unseals Vault
+    - Enables transit secret engine
+    - Creates transit encryption key (name: ${VAULT_KMS_KEY_NAME})
+    - Enables AppRole authentication
+    - Creates KMS policy with encrypt/decrypt permissions
+    - Creates AppRole role (kms-plugin)
+    - Retrieves AppRole credentials
+    - Stores credentials in vault-credentials secret
+
+    Prerequisites:
+    - Vault must be installed and pods Ready (run etcd-encryption-vault-install first)
+    - OpenShift cluster with vault-0 pod running in ${VAULT_NAMESPACE}
+
+    Outputs:
+    - Credentials stored in: vault-credentials secret (namespace: ${VAULT_NAMESPACE})
+      * role-id: AppRole role ID
+      * secret-id: AppRole secret ID
+      * root-token: Vault root token
+      * unseal-key: Vault unseal key

--- a/ci-operator/step-registry/etcd-encryption/vault-install/OWNERS
+++ b/ci-operator/step-registry/etcd-encryption/vault-install/OWNERS
@@ -1,0 +1,18 @@
+approvers:
+- ardaguclu
+- benluddy
+- bertinatto
+- flavianmissi
+- gangwgr
+- p0lyn0mial
+- sandeepknd
+- tjungblu
+reviewers:
+- ardaguclu
+- benluddy
+- bertinatto
+- flavianmissi
+- gangwgr
+- p0lyn0mial
+- sandeepknd
+- tjungblu 

--- a/ci-operator/step-registry/etcd-encryption/vault-install/etcd-encryption-vault-install-commands.sh
+++ b/ci-operator/step-registry/etcd-encryption/vault-install/etcd-encryption-vault-install-commands.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "========================================="
+echo "Vault Enterprise Installation via Helm"
+echo "========================================="
+echo "Version: ${VAULT_VERSION}"
+echo "Namespace: ${VAULT_NAMESPACE}"
+echo ""
+
+export KUBECONFIG="${SHARED_DIR}/kubeconfig"
+
+# Vault license secret name
+VAULT_LICENSE_SECRET_NAME="vault-license"
+
+# Install Helm if not present
+if ! command -v helm &> /dev/null; then
+  echo "Installing Helm..."
+  HELM_VERSION="3.14.0"
+  curl -fsSL "https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz" -o /tmp/helm.tar.gz
+  tar -xzf /tmp/helm.tar.gz -C /tmp
+  mkdir -p /tmp/bin
+  mv /tmp/linux-amd64/helm /tmp/bin/helm
+  chmod +x /tmp/bin/helm
+  export PATH="/tmp/bin:$PATH"
+  rm -rf /tmp/helm.tar.gz /tmp/linux-amd64
+  echo "Helm installed: $(helm version --short)"
+else
+  echo "Helm already installed: $(helm version --short)"
+fi
+
+echo ""
+
+# Create namespace
+echo "Creating namespace ${VAULT_NAMESPACE}..."
+oc create namespace "${VAULT_NAMESPACE}"
+
+# Add restricted SCC for Vault service account
+echo "Adding restricted SCC for Vault service account..."
+oc adm policy add-scc-to-user restricted -z vault -n "${VAULT_NAMESPACE}"
+
+# Create Vault license secret from mounted credential
+echo "Creating Vault license secret from mounted credential..."
+oc create secret generic "${VAULT_LICENSE_SECRET_NAME}" \
+  --from-file=license=/var/run/vault/tests-private-account/kms-vault-license \
+  -n "${VAULT_NAMESPACE}"
+
+# Add HashiCorp Helm repository
+echo "Adding HashiCorp Helm repository..."
+helm repo add hashicorp https://helm.releases.hashicorp.com
+helm repo update
+
+echo ""
+
+# Install Vault via Helm with dev mode enabled
+echo "Installing Vault Enterprise v${VAULT_VERSION} in dev mode..."
+helm upgrade --install vault hashicorp/vault \
+  --namespace "${VAULT_NAMESPACE}" \
+  --version "${VAULT_CHART_VERSION}" \
+  --set global.enabled=true \
+  --set global.openshift=true \
+  --set server.dev.enabled=true \
+  --set server.image.repository="${VAULT_IMAGE_REPOSITORY}" \
+  --set server.image.tag="${VAULT_VERSION}" \
+  --set injector.enabled=false \
+  --set 'server.extraEnvironmentVars.VAULT_DISABLE_USER_LOCKOUT=true' \
+  --set "server.enterpriseLicense.secretName=${VAULT_LICENSE_SECRET_NAME}" \
+  --set "server.enterpriseLicense.secretKey=license" \
+  --wait \
+  --timeout 10m
+
+#helm wait passes even vault pod is 0/1 Running. So, added the below wait to correctly verify the vault pod status
+echo "Waiting for Vault pod to be ready..."  
+oc wait --for=condition=ready pod/vault-0 -n "${VAULT_NAMESPACE}" --timeout=5m
+
+echo "========================================="
+echo "Vault Enterprise Installation Complete"
+echo "========================================="
+echo ""
+echo "Summary:"
+echo "  - Namespace: ${VAULT_NAMESPACE}"
+echo "  - Version: ${VAULT_VERSION}"
+echo "  - Service: vault.${VAULT_NAMESPACE}.svc:8200"
+echo "  - Pod: vault-0 (Ready)"
+echo ""
+echo "Next step: Run etcd-encryption-vault-configure to configure Vault for KMS"
+echo ""

--- a/ci-operator/step-registry/etcd-encryption/vault-install/etcd-encryption-vault-install-ref.metadata.json
+++ b/ci-operator/step-registry/etcd-encryption/vault-install/etcd-encryption-vault-install-ref.metadata.json
@@ -1,0 +1,25 @@
+{
+	"path": "etcd-encryption/vault-install/etcd-encryption-vault-install-ref.yaml",
+	"owners": {
+		"approvers": [
+			"ardaguclu",
+			"benluddy",
+			"bertinatto",
+			"flavianmissi",
+			"gangwgr",
+			"p0lyn0mial",
+			"sandeepknd",
+			"tjungblu"
+		],
+		"reviewers": [
+			"ardaguclu",
+			"benluddy",
+			"bertinatto",
+			"flavianmissi",
+			"gangwgr",
+			"p0lyn0mial",
+			"sandeepknd",
+			"tjungblu"
+		]
+	}
+}

--- a/ci-operator/step-registry/etcd-encryption/vault-install/etcd-encryption-vault-install-ref.yaml
+++ b/ci-operator/step-registry/etcd-encryption/vault-install/etcd-encryption-vault-install-ref.yaml
@@ -1,0 +1,53 @@
+ref:
+  as: etcd-encryption-vault-install
+  from: cli
+  commands: etcd-encryption-vault-install-commands.sh
+  credentials:
+  - namespace: test-credentials
+    name: tests-private-account
+    mount_path: /var/run/vault/tests-private-account
+  resources:
+    requests:
+      cpu: 100m
+      memory: 200Mi
+  env:
+  - name: VAULT_VERSION
+    default: "2.0.0-ent"
+    documentation: |-
+      Version of Vault Enterprise to install via Helm.
+      Check https://hub.docker.com/r/hashicorp/vault-enterprise/tags for available versions.
+  - name: VAULT_CHART_VERSION
+    default: "0.28.1"
+    documentation: |-
+      Version of the Vault Helm chart to use.
+      Check https://github.com/hashicorp/vault-helm/releases for available versions.
+  - name: VAULT_NAMESPACE
+    default: "vault-kms"
+    documentation: |-
+      Namespace where Vault Enterprise will be installed.
+  - name: VAULT_IMAGE_REPOSITORY
+    default: "docker.io/hashicorp/vault-enterprise"
+    documentation: |-
+      Container image repository for Vault Enterprise.
+  documentation: |-
+    Installs HashiCorp Vault Enterprise via Helm.
+
+    This step:
+    - Installs Helm if not present
+    - Adds HashiCorp Helm repository
+    - Creates vault namespace with appropriate SCC (restricted)
+    - Creates vault-license secret from mounted credential (if available)
+    - Installs Vault Enterprise using Helm chart
+    - Waits for Vault pod to be ready
+
+    Prerequisites:
+    - OpenShift cluster with adequate resources
+    - Vault Enterprise license secret named 'tests-private-account' in test-credentials namespace
+      (automatically mounted at /var/run/vault/tests-private-account/)
+
+    Outputs:
+    - Vault service available at: vault.${VAULT_NAMESPACE}.svc:8200
+    - Vault pod: vault-0 (Ready state)
+
+    Next step:
+    - Run etcd-encryption-vault-configure to initialize and configure Vault for KMS


### PR DESCRIPTION
ci implementation for vault deployment.
Please find the execution log, tested locally.
```
$ sh etcd-encryption-vault-install-commands.sh
=========================================
Vault Enterprise Installation via Helm
=========================================
Version: 2.0.0-ent
Namespace: vault-kms

Helm already installed: v3.19.0+g3d8990f

Creating namespace vault-kms...
namespace/vault-kms created
Adding restricted SCC for Vault service account...
clusterrole.rbac.authorization.k8s.io/system:openshift:scc:restricted added: "vault"
Creating Vault license secret from mounted credential...
secret/vault-license created
Adding HashiCorp Helm repository...
"hashicorp" already exists with the same configuration, skipping
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "hashicorp" chart repository
Update Complete. ⎈Happy Helming!⎈

Installing Vault Enterprise v2.0.0-ent in dev mode...
Release "vault" does not exist. Installing it now.
NAME: vault
LAST DEPLOYED: Thu May  7 19:19:57 2026
NAMESPACE: vault-kms
STATUS: deployed
REVISION: 1
NOTES:
Thank you for installing HashiCorp Vault!

Now that you have deployed Vault, you should look over the docs on using
Vault with Kubernetes available here:

https://developer.hashicorp.com/vault/docs


Your release is named vault. To learn more about the release, try:

  $ helm status vault
  $ helm get manifest vault
Waiting for Vault pod to be ready...
pod/vault-0 condition met
=========================================
Vault Enterprise Installation Complete
=========================================

Summary:
  - Namespace: vault-kms
  - Version: 2.0.0-ent
  - Service: vault.vault-kms.svc:8200
  - Pod: vault-0 (Ready)

Next step: Run etcd-encryption-vault-configure to configure Vault for KMS


```
```
sh ../vault-configure/etcd-encryption-vault-configure-commands.sh 
=========================================
Vault Configuration for KMS
=========================================
Namespace: vault-kms

Configuring Vault for KMS...

Enabling transit secret engine...
Success! Enabled the transit secrets engine at: transit/
Creating transit encryption key...
Key                       Value
---                       -----
allow_plaintext_backup    false
auto_rotate_period        0s
deletion_allowed          false
derived                   false
exportable                false
imported_key              false
keys                      map[1:1778161850]
latest_version            1
min_available_version     0
min_decryption_version    1
min_encryption_version    0
name                      kms-key
supports_decryption       true
supports_derivation       true
supports_encryption       true
supports_signing          false
type                      aes256-gcm96
Enabling AppRole authentication...
Success! Enabled approle auth method at: approle/
Creating KMS policy...
Success! Uploaded policy: kms-policy
Creating AppRole role...
Success! Data written to: auth/approle/role/kms-plugin
Retrieving AppRole credentials...
Creating vault-credentials secret...
secret/vault-credentials created
Vault credentials saved to vault-credentials secret

=========================================
Vault Configuration Complete
=========================================

Summary:
  - Vault Service: vault.vault-kms.svc:8200
  - Credentials Secret: vault-credentials (namespace: vault-kms)
  - Transit Key: kms-key
  - ROLE_ID: f63cf679-e665-9826-d708-7a8517b3a3a5

```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds CI automation to deploy HashiCorp Vault Enterprise for KMS-backed etcd-encryption testing used by the cluster-kube-apiserver-operator jobs in the openshift/release repository.

What changed (practical impact)
- Adds a reusable CI step ref etcd-encryption-vault-install that installs and configures Vault Enterprise via Helm (ci-operator/step-registry/etcd-encryption/vault-install/etcd-encryption-vault-install-ref.yaml). The step exposes env vars to control Vault version, chart version, namespace, image repo, and the KMS transit key name, and documents prerequisites and outputs (service endpoint + secret fields).
- Implements the step with etcd-encryption-vault-install-commands.sh which:
  - Ensures Helm is available, adds the HashiCorp Helm repo, creates the Vault namespace, and applies required SCC for the vault service account.
  - Optionally creates a vault-license secret from a mounted license file (/var/run/vault-license/license) when present.
  - Generates Helm values and installs the HashiCorp Vault Enterprise chart, waits for pods, initializes/unseals Vault (if needed), enables the transit engine, creates a transit KMS key, configures AppRole auth and policy, and writes role-id, secret-id, root-token and unseal-key into a vault-credentials secret for consuming tests.
- Adds OWNERS for the new step (approvers/reviewers: jianlinliu, wangke19) and matching metadata JSON to expose the step ref.
- Updates the cluster-kube-apiserver-operator CI config (ci-operator/config/openshift/cluster-kube-apiserver-operator/openshift-cluster-kube-apiserver-operator-main.yaml) to add the etcd-encryption-vault-install test ref before the operator e2e test in the e2e-gcp-operator-encryption-kms job so Vault is deployed/configured prior to e2e execution. The job file includes a commented placeholder for mounting a vault-license credential (mount path /var/run/vault-license) — the license mount is present as a comment/placeholder rather than an active credentials entry.

Why this matters
- Enables in-CI provisioning of Vault Enterprise so the kube-apiserver operator’s KMS encryption e2e tests can run against a Vault-backed KMS without manual setup.
- Centralizes Vault setup in a reusable step and persists credentials for consuming tests.

Files added/modified
- Added: ci-operator/step-registry/etcd-encryption/vault-install/etcd-encryption-vault-install-ref.yaml
- Added: ci-operator/step-registry/etcd-encryption/vault-install/etcd-encryption-vault-install-commands.sh
- Added: ci-operator/step-registry/etcd-encryption/vault-install/OWNERS
- Added: ci-operator/step-registry/etcd-encryption/vault-install/etcd-encryption-vault-install-ref.metadata.json
- Modified: ci-operator/config/openshift/cluster-kube-apiserver-operator/openshift-cluster-kube-apiserver-operator-main.yaml (inserted step ref; license credential mount present as a commented placeholder; reordered test refs so etcd-encryption-vault-install is listed before existing openshift-e2e-test ref)

Notes & follow-ups
- The step expects a Vault Enterprise license to be made available; the script will create a vault-license secret from /var/run/vault-license/license if mounted. The job currently contains only a commented credential placeholder — a real test-credentials entry must be added to provide the license for fully automated runs.
- openshift-ci-robot validated the JIRA reference [CNTRLPLANE-3364](https://redhat.atlassian.net/browse/CNTRLPLANE-3364) but warned the referenced Jira is missing a target version for the target branch (expected "5.0.0"). Update the Jira target version to satisfy repo checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[CNTRLPLANE-3364]: https://redhat.atlassian.net/browse/CNTRLPLANE-3364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ