### PR TITLE
[DNM] Sync Serverless CI config/serverless-operator.yaml

### DIFF
--- a/ci-operator/config/openshift-knative/serverless-operator/.config.prowgen
+++ b/ci-operator/config/openshift-knative/serverless-operator/.config.prowgen
@@ -21,6 +21,7 @@ slack_reporter:
   - kitchensink-upgrade-c
   - mesh-e2e-c
   - olmv1-operator-e2e
+  - olmv1-operator-upgrade
   - operator-e2e-c
   - test-soak-c
   - test-upgrade-c

--- a/ci-operator/config/openshift-knative/serverless-operator/openshift-knative-serverless-operator-main__4.21-techpreview.yaml
+++ b/ci-operator/config/openshift-knative/serverless-operator/openshift-knative-serverless-operator-main__4.21-techpreview.yaml
@@ -171,6 +171,43 @@ tests:
           cpu: 100m
           memory: 200Mi
     workflow: openshift-e2e-aws
+- as: olmv1-operator-upgrade
+  cron: 45 7 * * 0
+  steps:
+    cluster_profile: aws-serverless
+    env:
+      BASE_DOMAIN: serverless.devcluster.openshift.com
+      FEATURE_SET: TechPreviewNoUpgrade
+      SPOT_INSTANCES: "true"
+      ZONES_COUNT: "1"
+    test:
+    - as: operator-upgrade
+      commands: GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin OLM_VERSION=v1 make test-upgrade
+      dependencies:
+      - env: SERVERLESS_KNATIVE_OPERATOR
+        name: serverless-knative-operator
+      - env: SERVERLESS_MUST_GATHER
+        name: serverless-must-gather
+      - env: SERVERLESS_INDEX
+        name: serverless-index
+      - env: SERVERLESS_BUNDLE
+        name: serverless-bundle
+      - env: SERVERLESS_OPENSHIFT_KNATIVE_OPERATOR
+        name: serverless-openshift-knative-operator
+      - env: SERVERLESS_SOURCE_IMAGE
+        name: serverless-source-image
+      - env: SERVERLESS_INGRESS
+        name: serverless-ingress
+      - env: SERVERLESS_METADATA_WEBHOOK
+        name: serverless-metadata-webhook
+      from: serverless-source-image
+      resources:
+        limits:
+          memory: 6Gi
+        requests:
+          cpu: 100m
+          memory: 200Mi
+    workflow: openshift-e2e-aws
 zz_generated_metadata:
   branch: main
   org: openshift-knative

--- a/ci-operator/config/openshift-knative/serverless-operator/openshift-knative-serverless-operator-main__420.yaml
+++ b/ci-operator/config/openshift-knative/serverless-operator/openshift-knative-serverless-operator-main__420.yaml
@@ -119,7 +119,7 @@ images:
         as:
         - $GO_BUILDER
     to: serverless-metadata-webhook
-  run_if_changed: ^non-existing$
+  skip_if_only_changed: ^.tekton/.*|^.konflux.*|^.github/.*|^rpms.lock.yaml$|^hack/(lib$|[^l].*|l[^i].*|li[^b].*|lib[^/].*)|^OWNERS.*|.*\.md
 releases:
   latest:
     release:
@@ -133,9 +133,9 @@ resources:
       cpu: 100m
       memory: 200Mi
 tests:
-- always_run: false
-  as: kitchensink-upgrade
+- as: kitchensink-upgrade
   optional: true
+  skip_if_only_changed: ^.tekton/.*|^.konflux.*|^.github/.*|^rpms.lock.yaml$|^hack/(lib$|[^l].*|l[^i].*|li[^b].*|lib[^/].*)|^OWNERS.*|.*\.md
   steps:
     allow_best_effort_post_steps: true
     allow_skip_on_success: true
@@ -219,8 +219,7 @@ tests:
           cpu: 100m
       timeout: 4h0m0s
     workflow: ipi-aws
-- always_run: false
-  as: kitchensink-upgrade-c
+- as: kitchensink-upgrade-c
   cron: 1 3 * * 1,5
   steps:
     allow_best_effort_post_steps: true

--- a/ci-operator/jobs/openshift-knative/serverless-operator/openshift-knative-serverless-operator-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-knative/serverless-operator/openshift-knative-serverless-operator-main-periodics.yaml
@@ -95,6 +95,100 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build03
+  cron: 45 7 * * 0
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-knative
+    repo: serverless-operator
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-serverless
+    ci-operator.openshift.io/variant: 4.21-techpreview
+    ci.openshift.io/generator: prowgen
+    job-release: "4.21"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-knative-serverless-operator-main-4.21-techpreview-olmv1-operator-upgrade
+  reporter_config:
+    slack:
+      channel: '#serverless-ci'
+      job_states_to_report:
+      - success
+      - failure
+      - error
+      report_template: '{{if eq .Status.State "success"}} :rainbow: Job *{{.Spec.Job}}*
+        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :rainbow: {{else}}
+        :volcano: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+        logs> :volcano: {{end}}'
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=olmv1-operator-upgrade
+      - --variant=4.21-techpreview
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build03
   cron: 23 1 * * 1,5
   decorate: true
   decoration_config:

--- a/ci-operator/jobs/openshift-knative/serverless-operator/openshift-knative-serverless-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-knative/serverless-operator/openshift-knative-serverless-operator-main-presubmits.yaml
@@ -984,7 +984,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-knative-serverless-operator-main-420-images
     rerun_command: /test 420-images
-    run_if_changed: ^non-existing$
+    skip_if_only_changed: ^.tekton/.*|^.konflux.*|^.github/.*|^rpms.lock.yaml$|^hack/(lib$|[^l].*|l[^i].*|li[^b].*|lib[^/].*)|^OWNERS.*|.*\.md
     spec:
       containers:
       - args:
@@ -1045,6 +1045,7 @@ presubmits:
     name: pull-ci-openshift-knative-serverless-operator-main-420-kitchensink-upgrade
     optional: true
     rerun_command: /test 420-kitchensink-upgrade
+    skip_if_only_changed: ^.tekton/.*|^.konflux.*|^.github/.*|^rpms.lock.yaml$|^hack/(lib$|[^l].*|l[^i].*|li[^b].*|lib[^/].*)|^OWNERS.*|.*\.md
     spec:
       containers:
       - args:


### PR DESCRIPTION
rehearse only, do not merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR updates the CI configuration for the openshift-knative/serverless-operator repository to add a new upgrade test job variant and adjust related reporting and skip conditions. The PR is marked DNM and intended for rehearsal purposes only.

## Changes

**New upgrade test job**: Added `olmv1-operator-upgrade` test job to the serverless-operator techpreview (4.21) configuration. This new job mirrors the existing e2e test structure, using the same environment and dependencies, but runs the `test-upgrade` target instead of the standard e2e tests.

**Slack reporter exclusion**: Updated the slack reporter configuration to exclude the new `olmv1-operator-upgrade` variant from successful/e2e reporting, preventing redundant notifications for this additional test variant.

**Refined test skip conditions**: Modified the 4.20 configuration to improve when tests execute by:
- Replacing `run_if_changed` with `skip_if_only_changed` for the serverless-metadata-webhook image build
- Updating the kitchensink-upgrade test step to skip runs when only documentation or Tekton-related files change

These changes collectively improve the serverless-operator CI pipeline by adding upgrade test coverage, refining which tests run based on the nature of code changes, and adjusting notifications accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->