### PR TITLE
gcp: Replace custom arm64 image with public one

### DIFF
--- a/ci-operator/step-registry/upi/gcp/arm/pre/upi-gcp-arm-pre-commands.sh
+++ b/ci-operator/step-registry/upi/gcp/arm/pre/upi-gcp-arm-pre-commands.sh
@@ -37,10 +37,9 @@ gcloud compute firewall-rules create "${INSTANCE_PREFIX}" \
   --network "${INSTANCE_PREFIX}" \
   --allow tcp:22,icmp
 
-# image-family openshift4-libvirt-rhel9 must exist in ${GOOGLE_PROJECT_ID} for this template
-# for more info see here: https://github.com/ironcladlou/openshift4-libvirt-gcp/blob/rhel8/IMAGES.md
 gcloud compute instances create "${INSTANCE_PREFIX}" \
-  --image-family openshift4-libvirt-rhel9-arm64 \
+  --image-family rhel-9-arm64 \
+  --image-project rhel-cloud \
   --zone "${GOOGLE_COMPUTE_ZONE}" \
   --machine-type c4a-standard-8 \
   --boot-disk-size 256GB \


### PR DESCRIPTION
This is missed during 6348e5f281e commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR updates the OpenShift CI infrastructure for ARM64 testing on GCP by replacing a custom internal image with a publicly available Red Hat Enterprise Linux image.

## Changes

The GCP UPI (User Provisioned Infrastructure) test step for ARM64 has been updated to use the public `rhel-9-arm64` image family from the `rhel-cloud` project, replacing the previous `openshift4-libvirt-rhel9-arm64` custom image. This change simplifies the ARM64 GCP infrastructure by removing the dependency on an internal/custom image in favor of a standardized public image.

This modification was previously missed during commit 6348e5f281e and is now being applied.

## Impact

The change affects the CI infrastructure's ARM64 test environment on GCP (`ci-operator/step-registry/upi/gcp/arm/pre/`), ensuring that ARM64 test instances boot from a more maintainable, publicly supported image rather than a custom one.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->