### PR TITLE
NO-JIRA: updates for sharding

### DIFF
--- a/ci-operator/config/openshift/release/openshift-release-main__ci-4.22.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__ci-4.22.yaml
@@ -77,6 +77,7 @@ tests:
     workflow: openshift-e2e-aws-ovn
 - as: e2e-gcp-ovn-rhcos10-fips-techpreview-serial
   interval: 168h
+  shard_count: 2
   steps:
     cluster_profile: openshift-org-gcp
     env:
@@ -222,6 +223,7 @@ tests:
     workflow: openshift-e2e-azure-serial
 - as: e2e-azure-ovn-techpreview-serial
   interval: 168h
+  shard_count: 2
   steps:
     cluster_profile: openshift-org-azure
     env:
@@ -233,6 +235,7 @@ tests:
   timeout: 5h0m0s
 - as: e2e-azure-ovn-rhcos10-techpreview-serial
   interval: 12h
+  shard_count: 2
   steps:
     cluster_profile: openshift-org-azure
     env:
@@ -351,6 +354,7 @@ tests:
     workflow: openshift-e2e-gcp-mount-ns-hiding
 - as: e2e-gcp-ovn-techpreview-serial
   interval: 168h
+  shard_count: 2
   steps:
     cluster_profile: openshift-org-gcp
     env:
@@ -362,6 +366,7 @@ tests:
   timeout: 5h0m0s
 - as: e2e-gcp-ovn-rhcos10-techpreview-serial
   interval: 12h
+  shard_count: 2
   steps:
     cluster_profile: openshift-org-gcp
     env:

--- a/ci-operator/config/openshift/release/openshift-release-main__ci-4.23.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__ci-4.23.yaml
@@ -49,6 +49,7 @@ tests:
     workflow: openshift-e2e-aws-ovn
 - as: e2e-gcp-ovn-rhcos10-fips-techpreview-serial
   interval: 168h
+  shard_count: 2
   steps:
     cluster_profile: openshift-org-gcp
     env:
@@ -194,6 +195,7 @@ tests:
     workflow: openshift-e2e-azure-serial
 - as: e2e-azure-ovn-techpreview-serial
   interval: 168h
+  shard_count: 2
   steps:
     cluster_profile: openshift-org-azure
     env:
@@ -205,6 +207,7 @@ tests:
   timeout: 5h0m0s
 - as: e2e-azure-ovn-rhcos10-techpreview-serial
   interval: 168h
+  shard_count: 2
   steps:
     cluster_profile: openshift-org-azure
     env:
@@ -323,6 +326,7 @@ tests:
     workflow: openshift-e2e-gcp-mount-ns-hiding
 - as: e2e-gcp-ovn-techpreview-serial
   interval: 168h
+  shard_count: 2
   steps:
     cluster_profile: openshift-org-gcp
     env:
@@ -334,6 +338,7 @@ tests:
   timeout: 5h0m0s
 - as: e2e-gcp-ovn-rhcos10-techpreview-serial
   interval: 168h
+  shard_count: 2
   steps:
     cluster_profile: openshift-org-gcp
     env:

--- a/ci-operator/config/openshift/release/openshift-release-main__ci-5.0.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__ci-5.0.yaml
@@ -72,6 +72,7 @@ tests:
     workflow: openshift-e2e-aws-ovn
 - as: e2e-gcp-ovn-rhcos10-fips-techpreview-serial
   interval: 168h
+  shard_count: 2
   steps:
     cluster_profile: openshift-org-gcp
     env:
@@ -244,6 +245,7 @@ tests:
     workflow: openshift-e2e-azure-serial
 - as: e2e-azure-ovn-serial-rhcos9-techpreview
   interval: 12h
+  shard_count: 2
   steps:
     cluster_profile: openshift-org-azure
     env:
@@ -256,6 +258,7 @@ tests:
   timeout: 5h0m0s
 - as: e2e-azure-ovn-serial-rhcos9-10-techpreview
   interval: 12h
+  shard_count: 2
   steps:
     cluster_profile: openshift-org-azure
     env:
@@ -269,6 +272,7 @@ tests:
   timeout: 5h0m0s
 - as: e2e-azure-ovn-techpreview-serial
   interval: 168h
+  shard_count: 2
   steps:
     cluster_profile: openshift-org-azure
     env:
@@ -280,6 +284,7 @@ tests:
   timeout: 5h0m0s
 - as: e2e-azure-ovn-rhcos10-techpreview-serial
   interval: 168h
+  shard_count: 2
   steps:
     cluster_profile: openshift-org-azure
     env:
@@ -456,6 +461,7 @@ tests:
     workflow: openshift-e2e-gcp-mount-ns-hiding
 - as: e2e-gcp-ovn-techpreview-serial
   interval: 168h
+  shard_count: 2
   steps:
     cluster_profile: openshift-org-gcp
     env:
@@ -467,6 +473,7 @@ tests:
   timeout: 5h0m0s
 - as: e2e-gcp-ovn-rhcos10-techpreview-serial
   interval: 168h
