### PR TITLE
trusted-execution-clusters: Intro Azure upstream CI

### DIFF
--- a/ci-operator/config/trusted-execution-clusters/operator/azure.yaml
+++ b/ci-operator/config/trusted-execution-clusters/operator/azure.yaml
@@ -1,0 +1,31 @@
+base_images:
+  telco-runner:
+    name: telco-runner
+    namespace: ci
+    tag: latest
+build_root:
+  image_stream_tag:
+    name: builder
+    namespace: ocp
+    tag: rhel-9-golang-1.25-openshift-4.21
+resources:
+  '*':
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: operator-lifecycle-azure-verify
+  capabilities:
+  - intranet
+  skip_if_only_changed: ^(\.github|LICENSES|bundle|docs|examples)/|^(README\.md|\.gitignore)$
+  steps:
+    test:
+    - chain: trusted-execution-clusters-operator-azure-lifecycle
+    post:
+    - chain: trusted-execution-clusters-operator-azure-cleanup
+zz_generated_metadata:
+  branch: main
+  org: trusted-execution-clusters
+  repo: operator

--- a/ci-operator/jobs/trusted-execution-clusters/operator/trusted-execution-clusters-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/trusted-execution-clusters/operator/trusted-execution-clusters-operator-main-presubmits.yaml
@@ -75,3 +75,68 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )operator-lifecycle-verify,?($|\s.*)
+  - agent: kubernetes-azure
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build07
+    context: ci/prow/operator-lifecycle-azure-verify
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      capability/intranet: intranet
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-trusted-execution-clusters-operator-main-operator-lifecycle-azure-verify
+    rerun_command: /test operator-lifecycle-azure-verify
+    skip_if_only_changed: ^(\.github|LICENSES|bundle|docs|examples)/|^(README\.md|\.gitignore)$
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=operator-lifecycle-azure-verify
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )operator-lifecycle-azure-verify,?($|\s.*)

--- a/ci-operator/step-registry/trusted-execution-clusters/operator-azure/OWNERS
+++ b/ci-operator/step-registry/trusted-execution-clusters/operator-azure/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - alicefr
+  - Jakob-Naucke
+approvers:
+  - alicefr
+  - Jakob-Naucke

--- a/ci-operator/step-registry/trusted-execution-clusters/operator-azure/cleanup/OWNERS
+++ b/ci-operator/step-registry/trusted-execution-clusters/operator-azure/cleanup/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - alicefr
+  - Jakob-Naucke
+approvers:
+  - alicefr
+  - Jakob-Naucke

--- a/ci-operator/step-registry/trusted-execution-clusters/operator-azure/cleanup/trusted-execution-clusters-operator-azure-cleanup-chain.metadata.json
+++ b/ci-operator/step-registry/trusted-execution-clusters/operator-azure/cleanup/trusted-execution-clusters-operator-azure-cleanup-chain.metadata.json
@@ -1,0 +1,13 @@
+{
+	"path": "trusted-execution-clusters/operator-azure/cleanup/trusted-execution-clusters-operator-azure-cleanup-chain.yaml",
+	"owners": {
+		"approvers": [
+			"alicefr",
+			"Jakob-Naucke"
+		],
+		"reviewers": [
+			"alicefr",
+			"Jakob-Naucke"
+		]
+	}
+}

--- a/ci-operator/step-registry/trusted-execution-clusters/operator-azure/cleanup/trusted-execution-clusters-operator-azure-cleanup-chain.yaml
+++ b/ci-operator/step-registry/trusted-execution-clusters/operator-azure/cleanup/trusted-execution-clusters-operator-azure-cleanup-chain.yaml
@@ -1,0 +1,6 @@
+chain:
+  as: trusted-execution-clusters-operator-azure-cleanup
+  steps:
+  - ref: trusted-execution-clusters-ref-operator-azure-deprovision
+  documentation: |-
+    Azure tests create a Kind VM. Remove its resource group.

--- a/ci-operator/step-registry/trusted-execution-clusters/operator-azure/lifecycle/OWNERS
+++ b/ci-operator/step-registry/trusted-execution-clusters/operator-azure/lifecycle/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - alicefr
+  - Jakob-Naucke
+approvers:
+  - alicefr
+  - Jakob-Naucke

