### PR TITLE
OTA-1866: Add TLS scanner presubmit jobs to OSUS components

### DIFF
--- a/ci-operator/config/openshift/cincinnati-operator/openshift-cincinnati-operator-master.yaml
+++ b/ci-operator/config/openshift/cincinnati-operator/openshift-cincinnati-operator-master.yaml
@@ -15,6 +15,10 @@ base_images:
     name: cincinnati-graph-data
     namespace: cincinnati-ci-public
     tag: stable
+  tls-scanner-tool:
+    name: "4.22"
+    namespace: ocp
+    tag: tls-scanner-tool
   ubi:
     name: ubi
     namespace: ocp
@@ -98,6 +102,36 @@ tests:
         requests:
           cpu: 500m
           memory: 1000Mi
+    workflow: generic-claim
+- always_run: false
+  as: install-bundle-tls-scan
+  cluster_claim:
+    architecture: amd64
+    cloud: aws
+    owner: openshift-ci
+    product: ocp
+    timeout: 1h0m0s
+    version: "4.18"
+  optional: true
+  steps:
+    env:
+      SCAN_NAMESPACE: install-osus-here
+    test:
+    - as: install
+      cli: latest
+      commands: |
+        oc create namespace install-osus-here
+        operator-sdk run bundle -n install-osus-here "$OO_BUNDLE" --security-context-config restricted
+        oc wait --for condition=Available -n install-osus-here deployment updateservice-operator
+      dependencies:
+      - env: OO_BUNDLE
+        name: cincinnati-bundle
+      from: operator-sdk
+      resources:
+        requests:
+          cpu: 500m
+          memory: 1000Mi
+    - ref: tls-scanner-run
     workflow: generic-claim
 - as: scorecard
   steps:

--- a/ci-operator/config/openshift/cincinnati-operator/openshift-cincinnati-operator-master.yaml
+++ b/ci-operator/config/openshift/cincinnati-operator/openshift-cincinnati-operator-master.yaml
@@ -16,7 +16,7 @@ base_images:
     namespace: cincinnati-ci-public
     tag: stable
   tls-scanner-tool:
-    name: "4.22"
+    name: "5.0"
     namespace: ocp
     tag: tls-scanner-tool
   ubi:

--- a/ci-operator/config/openshift/cincinnati-operator/openshift-cincinnati-operator-master.yaml
+++ b/ci-operator/config/openshift/cincinnati-operator/openshift-cincinnati-operator-master.yaml
@@ -105,16 +105,11 @@ tests:
     workflow: generic-claim
 - always_run: false
   as: install-bundle-tls-scan
-  cluster_claim:
-    architecture: amd64
-    cloud: aws
-    owner: openshift-ci
-    product: ocp
-    timeout: 1h0m0s
-    version: "4.18"
   optional: true
   steps:
+    cluster_profile: openshift-org-aws
     env:
+      COMPUTE_NODE_TYPE: m5.2xlarge
       SCAN_NAMESPACE: install-osus-here
     test:
     - as: install
@@ -132,7 +127,7 @@ tests:
           cpu: 500m
           memory: 1000Mi
     - ref: tls-scanner-run
-    workflow: generic-claim
+    workflow: ipi-aws
 - as: scorecard
   steps:
     allow_best_effort_post_steps: true

--- a/ci-operator/config/openshift/cincinnati/openshift-cincinnati-master.yaml
+++ b/ci-operator/config/openshift/cincinnati/openshift-cincinnati-master.yaml
@@ -8,7 +8,7 @@ base_images:
     namespace: cincinnati-ci-public
     tag: ci-1.35.2
   tls-scanner-tool:
-    name: "4.22"
+    name: "5.0"
     namespace: ocp
     tag: tls-scanner-tool
   ubi:

--- a/ci-operator/config/openshift/cincinnati/openshift-cincinnati-master.yaml
+++ b/ci-operator/config/openshift/cincinnati/openshift-cincinnati-master.yaml
@@ -7,6 +7,10 @@ base_images:
     name: openapi-validator
     namespace: cincinnati-ci-public
     tag: ci-1.35.2
+  tls-scanner-tool:
+    name: "4.22"
+    namespace: ocp
+    tag: tls-scanner-tool
   ubi:
     name: ubi
     namespace: ocp
@@ -177,6 +181,32 @@ tests:
         requests:
           cpu: 100m
           memory: 200Mi
+    workflow: generic-claim
+- always_run: false
+  as: olm-e2e-tls-scan
+  cluster_claim:
+    architecture: amd64
+    cloud: aws
+    owner: openshift-ci
+    product: ocp
+    timeout: 1h0m0s
+    version: "4.18"
+  optional: true
+  steps:
+    env:
+      SCAN_NAMESPACE: openshift-update-service
+    test:
+    - as: openshift-e2e-test
+      commands: just run_e2e
+      dependencies:
+      - env: CINCINNATI_IMAGE
+        name: deploy
+      from: e2e-test
+      resources:
+        requests:
+          cpu: 100m
+          memory: 200Mi
+    - ref: tls-scanner-run
     workflow: generic-claim
 - as: osus-e2e
   cluster_claim:

--- a/ci-operator/config/openshift/cincinnati/openshift-cincinnati-master.yaml
+++ b/ci-operator/config/openshift/cincinnati/openshift-cincinnati-master.yaml
@@ -81,6 +81,12 @@ promotion:
     - downstream-deploy
     name: cincinnati-build-root
     namespace: cincinnati-ci
