### PR TITLE
Add josecastillolema to nvidia-ci OWNERS file

### DIFF
--- a/ci-operator/config/rh-ecosystem-edge/nvidia-ci/OWNERS
+++ b/ci-operator/config/rh-ecosystem-edge/nvidia-ci/OWNERS
@@ -7,6 +7,7 @@
 approvers:
 - empovit
 - ggordanired
+- josecastillolema
 - nikitabugrovsky
 - shiraezra
 - tomernewman
@@ -16,6 +17,7 @@ options: {}
 reviewers:
 - empovit
 - ggordanired
+- josecastillolema
 - nikitabugrovsky
 - shiraezra
 - tomernewman

--- a/ci-operator/step-registry/nvidia-gpu-operator/OWNERS
+++ b/ci-operator/step-registry/nvidia-gpu-operator/OWNERS
@@ -2,6 +2,7 @@ approvers:
 - empovit
 - fabiendupont
 - ggordanired
+- josecastillolema
 - TomerNewman
 - wabouhamad
 - ybettan
@@ -10,6 +11,7 @@ reviewers:
 - empovit
 - fabiendupont
 - ggordanired
+- josecastillolema
 - TomerNewman
 - wabouhamad
 - ybettan

--- a/ci-operator/step-registry/nvidia-gpu-operator/e2e-aws/OWNERS
+++ b/ci-operator/step-registry/nvidia-gpu-operator/e2e-aws/OWNERS
@@ -2,6 +2,7 @@ approvers:
 - empovit
 - fabiendupont
 - ggordanired
+- josecastillolema
 - TomerNewman
 - wabouhamad
 - ybettan
@@ -10,6 +11,7 @@ reviewers:
 - empovit
 - fabiendupont
 - ggordanired
+- josecastillolema
 - TomerNewman
 - wabouhamad
 - ybettan

--- a/ci-operator/step-registry/nvidia-gpu-operator/e2e-aws/nvidia-gpu-operator-e2e-aws-workflow.metadata.json
+++ b/ci-operator/step-registry/nvidia-gpu-operator/e2e-aws/nvidia-gpu-operator-e2e-aws-workflow.metadata.json
@@ -5,6 +5,7 @@
 			"empovit",
 			"fabiendupont",
 			"ggordanired",
+			"josecastillolema",
 			"TomerNewman",
 			"wabouhamad",
 			"ybettan"
@@ -13,6 +14,7 @@
 			"empovit",
 			"fabiendupont",
 			"ggordanired",
+			"josecastillolema",
 			"TomerNewman",
 			"wabouhamad",
 			"ybettan"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR adds `josecastillolema` as an approver and reviewer across the NVIDIA GPU Operator CI configuration in the OpenShift release repository.

The changes grant code review and approval permissions in the following areas:

- **nvidia-ci repository CI**: Updated the synced OWNERS file for the rh-ecosystem-edge/nvidia-ci project that provides CI configuration for the main NVIDIA CI component
- **nvidia-gpu-operator step registry**: Added to approvers/reviewers for GPU operator test step definitions used in CI workflows
- **nvidia-gpu-operator e2e-aws tests**: Added to approvers/reviewers for the AWS-based end-to-end testing workflow for the GPU operator
- **Workflow metadata**: Updated the metadata configuration for the e2e-aws workflow

These are auto-generated OWNERS files that control who can approve and review changes to NVIDIA-related CI infrastructure and test workflows in the OpenShift CI system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->