### PR TITLE
OCM-23810: Migrate cs-hcp-e2e-staging-main FVT to Prow

### DIFF
--- a/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__ocm-fvt-rosa-hcp-staging.yaml
+++ b/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__ocm-fvt-rosa-hcp-staging.yaml
@@ -324,6 +324,46 @@ tests:
   secrets:
   - mount_path: /usr/local/cs-qe-credentials
     name: cs-qe-credentials
+- as: ocm-fvt-periodic-cs-hcp-e2e-staging-main
+  capabilities:
+  - nested-podman
+  commands: |
+    JOB_LINK="https://prow.ci.openshift.org/view/gs/test-platform-results/"
+    if [ -n "${PULL_NUMBER:-}" ]; then
+      JOB_LINK="${JOB_LINK}pr-logs/pull/openshift_release/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
+    else
+      JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
+    fi
+
+    podman_env_file="$(mktemp /tmp/podman.env.XXXXXX)"
+    trap 'rm -f "${podman_env_file}"' EXIT
+    umask 077
+    env -i bash --norc --noprofile << EOF > "${podman_env_file}"
+    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
+    export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
+    export ENABLE_JIRA_REPORTING=true
+    export JOB_LINK="${JOB_LINK}"
+    source /usr/local/cs-qe-credentials/ocm-tokens
+    source /usr/local/cs-qe-credentials/jira-cred
+    env | grep -v '^_='
+    EOF
+
+    podman run \
+    --authfile /usr/local/cs-qe-credentials/.dockerconfigjson \
+    --env-file "${podman_env_file}" \
+    -v /usr/local/cs-qe-credentials:/credentials:ro,z \
+    --rm \
+    quay.io/redhat-services-prod/ocmci/ocmci:latest \
+    ocmtest test --service cms --job cs-hcp-e2e-staging-main --reportJiraTicket
+  container:
+    from: nested-podman
+    memory_backed_volume:
+      size: 1Gi
+  cron: 30 9 * * *
+  nested_podman: true
+  secrets:
+  - mount_path: /usr/local/cs-qe-credentials
+    name: cs-qe-credentials
 zz_generated_metadata:
   branch: main
   org: openshift-online

--- a/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-periodics.yaml
@@ -865,6 +865,78 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build06
+  cron: 30 9 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-online
+    repo: rosa-e2e
+  labels:
+    capability/nested-podman: nested-podman
+    ci-operator.openshift.io/variant: ocm-fvt-rosa-hcp-staging
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-online-rosa-e2e-main-ocm-fvt-rosa-hcp-staging-ocm-fvt-periodic-cs-hcp-e2e-staging-main
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/cs-qe-credentials
+      - --target=ocm-fvt-periodic-cs-hcp-e2e-staging-main
+      - --variant=ocm-fvt-rosa-hcp-staging
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /secrets/cs-qe-credentials
+        name: cs-qe-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: cs-qe-credentials
+      secret:
+        secretName: cs-qe-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build06
   cron: 0 8 * * *
   decorate: true
   decoration_config:


### PR DESCRIPTION
## Summary
- Add cs-hcp-e2e-staging-main periodic job to the ocm-fvt-rosa-hcp-staging variant
- Uses existing nested-podman + ocmci pattern matching other FVT migration jobs
- Cron set to 30 9 UTC daily, staggered from existing jobs (0 8 and 0 9)

Jira: https://redhat.atlassian.net/browse/OCM-23810

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds a new periodic Prow test to the openshift/release CI configuration for the openshift-online/rosa-e2e repository (variant: ocm-fvt-rosa-hcp-staging), migrating the cs-hcp-e2e-staging FVT to the established nested-podman + ocmci pattern.

What changed (practical impact)
- CI/infrastructure affected: openshift/release — modifies ci-operator config for openshift-online/rosa-e2e (variant ocm-fvt-rosa-hcp-staging).
- New periodic job: ocm-fvt-periodic-cs-hcp-e2e-staging-main.
- Schedule: daily at 09:30 UTC (cron: "30 9 * * *") to stagger from other jobs.
- Execution pattern: runs inside nested-podman (container from base image nested-podman) and launches quay.io/redhat-services-prod/ocmci/ocmci:latest via podman, matching other migrated FVT jobs.
- Test invocation: ocmtest test --service cms --job cs-hcp-e2e-staging-main --reportJiraTicket.
- Credentials and environment:
  - Mounts the cs-qe-credentials secret at /usr/local/cs-qe-credentials and uses its .dockerconfigjson as podman --authfile.
  - Creates a temporary env file (mktemp), uses umask 077 and trap cleanup, exports AWS credential paths, ENABLE_JIRA_REPORTING=true and JOB_LINK, then sources ocm tokens and Jira creds from the mounted secret and passes the env file into podman.
- Resources: allocates a 1Gi memory_backed_volume for the nested-podman container.
- Variant metadata: zz_generated_metadata lists branch main, org openshift-online, repo rosa-e2e, variant ocm-fvt-rosa-hcp-staging.

Related issue
- Tracks Jira [OCM-23810](https://redhat.atlassian.net/browse/OCM-23810): https://redhat.atlassian.net/browse/OCM-23810

Review notes
- The openshift-ci-robot confirmed the Jira reference but warned the referenced Jira issue has no target version set for branch main (it expected "5.0.0"); consider updating the Jira issue if needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[OCM-23810]: https://redhat.atlassian.net/browse/OCM-23810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