### PR TITLE
neuron-ci: increase KMM suite timeout from 1h to 80m

### DIFF
--- a/ci-operator/step-registry/aws-neuron-operator/kmm-test/aws-neuron-operator-kmm-test-commands.sh
+++ b/ci-operator/step-registry/aws-neuron-operator/kmm-test/aws-neuron-operator-kmm-test-commands.sh
@@ -46,7 +46,7 @@ echo "Running KMM tests with labels: ${ECO_TEST_LABELS}"
 TEST_EXIT_CODE=0
 
 ginkgo --label-filter="${ECO_TEST_LABELS}" \
-    --timeout=1h \
+    --timeout=80m \
     --v \
     --keep-going \
     --junit-report=junit_kmm_modules.xml \


### PR DESCRIPTION
## Summary
- Increase Ginkgo `--timeout` from `1h` to `80m` for the KMM sanity test step
- The KMM suite runs ~47 tests which took 59.5 minutes on a 2-node ROSA HCP cluster after Neuron E2E tests
- Test 53677 was killed by the suite timeout after only 26.9s of execution — it was the last test to run and the suite ran out of time
- 80m provides headroom while staying within the step's existing 90m timeout

## Test plan
- [ ] Verify Prow rehearsal passes
- [ ] Trigger a Neuron CI job and confirm KMM tests complete within the new timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)