### PR TITLE
Enable ocp-qe-perfscale-ci-main-metal-5.0-nightly jobs

### DIFF
--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__metal-4.20-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__metal-4.20-nightly-x86.yaml
@@ -24,44 +24,6 @@ resources:
       cpu: 100m
       memory: 200Mi
 tests:
-- as: udn-bgp
-  capabilities:
-  - intranet
-  cron: 0 17 * * 3
-  reporter_config:
-    channel: '#ocp-qe-scale-ci-results'
-    job_states_to_report:
-    - success
-    - failure
-    - error
-    report_template: '{{if eq .Status.State "success"}} :white_check_mark: Job *{{.Spec.Job}}*
-      ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :white_check_mark:
-      {{else}} :warning:  Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
-      logs> :warning: {{end}}'
-  restrict_network_access: false
-  steps:
-    cluster_profile: metal-perfscale-cpt
-    env:
-      INFRA: "false"
-      NETWORK_WORKLOAD: udn-bgp
-      NUM_HYBRID_WORKER_NODES: "24"
-      NUM_NODES: "6"
-      NUM_WORKER_NODES: "0"
-      PUBLIC_VLAN: "false"
-      STARTING_NODE: "4"
-      TYPE: hmno
-    post:
-    - ref: openshift-qe-installer-bm-day2-network-workloads-post
-    test:
-    - ref: openshift-qe-installer-bm-ping
-    - ref: openshift-qe-installer-bm-poweroff
-    - ref: openshift-qe-installer-bm-foreman
-    - ref: openshift-qe-installer-bm-prereqs
-    - ref: openshift-qe-installer-bm-deploy
-    - ref: openshift-qe-cluster-health
-    - ref: openshift-qe-installer-bm-day2-label
-    - ref: openshift-qe-installer-bm-day2-network-workloads
-    - ref: openshift-qe-udn-bgp
 - as: weekly-telco-core-cpt
   capabilities:
   - intranet

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__metal-4.22-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__metal-4.22-nightly-x86.yaml
@@ -60,6 +60,7 @@ tests:
     - chain: openshift-qe-data-path-tests
     - ref: openshift-qe-orion-data-path
     - ref: openshift-qe-orion-ingress
+    - ref: openshift-qe-orion-virt-data-path
     - ref: openshift-qe-virt-udn-density
     - ref: openshift-qe-orion-virt-udn-density
     - ref: openshift-qe-virt-density-nomount

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__metal-5.0-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__metal-5.0-nightly-x86.yaml
@@ -17,7 +17,7 @@ releases:
     candidate:
       product: ocp
       stream: nightly
-      version: "4.21"
+      version: "5.0"
 resources:
   '*':
     requests:
@@ -44,13 +44,13 @@ tests:
     cluster_profile: metal-perfscale-cpt
     env:
       BOND: "true"
-      CNV_VERSION: "4.21"
+      CNV_VERSION: "5.0"
       CONFIG: config/standard-scalelab.yml
       INFRA: "true"
       OUTPUT_FORMAT: JUNIT
       PUBLIC_VLAN: "false"
       RUN_ORION: deferred
-      VERSION: "4.21"
+      VERSION: "5.0"
       VM: "true"
     post:
     - ref: openshift-qe-installer-bm-must-gather
@@ -63,14 +63,14 @@ tests:
     - ref: openshift-qe-orion-virt-data-path
     - ref: openshift-qe-virt-udn-density
     - ref: openshift-qe-orion-virt-udn-density
-    - ref: openshift-qe-virt-density
-    - ref: openshift-qe-orion-virt-density
+    - ref: openshift-qe-virt-density-nomount
+    - ref: openshift-qe-orion-virt-density-nomount
     - ref: openshift-qe-orion-report
     workflow: openshift-qe-installer-bm-deploy
 - as: udn-bgp
   capabilities:
   - intranet
-  cron: 0 17 * * 1
+  cron: 0 17 * * 3
   reporter_config:
     channel: '#ocp-qe-scale-ci-results'
     job_states_to_report:
@@ -105,8 +105,31 @@ tests:
     - ref: openshift-qe-installer-bm-day2-label
     - ref: openshift-qe-installer-bm-day2-network-workloads
     - ref: openshift-qe-udn-bgp
