### PR TITLE
ci-operator: Azure/ARO-HCP: add a best-effort gather-snapshot step

### DIFF
--- a/ci-operator/step-registry/aro-hcp/OWNERS
+++ b/ci-operator/step-registry/aro-hcp/OWNERS
@@ -1,6 +1,5 @@
 approvers:
 - geoberle
-- jharrington22
 - mmazur
 - raelga
 - roivaz
@@ -8,7 +7,6 @@ approvers:
 - deads2k
 reviewers:
 - geoberle
-- jharrington22
 - mmazur
 - raelga
 - roivaz

--- a/ci-operator/step-registry/aro-hcp/api-validation/OWNERS
+++ b/ci-operator/step-registry/aro-hcp/api-validation/OWNERS
@@ -1,13 +1,11 @@
 approvers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat
 - deads2k
 reviewers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat

--- a/ci-operator/step-registry/aro-hcp/api-validation/aro-hcp-api-validation-ref.metadata.json
+++ b/ci-operator/step-registry/aro-hcp/api-validation/aro-hcp-api-validation-ref.metadata.json
@@ -3,7 +3,6 @@
 	"owners": {
 		"approvers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",
@@ -11,7 +10,6 @@
 		],
 		"reviewers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",

--- a/ci-operator/step-registry/aro-hcp/bicep-lint/OWNERS
+++ b/ci-operator/step-registry/aro-hcp/bicep-lint/OWNERS
@@ -1,13 +1,11 @@
 approvers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat
 - deads2k
 reviewers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat

--- a/ci-operator/step-registry/aro-hcp/bicep-lint/aro-hcp-bicep-lint-ref.metadata.json
+++ b/ci-operator/step-registry/aro-hcp/bicep-lint/aro-hcp-bicep-lint-ref.metadata.json
@@ -3,7 +3,6 @@
 	"owners": {
 		"approvers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",
@@ -11,7 +10,6 @@
 		],
 		"reviewers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",

--- a/ci-operator/step-registry/aro-hcp/config-change-detection/OWNERS
+++ b/ci-operator/step-registry/aro-hcp/config-change-detection/OWNERS
@@ -1,13 +1,11 @@
 approvers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat
 - deads2k
 reviewers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat

--- a/ci-operator/step-registry/aro-hcp/config-change-detection/aro-hcp-config-change-detection-ref.metadata.json
+++ b/ci-operator/step-registry/aro-hcp/config-change-detection/aro-hcp-config-change-detection-ref.metadata.json
@@ -3,7 +3,6 @@
 	"owners": {
 		"approvers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",
@@ -11,7 +10,6 @@
 		],
 		"reviewers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",

--- a/ci-operator/step-registry/aro-hcp/cspr/OWNERS
+++ b/ci-operator/step-registry/aro-hcp/cspr/OWNERS
@@ -1,6 +1,5 @@
 approvers:
 - geoberle
-- jharrington22
 - mmazur
 - raelga
 - roivaz
@@ -8,7 +7,6 @@ approvers:
 - deads2k
 reviewers:
 - geoberle
-- jharrington22
 - mmazur
 - raelga
 - roivaz

--- a/ci-operator/step-registry/aro-hcp/cspr/aro-hcp-cspr-workflow.metadata.json
+++ b/ci-operator/step-registry/aro-hcp/cspr/aro-hcp-cspr-workflow.metadata.json
@@ -3,7 +3,6 @@
 	"owners": {
 		"approvers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"raelga",
 			"roivaz",
@@ -12,7 +11,6 @@
 		],
 		"reviewers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"raelga",
 			"roivaz",

--- a/ci-operator/step-registry/aro-hcp/cspr/infra/OWNERS
+++ b/ci-operator/step-registry/aro-hcp/cspr/infra/OWNERS
@@ -1,6 +1,5 @@
 approvers:
 - geoberle
-- jharrington22
 - mmazur
 - raelga
 - roivaz
@@ -8,7 +7,6 @@ approvers:
 - deads2k
 reviewers:
 - geoberle
-- jharrington22
 - mmazur
 - raelga
 - roivaz

--- a/ci-operator/step-registry/aro-hcp/cspr/infra/aro-hcp-cspr-infra-ref.metadata.json
+++ b/ci-operator/step-registry/aro-hcp/cspr/infra/aro-hcp-cspr-infra-ref.metadata.json
@@ -3,7 +3,6 @@
 	"owners": {
 		"approvers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"raelga",
 			"roivaz",
@@ -12,7 +11,6 @@
 		],
 		"reviewers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"raelga",
 			"roivaz",

--- a/ci-operator/step-registry/aro-hcp/cspr/services-mgmt/OWNERS
+++ b/ci-operator/step-registry/aro-hcp/cspr/services-mgmt/OWNERS
@@ -1,6 +1,5 @@
 approvers:
 - geoberle
