### PR TITLE
DNM: NO-JIRA: hypershift: add temporary CI config for fix-422-e2e branch

### DIFF
--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-fix-422-e2e.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-fix-422-e2e.yaml
@@ -1,0 +1,76 @@
+base_images:
+  cli:
+    name: "4.22"
+    namespace: ocp
+    tag: cli
+build_root:
+  from_repository: true
+  use_build_cache: true
+images:
+  items:
+  - to: hypershift-operator
+  - dockerfile_path: Dockerfile.control-plane
+    to: hypershift
+  - dockerfile_path: Dockerfile.e2e
+    to: hypershift-tests
+releases:
+  initial:
+    candidate:
+      product: ocp
+      relative: 1
+      stream: ci
+      version: "4.22"
+  latest:
+    integration:
+      name: "4.22"
+      namespace: ocp
+  n1minor:
+    candidate:
+      product: ocp
+      stream: ci
+      version: "4.21"
+  n2minor:
+    candidate:
+      product: ocp
+      stream: ci
+      version: "4.20"
+  n3minor:
+    candidate:
+      product: ocp
+      stream: ci
+      version: "4.19"
+  n4minor:
+    candidate:
+      product: ocp
+      stream: ci
+      version: "4.18"
+resources:
+  '*':
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- always_run: false
+  as: e2e-aws
+  capabilities:
+  - build-tmpfs
+  steps:
+    cluster_profile: hypershift-aws
+    dependencies:
+      OCP_IMAGE_N1: release:n1minor
+      OCP_IMAGE_N2: release:n2minor
+      OCP_IMAGE_N3: release:n3minor
+      OCP_IMAGE_N4: release:n4minor
+    env:
+      ENABLE_HYPERSHIFT_CERT_ROTATION_SCALE: "true"
+      REQUEST_SERVING_COMPONENT_TEST: "true"
+    post:
+    - ref: hypershift-analyze-e2e-failure
+    - chain: hypershift-destroy-nested-management-cluster
+    workflow: hypershift-aws-e2e-nested
+zz_generated_metadata:
+  branch: fix-422-e2e
+  org: openshift
+  repo: hypershift

--- a/ci-operator/jobs/openshift/hypershift/openshift-hypershift-fix-422-e2e-presubmits.yaml
+++ b/ci-operator/jobs/openshift/hypershift/openshift-hypershift-fix-422-e2e-presubmits.yaml
@@ -1,0 +1,136 @@
+presubmits:
+  openshift/hypershift:
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^fix-422-e2e$
+    - ^fix-422-e2e-
+    cluster: build01
+    context: ci/prow/e2e-aws
+    decorate: true
+    labels:
+      capability/build-tmpfs: build-tmpfs
+      ci-operator.openshift.io/cloud: hypershift-aws
+      ci-operator.openshift.io/cloud-cluster-profile: hypershift-aws
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-hypershift-fix-422-e2e-e2e-aws
+    rerun_command: /test e2e-aws
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-aws
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )(e2e-aws|remaining-required),?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^fix-422-e2e$
+    - ^fix-422-e2e-
+    cluster: build01
+    context: ci/prow/images
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-hypershift-fix-422-e2e-images
+    rerun_command: /test images
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=[images]
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )images,?($|\s.*)


### PR DESCRIPTION
## Summary
- Adds a temporary CI config for the `fix-422-e2e` branch in openshift/hypershift
- Builds the `hypershift-tests` image from the branch source and tests against 4.22 OCP releases
- Validates that version gates added to the e2e tests (CAPI condition bubbling, Karpenter v1 API) allow the main test binary to run against 4.22 clusters

## Context
PR https://github.com/openshift/release/pull/78912 switches the 4.22 branch to use the pre-built `hypershift-tests` image from main. However, the main e2e binary has tests that are incompatible with 4.22 (CAPI condition aggregation, Karpenter v1 API). The hypershift branch at https://github.com/openshift/hypershift/tree/fix-422-e2e adds the necessary version gates.

This config allows us to validate the fix by running `/test e2e-aws` on a PR targeting the `fix-422-e2e` branch.

## Test plan
- [ ] Open a PR on openshift/hypershift targeting `fix-422-e2e` and run `/test e2e-aws`
- [ ] Verify TestNodePool subtests pass (CAPI condition bubbling skipped on 4.22)
- [ ] Verify TestKarpenter is skipped on 4.22

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds temporary OpenShift CI configuration (in openshift/release) to validate fixes on the hypershift fix-422-e2e branch by building and testing hypershift artifacts from that branch against OpenShift 4.22.

What changed, in practical terms:
- Added a ci-operator config (ci-operator/config/openshift/hypershift/openshift-hypershift-fix-422-e2e.yaml) that:
  - Builds hypershift images (hypershift-operator, hypershift, hypershift-tests) from the fix-422-e2e branch.
  - Targets OpenShift 4.22 (ci/integration streams) and pins older minors (4.21–4.18) as dependencies.
  - Defines an e2e workflow (hypershift-aws-e2e-nested) using the hypershift-aws cluster profile, sets resource requests/limits, enables cert-rotation/serving-component env flags, and runs post-steps to analyze failures and destroy nested clusters.
- Added presubmit job entries (ci-operator/jobs/openshift/hypershift/openshift-hypershift-fix-422-e2e-presubmits.yaml) that:
  - Define a non-always-run e2e presubmit (pull-ci-openshift-hypershift-fix-422-e2e-e2e-aws) which can be triggered with "/test e2e-aws" on PRs targeting branches matching ^fix-422-e2e($|-) and mounts required secrets.
  - Define an always-run images presubmit (pull-ci-openshift-hypershift-fix-422-e2e-images) triggered with "/test images" for the same branch pattern.
  - Use the standard ci-operator container image and serviceAccountName: ci-operator.

Purpose and test plan:
- Validate version-gate changes on the hypershift fix-422-e2e branch that enable the main e2e binary to run against 4.22 (CAPI condition bubbling handling and Karpenter v1 API gating).
- Intended workflow: open a PR against openshift/hypershift's fix-422-e2e branch and run "/test e2e-aws"; verify TestNodePool subtests behave with CAPI condition bubbling skipped on 4.22 and that TestKarpenter is skipped on 4.22.

Notes:
- This is a branch-scoped, temporary CI configuration (metadata tags branch: fix-422-e2e, repo: openshift/hypershift).
- No source code or exported/public API changes — only CI job/config manifests were added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->