### PR TITLE
multiarch: migrate 4.16 homogeneous s390x jobs to libvirt VPN

### DIFF
--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.16.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.16.yaml
@@ -372,18 +372,20 @@ tests:
     workflow: openshift-upgrade-azure
 - as: ocp-e2e-ovn-remote-libvirt-s390x
   capabilities:
-  - sshd-bastion
+  - intranet
   cron: 0 12 * * 5
   steps:
-    cluster_profile: libvirt-s390x-1
+    cluster_profile: libvirt-s390x-vpn
     dependencies:
       OPENSHIFT_INSTALL_TARGET: release:s390x-latest
     env:
       ARCH: s390x
       BRANCH: "4.16"
+      ETCD_DISK_SPEED: slow
       NODE_TUNING: "true"
       TEST_TYPE: conformance-parallel
-    workflow: openshift-e2e-libvirt-upi
+      USE_EXTERNAL_DNS: "true"
+    workflow: openshift-e2e-libvirt-vpn
 - as: ocp-e2e-ovn-remote-libvirt-s390x-heterogeneous
   capabilities:
   - sshd-bastion
@@ -400,72 +402,82 @@ tests:
     workflow: openshift-e2e-libvirt-upi-heterogeneous
 - as: ocp-heavy-build-ovn-remote-libvirt-s390x
   capabilities:
-  - sshd-bastion
+  - intranet
   cron: 0 0 26 1 *
   steps:
-    cluster_profile: libvirt-s390x-1
+    cluster_profile: libvirt-s390x-vpn
     dependencies:
       OPENSHIFT_INSTALL_TARGET: release:s390x-latest
     env:
       ARCH: s390x
       BRANCH: "4.16"
+      ETCD_DISK_SPEED: slow
       NODE_TUNING: "true"
       TEST_TYPE: heavy-build
-    workflow: openshift-e2e-libvirt-upi
+      USE_EXTERNAL_DNS: "true"
+    workflow: openshift-e2e-libvirt-vpn
 - as: ocp-image-ecosystem-ovn-remote-libvirt-s390x
   capabilities:
-  - sshd-bastion
+  - intranet
   cron: 0 0 28 1 *
   steps:
-    cluster_profile: libvirt-s390x-1
+    cluster_profile: libvirt-s390x-vpn
     dependencies:
-      OPENSHIFT_INSTALL_TARGET: release:multi-latest
+      OPENSHIFT_INSTALL_TARGET: release:s390x-latest
     env:
       ARCH: s390x
       BRANCH: "4.16"
+      ETCD_DISK_SPEED: slow
       TEST_TYPE: image-ecosystem
-    workflow: openshift-e2e-libvirt-upi
+      USE_EXTERNAL_DNS: "true"
+    workflow: openshift-e2e-libvirt-vpn
 - as: ocp-jenkins-e2e-ovn-remote-libvirt-s390x
   capabilities:
-  - sshd-bastion
+  - intranet
   cron: 0 0 29 1 *
   steps:
-    cluster_profile: libvirt-s390x-1
+    cluster_profile: libvirt-s390x-vpn
     dependencies:
-      OPENSHIFT_INSTALL_TARGET: release:multi-latest
+      OPENSHIFT_INSTALL_TARGET: release:s390x-latest
     env:
       ARCH: s390x
       BRANCH: "4.16"
+      ETCD_DISK_SPEED: slow
       TEST_TYPE: jenkins-e2e-rhel-only
-    workflow: openshift-e2e-libvirt-upi
+      USE_EXTERNAL_DNS: "true"
+    workflow: openshift-e2e-libvirt-vpn
 - as: ocp-e2e-serial-ovn-remote-libvirt-s390x
   capabilities:
-  - sshd-bastion
+  - intranet
   cron: 0 0 30 1 *
   steps:
-    cluster_profile: libvirt-s390x-1
+    cluster_profile: libvirt-s390x-vpn
     dependencies:
       OPENSHIFT_INSTALL_TARGET: release:s390x-latest
     env:
       ARCH: s390x
       BRANCH: "4.16"
+      ETCD_DISK_SPEED: slow
       TEST_TYPE: conformance-serial
-    workflow: openshift-e2e-libvirt-upi
+      USE_EXTERNAL_DNS: "true"
+    workflow: openshift-e2e-libvirt-vpn
 - as: ocp-fips-ovn-remote-libvirt-s390x
   capabilities:
-  - sshd-bastion
+  - intranet
   cron: 0 16 * * 5
   steps:
-    cluster_profile: libvirt-s390x-1
+    cluster_profile: libvirt-s390x-vpn
     dependencies:
       OPENSHIFT_INSTALL_TARGET: release:s390x-latest
     env:
       ARCH: s390x
       BRANCH: "4.16"
+      ETCD_DISK_SPEED: slow
       FIPS_ENABLED: "true"
       NODE_TUNING: "true"
       TEST_TYPE: conformance-parallel