+  shard_count: 2
   steps:
     cluster_profile: openshift-org-gcp
     env:

--- a/core-services/release-controller/_releases/priv/release-ocp-4.22.json
+++ b/core-services/release-controller/_releases/priv/release-ocp-4.22.json
@@ -273,11 +273,18 @@
                 "name": "periodic-ci-openshift-release-main-ci-4.22-e2e-azure-ovn-techpreview-priv"
             }
         },
-        "azure-ovn-techpreview-serial": {
+        "azure-ovn-techpreview-serial-1of2": {
             "disabled": true,
             "optional": true,
             "prowJob": {
-                "name": "periodic-ci-openshift-release-main-ci-4.22-e2e-azure-ovn-techpreview-serial-priv"
+                "name": "periodic-ci-openshift-release-main-ci-4.22-e2e-azure-ovn-techpreview-serial-1of2-priv"
+            }
+        },
+        "azure-ovn-techpreview-serial-2of2": {
+            "disabled": true,
+            "optional": true,
+            "prowJob": {
+                "name": "periodic-ci-openshift-release-main-ci-4.22-e2e-azure-ovn-techpreview-serial-2of2-priv"
             }
         },
         "azure-ovn-upgrade-out-of-change": {
@@ -360,11 +367,18 @@
                 "name": "periodic-ci-openshift-release-main-ci-4.22-e2e-gcp-ovn-techpreview-priv"
             }
         },
-        "gcp-ovn-techpreview-serial": {
+        "gcp-ovn-techpreview-serial-1of2": {
             "disabled": true,
             "optional": true,
             "prowJob": {
-                "name": "periodic-ci-openshift-release-main-ci-4.22-e2e-gcp-ovn-techpreview-serial-priv"
+                "name": "periodic-ci-openshift-release-main-ci-4.22-e2e-gcp-ovn-techpreview-serial-1of2-priv"
+            }
+        },
+        "gcp-ovn-techpreview-serial-2of2": {
+            "disabled": true,
+            "optional": true,
+            "prowJob": {
+                "name": "periodic-ci-openshift-release-main-ci-4.22-e2e-gcp-ovn-techpreview-serial-2of2-priv"
             }
         },
         "gcp-ovn-upgrade-4.22-minor": {

--- a/core-services/release-controller/_releases/priv/release-ocp-5.0.json
+++ b/core-services/release-controller/_releases/priv/release-ocp-5.0.json
@@ -273,11 +273,18 @@
                 "name": "periodic-ci-openshift-release-main-ci-5.0-e2e-azure-ovn-techpreview-priv"
             }
         },
-        "azure-ovn-techpreview-serial": {
+        "azure-ovn-techpreview-serial-1of2": {
             "disabled": true,
             "optional": true,
             "prowJob": {
-                "name": "periodic-ci-openshift-release-main-ci-5.0-e2e-azure-ovn-techpreview-serial-priv"
+                "name": "periodic-ci-openshift-release-main-ci-5.0-e2e-azure-ovn-techpreview-serial-1of2-priv"
+            }
+        },
+        "azure-ovn-techpreview-serial-2of2": {
+            "disabled": true,
+            "optional": true,
+            "prowJob": {
+                "name": "periodic-ci-openshift-release-main-ci-5.0-e2e-azure-ovn-techpreview-serial-2of2-priv"
             }
         },
         "azure-ovn-upgrade-out-of-change": {
@@ -370,11 +377,18 @@
                 "name": "periodic-ci-openshift-release-main-ci-5.0-e2e-gcp-ovn-techpreview-priv"
             }
         },
-        "gcp-ovn-techpreview-serial": {
+        "gcp-ovn-techpreview-serial-1of2": {
             "disabled": true,
             "optional": true,
             "prowJob": {
-                "name": "periodic-ci-openshift-release-main-ci-5.0-e2e-gcp-ovn-techpreview-serial-priv"
+                "name": "periodic-ci-openshift-release-main-ci-5.0-e2e-gcp-ovn-techpreview-serial-1of2-priv"
+            }
+        },
+        "gcp-ovn-techpreview-serial-2of2": {
+            "disabled": true,
+            "optional": true,
+            "prowJob": {
+                "name": "periodic-ci-openshift-release-main-ci-5.0-e2e-gcp-ovn-techpreview-serial-2of2-priv"
             }
         },
         "gcp-ovn-upgrade-5.0-major": {

--- a/core-services/release-controller/_releases/release-ocp-4.22.json
+++ b/core-services/release-controller/_releases/release-ocp-4.22.json
@@ -270,10 +270,16 @@
         "name": "periodic-ci-openshift-release-main-ci-4.22-e2e-azure-ovn-techpreview"
       }
     },