+releases:
+  latest:
+    release:
+      architecture: multi
+      channel: candidate
+      version: "4.18"
 resources:
   '*':
     requests:
@@ -184,16 +190,11 @@ tests:
     workflow: generic-claim
 - always_run: false
   as: olm-e2e-tls-scan
-  cluster_claim:
-    architecture: amd64
-    cloud: aws
-    owner: openshift-ci
-    product: ocp
-    timeout: 1h0m0s
-    version: "4.18"
   optional: true
   steps:
+    cluster_profile: openshift-org-aws
     env:
+      COMPUTE_NODE_TYPE: m5.2xlarge
       SCAN_NAMESPACE: openshift-update-service
     test:
     - as: openshift-e2e-test
@@ -207,7 +208,7 @@ tests:
           cpu: 100m
           memory: 200Mi
     - ref: tls-scanner-run
-    workflow: generic-claim
+    workflow: ipi-aws
 - as: osus-e2e
   cluster_claim:
     architecture: amd64

--- a/ci-operator/jobs/openshift/cincinnati-operator/openshift-cincinnati-operator-master-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cincinnati-operator/openshift-cincinnati-operator-master-presubmits.yaml
@@ -352,6 +352,91 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )install-bundle,?($|\s.*)
   - agent: kubernetes
+    always_run: false
+    branches:
+    - ^master$
+    - ^master-
+    cluster: build07
+    context: ci/prow/install-bundle-tls-scan
+    decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - build/Dockerfile
+      - dev/Dockerfile
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cincinnati-operator-master-install-bundle-tls-scan
+    optional: true
+    rerun_command: /test install-bundle-tls-scan
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=install-bundle-tls-scan
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )install-bundle-tls-scan,?($|\s.*)
+  - agent: kubernetes
     always_run: true
     branches:
     - ^master$

--- a/ci-operator/jobs/openshift/cincinnati/openshift-cincinnati-master-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cincinnati/openshift-cincinnati-master-presubmits.yaml
@@ -23,6 +23,7 @@ presubmits:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
         - --target=cargo-test
         command:
         - ci-operator
@@ -44,6 +45,9 @@ presubmits:
         - mountPath: /etc/boskos
           name: boskos
           readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
@@ -64,6 +68,9 @@ presubmits:
           - key: credentials
             path: credentials
           secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
@@ -218,6 +225,90 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )olm-e2e,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^master$
+    - ^master-
+    cluster: build06
+    context: ci/prow/olm-e2e-tls-scan
+    decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - dist/Dockerfile.deploy/Dockerfile
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cincinnati-master-olm-e2e-tls-scan
+    optional: true
+    rerun_command: /test olm-e2e-tls-scan
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=olm-e2e-tls-scan
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )olm-e2e-tls-scan,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:


### PR DESCRIPTION
Add optional presubmit jobs for OSUS components to verify that the OSUS respects the centralized TLS configuration. The PR leverages existing e2e jobs to deploy the components and ensure that they are working correctly before proceeding to the TLS scanning. The introduction of these jobs will allow us in the future to run these tests as needed without the need to run the TLS-scanner manually.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR updates OpenShift CI configuration (openshift/release) for the OSUS components cincinnati and cincinnati-operator to add optional presubmit flows that run a TLS scanner after existing e2e deployment flows. The goal is to automatically validate that these components respect the centralized TLS configuration without changing runtime code.

## Practical changes

- A new tls-scanner-tool base image entry (namespace: ocp, name: "5.0", tag: tls-scanner-tool) was added to both:
  - ci-operator/config/openshift/cincinnati-operator/openshift-cincinnati-operator-master.yaml
  - ci-operator/config/openshift/cincinnati/openshift-cincinnati-master.yaml

- cincinnati-operator:
  - Introduces an optional test flow install-bundle-tls-scan (always_run: false, optional: true).
  - The flow claims an AWS cluster (cluster_profile: openshift-org-aws), sets COMPUTE_NODE_TYPE: m5.2xlarge and SCAN_NAMESPACE: install-osus-here, deploys the cincinnati bundle into that namespace, waits for the updateservice-operator deployment to be Available, then invokes the shared tls-scanner-run ref.
  - Install-step resource requests mirror the existing install-bundle step.

- cincinnati:
  - Adds an optional olm-e2e-tls-scan job (always_run: false, optional: true).
  - The job reuses the existing olm-e2e deployment (just run_e2e from the e2e-test image) then invokes tls-scanner-run; it sets COMPUTE_NODE_TYPE: m5.2xlarge and SCAN_NAMESPACE: openshift-update-service and is wired to the ipi-aws workflow.
  - Adds releases.latest.release entries (architecture: multi, channel: candidate, version: "4.18") in both configs.

## Behavior and rationale

- Both jobs reuse existing deployment/e2e workflows to deploy components and validate basic functionality before running the TLS scanner, minimizing duplicated deployment logic.
- Jobs are optional (not blocking CI) and increase compute sizing for scan runs (COMPUTE_NODE_TYPE: m5.2xlarge) to accommodate scanning.
- Changes are limited to CI configuration (no runtime code changes).

## Notable metadata

- Commit updates tls-scanner-tool base image version.
- Files changed: the two ci-operator YAMLs under ci-operator/config/openshift/cincinnati{,-operator}/ for master branch CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->