### PR TITLE
coreos/rhel-coreos-config: consolidate duplicate build-test jobs

### DIFF
--- a/ci-operator/config/coreos/rhel-coreos-config/coreos-rhel-coreos-config-main.yaml
+++ b/ci-operator/config/coreos/rhel-coreos-config/coreos-rhel-coreos-config-main.yaml
@@ -29,7 +29,7 @@ resources:
     requests:
       cpu: 100m
       memory: 200Mi
-  rhcos-9-build-test-metal:
+  rhcos-9-build-test:
     limits:
       devices.kubevirt.io/kvm: "1"
     requests:
@@ -37,7 +37,7 @@ resources:
       devices.kubevirt.io/kvm: "1"
       ephemeral-storage: 40Gi
       memory: 3Gi
-  rhcos-9-build-test-qemu:
+  rhcos-10-build-test:
     limits:
       devices.kubevirt.io/kvm: "1"
     requests:
@@ -45,7 +45,7 @@ resources:
       devices.kubevirt.io/kvm: "1"
       ephemeral-storage: 40Gi
       memory: 3Gi
-  rhcos-10-build-test-metal:
+  scos-9-build-test:
     limits:
       devices.kubevirt.io/kvm: "1"
     requests:
@@ -53,39 +53,7 @@ resources:
       devices.kubevirt.io/kvm: "1"
       ephemeral-storage: 40Gi
       memory: 3Gi
-  rhcos-10-build-test-qemu:
-    limits:
-      devices.kubevirt.io/kvm: "1"
-    requests:
-      cpu: 2000m
-      devices.kubevirt.io/kvm: "1"
-      ephemeral-storage: 40Gi
-      memory: 3Gi
-  scos-9-build-test-metal:
-    limits:
-      devices.kubevirt.io/kvm: "1"
-    requests:
-      cpu: 2000m
-      devices.kubevirt.io/kvm: "1"
-      ephemeral-storage: 40Gi
-      memory: 3Gi
-  scos-9-build-test-qemu:
-    limits:
-      devices.kubevirt.io/kvm: "1"
-    requests:
-      cpu: 2000m
-      devices.kubevirt.io/kvm: "1"
-      ephemeral-storage: 40Gi
-      memory: 3Gi
-  scos-10-build-test-metal:
-    limits:
-      devices.kubevirt.io/kvm: "1"
-    requests:
-      cpu: 2000m
-      devices.kubevirt.io/kvm: "1"
-      ephemeral-storage: 40Gi
-      memory: 3Gi
-  scos-10-build-test-qemu:
+  scos-10-build-test:
     limits:
       devices.kubevirt.io/kvm: "1"
     requests:
@@ -101,75 +69,39 @@ tests:
   container:
     from: src
   skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
-- as: rhcos-9-build-test-qemu
+- as: rhcos-9-build-test
   capabilities:
   - kvm
   commands: |
-    REGISTRY_AUTH_FILE=/var/run/secrets/ci-pull-credentials/.dockerconfigjson /src/ci/prow-entrypoint.sh rhcos-9-build-test-qemu
+    REGISTRY_AUTH_FILE=/var/run/secrets/ci-pull-credentials/.dockerconfigjson /src/ci/prow-entrypoint.sh rhcos-9-build-test
   container:
     from: build-image
   secret:
     mount_path: /var/run/secrets/ci-pull-credentials
     name: ci-pull-credentials
   skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
-- as: rhcos-9-build-test-metal
+- as: rhcos-10-build-test
   capabilities:
   - kvm
   commands: |
-    REGISTRY_AUTH_FILE=/var/run/secrets/ci-pull-credentials/.dockerconfigjson /src/ci/prow-entrypoint.sh rhcos-9-build-test-metal
+    REGISTRY_AUTH_FILE=/var/run/secrets/ci-pull-credentials/.dockerconfigjson /src/ci/prow-entrypoint.sh rhcos-10-build-test
   container:
     from: build-image
   secret:
     mount_path: /var/run/secrets/ci-pull-credentials
     name: ci-pull-credentials
   skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
-- as: rhcos-10-build-test-qemu
+- as: scos-9-build-test
   capabilities:
   - kvm
