### PR TITLE
[DNM]e2e-metal-ipi-ovn-ipv4-bm-bond

### DIFF
--- a/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.22.yaml
+++ b/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.22.yaml
@@ -99,6 +99,24 @@ tests:
     env:
       EXTRA_MG_ARGS: --host-network
     workflow: baremetalds-e2e-ovn-ipv4
+- always_run: false
+  as: e2e-metal-ipi-ovn-ipv4-bm-bond
+  capabilities:
+  - intranet
+  optional: true
+  steps:
+    cluster_profile: equinix-ocp-metal
+    env:
+      DEVSCRIPTS_CONFIG: |
+        IP_STACK=v4
+        NETWORK_TYPE=OVNKubernetes
+        BOND_PRIMARY_INTERFACE=true
+        NETWORK_CONFIG_FOLDER=./network-configs/bond
+        ASSETS_EXTRA_FOLDER=./network-configs/nmstate-brex-bond
+    test:
+    - ref: wait
+    workflow: baremetalds-e2e-ovn-ipv4
+  timeout: 6h0m0s
 - as: e2e-metal-ipi-ovn-ipv6
   capabilities:
   - intranet

--- a/ci-operator/jobs/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.22-presubmits.yaml
@@ -2769,6 +2769,90 @@ presubmits:
     - ^release-4\.22$
     - ^release-4\.22-
     cluster: build09
+    context: ci/prow/e2e-metal-ipi-ovn-ipv4-bm-bond
+    decorate: true
+    decoration_config:
+      timeout: 6h0m0s
+    labels:
+      capability/intranet: intranet
+      ci-operator.openshift.io/cloud: equinix-ocp-metal
+      ci-operator.openshift.io/cloud-cluster-profile: equinix-ocp-metal
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-ovn-kubernetes-release-4.22-e2e-metal-ipi-ovn-ipv4-bm-bond
+    optional: true
+    rerun_command: /test e2e-metal-ipi-ovn-ipv4-bm-bond
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-metal-ipi-ovn-ipv4-bm-bond
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-metal-ipi-ovn-ipv4-bm-bond,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.22$
+    - ^release-4\.22-
+    cluster: build09
     context: ci/prow/e2e-metal-ipi-ovn-ipv6
     decorate: true
     labels:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds a new optional OpenShift CI e2e job to the openshift/release repository’s OVN Kubernetes 4.22 ci-operator config: a test named e2e-metal-ipi-ovn-ipv4-bm-bond in ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.22.yaml.

Practical effect:
- Targets the OVN Kubernetes 4.22 component’s CI configuration in openshift/release.
- Introduces an Equinix bare-metal job (cluster_profile: equinix-ocp-metal) that runs the existing baremetalds-e2e-ovn-ipv4 workflow with configuration to validate network bonding:
  - DEVSCRIPTS_CONFIG sets IP_STACK=v4, NETWORK_TYPE=OVNKubernetes and BOND_PRIMARY_INTERFACE=true.
  - Network asset paths set via NETWORK_CONFIG_FOLDER and ASSETS_EXTRA_FOLDER for bond/nmstate assets.
- Job is optional and non-blocking (always_run: false, optional: true) and scoped with the intranet capability.
- Includes a test wait step and a 6-hour timeout.

This enables CI validation of OVN IPv4 installs on bare-metal with a bonded primary interface (network redundancy testing). The PR is marked [DNM], indicating it’s a draft/test change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->