### PR TITLE
[do not merge] test

### DIFF
--- a/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__ocm-fvt-rosa-hcp-integration.yaml
+++ b/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__ocm-fvt-rosa-hcp-integration.yaml
@@ -1,0 +1,69 @@
+base_images:
+  nested-podman:
+    name: nested-podman
+    namespace: ci
+    tag: latest
+build_root:
+  image_stream_tag:
+    name: builder
+    namespace: ocp
+    tag: rhel-9-golang-1.24-openshift-4.22
+releases:
+  latest:
+    candidate:
+      product: ocp
+      stream: nightly
+      version: "4.22"
+resources:
+  '*':
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: ocm-fvt-periodic-cs-rosa-hcp-backup-restore-integration-main
+  capabilities:
+  - nested-podman
+  commands: |
+    JOB_LINK="https://prow.ci.openshift.org/view/gs/test-platform-results/"
+    if [ -n "${PULL_NUMBER:-}" ]; then
+      JOB_LINK="${JOB_LINK}pr-logs/pull/openshift_release/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
+    else
+      JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
+    fi
+
+    env -i bash --norc --noprofile << EOF > /tmp/podman.env
+    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
+    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
+    export ENABLE_JIRA_REPORTING=true
+    export JOB_LINK="${JOB_LINK}"
+    source /usr/local/cs-qe-credentials/ocm-tokens
+    source /usr/local/cs-qe-credentials/jira-cred
+    env | grep -v '^_='
+    EOF
+
+    mkdir -p /tmp/ocmci-output
+
+    podman run \
+    --authfile /usr/local/cs-qe-credentials/.dockerconfigjson \
+    --env-file /tmp/podman.env \
+    -v /usr/local/cs-qe-credentials:/credentials:ro,z \
+    -v /tmp/ocmci-output:/ocmci-common/output:z \
+    --rm \
+    quay.io/redhat-services-prod/ocmci/ocmci-common:latest \
+    ocmtest test --service cms --job cs-rosa-hcp-backup-restore-integration-main --reportJiraTicket
+  container:
+    from: nested-podman
+    memory_backed_volume:
+      size: 1Gi
+  cron: 0 8 * * *
+  nested_podman: true
+  secrets:
+  - mount_path: /usr/local/cs-qe-credentials
+    name: cs-qe-credentials
+zz_generated_metadata:
+  branch: main
+  org: openshift-online
+  repo: rosa-e2e
+  variant: ocm-fvt-rosa-hcp-integration

--- a/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-periodics.yaml
@@ -875,6 +875,78 @@ periodics:
     repo: rosa-e2e
   labels:
     capability/nested-podman: nested-podman
+    ci-operator.openshift.io/variant: ocm-fvt-rosa-hcp-integration
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-online-rosa-e2e-main-ocm-fvt-rosa-hcp-integration-ocm-fvt-periodic-cs-rosa-hcp-backup-restore-integration-main
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/cs-qe-credentials
+      - --target=ocm-fvt-periodic-cs-rosa-hcp-backup-restore-integration-main
+      - --variant=ocm-fvt-rosa-hcp-integration
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /secrets/cs-qe-credentials
+        name: cs-qe-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: cs-qe-credentials
+      secret:
+        secretName: cs-qe-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build06
+  cron: 0 8 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-online
+    repo: rosa-e2e
+  labels:
+    capability/nested-podman: nested-podman
     ci-operator.openshift.io/variant: ocm-fvt-rosa-hcp-staging
     ci.openshift.io/generator: prowgen
     job-release: "4.22"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds a new periodic OpenShift CI job to the openshift-online/rosa-e2e configuration that runs a ROSA HCP backup-and-restore integration test and wires credentials/Jira reporting into the run.

What changed
- Adds a daily (cron: "0 8 * * *") periodic job: periodic-ci-openshift-online-rosa-e2e-main-ocm-fvt-rosa-hcp-integration-ocm-fvt-periodic-cs-rosa-hcp-backup-restore-integration-main which invokes the test target ocm-fvt-periodic-cs-rosa-hcp-backup-restore-integration-main.
- Job runs inside nested-podman (base image from: ci/nested-podman:latest) and uses the OCP builder image stream tag ocp/builder:rhel-9-golang-1.24-openshift-4.22.
- Sets pod-wide resource defaults: requests cpu: 100m, memory: 200Mi; memory limit: 4Gi.
- Test step behavior:
  - Constructs a JOB_LINK pointing to prow test results (uses PR path when PULL_NUMBER is set) and emits debug output.
  - Creates a temporary podman env file, sources AWS/OCM tokens and Jira credentials from the mounted secret cs-qe-credentials (mounted at /usr/local/cs-qe-credentials), exports credential file paths and ENABLE_JIRA_REPORTING=true, writes JOB_LINK to the env file.
  - Runs quay.io/redhat-services-prod/ocmci/ocmci-common:latest via podman with the authfile and env file, executing: ocmtest test --service cms --job cs-rosa-hcp-backup-restore-integration-main --reportJiraTicket.
- Adds zz_generated_metadata for branch/org/repo/variant: main / openshift-online / rosa-e2e / ocm-fvt-rosa-hcp-integration.

Impact
- Adds automated daily verification of ROSA HCP backup-and-restore workflows to the OpenShift CI pipeline with credentials sourced from cs-qe-credentials and Jira reporting enabled, helping detect regressions in backup/restore functionality for ROSA HCP clusters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->