### PR TITLE
NO-JIRA: feat: add promotion step for tnt repo to create ci image

### DIFF
--- a/ci-operator/config/openshift-eng/two-node-toolbox/openshift-eng-two-node-toolbox-main.yaml
+++ b/ci-operator/config/openshift-eng/two-node-toolbox/openshift-eng-two-node-toolbox-main.yaml
@@ -8,6 +8,15 @@ build_root:
     name: release
     namespace: openshift
     tag: rhel-9-release-golang-1.24-openshift-4.20
+images:
+  items:
+  - dockerfile_path: images/Containerfile.ci
+    from: root
+    to: two-node-toolbox
+promotion:
+  to:
+  - name: two-node-toolbox
+    namespace: ci
 resources:
   '*':
     requests:

--- a/ci-operator/jobs/openshift-eng/two-node-toolbox/openshift-eng-two-node-toolbox-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift-eng/two-node-toolbox/openshift-eng-two-node-toolbox-main-postsubmits.yaml
@@ -1,0 +1,62 @@
+postsubmits:
+  openshift-eng/two-node-toolbox:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    cluster: build01
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/is-promotion: "true"
+      ci.openshift.io/generator: prowgen
+    max_concurrency: 1
+    name: branch-ci-openshift-eng-two-node-toolbox-main-images
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --image-mirror-push-secret=/etc/push-secret/.dockerconfigjson
+        - --promote
+        - --report-credentials-file=/etc/report/credentials
+        - --target=[images]
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/push-secret
+          name: push-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: push-secret
+        secret:
+          secretName: registry-push-credentials-ci-central
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator

--- a/ci-operator/jobs/openshift-eng/two-node-toolbox/openshift-eng-two-node-toolbox-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-eng/two-node-toolbox/openshift-eng-two-node-toolbox-main-presubmits.yaml
@@ -1,6 +1,61 @@
 presubmits:
   openshift-eng/two-node-toolbox:
   - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build04
+    context: ci/prow/images
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-eng-two-node-toolbox-main-images
+    rerun_command: /test images
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=[images]
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )images,?($|\s.*)
+  - agent: kubernetes
     always_run: false
     branches:
     - ^main$


### PR DESCRIPTION
currently TNT is only used internally to deploy clusters, adding a step to promote an image to the ci registry this will allow us to use TNT in ci to deploy clusters if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds ci-operator configuration to build and promote the Two Node Toolbox (openshift-eng/two-node-toolbox) image so the image is published to the OpenShift CI registry (ci/two-node-toolbox). That makes TNT available for CI jobs that need to deploy clusters.

## What changed

- Added ci-operator config: ci-operator/config/openshift-eng/two-node-toolbox/openshift-eng-two-node-toolbox-main.yaml.
  - Declares an image build (images.items) that builds from images/Containerfile.ci and publishes to image stream tag two-node-toolbox.
  - Sets build_root to use the release image_stream_tag: release/ rhel-9-release-golang-1.24-openshift-4.20 from the openshift namespace.
  - Configures promotion.to to push the resulting two-node-toolbox image into the ci namespace.
  - Adds a shellcheck base image and a shellcheck test (runs `make shellcheck`) with a run_if_changed pattern.
  - Adds small default resource requests for containers (cpu: 100m, memory: 200Mi).

## Practical impact

TNT can now be built by OpenShift CI and promoted into the CI registry (ci/two-node-toolbox), enabling CI jobs to pull and use the toolbox image for cluster deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->