### PR TITLE
Onboard openshift-online/rosa-boundary to Prow

### DIFF
--- a/ci-operator/config/openshift-online/rosa-boundary/OWNERS
+++ b/ci-operator/config/openshift-online/rosa-boundary/OWNERS
@@ -1,0 +1,13 @@
+# DO NOT EDIT; this file is auto-generated using https://github.com/openshift/ci-tools.
+# Fetched from https://github.com/openshift-online/rosa-boundary root OWNERS
+# If the repo had OWNERS_ALIASES then the aliases were expanded
+# Logins who are not members of 'openshift' organization were filtered out
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+- jhjaggars
+- tiwillia
+options: {}
+reviewers:
+- jhjaggars
+- tiwillia

--- a/ci-operator/config/openshift-online/rosa-boundary/openshift-online-rosa-boundary-main.yaml
+++ b/ci-operator/config/openshift-online/rosa-boundary/openshift-online-rosa-boundary-main.yaml
@@ -36,6 +36,7 @@ resources:
 tests:
 - as: lambda-unit-tests
   commands: |
+    export UV_CACHE_DIR=/tmp/uv-cache
     cd /workspace/rosa-boundary/lambda/create-investigation
     uv run pytest test_handler.py -v
   container:

--- a/ci-operator/config/openshift-online/rosa-boundary/openshift-online-rosa-boundary-main.yaml
+++ b/ci-operator/config/openshift-online/rosa-boundary/openshift-online-rosa-boundary-main.yaml
@@ -1,0 +1,46 @@
+base_images:
+  ubi-python:
+    name: ubi-python-311
+    namespace: ocp
+    tag: "9"
+build_root:
+  image_stream_tag:
+    name: release
+    namespace: openshift
+    tag: rhel-9-release-golang-1.23-openshift-4.18
+images:
+  items:
+  - dockerfile_literal: |
+      FROM ubi-python
+      USER 0
+      COPY . /workspace/
+      WORKDIR /workspace/rosa-boundary/lambda/create-investigation
+      RUN pip install uv && uv sync
+    from: ubi-python
+    inputs:
+      src:
+        paths:
+        - destination_dir: .
+          source_path: /go/src/github.com/openshift-online/rosa-boundary
+    to: lambda-test-runner
+prowgen:
+  expose: true
+  private: true
+resources:
+  '*':
+    limits:
+      memory: 1Gi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: lambda-unit-tests
+  commands: |
+    cd /workspace/rosa-boundary/lambda/create-investigation
+    uv run pytest test_handler.py -v
+  container:
+    from: lambda-test-runner
+zz_generated_metadata:
+  branch: main
+  org: openshift-online
+  repo: rosa-boundary

--- a/ci-operator/config/openshift-online/rosa-boundary/openshift-online-rosa-boundary-main.yaml
+++ b/ci-operator/config/openshift-online/rosa-boundary/openshift-online-rosa-boundary-main.yaml
@@ -37,6 +37,7 @@ tests:
 - as: lambda-unit-tests
   commands: |
     export UV_CACHE_DIR=/tmp/uv-cache
+    export AWS_DEFAULT_REGION=us-east-1
     cd /workspace/rosa-boundary/lambda/create-investigation
     uv run pytest test_handler.py -v
   container:

--- a/ci-operator/jobs/openshift-online/rosa-boundary/OWNERS
+++ b/ci-operator/jobs/openshift-online/rosa-boundary/OWNERS
@@ -1,0 +1,13 @@
+# DO NOT EDIT; this file is auto-generated using https://github.com/openshift/ci-tools.
+# Fetched from https://github.com/openshift-online/rosa-boundary root OWNERS
+# If the repo had OWNERS_ALIASES then the aliases were expanded
+# Logins who are not members of 'openshift' organization were filtered out
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+- jhjaggars
+- tiwillia
+options: {}
+reviewers:
+- jhjaggars
+- tiwillia

--- a/ci-operator/jobs/openshift-online/rosa-boundary/openshift-online-rosa-boundary-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-online/rosa-boundary/openshift-online-rosa-boundary-main-presubmits.yaml
@@ -1,0 +1,134 @@
+presubmits:
+  openshift-online/rosa-boundary:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build01
+    context: ci/prow/images
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-online-rosa-boundary-main-images
+    rerun_command: /test images
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --target=[images]
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: github-credentials-openshift-ci-robot-private-git-cloner
+        secret:
+          secretName: github-credentials-openshift-ci-robot-private-git-cloner
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )images,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build01
+    context: ci/prow/lambda-unit-tests
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-online-rosa-boundary-main-lambda-unit-tests
+    rerun_command: /test lambda-unit-tests
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --target=lambda-unit-tests
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: github-credentials-openshift-ci-robot-private-git-cloner
+        secret:
+          secretName: github-credentials-openshift-ci-robot-private-git-cloner
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )lambda-unit-tests,?($|\s.*)

