### PR TITLE
switch e2e-aws-ovn-public-ipv4-pool to aws-1 cluster profile for 4.22

### DIFF
--- a/ci-operator/config/openshift/installer/openshift-installer-release-4.22.yaml
+++ b/ci-operator/config/openshift/installer/openshift-installer-release-4.22.yaml
@@ -1471,9 +1471,11 @@ tests:
     cluster_profile: openshift-org-aws
     env:
       AWS_PUBLIC_IPV4_POOL_ID: ipv4pool-ec2-0768267342e327ea9
+      AWS_REGION_OVERWRITE: us-east-1
+      ENFORCE_IPV4_POOL: "yes"
     leases:
     - env: LEASED_RESOURCE
-      resource_type: aws-3-quota-slice
+      resource_type: aws-quota-slice
     workflow: openshift-e2e-aws
 - always_run: false
   as: e2e-aws-ovn-public-ipv4-pool-disabled

--- a/ci-operator/step-registry/ipi/conf/aws/byo-ipv4-pool-public/ipi-conf-aws-byo-ipv4-pool-public-commands.sh
+++ b/ci-operator/step-registry/ipi/conf/aws/byo-ipv4-pool-public/ipi-conf-aws-byo-ipv4-pool-public-commands.sh
@@ -34,7 +34,7 @@ if version_lt "${ocp_version}" "4.16"; then
 fi
 
 export AWS_SHARED_CREDENTIALS_FILE="${CLUSTER_PROFILE_DIR}/.awscred"
-export AWS_REGION="${LEASED_RESOURCE}"
+export AWS_REGION="${AWS_REGION_OVERWRITE:-${LEASED_RESOURCE}}"
 
 CONFIG="${SHARED_DIR}/install-config.yaml"
 


### PR DESCRIPTION
Use aws-quota-slice lease to pin the job to us-east-1.

Notes: I need to run a rehearsal to cover this install scenarion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
OpenShift CI configuration (openshift/installer release-4.22) — updates CI job and step-registry to support running the e2e-aws-ovn-public-ipv4-pool install in the aws-1 cluster profile and pin it to us-east-1.

What changed practically
- ci-operator config: the e2e-aws-ovn-public-ipv4-pool job for the 4.22 release now sets AWS_REGION_OVERWRITE=us-east-1 and ENFORCE_IPV4_POOL="yes" in the job environment (so the job is pinned to us-east-1 and will fail if a BYOIP pool is required but not available). The job’s lease resource_type was changed from aws-3-quota-slice to aws-quota-slice (to acquire the aws-quota-slice lease for regional placement). The job is intended to run with the aws-1 cluster profile for this install scenario.
- step-registry script: the ipi-conf aws BYO IPv4 pool commands script now prefers AWS_REGION_OVERWRITE when determining AWS_REGION (AWS_REGION="${AWS_REGION_OVERWRITE:-${LEASED_RESOURCE}}"), falling back to the leased resource if overwrite is not set. The script’s pool-id persistence behavior is unchanged (it still writes the selected pool_id to ${SHARED_DIR}/ipv4_pool_id).

Additional notes
- No exported/public code entities were changed — only CI job/config and CI step script updates.
- The PR author placed the PR on hold and issued rehearsal commands (requested a rehearse for the specific 4.22 job, aborted, then re-requested the rehearse) to validate the install scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->