### PR TITLE
fix: update periodic-org-sync to ignore enterprise teams

### DIFF
--- a/ci-operator/jobs/infra-periodics.yaml
+++ b/ci-operator/jobs/infra-periodics.yaml
@@ -1397,6 +1397,7 @@ periodics:
           --fix-team-members \
           --fix-team-repos \
           --fix-repos \
+          --ignore-enterprise-teams \
           --github-hourly-tokens=600 \
           --github-allowed-burst=600 \
           --allow-repo-archival


### PR DESCRIPTION
The `periodic-org-sync` job is currently failing because of the presence of an Enterprise GH team in a managed GitHub org, which peribolos can't administer and thus needs to be ignored when reconciling the org configuration. The `--ignore-enterprise-teams` option enables the desired behavior; this option was added in kubernetes-sigs/prow#710, and the updated container image was added to `infra-periodics` configuration in #79012 (thanks @hoxhaeris!). This commit adds the `--ignore-enterprise-teams` option to the `peribolos` invocation for `periodic-org-sync`, which should hopefully unblock the job and permit GitHub configuration reconciliation for the `openshift` org to resume as normal.