### PR TITLE
DPTP-4814: expand dptp triage sops

### DIFF
--- a/docs/dptp-triage-sop/blackbox-probe-service-failing.md
+++ b/docs/dptp-triage-sop/blackbox-probe-service-failing.md
@@ -1,19 +1,107 @@
 # Blackbox Probe Service Failing
 
-This alert means the blackbox probe cannot successfully reach one of the monitored service endpoints.
+## Alert binding
 
-The probe checks the service list configured in:
-- [`blackbox_probe.yaml`](../../clusters/app.ci/openshift-user-workload-monitoring/blackbox_probe.yaml)
+| Field | Value |
+|-------|-------|
+| **Alerts** | `ProbeFailing` (≥1m), `ProbeFailing-Lenient` (≥5m) |
+| **Cluster** | `app.ci` |
+| **Rules** | [`ci-alerts_prometheusrule.yaml`](../../clusters/app.ci/openshift-user-workload-monitoring/mixins/prometheus_out/ci-alerts_prometheusrule.yaml) — `blackbox` group |
+| **Severity** | `critical` |
+| **Prober** | Deployment **`blackbox-prober`** in namespace **`ci`** ([`blackbox_prober.yaml`](../../clusters/app.ci/openshift-user-workload-monitoring/blackbox_prober.yaml)); Prometheus probes call **`blackbox-prober.ci.svc`**. |
+
+This alert means the blackbox exporter cannot successfully scrape one of the targets listed in [`blackbox_probe.yaml`](../../clusters/app.ci/openshift-user-workload-monitoring/blackbox_probe.yaml). The failing HTTP/HTTPS URL is in **`{{ $labels.instance }}`** on the alert.
 
 ## Symptom
-- `ProbeFailing` (strict): the probe has been failing for at least 1 minute.
-- `ProbeFailing-Lenient`: the probe has been failing for at least 5 minutes.
 
-The alert includes the failing service URL in `{{ $labels.instance }}`.
+- **`ProbeFailing`**: failing ≥ **1 minute**.
+- **`ProbeFailing-Lenient`**: failing ≥ **5 minutes**.
 
-## Resolution
-1. Open the failing service URL from the alert and verify if it is reachable.
-2. Check if the service itself is down, degraded, or returning unexpected status codes.
-3. If the service is healthy in a browser, investigate networking/DNS/TLS issues between the prober and the service, consider also tunning alert.
-4. If the service is intentionally unavailable or no longer needed, update `blackbox_probe.yaml` accordingly.
-5. If this is a real outage, notify the relevant service owners and track remediation.
+## Diagnose
+
+### 1) Confirm prober pods are healthy
+
+```bash
+CTX=app.ci
+
+oc --context "$CTX" get pods -n ci -l app=blackbox-prober -o wide
+oc --context "$CTX" describe pod -n ci -l app=blackbox-prober | grep -A20 '^Conditions:'
+```
+
+If pods are **CrashLoop** / **Pending**, fix prober first—otherwise downstream targets all fail.
+
+### 2) Read blackbox exporter logs (target errors, TLS, timeouts)
+
+```bash
+oc --context "$CTX" logs -n ci -l app=blackbox-prober --tail=200 --all-containers=true
+```
+
+Look for **`statusCode`**, **`tls`**, **`timeout`**, **`connection refused`** matching the **`instance`** host.
+
+### 3) Test connectivity from inside the cluster (same network path as probes)
+
+The **`blackbox-exporter`** image is minimal—**`oc exec` often has no shell**. Prefer a short-lived debug pod with **`curl`**:
+
+```bash
+TARGET='https://example.apps.ci.l2s4.p1.openshiftapps.com/healthz'
+
+oc --context "$CTX" run bb-debug-"$(date +%s)" -n ci --rm -i --restart=Never \
+  --image=curlimages/curl:latest \
+  -- curl -vk --max-time 20 "$TARGET"
+```
+
+Delete manually if **`--rm`** did not clean up (policy permitting):
+
+```bash
+oc --context "$CTX" delete pod -n ci bb-debug-<suffix>
+```
+
+**Interpretation:**
+
+- **Connection refused / no route**: target Service endpoints down, Route missing, or NetworkPolicy—inspect target namespace.
+- **HTTP 5xx**: application degraded—engage service owners.
+- **TLS verify errors**: cert mismatch or expired cert—check Route **`spec.tls`** / cert secrets; correlate with alert **`SSLCertExpiringSoon`** on the same target ([`ci-alerts_prometheusrule.yaml`](../../clusters/app.ci/openshift-user-workload-monitoring/mixins/prometheus_out/ci-alerts_prometheusrule.yaml)).
+
+### 4) Map URL → OpenShift Route / Service (when host is `*.apps.ci…`)
+
+```bash
+HOST=$(echo "$TARGET" | sed -e 's|https\?://||' -e 's|/.*||')
+oc --context "$CTX" get routes --all-namespaces -o json \
+  | jq -r --arg h "$HOST" '.items[] | select(.spec.host==$h) | "\(.metadata.namespace)/\(.metadata.name)"'
+```
+
+Then inspect backing Service / Deployment:
+
+```bash
+NS=<route-namespace>
+ROUTE=<route-name>
+
+oc --context "$CTX" get route -n "$NS" "$ROUTE" -o yaml
+oc --context "$CTX" get endpoints -n "$NS" "$(oc --context "$CTX" get route -n "$NS" "$ROUTE" -o jsonpath='{.spec.to.name}')" -o yaml
+```
+
+### 5) Compare external vs in-cluster
+
+From your workstation (if permitted):
+
+```bash
+curl -vk --max-time 15 "$TARGET"
+```
+
+- Works **externally** but fails **from prober**: cluster egress / DNS / split-horizon issue.
+- Fails **both**: likely real outage or global routing problem.
+
+## Fix
+
+1. **Restore the failing component** (rollout pod/Deployment behind Route; fix TLS secret; repair DNS).
+2. **Tune obsolete alerts**: if target intentionally removed, edit **`blackbox_probe.yaml`** and remove/update module/target—open PR on **`openshift/release`**.
+3. **Tune thresholds**: only after confirming benign blips—prefer fixing root cause.
+
+## Verify
+
+- Prometheus **`probe_success{job=~"blackbox|blackbox-lenient", instance="<url>"} == 1`** for sustained window.
+- Alert clears in Alertmanager / Slack.
+
+## Escalation
+
+If multiple unrelated targets fail simultaneously, suspect **cluster networking / ingress** on **`app.ci`**—page **`@dptp-triage`** with prober logs + output from the **`curlimages/curl`** debug pod command above.

--- a/docs/dptp-triage-sop/build-farm-scheduling-pressure.md
+++ b/docs/dptp-triage-sop/build-farm-scheduling-pressure.md
@@ -1,6 +1,6 @@
 # Build Farm Scheduling Pressure
 
