### PR TITLE
no-jira: Add skillsaw lint and LLM security scan Prow jobs for agentic-skills

### DIFF
--- a/ci-operator/config/openshift/agentic-skills/openshift-agentic-skills-main.yaml
+++ b/ci-operator/config/openshift/agentic-skills/openshift-agentic-skills-main.yaml
@@ -13,14 +13,14 @@ images:
       FROM python-311
       COPY . /src
       WORKDIR /src
-      RUN pip install cisco-ai-skill-scanner
+      RUN pip install "cisco-ai-skill-scanner[vertex]" skillsaw
     from: python-311
     inputs:
       src:
         paths:
         - destination_dir: .
           source_path: /go/src/github.com/openshift/agentic-skills/.
-    to: skill-scanner
+    to: skill-tools
 promotion:
   to:
   - name: "5.0"
@@ -39,14 +39,16 @@ resources:
       cpu: 100m
       memory: 200Mi
 tests:
-- as: eval
-  commands: |
-    skill-scanner scan-all . --recursive --check-overlap --format json \
-      --fail-on-severity medium \
-      --output "${ARTIFACT_DIR}/skill-scanner-report.json"
-  container:
-    from: skill-scanner
-  skip_if_only_changed: ^(README\.md|OWNERS|LICENSE|AGENTS\.md|CLAUDE\.md|\.gitignore)$
+- as: lint
+  skip_if_only_changed: ^(README\.md|OWNERS|LICENSE|\.gitignore)$
+  steps:
+    test:
+    - ref: openshift-harness-lint
+- as: security-scan
+  skip_if_only_changed: ^(README\.md|OWNERS|LICENSE|\.gitignore)$
+  steps:
+    test:
+    - ref: openshift-harness-security-scan
 zz_generated_metadata:
   branch: main
   org: openshift

--- a/ci-operator/jobs/openshift/agentic-skills/openshift-agentic-skills-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/agentic-skills/openshift-agentic-skills-main-presubmits.yaml
@@ -1,68 +1,6 @@
 presubmits:
   openshift/agentic-skills:
   - agent: kubernetes
-    always_run: false
-    branches:
-    - ^main$
-    - ^main-
-    cluster: build04
-    context: ci/prow/eval
-    decorate: true
-    labels:
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-agentic-skills-main-eval
-    rerun_command: /test eval
-    skip_if_only_changed: ^(README\.md|OWNERS|LICENSE|AGENTS\.md|CLAUDE\.md|\.gitignore)$
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --report-credentials-file=/etc/report/credentials
-        - --target=eval
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )eval,?($|\s.*)
-  - agent: kubernetes
     always_run: true
     branches:
     - ^main$
@@ -116,3 +54,161 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )images,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build04
+    context: ci/prow/lint
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-agentic-skills-main-lint
+    rerun_command: /test lint
+    skip_if_only_changed: ^(README\.md|OWNERS|LICENSE|\.gitignore)$
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=lint
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )lint,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build04
+    context: ci/prow/security-scan
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-agentic-skills-main-security-scan
+    rerun_command: /test security-scan
+    skip_if_only_changed: ^(README\.md|OWNERS|LICENSE|\.gitignore)$
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=security-scan
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )security-scan,?($|\s.*)

--- a/ci-operator/step-registry/openshift/harness/OWNERS
+++ b/ci-operator/step-registry/openshift/harness/OWNERS
@@ -1,0 +1,12 @@
+approvers:
+- bryan-cox
+- cblecker
+- Cali0707
+- enxebre
+- stbenjam
+reviewers:
+- bryan-cox
+- cblecker
+- Cali0707
+- enxebre
+- stbenjam

--- a/ci-operator/step-registry/openshift/harness/lint/OWNERS
+++ b/ci-operator/step-registry/openshift/harness/lint/OWNERS
@@ -1,0 +1,12 @@
+approvers:
+- bryan-cox
+- cblecker
+- Cali0707
+- enxebre
+- stbenjam
+reviewers:
+- bryan-cox
+- cblecker
+- Cali0707
+- enxebre
+- stbenjam

--- a/ci-operator/step-registry/openshift/harness/lint/openshift-harness-lint-commands.sh
+++ b/ci-operator/step-registry/openshift/harness/lint/openshift-harness-lint-commands.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "Running skillsaw linter..."
+skillsaw -v

