### PR TITLE
multiarch: increase 4.22 s390x libvirt job resources

### DIFF
--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.22.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.22.yaml
@@ -472,6 +472,8 @@ tests:
     env:
       ARCH: s390x
       BRANCH: "4.22"
+      DOMAIN_MEMORY: "30709"
+      DOMAIN_VCPUS: "13"
       ETCD_DISK_SPEED: slow
       NODE_TUNING: "true"
       TEST_TYPE: conformance-parallel
@@ -567,6 +569,8 @@ tests:
     env:
       ARCH: s390x
       BRANCH: "4.22"
+      DOMAIN_MEMORY: "30709"
+      DOMAIN_VCPUS: "13"
       ETCD_DISK_SPEED: slow
       FIPS_ENABLED: "true"
       NODE_TUNING: "true"

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.22.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.22.yaml
@@ -472,8 +472,8 @@ tests:
     env:
       ARCH: s390x
       BRANCH: "4.22"
-      DOMAIN_MEMORY: "30709"
-      DOMAIN_VCPUS: "13"
+      DOMAIN_MEMORY: "36864"
+      DOMAIN_VCPUS: "15"
       ETCD_DISK_SPEED: slow
       NODE_TUNING: "true"
       TEST_TYPE: conformance-parallel
@@ -569,8 +569,8 @@ tests:
     env:
       ARCH: s390x
       BRANCH: "4.22"
-      DOMAIN_MEMORY: "30709"
-      DOMAIN_VCPUS: "13"
+      DOMAIN_MEMORY: "36864"
+      DOMAIN_VCPUS: "15"
       ETCD_DISK_SPEED: slow
       FIPS_ENABLED: "true"
       NODE_TUNING: "true"


### PR DESCRIPTION
Raise DOMAIN_MEMORY and DOMAIN_VCPUS by 25% for the 4.22 conformance-parallel and FIPS IBM Z libvirt periodic jobs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR updates the OpenShift CI multiarch configuration in ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.22.yaml to raise libvirt domain resources for two IBM Z (s390x) 4.22 nightly test jobs.

What changed in practical terms
- Affects OpenShift CI job configuration (multiarch nightly 4.22) used to generate Prow jobs for multiarch testing on IBM Z.
- Two libvirt nightly test entries now set explicit libvirt domain resource env vars:
  - ocp-e2e-ovn-remote-libvirt-s390x (workflow: openshift-e2e-libvirt-vpn): DOMAIN_MEMORY="36864", DOMAIN_VCPUS="15"
  - ocp-fips-ovn-remote-libvirt-multi-z-z (workflow: openshift-e2e-libvirt-vpn-fips): DOMAIN_MEMORY="36864", DOMAIN_VCPUS="15"

Notes
- The PR description states a 25% increase, while the commit message mentions a 50% capacity bump; the actual changes in the file set DOMAIN_MEMORY to 36864 and DOMAIN_VCPUS to 15 (the file contains no previous values), so there is an inconsistency between the PR description and commit message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->