### PR TITLE
AUTOSCALE-586: Promote karpenter-operator image

### DIFF
--- a/ci-operator/config/openshift/karpenter-operator/openshift-karpenter-operator-main.yaml
+++ b/ci-operator/config/openshift/karpenter-operator/openshift-karpenter-operator-main.yaml
@@ -23,9 +23,19 @@ resources:
       memory: 200Mi
 tests:
 - as: e2e-aws
+  skip_if_only_changed: ^docs/|^\.github|\.md$|\.mdc$|^(?:.*/)?(?:\.gitignore|\.coderabbit\.yaml|OWNERS|OWNERS_ALIASES|PROJECT|LICENSE)$
   steps:
     cluster_profile: openshift-org-aws
     workflow: openshift-e2e-aws
+- as: verify
+  commands: |
+    export GOCACHE=/tmp/
+    export GOLANGCI_LINT_CACHE=/tmp/.cache
+    export GOPROXY=https://proxy.golang.org
+    make verify
+  container:
+    from: src
+  skip_if_only_changed: ^docs/|^\.github|\.md$|\.mdc$|^(?:.*/)?(?:\.gitignore|\.coderabbit\.yaml|OWNERS|OWNERS_ALIASES|PROJECT|LICENSE)$
 zz_generated_metadata:
   branch: main
   org: openshift

--- a/ci-operator/config/openshift/karpenter-operator/openshift-karpenter-operator-main.yaml
+++ b/ci-operator/config/openshift/karpenter-operator/openshift-karpenter-operator-main.yaml
@@ -1,5 +1,9 @@
 build_root:
   from_repository: true
+images:
+  items:
+  - dockerfile_path: Dockerfile
+    to: karpenter-operator
 promotion:
   to:
   - name: "5.0"

--- a/ci-operator/config/openshift/karpenter-operator/openshift-karpenter-operator-main.yaml
+++ b/ci-operator/config/openshift/karpenter-operator/openshift-karpenter-operator-main.yaml
@@ -30,6 +30,8 @@ tests:
   skip_if_only_changed: ^docs/|^\.github|\.md$|\.mdc$|^(?:.*/)?(?:\.gitignore|\.coderabbit\.yaml|OWNERS|OWNERS_ALIASES|PROJECT|LICENSE)$
   steps:
     cluster_profile: openshift-org-aws
+    env:
+      FEATURE_SET: DevPreviewNoUpgrade
     workflow: openshift-e2e-aws
 - as: verify
   commands: |

--- a/ci-operator/jobs/openshift/karpenter-operator/openshift-karpenter-operator-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/karpenter-operator/openshift-karpenter-operator-main-postsubmits.yaml
@@ -6,6 +6,10 @@ postsubmits:
     - ^main$
     cluster: build01
     decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - .ci-operator.yaml
+      - Dockerfile
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen

--- a/ci-operator/jobs/openshift/karpenter-operator/openshift-karpenter-operator-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/karpenter-operator/openshift-karpenter-operator-main-postsubmits.yaml
@@ -1,0 +1,60 @@
+postsubmits:
+  openshift/karpenter-operator:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    cluster: build01
+    decorate: true
+    labels:
+      ci-operator.openshift.io/is-promotion: "true"
+      ci.openshift.io/generator: prowgen
+    max_concurrency: 1
+    name: branch-ci-openshift-karpenter-operator-main-images
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --image-mirror-push-secret=/etc/push-secret/.dockerconfigjson
+        - --promote
+        - --report-credentials-file=/etc/report/credentials
+        - --target=[images]
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/push-secret
+          name: push-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: push-secret
+        secret:
+          secretName: registry-push-credentials-ci-central
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator

--- a/ci-operator/jobs/openshift/karpenter-operator/openshift-karpenter-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/karpenter-operator/openshift-karpenter-operator-main-presubmits.yaml
@@ -11,6 +11,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
+      - Dockerfile
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -92,6 +93,10 @@ presubmits:
     cluster: build06
     context: ci/prow/images
     decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - .ci-operator.yaml
+      - Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -146,6 +151,10 @@ presubmits:
     cluster: build03
     context: ci/prow/verify
     decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - .ci-operator.yaml
+      - Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"

--- a/ci-operator/jobs/openshift/karpenter-operator/openshift-karpenter-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/karpenter-operator/openshift-karpenter-operator-main-presubmits.yaml
@@ -85,6 +85,60 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-aws,?($|\s.*)
   - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build06
+    context: ci/prow/images
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-karpenter-operator-main-images
+    rerun_command: /test images
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=[images]
+        - --target=[release:latest]
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )images,?($|\s.*)
+  - agent: kubernetes
     always_run: false
     branches:
     - ^main$

--- a/ci-operator/jobs/openshift/karpenter-operator/openshift-karpenter-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/karpenter-operator/openshift-karpenter-operator-main-presubmits.yaml
@@ -1,7 +1,7 @@
 presubmits:
   openshift/karpenter-operator:
   - agent: kubernetes
-    always_run: true
+    always_run: false
     branches:
     - ^main$
     - ^main-
@@ -18,6 +18,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-karpenter-operator-main-e2e-aws
     rerun_command: /test e2e-aws
+    skip_if_only_changed: ^docs/|^\.github|\.md$|\.mdc$|^(?:.*/)?(?:\.gitignore|\.coderabbit\.yaml|OWNERS|OWNERS_ALIASES|PROJECT|LICENSE)$
     spec:
       containers:
       - args:
@@ -83,3 +84,65 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-aws,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build03
+    context: ci/prow/verify
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-karpenter-operator-main-verify
+    rerun_command: /test verify
+    skip_if_only_changed: ^docs/|^\.github|\.md$|\.mdc$|^(?:.*/)?(?:\.gitignore|\.coderabbit\.yaml|OWNERS|OWNERS_ALIASES|PROJECT|LICENSE)$
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=verify
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )verify,?($|\s.*)


### PR DESCRIPTION
Adds a postsubmit job to promote the karpenter-operator image to be published to the ci stream as release artifact.

Also adds the verify job to karpenter-operator repo which will check go vet, fmt, lint, and unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR updates OpenShift CI configuration for the openshift/karpenter-operator repository to add image promotion into the CI release stream and introduce PR-level verification.

Practical impact
- Affects OpenShift CI config for openshift/karpenter-operator: the component’s image is now built from the repo Dockerfile and promoted as a release artifact into the CI release stream; PRs to the component are validated with a new verify job that enforces formatting, vetting, linting and unit tests.

Key changes
1. Image build & promotion
   - Declares an image built from the repository Dockerfile (images mapping -> dockerfile_path: Dockerfile -> to: karpenter-operator).
   - Adds a postsubmit promotion job to publish the built image to the CI release stream as a release artifact.

2. Verify job (PR gating)
   - Adds a verify job in the karpenter-operator repository that runs make verify (go vet, go fmt, lint, unit tests) inside a container built from the repo (container.from: src). This gates PRs with automated checks.

3. e2e-aws behavior & test gating
   - Configures existing e2e-aws to skip runs when changes are limited to docs, GitHub metadata, Markdown, and similar non-code paths; the new verify job uses the same skip_if_only_changed rule.

Other notes
- No changes to exported/public code entities (CI/config-only).
- The PR links to [AUTOSCALE-586](https://redhat.atlassian.net/browse/AUTOSCALE-586) and includes rehearsals; CI bot noted the Jira issue is valid but flagged a missing/invalid target version for the PR's target branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[AUTOSCALE-586]: https://redhat.atlassian.net/browse/AUTOSCALE-586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