### PR TITLE
Add .claude/rules for HyperShift CI directories

### DIFF
--- a/.claude/rules/hypershift-aws.md
+++ b/.claude/rules/hypershift-aws.md
@@ -1,0 +1,84 @@
+---
+paths:
+  - "ci-operator/step-registry/hypershift/aws/**"
+---
+
+# HyperShift AWS Platform
+
+## Architecture
+
+AWS HyperShift uses the nested management cluster pattern:
+1. Root OpenShift cluster (pre-existing, shared)
+2. Nested management cluster (ephemeral HostedCluster on root, created per CI job)
+3. Guest HostedCluster (the cluster under test, created on the nested management cluster)
+
+Key workflow: `hypershift-aws-e2e-nested`
+
+## AWS Resources Created
+
+- EC2 instances for NodePools (configurable via `HYPERSHIFT_INSTANCE_TYPE`, default: m5.xlarge)
+- VPCs and security groups (or BYO VPC via shared account)
+- KMS keys for etcd and disk encryption
+- IAM roles and service accounts via STS
+- ELBs for API endpoints (Public, PublicAndPrivate, or Private access)
+- Auto Scaling Groups for NodePools
+- S3 bucket for OIDC issuer
+
+## Cluster Profile
+
+`hypershift-aws`
+
+## Credentials
+
+| Mount Path | Purpose |
+|---|---|
+| `/etc/hypershift-ci-jobs-awscreds/credentials` | HyperShift CI account AWS creds |
+| `/etc/hypershift-ci-jobs-awscreds/serviceaccount-signer.private` | SA token signing key |
+| `/etc/hypershift-pool-aws-credentials/credentials` | Pool AWS creds for nested tests |
+| `/etc/ci-pull-credentials/.dockerconfigjson` | Docker pull secrets |
+| `/etc/hypershift-kubeconfig/hypershift-ops-admin.kubeconfig` | Root management cluster kubeconfig |
+
+## OIDC
+
+S3-hosted issuer: `https://hypershift-ci-2-oidc.s3.us-east-1.amazonaws.com/shared-mgmt`
+
+## Key Environment Variables
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `HYPERSHIFT_AWS_REGION` | us-east-1 | AWS region |
+| `HYPERSHIFT_HC_ZONES` | us-east-1a | Availability zones for hosted cluster |
+| `HYPERSHIFT_ZONES` | us-east-1a,us-east-1b,us-east-1c | AZs for management cluster |
+| `HYPERSHIFT_INSTANCE_TYPE` | m5.xlarge | EC2 instance type |
+| `HYPERSHIFT_NODE_COUNT` | 3 | Worker node count |
+| `ENDPOINT_ACCESS` | Public | Public, PublicAndPrivate, or Private |
+| `HYPERSHIFT_DISK_ENCRYPTION` | | Enable disk encryption (reads `aws_kms_key_arn` from SHARED_DIR) |
+| `HYPERSHIFT_ETCD_ENCRYPTION` | | Enable etcd encryption (reads `aws_kms_key_arn` from SHARED_DIR) |
+| `HYPERSHIFT_SHARED_VPC` | | Use shared VPC account credentials |
+| `AWS_MULTI_ARCH` | | Enable multi-architecture testing |
+| `HYPERSHIFT_AUTONODE` | | Enable auto node scaling |
+| `PUBLIC_ONLY` | | Use only public subnets (requires 4.16+) |
+| `HYPERSHIFT_GUEST_INFRA_OCP_ACCOUNT` | | Use OCP account for guest infra |
+
+## SHARED_DIR Artifacts
+
+| File | Purpose |
+|---|---|
+| `aws_kms_key_arn` | KMS key ARN for encryption |
+| `hcp-role-arn` | HCP STS role ARN |
+| `sts-creds.json` | STS credentials JSON |
+| `nested_kubeconfig` | Guest cluster kubeconfig |
+| `cluster-name` | Generated cluster name |
+| `hypershift_create_cluster_render.yaml` | Rendered cluster manifest (if render-only) |
+
+## Subdirectories
+
+- `create/` — HostedCluster creation chain
+- `destroy/` — cleanup operations
+- `e2e/` — e2e workflows (nested, external, v2)
+- `run-e2e/` — e2e test execution (nested, external)
+- `conformance-*` — conformance variants (calico, cilium, proxy)
+- `reqserving-e2e/` — request serving isolation tests
+- `e2e-backuprestore/` — OADP backup/restore workflows
+- `oadp-setup/`, `oadp-destroy/` — OADP lifecycle
+- `cluster/` — cluster-level operations

--- a/.claude/rules/hypershift-aws.md
+++ b/.claude/rules/hypershift-aws.md
@@ -7,12 +7,14 @@ paths:
 
 ## Architecture
 
-AWS HyperShift uses the nested management cluster pattern:
+Most AWS workflows use a 3-tier nested management cluster pattern:
 1. Root OpenShift cluster (pre-existing, shared)
 2. Nested management cluster (ephemeral HostedCluster on root, created per CI job)
 3. Guest HostedCluster (the cluster under test, created on the nested management cluster)
 
 Key workflow: `hypershift-aws-e2e-nested`
+
+Note: Not all workflows follow the 3-tier model. Exceptions include `hypershift-aws-conformance` and `hypershift-aws-e2e-external` which use `hypershift-setup-root-management-cluster` (2-tier), `hypershift-aws-reqserving-e2e` which uses IPI to provision the management cluster, and `hypershift-aws-conformance-proxy` which uses IPI with proxy (`ipi-aws-pre-proxy`).
 
 ## AWS Resources Created
 
@@ -30,17 +32,17 @@ Key workflow: `hypershift-aws-e2e-nested`
 
 ## Credentials
 
-| Mount Path | Purpose |
+| File Path | Purpose |
 |---|---|
 | `/etc/hypershift-ci-jobs-awscreds/credentials` | HyperShift CI account AWS creds |
-| `/etc/hypershift-ci-jobs-awscreds/serviceaccount-signer.private` | SA token signing key |
 | `/etc/hypershift-pool-aws-credentials/credentials` | Pool AWS creds for nested tests |
 | `/etc/ci-pull-credentials/.dockerconfigjson` | Docker pull secrets |
-| `/etc/hypershift-kubeconfig/hypershift-ops-admin.kubeconfig` | Root management cluster kubeconfig |
+| `/etc/hypershift-kubeconfig/hypershift-ops-admin.kubeconfig` | Root management cluster kubeconfig (run-e2e/nested only) |
+| `/etc/hypershift-additional-pull-secret/.dockerconfigjson` | Additional pull secret for e2e tests (run-e2e/nested, run-e2e/external) |
 
 ## OIDC
 
-S3-hosted issuer: `https://hypershift-ci-2-oidc.s3.us-east-1.amazonaws.com/shared-mgmt`
+The S3 OIDC issuer URL (`https://hypershift-ci-2-oidc.s3.us-east-1.amazonaws.com/shared-mgmt`) is configured in the management cluster setup chain (outside `hypershift/aws/` scope). Within `hypershift/aws/`, the e2e tests reference S3 bucket `hypershift-ci-oidc` (via `--e2e.aws-oidc-s3-bucket-name=hypershift-ci-oidc`).
 
 ## Key Environment Variables
 
