### PR TITLE
[DNM]metal-ipi-ovn-metal-bond-debug

### DIFF
--- a/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.22.yaml
+++ b/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.22.yaml
@@ -118,6 +118,23 @@ tests:
       EXTRA_MG_ARGS: --host-network
     workflow: baremetalds-e2e-ovn-dualstack
 - always_run: false
+  as: e2e-metal-ipi-ovn-dualstack-bond-wait
+  capabilities:
+  - intranet
+  optional: true
+  steps:
+    cluster_profile: equinix-ocp-metal
+    env:
+      DEVSCRIPTS_CONFIG: |
+        IP_STACK=v4v6
+        NETWORK_TYPE=OVNKubernetes
+        BOND_PRIMARY_INTERFACE=true
+        NETWORK_CONFIG_FOLDER=./network-configs/bond
+    test:
+    - ref: wait
+    workflow: baremetalds-e2e-ovn-dualstack
+  timeout: 6h0m0s
+- always_run: false
   as: e2e-ovn-hybrid-step-registry
   optional: true
   steps:

--- a/ci-operator/jobs/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.22-presubmits.yaml
@@ -2441,6 +2441,90 @@ presubmits:
     - ^release-4\.22$
     - ^release-4\.22-
     cluster: build09
+    context: ci/prow/e2e-metal-ipi-ovn-dualstack-bond-wait
+    decorate: true
+    decoration_config:
+      timeout: 6h0m0s
+    labels:
+      capability/intranet: intranet
+      ci-operator.openshift.io/cloud: equinix-ocp-metal
+      ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-ovn-kubernetes-release-4.22-e2e-metal-ipi-ovn-dualstack-bond-wait
+    optional: true
+    rerun_command: /test e2e-metal-ipi-ovn-dualstack-bond-wait
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-metal-ipi-ovn-dualstack-bond-wait
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-metal-ipi-ovn-dualstack-bond-wait,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.22$
+    - ^release-4\.22-
+    cluster: build09
     context: ci/prow/e2e-metal-ipi-ovn-dualstack-local-gateway
     decorate: true
     labels:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR adds a new optional e2e test to the OVN Kubernetes CI configuration for OpenShift 4.22, enabling testing of dual-stack networking with bonded interfaces on bare metal infrastructure.

## What Changed

Added a new test entry `e2e-metal-ipi-ovn-dualstack-bond-wait` to the OVN Kubernetes release 4.22 CI configuration. This test expands the bare metal IPI testing coverage by validating OVN Kubernetes networking in a dual-stack (IPv4/IPv6) environment with interface bonding enabled.

## Practical Impact

The change extends OVN Kubernetes CI testing capabilities by introducing a dedicated test scenario for bonded network configurations on Equinix metal infrastructure. The test:
- Runs on bare metal (Equinix equinix-ocp-metal cluster profile)
- Validates dual-stack IP configuration (IPv4 and IPv6)
- Tests with network interface bonding as the primary interface
- Uses the existing baremetalds-e2e-ovn-dualstack workflow with a 6-hour timeout
- Is marked as optional and requires intranet access

This complements existing metal IPI tests for IPv4-only, IPv6-only, and dualstack scenarios by specifically validating bonding behavior.

Note: PR title includes "[DNM]" (Do Not Merge) designation, indicating this is a debug/experimental change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->