### PR TITLE
ci: add openshift-verify-vendor-commits required presubmit to 16 soft-fork repos

### DIFF
--- a/ci-operator/config/openshift/azure-service-operator/openshift-azure-service-operator-main.yaml
+++ b/ci-operator/config/openshift/azure-service-operator/openshift-azure-service-operator-main.yaml
@@ -71,6 +71,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: main
   org: openshift

--- a/ci-operator/config/openshift/azure-service-operator/openshift-azure-service-operator-release-4.19.yaml
+++ b/ci-operator/config/openshift/azure-service-operator/openshift-azure-service-operator-release-4.19.yaml
@@ -58,6 +58,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.19
   org: openshift

--- a/ci-operator/config/openshift/azure-service-operator/openshift-azure-service-operator-release-4.20.yaml
+++ b/ci-operator/config/openshift/azure-service-operator/openshift-azure-service-operator-release-4.20.yaml
@@ -58,6 +58,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.20
   org: openshift

--- a/ci-operator/config/openshift/azure-service-operator/openshift-azure-service-operator-release-4.21.yaml
+++ b/ci-operator/config/openshift/azure-service-operator/openshift-azure-service-operator-release-4.21.yaml
@@ -71,6 +71,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.21
   org: openshift

--- a/ci-operator/config/openshift/azure-service-operator/openshift-azure-service-operator-release-4.22.yaml
+++ b/ci-operator/config/openshift/azure-service-operator/openshift-azure-service-operator-release-4.22.yaml
@@ -71,6 +71,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.22
   org: openshift

--- a/ci-operator/config/openshift/azure-service-operator/openshift-azure-service-operator-release-4.23.yaml
+++ b/ci-operator/config/openshift/azure-service-operator/openshift-azure-service-operator-release-4.23.yaml
@@ -71,6 +71,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.23
   org: openshift

--- a/ci-operator/config/openshift/cloud-provider-aws/openshift-cloud-provider-aws-main.yaml
+++ b/ci-operator/config/openshift/cloud-provider-aws/openshift-cloud-provider-aws-main.yaml
@@ -136,6 +136,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: main
   org: openshift

--- a/ci-operator/config/openshift/cloud-provider-aws/openshift-cloud-provider-aws-release-4.19.yaml
+++ b/ci-operator/config/openshift/cloud-provider-aws/openshift-cloud-provider-aws-release-4.19.yaml
@@ -110,6 +110,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.19
   org: openshift

--- a/ci-operator/config/openshift/cloud-provider-aws/openshift-cloud-provider-aws-release-4.20.yaml
+++ b/ci-operator/config/openshift/cloud-provider-aws/openshift-cloud-provider-aws-release-4.20.yaml
@@ -130,6 +130,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.20
   org: openshift

--- a/ci-operator/config/openshift/cloud-provider-aws/openshift-cloud-provider-aws-release-4.21.yaml
+++ b/ci-operator/config/openshift/cloud-provider-aws/openshift-cloud-provider-aws-release-4.21.yaml
@@ -136,6 +136,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.21
   org: openshift

--- a/ci-operator/config/openshift/cloud-provider-aws/openshift-cloud-provider-aws-release-4.22.yaml
+++ b/ci-operator/config/openshift/cloud-provider-aws/openshift-cloud-provider-aws-release-4.22.yaml
@@ -136,6 +136,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.22
   org: openshift

--- a/ci-operator/config/openshift/cloud-provider-aws/openshift-cloud-provider-aws-release-4.23.yaml
+++ b/ci-operator/config/openshift/cloud-provider-aws/openshift-cloud-provider-aws-release-4.23.yaml
@@ -136,6 +136,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.23
   org: openshift

--- a/ci-operator/config/openshift/cloud-provider-azure/openshift-cloud-provider-azure-main.yaml
+++ b/ci-operator/config/openshift/cloud-provider-azure/openshift-cloud-provider-azure-main.yaml
@@ -137,6 +137,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: main
   org: openshift

--- a/ci-operator/config/openshift/cloud-provider-azure/openshift-cloud-provider-azure-release-4.19.yaml
+++ b/ci-operator/config/openshift/cloud-provider-azure/openshift-cloud-provider-azure-release-4.19.yaml
@@ -111,6 +111,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.19
   org: openshift

--- a/ci-operator/config/openshift/cloud-provider-azure/openshift-cloud-provider-azure-release-4.20.yaml
+++ b/ci-operator/config/openshift/cloud-provider-azure/openshift-cloud-provider-azure-release-4.20.yaml
@@ -138,6 +138,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.20
   org: openshift

--- a/ci-operator/config/openshift/cloud-provider-azure/openshift-cloud-provider-azure-release-4.21.yaml
+++ b/ci-operator/config/openshift/cloud-provider-azure/openshift-cloud-provider-azure-release-4.21.yaml
@@ -137,6 +137,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.21
   org: openshift

--- a/ci-operator/config/openshift/cloud-provider-azure/openshift-cloud-provider-azure-release-4.22.yaml
+++ b/ci-operator/config/openshift/cloud-provider-azure/openshift-cloud-provider-azure-release-4.22.yaml
@@ -137,6 +137,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.22
   org: openshift

--- a/ci-operator/config/openshift/cloud-provider-azure/openshift-cloud-provider-azure-release-4.23.yaml
+++ b/ci-operator/config/openshift/cloud-provider-azure/openshift-cloud-provider-azure-release-4.23.yaml
@@ -137,6 +137,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.23
   org: openshift

--- a/ci-operator/config/openshift/cloud-provider-gcp/openshift-cloud-provider-gcp-main.yaml
+++ b/ci-operator/config/openshift/cloud-provider-gcp/openshift-cloud-provider-gcp-main.yaml
@@ -122,6 +122,10 @@ tests:
   commands: openshift-hack/test-unit.sh
   container:
     from: src
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: main
   org: openshift

--- a/ci-operator/config/openshift/cloud-provider-gcp/openshift-cloud-provider-gcp-release-4.19.yaml
+++ b/ci-operator/config/openshift/cloud-provider-gcp/openshift-cloud-provider-gcp-release-4.19.yaml
@@ -118,6 +118,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.19
   org: openshift

--- a/ci-operator/config/openshift/cloud-provider-gcp/openshift-cloud-provider-gcp-release-4.20.yaml
+++ b/ci-operator/config/openshift/cloud-provider-gcp/openshift-cloud-provider-gcp-release-4.20.yaml
@@ -126,6 +126,10 @@ tests:
   commands: openshift-hack/test-unit.sh
   container:
     from: src
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.20
   org: openshift

--- a/ci-operator/config/openshift/cloud-provider-gcp/openshift-cloud-provider-gcp-release-4.21.yaml
+++ b/ci-operator/config/openshift/cloud-provider-gcp/openshift-cloud-provider-gcp-release-4.21.yaml
@@ -126,6 +126,10 @@ tests:
   commands: openshift-hack/test-unit.sh
   container:
     from: src
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.21
   org: openshift

--- a/ci-operator/config/openshift/cloud-provider-gcp/openshift-cloud-provider-gcp-release-4.22.yaml
+++ b/ci-operator/config/openshift/cloud-provider-gcp/openshift-cloud-provider-gcp-release-4.22.yaml
@@ -126,6 +126,10 @@ tests:
   commands: openshift-hack/test-unit.sh
   container:
     from: src
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.22
   org: openshift

--- a/ci-operator/config/openshift/cloud-provider-gcp/openshift-cloud-provider-gcp-release-4.23.yaml
+++ b/ci-operator/config/openshift/cloud-provider-gcp/openshift-cloud-provider-gcp-release-4.23.yaml
@@ -122,6 +122,10 @@ tests:
   commands: openshift-hack/test-unit.sh
   container:
     from: src
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.23
   org: openshift

--- a/ci-operator/config/openshift/cloud-provider-ibm/openshift-cloud-provider-ibm-main.yaml
+++ b/ci-operator/config/openshift/cloud-provider-ibm/openshift-cloud-provider-ibm-main.yaml
@@ -89,6 +89,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: main
   org: openshift

--- a/ci-operator/config/openshift/cloud-provider-ibm/openshift-cloud-provider-ibm-release-4.19.yaml
+++ b/ci-operator/config/openshift/cloud-provider-ibm/openshift-cloud-provider-ibm-release-4.19.yaml
@@ -68,6 +68,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.19
   org: openshift

--- a/ci-operator/config/openshift/cloud-provider-ibm/openshift-cloud-provider-ibm-release-4.20.yaml
+++ b/ci-operator/config/openshift/cloud-provider-ibm/openshift-cloud-provider-ibm-release-4.20.yaml
@@ -89,6 +89,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.20
   org: openshift

--- a/ci-operator/config/openshift/cloud-provider-ibm/openshift-cloud-provider-ibm-release-4.21.yaml
+++ b/ci-operator/config/openshift/cloud-provider-ibm/openshift-cloud-provider-ibm-release-4.21.yaml
@@ -89,6 +89,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.21
   org: openshift

--- a/ci-operator/config/openshift/cloud-provider-ibm/openshift-cloud-provider-ibm-release-4.22.yaml
+++ b/ci-operator/config/openshift/cloud-provider-ibm/openshift-cloud-provider-ibm-release-4.22.yaml
@@ -89,6 +89,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.22
   org: openshift

