### PR TITLE
fix(acm): safe array expansion in fast-forward script

### DIFF
--- a/ci-operator/step-registry/ocm/ci/fastforward-multiple/ocm-ci-fastforward-multiple-commands.sh
+++ b/ci-operator/step-registry/ocm/ci/fastforward-multiple/ocm-ci-fastforward-multiple-commands.sh
@@ -6,9 +6,10 @@ shopt -s extglob
 exit_code=0
 
 # Track failures for summary report
-declare -a FAILED_FASTFORWARDS
-declare -a FAILED_TEKTON
-declare -a SKIPPED_NO_ACCESS
+FAILED_FASTFORWARDS=()
+FAILED_TEKTON=()
+SKIPPED_NO_ACCESS=()
+CLEANED_BRANCHES=()
 TOTAL_FASTFORWARDS=0
 SUCCESSFUL_FASTFORWARDS=0
 TOTAL_TEKTON=0
@@ -1442,7 +1443,7 @@ echo ""
 echo "Repositories:"
 echo "  Total:        ${TOTAL_REPOS}"
 echo "  Processed:    ${PROCESSED_REPOS}"
-echo "  Skipped:      ${#SKIPPED_NO_ACCESS[@]:-0}"
+echo "  Skipped:      ${#SKIPPED_NO_ACCESS[@]}"
 echo ""
 
 # Fast-forward summary
@@ -1465,7 +1466,7 @@ echo "  Stale ff-* branches deleted: ${TOTAL_CLEANED}"
 echo ""
 
 # List skipped repos