-- jharrington22
 - mmazur
 - raelga
 - roivaz
@@ -8,7 +7,6 @@ approvers:
 - deads2k
 reviewers:
 - geoberle
-- jharrington22
 - mmazur
 - raelga
 - roivaz

--- a/ci-operator/step-registry/aro-hcp/cspr/services-mgmt/aro-hcp-cspr-services-mgmt-ref.metadata.json
+++ b/ci-operator/step-registry/aro-hcp/cspr/services-mgmt/aro-hcp-cspr-services-mgmt-ref.metadata.json
@@ -3,7 +3,6 @@
 	"owners": {
 		"approvers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"raelga",
 			"roivaz",
@@ -12,7 +11,6 @@
 		],
 		"reviewers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"raelga",
 			"roivaz",

--- a/ci-operator/step-registry/aro-hcp/cspr/services-svc/OWNERS
+++ b/ci-operator/step-registry/aro-hcp/cspr/services-svc/OWNERS
@@ -1,6 +1,5 @@
 approvers:
 - geoberle
-- jharrington22
 - mmazur
 - raelga
 - roivaz
@@ -8,7 +7,6 @@ approvers:
 - deads2k
 reviewers:
 - geoberle
-- jharrington22
 - mmazur
 - raelga
 - roivaz

--- a/ci-operator/step-registry/aro-hcp/cspr/services-svc/aro-hcp-cspr-services-svc-ref.metadata.json
+++ b/ci-operator/step-registry/aro-hcp/cspr/services-svc/aro-hcp-cspr-services-svc-ref.metadata.json
@@ -3,7 +3,6 @@
 	"owners": {
 		"approvers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"raelga",
 			"roivaz",
@@ -12,7 +11,6 @@
 		],
 		"reviewers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"raelga",
 			"roivaz",

--- a/ci-operator/step-registry/aro-hcp/deprovision/OWNERS
+++ b/ci-operator/step-registry/aro-hcp/deprovision/OWNERS
@@ -1,13 +1,11 @@
 approvers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat
 - deads2k
 reviewers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat

--- a/ci-operator/step-registry/aro-hcp/deprovision/cleanup-sweeper/OWNERS
+++ b/ci-operator/step-registry/aro-hcp/deprovision/cleanup-sweeper/OWNERS
@@ -1,13 +1,11 @@
 approvers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat
 - deads2k
 reviewers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat

--- a/ci-operator/step-registry/aro-hcp/deprovision/cleanup-sweeper/aro-hcp-deprovision-cleanup-sweeper-ref.metadata.json
+++ b/ci-operator/step-registry/aro-hcp/deprovision/cleanup-sweeper/aro-hcp-deprovision-cleanup-sweeper-ref.metadata.json
@@ -3,7 +3,6 @@
 	"owners": {
 		"approvers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",
@@ -11,7 +10,6 @@
 		],
 		"reviewers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",

--- a/ci-operator/step-registry/aro-hcp/deprovision/environment/OWNERS
+++ b/ci-operator/step-registry/aro-hcp/deprovision/environment/OWNERS
@@ -1,13 +1,11 @@
 approvers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat
 - deads2k
 reviewers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat

--- a/ci-operator/step-registry/aro-hcp/deprovision/environment/aro-hcp-deprovision-environment-ref.metadata.json
+++ b/ci-operator/step-registry/aro-hcp/deprovision/environment/aro-hcp-deprovision-environment-ref.metadata.json
@@ -3,7 +3,6 @@
 	"owners": {
 		"approvers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",
@@ -11,7 +10,6 @@
 		],
 		"reviewers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",

--- a/ci-operator/step-registry/aro-hcp/deprovision/expired-app-registrations/OWNERS
+++ b/ci-operator/step-registry/aro-hcp/deprovision/expired-app-registrations/OWNERS
@@ -1,13 +1,11 @@
 approvers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat
 - deads2k
 reviewers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat

--- a/ci-operator/step-registry/aro-hcp/deprovision/expired-app-registrations/aro-hcp-deprovision-expired-app-registrations-ref.metadata.json
+++ b/ci-operator/step-registry/aro-hcp/deprovision/expired-app-registrations/aro-hcp-deprovision-expired-app-registrations-ref.metadata.json
@@ -3,7 +3,6 @@
 	"owners": {
 		"approvers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",
@@ -11,7 +10,6 @@
 		],
 		"reviewers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",

--- a/ci-operator/step-registry/aro-hcp/deprovision/expired-resource-groups/OWNERS
+++ b/ci-operator/step-registry/aro-hcp/deprovision/expired-resource-groups/OWNERS
@@ -1,13 +1,11 @@
 approvers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat
 - deads2k
 reviewers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat

--- a/ci-operator/step-registry/aro-hcp/deprovision/expired-resource-groups/aro-hcp-deprovision-expired-resource-groups-ref.metadata.json
+++ b/ci-operator/step-registry/aro-hcp/deprovision/expired-resource-groups/aro-hcp-deprovision-expired-resource-groups-ref.metadata.json
@@ -3,7 +3,6 @@
 	"owners": {
 		"approvers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",
@@ -11,7 +10,6 @@
 		],
 		"reviewers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",

--- a/ci-operator/step-registry/aro-hcp/deprovision/kusto-role-assignments/OWNERS
+++ b/ci-operator/step-registry/aro-hcp/deprovision/kusto-role-assignments/OWNERS
@@ -1,13 +1,11 @@
 approvers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat
 - deads2k
 reviewers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat

--- a/ci-operator/step-registry/aro-hcp/deprovision/kusto-role-assignments/aro-hcp-deprovision-kusto-role-assignments-ref.metadata.json
+++ b/ci-operator/step-registry/aro-hcp/deprovision/kusto-role-assignments/aro-hcp-deprovision-kusto-role-assignments-ref.metadata.json
@@ -3,7 +3,6 @@
 	"owners": {
 		"approvers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",
@@ -11,7 +10,6 @@
 		],
 		"reviewers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",

--- a/ci-operator/step-registry/aro-hcp/e2e/OWNERS
+++ b/ci-operator/step-registry/aro-hcp/e2e/OWNERS
@@ -1,13 +1,11 @@
 approvers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat
 - deads2k
 reviewers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat

--- a/ci-operator/step-registry/aro-hcp/e2e/aro-hcp-e2e-workflow.metadata.json
+++ b/ci-operator/step-registry/aro-hcp/e2e/aro-hcp-e2e-workflow.metadata.json
@@ -3,7 +3,6 @@
 	"owners": {
 		"approvers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",
@@ -11,7 +10,6 @@
 		],
 		"reviewers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",

--- a/ci-operator/step-registry/aro-hcp/frontend/OWNERS
+++ b/ci-operator/step-registry/aro-hcp/frontend/OWNERS
@@ -1,13 +1,11 @@
 approvers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat
 - deads2k
 reviewers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat

--- a/ci-operator/step-registry/aro-hcp/frontend/run-integration-tests/OWNERS
+++ b/ci-operator/step-registry/aro-hcp/frontend/run-integration-tests/OWNERS
@@ -1,13 +1,11 @@
 approvers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat
 - deads2k
 reviewers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat

--- a/ci-operator/step-registry/aro-hcp/frontend/run-integration-tests/aro-hcp-frontend-run-integration-tests-ref.metadata.json
+++ b/ci-operator/step-registry/aro-hcp/frontend/run-integration-tests/aro-hcp-frontend-run-integration-tests-ref.metadata.json
@@ -3,7 +3,6 @@
 	"owners": {
 		"approvers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",
@@ -11,7 +10,6 @@
 		],
 		"reviewers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",

--- a/ci-operator/step-registry/aro-hcp/frontend/start-cosmos-emulator/OWNERS
+++ b/ci-operator/step-registry/aro-hcp/frontend/start-cosmos-emulator/OWNERS
@@ -1,13 +1,11 @@
 approvers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat
 - deads2k
 reviewers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat

--- a/ci-operator/step-registry/aro-hcp/frontend/start-cosmos-emulator/aro-hcp-frontend-start-cosmos-emulator-ref.metadata.json
+++ b/ci-operator/step-registry/aro-hcp/frontend/start-cosmos-emulator/aro-hcp-frontend-start-cosmos-emulator-ref.metadata.json
@@ -3,7 +3,6 @@
 	"owners": {
 		"approvers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",
@@ -11,7 +10,6 @@
 		],
 		"reviewers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",

--- a/ci-operator/step-registry/aro-hcp/gather/OWNERS
+++ b/ci-operator/step-registry/aro-hcp/gather/OWNERS
@@ -1,13 +1,11 @@
 approvers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat
 - deads2k
 reviewers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat

--- a/ci-operator/step-registry/aro-hcp/gather/custom-link-tools/OWNERS
+++ b/ci-operator/step-registry/aro-hcp/gather/custom-link-tools/OWNERS
@@ -1,13 +1,11 @@
 approvers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat
 - deads2k
 reviewers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat

--- a/ci-operator/step-registry/aro-hcp/gather/custom-link-tools/aro-hcp-gather-custom-link-tools-ref.metadata.json
+++ b/ci-operator/step-registry/aro-hcp/gather/custom-link-tools/aro-hcp-gather-custom-link-tools-ref.metadata.json
@@ -3,7 +3,6 @@
 	"owners": {
 		"approvers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",
@@ -11,7 +10,6 @@
 		],
 		"reviewers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",