--- a/ci-operator/config/openshift/cloud-provider-ibm/openshift-cloud-provider-ibm-release-4.23.yaml
+++ b/ci-operator/config/openshift/cloud-provider-ibm/openshift-cloud-provider-ibm-release-4.23.yaml
@@ -89,6 +89,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.23
   org: openshift

--- a/ci-operator/config/openshift/cloud-provider-nutanix/openshift-cloud-provider-nutanix-main.yaml
+++ b/ci-operator/config/openshift/cloud-provider-nutanix/openshift-cloud-provider-nutanix-main.yaml
@@ -88,6 +88,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: main
   org: openshift

--- a/ci-operator/config/openshift/cloud-provider-nutanix/openshift-cloud-provider-nutanix-release-4.19.yaml
+++ b/ci-operator/config/openshift/cloud-provider-nutanix/openshift-cloud-provider-nutanix-release-4.19.yaml
@@ -67,6 +67,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.19
   org: openshift

--- a/ci-operator/config/openshift/cloud-provider-nutanix/openshift-cloud-provider-nutanix-release-4.20.yaml
+++ b/ci-operator/config/openshift/cloud-provider-nutanix/openshift-cloud-provider-nutanix-release-4.20.yaml
@@ -88,6 +88,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.20
   org: openshift

--- a/ci-operator/config/openshift/cloud-provider-nutanix/openshift-cloud-provider-nutanix-release-4.21.yaml
+++ b/ci-operator/config/openshift/cloud-provider-nutanix/openshift-cloud-provider-nutanix-release-4.21.yaml
@@ -88,6 +88,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.21
   org: openshift

--- a/ci-operator/config/openshift/cloud-provider-nutanix/openshift-cloud-provider-nutanix-release-4.22.yaml
+++ b/ci-operator/config/openshift/cloud-provider-nutanix/openshift-cloud-provider-nutanix-release-4.22.yaml
@@ -88,6 +88,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.22
   org: openshift

--- a/ci-operator/config/openshift/cloud-provider-nutanix/openshift-cloud-provider-nutanix-release-4.23.yaml
+++ b/ci-operator/config/openshift/cloud-provider-nutanix/openshift-cloud-provider-nutanix-release-4.23.yaml
@@ -88,6 +88,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.23
   org: openshift

--- a/ci-operator/config/openshift/cloud-provider-vpc-controller/openshift-cloud-provider-vpc-controller-master.yaml
+++ b/ci-operator/config/openshift/cloud-provider-vpc-controller/openshift-cloud-provider-vpc-controller-master.yaml
@@ -17,6 +17,10 @@ tests:
   commands: make vet
   container:
     from: src
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: master
   org: openshift

--- a/ci-operator/config/openshift/cloud-provider-vsphere/openshift-cloud-provider-vsphere-main.yaml
+++ b/ci-operator/config/openshift/cloud-provider-vsphere/openshift-cloud-provider-vsphere-main.yaml
@@ -88,6 +88,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: main
   org: openshift

--- a/ci-operator/config/openshift/cloud-provider-vsphere/openshift-cloud-provider-vsphere-release-4.19.yaml
+++ b/ci-operator/config/openshift/cloud-provider-vsphere/openshift-cloud-provider-vsphere-release-4.19.yaml
@@ -88,6 +88,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.19
   org: openshift

--- a/ci-operator/config/openshift/cloud-provider-vsphere/openshift-cloud-provider-vsphere-release-4.20.yaml
+++ b/ci-operator/config/openshift/cloud-provider-vsphere/openshift-cloud-provider-vsphere-release-4.20.yaml
@@ -88,6 +88,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.20
   org: openshift

--- a/ci-operator/config/openshift/cloud-provider-vsphere/openshift-cloud-provider-vsphere-release-4.21.yaml
+++ b/ci-operator/config/openshift/cloud-provider-vsphere/openshift-cloud-provider-vsphere-release-4.21.yaml
@@ -88,6 +88,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.21
   org: openshift

--- a/ci-operator/config/openshift/cloud-provider-vsphere/openshift-cloud-provider-vsphere-release-4.22.yaml
+++ b/ci-operator/config/openshift/cloud-provider-vsphere/openshift-cloud-provider-vsphere-release-4.22.yaml
@@ -88,6 +88,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.22
   org: openshift

--- a/ci-operator/config/openshift/cloud-provider-vsphere/openshift-cloud-provider-vsphere-release-4.23.yaml
+++ b/ci-operator/config/openshift/cloud-provider-vsphere/openshift-cloud-provider-vsphere-release-4.23.yaml
@@ -88,6 +88,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.23
   org: openshift

--- a/ci-operator/config/openshift/cluster-api-provider-alibaba/openshift-cluster-api-provider-alibaba-main.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-alibaba/openshift-cluster-api-provider-alibaba-main.yaml
@@ -49,6 +49,10 @@ tests:
   steps:
     cluster_profile: openshift-org-aws
     workflow: openshift-e2e-aws-serial
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: main
   org: openshift

--- a/ci-operator/config/openshift/cluster-api-provider-alibaba/openshift-cluster-api-provider-alibaba-release-4.19.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-alibaba/openshift-cluster-api-provider-alibaba-release-4.19.yaml
@@ -49,6 +49,10 @@ tests:
   steps:
     cluster_profile: openshift-org-aws
     workflow: openshift-e2e-aws-serial
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.19
   org: openshift

--- a/ci-operator/config/openshift/cluster-api-provider-alibaba/openshift-cluster-api-provider-alibaba-release-4.20.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-alibaba/openshift-cluster-api-provider-alibaba-release-4.20.yaml
@@ -49,6 +49,10 @@ tests:
   steps:
     cluster_profile: openshift-org-aws
     workflow: openshift-e2e-aws-serial
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.20
   org: openshift

--- a/ci-operator/config/openshift/cluster-api-provider-alibaba/openshift-cluster-api-provider-alibaba-release-4.21.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-alibaba/openshift-cluster-api-provider-alibaba-release-4.21.yaml
@@ -49,6 +49,10 @@ tests:
   steps:
     cluster_profile: openshift-org-aws
     workflow: openshift-e2e-aws-serial
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.21
   org: openshift

--- a/ci-operator/config/openshift/cluster-api-provider-alibaba/openshift-cluster-api-provider-alibaba-release-4.22.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-alibaba/openshift-cluster-api-provider-alibaba-release-4.22.yaml
@@ -49,6 +49,10 @@ tests:
   steps:
     cluster_profile: openshift-org-aws
     workflow: openshift-e2e-aws-serial
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.22
   org: openshift

--- a/ci-operator/config/openshift/cluster-api-provider-alibaba/openshift-cluster-api-provider-alibaba-release-4.23.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-alibaba/openshift-cluster-api-provider-alibaba-release-4.23.yaml
@@ -49,6 +49,10 @@ tests:
   steps:
     cluster_profile: openshift-org-aws
     workflow: openshift-e2e-aws-serial
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.23
   org: openshift

--- a/ci-operator/config/openshift/cluster-api-provider-aws/openshift-cluster-api-provider-aws-main.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-aws/openshift-cluster-api-provider-aws-main.yaml
@@ -121,6 +121,10 @@ tests:
   commands: make -C openshift verify
   container:
     from: src
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: main
   org: openshift

--- a/ci-operator/config/openshift/cluster-api-provider-aws/openshift-cluster-api-provider-aws-release-4.19.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-aws/openshift-cluster-api-provider-aws-release-4.19.yaml
@@ -113,6 +113,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.19
   org: openshift

--- a/ci-operator/config/openshift/cluster-api-provider-aws/openshift-cluster-api-provider-aws-release-4.20.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-aws/openshift-cluster-api-provider-aws-release-4.20.yaml
@@ -114,6 +114,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.20
   org: openshift

--- a/ci-operator/config/openshift/cluster-api-provider-aws/openshift-cluster-api-provider-aws-release-4.21.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-aws/openshift-cluster-api-provider-aws-release-4.21.yaml
@@ -117,6 +117,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.21
   org: openshift

--- a/ci-operator/config/openshift/cluster-api-provider-aws/openshift-cluster-api-provider-aws-release-4.22.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-aws/openshift-cluster-api-provider-aws-release-4.22.yaml
@@ -121,6 +121,10 @@ tests:
   commands: make -C openshift verify
   container:
     from: src
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.22
   org: openshift

--- a/ci-operator/config/openshift/cluster-api-provider-aws/openshift-cluster-api-provider-aws-release-4.23.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-aws/openshift-cluster-api-provider-aws-release-4.23.yaml
@@ -121,6 +121,10 @@ tests:
   commands: make -C openshift verify
   container:
     from: src
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.23
   org: openshift

--- a/ci-operator/config/openshift/cluster-api-provider-azure/openshift-cluster-api-provider-azure-main.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-azure/openshift-cluster-api-provider-azure-main.yaml
@@ -140,6 +140,10 @@ tests:
   commands: make -C openshift verify
   container:
     from: src
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: main
   org: openshift

--- a/ci-operator/config/openshift/cluster-api-provider-azure/openshift-cluster-api-provider-azure-release-4.19.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-azure/openshift-cluster-api-provider-azure-release-4.19.yaml
@@ -128,6 +128,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.19
   org: openshift

