### PR TITLE
NO-JIRA: fix: resolve install failure for tna platform none

### DIFF
--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22.yaml
@@ -857,6 +857,7 @@ tests:
         AGENT_E2E_TEST_SCENARIO=TNA_IPV4
         AGENT_PLATFORM_TYPE=none
         NETWORK_TYPE=OVNKubernetes
+        NUM_WORKERS=0
     test:
     - chain: agent-test
     workflow: agent-e2e-two-node-arbiter-ipv4

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.23.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.23.yaml
@@ -823,6 +823,21 @@ tests:
   steps:
     cluster_profile: equinix-edge-enablement
     workflow: baremetalds-two-node-arbiter-e2e-openshift-test-private-tests
+- as: e2e-agent-ovn-two-node-arbiter-none-platform
+  capabilities:
+  - intranet
+  cron: '@daily'
+  steps:
+    cluster_profile: equinix-edge-enablement
+    env:
+      DEVSCRIPTS_CONFIG: |
+        AGENT_E2E_TEST_SCENARIO=TNA_IPV4
+        AGENT_PLATFORM_TYPE=none
+        NETWORK_TYPE=OVNKubernetes
+        NUM_WORKERS=0
+    test:
+    - chain: agent-test
+    workflow: agent-e2e-two-node-arbiter-ipv4
 - as: e2e-metal-ovn-two-node-fencing-extended
   capabilities:
   - intranet

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
@@ -916,6 +916,21 @@ tests:
   steps:
     cluster_profile: equinix-edge-enablement
     workflow: baremetalds-two-node-arbiter-e2e-openshift-test-private-tests
+- as: e2e-agent-ovn-two-node-arbiter-none-platform
+  capabilities:
+  - intranet
+  cron: '@daily'
+  steps:
+    cluster_profile: equinix-edge-enablement
+    env:
+      DEVSCRIPTS_CONFIG: |
+        AGENT_E2E_TEST_SCENARIO=TNA_IPV4
+        AGENT_PLATFORM_TYPE=none
+        NETWORK_TYPE=OVNKubernetes
+        NUM_WORKERS=0
+    test:
+    - chain: agent-test
+    workflow: agent-e2e-two-node-arbiter-ipv4
 - as: e2e-metal-ovn-two-node-fencing-extended
   capabilities:
   - intranet


### PR DESCRIPTION
add no workers since the default upstream script now ingests default worker value of 3
added missing lane for 4.23 and 5.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes CI test configuration for OpenShift's Trusted Node Agent (TNA) platform testing by addressing worker count configuration and adding missing test lanes.

## Changes Made

**Updated existing test in v4.22:**
- Modified the `e2e-agent-ovn-two-node-arbiter-none-platform` test to explicitly set `NUM_WORKERS=0` in the environment configuration. This is necessary because the upstream test script now defaults to 3 workers, but TNA's "none" platform requires zero workers.

**Added missing test lanes in v4.23 and v5.0:**
- Introduced the `e2e-agent-ovn-two-node-arbiter-none-platform` test configuration to both the 4.23 and 5.0 release branches. Each test:
  - Runs daily on the `equinix-edge-enablement` cluster profile
  - Configures the agent E2E test with `AGENT_E2E_TEST_SCENARIO=TNA_IPV4`, `AGENT_PLATFORM_TYPE=none`, `NETWORK_TYPE=OVNKubernetes`, and `NUM_WORKERS=0`
  - Executes the `agent-e2e-two-node-arbiter-ipv4` workflow

## Impact

These changes ensure that TNA installation testing for the "none" platform type (which uses no worker nodes) works correctly across OpenShift releases 4.22, 4.23, and 5.0 by aligning with the new upstream default worker count behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->