### PR TITLE
rh-ecosystem-edge/kernel-module-management: bump Go builder to 1.24 for release-2.4, 2.5, 2.6

### DIFF
--- a/ci-operator/config/rh-ecosystem-edge/kernel-module-management/rh-ecosystem-edge-kernel-module-management-release-2.4.yaml
+++ b/ci-operator/config/rh-ecosystem-edge/kernel-module-management/rh-ecosystem-edge-kernel-module-management-release-2.4.yaml
@@ -2,7 +2,7 @@ base_images:
   go-builder:
     name: builder
     namespace: ocp
-    tag: rhel-9-golang-1.23-openshift-4.19
+    tag: rhel-9-golang-1.24-openshift-4.22
   operator-sdk:
     name: "4.16"
     namespace: origin
@@ -12,7 +12,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: rhel-9-release-golang-1.23-openshift-4.19
+    tag: rhel-9-release-golang-1.24-openshift-4.22
 images:
   items:
   - build_args:

--- a/ci-operator/config/rh-ecosystem-edge/kernel-module-management/rh-ecosystem-edge-kernel-module-management-release-2.5.yaml
+++ b/ci-operator/config/rh-ecosystem-edge/kernel-module-management/rh-ecosystem-edge-kernel-module-management-release-2.5.yaml
@@ -2,7 +2,7 @@ base_images:
   go-builder:
     name: builder
     namespace: ocp
-    tag: rhel-9-golang-1.23-openshift-4.19
+    tag: rhel-9-golang-1.24-openshift-4.22
   operator-sdk:
     name: "4.16"
     namespace: origin
@@ -12,7 +12,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: rhel-9-release-golang-1.23-openshift-4.19
+    tag: rhel-9-release-golang-1.24-openshift-4.22
 images:
   items:
   - build_args:

--- a/ci-operator/config/rh-ecosystem-edge/kernel-module-management/rh-ecosystem-edge-kernel-module-management-release-2.6.yaml
+++ b/ci-operator/config/rh-ecosystem-edge/kernel-module-management/rh-ecosystem-edge-kernel-module-management-release-2.6.yaml
@@ -2,7 +2,7 @@ base_images:
   go-builder:
     name: builder
     namespace: ocp
-    tag: rhel-9-golang-1.23-openshift-4.19
+    tag: rhel-9-golang-1.24-openshift-4.22
   operator-sdk:
     name: "4.16"
     namespace: origin
@@ -12,7 +12,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: rhel-9-release-golang-1.23-openshift-4.19
+    tag: rhel-9-release-golang-1.24-openshift-4.22
 images:
   items:
   - build_args:


### PR DESCRIPTION
## Summary
- Bump the Go builder image from `golang-1.23` to `golang-1.24` (`openshift-4.19` → `openshift-4.22`) for KMM release branches 2.4, 2.5, and 2.6
- This is needed because the grpc v1.80.0 bump ([rh-ecosystem-edge/kernel-module-management#1788](https://github.com/rh-ecosystem-edge/kernel-module-management/pull/1788)) requires Go >= 1.24.0, and the current CI builder images only have Go 1.23

## Changes
Updates both `base_images.go-builder.tag` and `build_root.image_stream_tag.tag` in:
- `rh-ecosystem-edge-kernel-module-management-release-2.4.yaml`
- `rh-ecosystem-edge-kernel-module-management-release-2.5.yaml`
- `rh-ecosystem-edge-kernel-module-management-release-2.6.yaml`

From:
- `rhel-9-golang-1.23-openshift-4.19` → `rhel-9-golang-1.24-openshift-4.22`
- `rhel-9-release-golang-1.23-openshift-4.19` → `rhel-9-release-golang-1.24-openshift-4.22`

/cc @TomerNewman

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR updates the CI configuration for the rh-ecosystem-edge/kernel-module-management operator across three release branches (2.4, 2.5, and 2.6) to use Go 1.24 builder images instead of Go 1.23. 

The changes update the base image tags in the CI pipeline configurations:
- Go builder: `rhel-9-golang-1.23-openshift-4.19` → `rhel-9-golang-1.24-openshift-4.22`
- Build root release image: `rhel-9-release-golang-1.23-openshift-4.19` → `rhel-9-release-golang-1.24-openshift-4.22`

This is necessary because a required dependency (grpc v1.80.0) now requires Go 1.24.0 or newer. Each modified configuration file receives 2 line changes to update these image tag references. The actual CI job logic and test configuration remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->