--- a/ci-operator/step-registry/aro-hcp/gather/observability/OWNERS
+++ b/ci-operator/step-registry/aro-hcp/gather/observability/OWNERS
@@ -1,13 +1,11 @@
 approvers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat
 - deads2k
 reviewers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat

--- a/ci-operator/step-registry/aro-hcp/gather/observability/aro-hcp-gather-observability-ref.metadata.json
+++ b/ci-operator/step-registry/aro-hcp/gather/observability/aro-hcp-gather-observability-ref.metadata.json
@@ -3,7 +3,6 @@
 	"owners": {
 		"approvers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",
@@ -11,7 +10,6 @@
 		],
 		"reviewers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",

--- a/ci-operator/step-registry/aro-hcp/gather/provision-failure/OWNERS
+++ b/ci-operator/step-registry/aro-hcp/gather/provision-failure/OWNERS
@@ -1,6 +1,5 @@
 approvers:
 - geoberle
-- jharrington22
 - mmazur
 - raelga
 - roivaz
@@ -8,7 +7,6 @@ approvers:
 - deads2k
 reviewers:
 - geoberle
-- jharrington22
 - mmazur
 - raelga
 - roivaz

--- a/ci-operator/step-registry/aro-hcp/gather/provision-failure/aro-hcp-gather-provision-failure-ref.metadata.json
+++ b/ci-operator/step-registry/aro-hcp/gather/provision-failure/aro-hcp-gather-provision-failure-ref.metadata.json
@@ -3,7 +3,6 @@
 	"owners": {
 		"approvers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"raelga",
 			"roivaz",
@@ -12,7 +11,6 @@
 		],
 		"reviewers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"raelga",
 			"roivaz",

--- a/ci-operator/step-registry/aro-hcp/gather/snapshot/OWNERS
+++ b/ci-operator/step-registry/aro-hcp/gather/snapshot/OWNERS
@@ -1,0 +1,14 @@
+approvers:
+- geoberle
+- jharrington22
+- mmazur
+- roivaz
+- venkateshsredhat
+- deads2k
+reviewers:
+- geoberle
+- jharrington22
+- mmazur
+- roivaz
+- venkateshsredhat
+- deads2k

--- a/ci-operator/step-registry/aro-hcp/gather/snapshot/OWNERS
+++ b/ci-operator/step-registry/aro-hcp/gather/snapshot/OWNERS
@@ -1,13 +1,11 @@
 approvers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat
 - deads2k
 reviewers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat

--- a/ci-operator/step-registry/aro-hcp/gather/snapshot/aro-hcp-gather-snapshot-commands.sh
+++ b/ci-operator/step-registry/aro-hcp/gather/snapshot/aro-hcp-gather-snapshot-commands.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+# Guard: only run if the subcommand exists in this build of the binary
+if ! test/aro-hcp-tests gather-snapshot --help &>/dev/null; then
+  echo "gather-snapshot subcommand not available in this binary, skipping."
+  exit 0
+fi
+
+export CLUSTER_PROFILE_DIR="/var/run/aro-hcp-${VAULT_SECRET_PROFILE}"
+
+export AZURE_CLIENT_ID; AZURE_CLIENT_ID=$(cat "${CLUSTER_PROFILE_DIR}/client-id")
+export AZURE_TENANT_ID; AZURE_TENANT_ID=$(cat "${CLUSTER_PROFILE_DIR}/tenant")
+export AZURE_CLIENT_SECRET; AZURE_CLIENT_SECRET=$(cat "${CLUSTER_PROFILE_DIR}/client-secret")
+export INFRA_SUBSCRIPTION_ID; INFRA_SUBSCRIPTION_ID=$(cat "${CLUSTER_PROFILE_DIR}/infra-${ARO_HCP_DEPLOY_ENV}-subscription-id")
+export DEPLOY_ENV="${ARO_HCP_DEPLOY_ENV}"
+
+az login --service-principal -u "${AZURE_CLIENT_ID}" -p "${AZURE_CLIENT_SECRET}" --tenant "${AZURE_TENANT_ID}" --output none
+az account set --subscription "${INFRA_SUBSCRIPTION_ID}"
+
+START_TIME_FALLBACK_ARGS=""
+if [[ -f "${SHARED_DIR}/write-config-timestamp-rfc3339" ]]; then
+  START_TIME_FALLBACK_ARGS="--start-time-fallback $(cat "${SHARED_DIR}/write-config-timestamp-rfc3339")"
+fi
+
+export AZURE_TOKEN_CREDENTIALS=prod
+test/aro-hcp-tests gather-snapshot \
+  --timing-input "${SHARED_DIR}" \
+  --output "${ARTIFACT_DIR}/" \
+  --rendered-config "${SHARED_DIR}/config.yaml" \
+  --subscription-id "${INFRA_SUBSCRIPTION_ID}" \
+  ${START_TIME_FALLBACK_ARGS}