-Alerts: **BuildFarmHighPendingPods**, **BuildFarmNodePressure** (Slack: **#ops-testplatform**).
+**Alerts:** `BuildFarmHighPendingPods`, `BuildFarmNodePressure` — **Slack:** `#ops-testplatform`. **Rules:** [`build-farm-scheduling-pressure_prometheusrule.yaml`](../../clusters/build-clusters/common_except_app.ci/openshift-monitoring/build-farm-scheduling-pressure_prometheusrule.yaml) (per build cluster). **Severity:** `warning`.
 
 ## What the alerts mean
 

--- a/docs/dptp-triage-sop/ghproxy-too-many-pending-alerts.md
+++ b/docs/dptp-triage-sop/ghproxy-too-many-pending-alerts.md
@@ -1,5 +1,14 @@
 # ghproxy Too Many Pending Alerts
 
+## Alert binding
+
+| Field | Value |
+|-------|-------|
+| **Alert** | `ghproxy-too-many-pending-alerts` |
+| **Cluster** | `app.ci` |
+| **Rules** | [`ci-alerts_prometheusrule.yaml`](../../clusters/app.ci/openshift-user-workload-monitoring/mixins/prometheus_out/ci-alerts_prometheusrule.yaml); source [`ghproxy_alerts.libsonnet`](../../clusters/app.ci/openshift-user-workload-monitoring/mixins/_prometheus/ghproxy_alerts.libsonnet) |
+| **Severity** | `critical` |
+
 This SOP covers `ghproxy-too-many-pending-alerts` on `app.ci`.
 
 ## What this alert means
@@ -13,6 +22,47 @@ The dangerous case is a trend: repeated firings or sustained queue growth over t
 
 - One isolated firing: monitor, but do not treat as an outage by default.
 - Multiple firings or sustained backlog: investigate immediately.
+
+## Diagnose on-cluster (`app.ci`)
+
+Deployment **`ghproxy`** lives in namespace **`ci`** ([`ghproxy.yaml`](../../clusters/app.ci/prow/03_deployment/ghproxy.yaml), labels **`app=prow`**, **`component=ghproxy`**).
+
+### 1) Pod health
+
+```bash
+CTX=app.ci
+
+oc --context "$CTX" get pods -n ci -l app=prow,component=ghproxy -o wide
+oc --context "$CTX" describe pod -n ci -l app=prow,component=ghproxy | grep -A12 '^Conditions:'
+```
+
+### 2) Recent ghproxy logs (errors, cache, upstream GitHub)
+
+```bash
+oc --context "$CTX" logs -n ci deploy/ghproxy --tail=300 \
+  | grep -iE 'error|429|403|timeout|backoff' || true
+```
+
+Interpret:
+
+- **429 / 403 spikes**: GitHub rate limit / token permission—correlate with token metrics below.
+- **Dial / TLS errors**: egress or GitHub incident.
+
+### 3) Metrics port (inline sanity)
+
+Service **`ghproxy`** exposes **`9090`** named **`metrics`**—scrape targets should be **`UP`** in monitoring; if local pod healthy but alert persists, verify Service endpoints:
+
+```bash
+oc --context "$CTX" get endpoints -n ci ghproxy -o yaml
+```
+
+### 4) In-flight ConfigMap / deployment drift
+
+```bash
+oc --context "$CTX" get deploy/ghproxy -n ci -o yaml | grep -A3 ' image:'
+```
+
+Compare with Git [`ghproxy.yaml`](../../clusters/app.ci/prow/03_deployment/ghproxy.yaml) if image unexpectedly old.
 
 ## Investigation queries (Prometheus on app.ci)
 

--- a/docs/dptp-triage-sop/high-ci-operator-error-rate.md
+++ b/docs/dptp-triage-sop/high-ci-operator-error-rate.md
@@ -1,33 +1,121 @@
 # High CI Operator Error Rate
 
-This SOP covers `high-ci-operator-error-rate` on `app.ci`.
+## Alert binding
+
+| Field | Value |
+|-------|-------|
+| **Alert** | `high-ci-operator-error-rate` |
+| **Cluster** | `app.ci` |
+| **Rule group** | `ci-operator-error` in [`ci-alerts_prometheusrule.yaml`](../../clusters/app.ci/openshift-user-workload-monitoring/mixins/prometheus_out/ci-alerts_prometheusrule.yaml) |
+| **Severity** | `critical` |
+| **Related** | [`high-ci-operator-infra-error-rate.md`](high-ci-operator-infra-error-rate.md) — infra-correlated variant (multi-job gate + lower rate threshold). |
 
 ## What this alert means
 
-This alert fires when failed CI Operator executions exceed the configured rate threshold for a specific `reason`.
-An individual trigger is not always dangerous. Repeated triggers and sustained trends are the real risk.
-A high failure value for this alert can indicate an ongoing outage affecting one cluster or multiple clusters.
+This alert fires when failed CI Operator executions exceed **0.08/s** (30m rate) for a specific **`reason`** label on **`ci_operator_error_rate`**. It **does not** require multiple jobs—single-repo storms can page. Treat sustained repeats as higher urgency than one short spike.
+
+## Prerequisites
+
+- **`oc`** context for **`app.ci`** and any **build-farm** cluster referenced in failing jobs.
+- Slack / Alert labels: capture **`reason`** and CI Search URL.
 
 ## Most common reasons
 
 ### `executing_graph:step_failed:building_project_image`
 
-This usually means a project image build step failed while ci-operator was executing the step graph.
-Common causes include Dockerfile/build context issues, base image/input image issues, registry pull/push errors, or transient cluster build failures.
+Project image build step failed in the ci-operator graph (Dockerfile, inputs, registry pull/push, cluster build).
 
 ### `executing_graph:interrupted`
 
-This usually means graph execution was canceled/interrupted instead of naturally failing a test step.
-Common causes include job cancellation, process interruption, namespace deletion, or other external stop conditions.
+Graph stopped due to cancel/interrupt (human cancel, infra churn, namespace teardown), not a failed test assertion.
 
-## Triage (actionable)
+## Diagnose
 
-1. Open CI search from the alert and group failures by `job`, `reason`, and `cluster` in the same time window.
-2. Decide if this is isolated noise or a trend:
-   - isolated/short burst: monitor
-   - repeated/sustained increase: treat as incident
-3. Look for dominant patterns (same repo, branch, cluster, step, and failure signature).
-4. Intervene based on dominant reason:
-   - For `building_project_image`, inspect build pod logs/events and fix build inputs or image pipeline issues.
-   - For `interrupted`, investigate cancellation causes (cluster instability, namespace churn, manual/system cancels).
-5. Continue monitoring after mitigation to confirm the error-rate trend drops.
+### 1) Quantify blast radius
+
+1. Open **CI Search** from the alert (`reason` in query).
+2. Bucket failures by **`job_name`**, repo, **cluster**, and time—answer: **one repo** vs **many**.
+3. If **many jobs / clusters** share the same **`reason`**, treat like an infra incident and also read [`high-ci-operator-infra-error-rate.md`](high-ci-operator-infra-error-rate.md).
+
+### 2) Pick one failing ProwJob and resolve build metadata
+
+```bash
+CTX=app.ci
+JOB_NAME=<prowjob.metadata.name>
+
+oc --context "$CTX" get prowjob.prow.k8s.io -n ci "$JOB_NAME" \
+  -o custom-columns='STATE:.status.state,JOB:.spec.job,URL:.status.url'
+```
+
+### 3) Locate ci-operator pod via `prow.k8s.io/build-id`
+
+```bash
+BUILD_ID=<from Deck URL>
+
+oc --context "$CTX" get pods --all-namespaces \
+  -l prow.k8s.io/build-id="$BUILD_ID" \
+  -o custom-columns='NS:.metadata.namespace,NAME:.metadata.name,PHASE:.status.phase'
+```
+
+Pick **`TEST_NS=ci-op-*`**. List containers:
+
+```bash
+TEST_NS=<ci-op-xxxxxxxx>
+oc --context "$CTX" get pods -n "$TEST_NS" -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{range .spec.containers[*]}{.name}{" "}{end}{"\n"}{end}'
+```
+
+### 4) Logs — ci-operator (`test` container)
+
+```bash
+OP_POD=$(oc --context "$CTX" get pods -n "$TEST_NS" -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | grep -E '^ci-operator-' | head -1)
+
+if [[ -z "$OP_POD" ]]; then
+  echo "No ci-operator-* pod in ${TEST_NS}; use GCS artifacts from the ProwJob status.url / Deck build."
+else
+  oc --context "$CTX" logs -n "$TEST_NS" "$OP_POD" -c test --tail=1500 \
+    | grep -E 'Reporting job state|step_failed|building_project_image|interrupted|level=error' | tail -80
+fi
+```
+
+### 5) Logs — failing build / test pod
+
+From the same namespace, identify **`build`/`src`/`test`** pods referenced in ci-operator output:
+
+```bash
+oc --context "$CTX" get pods -n "$TEST_NS"
+oc --context "$CTX" describe pod -n "$TEST_NS" <suspect-pod>
+oc --context "$CTX" logs -n "$TEST_NS" <suspect-pod> -c <container> --tail=400
+```
+
+### 6) Events (scheduling, mounts, OOM)
+
+```bash
+oc --context "$CTX" get events -n "$TEST_NS" --sort-by=.lastTimestamp | tail -40
+```
+
+## Fix / mitigate
+
+### `building_project_image`
+
+1. Fix **Dockerfile / inputs** or **base image** per log—often repo-owned.
+2. For **registry flakes**, verify **`registry.ci.openshift.org`** / mirror health; compare with other jobs pulling same image.
+3. Re-run **after** fix: prefer **`/retest`** or Prow **rerun** from Deck rather than ad-hoc cluster tweaks.
+
+### `interrupted`
+
+1. Check **whether namespace disappeared early** (`Terminating`, quota, cluster instability).
+2. Correlate with **apiserver / node** events on the execution cluster context.
+3. If mass interrupts during **platform maintenance**, silence/route per policy—not job-by-job kills.
+
+## Verify
+
+- CI Search shows **falling failure rate** for the same **`reason`** window-over-window.
+- Spot-check one replayed job reaches **`success`** state:
+
+```bash
+oc --context app.ci get prowjob.prow.k8s.io -n ci "$JOB_NAME" -o jsonpath='{.status.state}{"\n"}'
+```
+
+## Escalation
+
+Ping **`@dptp-triage`** when **`reason`** trend blocks merging across repositories or multiple clusters show identical failures without an obvious repo-owned fix.

--- a/docs/dptp-triage-sop/high-ci-operator-infra-error-rate.md
+++ b/docs/dptp-triage-sop/high-ci-operator-infra-error-rate.md
@@ -1,19 +1,158 @@
 # High CI Operator Infra Error Rate
 
-This alert fires when CI Operator failures with one infrastructure-like `reason` stay above the configured rate.
+## Alert binding
 
-## Why it is failing
+| Field | Value |
+|-------|-------|
+| **Alert** | `high-ci-operator-infra-error-rate` |
+| **Cluster** | `app.ci` (user workload monitoring) |
+| **Rule group** | `ci-operator-infra-error` in [`ci-alerts_prometheusrule.yaml`](../../clusters/app.ci/openshift-user-workload-monitoring/mixins/prometheus_out/ci-alerts_prometheusrule.yaml) |
+| **Severity** | `critical` |
+| **Related** | [`high-ci-operator-error-rate.md`](high-ci-operator-error-rate.md) — non-infra variant (higher rate threshold, no multi-job correlation). Slack text for this alert may omit an SOP URL; use this document whenever the alert name matches. |
 
-Most common reasons are:
+## What this alert means
+
+The rule keeps failing CI Operator executions for one **`reason`** above **0.02/s** (30m rate) **only if** that **`reason`** appears across **≥3** distinct **`job_name`** values (excluding rehearses). That pattern targets **shared infrastructure** regressions rather than a single repo flake.
+
+## Prerequisites
+
+- **`oc`** with a context that can read **`app.ci`** (and **build-farm** contexts if failures reference those clusters). Replace **`app.ci`** below if your kubeconfig uses another context name.
+- **Labels from Slack**: note **`reason`** (and any **`job_name`** / **`cluster`** hints embedded in CI Search links).
+
+## Common `reason` values
+
+(See [`dptp_alerts.libsonnet`](../../clusters/app.ci/openshift-user-workload-monitoring/mixins/_prometheus/dptp_alerts.libsonnet) — rule `high-ci-operator-infra-error-rate`.)
+
 - `executing_graph:step_failed:creating_release_images`
 - `executing_graph:step_failed:tagging_input_image`
 - `executing_graph:step_failed:building_project_image:pod_pending`
 - `executing_graph:step_failed:utilizing_cluster_claim:acquiring_cluster_claim`
 - `executing_graph:step_failed:importing_release`
 
-## Possible mitigations
+## Diagnose (repeat per dominant `reason`)
 
-1. Open CI search from the alert and identify the dominant `reason`.
-2. For image/release reasons (especially `creating_release_images`, but also `tagging_input_image`, `importing_release`): check if there is possibility to fix image/tag/manifest or import issues, then retrigger affected jobs.
-3. Other issues are more rare and require deeper investigation
+### 1) Confirm breadth (matches “infra” intent)
 
+1. Open **CI Search** from the alert (pre-filled `Reporting job state` / `reason`).
+2. In the incident window, confirm **multiple distinct `job_name` values** fail with the same **`reason`** (the Prometheus rule requires ≥3 jobs).
+3. Note **one representative `job_name`**, **build ID** (from Deck / Prow URL), and **cluster** (build farm name or `app.ci`).
+
+### 2) Map build → namespaces and pods on `app.ci`
+
+ProwJobs live in namespace **`ci`**. Test workloads run in ephemeral **`ci-op-*`** namespaces (and pods carry **`prow.k8s.io/build-id`**).
+
+**`JOB_NAME`** for **`oc get prowjob.prow.k8s.io … "$JOB_NAME"`** must be the **`ProwJob` object’s `metadata.name`** (Kubernetes resource name), **not** **`spec.job`** (the human-readable string behind Deck’s **`job=`** filter) and **not** the numeric **`BUILD_ID`** from the artifact URL. If you only have **`spec.job`** or **`BUILD_ID`**, resolve **`metadata.name`** first:
+
+```bash
+CTX=app.ci
+
+# Option A — you already have metadata.name (from kubectl/oc columns NAME, or copied from API):
+JOB_NAME=<metadata.name>
+
+# Option B — only spec.job / Deck job= string (may match multiple runs; newest last):
+SPEC_JOB=<spec.job value>
+JOB_NAME=$(oc --context "$CTX" get prowjobs.prow.k8s.io -n ci \
+  --sort-by=.metadata.creationTimestamp \
+  -o jsonpath='{range .items[*]}{.spec.job}{"\t"}{.metadata.name}{"\n"}{end}' \
+  | awk -F'\t' -v j="$SPEC_JOB" '$1 == j {print $2}' | tail -1)
+
+# Option C — only BUILD_ID (matches status.build_id on the ProwJob):
+BUILD_ID=<digits-from-deck-url>
+JOB_NAME=$(oc --context "$CTX" get prowjobs.prow.k8s.io -n ci \
+  --sort-by=.metadata.creationTimestamp \
+  -o jsonpath='{range .items[*]}{.status.build_id}{"\t"}{.metadata.name}{"\n"}{end}' \
+  | awk -F'\t' -v b="$BUILD_ID" '$1 == b {print $2}' | tail -1)
+
+oc --context "$CTX" get prowjob.prow.k8s.io -n ci "$JOB_NAME" -o yaml
+```
+
+Extract **build ID** from the Deck URL (`…/view/gs/origin-ci-test/pr-logs/pull/…/<BUILD_ID>/…`) or from **`status.build_id`** / labels:
+
+```bash
+BUILD_ID=<digits-from-deck-url>
+
+oc --context "$CTX" get pods --all-namespaces \
+  -l prow.k8s.io/build-id="$BUILD_ID" \
+  -o custom-columns='NS:.metadata.namespace,NAME:.metadata.name,PHASE:.status.phase'
+```
+
+Identify the row whose namespace matches **`ci-op-*`** (that is the ci-operator test namespace). Then:
+
+```bash
+TEST_NS=<ci-op-xxxxxxxx>
+oc --context "$CTX" get pods -n "$TEST_NS" -o wide
+```
+
+Find the **`ci-operator`** pod (name prefix often `ci-operator-*`):
+
+```bash
+OP_POD=$(oc --context "$CTX" get pods -n "$TEST_NS" -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | grep -E '^ci-operator-' | head -1)
+echo "$OP_POD"
+```
+
+### 3) Pull ci-operator logs for the failure signature
+
+```bash
+oc --context "$CTX" logs -n "$TEST_NS" "$OP_POD" -c test --tail=800 \
+  | grep -E 'Reporting job state|step_failed|level=error|reason=' || true
+```
+
+Narrow to the alert **`reason`** string:
+
+```bash
+REASON='<paste exact reason from alert labels>'
+oc --context "$CTX" logs -n "$TEST_NS" "$OP_POD" -c test --tail=2000 \
+  | grep -F "$REASON" | tail -50
+```
+
+### 4) If the failure references image pulls / release payloads
+
+On a workstation with pull access (or from a debug pod—follow org policy), image checks help distinguish **missing tag** vs **registry outage**:
+
+```bash
+# Example only — replace with image reference from the log line
+oc image info registry.ci.openshift.org/ocp/release@sha256:...
+```
+
+If many jobs fail `importing_release` / `creating_release_images`, escalate toward **release/registry** paths and cross-check [`openshift-mirroring-failures.md`](openshift-mirroring-failures.md) / [`misc.md`](misc.md) (`quay-io-image-mirroring-failures`).
+
+### 5) If `reason` ends with `:pod_pending` or mentions scheduling
+
+Run on the **cluster where the test pod should land** (often a **buildNN** context):
+
+```bash
+BF=build01   # or build02, … per failure output
+
+oc --context "$BF" get pods -n ci --field-selector=status.phase=Pending --no-headers | wc -l
+oc --context "$BF" get events -n ci --sort-by=.lastTimestamp | tail -30
+```
+
+Follow [`build-farm-scheduling-pressure.md`](build-farm-scheduling-pressure.md) if Pending counts / `FailedScheduling` dominate.
+
+### 6) If `reason` contains `acquiring_cluster_claim` / lease
+
+Treat as **Hive / pool / quota** pressure in addition to ci-operator logs:
+
+```bash
+oc --context hosted-mgmt get clusterclaims -n ci-cluster-pool --sort-by=.metadata.creationTimestamp | tail
+```
+
+(Adjust pool namespace if your alert references a different pool—see Hive runbooks.)
+
+## Fix / mitigate
+
+1. **Registry / image / release payload**: restore image promotion or fix broken image job (often repo-specific); use **`make job JOB=…`** from a clean **`openshift/release`** checkout only when you intend to re-run the producing job—see patterns in [`misc.md`](misc.md).
+2. **Scheduling / capacity**: scale MachineSets / fix autoscaler / relieve taints per build-farm SOP—not `app.ci` mutations unless the workload truly runs on `app.ci`.
+3. **Cluster claims / leases**: free stuck claims, expand pool, or fix cloud-side deletion blockers per Hive / cloud owner process.
+4. **Transient GitHub / API**: retry failed jobs after upstream recovery; confirm error rate falls in Prometheus.
+
+After mitigation:
+
+```bash
+# Example: rate should fall below rule threshold for that reason
+# (run in OpenShift console Prometheus UI on app.ci user workload stack)
+```
+
+## Escalation
+
+If merges or release pipelines stall broadly, notify **`@dptp-triage`** with **CI Search links**, dominant **`reason`**, **`BUILD_ID`**, **`TEST_NS`**, and clusters impacted.

--- a/docs/dptp-triage-sop/hive.md
+++ b/docs/dptp-triage-sop/hive.md
@@ -2,6 +2,8 @@
 
 ### hosted-mgmt-blocked-deprovision
 
+**Alert:** `hosted-mgmt-blocked-deprovision` — **cluster:** `hosted-mgmt`. **Rule:** [`hosted-mgmt-alerts_prometheusrule.yaml`](../../clusters/hosted-mgmt/hosted-mgmt-alerts_prometheusrule.yaml). **Severity:** `critical`.
+
 #### Runbook
 
 * Find out the name of the cluster pool that the `clusterdeployment` is from. The namespace and the name are usually the same and displayed in the alert's message

--- a/docs/dptp-triage-sop/misc.md
+++ b/docs/dptp-triage-sop/misc.md
@@ -38,6 +38,8 @@ The logs can be deleted in case of leak of secrets or other sensitive informatio
 quay-io-image-mirroring-failures
 ================================
 
+**Alert:** `quay-io-image-mirroring-failures` — **cluster:** `app.ci`. **Rules:** [`ci-alerts_prometheusrule.yaml`](../../clusters/app.ci/openshift-user-workload-monitoring/mixins/prometheus_out/ci-alerts_prometheusrule.yaml) — group `quay-io-image-mirroring`. **Severity:** `critical`.
+
 The alert is fired if there are many failures of `oc image mirror` in `ci-images-mirror`.
 
 Choose a method below - pod logs, cloudwatch or splunk - and then we can run the command locally in our computer:
@@ -52,11 +54,11 @@ $ oc image mirror --keep-manifest-list --registry-config=/tmp/qci.json --continu
 If it reproduces the same error, mostly, it is caused by a broken source image. In that case, we should
 - Fix the source image, e.g. by rebuilding the image from **Pod logs** example below:
   - Inside `release` repo search for the job that promotes the image: `grep -r 'to: cluster-capi-operator'`
-  - Observe the directory three of the returned files: `ci-operator/config/openshift/cluster-capi-operator/`
+  - Observe the directory tree of the returned files: `ci-operator/config/openshift/cluster-capi-operator/`
   - Find the equivalent `ProwJob`, e.g. `ci-operator/jobs/openshift/cluster-capi-operator/openshift-cluster-capi-operator-release-4.16-postsubmits.yaml`
   - Pick the right `ProwJob` from the file, e.g. `branch-ci-openshift-cluster-capi-operator-release-4.16-okd-scos-images`
   - Execute from inside `release` repository: `make job JOB='branch-ci-openshift-cluster-capi-operator-release-4.16-okd-scos-images' BASE_REF=release-4.16`
-- Ignore the mirroring otherwise: See [RFE-5363](https://issues.redhat.com/browse/) for example.
+- Ignore the mirroring otherwise: See [RFE-5363](https://issues.redhat.com/browse/RFE-5363) for example.
 
 
 Pod logs

--- a/docs/dptp-triage-sop/openshift-mirroring-failures.md
+++ b/docs/dptp-triage-sop/openshift-mirroring-failures.md
@@ -1,5 +1,14 @@
 # OpenShift Mirroring Failures
 
+## Alert binding
+
+| Field | Value |
+|-------|-------|
+| **Alert** | `openshift-mirroring-failures` |
+| **Cluster** | `app.ci` |
+| **Rules** | [`ci-alerts_prometheusrule.yaml`](../../clusters/app.ci/openshift-user-workload-monitoring/mixins/prometheus_out/ci-alerts_prometheusrule.yaml) — group `openshift-mirroring-failures` |
+| **Severity** | `critical` |
+
 This SOP covers the `openshift-mirroring-failures` alert on `app.ci`.
 
 ## What this alert means
@@ -24,6 +33,58 @@ The exact fix depends on the failure type, but the path to recovery is usually f
    - Destination push/auth problem (permission denied, auth/credentials)
    - Registry/network/transient problem (timeouts, temporary API failures)
 5. Apply the minimal fix needed to get a successful run.
+
+## Diagnose with `oc` on `app.ci`
+
+### 1) List recent ProwJobs for the periodic
+
+Job name in Deck/Prow: **`periodic-image-mirroring-openshift`**.
+
+```bash
+CTX=app.ci
+
+oc --context "$CTX" get prowjobs.prow.k8s.io -n ci \
+  --sort-by=.metadata.creationTimestamp \
+  | { grep periodic-image-mirroring-openshift || true; } | tail -10
+```
+
+Pick the newest **`STATE=failure`** row’s **`NAME`**.
+
+### 2) Inspect ProwJob status (URLs, finish time)
+
+```bash
+PJ=<name-from-previous-command>
+
+oc --context "$CTX" get prowjob.prow.k8s.io -n ci "$PJ" -o yaml | sed -n '1,120p'
+```
+
+Note **`status.url`** (artifact browser) and **`status.build_id`**.
+
+### 3) Find runner pods (while still retained)
+
+```bash
+BUILD_ID=<status.build_id>
+
+oc --context "$CTX" get pods --all-namespaces \
+  -l prow.k8s.io/build-id="$BUILD_ID" \
+  -o custom-columns='NS:.metadata.namespace,NAME:.metadata.name,PHASE:.status.phase'
+```
+
+Typical mirror workload namespaces begin with **`ci-op-`** or stay in **`ci`** depending on agent—use **`NS`** from the row whose **`NAME`** references **`image-mirroring`** / **`ci-operator`**.
+
+### 4) Stream ci-operator / test logs locally
+
+```bash
+TEST_NS=<namespace-from-above>
+OPERATOR_POD=$(oc --context "$CTX" get pods -n "$TEST_NS" -o name | grep ci-operator | head -1 | sed 's|pod/||')
+
+oc --context "$CTX" logs -n "$TEST_NS" "$OPERATOR_POD" -c test --tail=400 \
+  | grep -iE 'image mirror|manifest unknown|unauthorized|FORBIDDEN|error:|level=error' || true
+```
+
+### 5) If pods already GC’d
+
+Fall back to **GCS artifact path** from **`status.url`** (same content as CI Search would index).
 
 ## Common recovery actions
 

--- a/docs/dptp-triage-sop/openshift-priv-image-building-jobs.md
+++ b/docs/dptp-triage-sop/openshift-priv-image-building-jobs.md
@@ -1,4 +1,14 @@
 # OpenShift Priv Image Building Jobs
+
+## Alert binding
+
+| Field | Value |
+|-------|-------|
+| **Alert** | `openshift-priv-image-building-jobs-failing` |
+| **Cluster** | `app.ci` |
+| **Rules** | [`ci-alerts_prometheusrule.yaml`](../../clusters/app.ci/openshift-user-workload-monitoring/mixins/prometheus_out/ci-alerts_prometheusrule.yaml) — group `openshift-priv-image-building-jobs-failing` |
+| **Severity** | `critical` |
+
 This alert fires when an `openshift-priv` image-building job has a poor 12h success ratio while its corresponding public `openshift` image-building job remains healthy.
 The images built from these jobs are often not used, but they do need to be readily available when needed for a CVE fix.
 The alert compares paired jobs by suffix:
@@ -25,3 +35,63 @@ Alert message contains:
 2. Open the linked public counterpart and confirm it is healthy (it should be, by rule design).
 3. If priv-only failures persist, reach out to repo owners and/or CI maintainers with both links and failure signatures.
 4. If the public job is also failing but this alert fired, treat that as a rule/parsing edge case and open a release-repo PR to refine matching.
+
+## Diagnose with `oc` (`app.ci`)
+
+Set names from the Slack alert (**`job_tail`** suffix):
+
+```bash
+CTX=app.ci
+# TAIL = Prometheus label job_tail (regex capture after branch-ci-openshift-priv-). Example: hypershift-main-images — not openshift-hypershift-main-images or branch-ci-openshift-${TAIL} duplicates openshift.
+TAIL=<job_tail-from-alert>
+PRIV_JOB="branch-ci-openshift-priv-${TAIL}"
+PUB_JOB="branch-ci-openshift-${TAIL}"
+```
+
+### 1) Latest ProwJob objects
+
+```bash
+oc --context "$CTX" get prowjobs.prow.k8s.io -n ci \
+  --sort-by=.metadata.creationTimestamp \
+  | grep -E "$PRIV_JOB|$PUB_JOB" | tail -20
+```
+
+Capture **`NAME`** for one failing **`PRIV_JOB`** run.
+
+### 2) Compare states side-by-side
+
+```bash
+PRIV_PJ=<priv-prowjob-name>
+PUB_PJ=<public-prowjob-name>
+
+oc --context "$CTX" get prowjob.prow.k8s.io -n ci "$PRIV_PJ" \
+  -o custom-columns='JOB:.spec.job,STATE:.status.state,START:.status.startTime,URL:.status.url'
+
+oc --context "$CTX" get prowjob.prow.k8s.io -n ci "$PUB_PJ" \
+  -o custom-columns='JOB:.spec.job,STATE:.status.state,START:.status.startTime,URL:.status.url'
+```
+
+### 3) ci-operator logs for the failing priv build
+
+```bash
+BUILD_ID=<from priv Deck URL>
+
+oc --context "$CTX" get pods --all-namespaces \
+  -l prow.k8s.io/build-id="$BUILD_ID" \
+  -o custom-columns='NS:.metadata.namespace,NAME:.metadata.name'
+
+TEST_NS=<ci-op-*>
+
+OP_POD=$(oc --context "$CTX" get pods -n "$TEST_NS" -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | grep '^ci-operator-' | head -1)
+
+oc --context "$CTX" logs -n "$TEST_NS" "$OP_POD" -c test --tail=600 \
+  | grep -iE 'level=error|step_failed|Reason:' | tail -40
+```
+
+### 4) Policy reminder
+
+**`openshift-priv`** builds often need extra credentials—failures may be **RBAC / secret mount** on private Git sidecars; compare with healthy public job pod specs only via **`oc describe`** (avoid dumping Secret data):
+
+```bash
+oc --context "$CTX" describe prowjob.prow.k8s.io -n ci "$PRIV_PJ" | tail -40
+```

--- a/docs/dptp-triage-sop/pod-scaler-admission.md
+++ b/docs/dptp-triage-sop/pod-scaler-admission.md
@@ -1,18 +1,111 @@
 # pod-scaler admission resource warning
 
-This alert fires when the `pod-scaler admission` service determines 
-that a job needs ten times more amount of a given resource (memory or cpu) than is configured in its specification.
-As this may indicate potential leaks, the job owner(s) should be notified.
+## Alert binding
 
-### Useful Links
-- [Prometheus Error Rate Graph](https://console-openshift-console.apps.ci.l2s4.p1.openshiftapps.com/monitoring/query-browser?query0=sum+by+%28workload_name%2C+workload_type%2C+determined_amount%2C+configured_amount%2C+resource_type%29+%28pod_scaler_admission_high_determined_resource%7Bworkload_type%21%7E%22undefined%7Cbuild%22%7D%29)
-- the Prometheus metric `pod_scaler_admission_high_determined_resource` contains information used to determine the job owner(s):
-  - **workload_name** in format `<pod name>-<container name>`
-  - **workload_type** is one of: 
-    - step (a multi-stage step)
-    - prowjob
-    - build
-  - **resource_type** indicates the resource in question; is either memory or cpu
+| Field | Value |
+|-------|-------|
+| **Alert** | `pod-scaler-admission-resource-warning` |
+| **Cluster** | `app.ci` |
+| **Rules** | [`ci-alerts_prometheusrule.yaml`](../../clusters/app.ci/openshift-user-workload-monitoring/mixins/prometheus_out/ci-alerts_prometheusrule.yaml) — group `pod-scaler-admission-resource-warning` |
+| **Severity** | `critical` |
 
-### Resolution
-Determine the job owner(s), reach out to them and let them know of the discrepancy.
+This alert fires when **pod-scaler admission** observes a workload using roughly **10×** the **CPU or memory** declared in CI configuration—usually wrong limits, a leak, or an undersized declaration. **Do not** scale cluster capacity as the first response; notify **job/config owners**.
+
+## Prerequisites
+
+- **`rg` (ripgrep)** on **`PATH`** for **Diagnose §5** (`rg -n 'resources:' ci-operator/config/<org>/<repo>/`). Install via OS package (**`dnf install ripgrep`**, **`apt install ripgrep`**, **`brew install ripgrep`**) or [upstream releases](https://github.com/BurntSushi/ripgrep/releases).
+
+## Labels you need from Slack / Prometheus
+
+From the alert or [this Console query](https://console-openshift-console.apps.ci.l2s4.p1.openshiftapps.com/monitoring/query-browser?query0=sum+by+%28workload_name%2C+workload_type%2C+determined_amount%2C+configured_amount%2C+resource_type%29+%28pod_scaler_admission_high_determined_resource%7Bworkload_type%21%7E%22undefined%7Cbuild%22%7D%29):
+
+| Label | Meaning |
+|-------|---------|
+| **`workload_name`** | `<pod>-<container>` fingerprint admission saw |
+| **`workload_type`** | `step`, `prowjob`, … (`build` alerts filtered out of rule) |
+| **`resource_type`** | `cpu` or `memory` |
+| **`determined_amount`** / **`configured_amount`** | Observed vs declared signal |
+
+## Diagnose
+
+### 1) Confirm pod-scaler components are up
+
+Pod scaler runs in **`ci`** ([`pod-scaler.yaml`](../../clusters/app.ci/pod-scaler/pod-scaler.yaml), [`pod-scaler-ui.yaml`](../../clusters/app.ci/pod-scaler/pod-scaler-ui.yaml)):
+
+```bash
+CTX=app.ci
+
+oc --context "$CTX" get deploy -n ci pod-scaler-producer pod-scaler-ui
+oc --context "$CTX" get pods -n ci -l 'component in (pod-scaler-producer,pod-scaler-ui)' -o wide
+```
+
+If **`pod-scaler-producer`** is unhealthy, fix it **before** blaming workloads—see alerts **`pod-scaler-producer-Singleton-Down`** / **`pod-scaler-ui-Down`**.
+
+### 2) Capture admission / producer logs around the timestamp
+
+```bash
+oc --context "$CTX" logs -n ci deploy/pod-scaler-producer --since=30m --tail=400 \
+  | grep -iE 'admission|high_determined|workload' || true
+```
+
+### 3) Map `workload_type=prowjob` → ProwJob object
+
+```bash
+# If workload_name looks like mypod-ci-operator — extract prowjob name from CI / Deck instead:
+PJ=<prowjob-name-from-deck>
+
+oc --context "$CTX" get prowjob.prow.k8s.io -n ci "$PJ" -o yaml
+```
+
+Look under **`spec`** for **`refs.org`**, **`refs.repo`**, **`refs.pulls`**, **`job`**.
+
+### 4) Map `workload_type=step` → ci-operator config namespace
+
+Use **`prow.k8s.io/build-id`** from Deck URL:
+
+```bash
+BUILD_ID=<digits>
+CTX=app.ci
+
+oc --context "$CTX" get pods --all-namespaces \
+  -l prow.k8s.io/build-id="$BUILD_ID" \
+  -o custom-columns='NS:.metadata.namespace,NAME:.metadata.name'
+```
+
+Open **`TEST_NS=ci-op-*`**, describe the pod referenced by **`workload_name`** prefix:
+
+```bash
+TEST_NS=<ci-op-xxxx>
+POD_PREFIX=<pod prefix before first '-' if needed>
+
+oc --context "$CTX" get pods -n "$TEST_NS"
+oc --context "$CTX" describe pod -n "$TEST_NS" <exact-pod-name>
+```
+
+Check **`requests`/`limits`** on the container named after **`workload_name`** suffix.
+
+### 5) Compare with declared CI resources
+
+Locate **`ci-operator`** configuration in **`openshift/release`**:
+
+```bash
+# From repo root — replace repo/component
+rg -n 'resources:' ci-operator/config/<org>/<repo>/ | head
+```
+
+Owners should align **`requests`/`limits`** with **`pod-scaler`** recommendations or justify outliers.
+
+## Fix
+
+1. **Repo owners** update **`ci-operator`** config (memory/CPU requests & limits) or fix leaks in tests/builds.
+2. **No cluster mutation** unless producers are broken—escalate bad **`pod-scaler`** behavior separately.
+3. After merge, watch **`pod_scaler_admission_high_determined_resource`** time series for that workload disappear.
+
+## Verify
+
+- Alert clears after workloads roll with new resource declarations.
+- Optional: re-query Prometheus for label set **`workload_name="…"`** — should be absent post-fix.
+
+## Escalation
+
+If **`pod-scaler-producer`** is healthy but admissions look clearly wrong (false positives), **`@dptp-triage`** with **metric snapshot**, **ProwJob** link, and **pod describe** output.

--- a/docs/dptp-triage-sop/prow-job-state-pileup.md
+++ b/docs/dptp-triage-sop/prow-job-state-pileup.md
@@ -1,18 +1,104 @@
 # Prow Job State Pileup
 
-Alerts: **TriggeredProwJobsPileup**, **SchedulingProwJobsPileup**.
+## Alert binding
 
-## Triggered Peak Above Threshold
+| Field | Value |
+|-------|-------|
+| **Alerts** | `TriggeredProwJobsPileup`, `SchedulingProwJobsPileup` |
+| **Cluster** | `app.ci` |
+| **Rules** | [`ci-alerts_prometheusrule.yaml`](../../clusters/app.ci/openshift-user-workload-monitoring/mixins/prometheus_out/ci-alerts_prometheusrule.yaml) — `prow` group; definitions in [`prow_alerts.libsonnet`](../../clusters/app.ci/openshift-user-workload-monitoring/mixins/_prometheus/prow_alerts.libsonnet) |
+| **Thresholds** | **Triggered**: `max_over_time(sum(prowjobs{job="prow-controller-manager",state="triggered"})[5m:]) > 450`. **Scheduling**: same with **`state="scheduling"`**, threshold **`300`**. |
+| **Severity** | `Triggered…` **critical**, `Scheduling…` **warning** |
+| **Related** | Build farm Pending / pressure — [`build-farm-scheduling-pressure.md`](build-farm-scheduling-pressure.md). |
 
-1. Open [Plank dashboard](https://ci-route-ci-grafana.apps.ci.l2s4.p1.openshiftapps.com/d/e1778910572e3552a935c2035ce80369/plank-dashboard).
-2. In panel **"Number of Prow jobs by state with cluster"**, review overall `triggered` pressure across clusters.
-3. Confirm the 5-minute `triggered` peak is above the configured alert threshold and determine if it is still rising.
-4. Compare pressure against plank running-job limit (`max_concurrency`) from [core-services/prow/02_config/_config.yaml](https://github.com/openshift/release/blob/main/core-services/prow/02_config/_config.yaml).
+## What “pileup” means
 
-## Scheduling Peak Above Threshold
+**`triggered`**: jobs accepted by Prow but not yet running—often backlog before scheduling assigns a cluster.
 
-1. Open [Plank dashboard](https://ci-route-ci-grafana.apps.ci.l2s4.p1.openshiftapps.com/d/e1778910572e3552a935c2035ce80369/plank-dashboard).
-2. In panel **"Number of Prow jobs by state with cluster"**, review overall `scheduling` pressure across clusters.
-3. Confirm the 5-minute `scheduling` peak is above the configured alert threshold and determine if it is still rising.
-4. Compare current pressure to plank `max_concurrency` from [core-services/prow/02_config/_config.yaml](https://github.com/openshift/release/blob/main/core-services/prow/02_config/_config.yaml) to judge proximity to running-job limit.
+**`scheduling`**: jobs assigned/placed into scheduling state but not yet fully running pods—often overlaps with build-farm capacity / plank concurrency pressure.
 
+## Prerequisites
+
+- **`oc`** access to **`app.ci`** (`ci` namespace hosts **`prow-controller-manager`**, **`sinker`**, **`deck`**, etc.).
+- Grafana **Plank dashboard** link from runbook steps below.
+
+## Diagnose on-cluster (`app.ci`)
+
+### 1) Controller health and recent restarts
+
+```bash
+CTX=app.ci
+
+oc --context "$CTX" get deploy -n ci prow-controller-manager sinker deck tide horologium
+oc --context "$CTX" get pods -n ci -l 'app=prow,component=prow-controller-manager' -o wide
+oc --context "$CTX" logs -n ci deploy/prow-controller-manager --tail=200 \
+  | grep -iE 'error|fail|backoff' || true
+```
+
+### 2) Workqueue depth (matches related alert pattern)
+
+**Prometheus stack:** Prow metrics used by these alerts (including **`workqueue_depth`** and **`prowjobs{job="prow-controller-manager",…}`**) are scraped into **user workload monitoring** on **app.ci**—PrometheusRules live under [`openshift-user-workload-monitoring`](../../clusters/app.ci/openshift-user-workload-monitoring/). Use **Administrator → Observe → Metrics** on the cluster console, not only platform monitoring, when a query returns empty.
+
+**Query:** PromQL **`workqueue_depth{name=~"crier.*|plank"}`** — [pre-filled Query browser on app.ci](https://console-openshift-console.apps.ci.l2s4.p1.openshiftapps.com/monitoring/query-browser?query0=workqueue_depth%7Bname%3D~%22crier.*%7Cplank%22%7D).
+
+**Alert rule:** [`ci-alerts_prometheusrule.yaml`](../../clusters/app.ci/openshift-user-workload-monitoring/mixins/prometheus_out/ci-alerts_prometheusrule.yaml) — alert **`Controller backlog is not being drained`** (`workqueue_depth{name=~"crier.*|plank"} > 100`).
+
+**On-cluster targets:** **`plank`** runs inside **`deploy/prow-controller-manager`** when enabled (**`--enable-controller=plank`** in [`prow-controller-manager.yaml`](../../clusters/app.ci/prow/03_deployment/prow-controller-manager.yaml)); **`crier`** is **`deploy/crier`**. For **`workqueue_depth`** series whose **`name`** matches **`plank`**, follow **`prow-controller-manager`** logs (§1); for **`crier.*`**, follow **`crier`** logs.
+
+If **`workqueue_depth`** stays **>100** for **`plank`** / **`crier`** for **~20m**, treat as controller backlog not draining; gather **`prow-controller-manager`** and **`crier`** logs from the same window.
+
+### 3) Count triggered vs scheduling jobs (Prometheus)
+
+Use Grafana panel **“Number of Prow jobs by state with cluster”** on [Plank dashboard](https://ci-route-ci-grafana.apps.ci.l2s4.p1.openshiftapps.com/d/e1778910572e3552a935c2035ce80369/plank-dashboard).
+
+Raw inspect (Console Prometheus on **`app.ci`**):
+
+```promql
+sum(prowjobs{job="prow-controller-manager", state="triggered"})
+sum(prowjobs{job="prow-controller-manager", state="scheduling"})
+```
+
+Confirm values breach rule thresholds above during the incident window.
+
+### 4) Pending / unscheduled jobs (symptom → build farms)
+
+If **`scheduling`** dominates, follow [`build-farm-scheduling-pressure.md`](build-farm-scheduling-pressure.md) **per build cluster**—Pending pods in **`ci`** namespace drive plank slots.
+
+### 5) GitHub / hook saturation (when `triggered` grows)
+
+If **`hook`** or **`ghproxy`** incidents coincide, check:
+
+```bash
+oc --context "$CTX" get pods -n ci -l 'component in (hook,ghproxy)' -o wide
+oc --context "$CTX" logs -n ci deploy/hook --tail=150
+oc --context "$CTX" logs -n ci deploy/ghproxy --tail=150
+```
+
+Cross-reference [`ghproxy-too-many-pending-alerts.md`](ghproxy-too-many-pending-alerts.md).
+
+## Configuration knobs (read-only triage first)
+
+- **`max_concurrency`** (global running job cap): [`core-services/prow/02_config/_config.yaml`](https://github.com/openshift/release/blob/main/core-services/prow/02_config/_config.yaml).
+- **Per-repo burst limits** live under same Prow config tree—coordinate changes via **`openshift/release`** PR; do **not** hot-edit production without process.
+
+## Fix patterns
+
+1. **Build farm capacity**: relieve Pending / node pressure (autoscaler, MachineSets) per build-farm SOP.
+2. **Stuck controller**: restart **only** after two operators agree—capture logs first:
+
+   ```bash
+   oc --context app.ci rollout restart deploy/prow-controller-manager -n ci
+   oc --context app.ci rollout status deploy/prow-controller-manager -n ci
+   ```
+
+3. **External dependency** (GitHub outage): wait / reduce trigger volume—communicate in **`#ops-testplatform`**.
+4. **Bad config change**: revert offending Prow **`ConfigMap`** / **`Horologium`** periodic only via normal GitOps flow.
+
+## Verify
+
+- Grafana: **`triggered`** / **`scheduling`** counts fall below historical baseline and alert clears.
+- **`workqueue_depth`** returns to normal.
+
+## Escalation
+
+Sustained pileup with **merge queue impact** → **`@dptp-triage`** with Grafana screenshots + **`oc`** logs bundle (`prow-controller-manager`, `sinker`, build-farm Pending snapshot).

--- a/docs/dptp-triage-sop/qci-pruner-timeout.md
+++ b/docs/dptp-triage-sop/qci-pruner-timeout.md
@@ -1,5 +1,14 @@
-QCI Pruner Job Timeout
-======================
+# QCI Pruner Job Timeout
+
+## Job binding
+
+| Field | Value |
+|-------|-------|
+| **ProwJob** | `periodic-openshift-release-qci-pruner` |
+| **Signal** | Job failure / 12h timeout; Slack **`#ops-testplatform`** via reporter template ([`infra-periodics.yaml`](../../ci-operator/jobs/infra-periodics.yaml)) |
+| **Script** | [`hack/qci_registry_pruner.py`](../../hack/qci_registry_pruner.py) |
+
+---
 
 The `periodic-openshift-release-qci-pruner` job is responsible for pruning old tags from the `quay.io/openshift/ci` repository. The job runs daily and has a 12-hour timeout. When the job fails with a timeout error, it indicates that the pruner script is taking longer than expected to process all tags.
 


### PR DESCRIPTION
/cc @openshift/test-platform 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR expands and standardizes DPTP triage SOP documentation under docs/dptp-triage-sop to improve on-call troubleshooting for OpenShift CI (DPTP). It is documentation-only and does not change code, APIs, generated Prow job definitions, or cluster manifests.

What changed (practical impact)
- Added explicit "Alert binding" (and a few "Job binding") sections across many SOPs so responders can quickly map alerts/jobs to PrometheusRule files, cluster/context, severity, rule groups, and related docs.
- Reorganized SOPs into a consistent, workflow-oriented format (Alert binding → meaning/prereqs → Diagnose (on-cluster) → Fix/Mitigate → Verify → Escalation) to make triage repeatable and faster.
- Inserted concrete on-cluster diagnostic steps and example oc/kubectl/ProwJob commands in multiple SOPs (notably: blackbox-probe-service-failing.md, ghproxy-too-many-pending-alerts.md, openshift-mirroring-failures.md, openshift-priv-image-building-jobs.md, high-ci-operator-error-rate.md, high-ci-operator-infra-error-rate.md, prow-job-state-pileup.md, pod-scaler-admission.md). These additions give on-call engineers the exact commands and investigative workflow to locate failures and affected pods/builds.
- Enriched alert metadata and formatting (severity, rule file links, rule groups, Slack channels) in smaller SOPs (hive.md, misc.md, build-farm-scheduling-pressure.md, qci-pruner-timeout.md).
- Rewrote several short triage notes into full runbooks with clearer firing semantics, thresholds, and escalation guidance (notably high-ci-operator-* and prow-job-state-pileup).

Scope / files affected
- Documentation under docs/dptp-triage-sop including (but not limited to): blackbox-probe-service-failing.md, build-farm-scheduling-pressure.md, ghproxy-too-many-pending-alerts.md, high-ci-operator-error-rate.md, high-ci-operator-infra-error-rate.md, hive.md, misc.md, openshift-mirroring-failures.md, openshift-priv-image-building-jobs.md, pod-scaler-admission.md, prow-job-state-pileup.md, qci-pruner-timeout.md.

Repository / infrastructure impact
- Documentation-only changes improving runbooks for DPTP/OpenShift CI on-call operations. No changes to CI job code, generated Prow job files, cluster manifests, or runtime configuration.

Administrative notes
- PR references Jira [DPTP-4814](https://redhat.atlassian.net/browse/DPTP-4814) (robot confirmed valid). The Jira lifecycle robot flagged the Jira issue as missing/invalid target version for the target branch (expected "5.0.0").
- PR body contains a single "/cc @openshift/test-platform" line.
- Estimated review effort: mostly Medium for the larger rewrites; some smaller edits flagged as Low.

If useful, I can produce a one-line changelog for the PR description or a checklist enumerating which SOPs gained diagnostic commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[DPTP-4814]: https://redhat.atlassian.net/browse/DPTP-4814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