+- as: weekly-eip
+  capabilities:
+  - intranet
+  cron: 0 17 * * 1
+  restrict_network_access: false
+  steps:
+    cluster_profile: metal-perfscale-cpt
+    env:
+      ITERATIONS: "2400"
+      NUM_HYBRID_WORKER_NODES: "24"
+      NUM_NODES: "6"
+      NUM_WORKER_NODES: "0"
+      PUBLIC_VLAN: "false"
+      STARTING_NODE: "4"
+      TYPE: hmno
+    test:
+    - ref: openshift-qe-installer-bm-ping
+    - ref: openshift-qe-installer-bm-poweroff
+    - ref: openshift-qe-installer-bm-foreman
+    - ref: openshift-qe-installer-bm-prereqs
+    - ref: openshift-qe-installer-bm-deploy
+    - ref: openshift-qe-cluster-health
+    - ref: openshift-qe-egressip
 zz_generated_metadata:
   branch: main
   org: openshift-eng
   repo: ocp-qe-perfscale-ci
-  variant: metal-4.21-nightly-x86
+  variant: metal-5.0-nightly-x86

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__metal-5.0-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__metal-5.0-nightly-x86.yaml
@@ -70,7 +70,7 @@ tests:
 - as: udn-bgp
   capabilities:
   - intranet
-  cron: 0 17 * * 3
+  cron: 0 17 * * 1
   reporter_config:
     channel: '#ocp-qe-scale-ci-results'
     job_states_to_report:
@@ -108,7 +108,7 @@ tests:
 - as: weekly-eip
   capabilities:
   - intranet
-  cron: 0 17 * * 1
+  cron: 0 17 * * 3
   restrict_network_access: false
   steps:
     cluster_profile: metal-perfscale-cpt

--- a/ci-operator/jobs/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main-periodics.yaml
@@ -6349,101 +6349,6 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build10
-  cron: 0 17 * * 3
-  decorate: true
-  decoration_config:
-    skip_cloning: true
-  extra_refs:
-  - base_ref: main
-    org: openshift-eng
-    repo: ocp-qe-perfscale-ci
-  labels:
-    capability/intranet: intranet
-    ci-operator.openshift.io/cloud: metal-perfscale-cpt
-    ci-operator.openshift.io/cloud-cluster-profile: metal-perfscale-cpt
-    ci-operator.openshift.io/variant: metal-4.20-nightly-x86
-    ci.openshift.io/generator: prowgen
-    job-release: "4.20"
-    pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-metal-4.20-nightly-x86-udn-bgp
-  reporter_config:
-    slack:
-      channel: '#ocp-qe-scale-ci-results'
-      job_states_to_report:
-      - success
-      - failure
-      - error
-      report_template: '{{if eq .Status.State "success"}} :white_check_mark: Job *{{.Spec.Job}}*
-        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :white_check_mark:
-        {{else}} :warning:  Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
-        logs> :warning: {{end}}'
-  spec:
-    containers:
-    - args:
-      - --gcs-upload-secret=/secrets/gcs/service-account.json
-      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-      - --lease-server-credentials-file=/etc/boskos/credentials
-      - --report-credentials-file=/etc/report/credentials
-      - --secret-dir=/secrets/ci-pull-credentials
-      - --target=udn-bgp
-      - --variant=metal-4.20-nightly-x86
-      command:
-      - ci-operator
-      env:
-      - name: HTTP_SERVER_IP
-        valueFrom:
-          fieldRef:
-            fieldPath: status.podIP
-      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-      imagePullPolicy: Always
-      name: ""
-      ports:
-      - containerPort: 8080
-        name: http
-      resources:
-        requests:
-          cpu: 10m
-      volumeMounts:
-      - mountPath: /etc/boskos
-        name: boskos
-        readOnly: true
-      - mountPath: /secrets/ci-pull-credentials
-        name: ci-pull-credentials
-        readOnly: true
-      - mountPath: /secrets/gcs
-        name: gcs-credentials
-        readOnly: true
-      - mountPath: /secrets/manifest-tool
-        name: manifest-tool-local-pusher
-        readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
-      - mountPath: /etc/report
-        name: result-aggregator
-        readOnly: true
-    serviceAccountName: ci-operator
-    volumes:
-    - name: boskos
-      secret:
-        items:
-        - key: credentials
-          path: credentials
-        secretName: boskos-credentials
-    - name: ci-pull-credentials
-      secret:
-        secretName: ci-pull-credentials
-    - name: manifest-tool-local-pusher
-      secret:
-        secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
-    - name: result-aggregator
-      secret:
-        secretName: result-aggregator
-- agent: kubernetes
-  cluster: build10
   cron: 0 17 * * 4
   decorate: true
   decoration_config:
@@ -6482,196 +6387,6 @@ periodics:
       - --secret-dir=/secrets/ci-pull-credentials
       - --target=weekly-telco-core-cpt
       - --variant=metal-4.20-nightly-x86
-      command:
-      - ci-operator
-      env:
-      - name: HTTP_SERVER_IP
-        valueFrom:
-          fieldRef:
-            fieldPath: status.podIP
-      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-      imagePullPolicy: Always
-      name: ""
-      ports:
-      - containerPort: 8080
-        name: http
-      resources:
-        requests:
-          cpu: 10m
-      volumeMounts:
-      - mountPath: /etc/boskos
-        name: boskos
-        readOnly: true
-      - mountPath: /secrets/ci-pull-credentials
-        name: ci-pull-credentials
-        readOnly: true
-      - mountPath: /secrets/gcs
-        name: gcs-credentials
-        readOnly: true
-      - mountPath: /secrets/manifest-tool
-        name: manifest-tool-local-pusher
-        readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
-      - mountPath: /etc/report
-        name: result-aggregator
-        readOnly: true
-    serviceAccountName: ci-operator
-    volumes:
-    - name: boskos
-      secret:
-        items:
-        - key: credentials
-          path: credentials
-        secretName: boskos-credentials
-    - name: ci-pull-credentials
-      secret:
-        secretName: ci-pull-credentials
-    - name: manifest-tool-local-pusher
-      secret:
-        secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
-    - name: result-aggregator
-      secret:
-        secretName: result-aggregator
-- agent: kubernetes
-  cluster: build10
-  cron: 30 0 * * *
-  decorate: true
-  decoration_config:
-    skip_cloning: true
-  extra_refs:
-  - base_ref: main
-    org: openshift-eng
-    repo: ocp-qe-perfscale-ci
-  labels:
-    capability/intranet: intranet
-    ci-operator.openshift.io/cloud: metal-perfscale-cpt
-    ci-operator.openshift.io/cloud-cluster-profile: metal-perfscale-cpt
-    ci-operator.openshift.io/variant: metal-4.21-nightly-x86
-    ci.openshift.io/generator: prowgen
-    job-release: "4.21"
-    pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-metal-4.21-nightly-x86-daily-virt-6nodes
-  reporter_config:
-    slack:
-      channel: '#ocp-qe-scale-ci-results'
-      job_states_to_report:
-      - success
-      - failure
-      - error
-      report_template: '{{if eq .Status.State "success"}} :white_check_mark: Job *{{.Spec.Job}}*
-        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :white_check_mark:
-        {{else}} :warning:  Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
-        logs> :warning: {{end}}'
-  spec:
-    containers:
-    - args:
-      - --gcs-upload-secret=/secrets/gcs/service-account.json
-      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-      - --lease-server-credentials-file=/etc/boskos/credentials
-      - --report-credentials-file=/etc/report/credentials
-      - --secret-dir=/secrets/ci-pull-credentials
-      - --target=daily-virt-6nodes
-      - --variant=metal-4.21-nightly-x86
-      command:
-      - ci-operator
-      env:
-      - name: HTTP_SERVER_IP
-        valueFrom:
-          fieldRef:
-            fieldPath: status.podIP
-      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-      imagePullPolicy: Always
-      name: ""
-      ports:
-      - containerPort: 8080
-        name: http
-      resources:
-        requests:
-          cpu: 10m
-      volumeMounts:
-      - mountPath: /etc/boskos
-        name: boskos
-        readOnly: true
-      - mountPath: /secrets/ci-pull-credentials
-        name: ci-pull-credentials
-        readOnly: true
-      - mountPath: /secrets/gcs
-        name: gcs-credentials
-        readOnly: true
-      - mountPath: /secrets/manifest-tool
-        name: manifest-tool-local-pusher
-        readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
-      - mountPath: /etc/report
-        name: result-aggregator
-        readOnly: true
-    serviceAccountName: ci-operator
-    volumes:
-    - name: boskos
-      secret:
-        items:
-        - key: credentials
-          path: credentials
-        secretName: boskos-credentials
-    - name: ci-pull-credentials
-      secret:
-        secretName: ci-pull-credentials
-    - name: manifest-tool-local-pusher
-      secret:
-        secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
-    - name: result-aggregator
-      secret:
-        secretName: result-aggregator
-- agent: kubernetes
-  cluster: build10
-  cron: 0 17 * * 1
-  decorate: true
-  decoration_config:
-    skip_cloning: true
-  extra_refs:
-  - base_ref: main
-    org: openshift-eng
-    repo: ocp-qe-perfscale-ci
-  labels:
-    capability/intranet: intranet
-    ci-operator.openshift.io/cloud: metal-perfscale-cpt
-    ci-operator.openshift.io/cloud-cluster-profile: metal-perfscale-cpt
-    ci-operator.openshift.io/variant: metal-4.21-nightly-x86
-    ci.openshift.io/generator: prowgen
-    job-release: "4.21"
-    pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-metal-4.21-nightly-x86-udn-bgp
-  reporter_config:
-    slack:
-      channel: '#ocp-qe-scale-ci-results'
-      job_states_to_report:
-      - success
-      - failure
-      - error
-      report_template: '{{if eq .Status.State "success"}} :white_check_mark: Job *{{.Spec.Job}}*
-        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :white_check_mark:
-        {{else}} :warning:  Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
-        logs> :warning: {{end}}'
-  spec:
-    containers:
-    - args:
-      - --gcs-upload-secret=/secrets/gcs/service-account.json
-      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-      - --lease-server-credentials-file=/etc/boskos/credentials
-      - --report-credentials-file=/etc/report/credentials
-      - --secret-dir=/secrets/ci-pull-credentials
-      - --target=udn-bgp
-      - --variant=metal-4.21-nightly-x86
       command:
       - ci-operator
       env:
