### PR TITLE
Update the kubevirt-csi-driver golang images to 1.25

### DIFF
--- a/ci-operator/config/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-main.yaml
+++ b/ci-operator/config/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-main.yaml
@@ -12,7 +12,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: rhel-9-release-golang-1.22-openshift-4.17
+    tag: rhel-9-release-golang-1.25-openshift-4.22
 canonical_go_repository: github.com/kubevirt/csi-driver
 images:
   items:


### PR DESCRIPTION
Updated the image to point at golang 1.25 on openshift 4.22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Updates the CI build configuration for the kubevirt-csi-driver component to use Go 1.24 for OpenShift 4.21. The change modifies the base image stream tag in the ci-operator configuration from `rhel-9-release-golang-1.22-openshift-4.17` to `rhel-9-release-golang-1.24-openshift-4.21`, which affects how the kubevirt-csi-driver is built in the OpenShift CI pipeline.

## Changes

Updated the `build_root.image_stream_tag` configuration in the ci-operator config for kubevirt-csi-driver to use the newer Go 1.24 base image aligned with OpenShift 4.21, replacing the previous Go 1.22 image for OpenShift 4.17.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->