### PR TITLE
Add ocs-admins group to sync-rover-groups config

### DIFF
--- a/core-services/sync-rover-groups/_config.yaml
+++ b/core-services/sync-rover-groups/_config.yaml
@@ -89,6 +89,9 @@ groups:
   ocp-sustaining-jenkins-admins:
     clusters:
     - app.ci
+  ocs-admins:
+    clusters:
+    - app.ci
   ofcir-admin:
     clusters:
     - core-ci


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR adds the `ocs-admins` group to the sync-rover-groups configuration, enabling centralized management of this group's synchronization to the OpenShift CI cluster.

**What changed:**
The `_config.yaml` file in `core-services/sync-rover-groups/` now includes a new `ocs-admins` group entry configured to sync to the `app.ci` cluster. This configuration is consumed by the `sync-rover-groups` tool from ci-tools, which automatically manages group memberships across OpenShift CI infrastructure clusters.

**Impact:**
This change allows the `ocs-admins` group to be managed through the centralized group synchronization system. Group members will now be automatically synchronized to have appropriate access on the `app.ci` cluster, complementing the existing RBAC bindings already defined for this group in the cluster manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->