### PR TITLE
Add repo configuration for edge-context

### DIFF
--- a/core-services/prow/02_config/openshift-eng/edge-context/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-eng/edge-context/_pluginconfig.yaml
@@ -1,0 +1,26 @@
+approve:
+- repos:
+  - openshift-eng/edge-context
+  require_self_approval: false
+lgtm:
+- repos:
+  - openshift-eng/edge-context
+  review_acts_as_lgtm: true
+plugins:
+  openshift-eng/edge-context:
+    plugins:
+    - approve
+    - hold
+    - label
+    - lgtm
+    - trigger
+    - verify-owners
+    - wip
+    - jira
+triggers:
+- org_invite:
+    prominent: {}
+  repos:
+  - openshift-eng/edge-context
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-eng/edge-context/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift-eng/edge-context/_prowconfig.yaml
@@ -1,0 +1,13 @@
+tide:
+  queries:
+  - labels:
+    - approved
+    - lgtm
+    missingLabels:
+    - backports/unvalidated-commits
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - jira/invalid-bug
+    repos:
+    - openshift-eng/edge-context


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Add Prow CI configuration for openshift-eng/edge-context repository

This PR establishes Prow automation configuration for the `openshift-eng/edge-context` repository, enabling CI/CD workflows and automated merge processing.

### Changes

**Plugin Configuration** (`_pluginconfig.yaml`)
Sets up Prow plugin behavior for the repository:
- Approval workflow: Enables the `approve` plugin with self-approval optional, allowing contributors to approve their own PRs
- Code review: Configures `lgtm` (looks good to me) to treat approvals as code review signals
- Automated tooling: Enables standard plugins including `trigger` (for job scheduling), `hold` (for preventing merges), `label` (for label management), `wip` (work-in-progress detection), `verify-owners` (for OWNERS file validation), and `jira` (for issue tracking integration)
- Bot access: Grants the `openshift-merge-bot` permission to manage merges
- Org invitations: Enables notification handling for organization invitations

**Merge Automation Configuration** (`_prowconfig.yaml`)
Establishes Tide merge automation rules:
- **Required approvals**: PRs must have both `approved` and `lgtm` labels to be eligible for merge
- **Blocking conditions**: PRs are prevented from merging if they have any of these labels: `do-not-merge/hold`, `do-not-merge/work-in-progress`, `do-not-merge/invalid-owners-file`, `backports/unvalidated-commits`, or `jira/invalid-bug`

This configuration brings the repository into the OpenShift CI/CD infrastructure, establishing consistent automation and merge policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->