### PR TITLE
make always run to false for OTE cases

### DIFF
--- a/ci-operator/config/openshift/cluster-authentication-operator/openshift-cluster-authentication-operator-master.yaml
+++ b/ci-operator/config/openshift/cluster-authentication-operator/openshift-cluster-authentication-operator-master.yaml
@@ -246,7 +246,7 @@ tests:
       TEST_SUITE: openshift/conformance/serial
     workflow: idp-external-oidc-keycloak-aws
   timeout: 8h0m0s
-- always_run: true
+- always_run: false
   as: e2e-aws-operator-parallel-ote
   optional: true
   steps:
@@ -256,7 +256,7 @@ tests:
     test:
     - ref: openshift-e2e-test
     workflow: ipi-aws
-- always_run: true
+- always_run: false
   as: e2e-aws-operator-serial-ote
   optional: true
   steps:
@@ -266,7 +266,7 @@ tests:
     test:
     - ref: openshift-e2e-test
     workflow: ipi-aws
-- always_run: true
+- always_run: false
   as: e2e-aws-operator-encryption-serial-ote
   optional: true
   shard_count: 2
@@ -278,7 +278,7 @@ tests:
     - ref: openshift-e2e-test
     workflow: ipi-aws
   timeout: 4h0m0s
-- always_run: true
+- always_run: false
   as: e2e-aws-operator-encryption-rotation-serial-ote
   optional: true
   shard_count: 2
@@ -290,7 +290,7 @@ tests:
     - ref: openshift-e2e-test
     workflow: ipi-aws
   timeout: 4h0m0s
-- always_run: true
+- always_run: false
   as: e2e-aws-operator-encryption-perf-serial-ote
   optional: true
   shard_count: 2
@@ -302,7 +302,7 @@ tests:
     - ref: openshift-e2e-test
     workflow: ipi-aws
   timeout: 2h0m0s
-- always_run: true
+- always_run: false
   as: e2e-aws-operator-encryption-kms-serial-ote
   optional: true
   shard_count: 2

--- a/ci-operator/jobs/openshift/cluster-authentication-operator/openshift-cluster-authentication-operator-master-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-authentication-operator/openshift-cluster-authentication-operator-master-presubmits.yaml
@@ -409,7 +409,7 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-aws-external-oidc-conformance-serial,?($|\s.*)
   - agent: kubernetes
-    always_run: true
+    always_run: false
     branches:
     - ^master$
     - ^master-
@@ -493,7 +493,7 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-aws-operator-encryption-kms-serial-ote-1of2,?($|\s.*)
   - agent: kubernetes
-    always_run: true
+    always_run: false
     branches:
     - ^master$
     - ^master-
@@ -577,7 +577,7 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-aws-operator-encryption-kms-serial-ote-2of2,?($|\s.*)
   - agent: kubernetes
-    always_run: true
+    always_run: false
     branches:
     - ^master$
     - ^master-
@@ -661,7 +661,7 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-aws-operator-encryption-perf-serial-ote-1of2,?($|\s.*)
   - agent: kubernetes
-    always_run: true
+    always_run: false
     branches:
     - ^master$
     - ^master-
@@ -745,7 +745,7 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-aws-operator-encryption-perf-serial-ote-2of2,?($|\s.*)
   - agent: kubernetes
-    always_run: true
+    always_run: false
     branches:
     - ^master$
     - ^master-
@@ -829,7 +829,7 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-aws-operator-encryption-rotation-serial-ote-1of2,?($|\s.*)
   - agent: kubernetes
-    always_run: true
+    always_run: false
     branches:
     - ^master$
     - ^master-
@@ -913,7 +913,7 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-aws-operator-encryption-rotation-serial-ote-2of2,?($|\s.*)
   - agent: kubernetes
-    always_run: true
+    always_run: false
     branches:
     - ^master$
     - ^master-
@@ -997,7 +997,7 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-aws-operator-encryption-serial-ote-1of2,?($|\s.*)
   - agent: kubernetes
-    always_run: true
+    always_run: false
     branches:
     - ^master$
     - ^master-
@@ -1081,7 +1081,7 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-aws-operator-encryption-serial-ote-2of2,?($|\s.*)
   - agent: kubernetes
-    always_run: true
+    always_run: false
     branches:
     - ^master$
     - ^master-
@@ -1162,7 +1162,7 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-aws-operator-parallel-ote,?($|\s.*)
   - agent: kubernetes
-    always_run: true
+    always_run: false
     branches:
     - ^master$
     - ^master-


### PR DESCRIPTION
Hi Team,

As per earlier discussion have created new PR to make job to run as per required on our PR.  PTAL 

/assign @gangwgr @sandeepknd @kaleemsiddiqu 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR updates the Prow job configuration for the **cluster-authentication-operator** component to set `always_run: false` for six AWS-based OTE (Operator Test Extension) jobs:

- `e2e-aws-operator-parallel-ote`
- `e2e-aws-operator-serial-ote`
- `e2e-aws-operator-encryption-serial-ote`
- `e2e-aws-operator-encryption-rotation-serial-ote`
- `e2e-aws-operator-encryption-perf-serial-ote`
- `e2e-aws-operator-encryption-kms-serial-ote`

## Impact

By setting `always_run: false` on these jobs (which were previously always running on every PR), they will now only execute when explicitly triggered or when their configured run conditions are met. These jobs are already marked as `optional: true`, so this change aligns the job behavior with being on-demand rather than automatically executed on every contributor PR.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->