### PR TITLE
Prow 🚢 ✴️ openshift-eng/oape-ai-e2e workflow

### DIFF
--- a/ci-operator/config/openshift-eng/oape-ai-e2e/openshift-eng-oape-ai-e2e-main.yaml
+++ b/ci-operator/config/openshift-eng/oape-ai-e2e/openshift-eng-oape-ai-e2e-main.yaml
@@ -12,9 +12,13 @@ images:
     to: gh-token-minter
   - dockerfile_path: images/go-server.Dockerfile
     to: go-server
+  - dockerfile_path: prow-workflow/input.Dockerfile
+    to: workflow-input
 promotion:
   to:
-  - name: ai-e2e-agent
+  - excluded_images:
+    - workflow-input
+    name: ai-e2e-agent
     namespace: oape
     tag_by_commit: true
 resources:
@@ -24,6 +28,200 @@ resources:
     requests:
       cpu: 100m
       memory: 200Mi
+tests:
+- always_run: false
+  as: run-workflow
+  run_if_changed: ^prow-workflow/
+  steps:
+    env:
+      BONFIRE_NAMESPACE_DURATION: 3h
+    test:
+    - as: extract-params
+      commands: |
+        cp /params.env "${SHARED_DIR}/params.env"
+        cat "${SHARED_DIR}/params.env"
+      from: workflow-input
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+    - as: deploy-and-run
+      commands: |
+        set -euo pipefail
+
+        # --- Ephemeral namespace access ---
+        export KUBECONFIG="${SHARED_DIR}/ephemeral-kubeconfig"
+        NAMESPACE=$(cat "${SHARED_DIR}/ephemeral-namespace")
+        oc project "${NAMESPACE}"
+
+        # Load workflow params
+        source "${SHARED_DIR}/params.env"
+
+        # --- Create secrets from mounted CI credentials ---
+        oc create secret generic gcloud-adc \
+          --from-file=application_default_credentials.json=/var/run/gcloud-adc/application_default_credentials.json
+        oc create secret generic github-app \
+          --from-file=private-key.pem=/var/run/github-app/private-key.pem
+
+        # --- Create worker ConfigMap (env vars) ---
+        oc create configmap shift-worker-config \
+          --from-literal=CLAUDE_CODE_USE_VERTEX=1 \
+          --from-literal=CLOUD_ML_REGION=global \
+          --from-literal=ANTHROPIC_VERTEX_PROJECT_ID=itpc-gcp-hcm-pe-eng-claude \
+          --from-literal=ANTHROPIC_MODEL=claude-opus-4-6
+
+        # --- Deploy gh-token-minter ---
+        cat <<DEPLOYEOF | oc apply -f -
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: gh-token-minter
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: gh-token-minter
+          template:
+            metadata:
+              labels:
+                app: gh-token-minter
+            spec:
+              containers:
+              - name: minter
+                image: ${GH_TOKEN_MINTER_IMAGE}
+                ports:
+                - containerPort: 8081
+                env:
+                - name: GH_APP_ID
+                  value: "3065249"
+                - name: GH_APP_PEM_FILE_PATH
+                  value: /etc/github-app/private-key.pem
+                - name: LISTEN_PORT
+                  value: "8081"
+                volumeMounts:
+                - name: gh-app-key
+                  mountPath: /etc/github-app
+                  readOnly: true
+              volumes:
+              - name: gh-app-key
+                secret:
+                  secretName: github-app
+        ---
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: gh-token-minter
+        spec:
+          selector:
+            app: gh-token-minter
+          ports:
+          - port: 8081
+            targetPort: 8081
+        DEPLOYEOF
+
+        oc wait --for=condition=Available deployment/gh-token-minter --timeout=120s
+
+        # --- Mint GH token via port-forward ---
+        oc port-forward svc/gh-token-minter 8081:8081 &
+        PF_PID=$!
+        sleep 3
+
+        # Disable tracing due to token handling
+        set +x
+        TOKEN_RESP=$(curl -sf http://localhost:8081/token)
+        kill $PF_PID || true
+        GH_TOKEN=$(echo "$TOKEN_RESP" | jq -r '.token')
+
+        oc create secret generic gh-token-secret \
+          --from-literal=GH_TOKEN="${GH_TOKEN}"
+
+        # --- Create agent-worker Job ---
+        JOB_ID="ci-$(date +%s)"
+        cat <<JOBEOF | oc apply -f -
+        apiVersion: batch/v1
+        kind: Job
+        metadata:
+          name: shift-workflow-${JOB_ID}
+          labels:
+            app: shift-worker
+        spec:
+          backoffLimit: 0
+          template:
+            spec:
+              restartPolicy: Never
+              containers:
+              - name: worker
+                image: ${AGENT_WORKER_IMAGE}
+                command: ["sh", "-c", "python3.11 /app/main.py"]
+                env:
+                - name: EP_URL
+                  value: "${EP_URL}"
+                - name: REPO_URL
+                  value: "${REPO_URL}"
+                - name: BASE_BRANCH
+                  value: "${BASE_BRANCH}"
+                - name: PYTHONUNBUFFERED
+                  value: "1"
+                - name: GOOGLE_APPLICATION_CREDENTIALS
+                  value: /secrets/gcloud/application_default_credentials.json
+                envFrom:
+                - configMapRef:
+                    name: shift-worker-config
+                - secretRef:
+                    name: gh-token-secret
+                resources:
+                  requests:
+                    cpu: 500m
+                    memory: 512Mi
+                  limits:
+                    cpu: "2"
+                    memory: 4Gi
+                volumeMounts:
+                - name: gcloud-adc
+                  mountPath: /secrets/gcloud
+                  readOnly: true
+              volumes:
+              - name: gcloud-adc
+                secret:
+                  secretName: gcloud-adc
+        JOBEOF
+
+        echo "Agent-worker Job shift-workflow-${JOB_ID} created."
+
+        # --- Wait for pod, stream logs, check result ---
+        oc wait --for=condition=Ready pod -l job-name=shift-workflow-${JOB_ID} --timeout=300s || true
+        POD=$(oc get pods -l job-name=shift-workflow-${JOB_ID} -o jsonpath='{.items[0].metadata.name}')
+        oc logs -f "${POD}" || true
+
+        # Check final status
+        if oc wait --for=condition=complete --timeout=30s job/shift-workflow-${JOB_ID} 2>/dev/null; then
+          echo "Workflow completed successfully."
+        else
+          echo "Workflow failed."
+          exit 1
+        fi
+      credentials:
+      - mount_path: /var/run/gcloud-adc
+        name: oap-lts-claude-gcp-vertex-sa
+        namespace: test-credentials
+      - mount_path: /var/run/github-app
+        name: openshift-app-platform-shift-github-bot
+        namespace: test-credentials
+      dependencies:
+      - env: AGENT_WORKER_IMAGE
+        name: agent-worker
+      - env: GH_TOKEN_MINTER_IMAGE
+        name: gh-token-minter
+      from_image:
+        name: cli-jq
+        namespace: ocp
+        tag: latest
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+      timeout: 2h0m0s
+    workflow: ephemeral-namespace
 zz_generated_metadata:
   branch: main
   org: openshift-eng

--- a/ci-operator/config/openshift-eng/oape-ai-e2e/openshift-eng-oape-ai-e2e-main.yaml
+++ b/ci-operator/config/openshift-eng/oape-ai-e2e/openshift-eng-oape-ai-e2e-main.yaml
@@ -33,9 +33,7 @@ tests:
   as: run-workflow
   run_if_changed: ^prow-workflow/
   steps:
-    env:
-      BONFIRE_NAMESPACE_DURATION: 3h
-    test:
+    pre:
     - as: extract-params
       commands: |
         cp /params.env "${SHARED_DIR}/params.env"
@@ -45,183 +43,73 @@ tests:
         requests:
           cpu: 100m
           memory: 128Mi
-    - as: deploy-and-run
+    - as: mint-gh-token
       commands: |
         set -euo pipefail
+        GH_APP_ID=$(cat /var/run/github-app/app-id)
+        PEM_PATH="/var/run/github-app/private-key.pem"
 
-        # --- Ephemeral namespace access ---
-        export KUBECONFIG="${SHARED_DIR}/ephemeral-kubeconfig"
-        NAMESPACE=$(cat "${SHARED_DIR}/ephemeral-namespace")
-        oc project "${NAMESPACE}"
+        HEADER=$(printf '{"alg":"RS256","typ":"JWT"}' | openssl base64 -e -A | tr '+/' '-_' | tr -d '=')
+        NOW=$(date +%s)
+        EXP=$((NOW + 300))
+        PAYLOAD=$(printf '{"iat":%d,"exp":%d,"iss":"%s"}' "$NOW" "$EXP" "$GH_APP_ID" | openssl base64 -e -A | tr '+/' '-_' | tr -d '=')
+        UNSIGNED="${HEADER}.${PAYLOAD}"
+        SIGNATURE=$(printf '%s' "$UNSIGNED" | openssl dgst -sha256 -sign "$PEM_PATH" -binary | openssl base64 -e -A | tr '+/' '-_' | tr -d '=')
+        JWT="${UNSIGNED}.${SIGNATURE}"
 
-        # Load workflow params
-        source "${SHARED_DIR}/params.env"
+        INST_ID=$(curl -sf \
+          -H "Authorization: Bearer ${JWT}" \
+          -H "Accept: application/vnd.github+json" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/app/installations \
+          | python3 -c "import sys,json; print(json.load(sys.stdin)[0]['id'])")
 
-        # --- Create secrets from mounted CI credentials ---
-        oc create secret generic gcloud-adc \
-          --from-file=application_default_credentials.json=/var/run/gcloud-adc/application_default_credentials.json
-        oc create secret generic github-app \
-          --from-file=private-key.pem=/var/run/github-app/private-key.pem
-
-        # --- Create worker ConfigMap (env vars) ---
-        oc create configmap shift-worker-config \
-          --from-literal=CLAUDE_CODE_USE_VERTEX=1 \
-          --from-literal=CLOUD_ML_REGION=global \
-          --from-literal=ANTHROPIC_VERTEX_PROJECT_ID=itpc-gcp-hcm-pe-eng-claude \
-          --from-literal=ANTHROPIC_MODEL=claude-opus-4-6
-
-        # --- Deploy gh-token-minter ---
-        cat <<DEPLOYEOF | oc apply -f -
-        apiVersion: apps/v1
-        kind: Deployment
-        metadata:
-          name: gh-token-minter
-        spec:
-          replicas: 1
-          selector:
-            matchLabels:
-              app: gh-token-minter
-          template:
-            metadata:
-              labels:
-                app: gh-token-minter
-            spec:
-              containers:
-              - name: minter
-                image: ${GH_TOKEN_MINTER_IMAGE}
-                ports:
-                - containerPort: 8081
-                env:
-                - name: GH_APP_ID
-                  value: "3065249"
-                - name: GH_APP_PEM_FILE_PATH
-                  value: /etc/github-app/private-key.pem
-                - name: LISTEN_PORT
-                  value: "8081"
-                volumeMounts:
-                - name: gh-app-key
-                  mountPath: /etc/github-app
-                  readOnly: true
-              volumes:
-              - name: gh-app-key
-                secret:
-                  secretName: github-app
-        ---
-        apiVersion: v1
-        kind: Service
-        metadata:
-          name: gh-token-minter
-        spec:
-          selector:
-            app: gh-token-minter
-          ports:
-          - port: 8081
-            targetPort: 8081
-        DEPLOYEOF
-
-        oc wait --for=condition=Available deployment/gh-token-minter --timeout=120s
-
-        # --- Mint GH token via port-forward ---
-        oc port-forward svc/gh-token-minter 8081:8081 &
-        PF_PID=$!
-        sleep 3
-
-        # Disable tracing due to token handling
         set +x
-        TOKEN_RESP=$(curl -sf http://localhost:8081/token)
-        kill $PF_PID || true
-        GH_TOKEN=$(echo "$TOKEN_RESP" | jq -r '.token')
+        TOKEN=$(curl -sf -X POST \
+          -H "Authorization: Bearer ${JWT}" \
+          -H "Accept: application/vnd.github+json" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          "https://api.github.com/app/installations/${INST_ID}/access_tokens" \
+          | python3 -c "import sys,json; print(json.load(sys.stdin)['token'])")
+        echo "${TOKEN}" > "${SHARED_DIR}/gh-token"
+      credentials:
+      - mount_path: /var/run/github-app
+        name: openshift-app-platform-shift-github-bot
+        namespace: test-credentials
+      from: agent-worker
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+    test:
+    - as: agent-workflow
+      commands: |
+        set -euo pipefail
+        source "${SHARED_DIR}/params.env"
+        export EP_URL REPO_URL BASE_BRANCH
 
-        oc create secret generic gh-token-secret \
-          --from-literal=GH_TOKEN="${GH_TOKEN}"
+        set +x
+        export GH_TOKEN
+        GH_TOKEN=$(cat "${SHARED_DIR}/gh-token")
 
-        # --- Create agent-worker Job ---
-        JOB_ID="ci-$(date +%s)"
-        cat <<JOBEOF | oc apply -f -
-        apiVersion: batch/v1
-        kind: Job
-        metadata:
-          name: shift-workflow-${JOB_ID}
-          labels:
-            app: shift-worker
-        spec:
-          backoffLimit: 0
-          template:
-            spec:
-              restartPolicy: Never
-              containers:
-              - name: worker
-                image: ${AGENT_WORKER_IMAGE}
-                command: ["sh", "-c", "python3.11 /app/main.py"]
-                env:
-                - name: EP_URL
-                  value: "${EP_URL}"
-                - name: REPO_URL
-                  value: "${REPO_URL}"
-                - name: BASE_BRANCH
-                  value: "${BASE_BRANCH}"
-                - name: PYTHONUNBUFFERED
-                  value: "1"
-                - name: GOOGLE_APPLICATION_CREDENTIALS
-                  value: /secrets/gcloud/application_default_credentials.json
-                envFrom:
-                - configMapRef:
-                    name: shift-worker-config
-                - secretRef:
-                    name: gh-token-secret
-                resources:
-                  requests:
-                    cpu: 500m
-                    memory: 512Mi
-                  limits:
-                    cpu: "2"
-                    memory: 4Gi
-                volumeMounts:
-                - name: gcloud-adc
-                  mountPath: /secrets/gcloud
-                  readOnly: true
-              volumes:
-              - name: gcloud-adc
-                secret:
-                  secretName: gcloud-adc
-        JOBEOF
+        export GOOGLE_APPLICATION_CREDENTIALS="/var/run/gcloud-adc/application_default_credentials.json"
+        export CLAUDE_CODE_USE_VERTEX="1"
+        export CLOUD_ML_REGION="global"
+        export ANTHROPIC_VERTEX_PROJECT_ID="itpc-gcp-hcm-pe-eng-claude"
+        export ANTHROPIC_MODEL="claude-opus-4-6"
+        export PYTHONUNBUFFERED=1
 
-        echo "Agent-worker Job shift-workflow-${JOB_ID} created."
-
-        # --- Wait for pod, stream logs, check result ---
-        oc wait --for=condition=Ready pod -l job-name=shift-workflow-${JOB_ID} --timeout=300s || true
-        POD=$(oc get pods -l job-name=shift-workflow-${JOB_ID} -o jsonpath='{.items[0].metadata.name}')
-        oc logs -f "${POD}" || true
-
-        # Check final status
-        if oc wait --for=condition=complete --timeout=30s job/shift-workflow-${JOB_ID} 2>/dev/null; then
-          echo "Workflow completed successfully."
-        else
-          echo "Workflow failed."
-          exit 1
-        fi
+        gh auth setup-git && python3.11 main.py
       credentials:
       - mount_path: /var/run/gcloud-adc
         name: oap-lts-claude-gcp-vertex-sa
         namespace: test-credentials
-      - mount_path: /var/run/github-app
-        name: openshift-app-platform-shift-github-bot
-        namespace: test-credentials
-      dependencies:
-      - env: AGENT_WORKER_IMAGE
-        name: agent-worker
-      - env: GH_TOKEN_MINTER_IMAGE
-        name: gh-token-minter
-      from_image:
-        name: cli-jq
-        namespace: ocp
-        tag: latest
+      from: agent-worker
       resources:
         requests:
-          cpu: 100m
-          memory: 256Mi
-      timeout: 2h0m0s
-    workflow: ephemeral-namespace
+          cpu: "1"
+          memory: 500Mi
+      timeout: 2h30m0s
 zz_generated_metadata:
   branch: main
   org: openshift-eng

--- a/ci-operator/jobs/openshift-eng/oape-ai-e2e/openshift-eng-oape-ai-e2e-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift-eng/oape-ai-e2e/openshift-eng-oape-ai-e2e-main-postsubmits.yaml
@@ -11,6 +11,7 @@ postsubmits:
       - images/agent-worker.Dockerfile
       - images/gh-token-minter.Dockerfile
       - images/go-server.Dockerfile
+      - prow-workflow/input.Dockerfile
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen

--- a/ci-operator/jobs/openshift-eng/oape-ai-e2e/openshift-eng-oape-ai-e2e-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-eng/oape-ai-e2e/openshift-eng-oape-ai-e2e-main-presubmits.yaml
@@ -13,6 +13,7 @@ presubmits:
       - images/agent-worker.Dockerfile
       - images/gh-token-minter.Dockerfile
       - images/go-server.Dockerfile
+      - prow-workflow/input.Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -67,7 +68,11 @@ presubmits:
     context: ci/prow/run-workflow
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - images/agent-worker.Dockerfile
+      - images/gh-token-minter.Dockerfile
+      - images/go-server.Dockerfile
+      - prow-workflow/input.Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"

--- a/ci-operator/jobs/openshift-eng/oape-ai-e2e/openshift-eng-oape-ai-e2e-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-eng/oape-ai-e2e/openshift-eng-oape-ai-e2e-main-presubmits.yaml
@@ -55,3 +55,77 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )images,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build05
+    context: ci/prow/run-workflow
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-eng-oape-ai-e2e-main-run-workflow
+    rerun_command: /test run-workflow
+    run_if_changed: ^prow-workflow/
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --target=run-workflow
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )run-workflow,?($|\s.*)


