### PR TITLE
OCPEDGE-2484: TNA RHCOS10 CI validation and testing

### DIFF
--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22.yaml
@@ -544,12 +544,33 @@ tests:
   steps:
     cluster_profile: equinix-edge-enablement
     workflow: baremetalds-two-node-arbiter
+- as: e2e-metal-ovn-two-node-arbiter-rhcos10-techpreview
+  capabilities:
+  - intranet
+  interval: 168h
+  steps:
+    cluster_profile: equinix-edge-enablement
+    env:
+      OSSTREAM: rhel-10
+    workflow: baremetalds-two-node-arbiter-techpreview
 - as: e2e-agent-ovn-two-node-arbiter
   capabilities:
   - intranet
   cron: '@daily'
   steps:
     cluster_profile: equinix-edge-enablement
+    workflow: agent-e2e-two-node-arbiter-ipv4
+- as: e2e-agent-ovn-two-node-arbiter-rhcos10-techpreview
+  capabilities:
+  - intranet
+  interval: 168h
+  steps:
+    cluster_profile: equinix-edge-enablement
+    env:
+      DEVSCRIPTS_CONFIG: |
+        AGENT_E2E_TEST_SCENARIO=TNA_IPV4
+        FEATURE_SET="TechPreviewNoUpgrade"
+      OSSTREAM: rhel-10
     workflow: agent-e2e-two-node-arbiter-ipv4
 - as: e2e-agent-ovn-two-node-arbiter-ipv6
   capabilities:
@@ -853,6 +874,23 @@ tests:
   cron: 0 2 * * 1
   steps:
     cluster_profile: equinix-edge-enablement
+    workflow: baremetalds-two-node-arbiter-e2e-openshift-test-private-tests
+- as: e2e-metal-ovn-two-node-arbiter-private-tests-rhcos10-tp
+  capabilities:
+  - intranet
+  interval: 168h
+  steps:
+    cluster_profile: equinix-edge-enablement
+    env:
+      DEVSCRIPTS_CONFIG: |
+        IP_STACK=v4
+        NUM_MASTERS=2
+        NUM_ARBITERS=1
+        NUM_WORKERS=0
+        MASTER_MEMORY=32768
+        MASTER_DISK=100
+        FEATURE_SET="TechPreviewNoUpgrade"
+      OSSTREAM: rhel-10
     workflow: baremetalds-two-node-arbiter-e2e-openshift-test-private-tests
 - as: e2e-agent-ovn-two-node-arbiter-none-platform
   capabilities:

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.23.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.23.yaml
@@ -527,12 +527,33 @@ tests:
   steps:
     cluster_profile: equinix-edge-enablement
     workflow: baremetalds-two-node-arbiter
+- as: e2e-metal-ovn-two-node-arbiter-rhcos10-techpreview
+  capabilities:
+  - intranet
+  interval: 168h
+  steps:
+    cluster_profile: equinix-edge-enablement
+    env:
+      OSSTREAM: rhel-10
+    workflow: baremetalds-two-node-arbiter-techpreview
 - as: e2e-agent-ovn-two-node-arbiter
   capabilities:
   - intranet
   cron: '@daily'
   steps:
     cluster_profile: equinix-edge-enablement
+    workflow: agent-e2e-two-node-arbiter-ipv4
+- as: e2e-agent-ovn-two-node-arbiter-rhcos10-techpreview
+  capabilities:
+  - intranet
+  interval: 168h
+  steps:
+    cluster_profile: equinix-edge-enablement
+    env:
+      DEVSCRIPTS_CONFIG: |
+        AGENT_E2E_TEST_SCENARIO=TNA_IPV4
+        FEATURE_SET="TechPreviewNoUpgrade"
+      OSSTREAM: rhel-10
     workflow: agent-e2e-two-node-arbiter-ipv4
 - as: e2e-agent-ovn-two-node-arbiter-ipv6
   capabilities:
@@ -846,6 +867,23 @@ tests:
     test:
     - chain: agent-test
     workflow: agent-e2e-two-node-arbiter-ipv4
+- as: e2e-metal-ovn-two-node-arbiter-private-tests-rhcos10-tp
+  capabilities:
+  - intranet
+  interval: 168h
+  steps:
+    cluster_profile: equinix-edge-enablement
+    env:
+      DEVSCRIPTS_CONFIG: |
+        IP_STACK=v4
+        NUM_MASTERS=2
+        NUM_ARBITERS=1
+        NUM_WORKERS=0
+        MASTER_MEMORY=32768
+        MASTER_DISK=100
+        FEATURE_SET="TechPreviewNoUpgrade"
+      OSSTREAM: rhel-10
+    workflow: baremetalds-two-node-arbiter-e2e-openshift-test-private-tests
 - as: e2e-metal-ovn-two-node-fencing-extended
   capabilities:
   - intranet

