### PR TITLE
Gcp storageclass pre set default

### DIFF
--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22.yaml
@@ -1258,6 +1258,9 @@ tests:
     observers:
       enable:
       - observers-resource-watch
+    pre:
+    - ref: storage-conf-storageclass-pre-set-default-gcp
+    - chain: ipi-gcp-pre
     workflow: openshift-e2e-gcp-csi
 - as: e2e-aws-ovn-fips-serial
   interval: 168h

--- a/ci-operator/step-registry/storage/conf/storageclass/pre-set-default-gcp/OWNERS
+++ b/ci-operator/step-registry/storage/conf/storageclass/pre-set-default-gcp/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+- storage-approvers
+- duanwei33
+- Phaow
+reviewers:
+- storage-reviewers
+- duanwei33
+- Phaow

--- a/ci-operator/step-registry/storage/conf/storageclass/pre-set-default-gcp/OWNERS
+++ b/ci-operator/step-registry/storage/conf/storageclass/pre-set-default-gcp/OWNERS
@@ -1,8 +1,4 @@
 approvers:
 - storage-approvers
-- duanwei33
-- Phaow
 reviewers:
 - storage-reviewers
-- duanwei33
-- Phaow

--- a/ci-operator/step-registry/storage/conf/storageclass/pre-set-default-gcp/storage-conf-storageclass-pre-set-default-gcp-commands.sh
+++ b/ci-operator/step-registry/storage/conf/storageclass/pre-set-default-gcp/storage-conf-storageclass-pre-set-default-gcp-commands.sh
@@ -3,7 +3,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-cat << EOF > ${SHARED_DIR}/manifest_storageclass.yaml
+cat << EOF > "${SHARED_DIR}/manifest_storageclass.yaml"
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -19,7 +19,7 @@ allowVolumeExpansion: true
 reclaimPolicy: Delete
 EOF
 
-cat << EOF > ${SHARED_DIR}/manifest_cluster_csi_driver.yaml
+cat << EOF > "${SHARED_DIR}/manifest_cluster_csi_driver.yaml"
 apiVersion: operator.openshift.io/v1
 kind: "ClusterCSIDriver"
 metadata:

--- a/ci-operator/step-registry/storage/conf/storageclass/pre-set-default-gcp/storage-conf-storageclass-pre-set-default-gcp-commands.sh
+++ b/ci-operator/step-registry/storage/conf/storageclass/pre-set-default-gcp/storage-conf-storageclass-pre-set-default-gcp-commands.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+cat << EOF > ${SHARED_DIR}/manifest_storageclass.yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ${GCP_SC_DISK_TYPE}
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: pd.csi.storage.gke.io
+parameters:
+  type: ${GCP_SC_DISK_TYPE}
+  replication-type: none
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+EOF
+
+cat << EOF > ${SHARED_DIR}/manifest_cluster_csi_driver.yaml
+apiVersion: operator.openshift.io/v1
+kind: "ClusterCSIDriver"
+metadata:
+  name: "pd.csi.storage.gke.io"
+spec:
+  logLevel: Normal
+  managementState: Managed
+  operatorLogLevel: Normal
+  storageClassState: Unmanaged
+EOF

--- a/ci-operator/step-registry/storage/conf/storageclass/pre-set-default-gcp/storage-conf-storageclass-pre-set-default-gcp-ref.metadata.json
+++ b/ci-operator/step-registry/storage/conf/storageclass/pre-set-default-gcp/storage-conf-storageclass-pre-set-default-gcp-ref.metadata.json
@@ -1,0 +1,15 @@
+{
+	"path": "storage/conf/storageclass/pre-set-default-gcp/storage-conf-storageclass-pre-set-default-gcp-ref.yaml",
+	"owners": {
+		"approvers": [
+			"storage-approvers",
+			"duanwei33",
+			"Phaow"
+		],
+		"reviewers": [
+			"storage-reviewers",
+			"duanwei33",
+			"Phaow"
+		]
+	}
+}