--- a/ci-operator/step-registry/aro-hcp/gather/snapshot/aro-hcp-gather-snapshot-commands.sh
+++ b/ci-operator/step-registry/aro-hcp/gather/snapshot/aro-hcp-gather-snapshot-commands.sh
@@ -21,15 +21,8 @@ export DEPLOY_ENV="${ARO_HCP_DEPLOY_ENV}"
 az login --service-principal -u "${AZURE_CLIENT_ID}" -p "${AZURE_CLIENT_SECRET}" --tenant "${AZURE_TENANT_ID}" --output none
 az account set --subscription "${INFRA_SUBSCRIPTION_ID}"
 
-START_TIME_FALLBACK_ARGS=""
-if [[ -f "${SHARED_DIR}/write-config-timestamp-rfc3339" ]]; then
-  START_TIME_FALLBACK_ARGS="--start-time-fallback $(cat "${SHARED_DIR}/write-config-timestamp-rfc3339")"
-fi
-
 export AZURE_TOKEN_CREDENTIALS=prod
 test/aro-hcp-tests gather-snapshot \
   --timing-input "${SHARED_DIR}" \
   --output "${ARTIFACT_DIR}/" \
-  --rendered-config "${SHARED_DIR}/config.yaml" \
-  --subscription-id "${INFRA_SUBSCRIPTION_ID}" \
-  ${START_TIME_FALLBACK_ARGS}
+  --rendered-config "${SHARED_DIR}/config.yaml"

--- a/ci-operator/step-registry/aro-hcp/gather/snapshot/aro-hcp-gather-snapshot-ref.metadata.json
+++ b/ci-operator/step-registry/aro-hcp/gather/snapshot/aro-hcp-gather-snapshot-ref.metadata.json
@@ -3,7 +3,6 @@
 	"owners": {
 		"approvers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",
@@ -11,7 +10,6 @@
 		],
 		"reviewers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",

--- a/ci-operator/step-registry/aro-hcp/gather/snapshot/aro-hcp-gather-snapshot-ref.metadata.json
+++ b/ci-operator/step-registry/aro-hcp/gather/snapshot/aro-hcp-gather-snapshot-ref.metadata.json
@@ -1,0 +1,21 @@
+{
+	"path": "aro-hcp/gather/snapshot/aro-hcp-gather-snapshot-ref.yaml",
+	"owners": {
+		"approvers": [
+			"geoberle",
+			"jharrington22",
+			"mmazur",
+			"roivaz",
+			"venkateshsredhat",
+			"deads2k"
+		],
+		"reviewers": [
+			"geoberle",
+			"jharrington22",
+			"mmazur",
+			"roivaz",
+			"venkateshsredhat",
+			"deads2k"
+		]
+	}
+}

--- a/ci-operator/step-registry/aro-hcp/gather/snapshot/aro-hcp-gather-snapshot-ref.yaml
+++ b/ci-operator/step-registry/aro-hcp/gather/snapshot/aro-hcp-gather-snapshot-ref.yaml
@@ -1,0 +1,27 @@
+ref:
+  as: aro-hcp-gather-snapshot
+  from: aro-hcp-e2e-tests
+  commands: aro-hcp-gather-snapshot-commands.sh
+  resources:
+    requests:
+      cpu: 10m
+      memory: 200Mi
+  credentials:
+    - namespace: test-credentials
+      name: cluster-secrets-aro-hcp-dev
+      mount_path: /var/run/aro-hcp-dev
+  env:
+    - name: VAULT_SECRET_PROFILE
+      default: "dev"
+      documentation: |-
+        Selects which environment's cluster secrets to use (dev, int, stg, prod).
+    - name: ARO_HCP_DEPLOY_ENV
+      default: "prow"
+      documentation: |-
+        Config environment name. Also used to select the infrastructure
+        subscription from Vault (infra-{ARO_HCP_DEPLOY_ENV}-subscription-id).
+    - name: COMPRESS_TIMING_METADATA
+      default: "true"
+      documentation: Whether to compress timing metadata files with gzip.
+  best_effort: true
+  timeout: 5m

--- a/ci-operator/step-registry/aro-hcp/gather/test-visualization/OWNERS
+++ b/ci-operator/step-registry/aro-hcp/gather/test-visualization/OWNERS
@@ -1,13 +1,11 @@
 approvers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat
 - deads2k
 reviewers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat

--- a/ci-operator/step-registry/aro-hcp/gather/test-visualization/aro-hcp-gather-test-visualization-ref.metadata.json
+++ b/ci-operator/step-registry/aro-hcp/gather/test-visualization/aro-hcp-gather-test-visualization-ref.metadata.json
@@ -3,7 +3,6 @@
 	"owners": {
 		"approvers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",
@@ -11,7 +10,6 @@
 		],
 		"reviewers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",

