### PR TITLE
USHIFT-6958: Wait for instance OK before SSHing

### DIFF
--- a/ci-operator/step-registry/openshift/microshift/infra/aws/ec2/openshift-microshift-infra-aws-ec2-commands.sh
+++ b/ci-operator/step-registry/openshift/microshift/infra/aws/ec2/openshift-microshift-infra-aws-ec2-commands.sh
@@ -131,11 +131,12 @@ for aws_region in "${regions[@]}"; do
       echo "ec2-user" > "${SHARED_DIR}/ssh_user"
       echo "${CACHE_REGION}" > "${SHARED_DIR}/cache_region"
 
+      echo "Waiting up to 5 min for RHEL host to be up."
+      timeout 5m "${aws}" --region "${REGION}" ec2 wait instance-status-ok --instance-ids "${INSTANCE_ID}"
+
       ci_script_prologue
       scp -F "${HOME}/.ssh/config" "ec2-user@${HOST_PUBLIC_IP}:/tmp/init_output.txt" "${ARTIFACT_DIR}/init_ec2_output.txt"
 
-      echo "Waiting up to 5 min for RHEL host to be up."
-      timeout 5m "${aws}" --region "${REGION}" ec2 wait instance-status-ok --instance-id "${INSTANCE_ID}"
       exit 0
   fi
   save_stack_events_to_shared


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## MicroShift AWS EC2 infrastructure: wait for EC2 instance OK before SSH/SCP

This PR makes the MicroShift AWS EC2 provisioning step in the OpenShift CI configuration more reliable by waiting for the launched EC2 instance to report instance-status OK before attempting SSH-related operations.

What changed in practice
- The infra step script ci-operator/step-registry/openshift/microshift/infra/aws/ec2/openshift-microshift-infra-aws-ec2-commands.sh now runs:
  - timeout 5m aws --region "${REGION}" ec2 wait instance-status-ok --instance-ids "${INSTANCE_ID}"
  - then calls ci_script_prologue and performs scp to copy /tmp/init_output.txt from the host to ${ARTIFACT_DIR}/init_ec2_output.txt.
- The aws wait invocation was corrected to use --instance-ids (plural) for the same instance ID.

Impact
- Reduces race conditions and transient failures where SSH, script prologue execution, or the SCP of the init output would run against an instance not yet fully operational.
- Affects CI jobs that provision temporary EC2 instances for OpenShift MicroShift testing via this step in the openshift/release repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->