--- a/ci-operator/step-registry/trusted-execution-clusters/operator-azure/lifecycle/trusted-execution-clusters-operator-azure-lifecycle-chain.metadata.json
+++ b/ci-operator/step-registry/trusted-execution-clusters/operator-azure/lifecycle/trusted-execution-clusters-operator-azure-lifecycle-chain.metadata.json
@@ -1,0 +1,13 @@
+{
+	"path": "trusted-execution-clusters/operator-azure/lifecycle/trusted-execution-clusters-operator-azure-lifecycle-chain.yaml",
+	"owners": {
+		"approvers": [
+			"alicefr",
+			"Jakob-Naucke"
+		],
+		"reviewers": [
+			"alicefr",
+			"Jakob-Naucke"
+		]
+	}
+}

--- a/ci-operator/step-registry/trusted-execution-clusters/operator-azure/lifecycle/trusted-execution-clusters-operator-azure-lifecycle-chain.yaml
+++ b/ci-operator/step-registry/trusted-execution-clusters/operator-azure/lifecycle/trusted-execution-clusters-operator-azure-lifecycle-chain.yaml
@@ -1,0 +1,6 @@
+chain:
+  as: trusted-execution-clusters-operator-azure-lifecycle
+  steps:
+  - ref: trusted-execution-clusters-ref-operator-azure-test
+  documentation: |-
+    Create a VM for Kind on Azure. Run integration tests with Azure VMs, testing against the operator on that Kind cluster.

--- a/ci-operator/step-registry/trusted-execution-clusters/ref/operator/azure-deprovision/OWNERS
+++ b/ci-operator/step-registry/trusted-execution-clusters/ref/operator/azure-deprovision/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - alicefr
+  - Jakob-Naucke
+approvers:
+  - alicefr
+  - Jakob-Naucke

--- a/ci-operator/step-registry/trusted-execution-clusters/ref/operator/azure-deprovision/trusted-execution-clusters-ref-operator-azure-deprovision-commands.sh
+++ b/ci-operator/step-registry/trusted-execution-clusters/ref/operator/azure-deprovision/trusted-execution-clusters-ref-operator-azure-deprovision-commands.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -eu
+set -o pipefail
+
+if [ -z "${SHARED_DIR}" ]; then
+  echo "[ERROR] SHARED_DIR is not set. This script must run in Prow CI environment."
+  exit 1
+fi
+
+if [ ! -f "${SHARED_DIR}/az-resource-group" ]; then
+  echo "[ERROR] az-resource-group was not placed in SHARED_DIR"
+  exit 1
+fi
+
+rpm --import https://packages.microsoft.com/keys/microsoft.asc
+dnf install -y https://packages.microsoft.com/config/rhel/9.0/packages-microsoft-prod.rpm
+dnf install -y azure-cli
+
+secret_base=/var/run/azure-upstream-ci
+az login --service-principal \
+  --username "$(cat $secret_base/client-id)" \
+  --password "$(cat $secret_base/client-secret)" \
+  --tenant "$(cat $secret_base/tenant-id)"
+
+az_resource_group=$(cat "${SHARED_DIR}/az-resource-group")
+echo "[INFO] Delete Kind VM resource group $az_resource_group"
+az group delete --name "$az_resource_group" --yes
+echo "[SUCCESS] Deleted Kind VM resource group $az_resource_group"

--- a/ci-operator/step-registry/trusted-execution-clusters/ref/operator/azure-deprovision/trusted-execution-clusters-ref-operator-azure-deprovision-ref.metadata.json
+++ b/ci-operator/step-registry/trusted-execution-clusters/ref/operator/azure-deprovision/trusted-execution-clusters-ref-operator-azure-deprovision-ref.metadata.json
@@ -1,0 +1,13 @@
+{
+	"path": "trusted-execution-clusters/ref/operator/azure-deprovision/trusted-execution-clusters-ref-operator-azure-deprovision-ref.yaml",
+	"owners": {
+		"approvers": [
+			"alicefr",
+			"Jakob-Naucke"
+		],
+		"reviewers": [
+			"alicefr",
+			"Jakob-Naucke"
+		]
+	}
+}

--- a/ci-operator/step-registry/trusted-execution-clusters/ref/operator/azure-deprovision/trusted-execution-clusters-ref-operator-azure-deprovision-ref.yaml
+++ b/ci-operator/step-registry/trusted-execution-clusters/ref/operator/azure-deprovision/trusted-execution-clusters-ref-operator-azure-deprovision-ref.yaml
@@ -1,0 +1,19 @@
+ref:
+  as: trusted-execution-clusters-ref-operator-azure-deprovision
+  from_image:
+    namespace: ci
+    name: telco-runner
+    tag: latest
+  commands: trusted-execution-clusters-ref-operator-azure-deprovision-commands.sh
+  credentials:
+  - namespace: test-credentials
+    name: azure-upstream-ci
+    mount_path: /var/run/azure-upstream-ci
+  resources:
+    requests:
+      cpu: 500m
+      memory: 500Mi
+    limits:
+      memory: 1Gi
+  documentation: |-
+    Azure tests create a Kind VM. Remove its resource group.

