### PR TITLE
SPLAT-2748: Configured vsphere hybrid serial jobs to be sharded

### DIFF
--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22.yaml
@@ -1138,6 +1138,7 @@ tests:
     workflow: openshift-e2e-vsphere-hybrid-env
 - as: e2e-vsphere-ovn-hybrid-env-serial-techpreview
   cron: 50 7 * * *
+  shard_count: 2
   steps:
     cluster_profile: vsphere-elastic
     env:

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.23.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.23.yaml
@@ -1101,6 +1101,7 @@ tests:
     workflow: openshift-e2e-vsphere-hybrid-env
 - as: e2e-vsphere-ovn-hybrid-env-serial-techpreview
   cron: 35 18 * * 1
+  shard_count: 2
   steps:
     cluster_profile: vsphere-elastic
     env:

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
@@ -1246,6 +1246,7 @@ tests:
     workflow: openshift-e2e-vsphere-hybrid-env
 - as: e2e-vsphere-ovn-hybrid-env-serial-techpreview
   cron: 50 1 * * *
+  shard_count: 2
   steps:
     cluster_profile: vsphere-elastic
     env:


### PR DESCRIPTION
[SPLAT-2748](https://redhat.atlassian.net/browse/SPLAT-2748)

### Changes
- Configured vsphere hybrid serial jobs to be sharded (5.0, 4.23, 4.22)

[SPLAT-2748]: https://redhat.atlassian.net/browse/SPLAT-2748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR updates OpenShift CI job configuration in the openshift/release repository to shard the vsphere hybrid serial e2e job across three nightly release configurations (5.0, 4.23, and 4.22). Concretely, the ci-operator test entry named e2e-vsphere-ovn-hybrid-env-serial-techpreview in each of the following files now sets shard_count: 2 so the job will run split into two shards:

- ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
- ci-operator/config/openshift/release/openshift-release-main__nightly-4.23.yaml
- ci-operator/config/openshift/release/openshift-release-main__nightly-4.22.yaml

Additionally, the 4.23 config includes a minor adjustment to the TEST_SKIPS/skip regex (reworking a FeatureGate-prefixed skip and tightening related skip text). The PR references JIRA [SPLAT-2748](https://redhat.atlassian.net/browse/SPLAT-2748).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->