### PR TITLE
Grant secrets access to the ephemeral-cluster service account 2

### DIFF
--- a/clusters/app.ci/ephemeral-cluster/00_admin.yaml
+++ b/clusters/app.ci/ephemeral-cluster/00_admin.yaml
@@ -27,9 +27,7 @@ rules:
   resources:
   - secrets
   verbs:
-  - get
-  - watch
-  - list
+  - "*"
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
It turns out that https://github.com/openshift/release/pull/78946 wasn't sufficient.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR grants the `ephemeral-cluster` service account full permissions to manage Kubernetes Secret resources within the OpenShift CI infrastructure.

**What Changed:**
The `ClusterRole` for `ephemeral-cluster-admin` is updated to allow all operations on secrets. Previously, the service account was restricted to read-only operations (`get`, `watch`, `list`). This change grants `"*"` (all verbs), enabling the service account to create, delete, update, patch, and perform any other operation on Secret resources.

**Infrastructure Impact:**
The ephemeral-cluster is a critical component of the OpenShift CI infrastructure used for testing and provisioning temporary clusters. This change enables the ephemeral-cluster service account to fully manage secrets, which is essential for operational tasks such as creating credentials, updating authentication tokens, and managing configuration data needed during cluster provisioning and CI/CD workflows.

**Context:**
This change addresses limitations identified in a previous attempt (PR #78946) to grant proper secret access to this service account. The current approach provides unrestricted access, ensuring the ephemeral-cluster has the necessary permissions for its full operational scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->