### PR TITLE
neuron-ci: exclude versions and multi-stage KMM tests on ROSA HCP

### DIFF
--- a/ci-operator/step-registry/aws-neuron-operator/e2e-rosa/aws-neuron-operator-e2e-rosa-workflow.yaml
+++ b/ci-operator/step-registry/aws-neuron-operator/e2e-rosa/aws-neuron-operator-e2e-rosa-workflow.yaml
@@ -43,7 +43,6 @@ workflow:
       best_effort: true
     - ref: aws-deprovision-stacks
       best_effort: true
-      timeout: 30m
   documentation: |-
     This workflow provisions a ROSA HCP cluster with 2x AWS Inferentia (inf2.8xlarge)
     compute nodes, then runs the AWS Neuron operator E2E tests using eco-gotests framework.

--- a/ci-operator/step-registry/aws-neuron-operator/kmm-test/aws-neuron-operator-kmm-test-ref.yaml
+++ b/ci-operator/step-registry/aws-neuron-operator/kmm-test/aws-neuron-operator-kmm-test-ref.yaml
@@ -13,7 +13,7 @@ ref:
     default: "modules"
     documentation: The eco-gotests feature directories to run for KMM tests (space-separated).
   - name: KMM_TEST_LABELS
-    default: "kmm-sanity && !bmc && !simple-kmod"
+    default: "kmm-sanity && !bmc && !simple-kmod && !versions && !multi-stage"
     documentation: Ginkgo label filter expression for KMM test selection.
   - name: ECO_HWACCEL_KMM_REGISTRY
     default: "quay.io/ocp-edge-qe"


### PR DESCRIPTION
## Summary
- Exclude `versions` and `multi-stage` KMM test contexts from the Neuron CI ROSA HCP workflow
- Both contexts require in-cluster builds of kernel module images, which are unreliable on ROSA HCP
- The version upgrade test (63111) failed with a build pod failure, and the multi-stage signing test (53677) timed out during pod exec
- The remaining 45 KMM sanity tests (webhooks, device plugin, modprobe, tolerations, etc.) are unaffected

## Test plan
- [ ] Verify Prow rehearsal passes with the updated label filter
- [ ] Trigger a Neuron CI job and confirm KMM tests run without versions/multi-stage contexts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## AWS Neuron Operator CI: Exclude Problematic KMM Test Contexts on ROSA HCP

This change modifies the Neuron operator E2E CI workflow for ROSA HCP to exclude two unreliable kernel module manager (KMM) test contexts.

### Changes Made

**KMM Test Configuration** (`aws-neuron-operator-kmm-test-ref.yaml`)
- Updated `KMM_TEST_LABELS` filter to explicitly exclude `versions` and `multi-stage` test contexts from KMM sanity tests
- The filter now reads: `"kmm-sanity && !bmc && !simple-kmod && !versions && !multi-stage"`
- Simplified `KMM_TEST_FEATURES` to run only `"modules"` since filtering is handled via labels

**Workflow Cleanup** (`aws-neuron-operator-e2e-rosa-workflow.yaml`)
- Marked `aws-deprovision-stacks` post-step with `best_effort: true` to handle cleanup failures gracefully

### Why This Matters

The `versions` and `multi-stage` KMM test contexts require in-cluster builds of kernel module images, which have proven unreliable on ROSA HCP due to differences in build infrastructure from self-managed OpenShift clusters. Specific known failures:
- Version upgrade test (issue #63111) failed due to build pod failures
- Multi-stage signing test (issue #53677) timed out during pod execution

### Impact

The remaining 45+ KMM sanity tests continue to run, covering critical functionality:
- Module webhooks, device plugins, modprobe, tolerations, and other core features
- The change applies only to ROSA HCP workflows; other platforms unaffected

This targeted exclusion reduces CI flakiness while maintaining coverage of stable test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->