### PR TITLE
test:learning PR for pipeliles in perf CI job

### DIFF
--- a/ci-operator/config/openshift-pipelines/performance/openshift-pipelines-performance-main.yaml
+++ b/ci-operator/config/openshift-pipelines/performance/openshift-pipelines-performance-main.yaml
@@ -249,6 +249,18 @@ tests:
       TEST_SCENARIO: math
       TEST_SCENARIOS: 200/12 200/14 200/16 200/18 200/20
     workflow: openshift-pipelines-max-concurrency
+- as: max-concurrency-downstream-pipelines1-21-test
+  cron: 0 3 31 12 *
+  steps:
+    cluster_profile: aws-pipelines-performance
+    env:
+      DEPLOYMENT_TYPE: downstream
+      DEPLOYMENT_VERSION: "1.21"
+      MUST_GATHER_TIMEOUT: 35m
+      TEST_NAMESPACE: "5"
+      TEST_SCENARIO: math
+      TEST_SCENARIOS: 200/12
+    workflow: openshift-pipelines-max-concurrency
 - as: max-concurrency-downstream-pipelines1-21
   cron: 0 6 11,26 * *
   steps:

--- a/ci-operator/jobs/openshift-pipelines/performance/openshift-pipelines-performance-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-pipelines/performance/openshift-pipelines-performance-main-periodics.yaml
@@ -1601,6 +1601,86 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build06
+  cron: 0 3 31 12 *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-pipelines
+    repo: performance
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-pipelines-performance
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-pipelines-performance-main-max-concurrency-downstream-pipelines1-21-test
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=max-concurrency-downstream-pipelines1-21-test
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build06
   cron: 0 6 * * *
   decorate: true
   decoration_config:


### PR DESCRIPTION
Learning PR to understand Prow workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This learning PR adds a single scheduled performance test to the OpenShift Pipelines performance CI configuration. The change introduces a new recurring test job named `max-concurrency-downstream-pipelines1-21-test` to the Pipelines performance testing suite.

## What Changed

**File modified:** `ci-operator/config/openshift-pipelines/performance/openshift-pipelines-performance-main.yaml`

A new test entry was added that:
- Runs on a fixed schedule (December 31st at 3 AM UTC)
- Targets Pipelines version 1.21 
- Executes the `openshift-pipelines-max-concurrency` workflow
- Tests with a specific scenario configuration (`TEST_SCENARIOS: 200/12`)

## Practical Impact

This adds one additional performance test to the OpenShift Pipelines CI pipeline. The scheduled test will help validate the performance characteristics of OpenShift Pipelines under concurrent load conditions as part of the nightly/periodic testing suite.

**Note:** This is a learning/exploratory PR authored to understand Prow workflow mechanics and CI configuration patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->