--- a/core-services/release-controller/_releases/priv/release-ocp-4.22.json
+++ b/core-services/release-controller/_releases/priv/release-ocp-4.22.json
@@ -11,6 +11,14 @@
     "referenceMode": "source",
     "to": "release-priv",
     "verify": {
+        "agent-ovn-two-node-arbiter-rhcos10-techpreview": {
+            "disabled": true,
+            "maxRetries": 2,
+            "optional": true,
+            "prowJob": {
+                "name": "periodic-ci-openshift-release-main-nightly-4.22-e2e-agent-ovn-two-node-arbiter-rhcos10-techpreview-priv"
+            }
+        },
         "aggregated-aws-ovn-single-node-upgrade-4.22-micro": {
             "aggregatedProwJob": {
                 "analysisJobCount": 10
@@ -544,6 +552,22 @@
             "optional": true,
             "prowJob": {
                 "name": "periodic-ci-openshift-release-main-nightly-4.22-metal-ovn-single-node-recert-cluster-rename-priv"
+            }
+        },
+        "metal-ovn-two-node-arbiter-private-tests-rhcos10-tp": {
+            "disabled": true,
+            "maxRetries": 2,
+            "optional": true,
+            "prowJob": {
+                "name": "periodic-ci-openshift-release-main-nightly-4.22-e2e-metal-ovn-two-node-arbiter-private-tests-rhcos10-tp-priv"
+            }
+        },
+        "metal-ovn-two-node-arbiter-rhcos10-techpreview": {
+            "disabled": true,
+            "maxRetries": 2,
+            "optional": true,
+            "prowJob": {
+                "name": "periodic-ci-openshift-release-main-nightly-4.22-e2e-metal-ovn-two-node-arbiter-rhcos10-techpreview-priv"
             }
         },
         "microshift-ovn-conformance-parallel": {

--- a/core-services/release-controller/_releases/priv/release-ocp-4.23.json
+++ b/core-services/release-controller/_releases/priv/release-ocp-4.23.json
@@ -11,6 +11,14 @@
     "referenceMode": "source",
     "to": "release-priv",
     "verify": {
+        "agent-ovn-two-node-arbiter-rhcos10-techpreview": {
+            "disabled": true,
+            "maxRetries": 2,
+            "optional": true,
+            "prowJob": {
+                "name": "periodic-ci-openshift-release-main-nightly-4.23-e2e-agent-ovn-two-node-arbiter-rhcos10-techpreview-priv"
+            }
+        },
         "aws-ovn-serial-1of2": {
             "disabled": true,
             "maxRetries": 1,
@@ -131,6 +139,22 @@
             "optional": true,
             "prowJob": {
                 "name": "periodic-ci-openshift-release-main-nightly-4.23-e2e-metal-ipi-ovn-ipv6-priv"
+            }
+        },
+        "metal-ovn-two-node-arbiter-private-tests-rhcos10-tp": {
+            "disabled": true,
+            "maxRetries": 2,
+            "optional": true,
+            "prowJob": {
+                "name": "periodic-ci-openshift-release-main-nightly-4.23-e2e-metal-ovn-two-node-arbiter-private-tests-rhcos10-tp-priv"
+            }
+        },
+        "metal-ovn-two-node-arbiter-rhcos10-techpreview": {
+            "disabled": true,
+            "maxRetries": 2,
+            "optional": true,
+            "prowJob": {
+                "name": "periodic-ci-openshift-release-main-nightly-4.23-e2e-metal-ovn-two-node-arbiter-rhcos10-techpreview-priv"
             }
         }
     }

--- a/core-services/release-controller/_releases/release-ocp-4.22.json
+++ b/core-services/release-controller/_releases/release-ocp-4.22.json
@@ -661,6 +661,27 @@
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-nightly-4.22-fips-payload-scan"
       }
+    },
+    "metal-ovn-two-node-arbiter-rhcos10-techpreview": {
+      "optional": true,
+      "maxRetries": 2,
+      "prowJob": {
+        "name": "periodic-ci-openshift-release-main-nightly-4.22-e2e-metal-ovn-two-node-arbiter-rhcos10-techpreview"
+      }
+    },
+    "agent-ovn-two-node-arbiter-rhcos10-techpreview": {
+      "optional": true,
+      "maxRetries": 2,
+      "prowJob": {
+        "name": "periodic-ci-openshift-release-main-nightly-4.22-e2e-agent-ovn-two-node-arbiter-rhcos10-techpreview"
+      }
+    },
+    "metal-ovn-two-node-arbiter-private-tests-rhcos10-tp": {
+      "optional": true,
+      "maxRetries": 2,
+      "prowJob": {
+        "name": "periodic-ci-openshift-release-main-nightly-4.22-e2e-metal-ovn-two-node-arbiter-private-tests-rhcos10-tp"
+      }
     }
   }
 }

