### PR TITLE
Fail on version mismatch instead of silently falling back

### DIFF
--- a/ci-operator/step-registry/rosa/cluster/provision/rosa-cluster-provision-commands.sh
+++ b/ci-operator/step-registry/rosa/cluster/provision/rosa-cluster-provision-commands.sh
@@ -262,8 +262,15 @@ echo -e "Available cluster versions:\n${versionList}"
 # If account-roles-create fell back to a different version, use it. This overrides
 # release:latest resolution so the cluster version matches the account roles.
 if [[ -f "${SHARED_DIR}/openshift_version" ]]; then
-  OPENSHIFT_VERSION=$(cat "${SHARED_DIR}/openshift_version")
-  log "Using version ${OPENSHIFT_VERSION} from account-roles-create step (fallback)"
+  FALLBACK_VERSION=$(cat "${SHARED_DIR}/openshift_version")
+  REQUESTED_MAJOR_MINOR=$(echo "${OPENSHIFT_VERSION}" | cut -d'.' -f1,2)
+  FALLBACK_MAJOR_MINOR=$(echo "${FALLBACK_VERSION}" | cut -d'.' -f1,2)
+  if [[ "${REQUESTED_MAJOR_MINOR}" =~ ^[0-9]+\.[0-9]+$ && "${REQUESTED_MAJOR_MINOR}" != "${FALLBACK_MAJOR_MINOR}" ]]; then
+    log "ERROR: Requested version ${OPENSHIFT_VERSION} but account-roles fell back to ${FALLBACK_VERSION}. Version ${OPENSHIFT_VERSION} may not be available for this cluster type."
+    exit 1
+  fi
+  OPENSHIFT_VERSION="${FALLBACK_VERSION}"
+  log "Using version ${OPENSHIFT_VERSION} from account-roles-create step"
 fi
 
 # If OPENSHIFT_VERSION is set to "release:latest", look at the environment variable


### PR DESCRIPTION
## Summary

- When OPENSHIFT_VERSION=4.23 is requested but not available, account-roles-create silently falls back to the latest version (e.g. 5.0) and writes it to SHARED_DIR/openshift_version. The provision step then provisions a mismatched cluster but the job reports as 4.23 SUCCESS.
- Add a major.minor comparison that fails fast when the fallback version does not match what was requested, with a clear error message.
- Uses a regex guard so the check only applies to concrete version numbers, not release:latest.

## Test plan

- [ ] Verify jobs requesting a valid version (e.g. 4.22) still work when account-roles resolves a matching patch version
- [ ] Verify jobs requesting an unavailable version (e.g. 4.23) fail with a clear error instead of silently provisioning a different version
- [ ] Verify release:latest jobs are unaffected by the check