### PR TITLE
Bump UPI image refs to 4.22

### DIFF
--- a/ci-operator/step-registry/ipi/install/heterogeneous/ipi-install-heterogeneous-ref.yaml
+++ b/ci-operator/step-registry/ipi/install/heterogeneous/ipi-install-heterogeneous-ref.yaml
@@ -2,7 +2,7 @@ ref:
   as: ipi-install-heterogeneous
   from_image:
     namespace: ocp
-    name: "4.21"
+    name: "4.22"
     tag: upi-installer
   grace_period: 10m
   commands: ipi-install-heterogeneous-commands.sh

--- a/ci-operator/step-registry/ipi/install/monitoringpvc/ipi-install-monitoringpvc-ref.yaml
+++ b/ci-operator/step-registry/ipi/install/monitoringpvc/ipi-install-monitoringpvc-ref.yaml
@@ -2,7 +2,7 @@ ref:
   as: ipi-install-monitoringpvc
   from_image:
     namespace: ocp
-    name: "4.12"
+    name: "4.22"
     tag: upi-installer
   commands: ipi-install-monitoringpvc-commands.sh
   resources:

--- a/ci-operator/step-registry/ipi/install/post/featureset/ipi-install-post-featureset-ref.yaml
+++ b/ci-operator/step-registry/ipi/install/post/featureset/ipi-install-post-featureset-ref.yaml
@@ -2,7 +2,7 @@ ref:
   as: ipi-install-post-featureset
   from_image:
     namespace: ocp
-    name: "4.14"
+    name: "4.22"
     tag: upi-installer
   commands: ipi-install-post-featureset-commands.sh
   resources:

--- a/ci-operator/step-registry/ipi/install/post/monitoringpvc/ipi-install-post-monitoringpvc-ref.yaml
+++ b/ci-operator/step-registry/ipi/install/post/monitoringpvc/ipi-install-post-monitoringpvc-ref.yaml
@@ -2,7 +2,7 @@ ref:
   as: ipi-install-post-monitoringpvc
   from_image:
     namespace: ocp
-    name: "4.12"
+    name: "4.22"
     tag: upi-installer
   commands: ipi-install-post-monitoringpvc-commands.sh
   resources:


### PR DESCRIPTION
Bump upi installer image version to 4.22. Particularly to pick up a bug fix in oc in 4.22 to filter tech preview credentials requests manifests.

Also needs https://github.com/openshift/installer/pull/10538 but merge order doesn't matter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
Updates UPI (User Provisioned Infrastructure) installer step definitions in the OpenShift CI configuration to use OpenShift version 4.22. This brings the CI testing infrastructure in line with a bug fix in the `oc` tool that filters tech preview credentials requests manifests.

## Changes
Four IPI installation step configurations in the CI step registry were updated to target OpenShift 4.22:

- **ipi-install-heterogeneous**: Updated from 4.21 to 4.22
- **ipi-install-monitoringpvc**: Updated from 4.12 to 4.22  
- **ipi-install-post-featureset**: Updated from 4.14 to 4.22
- **ipi-install-post-monitoringpvc**: Updated from 4.12 to 4.22

Each update is a single-line change to the version reference in the respective step's configuration manifest. No functional logic or command definitions were modified.

## Impact
These changes affect the CI infrastructure for testing OpenShift installer components. By updating to 4.22, the CI will use a newer version of the installer tooling in test workflows, enabling the bug fix for handling tech preview credentials that was introduced in that version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->