### PR TITLE
NO-JIRA: feat: add pacemaker cluster resource in gather extra

### DIFF
--- a/ci-operator/step-registry/gather/extra/gather-extra-commands.sh
+++ b/ci-operator/step-registry/gather/extra/gather-extra-commands.sh
@@ -138,6 +138,7 @@ queue ${ARTIFACT_DIR}/releaseinfo.json oc --insecure-skip-tls-verify --request-t
 queue ${ARTIFACT_DIR}/clusterrolebindings.json oc --insecure-skip-tls-verify --request-timeout=5s get clusterrolebindings --all-namespaces -o json
 queue ${ARTIFACT_DIR}/networkpolicies.json oc --insecure-skip-tls-verify --request-timeout=5s get networkpolicies --all-namespaces -o json
 queue ${ARTIFACT_DIR}/oc_cmds/networkpolicies oc --insecure-skip-tls-verify --request-timeout=5s get networkpolicies --all-namespaces
+queue ${ARTIFACT_DIR}/pacemakercluster-cluster.json oc --insecure-skip-tls-verify --request-timeout=5s get pacemakerclusters cluster -ojson
 
 FILTER=gzip queue ${ARTIFACT_DIR}/openapi.json.gz oc --insecure-skip-tls-verify --request-timeout=5s get --raw /openapi/v2
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Enhances OpenShift CI artifact collection with Pacemaker cluster diagnostics

This PR adds Pacemaker cluster resource collection to the OpenShift CI test infrastructure's "gather extra" step. The change extends the diagnostic artifacts collected during CI test runs to now include Pacemaker cluster state information, which will be saved as `pacemakercluster-cluster.json`.

### What's changing

The modification adds a single command to the artifact gathering script used across OpenShift CI test execution. This command queries Pacemaker cluster resources from the test cluster and stores the output as a JSON artifact for later analysis and debugging.

### Note

The added command uses `-ojson` as a flag, which appears to be missing a space and should likely be `-o json` to align with standard OpenShift CLI conventions used throughout the rest of the artifact collection script. This may warrant verification during review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->