### PR TITLE
Remove `bartoszmajsak` from maistra

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -300,7 +300,6 @@ aliases:
   - rcernich
   - yxun
   - dgn
-  - bartoszmajsak
   - FilipB
   - bmangoen
   - mayleighnmyers
@@ -315,7 +314,6 @@ aliases:
   - rcernich
   - yxun
   - dgn
-  - bartoszmajsak
   - FilipB
   - bmangoen
   - mayleighnmyers


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR removes the user `bartoszmajsak` from the Maistra project's CI ownership groups in the OWNERS_ALIASES file. Specifically, `bartoszmajsak` is removed from both the `maistra-approvers` and `maistra-reviewers` alias groups, which control code review and approval permissions for Maistra-related CI configurations and pull requests in the OpenShift CI infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->