--- a/ci-operator/step-registry/trusted-execution-clusters/ref/operator/azure-test/OWNERS
+++ b/ci-operator/step-registry/trusted-execution-clusters/ref/operator/azure-test/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - alicefr
+  - Jakob-Naucke
+approvers:
+  - alicefr
+  - Jakob-Naucke

--- a/ci-operator/step-registry/trusted-execution-clusters/ref/operator/azure-test/trusted-execution-clusters-ref-operator-azure-test-commands.sh
+++ b/ci-operator/step-registry/trusted-execution-clusters/ref/operator/azure-test/trusted-execution-clusters-ref-operator-azure-test-commands.sh
@@ -1,0 +1,193 @@
+#!/bin/bash -eu
+set -o pipefail
+
+log_info() {
+  echo "[INFO] $1"
+}
+
+log_warn() {
+  echo "[WARN] $1"
+}
+
+log_error() {
+  echo "[ERROR] $1"
+}
+
+log_success() {
+  echo "[SUCCESS] $1"
+}
+
+if [ -z "${SHARED_DIR}" ]; then
+  log_error "SHARED_DIR is not set. This script must run in Prow CI environment."
+  exit 1
+fi
+
+repository=github.com/trusted-execution-clusters/operator
+src_dir=/go/src/$repository
+if [ ! -d $src_dir ]; then
+  log_info "No existing checkout (presumed rehearsal PR), creating checkout"
+  mkdir -p /go/src
+  git clone https://$repository $src_dir
+  log_success "Checked out $repository"
+fi
+pushd /go/src/$repository/..
+
+rpm --import https://packages.microsoft.com/keys/microsoft.asc
+dnf install -y https://packages.microsoft.com/config/rhel/9.0/packages-microsoft-prod.rpm
+dnf install -y azure-cli cargo g++ jq rustfmt
+
+log_info "Setup an ephemeral Azure VM for a Kind cluster"
+secret_base=/var/run/azure-upstream-ci
+test_id=$(uuidgen | cut -d- -f1)
+
+az_region=eastus
+az_resource_group=upstream-ci-$test_id
+echo "$az_resource_group" > "$SHARED_DIR/az-resource-group"
+kind_vm_user=ci
+kind_vm_name=kind-vm
+kind_vm_image=$(grep KIND_HOST_URN operator/Makefile | cut -d= -f2 | tr -d ' ')
+vm_size=Standard_D2s_v3
+
+AZURE_SUBSCRIPTION_ID=$(cat $secret_base/subscription-id)
+export AZURE_SUBSCRIPTION_ID
+az login --service-principal \
+  --username "$(cat $secret_base/client-id)" \
+  --password "$(cat $secret_base/client-secret)" \
+  --tenant "$(cat $secret_base/tenant-id)"
+
+log_info "Create Azure resource group $az_resource_group"
+az group create \
+  --location $az_region \
+  --resource-group "$az_resource_group"
+log_info "Create Azure VM $kind_vm_name of image $kind_vm_image"
+kind_vm_ip=$(az vm create \
+  --name $kind_vm_name \
+  --resource-group "$az_resource_group" \
+  --size $vm_size \
+  --image "$kind_vm_image" \
+  --admin-username $kind_vm_user \
+  --generate-ssh-keys | jq -r .publicIpAddress)
+log_success "Created Azure VM $kind_vm_name (public IP $kind_vm_ip), waiting for availability"
+az vm wait --created \
+  --name $kind_vm_name \
+  --resource-group "$az_resource_group"
+
+SSHOPTS=(
+  -o ConnectTimeout=30
+  -o StrictHostKeyChecking=no
+  -o UserKnownHostsFile=/dev/null
+)
+
+ssh "${SSHOPTS[@]}" $kind_vm_user@"$kind_vm_ip" echo
+log_success "Azure VM $kind_vm_name has SSH access"
+
+log_info "Open ports on Azure VM"
+nsg=$(az vm show \
+  --resource-group "$az_resource_group" \
+  --name $kind_vm_name \
+  --query "networkProfile.networkInterfaces[0].id" -o tsv | \
+  xargs az network nic show --query "networkSecurityGroup.id" -o tsv --ids | \
+  cut -d/ -f9)
+ports=(6443 8000 8080)
+for i in "${!ports[@]}"; do
+  port=${ports[$i]}
+  az network nsg rule create \
+    --resource-group "$az_resource_group" \
+    --nsg-name "$nsg" \
+    --name "allow-$port" \
+    --priority $((1001 + i)) \
+    --source-address-prefixes "*" \
+    --destination-port-ranges "$port" \
+    --protocol Tcp \
+    --access Allow \
+    --direction Inbound
+done
+log_success "Opened ports on Azure VM"
+
+log_info "Transfer source to Azure VM"
+src_tarball=tec-src.tgz
+tar czf $src_tarball operator
+# shellcheck disable=SC2029
+scp "${SSHOPTS[@]}" $src_tarball $kind_vm_user@"$kind_vm_ip":~
+popd
+provision=$(mktemp)
+cat > "$provision" << 'PROVISION'
+#!/bin/bash -eu
+set -o pipefail
+
+sudo dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+sudo dnf install -y docker-ce docker-ce-cli containerd.io golang
+
+for lv in home tmp var; do
+  sudo lvextend -r -L +10G /dev/mapper/rootvg-${lv}lv
+done
+
+mkdir -p ~/go/bin
+PATH=$HOME/go/bin:$PATH
+
+tar xf tec-src.tgz
+pushd operator
+
+go install github.com/mikefarah/yq/v4
+go install sigs.k8s.io/kind
+
+KUBEADM_CONFIG=$(cat <<EOF
+kind: ClusterConfiguration
+apiServer:
+  certSANs:
+    - "0.0.0.0"
+    - "$1"
+EOF
+)
+KIND_IMAGE=$(awk '/kindest/ {print $NF}' Cargo.toml)
+export KUBEADM_CONFIG KIND_IMAGE
+yq -i '.networking.apiServerAddress = "0.0.0.0" |
+       .networking.apiServerPort = 6443 |
+       .nodes[0].image = env(KIND_IMAGE) |
+       .nodes[0].kubeadmConfigPatches[0] = strenv(KUBEADM_CONFIG)' kind/config.yaml
+
+# Tests' k8s interaction comes from Prow host, but kubectl is required for some cluster setup extras
+k8s_version=$(cut -d: -f2 <<< "$KIND_IMAGE")
+sudo curl -Lo /usr/local/bin/kubectl "https://dl.k8s.io/release/${k8s_version}/bin/linux/amd64/kubectl"
+sudo chmod +x /usr/local/bin/kubectl
+
+sudo usermod -aG docker "$(whoami)"
+sudo mkdir -p /etc/docker
+echo '{"insecure-registries": ["localhost:5000"]}' | sudo tee /etc/docker/daemon.json
+sudo systemctl start docker
+PROVISION
+chmod +x "$provision"
+scp "${SSHOPTS[@]}" "$provision" $kind_vm_user@"$kind_vm_ip":~/provision.sh
+rm "$provision"
+
+log_info "Prepare Kind cluster on Azure VM"
+log_warn "kind/config.yaml has some custom modifications applied. Refer to openshift/release repository for details."
+# shellcheck disable=SC2029
+ssh "${SSHOPTS[@]}" ${kind_vm_user}@"$kind_vm_ip" "\$HOME/provision.sh $kind_vm_ip"
+log_success "Prepare Kind cluster on Azure VM"
+
+log_info "Create Kind cluster on Azure VM"
+ssh "${SSHOPTS[@]}" ${kind_vm_user}@"$kind_vm_ip" "cd \$HOME/operator && PATH=\$HOME/go/bin:\$PATH RUNTIME=docker make cluster-up"
+
+pushd /go/src/$repository
+make yq
+kubeconf=~/.kube/config
+mkdir -p ~/.kube
+scp "${SSHOPTS[@]}" $kind_vm_user@"$kind_vm_ip":~/.kube/config $kubeconf
+# shellcheck disable=SC2211
+bin/yq* -i ".clusters[0].cluster.server = \"https://$kind_vm_ip:6443\"" $kubeconf
+kubectl get pods
+log_success "Created Kind cluster on Azure VM"
+
+log_info "Build operator images on Azure VM"
+ssh "${SSHOPTS[@]}" ${kind_vm_user}@"$kind_vm_ip" "cd \$HOME/operator && CONTAINER_CLI=docker REGISTRY=localhost:5000 make -j2 push"
+log_success "Built & pushed operator images"
+
+log_info "Run integration tests"
+eval "$(ssh-agent)"
+PLATFORM=kind_public VIRT_PROVIDER=azure REGISTRY=localhost:5000 \
+  TEST_NAMESPACE_PREFIX="$az_resource_group-" \
+  TEST_IMAGE=$(cat $secret_base/test-image) \
+  CLUSTER_URL="$kind_vm_ip" \
+  make integration-tests
+log_success "Ran integration tests"