@@ -48,37 +50,54 @@ S3-hosted issuer: `https://hypershift-ci-2-oidc.s3.us-east-1.amazonaws.com/share
 |---|---|---|
 | `HYPERSHIFT_AWS_REGION` | us-east-1 | AWS region |
 | `HYPERSHIFT_HC_ZONES` | us-east-1a | Availability zones for hosted cluster |
-| `HYPERSHIFT_ZONES` | us-east-1a,us-east-1b,us-east-1c | AZs for management cluster |
 | `HYPERSHIFT_INSTANCE_TYPE` | m5.xlarge | EC2 instance type |
 | `HYPERSHIFT_NODE_COUNT` | 3 | Worker node count |
 | `ENDPOINT_ACCESS` | Public | Public, PublicAndPrivate, or Private |
-| `HYPERSHIFT_DISK_ENCRYPTION` | | Enable disk encryption (reads `aws_kms_key_arn` from SHARED_DIR) |
-| `HYPERSHIFT_ETCD_ENCRYPTION` | | Enable etcd encryption (reads `aws_kms_key_arn` from SHARED_DIR) |
-| `HYPERSHIFT_SHARED_VPC` | | Use shared VPC account credentials |
-| `AWS_MULTI_ARCH` | | Enable multi-architecture testing |
-| `HYPERSHIFT_AUTONODE` | | Enable auto node scaling |
-| `PUBLIC_ONLY` | | Use only public subnets (requires 4.16+) |
-| `HYPERSHIFT_GUEST_INFRA_OCP_ACCOUNT` | | Use OCP account for guest infra |
+| `HYPERSHIFT_DISK_ENCRYPTION` | false | Enable disk encryption (reads `aws_kms_key_arn` from SHARED_DIR) |
+| `HYPERSHIFT_ETCD_ENCRYPTION` | false | Enable etcd encryption (reads `aws_kms_key_arn` from SHARED_DIR) |
+| `HYPERSHIFT_SHARED_VPC` | false | Use shared VPC account credentials |
+| `AWS_MULTI_ARCH` | false | Enable multi-architecture testing |
+| `HYPERSHIFT_AUTONODE` | false | Enable auto node scaling |
+| `PUBLIC_ONLY` | false | Use only public subnets (requires 4.16+) |
+| `HYPERSHIFT_GUEST_INFRA_OCP_ACCOUNT` | false | Use OCP account for guest infra |
+| `HYPERSHIFT_BASE_DOMAIN` | (empty) | Cluster FQDN base domain |
+| `HYPERSHIFT_EXTERNAL_DNS_DOMAIN` | (empty) | External DNS domain |
+| `HYPERSHIFT_CP_AVAILABILITY_POLICY` | SingleReplica | Control plane availability |
+| `HYPERSHIFT_CREATE_CLUSTER_RENDER` | false | Render cluster manifest without creating |
+| `ENABLE_ICSP` | false | Enable ImageContentSourcePolicy |
+| `HYPERSHIFT_HC_RELEASE_IMAGE` | (empty) | Guest cluster release image override |
+| `RUN_UPGRADE_TEST` | false | Enable upgrade tests |
+| `TECH_PREVIEW_NO_UPGRADE` | false | Skip upgrades for tech preview |
+| `HYPERSHIFT_INFRA_AVAILABILITY_POLICY` | SingleReplica | Infrastructure availability |
+| `HYPERSHIFT_NETWORK_TYPE` | (empty) | Cluster SDN provider (OVNKubernetes, or Other for BYO CNI like Calico/Cilium) |
+| `EXTRA_ARGS` | (empty) | Additional `hypershift create cluster` arguments |
 
 ## SHARED_DIR Artifacts
 
 | File | Purpose |
 |---|---|
 | `aws_kms_key_arn` | KMS key ARN for encryption |
-| `hcp-role-arn` | HCP STS role ARN |
-| `sts-creds.json` | STS credentials JSON |
 | `nested_kubeconfig` | Guest cluster kubeconfig |
 | `cluster-name` | Generated cluster name |
 | `hypershift_create_cluster_render.yaml` | Rendered cluster manifest (if render-only) |
+| `management_cluster_kubeconfig` | Management cluster kubeconfig (default KUBECONFIG for run-e2e) |
+| `management_cluster_name` | Management cluster name |
+| `management_cluster_namespace` | Management cluster namespace |
+| `mgmt_icsp.yaml` | Image content source policy |
 
 ## Subdirectories
 
-- `create/` — HostedCluster creation chain
+- `create/` — HostedCluster creation chain (includes `nodepool/` for multi-arch)
 - `destroy/` — cleanup operations
-- `e2e/` — e2e workflows (nested, external, v2)
+- `e2e/` — e2e workflows (nested, external, external/oidc, cluster, metrics)
+- `e2e-v2/` — v2 e2e workflow
 - `run-e2e/` — e2e test execution (nested, external)
-- `conformance-*` — conformance variants (calico, cilium, proxy)
+- `conformance/` — base AWS conformance workflow
+- `conformance-calico/` — Calico conformance variant (uses 3-tier nested model)
+- `conformance-cilium/` — Cilium conformance variant (uses 3-tier nested model)
+- `conformance-proxy/` — proxy conformance variant
 - `reqserving-e2e/` — request serving isolation tests
+- `run-reqserving-e2e/` — request serving e2e test execution
 - `e2e-backuprestore/` — OADP backup/restore workflows
 - `oadp-setup/`, `oadp-destroy/` — OADP lifecycle
 - `cluster/` — cluster-level operations

--- a/.claude/rules/hypershift-azure-common.md
+++ b/.claude/rules/hypershift-azure-common.md
@@ -1,0 +1,61 @@
+---
+paths:
+  - "ci-operator/step-registry/hypershift/azure/**"
+---
+
+# HyperShift Azure — Common Context
+
+Azure HyperShift has two deployment models. See the model-specific rules for details:
+- **Managed (ARO-HCP)**: AKS management cluster — see `hypershift-azure-managed.md`
+- **Self-managed**: OpenShift management clusters — see `hypershift-azure-self-managed.md`
+
+## Azure Resources Created (Both Models)
+
+- Resource Groups (custom or auto-generated)
+- VNets, Subnets, NSGs (or BYO via `HYPERSHIFT_CUSTOM_VNET/SUBNET/NSG`)
+- VM instances for NodePools
+- Managed Identities (control plane and data plane)
+- Azure Key Vault for secrets and encryption
+- Disk Encryption Sets (DES) for disk encryption
+- Azure DNS zones for KAS DNS management
+- Storage accounts for diagnostics
+
+## Shared Credentials
+
+| Mount Path | Contents |
+|---|---|
+| `/etc/hypershift-ci-jobs-azurecreds/credentials.json` | Azure service principal |
+| `/etc/hypershift-ci-jobs-azurecreds/oidc-issuer-url.json` | OIDC issuer URL for WIF |
+| `/etc/hypershift-ci-jobs-azurecreds/serviceaccount-signer.private` | SA token signing key |
+| `/etc/ci-pull-credentials/.dockerconfigjson` | Docker pull secrets |
+
+## Shared Environment Variables
+
+| Variable | Purpose |
+|---|---|
+| `HYPERSHIFT_AZURE_LOCATION` | Azure region (centralus for self-managed, eastus for managed) |
+| `HYPERSHIFT_EXTERNAL_DNS_DOMAIN` | External DNS domain |
+| `HYPERSHIFT_DYNAMIC_DNS` | Custom KAS DNS name |
+| `HYPERSHIFT_CUSTOM_RESOURCE_GROUP` | Use custom resource group from `${SHARED_DIR}/resourcegroup` |
+| `HYPERSHIFT_CUSTOM_VNET` | BYO VNet from `${SHARED_DIR}/azure_vnet_id` |
+| `HYPERSHIFT_CUSTOM_SUBNET` | BYO subnet from `${SHARED_DIR}/azure_subnet_id` |
+| `HYPERSHIFT_CUSTOM_NSG` | BYO NSG from `${SHARED_DIR}/azure_nsg_id` |
+| `HYPERSHIFT_DISK_ENCRYPTION` | Use DES from `${SHARED_DIR}/azure_des_id` |
+| `HYPERSHIFT_ETCD_ENCRYPTION` | Use Key Vault key from `${SHARED_DIR}/azure_active_key_url` |
+| `HYPERSHIFT_ENCRYPTION_AT_HOST` | VM host encryption (Enabled/Disabled) |
+| `HYPERSHIFT_NP_AUTOREPAIR` | Machine autorepair with health checks |
+| `HYPERSHIFT_AZURE_FIPS` | Enable FIPS mode |
+
+## Shared SHARED_DIR Artifacts
+
+| File | Purpose |
+|---|---|
+| `azure_des_id` | Disk Encryption Set resource ID |
+| `azure_active_key_url` | Key Vault encryption key URL |
+| `azure_vnet_id` | Virtual Network resource ID |
+| `azure_subnet_id` | Subnet resource ID |
+| `azure_nsg_id` | Network Security Group resource ID |
+| `azure_storage_account_blob_endpoint` | Storage account URI (diagnostics) |
+| `resourcegroup` | Custom resource group name |
+| `nested_kubeconfig` | Guest cluster kubeconfig |
+| `cluster-name` | Generated cluster name |

--- a/.claude/rules/hypershift-azure-common.md
+++ b/.claude/rules/hypershift-azure-common.md
@@ -20,21 +20,41 @@ Azure HyperShift has two deployment models. See the model-specific rules for det
 - Azure DNS zones for KAS DNS management
 - Storage accounts for diagnostics
 
-## Shared Credentials
+## Shared Credentials (Both Models)
+
+| Mount Path | Contents |
+|---|---|
+| `/etc/ci-pull-credentials/.dockerconfigjson` | Docker pull secrets |
+
+### Create Chain Credentials
+
+These credentials are used by the `hypershift-azure-create` chain. The primary self-managed e2e workflow uses different credential paths (see `hypershift-azure-self-managed.md`), but some cucushift-based self-managed workflows also use this chain.
 
 | Mount Path | Contents |
 |---|---|
 | `/etc/hypershift-ci-jobs-azurecreds/credentials.json` | Azure service principal |
 | `/etc/hypershift-ci-jobs-azurecreds/oidc-issuer-url.json` | OIDC issuer URL for WIF |
 | `/etc/hypershift-ci-jobs-azurecreds/serviceaccount-signer.private` | SA token signing key |
-| `/etc/ci-pull-credentials/.dockerconfigjson` | Docker pull secrets |
+| `/etc/hypershift-aro-azurecreds/` | ARO Azure creds (fallback when `USE_HYPERSHIFT_AZURE_CREDS` is false) |
+| `/etc/hypershift-selfmanaged-azurecreds/workload-identities.json` | Self-managed workload identities (when `HYPERSHIFT_AZURE_SELF_MANAGED=true`) |
 
-## Shared Environment Variables
+## Shared Environment Variables (Both Models)
 
 | Variable | Purpose |
 |---|---|
-| `HYPERSHIFT_AZURE_LOCATION` | Azure region (centralus for self-managed, eastus for managed) |
+| `HYPERSHIFT_AZURE_LOCATION` | Azure region (default: eastus in create/destroy chains; overridden to centralus in self-managed workflow and ref) |
 | `HYPERSHIFT_EXTERNAL_DNS_DOMAIN` | External DNS domain |
+| `CI_TESTS_RUN` | Test regex filter for selecting which e2e tests to run |
+
+### Create Chain Environment Variables
+
+These env vars are defined in the `hypershift-azure-create` chain.
+
+| Variable | Purpose |
+|---|---|
+| `USE_HYPERSHIFT_AZURE_CREDS` | Select HyperShift OSD credential set (true/false) |
+| `HYPERSHIFT_AZURE_CP_MI` | Enable managed identity auth (true/false) |
+| `HYPERSHIFT_AZURE_SELF_MANAGED` | Use self-managed workload identities file (true/false) |
 | `HYPERSHIFT_DYNAMIC_DNS` | Custom KAS DNS name |
 | `HYPERSHIFT_CUSTOM_RESOURCE_GROUP` | Use custom resource group from `${SHARED_DIR}/resourcegroup` |
 | `HYPERSHIFT_CUSTOM_VNET` | BYO VNet from `${SHARED_DIR}/azure_vnet_id` |
@@ -42,20 +62,37 @@ Azure HyperShift has two deployment models. See the model-specific rules for det
 | `HYPERSHIFT_CUSTOM_NSG` | BYO NSG from `${SHARED_DIR}/azure_nsg_id` |
 | `HYPERSHIFT_DISK_ENCRYPTION` | Use DES from `${SHARED_DIR}/azure_des_id` |
 | `HYPERSHIFT_ETCD_ENCRYPTION` | Use Key Vault key from `${SHARED_DIR}/azure_active_key_url` |
-| `HYPERSHIFT_ENCRYPTION_AT_HOST` | VM host encryption (Enabled/Disabled) |
+| `HYPERSHIFT_ENCRYPTION_AT_HOST` | VM host encryption (true/false) |
 | `HYPERSHIFT_NP_AUTOREPAIR` | Machine autorepair with health checks |
 | `HYPERSHIFT_AZURE_FIPS` | Enable FIPS mode |
+| `HYPERSHIFT_NODE_COUNT` | NodePool replica count (default: 3 in create chain) |
+| `DNS_ZONE_RG_NAME` | DNS zone resource group (default: os4-common; also used by destroy chain) |
 
-## Shared SHARED_DIR Artifacts
+## Shared SHARED_DIR Artifacts (Both Models)
 
 | File | Purpose |
 |---|---|
-| `azure_des_id` | Disk Encryption Set resource ID |
-| `azure_active_key_url` | Key Vault encryption key URL |
-| `azure_vnet_id` | Virtual Network resource ID |
-| `azure_subnet_id` | Subnet resource ID |
-| `azure_nsg_id` | Network Security Group resource ID |
-| `azure_storage_account_blob_endpoint` | Storage account URI (diagnostics) |
-| `resourcegroup` | Custom resource group name |
-| `nested_kubeconfig` | Guest cluster kubeconfig |
-| `cluster-name` | Generated cluster name |
+| `management_cluster_kubeconfig` | Management cluster kubeconfig |
+| `management_cluster_name` | Management cluster name |
+| `management_cluster_namespace` | Management cluster namespace |
+
+### Create Chain SHARED_DIR Artifacts
+
+These artifacts are consumed by the `hypershift-azure-create` chain from upstream provisioning steps, except `cluster-name` and `nested_kubeconfig` which are produced by the create chain. The destroy chain only reads `resourcegroup`.
+
+| File | Direction | Purpose |
+|---|---|---|
+| `azure_des_id` | consumed | Disk Encryption Set resource ID |
+| `azure_active_key_url` | consumed | Key Vault encryption key URL |
+| `azure_vnet_id` | consumed | Virtual Network resource ID |
+| `azure_subnet_id` | consumed | Subnet resource ID |
+| `azure_nsg_id` | consumed | Network Security Group resource ID |
+| `azure_storage_account_blob_endpoint` | consumed | Storage account URI (diagnostics) |
+| `resourcegroup` | consumed | Custom resource group name (also read by destroy chain) |
+| `hypershift_hc_annotations` | consumed | HostedCluster annotations (one per line, used for AKS) |
+| `cluster-name` | produced | Generated cluster name |
+| `nested_kubeconfig` | produced | Guest/hosted cluster kubeconfig |
+
+### Destroy Chain
+
+The `hypershift-azure-destroy` chain mounts `hypershift-ci-jobs-azurecreds` and uses the following env vars: `USE_HYPERSHIFT_AZURE_CREDS`, `HYPERSHIFT_AZURE_LOCATION`, `HYPERSHIFT_CUSTOM_RESOURCE_GROUP`, and `DNS_ZONE_RG_NAME`.

--- a/.claude/rules/hypershift-azure-managed.md
+++ b/.claude/rules/hypershift-azure-managed.md
@@ -1,0 +1,77 @@
+---
+paths:
+  - "ci-operator/step-registry/hypershift/azure/aks/**"
+  - "ci-operator/step-registry/hypershift/azure/run-e2e/**"
+---
+
+# HyperShift Azure Managed (ARO-HCP)
+
+Also known as ARO HCP (Azure Red Hat OpenShift Hosted Control Planes).
+
+Shared Azure context (resources, credentials, BYO networking, encryption) is in `hypershift-azure-common.md`.
+
+## Architecture
+
+Uses **AKS (Azure Kubernetes Service)** as the management cluster. AKS is a managed Kubernetes service — not OpenShift. The HyperShift operator is installed on AKS, and hosted cluster control planes run as pods on AKS.
+
+This is different from self-managed Azure, which uses OpenShift management clusters.
+
+## Workflow
+
+`hypershift-azure-aks-e2e`:
+1. Provision AKS cluster via `cucushift-installer-rehearse-azure-aks-provision`
+2. Attach Azure Key Vault via `hypershift-azure-aks-attach-kv`
+3. Install HyperShift operator via `hypershift-install` (with `AKS=true`)
+4. Run e2e tests via `hypershift-azure-run-e2e`
+5. Deprovision AKS cluster
+
+## Cluster Profile
+
+`hypershift-aks`
+
+## AKS-Specific Features
+
+- Azure Key Vault integration for K8s secrets (via `azure-keyvault-secrets-provider` addon)
+- AKS cluster autoscaler: `AKS_CLUSTER_AUTOSCALER_MIN_NODES` / `AKS_CLUSTER_AUTOSCALER_MAX_NODES`
+- Marketplace image support: `HYPERSHIFT_AZURE_MARKETPLACE_IMAGE_*` (publisher, offer, SKU, version)
+- Managed service flag: `--managed-service=ARO-HCP` passed to hypershift install
+
+## Managed-Specific Credentials
+
+In addition to the shared credentials in `hypershift-azure-common.md`:
+
+| Mount Path | Contents |
+|---|---|
+| `/etc/hypershift-ci-jobs-azurecreds/managed-identities.json` | Managed identity mappings |
+| `/etc/hypershift-ci-jobs-azurecreds/dataplane-identities.json` | Data plane identity mappings |
+| `/etc/hypershift-ci-jobs-azurecreds/aks-kms-info.json` | AKS KMS configuration |
+
+## Managed-Specific Environment Variables
+
+In addition to the shared env vars in `hypershift-azure-common.md`:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `AKS` | true | Indicates management cluster is AKS |
+| `USE_HYPERSHIFT_AZURE_CREDS` | true | Use HyperShift OSD account |
+| `HYPERSHIFT_AZURE_CP_MI` | | Use managed identities for control plane |
+| `AUTH_THROUGH_CERTS` | false | Azure Key Vault certificate auth |
+| `HYPERSHIFT_AZURE_MARKETPLACE_ENABLED` | | Use Azure Marketplace images |
+
+## Managed-Specific SHARED_DIR Artifacts
+
+In addition to the shared artifacts in `hypershift-azure-common.md`:
+
+| File | Purpose |
+|---|---|
+| `azure-marketplace-image-sku` | Marketplace image SKU |
+| `azure-marketplace-image-version` | Marketplace image version |
+| `hypershift_hc_annotations` | HostedCluster annotations (one per line) |
+
+## AKS Subdirectories
+
+- `aks/e2e/` — AKS e2e workflow
+- `aks/attach-kv/` — Key Vault attachment to AKS cluster
+- `aks/conformance/` — AKS conformance tests
+- `aks/external-oidc/` — External OIDC provider for AKS
+- `run-e2e/` — e2e test execution for managed/AKS

--- a/.claude/rules/hypershift-azure-managed.md
+++ b/.claude/rules/hypershift-azure-managed.md
@@ -22,8 +22,9 @@ This is different from self-managed Azure, which uses OpenShift management clust
 1. Provision AKS cluster via `cucushift-installer-rehearse-azure-aks-provision`
 2. Attach Azure Key Vault via `hypershift-azure-aks-attach-kv`
 3. Install HyperShift operator via `hypershift-install` (with `AKS=true`)
-4. Run e2e tests via `hypershift-azure-run-e2e`
-5. Deprovision AKS cluster
+4. Get guest annotations via `cucushift-hypershift-extended-k8s-mgmt-get-guest-annotations`
+5. Run e2e tests via `hypershift-azure-run-e2e`
+6. Deprovision AKS cluster
 
 ## Cluster Profile
 
@@ -45,6 +46,8 @@ In addition to the shared credentials in `hypershift-azure-common.md`:
 | `/etc/hypershift-ci-jobs-azurecreds/managed-identities.json` | Managed identity mappings |
 | `/etc/hypershift-ci-jobs-azurecreds/dataplane-identities.json` | Data plane identity mappings |
 | `/etc/hypershift-ci-jobs-azurecreds/aks-kms-info.json` | AKS KMS configuration |
+| `/etc/hypershift-additional-pull-secret/.dockerconfigjson` | Additional pull secret for e2e tests |
+| `/etc/hypershift-kubeconfig/hypershift-ops-admin.kubeconfig` | Root management cluster kubeconfig (MGMT_PARENT_KUBECONFIG default) |
 
 ## Managed-Specific Environment Variables
 
@@ -52,11 +55,15 @@ In addition to the shared env vars in `hypershift-azure-common.md`:
 
 | Variable | Default | Purpose |
 |---|---|---|
-| `AKS` | true | Indicates management cluster is AKS |
-| `USE_HYPERSHIFT_AZURE_CREDS` | true | Use HyperShift OSD account |
-| `HYPERSHIFT_AZURE_CP_MI` | | Use managed identities for control plane |
+| `AKS` | false (overridden to `true` at workflow level) | Indicates management cluster is AKS |
+| `USE_HYPERSHIFT_AZURE_CREDS` | false (overridden to `true` at workflow level) | Use HyperShift OSD account |
 | `AUTH_THROUGH_CERTS` | false | Azure Key Vault certificate auth |
-| `HYPERSHIFT_AZURE_MARKETPLACE_ENABLED` | | Use Azure Marketplace images |
+| `HYPERSHIFT_MANAGED_SERVICE` | ARO-HCP | Managed service identifier passed to hypershift install |
+| `TECH_PREVIEW_NO_UPGRADE` | false | Skip upgrades for tech preview |
+| `HYPERSHIFT_AZURE_MARKETPLACE_IMAGE_OFFER` | aro4 | Azure Marketplace image offer |
+| `HYPERSHIFT_AZURE_MARKETPLACE_IMAGE_PUBLISHER` | azureopenshift | Marketplace publisher |
+| `HYPERSHIFT_AZURE_MARKETPLACE_IMAGE_VERSION` | 419.6.20250523 | Marketplace image version (pinned, updated periodically) |
+| `HYPERSHIFT_AZURE_MARKETPLACE_IMAGE_SKU` | aro_419 | Marketplace image SKU (pinned, updated periodically) |
 
 ## Managed-Specific SHARED_DIR Artifacts
 
@@ -64,9 +71,8 @@ In addition to the shared artifacts in `hypershift-azure-common.md`:
 
 | File | Purpose |
 |---|---|
-| `azure-marketplace-image-sku` | Marketplace image SKU |
-| `azure-marketplace-image-version` | Marketplace image version |
 | `hypershift_hc_annotations` | HostedCluster annotations (one per line) |
+| `resourcegroup_aks` | AKS resource group name (used by attach-kv) |
 
 ## AKS Subdirectories
 

--- a/.claude/rules/hypershift-azure-self-managed.md
+++ b/.claude/rules/hypershift-azure-self-managed.md
@@ -1,0 +1,103 @@
+---
+paths:
+  - "ci-operator/step-registry/hypershift/azure/e2e/**"
+  - "ci-operator/step-registry/hypershift/azure/run-e2e-self-managed/**"
+  - "ci-operator/step-registry/hypershift/azure/create/**"
+  - "ci-operator/step-registry/hypershift/azure/destroy/**"
+  - "ci-operator/step-registry/hypershift/azure/setup-private-link/**"
+  - "ci-operator/step-registry/hypershift/azure/kas-dns-update/**"
+---
+
+# HyperShift Azure Self-Managed
+
+Shared Azure context (resources, credentials, BYO networking, encryption) is in `hypershift-azure-common.md`.
+
+## Architecture
+
+Uses **OpenShift management clusters** — the same nested management cluster pattern as AWS. A nested OpenShift HostedCluster is created on a pre-existing root cluster, then the HyperShift operator is installed on it.
+
+This is different from managed Azure (ARO-HCP), which uses AKS as the management cluster.
+
+Key distinction: self-managed sets `AZURE_SELF_MANAGED=true`, which skips the `--managed-service=ARO-HCP` flag during hypershift install.
+
+## Workflow
+
+`hypershift-azure-e2e-self-managed`:
+1. Set up nested OpenShift management cluster via `hypershift-setup-nested-management-cluster` (with `CLOUD_PROVIDER=Azure`)
+2. Configure Azure Private Link via `hypershift-azure-setup-private-link`
+3. Install HyperShift operator via `hypershift-install` (with `AZURE_SELF_MANAGED=true`)
+4. Run e2e tests via `hypershift-azure-run-e2e-self-managed`
+5. Destroy management cluster via `hypershift-destroy-nested-management-cluster`
+
+## Cluster Profile
+
+`hypershift-azure`
+
+## Management Cluster Details
+
+- Root cluster kubeconfig: `/etc/hypershift-kubeconfig-azure/hypershift-ops-admin.kubeconfig`
+- Cluster name: derived from `PROW_JOB_ID` hash (same pattern as AWS)
+- Instance type: `Standard_D16s_v3` (default)
+- Etcd storage class: `managed-csi-premium-v2` (Premium SSD v2, created during setup)
+- Base domain: `hcp-sm-azure.azure.devcluster.openshift.com`
+- Location: `centralus`
+
+## Private Link
+
+Self-managed Azure uses Azure Private Link to provide secure connectivity between the management cluster and hosted cluster API servers.
+
+Setup step: `hypershift-azure-setup-private-link`
+
+Private Link artifacts in SHARED_DIR:
+- `azure_pls_resource_group` — resource group for Private Link Services
+- `azure_private_link_creds_file` — Private Link credentials
+- `azure_private_nat_subnet_id` — NAT subnet for private endpoints
+
+## KAS DNS Update
+
+Step `hypershift-azure-kas-dns-update` updates Azure DNS CNAME records for custom KAS (Kubernetes API Server) DNS names. Used when `HYPERSHIFT_DYNAMIC_DNS` is set.
+
+## Self-Managed-Specific Credentials
+
+In addition to the shared credentials in `hypershift-azure-common.md`:
+
+| Mount Path | Contents |
+|---|---|
+| `/etc/hypershift-ci-jobs-self-managed-azure/credentials.json` | Self-managed Azure service principal |
+| `/etc/hypershift-ci-jobs-self-managed-azure-e2e/` | Self-managed e2e-specific creds |
+| `/etc/hypershift-kubeconfig-azure/hypershift-ops-admin.kubeconfig` | Root management cluster kubeconfig |
+
+## Self-Managed-Specific Environment Variables
+
+In addition to the shared env vars in `hypershift-azure-common.md`:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `AZURE_SELF_MANAGED` | true | Self-managed mode (skips `--managed-service=ARO-HCP`) |
+| `CLOUD_PROVIDER` | Azure | Cloud provider for management cluster setup |
+| `HYPERSHIFT_ETCD_STORAGE_CLASS` | managed-csi-premium-v2 | Storage class for etcd |
+| `HYPERSHIFT_NODE_COUNT` | 2 | Worker node count |
+| `AZURE_PRIVATE_CREDS_FILE` | | Path to Private Link credentials |
+| `AZURE_PLS_RESOURCE_GROUP` | | Resource group for Private Link Services |
+
+## Self-Managed-Specific SHARED_DIR Artifacts
+
+In addition to the shared artifacts in `hypershift-azure-common.md`:
+
+| File | Purpose |
+|---|---|
+| `management_cluster_kubeconfig` | Nested management cluster kubeconfig |
+| `management_cluster_name` | Management cluster name |
+| `management_cluster_namespace` | Management cluster namespace |
+| `azure_pls_resource_group` | Private Link Services resource group |
+| `azure_private_link_creds_file` | Private Link credentials |
+| `azure_private_nat_subnet_id` | NAT subnet for private endpoints |
+
+## Self-Managed Subdirectories
+
+- `e2e/self-managed/` — self-managed e2e workflow definition
+- `run-e2e-self-managed/` — e2e test execution (ref + commands script)
+- `create/` — HostedCluster creation chain
+- `destroy/` — cleanup operations
+- `setup-private-link/` — Azure Private Link/Private Endpoint setup
+- `kas-dns-update/` — Azure DNS CNAME updates for custom KAS DNS

--- a/.claude/rules/hypershift-azure-self-managed.md
+++ b/.claude/rules/hypershift-azure-self-managed.md
@@ -1,11 +1,8 @@
 ---
 paths:
-  - "ci-operator/step-registry/hypershift/azure/e2e/**"
+  - "ci-operator/step-registry/hypershift/azure/e2e/self-managed/**"
   - "ci-operator/step-registry/hypershift/azure/run-e2e-self-managed/**"
-  - "ci-operator/step-registry/hypershift/azure/create/**"
-  - "ci-operator/step-registry/hypershift/azure/destroy/**"
   - "ci-operator/step-registry/hypershift/azure/setup-private-link/**"
-  - "ci-operator/step-registry/hypershift/azure/kas-dns-update/**"
 ---
 
 # HyperShift Azure Self-Managed
@@ -18,16 +15,17 @@ Uses **OpenShift management clusters** — the same nested management cluster pa
 
 This is different from managed Azure (ARO-HCP), which uses AKS as the management cluster.
 
-Key distinction: self-managed sets `AZURE_SELF_MANAGED=true`, which skips the `--managed-service=ARO-HCP` flag during hypershift install.
+Key distinction: self-managed sets `AZURE_SELF_MANAGED=true`, which skips the `--managed-service=ARO-HCP` flag during hypershift install. When Private Link credentials are available, it also adds `--private-platform=Azure`, `--azure-private-creds`, and `--azure-pls-resource-group` flags.
 
 ## Workflow
 
 `hypershift-azure-e2e-self-managed`:
-1. Set up nested OpenShift management cluster via `hypershift-setup-nested-management-cluster` (with `CLOUD_PROVIDER=Azure`)
-2. Configure Azure Private Link via `hypershift-azure-setup-private-link`
-3. Install HyperShift operator via `hypershift-install` (with `AZURE_SELF_MANAGED=true`)
-4. Run e2e tests via `hypershift-azure-run-e2e-self-managed`
-5. Destroy management cluster via `hypershift-destroy-nested-management-cluster`
+1. RBAC setup via `ipi-install-rbac`
+2. Set up nested OpenShift management cluster via `hypershift-setup-nested-management-cluster` (with `CLOUD_PROVIDER=Azure`)
+3. Configure Azure Private Link via `hypershift-azure-setup-private-link`
+4. Install HyperShift operator via `hypershift-install` (with `AZURE_SELF_MANAGED=true`)
+5. Run e2e tests via `hypershift-azure-run-e2e-self-managed`
+6. Destroy management cluster via `hypershift-destroy-nested-management-cluster`
 
 ## Cluster Profile
 
@@ -53,10 +51,6 @@ Private Link artifacts in SHARED_DIR:
 - `azure_private_link_creds_file` — Private Link credentials
 - `azure_private_nat_subnet_id` — NAT subnet for private endpoints
 
-## KAS DNS Update
-
-Step `hypershift-azure-kas-dns-update` updates Azure DNS CNAME records for custom KAS (Kubernetes API Server) DNS names. Used when `HYPERSHIFT_DYNAMIC_DNS` is set.
-
 ## Self-Managed-Specific Credentials
 
 In addition to the shared credentials in `hypershift-azure-common.md`:
@@ -66,6 +60,7 @@ In addition to the shared credentials in `hypershift-azure-common.md`:
 | `/etc/hypershift-ci-jobs-self-managed-azure/credentials.json` | Self-managed Azure service principal |
 | `/etc/hypershift-ci-jobs-self-managed-azure-e2e/` | Self-managed e2e-specific creds |
 | `/etc/hypershift-kubeconfig-azure/hypershift-ops-admin.kubeconfig` | Root management cluster kubeconfig |
+| `/etc/hypershift-additional-pull-secret/.dockerconfigjson` | Additional pull secret for e2e tests |
 
 ## Self-Managed-Specific Environment Variables
 
@@ -79,6 +74,11 @@ In addition to the shared env vars in `hypershift-azure-common.md`:
 | `HYPERSHIFT_NODE_COUNT` | 2 | Worker node count |
 | `AZURE_PRIVATE_CREDS_FILE` | | Path to Private Link credentials |
 | `AZURE_PLS_RESOURCE_GROUP` | | Resource group for Private Link Services |
+| `AZURE_PRIVATE_NAT_SUBNET_ID` | (empty) | NAT subnet for private endpoints (alternative to SHARED_DIR file) |
+| `CI_TESTS_RUN` | (empty) | Regex filter for e2e test selection |
+| `HYPERSHIFT_EXTERNAL_DNS_DOMAIN` | aks-e2e.hypershift.azure.devcluster.openshift.com | External DNS domain (workflow default) |
+| `HYPERSHIFT_AZURE_ZONES` | (empty) | Availability zones for hosted cluster |
+| `E2E_RESOURCE_REQUEST_OVERRIDES` | (empty) | Resource request overrides for e2e tests |
 
 ## Self-Managed-Specific SHARED_DIR Artifacts
 
@@ -86,9 +86,7 @@ In addition to the shared artifacts in `hypershift-azure-common.md`:
 
 | File | Purpose |
 |---|---|
-| `management_cluster_kubeconfig` | Nested management cluster kubeconfig |
-| `management_cluster_name` | Management cluster name |
-| `management_cluster_namespace` | Management cluster namespace |
+| `kubeconfig` | Copy of management cluster kubeconfig |
 | `azure_pls_resource_group` | Private Link Services resource group |
 | `azure_private_link_creds_file` | Private Link credentials |
 | `azure_private_nat_subnet_id` | NAT subnet for private endpoints |
@@ -97,7 +95,4 @@ In addition to the shared artifacts in `hypershift-azure-common.md`:
 
 - `e2e/self-managed/` — self-managed e2e workflow definition
 - `run-e2e-self-managed/` — e2e test execution (ref + commands script)
-- `create/` — HostedCluster creation chain
-- `destroy/` — cleanup operations
 - `setup-private-link/` — Azure Private Link/Private Endpoint setup
-- `kas-dns-update/` — Azure DNS CNAME updates for custom KAS DNS

--- a/.claude/rules/hypershift-config.md
+++ b/.claude/rules/hypershift-config.md
@@ -1,0 +1,51 @@
+---
+paths:
+  - "ci-operator/config/openshift/hypershift/**"
+  - "ci-operator/config/openshift-priv/hypershift/**"
+---
+
+# HyperShift CI Configuration
+
+## File Naming
+
+Config files follow `openshift-hypershift-{branch}[__{variant}].yaml`:
+- `openshift-hypershift-main.yaml` — main branch, builds all images
+- `openshift-hypershift-release-4.22.yaml` — release branch, pins OCP version in base_images
+- `openshift-hypershift-release-4.22__periodics.yaml` — periodic variant
+
+## Variants
+
+| Variant | Purpose |
+|---|---|
+| *(none)* | Default config: builds images, runs presubmit/postsubmit tests, promotes |
+| `__periodics` | Cron-scheduled tests. No image builds or promotion — pulls pre-built images from `hypershift` namespace |
+| `__mce` | MCE (Multicluster Engine) integration tests. Uses `MCE_VERSION` env var |
+| `__periodics-mce` | Periodic MCE tests. Agent-based, uses equinix-ocp-hcp cluster profile, includes Konflux flags |
+| `__periodics-hcm` | Periodic HCM tests. Uses hypershift-operator from `acm-d` (external build), stable OCP releases only |
+| `__okd-scos` | OKD with SCOS (Stream CoreOS) configuration |
+| `__mce-multi-version` | Monthly MCE multi-version compatibility tests |
+
+## Images Built (from main/release base configs)
+
+- `hypershift-operator` — core operator (default Dockerfile)
+- `hypershift` — control plane (Dockerfile.control-plane)
+- `hypershift-tests` — e2e test binary (Dockerfile.e2e)
+- `hypershift-cli` — operator + jq (derived image)
+
+## Promotion Targets
+
+- **ocp namespace** — hypershift image promoted to OCP release payload
+- **hypershift namespace** — hypershift-operator and hypershift-tests with `latest` tag (consumed by periodic variants)
+- **ci namespace** — hypershift-cli with `latest` tag
+
+## Release Branch Configs
+
+- Release configs pin OCP version in `base_images` (e.g., `"4.22"` instead of `"5.0"`)
+- `config-brancher` manages release branch configs from main — do not manually edit brancher-managed release configs
+- Periodic variants should go in separate `__periodics.yaml` files for CI analytical tooling
+
+## Important Rules
+
+- Never edit files in `ci-operator/jobs/` directly — edit config here and run `make update`
+- After any config change, run `make update` to regenerate `zz_generated_metadata` and Prow jobs
+- Commit both config and generated files together

--- a/.claude/rules/hypershift-config.md
+++ b/.claude/rules/hypershift-config.md
@@ -13,24 +13,29 @@ Config files follow `openshift-hypershift-{branch}[__{variant}].yaml`:
 - `openshift-hypershift-release-4.22.yaml` — release branch, pins OCP version in base_images
 - `openshift-hypershift-release-4.22__periodics.yaml` — periodic variant
 
+Files in `openshift-priv/hypershift/` use the prefix `openshift-priv-hypershift-*` (e.g., `openshift-priv-hypershift-main.yaml`).
+
 ## Variants
 
 | Variant | Purpose |
 |---|---|
 | *(none)* | Default config: builds images, runs presubmit/postsubmit tests, promotes |
 | `__periodics` | Cron-scheduled tests. No image builds or promotion — pulls pre-built images from `hypershift` namespace |
-| `__mce` | MCE (Multicluster Engine) integration tests. Uses `MCE_VERSION` env var |
-| `__periodics-mce` | Periodic MCE tests. Agent-based, uses equinix-ocp-hcp cluster profile, includes Konflux flags |
-| `__periodics-hcm` | Periodic HCM tests. Uses hypershift-operator from `acm-d` (external build), stable OCP releases only |
-| `__okd-scos` | OKD with SCOS (Stream CoreOS) configuration |
+| `__mce` | MCE image build and publishing. Builds hypershift-operator via stolostron toolchain for backplane registry (postsubmit only, releases 4.12-4.19) |
+| `__periodics-mce` | Periodic MCE integration tests across platforms (agent, AWS, kubevirt, IBM Z, Power). Uses `MCE_VERSION` env var. Konflux flags in 4.21+ |
+| `__periodics-hcm` | Periodic HCM tests (releases 4.16-4.21 only). Uses hypershift-operator from `acm-d` (external build), GA OCP releases (fast channel) only |
+| `__okd-scos` | OKD with SCOS (Stream CoreOS) configuration (main and release-4.21) |
 | `__mce-multi-version` | Monthly MCE multi-version compatibility tests |
+| `__equinix-cleanup` | Periodic equinix cluster leak checker (runs every 30 min). Uses `equinix-ocp-hcp` cluster profile |
 
 ## Images Built (from main/release base configs)
 
 - `hypershift-operator` — core operator (default Dockerfile)
 - `hypershift` — control plane (Dockerfile.control-plane)
 - `hypershift-tests` — e2e test binary (Dockerfile.e2e)
-- `hypershift-cli` — operator + jq (derived image)
+- `hypershift-cli` — operator + jq (derived image, main and 4.23+ release configs)
+
+Note: Image builds vary by release branch. Recent releases (4.23+) build all 4 images including `hypershift-cli`. Release 4.22 builds 3 images (no `hypershift-cli`). Releases 4.14-4.21 build only `hypershift` (control plane image), importing operator and test images from the `hypershift` namespace. Releases 4.12-4.13 build both `hypershift-operator` and `hypershift` (2 images). The main config is the canonical reference for the current image set.
 
 ## Promotion Targets
 
@@ -38,10 +43,13 @@ Config files follow `openshift-hypershift-{branch}[__{variant}].yaml`:
 - **hypershift namespace** — hypershift-operator and hypershift-tests with `latest` tag (consumed by periodic variants)
 - **ci namespace** — hypershift-cli with `latest` tag
 
+Release branch configs promote to the `ocp` namespace with the release version name. Releases 4.21-4.22 exclude `hypershift-operator` and `hypershift-tests` from promotion. Releases 4.23+ additionally exclude `hypershift-cli`. Release branches do not promote to `hypershift` or `ci` namespaces.
+
 ## Release Branch Configs
 
 - Release configs pin OCP version in `base_images` (e.g., `"4.22"` instead of `"5.0"`)
 - `config-brancher` manages release branch configs from main — do not manually edit brancher-managed release configs
+- Main currently targets release `5.0`. Release branch configs exist for 4.12 through 5.1 (older releases like 4.12-4.17 may no longer be actively maintained)
 - Periodic variants should go in separate `__periodics.yaml` files for CI analytical tooling
 
 ## Important Rules

--- a/.claude/rules/hypershift-platforms.md
+++ b/.claude/rules/hypershift-platforms.md
@@ -1,0 +1,100 @@
+---
+paths:
+  - "ci-operator/step-registry/hypershift/gcp/**"
+  - "ci-operator/step-registry/hypershift/kubevirt/**"
+  - "ci-operator/step-registry/hypershift/agent/**"
+  - "ci-operator/step-registry/hypershift/mce/**"
+  - "ci-operator/step-registry/hypershift/ibmcloud/**"
+  - "ci-operator/step-registry/hypershift/powervs/**"
+  - "ci-operator/step-registry/hypershift/openstack/**"
+---
+
+# HyperShift Additional Platforms
+
+## GCP
+
+Uses Workload Identity Federation (WIF) for OIDC-based service account authentication. Each hosted cluster component gets its own GCP service account (controlplane, nodepool, cloudcontroller, storage, imageregistry, network).
+
+**Key concepts:**
+- **Workload Identity Federation (WIF)**: K8s ServiceAccounts mapped to GCP ServiceAccounts via OIDC — requires pool ID, provider ID, project number
+- **Private Service Connect (PSC)**: Secure API server access without public endpoints
+- RHCOS boot image pinned to specific version (default: `projects/rhcos-cloud/global/images/rhcos-*`)
+
+**Setup chain**: `hypershift-gcp-control-plane-setup` → `hypershift-gcp-hosted-cluster-setup` → `hypershift-gcp-create`
+
+**SHARED_DIR artifacts**: `gcp-region`, `hosted-cluster-project-id`, `control-plane-project-id`, `wif-pool-id`, `wif-provider-id`, `wif-project-number`, per-SA files (`controlplane-sa`, `nodepool-sa`, etc.), `sa-signing-key-path`
+
+**Cluster profile**: `hypershift-gcp`
+
+## KubeVirt
+
+Nested virtualization model: KubeVirt VMs run as pods on the management cluster. The management cluster provides the compute, storage, and networking substrate.
+
+**Hosting layers**: bare metal, AWS, or Azure
+**Requires**: CNV (Container-native Virtualization) operator subscription
+
+**Key env vars:**
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `HYPERSHIFT_NODE_MEMORY` | 16Gi | Memory per VM |
+| `HYPERSHIFT_NODE_CPU_CORES` | 4 | CPU cores per VM |
+| `KUBEVIRT_CSI_INFRA` | | Storage class for KubeVirt CSI driver |
+| `ATTACH_DEFAULT_NETWORK` | | Network attachment (true/false) |
+| `IP_STACK` | v4 | Networking: v4, v6, or v4v6 (dual-stack) |
+| `CNV_SUBSCRIPTION_SOURCE` | redhat-operators | CNV operator source |
+| `DISCONNECTED` | false | Air-gapped/disconnected mode |
+
+**Credentials**: `/etc/cnv-nightly-pull-credentials`, `/var/run/cnv-ci-brew-pull-secret/token`
+
+**Subdirectories**: create/, install/, conformance/, e2e-nested/, run-e2e-local/, run-e2e-external/, destroy/, csi-e2e/
+
+## Agent (Bare Metal)
+
+Uses Metal3 BareMetalHost resources for worker node management. Deployed on Equinix/Packet infrastructure.
+
+**Create chain steps:**
+1. `hypershift-agent-create-config-dns` — DNS configuration
+2. `hypershift-agent-create-hostedcluster` — HostedCluster CR
+3. `hypershift-agent-create-proxy` — proxy for API access
+4. `hypershift-agent-create-add-worker-metal3` — add workers via Metal3
+5. `hypershift-agent-create-metallb` — MetalLB load balancing
+
+**Infrastructure env vars:**
+- `PACKET_PLAN`: m3.large.x86 (Equinix metal server type)
+- `NUM_EXTRA_WORKERS`: 3
+- `DEVSCRIPTS_CONFIG`: IP stack, network type, worker resources
+
+**SHARED_DIR artifacts**: `hosts.yaml` (BareMetalHost definitions), `packet-conf.sh`, `proxy-conf.sh`, `hostedcluster_name`
+
+## MCE (Multicluster Engine)
+
+MCE provides lifecycle management for HyperShift hosted clusters. `MCE_VERSION` (2.4-2.10) controls behavior — version 2.6+ uses IAM roles, <2.6 uses direct credentials.
+
+**Supported sub-platforms:**
+- `mce/aws/` — MCE on AWS
+- `mce/agent/` — Agent-based with AgentServiceConfig CR
+- `mce/kubevirt/` — MCE with KubeVirt
+- `mce/power/` — IBM Power Systems
+- `mce/ibmz/` — IBM Z (s390x)
+
+**Key env vars:**
+- `MCE_VERSION`: MCE release version (2.4, 2.5, ..., 2.10)
+- `HYPERSHIFT_CP_AVAILABILITY_POLICY`: SingleReplica or HighlyAvailable
+- `OVERRIDE_CPO_IMAGE`: Custom control plane operator image
+- `KONFLUX_DEPLOY_CATALOG_SOURCE`, `KONFLUX_DEPLOY_OPERATORS`: Konflux build flags
+
+**MCE agent workflow**: AgentServiceConfig CR orchestrates bare metal provisioning with LVM storage, MinIO for S3-compatible backup
+
+**Additional subdirectories**: install/, upgrade/, dump/, conf-os-images/, multi-version-test/
+
+## Cluster Profile Summary
+
+| Profile | Platform |
+|---|---|
+| `hypershift-aws` | AWS |
+| `hypershift-azure` | Azure self-managed (OpenShift management clusters) |
+| `hypershift-aks` | Azure managed / ARO-HCP (AKS management cluster) |
+| `hypershift-gcp` | GCP with Workload Identity Federation |
+| `hypershift-powervs` | IBM Power Systems |
+| `equinix-ocp-hcp` | Agent / bare metal (MCE) |

--- a/.claude/rules/hypershift-platforms.md
+++ b/.claude/rules/hypershift-platforms.md
@@ -4,9 +4,6 @@ paths:
   - "ci-operator/step-registry/hypershift/kubevirt/**"
   - "ci-operator/step-registry/hypershift/agent/**"
   - "ci-operator/step-registry/hypershift/mce/**"
-  - "ci-operator/step-registry/hypershift/ibmcloud/**"
-  - "ci-operator/step-registry/hypershift/powervs/**"
-  - "ci-operator/step-registry/hypershift/openstack/**"
 ---
 
 # HyperShift Additional Platforms
@@ -18,11 +15,15 @@ Uses Workload Identity Federation (WIF) for OIDC-based service account authentic
 **Key concepts:**
 - **Workload Identity Federation (WIF)**: K8s ServiceAccounts mapped to GCP ServiceAccounts via OIDC — requires pool ID, provider ID, project number
 - **Private Service Connect (PSC)**: Secure API server access without public endpoints
-- RHCOS boot image pinned to specific version (default: `projects/rhcos-cloud/global/images/rhcos-*`)
+- RHCOS boot image pinned to specific version (default: `projects/rhcos-cloud/global/images/rhcos-9-6-20250925-0-gcp-x86-64`)
 
-**Setup chain**: `hypershift-gcp-control-plane-setup` → `hypershift-gcp-hosted-cluster-setup` → `hypershift-gcp-create`
+**Setup steps**: `hypershift-gcp-control-plane-setup` (ref) and `hypershift-gcp-hosted-cluster-setup` (ref) are individual pre-steps in the `hypershift-gcp-gke-e2e-v2` workflow, followed by the `hypershift-gcp-create` chain
 
 **SHARED_DIR artifacts**: `gcp-region`, `hosted-cluster-project-id`, `control-plane-project-id`, `wif-pool-id`, `wif-provider-id`, `wif-project-number`, per-SA files (`controlplane-sa`, `nodepool-sa`, etc.), `sa-signing-key-path`
+
+**Management cluster**: GKE Autopilot (not an OpenShift cluster). The `gke/` subdirectory contains provision, prerequisites, deprovision, and e2e workflows.
+
+**Important subdirectories**: control-plane-setup/, hosted-cluster-setup/, create/, destroy/, run-e2e/, gke/
 
 **Cluster profile**: `hypershift-gcp`
 
@@ -37,17 +38,17 @@ Nested virtualization model: KubeVirt VMs run as pods on the management cluster.
 
 | Variable | Default | Purpose |
 |---|---|---|
-| `HYPERSHIFT_NODE_MEMORY` | 16Gi | Memory per VM |
+| `HYPERSHIFT_NODE_MEMORY` | 16 | Memory per VM (unit Gi is implicit) |
 | `HYPERSHIFT_NODE_CPU_CORES` | 4 | CPU cores per VM |
 | `KUBEVIRT_CSI_INFRA` | | Storage class for KubeVirt CSI driver |
 | `ATTACH_DEFAULT_NETWORK` | | Network attachment (true/false) |
 | `IP_STACK` | v4 | Networking: v4, v6, or v4v6 (dual-stack) |
-| `CNV_SUBSCRIPTION_SOURCE` | redhat-operators | CNV operator source |
+| `CNV_SUBSCRIPTION_SOURCE` | cnv-prerelease-catalog-source | CNV operator source |
 | `DISCONNECTED` | false | Air-gapped/disconnected mode |
 
 **Credentials**: `/etc/cnv-nightly-pull-credentials`, `/var/run/cnv-ci-brew-pull-secret/token`
 
-**Subdirectories**: create/, install/, conformance/, e2e-nested/, run-e2e-local/, run-e2e-external/, destroy/, csi-e2e/
+**Subdirectories**: create/, install/, conformance/, e2e-nested/, run-e2e-local/, run-e2e-external/, destroy/, csi-e2e/, azure/, baremetalds/, e2e-aws/, e2e-azure/, run-csi-e2e/, gather/, health-check/, custom-capk/, set-crio-permissions/
 
 ## Agent (Bare Metal)
 
@@ -65,11 +66,13 @@ Uses Metal3 BareMetalHost resources for worker node management. Deployed on Equi
 - `NUM_EXTRA_WORKERS`: 3
 - `DEVSCRIPTS_CONFIG`: IP stack, network type, worker resources
 
-**SHARED_DIR artifacts**: `hosts.yaml` (BareMetalHost definitions), `packet-conf.sh`, `proxy-conf.sh`, `hostedcluster_name`
+**SHARED_DIR artifacts**: `hosts.yaml` (BareMetalHost definitions, lab variant only), `packet-conf.sh`, `proxy-conf.sh`, `hostedcluster_name`
+
+**Subdirectories**: create/, check/, conformance/, destroy/
 
 ## MCE (Multicluster Engine)
 
-MCE provides lifecycle management for HyperShift hosted clusters. `MCE_VERSION` (2.4-2.10) controls behavior — version 2.6+ uses IAM roles, <2.6 uses direct credentials.
+MCE provides lifecycle management for HyperShift hosted clusters. `MCE_VERSION` (2.4+) controls behavior — on AWS, version 2.6+ uses IAM roles, <2.6 uses direct credentials.
 
 **Supported sub-platforms:**
 - `mce/aws/` — MCE on AWS
@@ -79,12 +82,13 @@ MCE provides lifecycle management for HyperShift hosted clusters. `MCE_VERSION` 
 - `mce/ibmz/` — IBM Z (s390x)
 
 **Key env vars:**
-- `MCE_VERSION`: MCE release version (2.4, 2.5, ..., 2.10)
+- `MCE_VERSION`: MCE release version (2.4+)
 - `HYPERSHIFT_CP_AVAILABILITY_POLICY`: SingleReplica or HighlyAvailable
-- `OVERRIDE_CPO_IMAGE`: Custom control plane operator image
-- `KONFLUX_DEPLOY_CATALOG_SOURCE`, `KONFLUX_DEPLOY_OPERATORS`: Konflux build flags
+- `OVERRIDE_HO_IMAGE`: Custom HyperShift Operator image (MCE install)
+- `OVERRIDE_CPO_IMAGE`: Custom control plane operator image (agent create hostedcluster)
+- `USE_KONFLUX_CATALOG`: Use Konflux catalog for MCE install (true/false)
 
-**MCE agent workflow**: AgentServiceConfig CR orchestrates bare metal provisioning with LVM storage, MinIO for S3-compatible backup
+**MCE agent workflow**: AgentServiceConfig CR orchestrates bare metal provisioning. LVM storage and MinIO (S3-compatible backup) are configured as separate workflow steps.
 
 **Additional subdirectories**: install/, upgrade/, dump/, conf-os-images/, multi-version-test/
 
@@ -97,4 +101,8 @@ MCE provides lifecycle management for HyperShift hosted clusters. `MCE_VERSION` 
 | `hypershift-aks` | Azure managed / ARO-HCP (AKS management cluster) |
 | `hypershift-gcp` | GCP with Workload Identity Federation |
 | `hypershift-powervs` | IBM Power Systems |
-| `equinix-ocp-hcp` | Agent / bare metal (MCE) |
+| `equinix-ocp-hcp` | Agent / bare metal |
+| `openshift-org-aws` | KubeVirt on AWS |
+| `openshift-org-azure` | KubeVirt on Azure |
+| `aws-kubevirt` | MCE KubeVirt GPU tests on AWS |
+| `openstack-vexxhost` | OpenStack nested conformance |

--- a/.claude/rules/hypershift-step-registry.md
+++ b/.claude/rules/hypershift-step-registry.md
@@ -1,0 +1,106 @@
+---
+paths:
+  - "ci-operator/step-registry/hypershift/**"
+---
+
+# HyperShift Step Registry
+
+## Architecture Overview
+
+HyperShift separates the hosted cluster control plane from the data plane:
+- **Management cluster**: hosts control plane components as pods in a namespace
+- **Guest/hosted cluster**: runs worker nodes with user workloads
+- In CI, this is a 3-tier model: Root cluster → Nested management cluster → HostedCluster
+
+## Management Cluster Model
+
+- **Root cluster**: pre-existing shared OpenShift cluster, accessed via credential kubeconfig (`hypershift-ops-admin.kubeconfig`)
+- **Nested management cluster**: ephemeral HostedCluster created on the root cluster per CI job. Cluster name derived from `PROW_JOB_ID` hash for uniqueness
+- Setup: `hypershift-setup-nested-management-cluster` chain
+- Destroy: `hypershift-destroy-nested-management-cluster` chain
+- Outputs to SHARED_DIR: `management_cluster_kubeconfig`, `management_cluster_name`, `management_cluster_namespace`
+
+Azure managed (ARO-HCP) is the exception — it uses AKS as management cluster instead of nested OpenShift.
+
+## Workflow Composition (pre/test/post)
+
+Standard workflow pattern:
+- **PRE**: `ipi-install-rbac` → management cluster setup → platform-specific setup → `hypershift-install` (operator deployment)
+- **TEST**: `run-e2e` or `conformance` chain
+- **POST**: `hypershift-dump` (diagnostics) → destroy hosted cluster → destroy management cluster
+- `allow_best_effort_post_steps: true` ensures cleanup runs even on test failure
+
+## HyperShift Install Step
+
+Deploys the HyperShift operator to the management cluster. Key controls:
+- `CLOUD_PROVIDER`: AWS or Azure
+- `AKS`: whether management cluster is AKS (managed Azure)
+- `AZURE_SELF_MANAGED`: skip `--managed-service=ARO-HCP` for self-managed Azure
+- `TECH_PREVIEW_NO_UPGRADE`, `ENABLE_HYPERSHIFT_CERT_ROTATION_SCALE`
+- `INSTALL_FROM_LATEST`: use `HYPERSHIFT_RELEASE_LATEST` instead of step image
+
+## Dump and Debug
+
+- `hypershift-dump` chain: `bin/hypershift dump cluster` collects artifacts
+- `hypershift-debug`: outputs debug tool links
+- `hypershift-k8sgpt`: AI-powered K8s diagnostics
+- Azure has additional `hypershift-dump-azure-diagnostics` step
+
+## E2E V2 Framework
+
+- Uses `test-e2e-v2` binary from `hypershift-tests` image
+- Ginkgo-based with JUnit reporting
+- Reads `${SHARED_DIR}/cluster-name`, fixed namespace `clusters`
+- Cleaner interface than V1 for test isolation
+
+## Step Registry File Conventions
+
+- `*-ref.yaml` + `*-commands.sh` = steps (atomic tasks)
+- `*-chain.yaml` = chains (ordered step sequences)
+- `*-workflow.yaml` = workflows (complete pre/test/post scenarios)
+- Security: disable `set -x` around credential handling (see root CLAUDE.md for pattern)
+
+## Common SHARED_DIR Artifacts
+
+| Artifact | Purpose |
+|---|---|
+| `management_cluster_kubeconfig` | Kubeconfig for the management cluster |
+| `management_cluster_name` | Name of the management cluster |
+| `management_cluster_namespace` | Namespace for management cluster resources |
+| `nested_kubeconfig` | Kubeconfig for the guest/hosted cluster |
+| `cluster-name` | Name of the created hosted cluster |
+| `kubeconfig` | Active kubeconfig (management or guest) |
+| `mgmt_icsp.yaml` | Image content source policy |
+
+## Common Environment Variables
+
+| Variable | Purpose |
+|---|---|
+| `KUBECONFIG` | Active cluster kubeconfig |
+| `CI_TESTS_RUN` | Regex filter for test selection |
+| `CLOUD_PROVIDER` | AWS, Azure, GCP, etc. |
+| `HYPERSHIFT_NODE_COUNT` | Worker node count |
+| `HYPERSHIFT_HC_RELEASE_IMAGE` | Guest cluster release image |
+| `HYPERSHIFT_BASE_DOMAIN` | Cluster FQDN base domain |
+| `HYPERSHIFT_EXTERNAL_DNS_DOMAIN` | External DNS domain |
+| `HYPERSHIFT_CP_AVAILABILITY_POLICY` | SingleReplica or HighlyAvailable |
+| `ENDPOINT_ACCESS` | Public, PublicAndPrivate, or Private |
+| `TECH_PREVIEW_NO_UPGRADE` | Skip upgrades for tech preview |
+| `RUN_UPGRADE_TEST` | Enable upgrade tests |
+
+## Directory Overview
+
+**Platforms**: aws/, azure/, gcp/, ibmcloud/, kubevirt/, openstack/, powervs/
+**MCE**: mce/ (Multicluster Engine with agent, kubevirt, power, ibmz support)
+**Operations**: install/, hostedcluster/, conformance/, e2e-v2/, e2e-backuprestore/
+**Infrastructure**: setup-nested-management-cluster/, setup-root-management-cluster/, destroy-nested-management-cluster/
+**Diagnostics**: dump/, debug/, analyze-e2e-failure/, k8sgpt/
+**AI/Automation**: agent/, agentic-qe/, review-agent/, jira-agent/, dependabot-triage/
+
+## Timeouts
+
+- Management cluster setup: 45m
+- HostedCluster create: 60m
+- E2E tests: 30m
+- Dump operations: 15m
+- Destroy: 45m (management), 1h (hosted)

--- a/.claude/rules/hypershift-step-registry.md
+++ b/.claude/rules/hypershift-step-registry.md
@@ -19,21 +19,27 @@ HyperShift separates the hosted cluster control plane from the data plane:
 - Setup: `hypershift-setup-nested-management-cluster` chain
 - Destroy: `hypershift-destroy-nested-management-cluster` chain
 - Outputs to SHARED_DIR: `management_cluster_kubeconfig`, `management_cluster_name`, `management_cluster_namespace`
+- **Root management cluster (alternative)**: `hypershift-setup-root-management-cluster` chain copies the root kubeconfig to `${SHARED_DIR}/kubeconfig` (not `management_cluster_kubeconfig`) without creating a nested cluster. Used by `hypershift-aws-e2e-external` and `hypershift-aws-conformance` for a simpler 2-tier model (root cluster → HostedCluster)
 
 Azure managed (ARO-HCP) is the exception — it uses AKS as management cluster instead of nested OpenShift.
 
 ## Workflow Composition (pre/test/post)
 
-Standard workflow pattern:
-- **PRE**: `ipi-install-rbac` → management cluster setup → platform-specific setup → `hypershift-install` (operator deployment)
+Most common workflow pattern (3-tier nested):
+- **PRE**: `ipi-install-rbac` → management cluster setup → `hypershift-install` (operator deployment) → platform-specific create (e.g., `hypershift-aws-create`)
 - **TEST**: `run-e2e` or `conformance` chain
-- **POST**: `hypershift-dump` (diagnostics) → destroy hosted cluster → destroy management cluster
-- `allow_best_effort_post_steps: true` ensures cleanup runs even on test failure
+- **POST**: destroy management cluster (dump is embedded in the destroy chain for 3-tier nested workflows; 2-tier workflows use separate `hypershift-dump` + platform-specific destroy)
+- Some workflows set `allow_best_effort_post_steps: true` to ensure cleanup runs even on test failure (e.g., `hypershift-agent-conformance`, `hypershift-aws-reqserving-e2e`); most workflows rely on default post-step behavior
+
+Alternative PRE patterns:
+- **Root management cluster (no nested, 2-tier)**: `hypershift-setup-root-management-cluster` copies root kubeconfig directly, skips `hypershift-install` (operator already on root cluster) (e.g., `hypershift-aws-conformance`, `hypershift-aws-e2e-external`)
+- **Hostedcluster workflow**: `openshift-cluster-bot-rbac` → `hypershift-hostedcluster-create`
+- **Agent conformance**: `assisted-baremetal-operator` → `enable-qe-catalogsource` → `hypershift-install` → `hypershift-agent-create`
 
 ## HyperShift Install Step
 
 Deploys the HyperShift operator to the management cluster. Key controls:
-- `CLOUD_PROVIDER`: AWS or Azure
+- `CLOUD_PROVIDER`: AWS, Azure, or GCP
 - `AKS`: whether management cluster is AKS (managed Azure)
 - `AZURE_SELF_MANAGED`: skip `--managed-service=ARO-HCP` for self-managed Azure
 - `TECH_PREVIEW_NO_UPGRADE`, `ENABLE_HYPERSHIFT_CERT_ROTATION_SCALE`
@@ -55,7 +61,7 @@ Deploys the HyperShift operator to the management cluster. Key controls:
 
 ## Step Registry File Conventions
 
-- `*-ref.yaml` + `*-commands.sh` = steps (atomic tasks)
+- `*-ref.yaml` + `*-commands.sh` = steps (atomic tasks with metadata and executable script)
 - `*-chain.yaml` = chains (ordered step sequences)
 - `*-workflow.yaml` = workflows (complete pre/test/post scenarios)
 - Security: disable `set -x` around credential handling (see root CLAUDE.md for pattern)
@@ -90,17 +96,19 @@ Deploys the HyperShift operator to the management cluster. Key controls:
 
 ## Directory Overview
 
-**Platforms**: aws/, azure/, gcp/, ibmcloud/, kubevirt/, openstack/, powervs/
+**Platforms**: aws/, azure/, gcp/, ibmcloud/, kubevirt/, openstack/, powervs/, agent/
 **MCE**: mce/ (Multicluster Engine with agent, kubevirt, power, ibmz support)
-**Operations**: install/, hostedcluster/, conformance/, e2e-v2/, e2e-backuprestore/
+**Operations**: install/, hostedcluster/, conformance/, e2e-v2/, e2e-backuprestore/, operatorhub/, optional-operators/, performanceprofile/
 **Infrastructure**: setup-nested-management-cluster/, setup-root-management-cluster/, destroy-nested-management-cluster/
 **Diagnostics**: dump/, debug/, analyze-e2e-failure/, k8sgpt/
-**AI/Automation**: agent/, agentic-qe/, review-agent/, jira-agent/, dependabot-triage/
+**AI/Automation**: agentic-qe/, review-agent/, jira-agent/, dependabot-triage/
 
 ## Timeouts
 
 - Management cluster setup: 45m
-- HostedCluster create: 60m
-- E2E tests: 30m
+- HostedCluster create: 35m (AWS), 45m (Azure), 60m (GCP, hostedcluster)
+- E2E tests (V2): 30m
+- E2E tests (V1 run-e2e): 2h
+- Conformance tests: 4h (14400s)
 - Dump operations: 15m
-- Destroy: 45m (management), 1h (hosted)
+- Destroy: 25m (Azure hosted), 45m (AWS hosted), 1h (hostedcluster generic)


### PR DESCRIPTION
## Summary
- Add 5 path-scoped `.claude/rules/` files that provide context when working in HyperShift CI directories
- Rules cover CI config variants, step registry architecture, and platform-specific details (AWS, Azure, GCP, KubeVirt, Agent, MCE)
- Rules load on-demand only when Claude reads files matching the path globs

## Files
- `.claude/rules/hypershift-config.md` — CI config naming, variants, promotion, brancher rules
- `.claude/rules/hypershift-step-registry.md` — Architecture (root→nested→hosted cluster), workflow composition, shared dir artifacts
- `.claude/rules/hypershift-aws.md` — AWS resources, IAM/STS/OIDC, KMS, credentials
- `.claude/rules/hypershift-azure.md` — Managed (ARO-HCP/AKS) vs self-managed, Private Link, Key Vault
- `.claude/rules/hypershift-platforms.md` — GCP/WIF, KubeVirt, Agent/bare metal, MCE, cluster profiles

## Test plan
- [ ] Start a new Claude Code session in the repo
- [ ] Read a file in `ci-operator/config/openshift/hypershift/` and verify `hypershift-config` rule loads
- [ ] Read a file in `ci-operator/step-registry/hypershift/azure/` and verify `hypershift-azure` rule loads
- [ ] Verify rules provide accurate context for common tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds seven path-scoped Claude Code rule documents under .claude/rules/ that provide on-demand, path-filtered contextual guidance for developers working on HyperShift CI configs and step-registry workflows in the openshift/release repository.

What changed and practical impact
- New rule files (load when Claude reads matching paths):
  - .claude/rules/hypershift-config.md — CI config conventions for HyperShift: supported ci-operator config globs (openshift/hypershift and openshift-priv/hypershift), file naming and variant semantics (__periodics, __mce, __periodics-mce, __periodics-hcm, __equinix-cleanup, etc.), which images are built per branch, promotion targets, brancher behavior, and required workflow for updating generated metadata.
  - .claude/rules/hypershift-step-registry.md — step-registry architecture and conventions: 3‑tier Root→Nested→HostedCluster models (and 2‑tier root exceptions), common workflow composition (pre/test/post), step/chain/workflow file conventions, SHARED_DIR artifacts, env var conventions, timeouts, and debug/dump steps.
  - .claude/rules/hypershift-aws.md — AWS platform guidance: common 3‑tier nested patterns and notable 2‑tier exceptions, AWS resources created (VPC, KMS, IAM/ST S, ELBs, S3 OIDC), cluster-profile mapping, credential mount paths, key env vars, SHARED_DIR artifacts, and aws/ subdirectory layout for create/destroy/e2e flows.
  - .claude/rules/hypershift-azure-common.md — shared Azure context used by both managed and self-managed flows: common resources, shared credentials/env vars, and shared SHARED_DIR artifacts.
  - .claude/rules/hypershift-azure-managed.md — ARO-HCP / AKS-managed specifics: AKS as management cluster, AKS workflow steps, managed credentials/env vars, AKS artifacts and aks/ subdirectories.
  - .claude/rules/hypershift-azure-self-managed.md — Azure self-managed specifics: nested OpenShift management cluster model, Private Link handling, KAS DNS notes, self-managed credentials/env vars, artifacts and subdirectories.
  - .claude/rules/hypershift-platforms.md — additional platforms (GCP with WIF/PSC, KubeVirt, Agent/bare metal, MCE, IBM Power/Z, OpenStack), cluster-profile mappings, platform-specific env vars, artifacts and subdirectory references.

Affected areas in the repo (practical)
- ci-operator/config/openshift/hypershift/** and ci-operator/config/openshift-priv/hypershift/**: Claude will surface hypershift-config guidance when editing CI configs (naming, variants, promotion and brancher rules, which images to build).
- ci-operator/step-registry/hypershift/** and platform subpaths (aws/, azure/, gcp/, kubevirt/, agent/, mce/, etc.): Claude will surface platform- and step-registry-specific guidance when editing steps, chains, and workflows (architecture, credentials, SHARED_DIR artifacts, timeouts, and debugging/dump workflows).

Content verification and corrections
- Rule text was iteratively corrected to match actual CI behavior and step-registry layout: boolean env var defaults, variant descriptions, credential mount paths, SHARED_DIR artifact names, subdirectory listings, MCE version handling, agent workflow details, cluster profiles, and adjusted timeouts/step sequences. The rules reference existing chains/steps and credential mount conventions used by the repository.

Recommended validation (as included in PR)
- Start a Claude Code session in this repo.
- Open files under ci-operator/config/openshift/hypershift/** to confirm hypershift-config.md loads and provides config guidance.
- Open step-registry files under ci-operator/step-registry/hypershift/** and platform subpaths (e.g., hypershift/azure/) to confirm the appropriate hypershift-* rule files load and provide accurate context for editing workflows, credential usage, artifacts, and debugging steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->