--- a/ci-operator/config/openshift/cluster-api-provider-azure/openshift-cluster-api-provider-azure-release-4.20.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-azure/openshift-cluster-api-provider-azure-release-4.20.yaml
@@ -136,6 +136,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.20
   org: openshift

--- a/ci-operator/config/openshift/cluster-api-provider-azure/openshift-cluster-api-provider-azure-release-4.21.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-azure/openshift-cluster-api-provider-azure-release-4.21.yaml
@@ -136,6 +136,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.21
   org: openshift

--- a/ci-operator/config/openshift/cluster-api-provider-azure/openshift-cluster-api-provider-azure-release-4.22.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-azure/openshift-cluster-api-provider-azure-release-4.22.yaml
@@ -140,6 +140,10 @@ tests:
   commands: make -C openshift verify
   container:
     from: src
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.22
   org: openshift

--- a/ci-operator/config/openshift/cluster-api-provider-azure/openshift-cluster-api-provider-azure-release-4.23.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-azure/openshift-cluster-api-provider-azure-release-4.23.yaml
@@ -140,6 +140,10 @@ tests:
   commands: make -C openshift verify
   container:
     from: src
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.23
   org: openshift

--- a/ci-operator/config/openshift/cluster-api-provider-gcp/openshift-cluster-api-provider-gcp-master.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-gcp/openshift-cluster-api-provider-gcp-master.yaml
@@ -106,6 +106,10 @@ tests:
   commands: make -C openshift verify
   container:
     from: src
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: master
   org: openshift

--- a/ci-operator/config/openshift/cluster-api-provider-gcp/openshift-cluster-api-provider-gcp-release-4.19.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-gcp/openshift-cluster-api-provider-gcp-release-4.19.yaml
@@ -101,6 +101,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.19
   org: openshift

--- a/ci-operator/config/openshift/cluster-api-provider-gcp/openshift-cluster-api-provider-gcp-release-4.20.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-gcp/openshift-cluster-api-provider-gcp-release-4.20.yaml
@@ -102,6 +102,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.20
   org: openshift

--- a/ci-operator/config/openshift/cluster-api-provider-gcp/openshift-cluster-api-provider-gcp-release-4.21.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-gcp/openshift-cluster-api-provider-gcp-release-4.21.yaml
@@ -102,6 +102,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.21
   org: openshift

--- a/ci-operator/config/openshift/cluster-api-provider-gcp/openshift-cluster-api-provider-gcp-release-4.22.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-gcp/openshift-cluster-api-provider-gcp-release-4.22.yaml
@@ -106,6 +106,10 @@ tests:
   commands: make -C openshift verify
   container:
     from: src
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.22
   org: openshift

--- a/ci-operator/config/openshift/cluster-api-provider-gcp/openshift-cluster-api-provider-gcp-release-4.23.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-gcp/openshift-cluster-api-provider-gcp-release-4.23.yaml
@@ -106,6 +106,10 @@ tests:
   commands: make -C openshift verify
   container:
     from: src
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.23
   org: openshift

--- a/ci-operator/config/openshift/cluster-api-provider-ibmcloud/openshift-cluster-api-provider-ibmcloud-main.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-ibmcloud/openshift-cluster-api-provider-ibmcloud-main.yaml
@@ -48,6 +48,10 @@ tests:
   commands: make -C openshift verify
   container:
     from: src
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: main
   org: openshift

--- a/ci-operator/config/openshift/cluster-api-provider-ibmcloud/openshift-cluster-api-provider-ibmcloud-release-4.19.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-ibmcloud/openshift-cluster-api-provider-ibmcloud-release-4.19.yaml
@@ -44,6 +44,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.19
   org: openshift

--- a/ci-operator/config/openshift/cluster-api-provider-ibmcloud/openshift-cluster-api-provider-ibmcloud-release-4.20.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-ibmcloud/openshift-cluster-api-provider-ibmcloud-release-4.20.yaml
@@ -44,6 +44,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.20
   org: openshift

--- a/ci-operator/config/openshift/cluster-api-provider-ibmcloud/openshift-cluster-api-provider-ibmcloud-release-4.21.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-ibmcloud/openshift-cluster-api-provider-ibmcloud-release-4.21.yaml
@@ -44,6 +44,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.21
   org: openshift

--- a/ci-operator/config/openshift/cluster-api-provider-ibmcloud/openshift-cluster-api-provider-ibmcloud-release-4.22.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-ibmcloud/openshift-cluster-api-provider-ibmcloud-release-4.22.yaml
@@ -48,6 +48,10 @@ tests:
   commands: make -C openshift verify
   container:
     from: src
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.22
   org: openshift

--- a/ci-operator/config/openshift/cluster-api-provider-ibmcloud/openshift-cluster-api-provider-ibmcloud-release-4.23.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-ibmcloud/openshift-cluster-api-provider-ibmcloud-release-4.23.yaml
@@ -48,6 +48,10 @@ tests:
   commands: make -C openshift verify
   container:
     from: src
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.23
   org: openshift

--- a/ci-operator/config/openshift/cluster-api-provider-nutanix/openshift-cluster-api-provider-nutanix-main.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-nutanix/openshift-cluster-api-provider-nutanix-main.yaml
@@ -79,6 +79,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: main
   org: openshift

--- a/ci-operator/config/openshift/cluster-api-provider-nutanix/openshift-cluster-api-provider-nutanix-release-4.21.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-nutanix/openshift-cluster-api-provider-nutanix-release-4.21.yaml
@@ -79,6 +79,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.21
   org: openshift

--- a/ci-operator/config/openshift/cluster-api-provider-nutanix/openshift-cluster-api-provider-nutanix-release-4.22.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-nutanix/openshift-cluster-api-provider-nutanix-release-4.22.yaml
@@ -79,6 +79,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.22
   org: openshift

--- a/ci-operator/config/openshift/cluster-api-provider-nutanix/openshift-cluster-api-provider-nutanix-release-4.23.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-nutanix/openshift-cluster-api-provider-nutanix-release-4.23.yaml
@@ -79,6 +79,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.23
   org: openshift

--- a/ci-operator/config/openshift/cluster-api-provider-vsphere/openshift-cluster-api-provider-vsphere-master.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-vsphere/openshift-cluster-api-provider-vsphere-master.yaml
@@ -107,6 +107,10 @@ tests:
   commands: make -C openshift verify
   container:
     from: src
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: master
   org: openshift

--- a/ci-operator/config/openshift/cluster-api-provider-vsphere/openshift-cluster-api-provider-vsphere-release-4.19.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-vsphere/openshift-cluster-api-provider-vsphere-release-4.19.yaml
@@ -102,6 +102,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.19
   org: openshift

--- a/ci-operator/config/openshift/cluster-api-provider-vsphere/openshift-cluster-api-provider-vsphere-release-4.20.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-vsphere/openshift-cluster-api-provider-vsphere-release-4.20.yaml
@@ -103,6 +103,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.20
   org: openshift

--- a/ci-operator/config/openshift/cluster-api-provider-vsphere/openshift-cluster-api-provider-vsphere-release-4.21.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-vsphere/openshift-cluster-api-provider-vsphere-release-4.21.yaml
@@ -103,6 +103,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.21
   org: openshift

--- a/ci-operator/config/openshift/cluster-api-provider-vsphere/openshift-cluster-api-provider-vsphere-release-4.22.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-vsphere/openshift-cluster-api-provider-vsphere-release-4.22.yaml
@@ -107,6 +107,10 @@ tests:
   commands: make -C openshift verify
   container:
     from: src
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.22
   org: openshift

--- a/ci-operator/config/openshift/cluster-api-provider-vsphere/openshift-cluster-api-provider-vsphere-release-4.23.yaml
+++ b/ci-operator/config/openshift/cluster-api-provider-vsphere/openshift-cluster-api-provider-vsphere-release-4.23.yaml
@@ -107,6 +107,10 @@ tests:
   commands: make -C openshift verify
   container:
     from: src
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.23
   org: openshift

--- a/ci-operator/config/openshift/cluster-api/openshift-cluster-api-master.yaml
+++ b/ci-operator/config/openshift/cluster-api/openshift-cluster-api-master.yaml
@@ -181,6 +181,10 @@ tests:
   commands: make -C openshift verify
   container:
     from: src
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: master
   org: openshift

--- a/ci-operator/config/openshift/cluster-api/openshift-cluster-api-release-4.19.yaml
+++ b/ci-operator/config/openshift/cluster-api/openshift-cluster-api-release-4.19.yaml
@@ -167,6 +167,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.19
   org: openshift

--- a/ci-operator/config/openshift/cluster-api/openshift-cluster-api-release-4.20.yaml
+++ b/ci-operator/config/openshift/cluster-api/openshift-cluster-api-release-4.20.yaml
@@ -168,6 +168,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.20
   org: openshift

--- a/ci-operator/config/openshift/cluster-api/openshift-cluster-api-release-4.21.yaml
+++ b/ci-operator/config/openshift/cluster-api/openshift-cluster-api-release-4.21.yaml
@@ -177,6 +177,10 @@ tests:
       CHECK_MOD_LIST: "false"
     test:
     - ref: go-verify-deps
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.21
   org: openshift

--- a/ci-operator/config/openshift/cluster-api/openshift-cluster-api-release-4.22.yaml
+++ b/ci-operator/config/openshift/cluster-api/openshift-cluster-api-release-4.22.yaml
@@ -181,6 +181,10 @@ tests:
   commands: make -C openshift verify
   container:
     from: src
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.22
   org: openshift