@@ -7052,6 +6767,280 @@ periodics:
       - --secret-dir=/secrets/ci-pull-credentials
       - --target=weekly-telco-core-cpt
       - --variant=metal-4.22-nightly-x86
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build10
+  cron: 30 0 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-eng
+    repo: ocp-qe-perfscale-ci
+  labels:
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: metal-perfscale-cpt
+    ci-operator.openshift.io/cloud-cluster-profile: metal-perfscale-cpt
+    ci-operator.openshift.io/variant: metal-5.0-nightly-x86
+    ci.openshift.io/generator: prowgen
+    job-release: "5.0"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-metal-5.0-nightly-x86-daily-virt-6nodes
+  reporter_config:
+    slack:
+      channel: '#ocp-qe-scale-ci-results'
+      job_states_to_report:
+      - success
+      - failure
+      - error
+      report_template: '{{if eq .Status.State "success"}} :white_check_mark: Job *{{.Spec.Job}}*
+        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :white_check_mark:
+        {{else}} :warning:  Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+        logs> :warning: {{end}}'
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=daily-virt-6nodes
+      - --variant=metal-5.0-nightly-x86
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build10
+  cron: 0 17 * * 3
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-eng
+    repo: ocp-qe-perfscale-ci
+  labels:
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: metal-perfscale-cpt
+    ci-operator.openshift.io/cloud-cluster-profile: metal-perfscale-cpt
+    ci-operator.openshift.io/variant: metal-5.0-nightly-x86
+    ci.openshift.io/generator: prowgen
+    job-release: "5.0"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-metal-5.0-nightly-x86-udn-bgp
+  reporter_config:
+    slack:
+      channel: '#ocp-qe-scale-ci-results'
+      job_states_to_report:
+      - success
+      - failure
+      - error
+      report_template: '{{if eq .Status.State "success"}} :white_check_mark: Job *{{.Spec.Job}}*
+        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :white_check_mark:
+        {{else}} :warning:  Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+        logs> :warning: {{end}}'
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=udn-bgp
+      - --variant=metal-5.0-nightly-x86
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build10
+  cron: 0 17 * * 1
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-eng
+    repo: ocp-qe-perfscale-ci
+  labels:
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: metal-perfscale-cpt
+    ci-operator.openshift.io/cloud-cluster-profile: metal-perfscale-cpt
+    ci-operator.openshift.io/variant: metal-5.0-nightly-x86
+    ci.openshift.io/generator: prowgen
+    job-release: "5.0"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-metal-5.0-nightly-x86-weekly-eip
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=weekly-eip
+      - --variant=metal-5.0-nightly-x86
       command:
       - ci-operator
       env:

--- a/ci-operator/jobs/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main-periodics.yaml
@@ -6919,7 +6919,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build10
-  cron: 0 17 * * 3
+  cron: 0 17 * * 1
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -7014,7 +7014,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build10
-  cron: 0 17 * * 1
+  cron: 0 17 * * 3
   decorate: true
   decoration_config:
     skip_cloning: true