--- a/ci-operator/step-registry/trusted-execution-clusters/ref/operator/azure-test/trusted-execution-clusters-ref-operator-azure-test-ref.metadata.json
+++ b/ci-operator/step-registry/trusted-execution-clusters/ref/operator/azure-test/trusted-execution-clusters-ref-operator-azure-test-ref.metadata.json
@@ -1,0 +1,13 @@
+{
+	"path": "trusted-execution-clusters/ref/operator/azure-test/trusted-execution-clusters-ref-operator-azure-test-ref.yaml",
+	"owners": {
+		"approvers": [
+			"alicefr",
+			"Jakob-Naucke"
+		],
+		"reviewers": [
+			"alicefr",
+			"Jakob-Naucke"
+		]
+	}
+}

--- a/ci-operator/step-registry/trusted-execution-clusters/ref/operator/azure-test/trusted-execution-clusters-ref-operator-azure-test-ref.yaml
+++ b/ci-operator/step-registry/trusted-execution-clusters/ref/operator/azure-test/trusted-execution-clusters-ref-operator-azure-test-ref.yaml
@@ -1,0 +1,20 @@
+ref:
+  as: trusted-execution-clusters-ref-operator-azure-test
+  from_image:
+    namespace: ci
+    name: telco-runner
+    tag: latest
+  commands: trusted-execution-clusters-ref-operator-azure-test-commands.sh
+  grace_period: 5m
+  credentials:
+  - namespace: test-credentials
+    name: azure-upstream-ci
+    mount_path: /var/run/azure-upstream-ci
+  resources:
+    requests:
+      cpu: 500m
+      memory: 500Mi
+    limits:
+      memory: 1Gi
+  documentation: |-
+    Create a VM for Kind on Azure. Run integration tests with Azure VMs, testing against the operator on that Kind cluster.