-    "azure-ovn-techpreview-serial": {
+    "azure-ovn-techpreview-serial-1of2": {
       "optional": true,
       "prowJob": {
-        "name": "periodic-ci-openshift-release-main-ci-4.22-e2e-azure-ovn-techpreview-serial"
+        "name": "periodic-ci-openshift-release-main-ci-4.22-e2e-azure-ovn-techpreview-serial-1of2"
+      }
+    },
+    "azure-ovn-techpreview-serial-2of2": {
+      "optional": true,
+      "prowJob": {
+        "name": "periodic-ci-openshift-release-main-ci-4.22-e2e-azure-ovn-techpreview-serial-2of2"
       }
     },
     "azure-ovn-upgrade-out-of-change": {
@@ -333,10 +339,16 @@
         "name": "periodic-ci-openshift-release-main-ci-4.22-e2e-gcp-ovn-techpreview"
       }
     },
-    "gcp-ovn-techpreview-serial": {
+    "gcp-ovn-techpreview-serial-1of2": {
       "optional": true,
       "prowJob": {
-        "name": "periodic-ci-openshift-release-main-ci-4.22-e2e-gcp-ovn-techpreview-serial"
+        "name": "periodic-ci-openshift-release-main-ci-4.22-e2e-gcp-ovn-techpreview-serial-1of2"
+      }
+    },
+    "gcp-ovn-techpreview-serial-2of2": {
+      "optional": true,
+      "prowJob": {
+        "name": "periodic-ci-openshift-release-main-ci-4.22-e2e-gcp-ovn-techpreview-serial-2of2"
       }
     },
     "gcp-ovn-upgrade-4.22-minor": {

--- a/core-services/release-controller/_releases/release-ocp-5.0.json
+++ b/core-services/release-controller/_releases/release-ocp-5.0.json
@@ -325,10 +325,16 @@
         "name": "periodic-ci-openshift-release-main-ci-5.0-e2e-azure-ovn-techpreview"
       }
     },
-    "azure-ovn-techpreview-serial": {
+    "azure-ovn-techpreview-serial-1of2": {
       "optional": true,
       "prowJob": {
-        "name": "periodic-ci-openshift-release-main-ci-5.0-e2e-azure-ovn-techpreview-serial"
+        "name": "periodic-ci-openshift-release-main-ci-5.0-e2e-azure-ovn-techpreview-serial-1of2"
+      }
+    },
+    "azure-ovn-techpreview-serial-2of2": {
+      "optional": true,
+      "prowJob": {
+        "name": "periodic-ci-openshift-release-main-ci-5.0-e2e-azure-ovn-techpreview-serial-2of2"
       }
     },
     "azure-ovn-upgrade-out-of-change": {
@@ -374,10 +380,16 @@
         "name": "periodic-ci-openshift-release-main-ci-5.0-e2e-gcp-ovn-techpreview"
       }
     },
-    "gcp-ovn-techpreview-serial": {
+    "gcp-ovn-techpreview-serial-1of2": {
       "optional": true,
       "prowJob": {
-        "name": "periodic-ci-openshift-release-main-ci-5.0-e2e-gcp-ovn-techpreview-serial"
+        "name": "periodic-ci-openshift-release-main-ci-5.0-e2e-gcp-ovn-techpreview-serial-1of2"
+      }
+    },
+    "gcp-ovn-techpreview-serial-2of2": {
+      "optional": true,
+      "prowJob": {
+        "name": "periodic-ci-openshift-release-main-ci-5.0-e2e-gcp-ovn-techpreview-serial-2of2"
       }
     },
     "gcp-ovn-upgrade-5.0-major": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR updates OpenShift CI configuration and release-controller mappings to shard long-running serial TechPreview test workloads so they run as two shards. Changes affect ci-operator test definitions in the openshift/release repo and the release-controller release manifests (public and priv) that map verify jobs to Prow job names.

### What changed in practical terms

- ci-operator configs (openshift/release)
  - Several ci-operator YAMLs for OCP 4.22, 4.23 and 5.0 (and related CI/nightly variants) add shard_count: 2 to multiple TechPreview "serial" test entries (e.g., e2e-*-ovn-*-techpreview-serial variants). This instructs the test harness to split those serial suites into two shards for execution.

- release-controller manifests (core-services/release-controller/_releases)
  - The public and private release JSON manifests for affected OCP releases replace single verify keys for certain techpreview serial jobs with per-shard verify keys (…-techpreview-serial-1of2 and …-techpreview-serial-2of2) and update prowJob.name values to point at the corresponding -1of2/-2of2 Prow jobs. Private manifest entries point to the -priv Prow job names and preserve previous disabled/optional semantics.

### Impact

- Serial TechPreview suites that previously ran as a single job will be executed as two shards, enabling parallelism and reduced CI turnaround for those verifications.
- The release-controller now references individual shard Prow jobs so verification mapping remains consistent with the sharded ci-operator behavior.
- Private job mappings retain their optional/disabled settings; public verify entries are split to match shard-level Prow job names.

### Notes from PR metadata
- Commit message: "NO-JIRA: sharding for 4.22 & 4.23"
- The PR author invoked rehearsals for the new periodic shard Prow jobs.
- An automated bot comment flagged the PR as referencing no JIRA.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->