--- a/ci-operator/config/openshift/cluster-api/openshift-cluster-api-release-4.23.yaml
+++ b/ci-operator/config/openshift/cluster-api/openshift-cluster-api-release-4.23.yaml
@@ -181,6 +181,10 @@ tests:
   commands: make -C openshift verify
   container:
     from: src
+- as: verify-vendor-commits
+  steps:
+    test:
+    - ref: openshift-verify-vendor-commits
 zz_generated_metadata:
   branch: release-4.23
   org: openshift

--- a/ci-operator/jobs/openshift/azure-service-operator/openshift-azure-service-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/azure-service-operator/openshift-azure-service-operator-main-presubmits.yaml
@@ -566,3 +566,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build05
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-azure-service-operator-main-verify-vendor-commits
+    path_alias: github.com/Azure/azure-service-operator
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/azure-service-operator/openshift-azure-service-operator-release-4.19-presubmits.yaml
+++ b/ci-operator/jobs/openshift/azure-service-operator/openshift-azure-service-operator-release-4.19-presubmits.yaml
@@ -341,3 +341,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.19$
+    - ^release-4\.19-
+    cluster: build03
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-azure-service-operator-release-4.19-verify-vendor-commits
+    path_alias: github.com/Azure/azure-service-operator
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/azure-service-operator/openshift-azure-service-operator-release-4.20-presubmits.yaml
+++ b/ci-operator/jobs/openshift/azure-service-operator/openshift-azure-service-operator-release-4.20-presubmits.yaml
@@ -341,3 +341,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.20$
+    - ^release-4\.20-
+    cluster: build03
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-azure-service-operator-release-4.20-verify-vendor-commits
+    path_alias: github.com/Azure/azure-service-operator
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/azure-service-operator/openshift-azure-service-operator-release-4.21-presubmits.yaml
+++ b/ci-operator/jobs/openshift/azure-service-operator/openshift-azure-service-operator-release-4.21-presubmits.yaml
@@ -566,3 +566,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.21$
+    - ^release-4\.21-
+    cluster: build05
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-azure-service-operator-release-4.21-verify-vendor-commits
+    path_alias: github.com/Azure/azure-service-operator
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/azure-service-operator/openshift-azure-service-operator-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift/azure-service-operator/openshift-azure-service-operator-release-4.22-presubmits.yaml
@@ -423,3 +423,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.22$
+    - ^release-4\.22-
+    cluster: build03
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-azure-service-operator-release-4.22-verify-vendor-commits
+    path_alias: github.com/Azure/azure-service-operator
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/azure-service-operator/openshift-azure-service-operator-release-4.23-presubmits.yaml
+++ b/ci-operator/jobs/openshift/azure-service-operator/openshift-azure-service-operator-release-4.23-presubmits.yaml
@@ -423,3 +423,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.23$
+    - ^release-4\.23-
+    cluster: build03
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-azure-service-operator-release-4.23-verify-vendor-commits
+    path_alias: github.com/Azure/azure-service-operator
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cloud-provider-aws/openshift-cloud-provider-aws-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-aws/openshift-cloud-provider-aws-main-presubmits.yaml
@@ -834,3 +834,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build03
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cloud-provider-aws-main-verify-vendor-commits
+    path_alias: k8s.io/cloud-provider-aws
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cloud-provider-aws/openshift-cloud-provider-aws-release-4.19-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-aws/openshift-cloud-provider-aws-release-4.19-presubmits.yaml
@@ -526,3 +526,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.19$
+    - ^release-4\.19-
+    cluster: build08
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cloud-provider-aws-release-4.19-verify-vendor-commits
+    path_alias: k8s.io/cloud-provider-aws
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cloud-provider-aws/openshift-cloud-provider-aws-release-4.20-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-aws/openshift-cloud-provider-aws-release-4.20-presubmits.yaml
@@ -609,3 +609,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.20$
+    - ^release-4\.20-
+    cluster: build03
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cloud-provider-aws-release-4.20-verify-vendor-commits
+    path_alias: k8s.io/cloud-provider-aws
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cloud-provider-aws/openshift-cloud-provider-aws-release-4.21-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-aws/openshift-cloud-provider-aws-release-4.21-presubmits.yaml
@@ -834,3 +834,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.21$
+    - ^release-4\.21-
+    cluster: build03
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cloud-provider-aws-release-4.21-verify-vendor-commits
+    path_alias: k8s.io/cloud-provider-aws
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cloud-provider-aws/openshift-cloud-provider-aws-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-aws/openshift-cloud-provider-aws-release-4.22-presubmits.yaml
@@ -691,3 +691,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.22$
+    - ^release-4\.22-
+    cluster: build03
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cloud-provider-aws-release-4.22-verify-vendor-commits
+    path_alias: k8s.io/cloud-provider-aws
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cloud-provider-aws/openshift-cloud-provider-aws-release-4.23-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-aws/openshift-cloud-provider-aws-release-4.23-presubmits.yaml
@@ -691,3 +691,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.23$
+    - ^release-4\.23-
+    cluster: build03
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cloud-provider-aws-release-4.23-verify-vendor-commits
+    path_alias: k8s.io/cloud-provider-aws
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cloud-provider-azure/openshift-cloud-provider-azure-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-azure/openshift-cloud-provider-azure-main-presubmits.yaml
@@ -858,3 +858,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-git-history,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build04
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cloud-provider-azure-main-verify-vendor-commits
+    path_alias: github.com/kubernetes-sigs/cloud-provider-azure
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cloud-provider-azure/openshift-cloud-provider-azure-release-4.19-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-azure/openshift-cloud-provider-azure-release-4.19-presubmits.yaml
@@ -549,3 +549,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-git-history,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.19$
+    - ^release-4\.19-
+    cluster: build08
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cloud-provider-azure-release-4.19-verify-vendor-commits
+    path_alias: github.com/kubernetes-sigs/cloud-provider-azure
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cloud-provider-azure/openshift-cloud-provider-azure-release-4.20-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-azure/openshift-cloud-provider-azure-release-4.20-presubmits.yaml
@@ -715,3 +715,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-git-history,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.20$
+    - ^release-4\.20-
+    cluster: build04
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cloud-provider-azure-release-4.20-verify-vendor-commits
+    path_alias: github.com/kubernetes-sigs/cloud-provider-azure
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cloud-provider-azure/openshift-cloud-provider-azure-release-4.21-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-azure/openshift-cloud-provider-azure-release-4.21-presubmits.yaml
@@ -858,3 +858,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-git-history,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.21$
+    - ^release-4\.21-
+    cluster: build11
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cloud-provider-azure-release-4.21-verify-vendor-commits
+    path_alias: github.com/kubernetes-sigs/cloud-provider-azure
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cloud-provider-azure/openshift-cloud-provider-azure-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-azure/openshift-cloud-provider-azure-release-4.22-presubmits.yaml
@@ -715,3 +715,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-git-history,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.22$
+    - ^release-4\.22-
+    cluster: build11
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cloud-provider-azure-release-4.22-verify-vendor-commits
+    path_alias: github.com/kubernetes-sigs/cloud-provider-azure
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cloud-provider-azure/openshift-cloud-provider-azure-release-4.23-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-azure/openshift-cloud-provider-azure-release-4.23-presubmits.yaml
@@ -715,3 +715,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-git-history,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.23$
+    - ^release-4\.23-
+    cluster: build04
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cloud-provider-azure-release-4.23-verify-vendor-commits
+    path_alias: github.com/kubernetes-sigs/cloud-provider-azure
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cloud-provider-gcp/openshift-cloud-provider-gcp-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-gcp/openshift-cloud-provider-gcp-main-presubmits.yaml
@@ -712,3 +712,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build04
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cloud-provider-gcp-main-verify-vendor-commits
+    path_alias: k8s.io/cloud-provider-gcp
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cloud-provider-gcp/openshift-cloud-provider-gcp-release-4.19-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-gcp/openshift-cloud-provider-gcp-release-4.19-presubmits.yaml
@@ -507,3 +507,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.19$
+    - ^release-4\.19-
+    cluster: build08
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cloud-provider-gcp-release-4.19-verify-vendor-commits
+    path_alias: k8s.io/cloud-provider-gcp
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cloud-provider-gcp/openshift-cloud-provider-gcp-release-4.20-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-gcp/openshift-cloud-provider-gcp-release-4.20-presubmits.yaml
@@ -575,6 +575,85 @@ presubmits:
     - ^release-4\.20$
     - ^release-4\.20-
     cluster: build08
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cloud-provider-gcp-release-4.20-verify-vendor-commits
+    path_alias: k8s.io/cloud-provider-gcp
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.20$
+    - ^release-4\.20-
+    cluster: build08
     context: ci/prow/verify-vendor-work
     decorate: true
     labels:

--- a/ci-operator/jobs/openshift/cloud-provider-gcp/openshift-cloud-provider-gcp-release-4.21-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-gcp/openshift-cloud-provider-gcp-release-4.21-presubmits.yaml
@@ -718,6 +718,85 @@ presubmits:
     - ^release-4\.21$
     - ^release-4\.21-
     cluster: build08
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cloud-provider-gcp-release-4.21-verify-vendor-commits
+    path_alias: k8s.io/cloud-provider-gcp
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.21$
+    - ^release-4\.21-
+    cluster: build08
     context: ci/prow/verify-vendor-work
     decorate: true
     labels:

--- a/ci-operator/jobs/openshift/cloud-provider-gcp/openshift-cloud-provider-gcp-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-gcp/openshift-cloud-provider-gcp-release-4.22-presubmits.yaml
@@ -575,6 +575,85 @@ presubmits:
     - ^release-4\.22$
     - ^release-4\.22-
     cluster: build08
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cloud-provider-gcp-release-4.22-verify-vendor-commits
+    path_alias: k8s.io/cloud-provider-gcp
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.22$
+    - ^release-4\.22-
+    cluster: build08
     context: ci/prow/verify-vendor-work
     decorate: true
     labels:

--- a/ci-operator/jobs/openshift/cloud-provider-gcp/openshift-cloud-provider-gcp-release-4.23-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-gcp/openshift-cloud-provider-gcp-release-4.23-presubmits.yaml
@@ -569,3 +569,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.23$
+    - ^release-4\.23-
+    cluster: build08
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cloud-provider-gcp-release-4.23-verify-vendor-commits
+    path_alias: k8s.io/cloud-provider-gcp
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cloud-provider-ibm/openshift-cloud-provider-ibm-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-ibm/openshift-cloud-provider-ibm-main-presubmits.yaml
@@ -717,6 +717,85 @@ presubmits:
     - ^main$
     - ^main-
     cluster: build04
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cloud-provider-ibm-main-verify-vendor-commits
+    path_alias: github.com/IBM-Cloud/cloud-provider-ibm
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build04
     context: ci/prow/vet
     decorate: true
     labels:

--- a/ci-operator/jobs/openshift/cloud-provider-ibm/openshift-cloud-provider-ibm-release-4.19-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-ibm/openshift-cloud-provider-ibm-release-4.19-presubmits.yaml
@@ -491,6 +491,85 @@ presubmits:
     - ^release-4\.19$
     - ^release-4\.19-
     cluster: build08
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cloud-provider-ibm-release-4.19-verify-vendor-commits
+    path_alias: github.com/IBM-Cloud/cloud-provider-ibm
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.19$
+    - ^release-4\.19-
+    cluster: build08
     context: ci/prow/vet
     decorate: true
     labels:

--- a/ci-operator/jobs/openshift/cloud-provider-ibm/openshift-cloud-provider-ibm-release-4.20-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-ibm/openshift-cloud-provider-ibm-release-4.20-presubmits.yaml
@@ -574,6 +574,85 @@ presubmits:
     - ^release-4\.20$
     - ^release-4\.20-
     cluster: build03
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cloud-provider-ibm-release-4.20-verify-vendor-commits
+    path_alias: github.com/IBM-Cloud/cloud-provider-ibm
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.20$
+    - ^release-4\.20-
+    cluster: build03
     context: ci/prow/vet
     decorate: true
     labels:

--- a/ci-operator/jobs/openshift/cloud-provider-ibm/openshift-cloud-provider-ibm-release-4.21-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-ibm/openshift-cloud-provider-ibm-release-4.21-presubmits.yaml
@@ -717,6 +717,85 @@ presubmits:
     - ^release-4\.21$
     - ^release-4\.21-
     cluster: build08
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cloud-provider-ibm-release-4.21-verify-vendor-commits
+    path_alias: github.com/IBM-Cloud/cloud-provider-ibm
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.21$
+    - ^release-4\.21-
+    cluster: build08
     context: ci/prow/vet
     decorate: true
     labels:

--- a/ci-operator/jobs/openshift/cloud-provider-ibm/openshift-cloud-provider-ibm-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-ibm/openshift-cloud-provider-ibm-release-4.22-presubmits.yaml
@@ -574,6 +574,85 @@ presubmits:
     - ^release-4\.22$
     - ^release-4\.22-
     cluster: build11
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cloud-provider-ibm-release-4.22-verify-vendor-commits
+    path_alias: github.com/IBM-Cloud/cloud-provider-ibm
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.22$
+    - ^release-4\.22-
+    cluster: build11
     context: ci/prow/vet
     decorate: true
     labels:

--- a/ci-operator/jobs/openshift/cloud-provider-ibm/openshift-cloud-provider-ibm-release-4.23-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-ibm/openshift-cloud-provider-ibm-release-4.23-presubmits.yaml
@@ -574,6 +574,85 @@ presubmits:
     - ^release-4\.23$
     - ^release-4\.23-
     cluster: build03
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cloud-provider-ibm-release-4.23-verify-vendor-commits
+    path_alias: github.com/IBM-Cloud/cloud-provider-ibm
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.23$
+    - ^release-4\.23-
+    cluster: build03
     context: ci/prow/vet
     decorate: true
     labels:

--- a/ci-operator/jobs/openshift/cloud-provider-nutanix/openshift-cloud-provider-nutanix-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-nutanix/openshift-cloud-provider-nutanix-main-presubmits.yaml
@@ -714,3 +714,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build04
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cloud-provider-nutanix-main-verify-vendor-commits
+    path_alias: github.com/nutanix-cloud-native/cloud-provider-nutanix
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cloud-provider-nutanix/openshift-cloud-provider-nutanix-release-4.19-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-nutanix/openshift-cloud-provider-nutanix-release-4.19-presubmits.yaml
@@ -487,3 +487,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.19$
+    - ^release-4\.19-
+    cluster: build08
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cloud-provider-nutanix-release-4.19-verify-vendor-commits
+    path_alias: github.com/nutanix-cloud-native/cloud-provider-nutanix
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cloud-provider-nutanix/openshift-cloud-provider-nutanix-release-4.20-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-nutanix/openshift-cloud-provider-nutanix-release-4.20-presubmits.yaml
@@ -571,3 +571,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.20$
+    - ^release-4\.20-
+    cluster: build03
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cloud-provider-nutanix-release-4.20-verify-vendor-commits
+    path_alias: github.com/nutanix-cloud-native/cloud-provider-nutanix
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cloud-provider-nutanix/openshift-cloud-provider-nutanix-release-4.21-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-nutanix/openshift-cloud-provider-nutanix-release-4.21-presubmits.yaml
@@ -714,3 +714,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.21$
+    - ^release-4\.21-
+    cluster: build04
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cloud-provider-nutanix-release-4.21-verify-vendor-commits
+    path_alias: github.com/nutanix-cloud-native/cloud-provider-nutanix
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cloud-provider-nutanix/openshift-cloud-provider-nutanix-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-nutanix/openshift-cloud-provider-nutanix-release-4.22-presubmits.yaml
@@ -571,3 +571,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.22$
+    - ^release-4\.22-
+    cluster: build11
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cloud-provider-nutanix-release-4.22-verify-vendor-commits
+    path_alias: github.com/nutanix-cloud-native/cloud-provider-nutanix
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cloud-provider-nutanix/openshift-cloud-provider-nutanix-release-4.23-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-nutanix/openshift-cloud-provider-nutanix-release-4.23-presubmits.yaml
@@ -571,3 +571,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.23$
+    - ^release-4\.23-
+    cluster: build03
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cloud-provider-nutanix-release-4.23-verify-vendor-commits
+    path_alias: github.com/nutanix-cloud-native/cloud-provider-nutanix
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cloud-provider-vpc-controller/openshift-cloud-provider-vpc-controller-master-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-vpc-controller/openshift-cloud-provider-vpc-controller-master-presubmits.yaml
@@ -6,6 +6,80 @@ presubmits:
     - ^master$
     - ^master-
     cluster: build04
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cloud-provider-vpc-controller-master-verify-vendor-commits
+    path_alias: github.com/IBM-Cloud/cloud-provider-vpc-controller
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^master$
+    - ^master-
+    cluster: build04
     context: ci/prow/vet
     decorate: true
     decoration_config:

--- a/ci-operator/jobs/openshift/cloud-provider-vsphere/openshift-cloud-provider-vsphere-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-vsphere/openshift-cloud-provider-vsphere-main-presubmits.yaml
@@ -774,3 +774,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-git-history,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: vsphere02
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cloud-provider-vsphere-main-verify-vendor-commits
+    path_alias: github.com/kubernetes/cloud-provider-vsphere
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cloud-provider-vsphere/openshift-cloud-provider-vsphere-release-4.19-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-vsphere/openshift-cloud-provider-vsphere-release-4.19-presubmits.yaml
@@ -631,3 +631,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-git-history,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.19$
+    - ^release-4\.19-
+    cluster: vsphere02
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cloud-provider-vsphere-release-4.19-verify-vendor-commits
+    path_alias: github.com/kubernetes/cloud-provider-vsphere
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cloud-provider-vsphere/openshift-cloud-provider-vsphere-release-4.20-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-vsphere/openshift-cloud-provider-vsphere-release-4.20-presubmits.yaml
@@ -631,3 +631,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-git-history,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.20$
+    - ^release-4\.20-
+    cluster: vsphere02
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cloud-provider-vsphere-release-4.20-verify-vendor-commits
+    path_alias: github.com/kubernetes/cloud-provider-vsphere
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cloud-provider-vsphere/openshift-cloud-provider-vsphere-release-4.21-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-vsphere/openshift-cloud-provider-vsphere-release-4.21-presubmits.yaml
@@ -774,3 +774,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-git-history,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.21$
+    - ^release-4\.21-
+    cluster: vsphere02
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cloud-provider-vsphere-release-4.21-verify-vendor-commits
+    path_alias: github.com/kubernetes/cloud-provider-vsphere
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cloud-provider-vsphere/openshift-cloud-provider-vsphere-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-vsphere/openshift-cloud-provider-vsphere-release-4.22-presubmits.yaml
@@ -631,3 +631,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-git-history,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.22$
+    - ^release-4\.22-
+    cluster: vsphere02
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cloud-provider-vsphere-release-4.22-verify-vendor-commits
+    path_alias: github.com/kubernetes/cloud-provider-vsphere
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cloud-provider-vsphere/openshift-cloud-provider-vsphere-release-4.23-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-vsphere/openshift-cloud-provider-vsphere-release-4.23-presubmits.yaml
@@ -631,3 +631,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-git-history,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.23$
+    - ^release-4\.23-
+    cluster: vsphere02
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cloud-provider-vsphere-release-4.23-verify-vendor-commits
+    path_alias: github.com/kubernetes/cloud-provider-vsphere
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cluster-api-provider-alibaba/openshift-cluster-api-provider-alibaba-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-alibaba/openshift-cluster-api-provider-alibaba-main-presubmits.yaml
@@ -402,6 +402,84 @@ presubmits:
     - ^main$
     - ^main-
     cluster: build03
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-api-provider-alibaba-main-verify-vendor-commits
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build03
     context: ci/prow/vet
     decorate: true
     labels:

--- a/ci-operator/jobs/openshift/cluster-api-provider-alibaba/openshift-cluster-api-provider-alibaba-release-4.19-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-alibaba/openshift-cluster-api-provider-alibaba-release-4.19-presubmits.yaml
@@ -344,6 +344,84 @@ presubmits:
     - ^release-4\.19$
     - ^release-4\.19-
     cluster: build03
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-api-provider-alibaba-release-4.19-verify-vendor-commits
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.19$
+    - ^release-4\.19-
+    cluster: build03
     context: ci/prow/vet
     decorate: true
     labels:

--- a/ci-operator/jobs/openshift/cluster-api-provider-alibaba/openshift-cluster-api-provider-alibaba-release-4.20-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-alibaba/openshift-cluster-api-provider-alibaba-release-4.20-presubmits.yaml
@@ -344,6 +344,84 @@ presubmits:
     - ^release-4\.20$
     - ^release-4\.20-
     cluster: build03
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-api-provider-alibaba-release-4.20-verify-vendor-commits
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.20$
+    - ^release-4\.20-
+    cluster: build03
     context: ci/prow/vet
     decorate: true
     labels:

--- a/ci-operator/jobs/openshift/cluster-api-provider-alibaba/openshift-cluster-api-provider-alibaba-release-4.21-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-alibaba/openshift-cluster-api-provider-alibaba-release-4.21-presubmits.yaml
@@ -344,6 +344,84 @@ presubmits:
     - ^release-4\.21$
     - ^release-4\.21-
     cluster: build03
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-api-provider-alibaba-release-4.21-verify-vendor-commits
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.21$
+    - ^release-4\.21-
+    cluster: build03
     context: ci/prow/vet
     decorate: true
     labels:

--- a/ci-operator/jobs/openshift/cluster-api-provider-alibaba/openshift-cluster-api-provider-alibaba-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-alibaba/openshift-cluster-api-provider-alibaba-release-4.22-presubmits.yaml
@@ -344,6 +344,84 @@ presubmits:
     - ^release-4\.22$
     - ^release-4\.22-
     cluster: build06
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-api-provider-alibaba-release-4.22-verify-vendor-commits
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.22$
+    - ^release-4\.22-
+    cluster: build06
     context: ci/prow/vet
     decorate: true
     labels:

--- a/ci-operator/jobs/openshift/cluster-api-provider-alibaba/openshift-cluster-api-provider-alibaba-release-4.23-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-alibaba/openshift-cluster-api-provider-alibaba-release-4.23-presubmits.yaml
@@ -344,6 +344,84 @@ presubmits:
     - ^release-4\.23$
     - ^release-4\.23-
     cluster: build03
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-api-provider-alibaba-release-4.23-verify-vendor-commits
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.23$
+    - ^release-4\.23-
+    cluster: build03
     context: ci/prow/vet
     decorate: true
     labels:

--- a/ci-operator/jobs/openshift/cluster-api-provider-aws/openshift-cluster-api-provider-aws-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-aws/openshift-cluster-api-provider-aws-main-presubmits.yaml
@@ -1041,3 +1041,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build11
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-api-provider-aws-main-verify-vendor-commits
+    path_alias: sigs.k8s.io/cluster-api-provider-aws
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cluster-api-provider-aws/openshift-cluster-api-provider-aws-release-4.19-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-aws/openshift-cluster-api-provider-aws-release-4.19-presubmits.yaml
@@ -835,3 +835,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.19$
+    - ^release-4\.19-
+    cluster: build11
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-api-provider-aws-release-4.19-verify-vendor-commits
+    path_alias: sigs.k8s.io/cluster-api-provider-aws
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cluster-api-provider-aws/openshift-cluster-api-provider-aws-release-4.20-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-aws/openshift-cluster-api-provider-aws-release-4.20-presubmits.yaml
@@ -836,3 +836,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.20$
+    - ^release-4\.20-
+    cluster: build11
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-api-provider-aws-release-4.20-verify-vendor-commits
+    path_alias: sigs.k8s.io/cluster-api-provider-aws
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cluster-api-provider-aws/openshift-cluster-api-provider-aws-release-4.21-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-aws/openshift-cluster-api-provider-aws-release-4.21-presubmits.yaml
@@ -979,3 +979,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.21$
+    - ^release-4\.21-
+    cluster: build11
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-api-provider-aws-release-4.21-verify-vendor-commits
+    path_alias: sigs.k8s.io/cluster-api-provider-aws
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cluster-api-provider-aws/openshift-cluster-api-provider-aws-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-aws/openshift-cluster-api-provider-aws-release-4.22-presubmits.yaml
@@ -898,3 +898,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.22$
+    - ^release-4\.22-
+    cluster: build11
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-api-provider-aws-release-4.22-verify-vendor-commits
+    path_alias: sigs.k8s.io/cluster-api-provider-aws
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cluster-api-provider-aws/openshift-cluster-api-provider-aws-release-4.23-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-aws/openshift-cluster-api-provider-aws-release-4.23-presubmits.yaml
@@ -898,3 +898,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.23$
+    - ^release-4\.23-
+    cluster: build11
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-api-provider-aws-release-4.23-verify-vendor-commits
+    path_alias: sigs.k8s.io/cluster-api-provider-aws
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cluster-api-provider-azure/openshift-cluster-api-provider-azure-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-azure/openshift-cluster-api-provider-azure-main-presubmits.yaml
@@ -1205,3 +1205,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build04
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-api-provider-azure-main-verify-vendor-commits
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cluster-api-provider-azure/openshift-cluster-api-provider-azure-release-4.19-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-azure/openshift-cluster-api-provider-azure-release-4.19-presubmits.yaml
@@ -916,3 +916,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.19$
+    - ^release-4\.19-
+    cluster: build08
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-api-provider-azure-release-4.19-verify-vendor-commits
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cluster-api-provider-azure/openshift-cluster-api-provider-azure-release-4.20-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-azure/openshift-cluster-api-provider-azure-release-4.20-presubmits.yaml
@@ -1000,3 +1000,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.20$
+    - ^release-4\.20-
+    cluster: build04
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-api-provider-azure-release-4.20-verify-vendor-commits
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cluster-api-provider-azure/openshift-cluster-api-provider-azure-release-4.21-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-azure/openshift-cluster-api-provider-azure-release-4.21-presubmits.yaml
@@ -1143,3 +1143,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.21$
+    - ^release-4\.21-
+    cluster: build11
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-api-provider-azure-release-4.21-verify-vendor-commits
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cluster-api-provider-azure/openshift-cluster-api-provider-azure-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-azure/openshift-cluster-api-provider-azure-release-4.22-presubmits.yaml
@@ -1062,3 +1062,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.22$
+    - ^release-4\.22-
+    cluster: build11
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-api-provider-azure-release-4.22-verify-vendor-commits
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cluster-api-provider-azure/openshift-cluster-api-provider-azure-release-4.23-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-azure/openshift-cluster-api-provider-azure-release-4.23-presubmits.yaml
@@ -1062,3 +1062,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.23$
+    - ^release-4\.23-
+    cluster: build04
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-api-provider-azure-release-4.23-verify-vendor-commits
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cluster-api-provider-gcp/openshift-cluster-api-provider-gcp-master-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-gcp/openshift-cluster-api-provider-gcp-master-presubmits.yaml
@@ -875,3 +875,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^master$
+    - ^master-
+    cluster: build08
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-api-provider-gcp-master-verify-vendor-commits
+    path_alias: sigs.k8s.io/cluster-api-provider-gcp
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cluster-api-provider-gcp/openshift-cluster-api-provider-gcp-release-4.19-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-gcp/openshift-cluster-api-provider-gcp-release-4.19-presubmits.yaml
@@ -669,3 +669,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.19$
+    - ^release-4\.19-
+    cluster: build08
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-api-provider-gcp-release-4.19-verify-vendor-commits
+    path_alias: sigs.k8s.io/cluster-api-provider-gcp
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cluster-api-provider-gcp/openshift-cluster-api-provider-gcp-release-4.20-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-gcp/openshift-cluster-api-provider-gcp-release-4.20-presubmits.yaml
@@ -670,3 +670,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.20$
+    - ^release-4\.20-
+    cluster: build08
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-api-provider-gcp-release-4.20-verify-vendor-commits
+    path_alias: sigs.k8s.io/cluster-api-provider-gcp
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cluster-api-provider-gcp/openshift-cluster-api-provider-gcp-release-4.21-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-gcp/openshift-cluster-api-provider-gcp-release-4.21-presubmits.yaml
@@ -813,3 +813,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.21$
+    - ^release-4\.21-
+    cluster: build08
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-api-provider-gcp-release-4.21-verify-vendor-commits
+    path_alias: sigs.k8s.io/cluster-api-provider-gcp
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cluster-api-provider-gcp/openshift-cluster-api-provider-gcp-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-gcp/openshift-cluster-api-provider-gcp-release-4.22-presubmits.yaml
@@ -732,3 +732,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.22$
+    - ^release-4\.22-
+    cluster: build08
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-api-provider-gcp-release-4.22-verify-vendor-commits
+    path_alias: sigs.k8s.io/cluster-api-provider-gcp
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cluster-api-provider-gcp/openshift-cluster-api-provider-gcp-release-4.23-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-gcp/openshift-cluster-api-provider-gcp-release-4.23-presubmits.yaml
@@ -732,3 +732,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.23$
+    - ^release-4\.23-
+    cluster: build08
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-api-provider-gcp-release-4.23-verify-vendor-commits
+    path_alias: sigs.k8s.io/cluster-api-provider-gcp
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cluster-api-provider-ibmcloud/openshift-cluster-api-provider-ibmcloud-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-ibmcloud/openshift-cluster-api-provider-ibmcloud-main-presubmits.yaml
@@ -525,3 +525,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build11
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-api-provider-ibmcloud-main-verify-vendor-commits
+    path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cluster-api-provider-ibmcloud/openshift-cluster-api-provider-ibmcloud-release-4.19-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-ibmcloud/openshift-cluster-api-provider-ibmcloud-release-4.19-presubmits.yaml
@@ -320,3 +320,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.19$
+    - ^release-4\.19-
+    cluster: build03
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-api-provider-ibmcloud-release-4.19-verify-vendor-commits
+    path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cluster-api-provider-ibmcloud/openshift-cluster-api-provider-ibmcloud-release-4.20-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-ibmcloud/openshift-cluster-api-provider-ibmcloud-release-4.20-presubmits.yaml
@@ -320,3 +320,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.20$
+    - ^release-4\.20-
+    cluster: build03
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-api-provider-ibmcloud-release-4.20-verify-vendor-commits
+    path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cluster-api-provider-ibmcloud/openshift-cluster-api-provider-ibmcloud-release-4.21-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-ibmcloud/openshift-cluster-api-provider-ibmcloud-release-4.21-presubmits.yaml
@@ -463,3 +463,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.21$
+    - ^release-4\.21-
+    cluster: build03
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-api-provider-ibmcloud-release-4.21-verify-vendor-commits
+    path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cluster-api-provider-ibmcloud/openshift-cluster-api-provider-ibmcloud-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-ibmcloud/openshift-cluster-api-provider-ibmcloud-release-4.22-presubmits.yaml
@@ -382,3 +382,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.22$
+    - ^release-4\.22-
+    cluster: build06
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-api-provider-ibmcloud-release-4.22-verify-vendor-commits
+    path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cluster-api-provider-ibmcloud/openshift-cluster-api-provider-ibmcloud-release-4.23-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-ibmcloud/openshift-cluster-api-provider-ibmcloud-release-4.23-presubmits.yaml
@@ -382,3 +382,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.23$
+    - ^release-4\.23-
+    cluster: build06
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-api-provider-ibmcloud-release-4.23-verify-vendor-commits
+    path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cluster-api-provider-nutanix/openshift-cluster-api-provider-nutanix-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-nutanix/openshift-cluster-api-provider-nutanix-main-presubmits.yaml
@@ -506,3 +506,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build06
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-api-provider-nutanix-main-verify-vendor-commits
+    path_alias: github.com/nutanix-cloud-native/cluster-api-provider-nutanix
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cluster-api-provider-nutanix/openshift-cluster-api-provider-nutanix-release-4.21-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-nutanix/openshift-cluster-api-provider-nutanix-release-4.21-presubmits.yaml
@@ -506,3 +506,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.21$
+    - ^release-4\.21-
+    cluster: build06
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-api-provider-nutanix-release-4.21-verify-vendor-commits
+    path_alias: github.com/nutanix-cloud-native/cluster-api-provider-nutanix
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cluster-api-provider-nutanix/openshift-cluster-api-provider-nutanix-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-nutanix/openshift-cluster-api-provider-nutanix-release-4.22-presubmits.yaml
@@ -506,3 +506,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.22$
+    - ^release-4\.22-
+    cluster: build06
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-api-provider-nutanix-release-4.22-verify-vendor-commits
+    path_alias: github.com/nutanix-cloud-native/cluster-api-provider-nutanix
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cluster-api-provider-nutanix/openshift-cluster-api-provider-nutanix-release-4.23-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-nutanix/openshift-cluster-api-provider-nutanix-release-4.23-presubmits.yaml
@@ -506,3 +506,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.23$
+    - ^release-4\.23-
+    cluster: build06
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-api-provider-nutanix-release-4.23-verify-vendor-commits
+    path_alias: github.com/nutanix-cloud-native/cluster-api-provider-nutanix
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cluster-api-provider-vsphere/openshift-cluster-api-provider-vsphere-master-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-vsphere/openshift-cluster-api-provider-vsphere-master-presubmits.yaml
@@ -877,3 +877,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^master$
+    - ^master-
+    cluster: vsphere02
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-api-provider-vsphere-master-verify-vendor-commits
+    path_alias: sigs.k8s.io/cluster-api-provider-vsphere
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cluster-api-provider-vsphere/openshift-cluster-api-provider-vsphere-release-4.19-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-vsphere/openshift-cluster-api-provider-vsphere-release-4.19-presubmits.yaml
@@ -671,3 +671,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.19$
+    - ^release-4\.19-
+    cluster: vsphere02
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-api-provider-vsphere-release-4.19-verify-vendor-commits
+    path_alias: sigs.k8s.io/cluster-api-provider-vsphere
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cluster-api-provider-vsphere/openshift-cluster-api-provider-vsphere-release-4.20-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-vsphere/openshift-cluster-api-provider-vsphere-release-4.20-presubmits.yaml
@@ -672,3 +672,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.20$
+    - ^release-4\.20-
+    cluster: vsphere02
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-api-provider-vsphere-release-4.20-verify-vendor-commits
+    path_alias: sigs.k8s.io/cluster-api-provider-vsphere
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cluster-api-provider-vsphere/openshift-cluster-api-provider-vsphere-release-4.21-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-vsphere/openshift-cluster-api-provider-vsphere-release-4.21-presubmits.yaml
@@ -815,3 +815,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.21$
+    - ^release-4\.21-
+    cluster: vsphere02
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-api-provider-vsphere-release-4.21-verify-vendor-commits
+    path_alias: sigs.k8s.io/cluster-api-provider-vsphere
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cluster-api-provider-vsphere/openshift-cluster-api-provider-vsphere-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-vsphere/openshift-cluster-api-provider-vsphere-release-4.22-presubmits.yaml
@@ -734,3 +734,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.22$
+    - ^release-4\.22-
+    cluster: vsphere02
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-api-provider-vsphere-release-4.22-verify-vendor-commits
+    path_alias: sigs.k8s.io/cluster-api-provider-vsphere
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cluster-api-provider-vsphere/openshift-cluster-api-provider-vsphere-release-4.23-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-provider-vsphere/openshift-cluster-api-provider-vsphere-release-4.23-presubmits.yaml
@@ -734,3 +734,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.23$
+    - ^release-4\.23-
+    cluster: vsphere02
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-api-provider-vsphere-release-4.23-verify-vendor-commits
+    path_alias: sigs.k8s.io/cluster-api-provider-vsphere
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cluster-api/openshift-cluster-api-master-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api/openshift-cluster-api-master-presubmits.yaml
@@ -1451,3 +1451,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^master$
+    - ^master-
+    cluster: build04
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-api-master-verify-vendor-commits
+    path_alias: sigs.k8s.io/cluster-api
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cluster-api/openshift-cluster-api-release-4.19-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api/openshift-cluster-api-release-4.19-presubmits.yaml
@@ -1163,3 +1163,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.19$
+    - ^release-4\.19-
+    cluster: build05
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-api-release-4.19-verify-vendor-commits
+    path_alias: sigs.k8s.io/cluster-api
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cluster-api/openshift-cluster-api-release-4.20-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api/openshift-cluster-api-release-4.20-presubmits.yaml
@@ -1164,3 +1164,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.20$
+    - ^release-4\.20-
+    cluster: build05
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-api-release-4.20-verify-vendor-commits
+    path_alias: sigs.k8s.io/cluster-api
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cluster-api/openshift-cluster-api-release-4.21-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api/openshift-cluster-api-release-4.21-presubmits.yaml
@@ -1389,3 +1389,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.21$
+    - ^release-4\.21-
+    cluster: build05
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-api-release-4.21-verify-vendor-commits
+    path_alias: sigs.k8s.io/cluster-api
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cluster-api/openshift-cluster-api-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api/openshift-cluster-api-release-4.22-presubmits.yaml
@@ -1308,3 +1308,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.22$
+    - ^release-4\.22-
+    cluster: build05
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-api-release-4.22-verify-vendor-commits
+    path_alias: sigs.k8s.io/cluster-api
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/jobs/openshift/cluster-api/openshift-cluster-api-release-4.23-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api/openshift-cluster-api-release-4.23-presubmits.yaml
@@ -1308,3 +1308,82 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )verify-deps,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.23$
+    - ^release-4\.23-
+    cluster: build05
+    context: ci/prow/verify-vendor-commits
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-api-release-4.23-verify-vendor-commits
+    path_alias: sigs.k8s.io/cluster-api
+    rerun_command: /test verify-vendor-commits
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=verify-vendor-commits
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify-vendor-commits,?($|\s.*)