--- a/core-services/release-controller/_releases/release-ocp-4.23.json
+++ b/core-services/release-controller/_releases/release-ocp-4.23.json
@@ -63,6 +63,27 @@
       },
       "upgrade": true
     },
+    "metal-ovn-two-node-arbiter-rhcos10-techpreview": {
+      "optional": true,
+      "maxRetries": 2,
+      "prowJob": {
+        "name": "periodic-ci-openshift-release-main-nightly-4.23-e2e-metal-ovn-two-node-arbiter-rhcos10-techpreview"
+      }
+    },
+    "agent-ovn-two-node-arbiter-rhcos10-techpreview": {
+      "optional": true,
+      "maxRetries": 2,
+      "prowJob": {
+        "name": "periodic-ci-openshift-release-main-nightly-4.23-e2e-agent-ovn-two-node-arbiter-rhcos10-techpreview"
+      }
+    },
+    "metal-ovn-two-node-arbiter-private-tests-rhcos10-tp": {
+      "optional": true,
+      "maxRetries": 2,
+      "prowJob": {
+        "name": "periodic-ci-openshift-release-main-nightly-4.23-e2e-metal-ovn-two-node-arbiter-private-tests-rhcos10-tp"
+      }
+    },
     "aws-ovn-serial-1of2": {
       "optional": true,
       "maxRetries": 1,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR updates OpenShift CI configuration to add RHCOS10 (RHEL 10 / TechPreview) Two-Node Arbiter (TNA) validation to nightly pipelines for both 4.23 and 4.22. It introduces new periodic e2e job specs and registers them with the release-controller so the jobs are known to release verification wiring (marked optional/disabled in priv configs).

## What changed in practical terms

- Added new periodic ci-operator job definitions for RHCOS10 TechPreview TNA scenarios (edge/enabled):
  - periodic-ci-openshift-release-main-nightly-4.23-e2e-metal-ovn-two-node-arbiter-rhcos10-techpreview — baremetalds two-node arbiter TechPreview, interval 168h, OSSTREAM: rhel-10.
  - periodic-ci-openshift-release-main-nightly-4.23-e2e-agent-ovn-two-node-arbiter-rhcos10-techpreview — agent-based two-node arbiter IPv4, interval 168h, OSSTREAM: rhel-10, DEVSCRIPTS_CONFIG sets AGENT_E2E_TEST_SCENARIO=TNA_IPV4 and FEATURE_SET="TechPreviewNoUpgrade".
  - periodic-ci-openshift-release-main-nightly-4.23-e2e-metal-ovn-two-node-arbiter-private-tests-rhcos10-tp — private-tests variant, interval 168h, OSSTREAM: rhel-10, DEVSCRIPTS_CONFIG sets IPv4 sizing/role counts and FEATURE_SET="TechPreviewNoUpgrade".
- The same three job variants were added to the nightly config for 4.22.

- Registered these jobs with the release-controller for the corresponding releases:
  - core-services/release-controller/_releases/release-ocp-4.23.json and release-ocp-4.22.json — added optional verify entries for the new Prow job names (maxRetries: 2).
  - core-services/release-controller/_releases/priv/release-ocp-4.23.json and priv/release-ocp-4.22.json — added corresponding disabled/optional priv verify entries (priv prow job names, maxRetries: 2).

## Files affected (high-level)

- ci-operator/config/openshift/release/openshift-release-main__nightly-4.23.yaml and openshift-release-main__nightly-4.22.yaml — new job specs and job-level env/workflow settings for RHCOS10 TNA variants.
- core-services/release-controller/_releases/release-ocp-4.23.json and release-ocp-4.22.json — added optional verify entries mapping to the new Prow jobs.
- core-services/release-controller/_releases/priv/release-ocp-4.23.json and priv/release-ocp-4.22.json — added disabled/optional priv verify entries.

## Notes / CI activity

- The PR author invoked /pj-rehearse to trigger the related periodic jobs and re-ran a subset of rehearse commands; /test release-controller-config was also invoked.
- The openshift-ci-robot confirmed the PR references Jira [OCPEDGE-2484](https://redhat.atlassian.net/browse/OCPEDGE-2484) but warned the referenced Jira epic is missing/invalid target version for this target branch (expected target version "5.0.0").
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[OCPEDGE-2484]: https://redhat.atlassian.net/browse/OCPEDGE-2484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