-  commands: |
-    REGISTRY_AUTH_FILE=/var/run/secrets/ci-pull-credentials/.dockerconfigjson /src/ci/prow-entrypoint.sh rhcos-10-build-test-qemu
-  container:
-    from: build-image
-  secret:
-    mount_path: /var/run/secrets/ci-pull-credentials
-    name: ci-pull-credentials
-  skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
-- as: rhcos-10-build-test-metal
-  capabilities:
-  - kvm
-  commands: |
-    REGISTRY_AUTH_FILE=/var/run/secrets/ci-pull-credentials/.dockerconfigjson /src/ci/prow-entrypoint.sh rhcos-10-build-test-metal
-  container:
-    from: build-image
-  secret:
-    mount_path: /var/run/secrets/ci-pull-credentials
-    name: ci-pull-credentials
-  skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
-- as: scos-9-build-test-qemu
-  capabilities:
-  - kvm
-  commands: /src/ci/prow-entrypoint.sh scos-9-build-test-qemu
+  commands: /src/ci/prow-entrypoint.sh scos-9-build-test
   container:
     from: build-image
   skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
-- as: scos-9-build-test-metal
+- as: scos-10-build-test
   capabilities:
   - kvm
-  commands: /src/ci/prow-entrypoint.sh scos-9-build-test-metal
-  container:
-    from: build-image
-  skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
-- as: scos-10-build-test-qemu
-  capabilities:
-  - kvm
-  commands: /src/ci/prow-entrypoint.sh scos-10-build-test-qemu
-  container:
-    from: build-image
-  skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
-- as: scos-10-build-test-metal
-  capabilities:
-  - kvm
-  commands: /src/ci/prow-entrypoint.sh scos-10-build-test-metal
+  commands: /src/ci/prow-entrypoint.sh scos-10-build-test
   container:
     from: build-image
   skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$

--- a/ci-operator/config/coreos/rhel-coreos-config/coreos-rhel-coreos-config-mintmaker-bootc-main-updates.yaml
+++ b/ci-operator/config/coreos/rhel-coreos-config/coreos-rhel-coreos-config-mintmaker-bootc-main-updates.yaml
@@ -29,7 +29,7 @@ resources:
     requests:
       cpu: 100m
       memory: 200Mi
-  rhcos-9-build-test-metal:
+  rhcos-9-build-test:
     limits:
       devices.kubevirt.io/kvm: "1"
     requests:
@@ -37,7 +37,7 @@ resources:
       devices.kubevirt.io/kvm: "1"
       ephemeral-storage: 40Gi
       memory: 3Gi
-  rhcos-9-build-test-qemu:
+  rhcos-10-build-test:
     limits:
       devices.kubevirt.io/kvm: "1"
     requests:
@@ -45,7 +45,7 @@ resources:
       devices.kubevirt.io/kvm: "1"
       ephemeral-storage: 40Gi
       memory: 3Gi
-  rhcos-10-build-test-metal:
+  scos-9-build-test:
     limits:
       devices.kubevirt.io/kvm: "1"
     requests:
@@ -53,39 +53,7 @@ resources:
       devices.kubevirt.io/kvm: "1"
       ephemeral-storage: 40Gi
       memory: 3Gi
-  rhcos-10-build-test-qemu:
-    limits:
-      devices.kubevirt.io/kvm: "1"
-    requests:
-      cpu: 2000m
-      devices.kubevirt.io/kvm: "1"
-      ephemeral-storage: 40Gi
-      memory: 3Gi
-  scos-9-build-test-metal:
-    limits:
-      devices.kubevirt.io/kvm: "1"
-    requests:
-      cpu: 2000m
-      devices.kubevirt.io/kvm: "1"
-      ephemeral-storage: 40Gi
-      memory: 3Gi
-  scos-9-build-test-qemu:
-    limits:
-      devices.kubevirt.io/kvm: "1"
-    requests:
-      cpu: 2000m
-      devices.kubevirt.io/kvm: "1"
-      ephemeral-storage: 40Gi
-      memory: 3Gi
-  scos-10-build-test-metal:
-    limits:
-      devices.kubevirt.io/kvm: "1"
-    requests:
-      cpu: 2000m
-      devices.kubevirt.io/kvm: "1"
-      ephemeral-storage: 40Gi
-      memory: 3Gi
-  scos-10-build-test-qemu:
+  scos-10-build-test:
     limits:
       devices.kubevirt.io/kvm: "1"
     requests:
@@ -102,11 +70,11 @@ tests:
     from: src
   postsubmit: true
   skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
-- as: rhcos-9-build-test-qemu
+- as: rhcos-9-build-test
   capabilities:
   - kvm
   commands: |