--- a/ci-operator/step-registry/openshift/harness/lint/openshift-harness-lint-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/harness/lint/openshift-harness-lint-ref.metadata.json
@@ -1,0 +1,19 @@
+{
+	"path": "openshift/harness/lint/openshift-harness-lint-ref.yaml",
+	"owners": {
+		"approvers": [
+			"bryan-cox",
+			"cblecker",
+			"Cali0707",
+			"enxebre",
+			"stbenjam"
+		],
+		"reviewers": [
+			"bryan-cox",
+			"cblecker",
+			"Cali0707",
+			"enxebre",
+			"stbenjam"
+		]
+	}
+}

--- a/ci-operator/step-registry/openshift/harness/lint/openshift-harness-lint-ref.yaml
+++ b/ci-operator/step-registry/openshift/harness/lint/openshift-harness-lint-ref.yaml
@@ -1,0 +1,14 @@
+ref:
+  as: openshift-harness-lint
+  from: skill-tools
+  commands: openshift-harness-lint-commands.sh
+  resources:
+    requests:
+      cpu: 100m
+      memory: 100Mi
+  timeout: 5m0s
+  grace_period: 30s
+  documentation: |-
+    Runs skillsaw to lint agent skills against the agentskills.io
+    specification. Validates skill frontmatter, naming conventions,
+    directory structure, and evals format.

--- a/ci-operator/step-registry/openshift/harness/security-scan/OWNERS
+++ b/ci-operator/step-registry/openshift/harness/security-scan/OWNERS
@@ -1,0 +1,12 @@
+approvers:
+- bryan-cox
+- cblecker
+- Cali0707
+- enxebre
+- stbenjam
+reviewers:
+- bryan-cox
+- cblecker
+- Cali0707
+- enxebre
+- stbenjam

--- a/ci-operator/step-registry/openshift/harness/security-scan/openshift-harness-security-scan-commands.sh
+++ b/ci-operator/step-registry/openshift/harness/security-scan/openshift-harness-security-scan-commands.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -euo pipefail
+
+LLM_FLAG=""
+if [[ "${USE_LLM}" == "true" ]]; then
+  LLM_FLAG="--use-llm"
+  echo "Running skill-scanner with LLM-based semantic analysis..."
+  echo "Model: ${SKILL_SCANNER_LLM_MODEL}"
+else
+  echo "Running skill-scanner with static rules only (LLM disabled)..."
+fi
+
+# shellcheck disable=SC2086
+skill-scanner scan-all . --recursive --check-overlap ${LLM_FLAG} \
+  --fail-on-severity medium \
+  --format json \
+  --output-json "${ARTIFACT_DIR}/skill-scanner-report.json" \
+  --format html \
+  --output-html "${ARTIFACT_DIR}/skill-scanner-summary.html" \
+  ${SCAN_ADDITIONAL_ARGS}

--- a/ci-operator/step-registry/openshift/harness/security-scan/openshift-harness-security-scan-ref.metadata.json
+++ b/ci-operator/step-registry/openshift/harness/security-scan/openshift-harness-security-scan-ref.metadata.json
@@ -1,0 +1,19 @@
+{
+	"path": "openshift/harness/security-scan/openshift-harness-security-scan-ref.yaml",
+	"owners": {
+		"approvers": [
+			"bryan-cox",
+			"cblecker",
+			"Cali0707",
+			"enxebre",
+			"stbenjam"
+		],
+		"reviewers": [
+			"bryan-cox",
+			"cblecker",
+			"Cali0707",
+			"enxebre",
+			"stbenjam"
+		]
+	}
+}

