### PR TITLE
openshift/openstack-test: bump memory limit

### DIFF
--- a/ci-operator/config/openshift/openstack-test/openshift-openstack-test-main.yaml
+++ b/ci-operator/config/openshift/openstack-test/openshift-openstack-test-main.yaml
@@ -22,7 +22,7 @@ releases:
 resources:
   '*':
     limits:
-      memory: 4Gi
+      memory: 8Gi
     requests:
       cpu: 100m
       memory: 200Mi

--- a/ci-operator/config/openshift/openstack-test/openshift-openstack-test-release-4.12.yaml
+++ b/ci-operator/config/openshift/openstack-test/openshift-openstack-test-release-4.12.yaml
@@ -24,7 +24,7 @@ releases:
 resources:
   '*':
     limits:
-      memory: 4Gi
+      memory: 8Gi
     requests:
       cpu: 100m
       memory: 200Mi

--- a/ci-operator/config/openshift/openstack-test/openshift-openstack-test-release-4.13.yaml
+++ b/ci-operator/config/openshift/openstack-test/openshift-openstack-test-release-4.13.yaml
@@ -24,7 +24,7 @@ releases:
 resources:
   '*':
     limits:
-      memory: 4Gi
+      memory: 8Gi
     requests:
       cpu: 100m
       memory: 200Mi

--- a/ci-operator/config/openshift/openstack-test/openshift-openstack-test-release-4.14.yaml
+++ b/ci-operator/config/openshift/openstack-test/openshift-openstack-test-release-4.14.yaml
@@ -24,7 +24,7 @@ releases:
 resources:
   '*':
     limits:
-      memory: 4Gi
+      memory: 8Gi
     requests:
       cpu: 100m
       memory: 200Mi

--- a/ci-operator/config/openshift/openstack-test/openshift-openstack-test-release-4.15.yaml
+++ b/ci-operator/config/openshift/openstack-test/openshift-openstack-test-release-4.15.yaml
@@ -24,7 +24,7 @@ releases:
 resources:
   '*':
     limits:
-      memory: 4Gi
+      memory: 8Gi
     requests:
       cpu: 100m
       memory: 200Mi

--- a/ci-operator/config/openshift/openstack-test/openshift-openstack-test-release-4.16.yaml
+++ b/ci-operator/config/openshift/openstack-test/openshift-openstack-test-release-4.16.yaml
@@ -22,7 +22,7 @@ releases:
 resources:
   '*':
     limits:
-      memory: 4Gi
+      memory: 8Gi
     requests:
       cpu: 100m
       memory: 200Mi

--- a/ci-operator/config/openshift/openstack-test/openshift-openstack-test-release-4.17.yaml
+++ b/ci-operator/config/openshift/openstack-test/openshift-openstack-test-release-4.17.yaml
@@ -22,7 +22,7 @@ releases:
 resources:
   '*':
     limits:
-      memory: 4Gi
+      memory: 8Gi
     requests:
       cpu: 100m
       memory: 200Mi

--- a/ci-operator/config/openshift/openstack-test/openshift-openstack-test-release-4.18.yaml
+++ b/ci-operator/config/openshift/openstack-test/openshift-openstack-test-release-4.18.yaml
@@ -22,7 +22,7 @@ releases:
 resources:
   '*':
     limits:
-      memory: 4Gi
+      memory: 8Gi
     requests:
       cpu: 100m
       memory: 200Mi

--- a/ci-operator/config/openshift/openstack-test/openshift-openstack-test-release-4.19.yaml
+++ b/ci-operator/config/openshift/openstack-test/openshift-openstack-test-release-4.19.yaml
@@ -22,7 +22,7 @@ releases:
 resources:
   '*':
     limits:
-      memory: 4Gi
+      memory: 8Gi
     requests:
       cpu: 100m
       memory: 200Mi

--- a/ci-operator/config/openshift/openstack-test/openshift-openstack-test-release-4.20.yaml
+++ b/ci-operator/config/openshift/openstack-test/openshift-openstack-test-release-4.20.yaml
@@ -22,7 +22,7 @@ releases:
 resources:
   '*':
     limits:
-      memory: 4Gi
+      memory: 8Gi
     requests:
       cpu: 100m
       memory: 200Mi

--- a/ci-operator/config/openshift/openstack-test/openshift-openstack-test-release-4.21.yaml
+++ b/ci-operator/config/openshift/openstack-test/openshift-openstack-test-release-4.21.yaml
@@ -22,7 +22,7 @@ releases:
 resources:
   '*':
     limits:
-      memory: 4Gi
+      memory: 8Gi
     requests:
       cpu: 100m
       memory: 200Mi

--- a/ci-operator/config/openshift/openstack-test/openshift-openstack-test-release-4.22.yaml
+++ b/ci-operator/config/openshift/openstack-test/openshift-openstack-test-release-4.22.yaml
@@ -22,7 +22,7 @@ releases:
 resources:
   '*':
     limits:
-      memory: 4Gi
+      memory: 8Gi
     requests:
       cpu: 100m
       memory: 200Mi

--- a/ci-operator/config/openshift/openstack-test/openshift-openstack-test-release-4.23.yaml
+++ b/ci-operator/config/openshift/openstack-test/openshift-openstack-test-release-4.23.yaml
@@ -22,7 +22,7 @@ releases:
 resources:
   '*':
     limits:
-      memory: 4Gi
+      memory: 8Gi
     requests:
       cpu: 100m
       memory: 200Mi

--- a/ci-operator/config/openshift/openstack-test/openshift-openstack-test-release-5.0.yaml
+++ b/ci-operator/config/openshift/openstack-test/openshift-openstack-test-release-5.0.yaml
@@ -23,7 +23,7 @@ releases:
 resources:
   '*':
     limits:
-      memory: 4Gi
+      memory: 8Gi
     requests:
       cpu: 100m
       memory: 200Mi

--- a/ci-operator/config/openshift/openstack-test/openshift-openstack-test-release-5.1.yaml
+++ b/ci-operator/config/openshift/openstack-test/openshift-openstack-test-release-5.1.yaml
@@ -22,7 +22,7 @@ releases:
 resources:
   '*':
     limits:
-      memory: 4Gi
+      memory: 8Gi
     requests:
       cpu: 100m
       memory: 200Mi


### PR DESCRIPTION
From 4Gi to 8Gi to fix OOM during Go compilation, as seen in recent promotion jobs at [1] and [2].

[1] https://prow.ci.openshift.org/view/gs/test-platform-results/logs/branch-ci-openshift-openstack-test-main-images/2049105686775730176
[2] https://prow.ci.openshift.org/view/gs/test-platform-results/logs/branch-ci-openshift-openstack-test-release-4.21-images/2051201632682643456

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR increases the memory limits used by the OpenShift CI jobs that run for the openshift/openstack-test repository: the wildcard container memory limit (`resources['*'].limits.memory`) is changed from 4Gi to 8Gi across main and the release branches listed below. The change is intended to address out-of-memory (OOM) failures observed during Go compilation in recent promotion job runs (see referenced failing logs in the PR description).

## What changed in practical terms

- The CI job definitions used by OpenShift's ci-operator for the openshift/openstack-test repository will allocate up to 8Gi of memory per container where the wildcard (`'*'`) resource selector applies, instead of the previous 4Gi.
- This applies to the main pipeline and the release pipelines used for image builds and promotions—so CI runs for all targeted branches will receive the higher memory limit.
- No other job behavior, commands, image promotion settings, test/workflow steps, or resource requests were altered.

## Files / branches affected

Memory limits were increased in the ci-operator config for:
- main branch config (openshift-openstack-test-main.yaml)
- release branches: 4.12 → 4.23
- future releases: 5.0, 5.1

(All changes are the same: resources['*'].limits.memory: 4Gi → 8Gi.)

## Impact

- CI jobs for openshift/openstack-test will have double the memory headroom for build/compile steps (notably Go compilation), reducing OOM-related failures during promotions and image builds.
- No change to resource requests means scheduling behavior may be unchanged; only the allowed limit is increased.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->