### PR TITLE
add mirroring of tls-scanner to quay

### DIFF
--- a/ci-operator/config/openshift/tls-scanner/openshift-tls-scanner-main.yaml
+++ b/ci-operator/config/openshift/tls-scanner/openshift-tls-scanner-main.yaml
@@ -21,8 +21,8 @@ images:
     to: tls-scanner-tool
 promotion:
   to:
-  - name: "5.0"
-    namespace: ocp
+  - name: tls-scanner
+    namespace: tls-scanner
 releases:
   initial:
     integration:

--- a/ci-operator/jobs/openshift/tls-scanner/openshift-tls-scanner-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/tls-scanner/openshift-tls-scanner-main-presubmits.yaml
@@ -23,7 +23,6 @@ presubmits:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --report-credentials-file=/etc/report/credentials
         - --target=[images]
-        - --target=[release:latest]
         command:
         - ci-operator
         image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest

--- a/core-services/image-mirroring/tls-scanner/OWNERS
+++ b/core-services/image-mirroring/tls-scanner/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+  - richardsonnick
+  - rhmdnd
+  - smith-xyz 
+reviewers:
+  - richardsonnick
+  - rhmdnd
+  - smith-xyz 

--- a/core-services/image-mirroring/tls-scanner/mapping_tls_scanner_quay
+++ b/core-services/image-mirroring/tls-scanner/mapping_tls_scanner_quay
@@ -1,1 +1,1 @@
-quay-proxy.ci.openshift.org/openshift/ci:tls-scanner_tls-scanner_latest quay.io/openshift/tls-scanner:latest
+quay-proxy.ci.openshift.org/openshift/ci:tls-scanner_tls-scanner_tls-scanner-tool quay.io/openshift/tls-scanner:latest

--- a/core-services/image-mirroring/tls-scanner/mapping_tls_scanner_quay
+++ b/core-services/image-mirroring/tls-scanner/mapping_tls_scanner_quay
@@ -1,0 +1,1 @@
+quay-proxy.ci.openshift.org/openshift/ci:tls-scanner_tls-scanner_latest quay.io/openshift/tls-scanner:latest


### PR DESCRIPTION
This PR:
* adds mirroring to quay of the tls-scanner image for use by other teams in CI
* addresses https://github.com/openshift/tls-scanner/issues/25#issuecomment-4170423291

cc   @richardsonnick  @rhmdnd @smith-xyz 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR configures mirroring so the tls-scanner image built by OpenShift CI is published to quay.io for reuse by other teams, and adds OWNERS for the mirror config.

What changed (practical terms)
- Image mirroring
  - Adds core-services/image-mirroring/tls-scanner/mapping_tls_scanner_quay mapping:
    - Mirrors registry.ci.openshift.org/ocp/tls-scanner:tls-scanner-tool → quay.io/openshift/tls-scanner:latest
    - (Mapping was added to make the CI-promoted image available on Quay as :latest for external consumption.)
  - Note: the mapping targets the imagestream tag produced by main CI (tls-scanner-tool), not a release-pinned ocp/5.0 tag.

- CI promotion
  - Updates ci-operator config (ci-operator/config/openshift/tls-scanner/openshift-tls-scanner-main.yaml) to promote the built image into an ocp/tls-scanner imagestream (non-versioned name) in addition to existing targets — enabling a stable, project-scoped :latest to be used for mirroring.

- Ownership
  - Adds core-services/image-mirroring/tls-scanner/OWNERS with approvers and reviewers: richardsonnick, rhmdnd, smith-xyz.

Review context / rationale
- Reviewers flagged two issues which were addressed in discussion:
  1. The imagestream tag promoted by main CI is tls-scanner-tool (not tls-scanner); the mapping was updated to reference the correct tag.
  2. Prefer promoting main to a non-versioned, project-specific imagestream (pattern used by numaresources-operator) so :latest can follow main while releases remain pinned to ocp/5.0 — this decouples main branch promotion from release branches and simplifies maintenance. The PR author agreed to adjust promotion/tagging accordingly.
- The PR was temporarily held by the author while promotion/mapping source was corrected; tls-scanner contains no secrets and is considered safe to mirror publicly.

Impact
- TLS Scanner images built by the repository's main CI will be mirrored to quay.io/openshift/tls-scanner:latest, enabling other teams to consume the image in CI without rebuilding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->