--- a/ci-operator/step-registry/openshift/harness/security-scan/openshift-harness-security-scan-ref.yaml
+++ b/ci-operator/step-registry/openshift/harness/security-scan/openshift-harness-security-scan-ref.yaml
@@ -1,0 +1,35 @@
+ref:
+  as: openshift-harness-security-scan
+  from: skill-tools
+  commands: openshift-harness-security-scan-commands.sh
+  credentials:
+  - mount_path: /var/run/claude-code-service-account
+    name: sa-claude-openshift-ci
+    namespace: test-credentials
+  env:
+  - name: GOOGLE_APPLICATION_CREDENTIALS
+    default: /var/run/claude-code-service-account/token
+    documentation: Path to the GCP service account key for Vertex AI access.
+  - name: SKILL_SCANNER_LLM_MODEL
+    default: vertex_ai/claude-sonnet-4-6
+    documentation: LiteLLM model string for LLM-based semantic analysis.
+  - name: VERTEXAI_LOCATION
+    default: global
+    documentation: Vertex AI region for model serving.
+  - name: USE_LLM
+    default: "true"
+    documentation: Set to "false" to disable LLM-based semantic analysis and use only static YARA rules.
+  - name: SCAN_ADDITIONAL_ARGS
+    default: ""
+    documentation: Additional arguments to pass to skill-scanner.
+  resources:
+    requests:
+      cpu: 100m
+      memory: 100Mi
+  timeout: 10m0s
+  grace_period: 5m0s
+  documentation: |-
+    Runs cisco-ai-skill-scanner with LLM-based semantic analysis
+    (via Vertex AI / Claude Sonnet) to detect prompt injection,
+    data exfiltration, command injection, and other agent security
+    issues. Fails on medium severity findings by default.


### PR DESCRIPTION
## Summary
- Add reusable step-registry refs `openshift-harness-lint` and `openshift-harness-security-scan` for agent skill validation
- `openshift-harness-lint` runs [skillsaw](https://github.com/stbenjam/skillsaw) to validate skills against the [agentskills.io spec](https://agentskills.io/specification)
- `openshift-harness-security-scan` runs [cisco-ai-skill-scanner](https://github.com/cisco-ai-defense/skill-scanner) with LLM-as-judge (Vertex AI / Claude Sonnet 4.6) to detect prompt injection, data exfiltration, and command injection
- Wire both refs to the `openshift/agentic-skills` main branch CI config, replacing the previous inline `eval` test
- Both refs share a single `skill-tools` pipeline image


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR updates OpenShift CI configuration to add two reusable step-registry refs and wire them into the openshift/agentic-skills main-branch pipeline, replacing the previous inline eval test.

### What changed (practical terms)
- Affected area: openshift/agentic-skills CI (ci-operator config) and new step-registry entries under ci-operator/step-registry/openshift/harness.
- The agentic-skills CI image build now installs both skillsaw and cisco-ai-skill-scanner[vertex] and publishes that image as to: skill-tools. The main-branch pipeline replaces the old inline `eval` test with two reusable refs:
  - lint — ref: openshift-harness-lint (runs skillsaw)
  - security-scan — ref: openshift-harness-security-scan (runs cisco-ai-skill-scanner, LLM-enabled by default)
- Both jobs use a skip-if-only-changed pattern: ^(README\.md|OWNERS|LICENSE|\.gitignore)$.

### New reusable step-registry refs
- openshift-harness-lint
  - Runs skillsaw via openshift-harness-lint-commands.sh from the skill-tools image.
  - Validates agentskills.io frontmatter, naming conventions, directory structure, and eval formats.
  - Requests: 100m CPU / 100Mi RAM; timeout 5m; 30s grace period.

- openshift-harness-security-scan
  - Runs skill-scanner (cisco-ai-skill-scanner) via openshift-harness-security-scan-commands.sh.
  - Default enables LLM-based semantic analysis (USE_LLM="true") with SKILL_SCANNER_LLM_MODEL=vertex_ai/claude-sonnet-4-6 and VERTEXAI_LOCATION=global.
  - Emits JSON and HTML reports to ARTIFACT_DIR, fails on medium severity findings by default, and accepts extra CLI args via SCAN_ADDITIONAL_ARGS.
  - Mounts credential sa-claude-openshift-ci from namespace test-credentials and sets GOOGLE_APPLICATION_CREDENTIALS to the mounted token path.
  - Requests: 100m CPU / 100Mi RAM; timeout 10m; 5m grace period.

### Metadata and OWNERS
- Added/updated OWNERS and step-ref metadata for the new refs and parent harness directory, adding approvers and reviewers: bryan-cox, cblecker, Cali0707, enxebre, stbenjam.

### Test plan / operational notes
- Prow rehearsals must pass for the new lint and security-scan jobs.
- The sa-claude-openshift-ci credential must be provisioned in the test-credentials namespace for LLM-based scans to authenticate to Vertex AI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->