### PR TITLE
Require lint check for openshift/agentic-skills

### DIFF
--- a/core-services/prow/02_config/openshift/agentic-skills/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/agentic-skills/_prowconfig.yaml
@@ -1,3 +1,14 @@
+branch-protection:
+  orgs:
+    openshift:
+      repos:
+        agentic-skills:
+          branches:
+            main:
+              protect: true
+              required_status_checks:
+                contexts:
+                - lint
 tide:
   queries:
   - labels:


### PR DESCRIPTION
## Summary
- Add branch protection requiring the `lint` GitHub Actions check to pass before merging to main on `openshift/agentic-skills`
- Mirrors the existing setup on `openshift-eng/ai-helpers`
- The lint job runs [skillsaw](https://github.com/stbenjam/skillsaw) to enforce the [agentskills.io specification](https://agentskills.io/specification)

Depends on: https://github.com/openshift/agentic-skills/pull/19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR enables branch protection on the `main` branch of the `openshift/agentic-skills` repository, requiring the `lint` status check to pass before PRs can be merged. 

The configuration adds a Prow branch protection rule that enforces execution of a GitHub Actions `lint` job, which runs skillsaw to validate changes against the agentskills.io specification. This mirrors the pattern already in place for `openshift-eng/ai-helpers`, ensuring consistent code quality enforcement across similar agent-based skill repositories.

The change applies only to the CI configuration for the agentic-skills repository and does not modify any code or exported entities. The existing Tide merge automation configuration for the repository remains intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->