--- a/ci-operator/step-registry/openshift-qe/virt-density-nomount/observer/openshift-qe-virt-density-nomount-observer-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/virt-density-nomount/observer/openshift-qe-virt-density-nomount-observer-commands.sh
@@ -46,7 +46,7 @@ fi
 pushd e2e-benchmarking/workloads/kube-burner-ocp-wrapper
 export WORKLOAD=virt-density
 
-EXTRA_FLAGS+=" --metrics-profile metrics.yml,cnv-metrics.yml --gc-metrics=false --vms-per-node=$VMS_PER_NODE --vmi-ready-threshold=${VMI_READY_THRESHOLD}s --profile-type=${PROFILE_TYPE} --burst=${BURST} --qps=${QPS} --mounts false"
+EXTRA_FLAGS+=" --metrics-profile metrics.yml,cnv-metrics.yml --gc-metrics=false --vms-per-node=$VMS_PER_NODE --vmi-ready-threshold=${VMI_READY_THRESHOLD}s --profile-type=${PROFILE_TYPE} --burst=${BURST} --qps=${QPS} --mounts=false"
 
 export ES_SERVER=""
 

--- a/ci-operator/step-registry/openshift-qe/virt-density-nomount/openshift-qe-virt-density-nomount-commands.sh
+++ b/ci-operator/step-registry/openshift-qe/virt-density-nomount/openshift-qe-virt-density-nomount-commands.sh
@@ -35,7 +35,7 @@ git clone $REPO_URL $TAG_OPTION --depth 1
 pushd e2e-benchmarking/workloads/kube-burner-ocp-wrapper
 export WORKLOAD=virt-density
 
-EXTRA_FLAGS="${VD_EXTRA_FLAGS} --metrics-profile metrics.yml,cnv-metrics.yml --gc-metrics=false --vms-per-node=$VMS_PER_NODE --vmi-ready-threshold=${VMI_READY_THRESHOLD}s --profile-type=${PROFILE_TYPE} --mounts false"
+EXTRA_FLAGS="${VD_EXTRA_FLAGS} --metrics-profile metrics.yml,cnv-metrics.yml --gc-metrics=false --vms-per-node=$VMS_PER_NODE --vmi-ready-threshold=${VMI_READY_THRESHOLD}s --profile-type=${PROFILE_TYPE} --mounts=false"
 
 export ES_SERVER="https://$ES_USERNAME:$ES_PASSWORD@$ES_HOST"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR updates the ocp-qe-perfscale-ci repository CI job definitions to enable and configure bare-metal nightly perf/scale testing for OCP 5.0 and to reorganize related scheduled network tests across variants. Changes are confined to ci-operator job definitions and schedules under ci-operator/config/openshift-eng/ocp-qe-perfscale-ci.

## What changed, in practical terms

- Adds/updates the metal-5.0-nightly-x86 pipeline:
  - Bumps the pipeline candidate OCP version to 5.0 (latest.candidate.version: 5.0) and updates zz_generated_metadata.variant to metal-5.0-nightly-x86.
  - daily-virt-6nodes: runs the bare-metal virtualization workflow against OCP 5.0 (VERSION: "5.0") and sets CNV_VERSION to "5.0". Replaces density tests with the "nomount" variants (openshift-qe-virt-density-nomount, openshift-qe-orion-virt-density-nomount) while retaining openshift-qe-orion-report and the openshift-qe-installer-bm-deploy workflow.
  - udn-bgp: cron moved from Mondays to Wednesdays at 17:00 UTC (cron: 0 17 * * 3).
  - weekly-eip: new scheduled job (cron: 0 17 * * 1) that runs BM deploy prerequisites/health checks and openshift-qe-egressip.

- Cleanup and small additions in older variants:
  - Removes the udn-bgp test entry from the metal-4.20-nightly-x86 configuration (consolidating that network test into the newer variant).
  - Adds a new test ref openshift-qe-orion-virt-data-path to the metal-4.22-nightly-x86 daily-virt-6nodes workflow.

## Impact

Enables automated perf/scale and virtualization networking validation on bare metal for OCP 5.0 in the perfscale QE CI, adjusts scheduling for existing network tests, removes a duplicate udn-bgp entry in the 4.20 variant, and makes a small test addition to the 4.22 variant. All changes are limited to CI job definitions and schedules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->