### PR TITLE
Add Chaos Job for RHOSO

### DIFF
--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__metal-rhoso-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__metal-rhoso-x86.yaml
@@ -252,6 +252,26 @@ tests:
     - ref: openshift-qe-rhoso-browbeat-run
     - ref: openshift-qe-rhoso-browbeat-results-backup
     - ref: openshift-qe-orion-rhoso
+- as: weekly-rhoso-chaos
+  capabilities:
+  - intranet
+  cron: 0 17 * * 5
+  restrict_network_access: false
+  steps:
+    cluster_profile: metal-perfscale-osp
+    env:
+      FOREMAN_OS: RHEL 9.4
+      NUM_NODES: "17"
+      STARTING_NODE: "4"
+      WORKLOAD: chaos
+      WORKLOAD_TYPE: workflow
+    test:
+    - ref: openshift-qe-rhoso-uninstaller
+    - ref: openshift-qe-installer-bm-foreman
+    - ref: openshift-qe-rhoso-installer-pre-provisioned
+    - ref: openshift-qe-rhoso-browbeat-install
+    - ref: openshift-qe-rhoso-browbeat-run
+    - ref: openshift-qe-rhoso-browbeat-results-backup
 zz_generated_metadata:
   branch: main
   org: openshift-eng

--- a/ci-operator/jobs/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main-periodics.yaml
@@ -7203,6 +7203,89 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build09
+  cron: 0 17 * * 5
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-eng
+    repo: ocp-qe-perfscale-ci
+  labels:
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: metal-perfscale-osp
+    ci-operator.openshift.io/cloud-cluster-profile: metal-perfscale-osp
+    ci-operator.openshift.io/variant: metal-rhoso-x86
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-metal-rhoso-x86-weekly-rhoso-chaos
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=weekly-rhoso-chaos
+      - --variant=metal-rhoso-x86
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build09
   cron: 0 5 * * 5
   decorate: true
   decoration_config:


### PR DESCRIPTION
this will run using the browbeat workflow and krkn plugin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR adds a new scheduled chaos engineering test job to the OpenShift CI infrastructure for RHOSO (Red Hat OpenStack Services on OpenShift).

The change adds a `weekly-rhoso-chaos` job to the ocp-qe-perfscale-ci configuration that runs weekly performance and scale testing with chaos workloads using the Browbeat framework and krkn plugin. The job is scheduled to run every Friday at 5 PM UTC on a 17-node metal cluster with RHEL 9.4, following the same pattern as other existing RHOSO weekly workload jobs (nova, neutron, keystone, glance, cinder, barbican, swift, and octavia).

The job orchestrates a complete test sequence: uninstalling previous deployments, provisioning the infrastructure via Foreman, installing RHOSO components, installing and running Browbeat (which executes chaos scenarios via the krkn plugin), and backing up test results. This enables regular chaos engineering validation for RHOSO deployments in the OpenShift CI system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->