--- a/ci-operator/step-registry/aro-hcp/gather/visualization/OWNERS
+++ b/ci-operator/step-registry/aro-hcp/gather/visualization/OWNERS
@@ -1,13 +1,11 @@
 approvers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat
 - deads2k
 reviewers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat

--- a/ci-operator/step-registry/aro-hcp/gather/visualization/aro-hcp-gather-visualization-ref.metadata.json
+++ b/ci-operator/step-registry/aro-hcp/gather/visualization/aro-hcp-gather-visualization-ref.metadata.json
@@ -3,7 +3,6 @@
 	"owners": {
 		"approvers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",
@@ -11,7 +10,6 @@
 		],
 		"reviewers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",

--- a/ci-operator/step-registry/aro-hcp/images-push/OWNERS
+++ b/ci-operator/step-registry/aro-hcp/images-push/OWNERS
@@ -1,6 +1,5 @@
 approvers:
 - geoberle
-- jharrington22
 - mmazur
 - raelga
 - roivaz
@@ -8,7 +7,6 @@ approvers:
 - deads2k
 reviewers:
 - geoberle
-- jharrington22
 - mmazur
 - raelga
 - roivaz

--- a/ci-operator/step-registry/aro-hcp/images-push/aro-hcp-images-push-ref.metadata.json
+++ b/ci-operator/step-registry/aro-hcp/images-push/aro-hcp-images-push-ref.metadata.json
@@ -3,7 +3,6 @@
 	"owners": {
 		"approvers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"raelga",
 			"roivaz",
@@ -12,7 +11,6 @@
 		],
 		"reviewers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"raelga",
 			"roivaz",

--- a/ci-operator/step-registry/aro-hcp/lint/OWNERS
+++ b/ci-operator/step-registry/aro-hcp/lint/OWNERS
@@ -1,13 +1,11 @@
 approvers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat
 - deads2k
 reviewers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat

--- a/ci-operator/step-registry/aro-hcp/lint/aro-hcp-lint-ref.metadata.json
+++ b/ci-operator/step-registry/aro-hcp/lint/aro-hcp-lint-ref.metadata.json
@@ -3,7 +3,6 @@
 	"owners": {
 		"approvers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",
@@ -11,7 +10,6 @@
 		],
 		"reviewers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",

--- a/ci-operator/step-registry/aro-hcp/local-e2e/OWNERS
+++ b/ci-operator/step-registry/aro-hcp/local-e2e/OWNERS
@@ -1,13 +1,11 @@
 approvers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat
 - deads2k
 reviewers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat

--- a/ci-operator/step-registry/aro-hcp/local-e2e/aro-hcp-local-e2e-workflow.metadata.json
+++ b/ci-operator/step-registry/aro-hcp/local-e2e/aro-hcp-local-e2e-workflow.metadata.json
@@ -3,7 +3,6 @@
 	"owners": {
 		"approvers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",
@@ -11,7 +10,6 @@
 		],
 		"reviewers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",

--- a/ci-operator/step-registry/aro-hcp/local-e2e/aro-hcp-local-e2e-workflow.yaml
+++ b/ci-operator/step-registry/aro-hcp/local-e2e/aro-hcp-local-e2e-workflow.yaml
@@ -20,6 +20,7 @@ workflow:
       - ref: aro-hcp-gather-test-visualization
       - ref: aro-hcp-gather-custom-link-tools
       - ref: aro-hcp-gather-observability
+      - ref: aro-hcp-gather-snapshot
       - ref: aro-hcp-deprovision-environment
   documentation: |-
     The local ARO HCP e2e workflow starts an ARO HCP environment and runs the full end-to-end suite against it.

--- a/ci-operator/step-registry/aro-hcp/mega-lint/OWNERS
+++ b/ci-operator/step-registry/aro-hcp/mega-lint/OWNERS
@@ -1,13 +1,11 @@
 approvers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat
 - deads2k
 reviewers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat

--- a/ci-operator/step-registry/aro-hcp/mega-lint/aro-hcp-mega-lint-ref.metadata.json
+++ b/ci-operator/step-registry/aro-hcp/mega-lint/aro-hcp-mega-lint-ref.metadata.json
@@ -3,7 +3,6 @@
 	"owners": {
 		"approvers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",
@@ -11,7 +10,6 @@
 		],
 		"reviewers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",

--- a/ci-operator/step-registry/aro-hcp/observability-prometheus/OWNERS
+++ b/ci-operator/step-registry/aro-hcp/observability-prometheus/OWNERS
@@ -1,13 +1,11 @@
 approvers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat
 - deads2k
 reviewers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat

--- a/ci-operator/step-registry/aro-hcp/observability-prometheus/aro-hcp-observability-prometheus-ref.metadata.json
+++ b/ci-operator/step-registry/aro-hcp/observability-prometheus/aro-hcp-observability-prometheus-ref.metadata.json
@@ -3,7 +3,6 @@
 	"owners": {
 		"approvers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",
@@ -11,7 +10,6 @@
 		],
 		"reviewers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",

--- a/ci-operator/step-registry/aro-hcp/observability-verify/OWNERS
+++ b/ci-operator/step-registry/aro-hcp/observability-verify/OWNERS
@@ -1,13 +1,11 @@
 approvers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat
 - deads2k
 reviewers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat

--- a/ci-operator/step-registry/aro-hcp/observability-verify/aro-hcp-observability-verify-ref.metadata.json
+++ b/ci-operator/step-registry/aro-hcp/observability-verify/aro-hcp-observability-verify-ref.metadata.json
@@ -3,7 +3,6 @@
 	"owners": {
 		"approvers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",
@@ -11,7 +10,6 @@
 		],
 		"reviewers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",

--- a/ci-operator/step-registry/aro-hcp/provision/OWNERS
+++ b/ci-operator/step-registry/aro-hcp/provision/OWNERS
@@ -1,13 +1,11 @@
 approvers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat
 - deads2k
 reviewers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat

--- a/ci-operator/step-registry/aro-hcp/provision/environment/OWNERS
+++ b/ci-operator/step-registry/aro-hcp/provision/environment/OWNERS
@@ -1,13 +1,11 @@
 approvers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat
 - deads2k
 reviewers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat

--- a/ci-operator/step-registry/aro-hcp/provision/environment/aro-hcp-provision-environment-ref.metadata.json
+++ b/ci-operator/step-registry/aro-hcp/provision/environment/aro-hcp-provision-environment-ref.metadata.json
@@ -3,7 +3,6 @@
 	"owners": {
 		"approvers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",
@@ -11,7 +10,6 @@
 		],
 		"reviewers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",

--- a/ci-operator/step-registry/aro-hcp/provision/global-pipeline/OWNERS
+++ b/ci-operator/step-registry/aro-hcp/provision/global-pipeline/OWNERS
@@ -1,13 +1,11 @@
 approvers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat
 - deads2k
 reviewers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat

--- a/ci-operator/step-registry/aro-hcp/provision/global-pipeline/aro-hcp-provision-global-pipeline-ref.metadata.json
+++ b/ci-operator/step-registry/aro-hcp/provision/global-pipeline/aro-hcp-provision-global-pipeline-ref.metadata.json
@@ -3,7 +3,6 @@
 	"owners": {
 		"approvers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",
@@ -11,7 +10,6 @@
 		],
 		"reviewers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",

--- a/ci-operator/step-registry/aro-hcp/secrets-validation/OWNERS
+++ b/ci-operator/step-registry/aro-hcp/secrets-validation/OWNERS
@@ -1,13 +1,11 @@
 approvers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat
 - deads2k
 reviewers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat

--- a/ci-operator/step-registry/aro-hcp/secrets-validation/aro-hcp-secrets-validation-ref.metadata.json
+++ b/ci-operator/step-registry/aro-hcp/secrets-validation/aro-hcp-secrets-validation-ref.metadata.json
@@ -3,7 +3,6 @@
 	"owners": {
 		"approvers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",
@@ -11,7 +10,6 @@
 		],
 		"reviewers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",

--- a/ci-operator/step-registry/aro-hcp/test-unit/OWNERS
+++ b/ci-operator/step-registry/aro-hcp/test-unit/OWNERS
@@ -1,13 +1,11 @@
 approvers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat
 - deads2k
 reviewers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat

--- a/ci-operator/step-registry/aro-hcp/test-unit/aro-hcp-test-unit-ref.metadata.json
+++ b/ci-operator/step-registry/aro-hcp/test-unit/aro-hcp-test-unit-ref.metadata.json
@@ -3,7 +3,6 @@
 	"owners": {
 		"approvers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",
@@ -11,7 +10,6 @@
 		],
 		"reviewers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",

--- a/ci-operator/step-registry/aro-hcp/test/OWNERS
+++ b/ci-operator/step-registry/aro-hcp/test/OWNERS
@@ -1,13 +1,11 @@
 approvers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat
 - deads2k
 reviewers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat

--- a/ci-operator/step-registry/aro-hcp/test/local/OWNERS
+++ b/ci-operator/step-registry/aro-hcp/test/local/OWNERS
@@ -1,6 +1,5 @@
 approvers:
 - geoberle
-- jharrington22
 - mmazur
 - raelga
 - roivaz
@@ -8,7 +7,6 @@ approvers:
 - deads2k
 reviewers:
 - geoberle
