### PR TITLE
Add unit tests and Dockerfile build for vcf-migration-operator

### DIFF
--- a/ci-operator/config/openshift/vcf-migration-operator/openshift-vcf-migration-operator-main.yaml
+++ b/ci-operator/config/openshift/vcf-migration-operator/openshift-vcf-migration-operator-main.yaml
@@ -1,8 +1,10 @@
+binary_build_commands: make build
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: golang-1.25
+  from_repository: true
+images:
+  items:
+  - dockerfile_path: Dockerfile
+    to: vcf-migration-operator
 promotion:
   to:
   - name: "5.0"
@@ -24,6 +26,11 @@ resources:
     requests:
       cpu: 100m
       memory: 200Mi
+tests:
+- as: unit
+  commands: make test
+  container:
+    from: src
 zz_generated_metadata:
   branch: main
   org: openshift

--- a/ci-operator/jobs/openshift/vcf-migration-operator/OWNERS
+++ b/ci-operator/jobs/openshift/vcf-migration-operator/OWNERS
@@ -1,0 +1,19 @@
+# DO NOT EDIT; this file is auto-generated using https://github.com/openshift/ci-tools.
+# Fetched from https://github.com/openshift/vcf-migration-operator root OWNERS
+# If the repo had OWNERS_ALIASES then the aliases were expanded
+# Logins who are not members of 'openshift' organization were filtered out
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+- annazivkovic
+- jcpowermac
+- mtulio
+- rvanderp3
+- vr4manta
+options: {}
+reviewers:
+- annazivkovic
+- jcpowermac
+- mtulio
+- rvanderp3
+- vr4manta

--- a/ci-operator/jobs/openshift/vcf-migration-operator/openshift-vcf-migration-operator-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/vcf-migration-operator/openshift-vcf-migration-operator-main-postsubmits.yaml
@@ -1,0 +1,60 @@
+postsubmits:
+  openshift/vcf-migration-operator:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    cluster: build01
+    decorate: true
+    labels:
+      ci-operator.openshift.io/is-promotion: "true"
+      ci.openshift.io/generator: prowgen
+    max_concurrency: 1
+    name: branch-ci-openshift-vcf-migration-operator-main-images
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --image-mirror-push-secret=/etc/push-secret/.dockerconfigjson
+        - --promote
+        - --report-credentials-file=/etc/report/credentials
+        - --target=[images]
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/push-secret
+          name: push-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: push-secret
+        secret:
+          secretName: registry-push-credentials-ci-central
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator

--- a/ci-operator/jobs/openshift/vcf-migration-operator/openshift-vcf-migration-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/vcf-migration-operator/openshift-vcf-migration-operator-main-presubmits.yaml
@@ -1,0 +1,117 @@
+presubmits:
+  openshift/vcf-migration-operator:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build01
+    context: ci/prow/images
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-vcf-migration-operator-main-images
+    rerun_command: /test images
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=[images]
+        - --target=[release:latest]
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )images,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build01
+    context: ci/prow/unit
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-vcf-migration-operator-main-unit
+    rerun_command: /test unit
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=unit
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )unit,?($|\s.*)


### PR DESCRIPTION
## Summary
- Switch CI build root to `from_repository: true` (uses `.ci-operator.yaml`)
- Add Dockerfile-based image build for `vcf-migration-operator`
- Add `binary_build_commands: make build`
- Add unit test step (`make test`) running in `src` container

Supersedes #78875

## Test plan
- [ ] Rehearsal job `ci/rehearse/.../unit` passes
- [ ] Rehearsal job `ci/rehearse/.../images` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR updates the OpenShift CI configuration for the openshift/vcf-migration-operator repository to move build control into the repo and add unit testing.

Key changes
- File updated: ci-operator/config/openshift/vcf-migration-operator/openshift-vcf-migration-operator-main.yaml
- Build root: switches to repository-managed build (build_root.from_repository: true) so the repo’s .ci-operator.yaml is used.
- Image build: adds a Dockerfile-based image build (images.items → dockerfile_path: Dockerfile → to: vcf-migration-operator).
- Binary build commands: adds binary_build_commands: make build.
- Unit tests: adds a tests entry that runs make test in a container built from the repo source (tests: as: unit, commands: make test, container.from: src).
- Promotion/release: promotion and release targets point to integration name "5.0" / namespace ocp (promotion to 5.0).
- Resource limits/requests and generated metadata preserved.

Impact
- Lets the vcf-migration-operator repository control its own build/test workflow via its Dockerfile and .ci-operator.yaml.
- Adds an automated unit-test step in CI and ensures the binary build uses make build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->