-if [[ ${#SKIPPED_NO_ACCESS[@]:-0} -gt 0 ]]; then
+if [[ ${#SKIPPED_NO_ACCESS[@]} -gt 0 ]]; then
   echo "Skipped Repositories (No Write Access):"
   for repo in "${SKIPPED_NO_ACCESS[@]+"${SKIPPED_NO_ACCESS[@]}"}"; do
     echo "  - ${repo}"
@@ -1474,7 +1475,7 @@ if [[ ${#SKIPPED_NO_ACCESS[@]:-0} -gt 0 ]]; then
 fi
 
 # List failures if any
-if [[ ${#FAILED_FASTFORWARDS[@]:-0} -gt 0 ]]; then
+if [[ ${#FAILED_FASTFORWARDS[@]} -gt 0 ]]; then
   echo "Failed Fast-Forward Operations:"
   for failure in "${FAILED_FASTFORWARDS[@]+"${FAILED_FASTFORWARDS[@]}"}"; do
     echo "  - ${failure}"
@@ -1482,7 +1483,7 @@ if [[ ${#FAILED_FASTFORWARDS[@]:-0} -gt 0 ]]; then
   echo ""
 fi
 
-if [[ ${#FAILED_TEKTON[@]:-0} -gt 0 ]]; then
+if [[ ${#FAILED_TEKTON[@]} -gt 0 ]]; then
   echo "Failed Tekton File Creations:"
   for failure in "${FAILED_TEKTON[@]+"${FAILED_TEKTON[@]}"}"; do
     echo "  - ${failure}"
@@ -1491,7 +1492,7 @@ if [[ ${#FAILED_TEKTON[@]:-0} -gt 0 ]]; then
 fi
 
 # List cleaned branches
-if [[ ${#CLEANED_BRANCHES[@]:-0} -gt 0 ]]; then
+if [[ ${#CLEANED_BRANCHES[@]} -gt 0 ]]; then
   echo "Cleaned Stale Branches:"
   for cleaned in "${CLEANED_BRANCHES[@]+"${CLEANED_BRANCHES[@]}"}"; do
     echo "  - ${cleaned}"

--- a/ci-operator/step-registry/ocm/ci/fastforward-multiple/ocm-ci-fastforward-multiple-commands.sh
+++ b/ci-operator/step-registry/ocm/ci/fastforward-multiple/ocm-ci-fastforward-multiple-commands.sh
@@ -1442,7 +1442,7 @@ echo ""
 echo "Repositories:"
 echo "  Total:        ${TOTAL_REPOS}"
 echo "  Processed:    ${PROCESSED_REPOS}"
-echo "  Skipped:      ${#SKIPPED_NO_ACCESS[@]}"
+echo "  Skipped:      ${#SKIPPED_NO_ACCESS[@]:-0}"
 echo ""
 
 # Fast-forward summary
@@ -1465,7 +1465,7 @@ echo "  Stale ff-* branches deleted: ${TOTAL_CLEANED}"
 echo ""
 
 # List skipped repos
-if [[ ${#SKIPPED_NO_ACCESS[@]} -gt 0 ]]; then
+if [[ ${#SKIPPED_NO_ACCESS[@]:-0} -gt 0 ]]; then
   echo "Skipped Repositories (No Write Access):"
   for repo in "${SKIPPED_NO_ACCESS[@]+"${SKIPPED_NO_ACCESS[@]}"}"; do
     echo "  - ${repo}"
@@ -1474,7 +1474,7 @@ if [[ ${#SKIPPED_NO_ACCESS[@]} -gt 0 ]]; then
 fi
 
 # List failures if any
-if [[ ${#FAILED_FASTFORWARDS[@]} -gt 0 ]]; then
+if [[ ${#FAILED_FASTFORWARDS[@]:-0} -gt 0 ]]; then
   echo "Failed Fast-Forward Operations:"
   for failure in "${FAILED_FASTFORWARDS[@]+"${FAILED_FASTFORWARDS[@]}"}"; do
     echo "  - ${failure}"
@@ -1482,7 +1482,7 @@ if [[ ${#FAILED_FASTFORWARDS[@]} -gt 0 ]]; then
   echo ""
 fi
 
-if [[ ${#FAILED_TEKTON[@]} -gt 0 ]]; then
+if [[ ${#FAILED_TEKTON[@]:-0} -gt 0 ]]; then
   echo "Failed Tekton File Creations:"
   for failure in "${FAILED_TEKTON[@]+"${FAILED_TEKTON[@]}"}"; do
     echo "  - ${failure}"
@@ -1491,7 +1491,7 @@ if [[ ${#FAILED_TEKTON[@]} -gt 0 ]]; then
 fi
 
 # List cleaned branches
-if [[ ${#CLEANED_BRANCHES[@]} -gt 0 ]]; then
+if [[ ${#CLEANED_BRANCHES[@]:-0} -gt 0 ]]; then
   echo "Cleaned Stale Branches:"
   for cleaned in "${CLEANED_BRANCHES[@]+"${CLEANED_BRANCHES[@]}"}"; do
     echo "  - ${cleaned}"


### PR DESCRIPTION
Fixes unbound variable error causing periodic job failure.

## Problem

Periodic job `periodic-ci-stolostron-acm-config-main-fast-forward` failed with:
```
/bin/bash: line 1447: SKIPPED_NO_ACCESS: unbound variable
```

[Failed run](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-stolostron-acm-config-main-fast-forward/2052110513516580864)

## Root Cause

Script uses `set -uo pipefail`. Array length checks like `${#ARRAY[@]}` fail when arrays are empty with `set -u`.

## Fix

Use safe parameter expansion `${#ARRAY[@]:-0}` for all array length checks:
- `SKIPPED_NO_ACCESS`
- `FAILED_FASTFORWARDS`
- `FAILED_TEKTON`
- `CLEANED_BRANCHES`

## Testing

Fix allows summary section to complete even when arrays are empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR fixes a recurring failure in the ACM (Advanced Cluster Management) CI infrastructure by correcting a Bash script error in the fast-forward synchronization workflow used by the stolostron/acm-config CI job.

## Problem
The periodic job periodic-ci-stolostron-acm-config-main-fast-forward was failing with "/bin/bash: line 1447: SKIPPED_NO_ACCESS: unbound variable". The fast-forward script runs with strict Bash options (set -uo pipefail), and checks like ${#ARRAY[@]} can cause an unbound-variable exit when arrays are unset under set -u.

## Solution
The fast-forward step script (ci-operator/step-registry/ocm/ci/fastforward-multiple/ocm-ci-fastforward-multiple-commands.sh) now ensures the tracking arrays are defined before they are inspected. The arrays FAILED_FASTFORWARDS, FAILED_TEKTON, SKIPPED_NO_ACCESS, and CLEANED_BRANCHES are initialized as empty arrays (ARRAY=()) so length checks and summary reporting no longer trigger unbound-variable errors. The change also removed incorrect use of default operators in the earlier commit; overall the script now safely handles empty/unset arrays under set -u.

## Impact
With these changes the periodic fast-forward job can complete its summary and finish successfully even when no failures occur. This stabilizes the stolostron/acm-config fast-forward workflow used by OpenShift CI to keep ACM repository branches and Tekton/config updates synchronized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->