--- a/ci-operator/step-registry/storage/conf/storageclass/pre-set-default-gcp/storage-conf-storageclass-pre-set-default-gcp-ref.metadata.json
+++ b/ci-operator/step-registry/storage/conf/storageclass/pre-set-default-gcp/storage-conf-storageclass-pre-set-default-gcp-ref.metadata.json
@@ -2,14 +2,10 @@
 	"path": "storage/conf/storageclass/pre-set-default-gcp/storage-conf-storageclass-pre-set-default-gcp-ref.yaml",
 	"owners": {
 		"approvers": [
-			"storage-approvers",
-			"duanwei33",
-			"Phaow"
+			"storage-approvers"
 		],
 		"reviewers": [
-			"storage-reviewers",
-			"duanwei33",
-			"Phaow"
+			"storage-reviewers"
 		]
 	}
 }

--- a/ci-operator/step-registry/storage/conf/storageclass/pre-set-default-gcp/storage-conf-storageclass-pre-set-default-gcp-ref.yaml
+++ b/ci-operator/step-registry/storage/conf/storageclass/pre-set-default-gcp/storage-conf-storageclass-pre-set-default-gcp-ref.yaml
@@ -1,5 +1,6 @@
 ref:
   as: storage-conf-storageclass-pre-set-default-gcp
+  from: cli
   commands: storage-conf-storageclass-pre-set-default-gcp-commands.sh
   resources:
     requests:

--- a/ci-operator/step-registry/storage/conf/storageclass/pre-set-default-gcp/storage-conf-storageclass-pre-set-default-gcp-ref.yaml
+++ b/ci-operator/step-registry/storage/conf/storageclass/pre-set-default-gcp/storage-conf-storageclass-pre-set-default-gcp-ref.yaml
@@ -1,0 +1,18 @@
+ref:
+  as: storage-conf-storageclass-pre-set-default-gcp
+  commands: storage-conf-storageclass-pre-set-default-gcp-commands.sh
+  resources:
+    requests:
+      cpu: 10m
+      memory: 100Mi
+  env:
+  - name: GCP_SC_DISK_TYPE
+    default: "pd-balanced"
+    documentation: |-
+      The GCP persistent disk type to use for the default StorageClass.
+      Valid values are "pd-balanced", "pd-ssd", "pd-standard", and "hyperdisk-balanced".
+  documentation: |-
+    The `storage-conf-storageclass-pre-set-default-gcp` step creates a default
+    StorageClass with a configurable GCP disk type and sets the ClusterCSIDriver
+    storageClassState to Unmanaged. Manifests are written to ${SHARED_DIR} for
+    injection at install time.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR adds a new ci-operator step that pre-configures a default GCP StorageClass and adjusts the OpenShift Release nightly-4.22 job to run that step before GCP e2e tests. It affects the OpenShift Release CI configuration (ci-operator job definitions) and the ci-operator step-registry used during test cluster provisioning on GCP.

## Changes
- OpenShift release CI (nightly-4.22)
  - Injects a new pre-step ref: storage-conf-storageclass-pre-set-default-gcp into the e2e GCP job sequence so it runs before ipi-gcp-pre and the openshift-e2e-gcp-csi workflow.

- New step registry entry: storage-conf-storageclass-pre-set-default-gcp
  - Adds a commands script that writes two manifests into ${SHARED_DIR} for install-time injection:
    - manifest_storageclass.yaml — a default StorageClass named by GCP_SC_DISK_TYPE (default "pd-balanced"), provisioner pd.csi.storage.gke.io, parameters include type=${GCP_SC_DISK_TYPE} and replication-type: none, volumeBindingMode: WaitForFirstConsumer, allowVolumeExpansion: true, reclaimPolicy: Delete, and annotation marking it as the default class.
    - manifest_cluster_csi_driver.yaml — a ClusterCSIDriver for pd.csi.storage.gke.io with managementState: Managed and storageClassState: Unmanaged.
  - Declares minimal resource requests (10m CPU, 100Mi memory).
  - Exposes GCP_SC_DISK_TYPE env var (default "pd-balanced"; docs list valid disk types: "pd-balanced", "pd-ssd", "pd-standard", "hyperdisk-balanced").

- Ownership metadata
  - Adds OWNERS listing approvers: storage-approvers and reviewers: storage-reviewers.
  - Adds a .metadata.json that maps the ref YAML path and records the same approvers/reviewers.

## Impact
GCP e2e jobs will now receive an injected default StorageClass and ClusterCSIDriver state at install time, making CSI-related tests run with a predictable, configurable storage configuration without requiring manual cluster changes. This change is scoped to CI configuration and test provisioning; no production code/API changes were made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->