### PR TITLE
no-jira: aws: add Arch to historical result filter columns

### DIFF
--- a/ci-operator/step-registry/cucushift/installer/googlesheet/update-result/cucushift-installer-googlesheet-update-result-commands.sh
+++ b/ci-operator/step-registry/cucushift/installer/googlesheet/update-result/cucushift-installer-googlesheet-update-result-commands.sh
@@ -591,8 +591,12 @@ jq '.[0] as $headers | [.[1:][] | [., $headers] | transpose | map({(.[1]): .[0]}
 # Filter results by each key
 for column in $(echo "$RESULT_SELECT_BY_COLUMNS" | jq -r '.[]');
 do
-  value="$(jq -r --arg c "$column" '.[$c]' "$OUT_SELECT_DICT")"
-  cat <<< "$(jq -r --arg c "$column" --arg v "$value" 'map(select(.[$c] == $v))' "$candidate_results")" > "$candidate_results"
+  if ! jq -e --arg c "$column" 'has($c)' "$OUT_SELECT_DICT" > /dev/null 2>&1; then
+    echo "Skipping filter for column '$column': not present in selected record"
+    continue
+  fi
+  value="$(jq -r --arg c "$column" '.[$c] // ""' "$OUT_SELECT_DICT")"
+  cat <<< "$(jq -r --arg c "$column" --arg v "$value" 'map(select((.[$c] // "") == $v))' "$candidate_results")" > "$candidate_results"
 done
 
 cat <<< "$(jq -r 'map(select(.OverallResult == "PASS")) | sort_by( (.CreatedDate | sub(",[ ]*$"; "") | strptime("%Y-%m-%d %H:%M:%S%z") | mktime) ) | reverse' "$candidate_results")" > "$candidate_results"

--- a/ci-operator/step-registry/cucushift/installer/googlesheet/update-result/cucushift-installer-googlesheet-update-result-ref.yaml
+++ b/ci-operator/step-registry/cucushift/installer/googlesheet/update-result/cucushift-installer-googlesheet-update-result-ref.yaml
@@ -22,7 +22,7 @@ ref:
       Default is ${PLATFORM}_${TEST_OBJECT}, e.g. "AWS_Regions"
   - name: RESULT_SELECT_BY_COLUMNS
     default: |
-      ["Region", "CPType", "CPFamily", "CType", "CFamily"]
+      ["Region", "Arch", "CPArch", "CArch", "CPType", "CPFamily", "CType", "CFamily"]
     documentation: >-
       Filter the test record by using these keys/columns from the Records sheet.
   documentation: >-


### PR DESCRIPTION
Prevent cross-architecture result contamination when the update-result step selects the best historical result from the Records sheet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR updates the cucushift Google Sheets result-update step in the OpenShift CI configuration to make historical-result selection architecture-aware and robust when selector keys are missing.

## What changed, in practical terms

- ci-operator/step-registry/cucushift/installer/googlesheet/update-result/cucushift-installer-googlesheet-update-result-ref.yaml
  - The default RESULT_SELECT_BY_COLUMNS list was expanded to include architecture column names:
    - ["Region", "Arch", "CPArch", "CArch", "CPType", "CPFamily", "CType", "CFamily"]
  - This configures the update-result step to consider machine architecture when matching historical records.

- ci-operator/step-registry/cucushift/installer/googlesheet/update-result/cucushift-installer-googlesheet-update-result-commands.sh
  - The candidate-result filtering loop now:
    - Skips a column if the selected-record dictionary (OUT_SELECT_DICT) does not have that key, logging "Skipping filter for column 'X': not present in selected record".
    - Reads selector values defensively using .[$c] // "" and applies filters with map(select((.[$c] // "") == $v)), preventing filtering by null/empty values.
  - These changes prevent the update-result logic from mixing results across architectures or from incorrectly narrowing candidates when selector keys are absent.

## Impact

- Affects the cucushift Google Sheets result-recording workflow in the OpenShift CI repository (used for UPI installer verification across AWS/Azure/GCP).
- Prevents cross-architecture contamination when selecting the best historical PASS result and avoids erroneous filtering when sheets or records omit the expected architecture columns. This yields more accurate baseline selection and result updates across AWS ("Arch"), Azure ("Arch"), and GCP ("CPArch", "CArch") sheets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->