### PR TITLE
Add --ignore-enterprise-teams flag to peribolos

### DIFF
--- a/ci-operator/jobs/infra-periodics.yaml
+++ b/ci-operator/jobs/infra-periodics.yaml
@@ -1399,7 +1399,8 @@ periodics:
           --fix-repos \
           --github-hourly-tokens=600 \
           --github-allowed-burst=600 \
-          --allow-repo-archival
+          --allow-repo-archival \
+          --ignore-enterprise-teams
       image: us-docker.pkg.dev/k8s-infra-prow/images/peribolos:v20260507-f8cedc561
       imagePullPolicy: Always
       name: ""


### PR DESCRIPTION
## Summary

- Adds the `--ignore-enterprise-teams` flag to the `periodic-org-sync` peribolos invocation
- This flag, introduced in [kubernetes-sigs/prow#710](https://github.com/kubernetes-sigs/prow/pull/710), skips enterprise-managed teams during org reconciliation, preventing 422/403 errors when peribolos attempts to modify or delete teams managed at the enterprise level