### PR DESCRIPTION
Create a Kind VM (also on Azure) as container platform. Run integration tests on Azure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Azure Upstream CI for trusted-execution-clusters Operator

This PR introduces Azure upstream CI infrastructure for the `trusted-execution-clusters/operator` repository, enabling integration testing on Azure cloud infrastructure.

### CI Configuration Changes

Added `ci-operator/config/trusted-execution-clusters/operator/azure.yaml` to define the main test job `operator-lifecycle-azure-verify`. This job:
- Runs the `trusted-execution-clusters-operator-azure-lifecycle` test chain
- Executes the `trusted-execution-clusters-operator-azure-cleanup` cleanup chain afterward
- Requires intranet capability
- Skips execution for documentation-only changes
- Uses `telco-runner:latest` container image for test execution

### Test Infrastructure

Added two main CI step chains:

**Azure Lifecycle Chain** (`trusted-execution-clusters-operator-azure-lifecycle`): Provisioning and testing flow that:
- Provisions an ephemeral Azure VM (Standard_D2s_v3, in eastus region)
- Creates a Kind Kubernetes cluster on the VM
- Builds and pushes the operator images to a local registry on the VM
- Runs the operator's integration tests against the Kind cluster
- Authenticates to Azure using service principal credentials

**Azure Cleanup Chain** (`trusted-execution-clusters-operator-azure-cleanup`): Resource cleanup that:
- Removes the provisioned Azure resource group after testing completes

### Implementation Details

The test step (`test.sh`) handles the full provisioning workflow:
- Clones the operator repository if not already present
- Installs required tooling (azure-cli, cargo, jq, rustfmt)
- Creates Azure resource group and VM using subscription credentials
- Configures networking (opens ports 6443, 8000, 8080)
- Sets up Kind cluster with Docker registry
- Builds and deploys operator images to the local registry
- Executes integration tests with proper environment configuration

The deprovision step (`deprovision.sh`) performs cleanup:
- Authenticates to Azure using service principal
- Deletes the Azure resource group created during testing

### Governance

Added OWNERS files specifying `alicefr`, `Jakob-Naucke`, `yalzhang`, and `fangge1212` as reviewers/approvers for the Azure test infrastructure components, along with corresponding metadata JSON files for tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->