### PR TITLE
PowerVC: Use verison 2.3.6

### DIFF
--- a/ci-operator/step-registry/ipi/conf/powervc/ipi-conf-powervc-commands.sh
+++ b/ci-operator/step-registry/ipi/conf/powervc/ipi-conf-powervc-commands.sh
@@ -6,8 +6,8 @@ set -o errexit
 set -o pipefail
 
 # Global constants
-readonly POWERVC_TOOL_VERSION="v2.2.0"
-readonly YQ_VERSION="v4.49.2"
+readonly POWERVC_TOOL_VERSION="v2.3.4"
+readonly YQ_VERSION="v4.53.2"
 
 # Global variables for cleanup
 BASTION_CREATED=false

--- a/ci-operator/step-registry/ipi/deprovision/deprovision/powervc/deprovision/ipi-deprovision-deprovision-powervc-deprovision-commands.sh
+++ b/ci-operator/step-registry/ipi/deprovision/deprovision/powervc/deprovision/ipi-deprovision-deprovision-powervc-deprovision-commands.sh
@@ -6,8 +6,8 @@ set -o errexit
 set -o pipefail
 
 # Global constants
-readonly POWERVC_TOOL_VERSION="v2.2.0"
-readonly YQ_VERSION="v4.49.2"
+readonly POWERVC_TOOL_VERSION="v2.3.4"
+readonly YQ_VERSION="v4.53.2"
 readonly MAX_DESTROY_ATTEMPTS=3
 readonly SECRETS_DIR="/var/run/powervc-ipi-cicd-secrets/powervc-creds"
 

--- a/ci-operator/step-registry/ipi/install/powervc/install/ipi-install-powervc-install-commands.sh
+++ b/ci-operator/step-registry/ipi/install/powervc/install/ipi-install-powervc-install-commands.sh
@@ -22,8 +22,8 @@ set -o errtrace
 #   DEBUG - Enable debug logging (default: false)
 
 # Global constants
-readonly POWERVC_TOOL_VERSION="v2.2.0"
-readonly YQ_VERSION="v4.49.2"
+readonly POWERVC_TOOL_VERSION="v2.3.4"
+readonly YQ_VERSION="v4.53.2"
 readonly IBMCLOUD_VERSION="2.43.0"
 
 # Color codes for output (only use if terminal supports it)


### PR DESCRIPTION
Use verison 2.3.6 of the PowerVC tools.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped PowerVC-Tool from v2.2.0 to v2.3.4 and yq from v4.49.2 to v4.53.2 in CI step scripts.
* **Impact**
  * PowerVC IPI CI workflows for cluster configuration, installation, and deprovisioning will now run with the updated tool versions; no functional behavior changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->