### PR TITLE
Bump peribolos image to v20260507-f8cedc561

### DIFF
--- a/ci-operator/jobs/infra-periodics.yaml
+++ b/ci-operator/jobs/infra-periodics.yaml
@@ -1400,7 +1400,7 @@ periodics:
           --github-hourly-tokens=600 \
           --github-allowed-burst=600 \
           --allow-repo-archival
-      image: us-docker.pkg.dev/k8s-infra-prow/images/peribolos:v20260504-92d6574a4
+      image: us-docker.pkg.dev/k8s-infra-prow/images/peribolos:v20260507-f8cedc561
       imagePullPolicy: Always
       name: ""
       resources:


### PR DESCRIPTION
## Summary

- Bumps the peribolos image used by `periodic-org-sync` from `v20260504-92d6574a4` to `v20260507-f8cedc561`
- The new image includes [kubernetes-sigs/prow#710](https://github.com/kubernetes-sigs/prow/pull/710), which fixes enterprise team reconciliation failures (422/403 errors when peribolos attempts to modify enterprise-managed teams)