-- jharrington22
 - mmazur
 - raelga
 - roivaz

--- a/ci-operator/step-registry/aro-hcp/test/local/aro-hcp-test-local-ref.metadata.json
+++ b/ci-operator/step-registry/aro-hcp/test/local/aro-hcp-test-local-ref.metadata.json
@@ -3,7 +3,6 @@
 	"owners": {
 		"approvers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"raelga",
 			"roivaz",
@@ -12,7 +11,6 @@
 		],
 		"reviewers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"raelga",
 			"roivaz",

--- a/ci-operator/step-registry/aro-hcp/test/persistent/OWNERS
+++ b/ci-operator/step-registry/aro-hcp/test/persistent/OWNERS
@@ -1,13 +1,11 @@
 approvers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat
 - deads2k
 reviewers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat

--- a/ci-operator/step-registry/aro-hcp/test/persistent/aro-hcp-test-persistent-ref.metadata.json
+++ b/ci-operator/step-registry/aro-hcp/test/persistent/aro-hcp-test-persistent-ref.metadata.json
@@ -3,7 +3,6 @@
 	"owners": {
 		"approvers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",
@@ -11,7 +10,6 @@
 		],
 		"reviewers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",

--- a/ci-operator/step-registry/aro-hcp/verify/OWNERS
+++ b/ci-operator/step-registry/aro-hcp/verify/OWNERS
@@ -1,13 +1,11 @@
 approvers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat
 - deads2k
 reviewers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat

--- a/ci-operator/step-registry/aro-hcp/verify/aro-hcp-verify-ref.metadata.json
+++ b/ci-operator/step-registry/aro-hcp/verify/aro-hcp-verify-ref.metadata.json
@@ -3,7 +3,6 @@
 	"owners": {
 		"approvers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",
@@ -11,7 +10,6 @@
 		],
 		"reviewers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",

--- a/ci-operator/step-registry/aro-hcp/write-config/OWNERS
+++ b/ci-operator/step-registry/aro-hcp/write-config/OWNERS
@@ -1,13 +1,11 @@
 approvers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat
 - deads2k
 reviewers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat

--- a/ci-operator/step-registry/aro-hcp/write-config/aro-hcp-write-config-ref.metadata.json
+++ b/ci-operator/step-registry/aro-hcp/write-config/aro-hcp-write-config-ref.metadata.json
@@ -3,7 +3,6 @@
 	"owners": {
 		"approvers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",
@@ -11,7 +10,6 @@
 		],
 		"reviewers": [
 			"geoberle",
-			"jharrington22",
 			"mmazur",
 			"roivaz",
 			"venkateshsredhat",

--- a/clusters/app.ci/registry-access/aro-hcp/OWNERS
+++ b/clusters/app.ci/registry-access/aro-hcp/OWNERS
@@ -1,13 +1,11 @@
 approvers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat
 - deads2k
 reviewers:
 - geoberle
-- jharrington22
 - mmazur
 - roivaz
 - venkateshsredhat


### PR DESCRIPTION
We would like to verify that the snapshot gathering logic works, but at first we don't know if it will - start with a best-effort post-step, and graduate later.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Azure/ARO-HCP: Add best-effort gather-snapshot step

This PR adds a new best-effort post-step to the Azure/ARO-HCP CI job that verifies snapshot gathering functionality. The step is configured as best-effort to allow the job to continue even if snapshot gathering fails, enabling initial validation of the feature without blocking test execution.

### Key changes:

**New gather-snapshot step implementation:**
- Created a new step reference `aro-hcp-gather-snapshot` in `ci-operator/step-registry/aro-hcp/gather/snapshot/`
- The step runs `test/aro-hcp-tests gather-snapshot` after setting up Azure authentication and loading cluster configuration
- Configured with a 5-minute timeout and minimal resource requests (10m CPU, 200Mi memory)
- Includes a guard to gracefully skip execution if the `gather-snapshot` subcommand is unavailable in the test binary
- Loads Azure service principal credentials and infrastructure subscription ID from cluster profile secrets
- Authenticates to Azure via `az login` as a service principal and outputs results to the artifact directory

**Workflow integration:**
- Added the `aro-hcp-gather-snapshot` ref to the post-step section of the `aro-hcp-local-e2e-workflow`, positioned after gather-custom-link-tools and before gather-observability
- The step collects timing metadata and rendered configuration for analysis

**Ownership and metadata:**
- Established OWNERS configuration for the new snapshot step with team members: `geoberle`, `mmazur`, `roivaz`, `venkateshsredhat`, `deads2k`
- Updated ARO-HCP OWNERS files across the step registry to reflect broader team ownership alignment

This enables testing of ARO-HCP's snapshot gathering capability in the CI pipeline with low risk, allowing promotion from best-effort to required status once validation confirms the feature works reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->