--- a/core-services/prow/02_config/openshift-online/rosa-boundary/OWNERS
+++ b/core-services/prow/02_config/openshift-online/rosa-boundary/OWNERS
@@ -1,0 +1,13 @@
+# DO NOT EDIT; this file is auto-generated using https://github.com/openshift/ci-tools.
+# Fetched from https://github.com/openshift-online/rosa-boundary root OWNERS
+# If the repo had OWNERS_ALIASES then the aliases were expanded
+# Logins who are not members of 'openshift' organization were filtered out
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+- jhjaggars
+- tiwillia
+options: {}
+reviewers:
+- jhjaggars
+- tiwillia

--- a/core-services/prow/02_config/openshift-online/rosa-boundary/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-online/rosa-boundary/_pluginconfig.yaml
@@ -1,0 +1,47 @@
+approve:
+- commandHelpLink: https://go.k8s.io/bot-commands
+  lgtm_acts_as_approve: true
+  repos:
+  - openshift-online/rosa-boundary
+  require_self_approval: true
+external_plugins:
+  openshift-online/rosa-boundary:
+  - endpoint: http://needs-rebase
+    events:
+    - issue_comment
+    - pull_request
+    name: needs-rebase
+plugins:
+  openshift-online/rosa-boundary:
+    plugins:
+    - assign
+    - blunderbuss
+    - cat
+    - dog
+    - heart
+    - golint
+    - goose
+    - help
+    - hold
+    - label
+    - lgtm
+    - lifecycle
+    - override
+    - pony
+    - retitle
+    - shrug
+    - sigmention
+    - skip
+    - trigger
+    - verify-owners
+    - owners-label
+    - wip
+    - yuks
+    - approve
+triggers:
+- org_invite:
+    prominent: {}
+  repos:
+  - openshift-online/rosa-boundary
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-online/rosa-boundary/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift-online/rosa-boundary/_prowconfig.yaml
@@ -1,0 +1,14 @@
+tide:
+  queries:
+  - labels:
+    - approved
+    - lgtm
+    missingLabels:
+    - backports/unvalidated-commits
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - jira/invalid-bug
+    - needs-rebase
+    repos:
+    - openshift-online/rosa-boundary


### PR DESCRIPTION
## Summary
- Enable Prow merge automation (Tide + plugins) for `openshift-online/rosa-boundary`
- Add lambda unit tests as a presubmit job (migrated from GitHub Actions)
- Configure approve/lgtm/hold/wip/verify-owners/needs-rebase plugin chain

## Test plan
- [ ] Prow job rehearsal passes on this PR
- [ ] Verify `/test lambda-unit-tests` triggers correctly on a rosa-boundary PR after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR onboards the openshift-online/rosa-boundary repository to OpenShift Prow: it adds CI operator config, per-repo Prow plugin configuration, Tide merge rules, and OWNERS so the repo’s PRs are managed and merged by Prow.

What changed (practical impact)
- CI job: Adds a ci-operator config that builds a lambda-test-runner image (UBI Python 3.11), copies the repo into /workspace, installs dependencies with uv, and defines a presubmit job named lambda-unit-tests. The presubmit sets UV_CACHE_DIR=/tmp/uv-cache, exports AWS_DEFAULT_REGION=us-east-1 (to avoid NoRegionError when lambda handler code creates boto3 clients at import time), and runs uv run pytest test_handler.py -v from lambda/create-investigation. This migrates the repository’s lambda unit tests from GitHub Actions to Prow.
- Prow plugins: Enables a plugin chain for openshift-online/rosa-boundary including approve (lgtm_acts_as_approve and require_self_approval), lgtm, hold, wip, verify-owners, owners-label and other standard plugins. Adds an external needs-rebase plugin entry (endpoint http://needs-rebase) listening on issue_comment and pull_request events.
- Tide (merge automation): Adds a Tide query for openshift-online/rosa-boundary that requires both approved and lgtm labels and blocks merges when specific gating labels are present (examples: backports/unvalidated-commits, do-not-merge/*, jira/invalid-bug, needs-rebase, invalid owners file, work-in-progress).
- OWNERS: Adds auto-generated OWNERS entries (approvers/reviewers: jhjaggars, tiwillia) under both ci-operator/config and core-services/prow/02_config so Prow/approve/verify-owners can operate.

Testing notes
- Prow rehearsal should validate the generated jobs on this PR.
- After merge, invoking /test lambda-unit-tests on a rosa-boundary PR should trigger the presubmit job in Prow.

Files added/updated (high level)
- ci-operator/config/openshift-online/rosa-boundary/openshift-online-rosa-boundary-main.yaml — image build and lambda-unit-tests presubmit (with UV_CACHE_DIR and AWS_DEFAULT_REGION fixes)
- ci-operator/config/openshift-online/rosa-boundary/OWNERS and core-services/prow/02_config/openshift-online/rosa-boundary/OWNERS — auto-generated OWNERS entries
- core-services/prow/02_config/openshift-online/rosa-boundary/_pluginconfig.yaml — per-repo plugin enablement and external needs-rebase plugin entry
- core-services/prow/02_config/openshift-online/rosa-boundary/_prowconfig.yaml — Tide query enforcing approved + lgtm and listing blocking labels

Overall effect
This PR establishes Prow-based CI and automated merge gating for openshift-online/rosa-boundary and migrates its lambda unit tests into OpenShift CI, including configuration tweaks (UV cache dir and AWS region) to ensure tests run in the Prow job environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->