-    workflow: openshift-e2e-libvirt-upi-fips
+      USE_EXTERNAL_DNS: "true"
+    workflow: openshift-e2e-libvirt-vpn-fips
 - as: ocp-e2e-ovn-remote-s2s-libvirt-ppc64le
   capabilities:
   - power-s2s-dns

--- a/ci-operator/jobs/openshift/multiarch/openshift-multiarch-main-periodics.yaml
+++ b/ci-operator/jobs/openshift/multiarch/openshift-multiarch-main-periodics.yaml
@@ -18913,7 +18913,6 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
   cron: 0 12 * * 5
   decorate: true
   decoration_config:
@@ -18923,9 +18922,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-1
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-1
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-4.16
     ci.openshift.io/generator: prowgen
     job-release: "4.16"
@@ -19414,7 +19413,6 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
   cron: 0 0 30 1 *
   decorate: true
   decoration_config:
@@ -19424,9 +19422,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-1
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-1
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-4.16
     ci.openshift.io/generator: prowgen
     job-release: "4.16"
@@ -20080,7 +20078,6 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
   cron: 0 16 * * 5
   decorate: true
   decoration_config:
@@ -20090,9 +20087,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-1
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-1
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-4.16
     ci.openshift.io/generator: prowgen
     job-release: "4.16"
@@ -20248,7 +20245,6 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
   cron: 0 0 26 1 *
   decorate: true
   decoration_config:
@@ -20258,9 +20254,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-1
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-1
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-4.16
     ci.openshift.io/generator: prowgen
     job-release: "4.16"
@@ -20415,7 +20411,6 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
   cron: 0 0 28 1 *
   decorate: true
   decoration_config:
@@ -20425,9 +20420,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-1
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-1
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-4.16
     ci.openshift.io/generator: prowgen
     job-release: "4.16"
@@ -20666,7 +20661,6 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
   cron: 0 0 29 1 *
   decorate: true
   decoration_config:
@@ -20676,9 +20670,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-1
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-1
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-4.16
     ci.openshift.io/generator: prowgen
     job-release: "4.16"

--- a/ci-operator/jobs/openshift/multiarch/openshift-multiarch-main-periodics.yaml
+++ b/ci-operator/jobs/openshift/multiarch/openshift-multiarch-main-periodics.yaml
@@ -18913,6 +18913,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
+  cluster: build09
   cron: 0 12 * * 5
   decorate: true
   decoration_config:
@@ -19413,6 +19414,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
+  cluster: build09
   cron: 0 0 30 1 *
   decorate: true
   decoration_config:
@@ -20078,6 +20080,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
+  cluster: build09
   cron: 0 16 * * 5
   decorate: true
   decoration_config:
@@ -20245,6 +20248,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
+  cluster: build09
   cron: 0 0 26 1 *
   decorate: true
   decoration_config:
@@ -20411,6 +20415,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
+  cluster: build09
   cron: 0 0 28 1 *
   decorate: true
   decoration_config:
@@ -20661,6 +20666,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
+  cluster: build09
   cron: 0 0 29 1 *
   decorate: true
   decoration_config:


### PR DESCRIPTION
- Switch cluster_profile from libvirt-s390x-1 to libvirt-s390x-vpn
- Replace sshd-bastion with intranet capability
- Use openshift-e2e-libvirt-vpn (vpn-fips for FIPS)
- Add ETCD_DISK_SPEED slow, USE_EXTERNAL_DNS, s390x-latest for image/jenkins
- Regenerate nightly-4.16 periodics (labels, cluster scheduling)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request migrates OpenShift's multiarch CI infrastructure for s390x (IBM System z) test jobs from the existing `libvirt-s390x-1` cluster to a new VPN-based setup (`libvirt-s390x-vpn`). 

## What Changed

The configuration in `ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.16.yaml` was updated to reconfigure 4.16 nightly periodics and homogeneous s390x test jobs with:

- **Cluster Profile**: Changed from `libvirt-s390x-1` to `libvirt-s390x-vpn` for infrastructure access
- **Network Access**: Replaced `sshd-bastion` capability with `intranet` capability for how jobs connect to the lab environment
- **Environment Variables**: Added `ETCD_DISK_SPEED: slow` and `USE_EXTERNAL_DNS: true` to configure test environment parameters

## Affected Jobs

The changes apply to multiple s390x libvirt-based CI jobs including:
- `ocp-e2e-ovn-remote-libvirt-s390x`
- `ocp-heavy-build-ovn-remote-libvirt-s390x`
- `ocp-image-ecosystem-ovn-remote-libvirt-s390x`
- `ocp-jenkins-e2e-ovn-remote-libvirt-s390x`
- `ocp-e2e-serial-ovn-remote-libvirt-s390x`
- `ocp-fips-ovn-remote-libvirt-s390x` (with FIPS variant)

## Impact

This migration moves s390x test infrastructure to a new VPN-based architecture, likely to improve reliability and security of remote lab access for testing on IBM System z hardware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->