### PR TITLE
OCPEDGE-2483: SNO RHCOS9 CI validation and testing

### DIFF
--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
@@ -155,6 +155,17 @@ tests:
       enable:
       - observers-resource-watch
     workflow: openshift-e2e-aws-single-node
+- as: e2e-aws-ovn-single-node-rhcos9-techpreview
+  interval: 168h
+  steps:
+    cluster_profile: openshift-org-aws
+    env:
+      FEATURE_SET: TechPreviewNoUpgrade
+      OS_IMAGE_STREAM: rhel-9
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: openshift-e2e-aws-single-node
 - as: e2e-aws-ovn-single-node-techpreview
   interval: 168h
   steps:


### PR DESCRIPTION
[OCPEDGE-2483]: https://redhat.atlassian.net/browse/OCPEDGE-2483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds comprehensive CI validation and testing infrastructure for Single Node OpenShift (SNO) clusters on AWS with RHCOS 10 and RHCOS 9, spanning OpenShift 4.23 and 5.0 releases.

**OpenShift 4.23 (RHCOS 10 Tech Preview)**
- Introduces SNO e2e test jobs for RHCOS 10 tech preview: `e2e-aws-ovn-single-node-rhcos10-techpreview` and a serial variant
- Configures tests with `FEATURE_SET=TechPreviewNoUpgrade` and `OS_IMAGE_STREAM=rhel-10` 
- All tests run on the `openshift-org-aws` cluster profile with 168-hour scheduling intervals in nightly pipelines
- Adds corresponding release-controller verification entries in both public (`release-ocp-4.23.json`) and private (`release-ocp-4.23.json`) configurations with upgrade and micro-upgrade variants

**OpenShift 5.0 (RHCOS 9 and RHCOS 10)**
- Adds multiple SNO test job variants for RHCOS 9 validation: serial and upgrade testing configurations
- Includes additional platform coverage (metal bare metal, vSphere, Azure, GCP) for both RHCOS 9 and RHCOS 10 tech preview
- Configures RHCOS 9 tests with `OS_IMAGE_STREAM=rhel-9`
- All new tests scheduled at 168-hour intervals in nightly pipelines
- Adds release-controller verification entries in public (`release-ocp-5.0.json`) and private configurations with upgrade and micro-upgrade variants

**Configuration Scope**
- Updates CI Operator configs across multiple nightly variant files (`openshift-release-main__nightly-4.23.yaml`, `openshift-release-main__nightly-5.0.yaml`) with new test matrix entries
- Enables resource-watch observers on all new test jobs for enhanced monitoring
- Upgrade candidates reference stable 4.22 releases as baseline

**Impact**: Enables validation of RHCOS 10 as a technology preview for OpenShift 4.23 and establishes comprehensive RHCOS 9 SNO upgrade and conformance testing for the OpenShift 5.0 release cycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->