### PR TITLE
ocp-virt-validation-checkup: add 4.22 jobs

### DIFF
--- a/ci-operator/config/openshift-cnv/ocp-virt-validation-checkup/openshift-cnv-ocp-virt-validation-checkup-release-4.22.yaml
+++ b/ci-operator/config/openshift-cnv/ocp-virt-validation-checkup/openshift-cnv-ocp-virt-validation-checkup-release-4.22.yaml
@@ -1,0 +1,54 @@
+build_root:
+  image_stream_tag:
+    name: release
+    namespace: openshift
+    tag: rhel-9-release-golang-1.24-openshift-4.22
+images:
+  items:
+  - dockerfile_path: ci/Dockerfile.ci
+    to: ocp-virt-validation-checkup
+releases:
+  latest:
+    candidate:
+      product: ocp
+      stream: nightly
+      version: "4.22"
+resources:
+  '*':
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 100m
+      memory: 600Mi
+tests:
+- as: unit
+  commands: make test
+  container:
+    from: src
+- as: e2e-aws
+  steps:
+    cluster_profile: aws-virtualization
+    env:
+      BASE_DOMAIN: cnv-ci.syseng.devcluster.openshift.com
+      CNV_VERSION: "4.22"
+    test:
+    - ref: interop-tests-deploy-cnv
+    - as: run-validation-checkup
+      cli: latest
+      commands: make ci-validate
+      dependencies:
+      - env: OCP_VIRT_VALIDATION_IMAGE
+        name: ocp-virt-validation-checkup
+      env:
+      - default: gp3
+        name: STORAGE_CLASS
+      from: src
+      resources:
+        requests:
+          cpu: 100m
+          memory: 600Mi
+    workflow: cnv-e2e-ipi-aws
+zz_generated_metadata:
+  branch: release-4.22
+  org: openshift-cnv
+  repo: ocp-virt-validation-checkup

--- a/ci-operator/config/openshift-cnv/ocp-virt-validation-checkup/openshift-cnv-ocp-virt-validation-checkup-release-4.22__periodics.yaml
+++ b/ci-operator/config/openshift-cnv/ocp-virt-validation-checkup/openshift-cnv-ocp-virt-validation-checkup-release-4.22__periodics.yaml
@@ -17,7 +17,7 @@ resources:
       memory: 600Mi
 tests:
 - as: e2e-azure
-  cron: 0 2 * * 1
+  cron: 0 20 * * 0
   steps:
     cluster_profile: azure-virtualization
     env:
@@ -99,7 +99,7 @@ tests:
     workflow: ipi-azure
   timeout: 9h0m0s
 zz_generated_metadata:
-  branch: main
+  branch: release-4.22
   org: openshift-cnv
   repo: ocp-virt-validation-checkup
   variant: periodics

--- a/ci-operator/jobs/openshift-cnv/ocp-virt-validation-checkup/openshift-cnv-ocp-virt-validation-checkup-release-4.22-periodics.yaml
+++ b/ci-operator/jobs/openshift-cnv/ocp-virt-validation-checkup/openshift-cnv-ocp-virt-validation-checkup-release-4.22-periodics.yaml
@@ -1,0 +1,84 @@
+periodics:
+- agent: kubernetes
+  cluster: build01
+  cron: 0 20 * * 0
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+    timeout: 9h0m0s
+  extra_refs:
+  - base_ref: release-4.22
+    org: openshift-cnv
+    repo: ocp-virt-validation-checkup
+  labels:
+    ci-operator.openshift.io/cloud: azure4
+    ci-operator.openshift.io/cloud-cluster-profile: azure-virtualization
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-cnv-ocp-virt-validation-checkup-release-4.22-periodics-e2e-azure
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-azure
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator

--- a/ci-operator/jobs/openshift-cnv/ocp-virt-validation-checkup/openshift-cnv-ocp-virt-validation-checkup-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift-cnv/ocp-virt-validation-checkup/openshift-cnv-ocp-virt-validation-checkup-release-4.22-presubmits.yaml
@@ -1,0 +1,205 @@
+presubmits:
+  openshift-cnv/ocp-virt-validation-checkup:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.22$
+    - ^release-4\.22-
+    cluster: build10
+    context: ci/prow/e2e-aws
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: aws-virtualization
+      ci.openshift.io/generator: prowgen
+      job-release: "4.22"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cnv-ocp-virt-validation-checkup-release-4.22-e2e-aws
+    rerun_command: /test e2e-aws
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-aws
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-aws,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.22$
+    - ^release-4\.22-
+    cluster: build01
+    context: ci/prow/images
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      job-release: "4.22"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cnv-ocp-virt-validation-checkup-release-4.22-images
+    rerun_command: /test images
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=[images]
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )images,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.22$
+    - ^release-4\.22-
+    cluster: build01
+    context: ci/prow/unit
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      job-release: "4.22"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cnv-ocp-virt-validation-checkup-release-4.22-unit
+    rerun_command: /test unit
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=unit
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )unit,?($|\s.*)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds CI configuration so the OpenShift Virtualization validation checkup repository (openshift-cnv/ocp-virt-validation-checkup) is tested against OpenShift 4.22. It introduces a new ci-operator release config and periodic jobs for the 4.22 release stream and updates an existing periodic to adjust the ODF operator channel.

## What changed in practical terms

- ci-operator release config for release-4.22
  - Adds ci-operator config to build the ocp-virt-validation-checkup image using buildroot image rhel-9-release-golang-1.24-openshift-4.22 and ci/Dockerfile.ci.
  - Sets global resource defaults (requests: cpu 100m, memory 600Mi; limits.memory: 4Gi).
  - Unit test: runs make test in the repo source container.
  - e2e AWS job: runs the cnv-e2e-ipi-aws workflow with cluster_profile: aws-virtualization, sets BASE_DOMAIN and CNV_VERSION=4.22, deploys CNV via interop-tests-deploy-cnv, then runs make ci-validate using the ocp-virt-validation-checkup image (STORAGE_CLASS default gp3). The run step requests cpu 100m / memory 600Mi.
  - Includes zz_generated_metadata for branch release-4.22 and org/repo openshift-cnv/ocp-virt-validation-checkup.

- Periodic CI config for release-4.22
  - Adds a weekly e2e-azure periodic (cron: 0 20 * * 0) using cluster_profile: azure-virtualization and the same buildroot and resource defaults.
  - Workflow installs CNV via cnv-ci (updates pull secrets, deploys CNV, patches KubeVirtHyperConverged defaultCPUModel to Broadwell), then extracts the validation image and runs make ci-validate (currently invoked with || true to tolerate known failures).
  - Sets runtime parameters and mounts required secrets/artifact dirs; uses timeouts (install 1h, validation 6.5h, overall 9h) and test parameters (STORAGE_CLASS, TEST_SKIPS, DRY_RUN, etc.).
  - Includes zz_generated_metadata for release-4.22.

- Adjustment to main periodic
  - Updates the existing main periodic config to use ODF_OPERATOR_CHANNEL: stable-4.21 instead of stable-4.20; no other changes to that workflow.

## Other notes

- A comment "/pj-rehearse" was posted requesting pj-rehearse (job rehearsals) for these changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->