### PR DESCRIPTION
Run a Claude agent orchestrated by Prow Job structured as a pre-submit.

The expected trigger is through a PR on [openshift-eng/oape-ai-e2e](https://github.com/openshift-eng/oape-ai-e2e) that updates the contents of [`prow-workflow/input.Dockerfile` file](https://github.com/openshift-eng/oape-ai-e2e/blob/main/prow-workflow/input.Dockerfile).


- [x] ❌ Approach 1 (using ephemeral namespace workflow): e339af03ad0b9c0a683c861a4c5163c5a4493ffc, din't work because the ephemeral namespace reservation timed out i.e. our flow was NEVER triggered! 😤 
- [x] ✅ Approach 2 (directly use inline CI built-ins): 5ac4f8c4c46d20bb2628a60572fe2a8f9b11d024, 
    - The workflow authored this PR https://github.com/openshift/cert-manager-operator/pull/423 upon rehearsal!

<details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changes to openshift-eng/oape-ai-e2e CI configuration

This PR adds a ci-operator image build and test to the openshift-eng/oape-ai-e2e CI config so a Claude-based agent (run from repository openshift-eng/oape-ai-e2e) can be executed automatically when files under prow-workflow/ change.

What this modifies practically
- New image build: workflow-input is built from prow-workflow/input.Dockerfile and added to the images list. This image is treated as an input/configuration image and is excluded from promotion for the ai-e2e-agent promotion target.
- New ci-operator test: run-workflow, triggered when changes match ^prow-workflow/. The test is a three-step flow:
  1. extract-params — copies /params.env from the workflow-input image into ${SHARED_DIR}/params.env and prints it.
  2. mint-gh-token — mounts GitHub App credentials, generates a GitHub App JWT, exchanges it for an installation access token via GitHub API, and writes the token to ${SHARED_DIR}/gh-token.
  3. agent-workflow — sources ${SHARED_DIR}/params.env, loads ${SHARED_DIR}/gh-token into GH_TOKEN, sets Google/Vertex and Anthropic/Claude env vars, performs gh auth setup, and runs python3.11 main.py from /app; mounts ADC at /var/run/gcloud-adc and uses a 2h30m timeout.

Behavioral intent
- The workflow is intended to run as a pre-submit triggered by PRs to openshift-eng/oape-ai-e2e that modify prow-workflow/input.Dockerfile (or other files under prow-workflow/), allowing CI to execute the Claude agent flow using parameters baked into the workflow-input image and a minted GitHub token.

Development/context notes
- The PR description documents two approaches: an ephemeral-namespace workflow (attempted in an earlier commit but failed due to namespace reservation timeouts) and a direct inline ci-operator built-ins approach. The current changes implement the inline ci-operator test and image build; the ephemeral-namespace approach was attempted but did not complete successfully.

Files changed (high level)
- ci-operator/config/openshift-eng/oape-ai-e2e/openshift-eng-oape-ai-e2e-main.yaml — adds the workflow-input image build, the run-workflow test, and updates promotion exclusions.

Lines changed: +87 / -1. Estimated review effort: High.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

</details>