### PR TITLE
Increase dal10 PowerVS quota slices from 1 to 4

### DIFF
--- a/ci-operator/step-registry/ipi/conf/powervs/ipi-conf-powervs-commands.sh
+++ b/ci-operator/step-registry/ipi/conf/powervs/ipi-conf-powervs-commands.sh
@@ -59,6 +59,18 @@ if [[ -n "${CLUSTER_NAME_MODIFIER}" ]]; then
   # Hopefully the entire hostname (including the BASE_DOMAIN) is less than 255 bytes.
   # Also, the CLUSTER_NAME seems to be truncated at 21 characters long.
   case "${LEASED_RESOURCE}" in
+    "dal10-powervs-3-quota-slice-0")
+      CLUSTER_NAME="p-dal10-0-${CLUSTER_NAME_MODIFIER}"
+    ;;
+    "dal10-powervs-3-quota-slice-1")
+      CLUSTER_NAME="p-dal10-1-${CLUSTER_NAME_MODIFIER}"
+    ;;
+    "dal10-powervs-3-quota-slice-2")
+      CLUSTER_NAME="p-dal10-2-${CLUSTER_NAME_MODIFIER}"
+    ;;
+    "dal10-powervs-3-quota-slice-3")
+      CLUSTER_NAME="p-dal10-3-${CLUSTER_NAME_MODIFIER}"
+    ;;
     "lon04-powervs-6-quota-slice-0")
       CLUSTER_NAME="p-lon04-0-${CLUSTER_NAME_MODIFIER}"
     ;;
@@ -134,9 +146,28 @@ POWERVS_ZONE=${LEASED_RESOURCE}
 PERSISTENT_TG=""
 PERSISTENT_VPC=""
 case "${LEASED_RESOURCE}" in
-   "dal10")
-      POWERVS_SERVICE_INSTANCE_ID=$(cat "/var/run/powervs-ipi-cicd-secrets/powervs-creds/POWERVS_SERVICE_INSTANCE_ID_DAL10")
+   "dal10-powervs-3-quota-slice-0")
+      POWERVS_SERVICE_INSTANCE_ID=$(cat "/var/run/powervs-ipi-cicd-secrets/powervs-creds/POWERVS_SERVICE_INSTANCE_ID_DAL10-0")
       POWERVS_REGION=dal
+      POWERVS_ZONE=dal10
+      VPCREGION=us-south
+   ;;
+   "dal10-powervs-3-quota-slice-1")
+      POWERVS_SERVICE_INSTANCE_ID=$(cat "/var/run/powervs-ipi-cicd-secrets/powervs-creds/POWERVS_SERVICE_INSTANCE_ID_DAL10-1")
+      POWERVS_REGION=dal
+      POWERVS_ZONE=dal10
+      VPCREGION=us-south
+   ;;
+   "dal10-powervs-3-quota-slice-2")
+      POWERVS_SERVICE_INSTANCE_ID=$(cat "/var/run/powervs-ipi-cicd-secrets/powervs-creds/POWERVS_SERVICE_INSTANCE_ID_DAL10-2")
+      POWERVS_REGION=dal
+      POWERVS_ZONE=dal10
+      VPCREGION=us-south
+   ;;
+   "dal10-powervs-3-quota-slice-3")
+      POWERVS_SERVICE_INSTANCE_ID=$(cat "/var/run/powervs-ipi-cicd-secrets/powervs-creds/POWERVS_SERVICE_INSTANCE_ID_DAL10-3")
+      POWERVS_REGION=dal
+      POWERVS_ZONE=dal10
       VPCREGION=us-south
    ;;
    "fran-powervs-8-quota-slice-0")

--- a/core-services/prow/02_config/_boskos.yaml
+++ b/core-services/prow/02_config/_boskos.yaml
@@ -5379,7 +5379,10 @@ resources:
   state: free
   type: powervs-2-quota-slice
 - names:
-  - dal10
+  - dal10-powervs-3-quota-slice-0
+  - dal10-powervs-3-quota-slice-1
+  - dal10-powervs-3-quota-slice-2
+  - dal10-powervs-3-quota-slice-3
   state: free
   type: powervs-3-quota-slice
 - names:

--- a/core-services/prow/02_config/generate-boskos.py
+++ b/core-services/prow/02_config/generate-boskos.py
@@ -465,9 +465,7 @@ CONFIG = {
         'syd04': 1,
         'syd05': 1,
     },
-    'powervs-3-quota-slice': {
-        'dal10': 1,
-    },
+    'powervs-3-quota-slice': {},
     'powervs-4-quota-slice': {
         'wdc06': 1,
     },
@@ -730,6 +728,9 @@ for i in range(0,2):
 
 for i in range(0,80):
     CONFIG['vsphere-elastic-quota-slice']['vsphere-elastic-{}'.format(i)] = 1
+
+for i in range(4):
+    CONFIG['powervs-3-quota-slice']['dal10-powervs-3-quota-slice-{}'.format(i)] = 1
 
 for i in range(4):
     CONFIG['powervs-5-quota-slice']['mad02-powervs-5-quota-slice-{}'.format(i)] = 1


### PR DESCRIPTION
This PR increases the dal10 PowerVS lease capacity from 1 to 4 quota slices to support more parallel CI jobs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR increases the OpenShift CI infrastructure's PowerVS quota capacity in the DAL10 region from 1 to 4 parallel quota slices, enabling more concurrent CI jobs to run on the PowerVS platform.

## Changes

**Infrastructure Impact**: The change enables the Prow CI system to provision up to 4 simultaneous PowerVS instances in the DAL10 region instead of the previous single instance. This directly increases parallelization capacity for CI jobs that require PowerVS infrastructure.

**Modified Components**:

1. **Boskos resource pool configuration** (`_boskos.yaml`): The `powervs-3-quota-slice` resource now defines 4 named quota slices (`dal10-powervs-3-quota-slice-0` through `-3`) instead of a single `dal10` entry, allowing the Prow scheduler to allocate up to 4 independent quota leases.

2. **Boskos generator script** (`generate-boskos.py`): Updated to programmatically generate the 4 quota-slice entries, ensuring consistency between the generated and source configurations.

3. **PowerVS IPI deployment script** (`ipi-conf-powervs-commands.sh`): Extended to recognize and properly route all 4 new DAL10 quota-slice identifiers to their respective PowerVS service instance credentials and regional settings (PowerVS region: `dal`, zone: `dal10`, VPC region: `us-south`).

This change maintains backward compatibility while expanding the infrastructure's capacity to run more parallel CI workflows in the PowerVS environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->