### PR TITLE
adding kcm-o ote ci

### DIFF
--- a/ci-operator/config/openshift/cluster-kube-controller-manager-operator/openshift-cluster-kube-controller-manager-operator-main.yaml
+++ b/ci-operator/config/openshift/cluster-kube-controller-manager-operator/openshift-cluster-kube-controller-manager-operator-main.yaml
@@ -84,6 +84,36 @@ tests:
     test:
     - ref: openshift-e2e-test
     workflow: ipi-gcp
+- always_run: false
+  as: e2e-aws-operator-preferred-host-ote
+  optional: true
+  steps:
+    cluster_profile: openshift-org-aws
+    env:
+      TEST_SUITE: openshift/cluster-kube-controller-manager-operator/operator/preferred-host
+    test:
+    - ref: openshift-e2e-test
+    workflow: ipi-aws
+- always_run: false
+  as: e2e-aws-operator-serial-ote
+  optional: true
+  steps:
+    cluster_profile: openshift-org-aws
+    env:
+      TEST_SUITE: openshift/cluster-kube-controller-manager-operator/operator/serial
+    test:
+    - ref: openshift-e2e-test
+    workflow: ipi-aws
+- always_run: false
+  as: e2e-aws-operator-ote
+  optional: true
+  steps:
+    cluster_profile: openshift-org-aws
+    env:
+      TEST_SUITE: openshift/cluster-kube-controller-manager-operator/operator/parallel
+    test:
+    - ref: openshift-e2e-test
+    workflow: ipi-aws
 - as: security
   optional: true
   steps:

--- a/ci-operator/config/openshift/cluster-kube-controller-manager-operator/openshift-cluster-kube-controller-manager-operator-main.yaml
+++ b/ci-operator/config/openshift/cluster-kube-controller-manager-operator/openshift-cluster-kube-controller-manager-operator-main.yaml
@@ -95,17 +95,7 @@ tests:
     - ref: openshift-e2e-test
     workflow: ipi-aws
 - always_run: false
-  as: e2e-aws-operator-serial-ote
-  optional: true
-  steps:
-    cluster_profile: openshift-org-aws
-    env:
-      TEST_SUITE: openshift/cluster-kube-controller-manager-operator/operator/serial
-    test:
-    - ref: openshift-e2e-test
-    workflow: ipi-aws
-- always_run: false
-  as: e2e-aws-operator-ote
+  as: e2e-aws-operator-parallel-ote
   optional: true
   steps:
     cluster_profile: openshift-org-aws

--- a/ci-operator/jobs/openshift/cluster-kube-controller-manager-operator/openshift-cluster-kube-controller-manager-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-kube-controller-manager-operator/openshift-cluster-kube-controller-manager-operator-main-presubmits.yaml
@@ -81,6 +81,87 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-aws-operator,?($|\s.*)
   - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build11
+    context: ci/prow/e2e-aws-operator-parallel-ote
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-kube-controller-manager-operator-main-e2e-aws-operator-parallel-ote
+    optional: true
+    rerun_command: /test e2e-aws-operator-parallel-ote
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-aws-operator-parallel-ote
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-aws-operator-parallel-ote,?($|\s.*)
+  - agent: kubernetes
     always_run: true
     branches:
     - ^main$
@@ -160,6 +241,87 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-aws-operator-preferred-host,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build11
+    context: ci/prow/e2e-aws-operator-preferred-host-ote
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-kube-controller-manager-operator-main-e2e-aws-operator-preferred-host-ote
+    optional: true
+    rerun_command: /test e2e-aws-operator-preferred-host-ote
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-aws-operator-preferred-host-ote
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-aws-operator-preferred-host-ote,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:


### PR DESCRIPTION
adding kcm-o ote ci

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR updates OpenShift CI configuration in the openshift/release repository for the cluster-kube-controller-manager-operator component by adding two optional AWS OTE (on-demand e2e) jobs to its ci-operator pipeline. These opt-in jobs allow maintainers to run targeted operator end-to-end tests on AWS IPI clusters without adding them to the default CI gating flow:

- e2e-aws-operator-preferred-host-ote — runs the operator preferred-host suite (TEST_SUITE: openshift/cluster-kube-controller-manager-operator/operator/preferred-host)
- e2e-aws-operator-parallel-ote — runs the operator parallel suite (TEST_SUITE: openshift/cluster-kube-controller-manager-operator/operator/parallel)

Both jobs target the openshift-org-aws cluster profile, use the ipi-aws workflow, reference the openshift-e2e-test test ref, and are configured optional: true / always_run: false (opt-in). These additions add on-demand e2e coverage for the operator while keeping the standard CI pipeline lightweight.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->