--- a/ci-operator/step-registry/openshift/verify-vendor-commits/OWNERS
+++ b/ci-operator/step-registry/openshift/verify-vendor-commits/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- damdo
+- radekmanak
+reviewers:
+- damdo
+- radekmanak

--- a/ci-operator/step-registry/openshift/verify-vendor-commits/openshift-verify-vendor-commits-commands.sh
+++ b/ci-operator/step-registry/openshift/verify-vendor-commits/openshift-verify-vendor-commits-commands.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [ -z "${PULL_BASE_SHA:-}" ]; then
+    echo "ERROR: PULL_BASE_SHA is not set; this check must run in a PR context."
+    exit 1
+fi
+
+echo "=== Vendor Commit Structure Check ==="
+echo "Checking commits from ${PULL_BASE_SHA} to HEAD"
+
+FAILED=0
+
+while IFS= read -r sha; do
+    subject=$(git log -1 --format='%s' "${sha}")
+
+    mapfile -t all_files < <(git diff-tree -m --no-commit-id -r --name-only "${sha}")
+
+    vendor_files=()
+    non_vendor_files=()
+    for f in "${all_files[@]}"; do
+        if [[ "${f}" =~ (^|/)vendor/ ]]; then
+            vendor_files+=("${f}")
+        else
+            non_vendor_files+=("${f}")
+        fi
+    done
+
+    if [[ ${#vendor_files[@]} -eq 0 ]]; then
+        continue
+    fi
+
+    if [[ ${#non_vendor_files[@]} -gt 0 ]]; then
+        echo ""
+        echo "ERROR: Commit ${sha} \"${subject}\" mixes vendor/ files with non-vendor files."
+        echo ""
+        echo "  Vendor files:     ${vendor_files[*]}"
+        echo "  Non-vendor files: ${non_vendor_files[*]}"
+        echo ""
+        echo "  This causes rebase conflicts when rebasebot cherry-picks the commit onto"
+        echo "  a new upstream (which has independently updated vendor/)."
+        echo ""
+        echo "  Fix: split into two commits:"
+        echo "    1. UPSTREAM: <pr_number>: <description>   <- go.mod, go.sum only"
+        echo "    2. UPSTREAM: <drop>: vendor               <- vendor/ only"
+        echo ""
+        echo "  Rebasebot regenerates vendor/ as the last commit after every rebase."
+        echo "  The vendor commit is therefore always dropped and recreated — it must"
+        echo "  never be carried forward."
+        FAILED=1
+        continue
+    fi
+
+    if ! echo "${subject}" | grep -qP '^UPSTREAM: <drop>:'; then
+        echo ""
+        echo "ERROR: Commit ${sha} \"${subject}\" touches only vendor/ files but is not"
+        echo "       tagged UPSTREAM: <drop>:"
+        echo ""
+        echo "  Fix: change the commit message prefix to:"
+        echo "    UPSTREAM: <drop>: <description>"
+        echo ""
+        echo "  Rebasebot skips UPSTREAM: <drop>: commits during cherry-pick and"
+        echo "  regenerates vendor/ fresh after the rebase completes."
+        FAILED=1
+    fi
+done < <(git log --format='%H' "${PULL_BASE_SHA}..HEAD")
+
+if [[ ${FAILED} -ne 0 ]]; then
+    exit 1
+fi
+
+echo "All commits passed vendor structure check."

--- a/ci-operator/step-registry/openshift/verify-vendor-commits/openshift-verify-vendor-commits-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/verify-vendor-commits/openshift-verify-vendor-commits-ref.metadata.json
@@ -1,0 +1,13 @@
+{
+	"path": "openshift/verify-vendor-commits/openshift-verify-vendor-commits-ref.yaml",
+	"owners": {
+		"approvers": [
+			"damdo",
+			"radekmanak"
+		],
+		"reviewers": [
+			"damdo",
+			"radekmanak"
+		]
+	}
+}

--- a/ci-operator/step-registry/openshift/verify-vendor-commits/openshift-verify-vendor-commits-ref.yaml
+++ b/ci-operator/step-registry/openshift/verify-vendor-commits/openshift-verify-vendor-commits-ref.yaml
@@ -1,0 +1,14 @@
+ref:
+  as: openshift-verify-vendor-commits
+  from: src
+  commands: openshift-verify-vendor-commits-commands.sh
+  resources:
+    requests:
+      cpu: 10m
+      memory: 100Mi
+  documentation: |-
+    Verifies that no PR commit mixes vendor/ changes with non-vendor changes,
+    and that every vendor-only commit is tagged UPSTREAM: <drop>:.
+
+    This prevents rebase conflicts in OpenShift soft-fork repositories where
+    rebasebot regenerates vendor/ as the last commit after every upstream rebase.


### PR DESCRIPTION
## Summary

- Adds a new step-registry ref `openshift-verify-vendor-commits` that enforces
  two invariants on every PR commit: (1) no commit may mix `vendor/` files with
  non-vendor files, and (2) every vendor-only commit must be tagged
  `UPSTREAM: <drop>:`.
- Wires the step as a required (non-optional) presubmit into 89 CI configs
  across 16 soft-fork repositories (`azure-service-operator`,
  `cloud-provider-{aws,azure,gcp,ibm,nutanix,vpc-controller,vsphere}`,
  `cluster-api`, `cluster-api-provider-{alibaba,aws,azure,gcp,ibmcloud,
  nutanix,vsphere}`) on `main`/`master` and `release-4.19` through `release-4.23`.

## Motivation

OpenShift soft-fork repositories maintain a `vendor/` directory that rebasebot
always regenerates as the final commit after each upstream rebase. When a PR
bundles `vendor/` changes with `go.mod`/`go.sum` in the same commit, or tags a
vendor-only commit incorrectly, rebasebot's cherry-pick nearly always conflicts
with the upstream's independently-updated `vendor/` — requiring manual
intervention across 16 repositories and all active branches.

## Test plan

- [ ] Prow rehearsal jobs pass for the affected repositories

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds a new OpenShift CI presubmit step, openshift-verify-vendor-commits, and wires it as a required presubmit across 89 CI configs for 16 soft-fork repositories (main/master and release-4.19 → release-4.23). The step enforces two invariants on every PR commit in the PR range (PULL_BASE_SHA..HEAD):

- Prevents commits that mix vendor/ files with non-vendor files (e.g., go.mod, go.sum, source code).
- Requires vendor-only commits to have a commit-subject tag beginning with "UPSTREAM: <drop>:" so rebasebot will skip them.

Practical impact
- Which CI is changed: many ci-operator job definitions for the following component repos now include the required verify-vendor-commits presubmit/test: azure-service-operator; cloud-provider-{aws, azure, gcp, ibm, nutanix, vpc-controller, vsphere}; cluster-api; cluster-api-provider-{alibaba, aws, azure, gcp, ibmcloud, nutanix, vsphere}.
- Behavior: PRs without vendor changes fast-path to pass. Violations produce diagnostics listing offending commits and files; the only bypass is the existing Prow /override.
- Ownership and metadata: the step-ref and metadata/OWNERS are added under ci-operator/step-registry/openshift/verify-vendor-commits; approvers/reviewers set to damdo and radekmanak.

Implementation details
- Adds a step-registry ref openshift-verify-vendor-commits with a new executable script (openshift-verify-vendor-commits-commands.sh) that:
  - Requires PULL_BASE_SHA, iterates commits in PULL_BASE_SHA..HEAD,
  - For each commit classifies changed paths into vendor vs non-vendor,
  - Fails commits that mix vendor and non-vendor changes,
  - Fails vendor-only commits whose subject does not match UPSTREAM: <drop>:,
  - Exits nonzero if any violations are found.
- The step is inserted into existing test matrices adjacent to existing verify/verify-deps stages in the affected ci-operator YAMLs. No other build/test logic or source code is modified.

Motivation
- Reduce manual conflict resolution and rebasebot failures when vendor/ is mixed into functional commits or vendor-only commits lack the UPSTREAM: <drop>: tag, by catching these patterns early in presubmit CI.

Test plan / rollout
- Prow rehearsal jobs are planned for the affected repositories (rehearsals checkbox present in PR metadata).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->