-    REGISTRY_AUTH_FILE=/var/run/secrets/ci-pull-credentials/.dockerconfigjson /src/ci/prow-entrypoint.sh rhcos-9-build-test-qemu
+    REGISTRY_AUTH_FILE=/var/run/secrets/ci-pull-credentials/.dockerconfigjson /src/ci/prow-entrypoint.sh rhcos-9-build-test
   container:
     from: build-image
   postsubmit: true
@@ -114,11 +82,11 @@ tests:
     mount_path: /var/run/secrets/ci-pull-credentials
     name: ci-pull-credentials
   skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
-- as: rhcos-9-build-test-metal
+- as: rhcos-10-build-test
   capabilities:
   - kvm
   commands: |
-    REGISTRY_AUTH_FILE=/var/run/secrets/ci-pull-credentials/.dockerconfigjson /src/ci/prow-entrypoint.sh rhcos-9-build-test-metal
+    REGISTRY_AUTH_FILE=/var/run/secrets/ci-pull-credentials/.dockerconfigjson /src/ci/prow-entrypoint.sh rhcos-10-build-test
   container:
     from: build-image
   postsubmit: true
@@ -126,58 +94,18 @@ tests:
     mount_path: /var/run/secrets/ci-pull-credentials
     name: ci-pull-credentials
   skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
-- as: rhcos-10-build-test-qemu
+- as: scos-9-build-test
   capabilities:
   - kvm
-  commands: |
-    REGISTRY_AUTH_FILE=/var/run/secrets/ci-pull-credentials/.dockerconfigjson /src/ci/prow-entrypoint.sh rhcos-10-build-test-qemu
-  container:
-    from: build-image
-  postsubmit: true
-  secret:
-    mount_path: /var/run/secrets/ci-pull-credentials
-    name: ci-pull-credentials
-  skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
-- as: rhcos-10-build-test-metal
-  capabilities:
-  - kvm
-  commands: |
-    REGISTRY_AUTH_FILE=/var/run/secrets/ci-pull-credentials/.dockerconfigjson /src/ci/prow-entrypoint.sh rhcos-10-build-test-metal
-  container:
-    from: build-image
-  postsubmit: true
-  secret:
-    mount_path: /var/run/secrets/ci-pull-credentials
-    name: ci-pull-credentials
-  skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
-- as: scos-9-build-test-qemu
-  capabilities:
-  - kvm
-  commands: /src/ci/prow-entrypoint.sh scos-9-build-test-qemu
+  commands: /src/ci/prow-entrypoint.sh scos-9-build-test
   container:
     from: build-image
   postsubmit: true
   skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
-- as: scos-9-build-test-metal
+- as: scos-10-build-test
   capabilities:
   - kvm
-  commands: /src/ci/prow-entrypoint.sh scos-9-build-test-metal
-  container:
-    from: build-image
-  postsubmit: true
-  skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
-- as: scos-10-build-test-qemu
-  capabilities:
-  - kvm
-  commands: /src/ci/prow-entrypoint.sh scos-10-build-test-qemu
-  container:
-    from: build-image
-  postsubmit: true
-  skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
-- as: scos-10-build-test-metal
-  capabilities:
-  - kvm
-  commands: /src/ci/prow-entrypoint.sh scos-10-build-test-metal
+  commands: /src/ci/prow-entrypoint.sh scos-10-build-test
   container:
     from: build-image
   postsubmit: true

--- a/ci-operator/jobs/coreos/rhel-coreos-config/coreos-rhel-coreos-config-main-presubmits.yaml
+++ b/ci-operator/jobs/coreos/rhel-coreos-config/coreos-rhel-coreos-config-main-presubmits.yaml
@@ -61,7 +61,7 @@ presubmits:
     - ^main$
     - ^main-
     cluster: build04
-    context: ci/prow/rhcos-10-build-test-metal
+    context: ci/prow/rhcos-10-build-test
     decorate: true
     decoration_config:
       skip_cloning: true
@@ -70,8 +70,8 @@ presubmits:
       ci.openshift.io/generator: prowgen
       devices.kubevirt.io/kvm: "1"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-coreos-rhel-coreos-config-main-rhcos-10-build-test-metal
-    rerun_command: /test rhcos-10-build-test-metal
+    name: pull-ci-coreos-rhel-coreos-config-main-rhcos-10-build-test
+    rerun_command: /test rhcos-10-build-test
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
     spec:
       containers:
@@ -80,7 +80,7 @@ presubmits:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=rhcos-10-build-test-metal
+        - --target=rhcos-10-build-test
         command:
         - ci-operator
         env:
@@ -127,14 +127,14 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )rhcos-10-build-test-metal,?($|\s.*)
+    trigger: (?m)^/test( | .* )rhcos-10-build-test,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:
     - ^main$
     - ^main-
     cluster: build04
-    context: ci/prow/rhcos-10-build-test-qemu
+    context: ci/prow/rhcos-9-build-test
     decorate: true
     decoration_config:
       skip_cloning: true
@@ -143,8 +143,8 @@ presubmits:
       ci.openshift.io/generator: prowgen
       devices.kubevirt.io/kvm: "1"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-coreos-rhel-coreos-config-main-rhcos-10-build-test-qemu
-    rerun_command: /test rhcos-10-build-test-qemu
+    name: pull-ci-coreos-rhel-coreos-config-main-rhcos-9-build-test
+    rerun_command: /test rhcos-9-build-test
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
     spec:
       containers:
@@ -153,7 +153,7 @@ presubmits:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=rhcos-10-build-test-qemu
+        - --target=rhcos-9-build-test
         command:
         - ci-operator
         env:
@@ -200,14 +200,14 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )rhcos-10-build-test-qemu,?($|\s.*)
+    trigger: (?m)^/test( | .* )rhcos-9-build-test,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:
     - ^main$
     - ^main-
     cluster: build04
-    context: ci/prow/rhcos-9-build-test-metal
+    context: ci/prow/scos-10-build-test
     decorate: true
     decoration_config:
       skip_cloning: true
@@ -216,8 +216,8 @@ presubmits:
       ci.openshift.io/generator: prowgen
       devices.kubevirt.io/kvm: "1"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-coreos-rhel-coreos-config-main-rhcos-9-build-test-metal
-    rerun_command: /test rhcos-9-build-test-metal
+    name: pull-ci-coreos-rhel-coreos-config-main-scos-10-build-test
+    rerun_command: /test scos-10-build-test
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
     spec:
       containers:
@@ -225,153 +225,7 @@ presubmits:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=rhcos-9-build-test-metal
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )rhcos-9-build-test-metal,?($|\s.*)
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - ^main$
-    - ^main-
-    cluster: build04
-    context: ci/prow/rhcos-9-build-test-qemu
-    decorate: true
-    decoration_config:
-      skip_cloning: true
-    labels:
-      capability/kvm: kvm
-      ci.openshift.io/generator: prowgen
-      devices.kubevirt.io/kvm: "1"
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-coreos-rhel-coreos-config-main-rhcos-9-build-test-qemu
-    rerun_command: /test rhcos-9-build-test-qemu
-    skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=rhcos-9-build-test-qemu
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )rhcos-9-build-test-qemu,?($|\s.*)
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - ^main$
-    - ^main-
-    cluster: build04
-    context: ci/prow/scos-10-build-test-metal
-    decorate: true
-    decoration_config:
-      skip_cloning: true
-    labels:
-      capability/kvm: kvm
-      ci.openshift.io/generator: prowgen
-      devices.kubevirt.io/kvm: "1"
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-coreos-rhel-coreos-config-main-scos-10-build-test-metal
-    rerun_command: /test scos-10-build-test-metal
-    skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --report-credentials-file=/etc/report/credentials
-        - --target=scos-10-build-test-metal
+        - --target=scos-10-build-test
         command:
         - ci-operator
         env:
@@ -412,14 +266,14 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )scos-10-build-test-metal,?($|\s.*)
+    trigger: (?m)^/test( | .* )scos-10-build-test,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:
     - ^main$
     - ^main-
     cluster: build04
-    context: ci/prow/scos-10-build-test-qemu
+    context: ci/prow/scos-9-build-test
     decorate: true
     decoration_config:
       skip_cloning: true
@@ -428,8 +282,8 @@ presubmits:
       ci.openshift.io/generator: prowgen
       devices.kubevirt.io/kvm: "1"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-coreos-rhel-coreos-config-main-scos-10-build-test-qemu
-    rerun_command: /test scos-10-build-test-qemu
+    name: pull-ci-coreos-rhel-coreos-config-main-scos-9-build-test
+    rerun_command: /test scos-9-build-test
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
     spec:
       containers:
@@ -437,7 +291,7 @@ presubmits:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --report-credentials-file=/etc/report/credentials
-        - --target=scos-10-build-test-qemu
+        - --target=scos-9-build-test
         command:
         - ci-operator
         env:
@@ -478,139 +332,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )scos-10-build-test-qemu,?($|\s.*)
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - ^main$
-    - ^main-
-    cluster: build04
-    context: ci/prow/scos-9-build-test-metal
-    decorate: true
-    decoration_config:
-      skip_cloning: true
-    labels:
-      capability/kvm: kvm
-      ci.openshift.io/generator: prowgen
-      devices.kubevirt.io/kvm: "1"
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-coreos-rhel-coreos-config-main-scos-9-build-test-metal
-    rerun_command: /test scos-9-build-test-metal
-    skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --report-credentials-file=/etc/report/credentials
-        - --target=scos-9-build-test-metal
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )scos-9-build-test-metal,?($|\s.*)
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - ^main$
-    - ^main-
-    cluster: build04
-    context: ci/prow/scos-9-build-test-qemu
-    decorate: true
-    decoration_config:
-      skip_cloning: true
-    labels:
-      capability/kvm: kvm
-      ci.openshift.io/generator: prowgen
-      devices.kubevirt.io/kvm: "1"
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-coreos-rhel-coreos-config-main-scos-9-build-test-qemu
-    rerun_command: /test scos-9-build-test-qemu
-    skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --report-credentials-file=/etc/report/credentials
-        - --target=scos-9-build-test-qemu
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )scos-9-build-test-qemu,?($|\s.*)
+    trigger: (?m)^/test( | .* )scos-9-build-test,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:

--- a/ci-operator/jobs/coreos/rhel-coreos-config/coreos-rhel-coreos-config-mintmaker-bootc-main-updates-postsubmits.yaml
+++ b/ci-operator/jobs/coreos/rhel-coreos-config/coreos-rhel-coreos-config-mintmaker-bootc-main-updates-postsubmits.yaml
@@ -12,7 +12,7 @@ postsubmits:
       capability/kvm: kvm
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-coreos-rhel-coreos-config-mintmaker-bootc-main-updates-rhcos-10-build-test-metal
+    name: branch-ci-coreos-rhel-coreos-config-mintmaker-bootc-main-updates-rhcos-10-build-test
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
     spec:
       containers:
@@ -21,7 +21,7 @@ postsubmits:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=rhcos-10-build-test-metal
+        - --target=rhcos-10-build-test
         command:
         - ci-operator
         env:
@@ -80,7 +80,7 @@ postsubmits:
       capability/kvm: kvm
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-coreos-rhel-coreos-config-mintmaker-bootc-main-updates-rhcos-10-build-test-qemu
+    name: branch-ci-coreos-rhel-coreos-config-mintmaker-bootc-main-updates-rhcos-9-build-test
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
     spec:
       containers:
@@ -89,7 +89,7 @@ postsubmits:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=rhcos-10-build-test-qemu
+        - --target=rhcos-9-build-test
         command:
         - ci-operator
         env:
@@ -148,7 +148,7 @@ postsubmits:
       capability/kvm: kvm
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-coreos-rhel-coreos-config-mintmaker-bootc-main-updates-rhcos-9-build-test-metal
+    name: branch-ci-coreos-rhel-coreos-config-mintmaker-bootc-main-updates-scos-10-build-test
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
     spec:
       containers:
@@ -156,143 +156,7 @@ postsubmits:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=rhcos-9-build-test-metal
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - ^mintmaker-bootc-main-updates$
-    cluster: build08
-    decorate: true
-    decoration_config:
-      skip_cloning: true
-    labels:
-      capability/kvm: kvm
-      ci.openshift.io/generator: prowgen
-    max_concurrency: 1
-    name: branch-ci-coreos-rhel-coreos-config-mintmaker-bootc-main-updates-rhcos-9-build-test-qemu
-    skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=rhcos-9-build-test-qemu
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - ^mintmaker-bootc-main-updates$
-    cluster: build08
-    decorate: true
-    decoration_config:
-      skip_cloning: true
-    labels:
-      capability/kvm: kvm
-      ci.openshift.io/generator: prowgen
-    max_concurrency: 1
-    name: branch-ci-coreos-rhel-coreos-config-mintmaker-bootc-main-updates-scos-10-build-test-metal
-    skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --report-credentials-file=/etc/report/credentials
-        - --target=scos-10-build-test-metal
+        - --target=scos-10-build-test
         command:
         - ci-operator
         env:
@@ -345,7 +209,7 @@ postsubmits:
       capability/kvm: kvm
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-coreos-rhel-coreos-config-mintmaker-bootc-main-updates-scos-10-build-test-qemu
+    name: branch-ci-coreos-rhel-coreos-config-mintmaker-bootc-main-updates-scos-9-build-test
     skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
     spec:
       containers:
@@ -353,129 +217,7 @@ postsubmits:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --report-credentials-file=/etc/report/credentials
-        - --target=scos-10-build-test-qemu
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - ^mintmaker-bootc-main-updates$
-    cluster: build08
-    decorate: true
-    decoration_config:
-      skip_cloning: true
-    labels:
-      capability/kvm: kvm
-      ci.openshift.io/generator: prowgen
-    max_concurrency: 1
-    name: branch-ci-coreos-rhel-coreos-config-mintmaker-bootc-main-updates-scos-9-build-test-metal
-    skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --report-credentials-file=/etc/report/credentials
-        - --target=scos-9-build-test-metal
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - ^mintmaker-bootc-main-updates$
-    cluster: build08
-    decorate: true
-    decoration_config:
-      skip_cloning: true
-    labels:
-      capability/kvm: kvm
-      ci.openshift.io/generator: prowgen
-    max_concurrency: 1
-    name: branch-ci-coreos-rhel-coreos-config-mintmaker-bootc-main-updates-scos-9-build-test-qemu
-    skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --report-credentials-file=/etc/report/credentials
-        - --target=scos-9-build-test-qemu
+        - --target=scos-9-build-test
         command:
         - ci-operator
         env:


### PR DESCRIPTION
Consolidate -qemu and -metal test variants that now execute the same code path after upstream changes. The rhel-coreos-config prow-entrypoint now calls run_build_test for both variants, building all artifacts upfront and running all kola tests.

Consolidated jobs:
- rhcos-9-build-test-metal + rhcos-9-build-test-qemu -> rhcos-9-build-test
- scos-9-build-test-metal + scos-9-build-test-qemu -> scos-9-build-test
- scos-10-build-test-metal + scos-10-build-test-qemu -> scos-10-build-test

https://github.com/coreos/rhel-coreos-config/pull/252
https://github.com/coreos/coreos-assembler/issues/3989

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR updates OpenShift CI configuration for the coreos/rhel-coreos-config repository to remove duplicate test variants that now run the same code path upstream. It consolidates the prior separate -qemu and -metal build-test jobs into single unified KVM-enabled build-test jobs and adjusts their resource profiles.

## What changed (practical impact)

- Affects CI operator config for the rhel-coreos-config component (ci-operator/config/coreos/rhel-coreos-config/*).
- Replaces the split job matrix so one job covers both QEMU and metal test scenarios (the prow entrypoint now drives the same run for both variants).
- Consolidated job names:
  - rhcos-9-build-test-qemu + rhcos-9-build-test-metal → rhcos-9-build-test
  - rhcos-10-build-test-qemu + rhcos-10-build-test-metal → rhcos-10-build-test
  - scos-9-build-test-qemu + scos-9-build-test-metal → scos-9-build-test
  - scos-10-build-test-qemu + scos-10-build-test-metal → scos-10-build-test

## CI/runtime changes

- Resource definitions: removes per-variant resource entries for the old qemu/metal jobs and adds unified resource entries for each consolidated job. Defaults and job requests/limits increase (notably CPU → 2000m, memory → 3Gi, ephemeral-storage → 40Gi) and KVM device access (devices.kubevirt.io/kvm: "1") is requested/limited for the consolidated jobs.
- Entrypoint/credentials:
  - RHCOS consolidated jobs set REGISTRY_AUTH_FILE and mount the ci-pull-credentials secret before calling ci/prow-entrypoint.sh.
  - SCOS consolidated jobs call ci/prow-entrypoint.sh without mounting the pull secret / explicit REGISTRY_AUTH_FILE.

## Files touched (representative)

- ci-operator/config/coreos/rhel-coreos-config/coreos-rhel-coreos-config-main.yaml
- ci-operator/config/coreos/rhel-coreos-config/coreos-rhel-coreos-config-mintmaker-bootc-main-updates.yaml

## Impact

- Removes redundant CI job variants and simplifies the job matrix while preserving test coverage for both QEMU and metal scenarios under a single job definition.
- Increases resource allocations and explicitly requests KVM device access for the consolidated jobs, which may change scheduling and resource consumption for those CI runs.
- Adjusts registry secret usage for RHCOS jobs (adds explicit pull credentials); SCOS behavior remains without explicit registry auth.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->