### PR TITLE
Changes in ci-tools-standalone repo tests

### DIFF
--- a/ci-operator/config/openshift/ci-tools-standalone/openshift-ci-tools-standalone-main.yaml
+++ b/ci-operator/config/openshift/ci-tools-standalone/openshift-ci-tools-standalone-main.yaml
@@ -41,6 +41,16 @@ images:
     to: ci-scheduling-webhook
   - additional_architectures:
     - arm64
+    context_dir: images/commenter/
+    from: os
+    inputs:
+      bin:
+        paths:
+        - destination_dir: .
+          source_path: /go/bin/commenter
+    to: commenter
+  - additional_architectures:
+    - arm64
     context_dir: images/determinize-peribolos/
     from: os
     inputs:
@@ -153,7 +163,7 @@ tests:
   container:
     from: golangci-lint
 - as: validate-vendor
-  commands: make validate-vendor
+  commands: make validate-modules
   container:
     from: src
   node_architecture: arm64


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes to ci-tools-standalone CI Configuration

This PR updates the OpenShift CI/Prow configuration for the `ci-tools-standalone` repository to evolve its build and validation processes:

### Key Changes

**New commenter image build**: Adds a new container image for a `commenter` tool to the repository's CI pipeline. The image is built from the `os` base image with binaries placed from the build output, supporting both x86_64 and arm64 architectures.

**Updated validation command**: Changes the `validate-vendor` test step to run `make validate-modules` instead of `make validate-vendor`. This reflects a shift in the repository's dependency validation strategy—moving from validating Go vendored dependencies to validating Go modules, indicating an update to how the project manages its dependencies.

These changes modernize the ci-tools-standalone project's CI infrastructure to support new tooling and adopt updated Go module validation practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->