### PR TITLE
CNTRLPLANE-3371: Re-enable KAS allowed CIDRs test in Azure v2 self-managed e2e

### DIFF
--- a/ci-operator/step-registry/hypershift/azure/run-e2e-v2-selfmanaged/hypershift-azure-run-e2e-v2-selfmanaged-chain.yaml
+++ b/ci-operator/step-registry/hypershift/azure/run-e2e-v2-selfmanaged/hypershift-azure-run-e2e-v2-selfmanaged-chain.yaml
@@ -27,7 +27,6 @@ chain:
       E2E_HOSTED_CLUSTER_NAMESPACE=clusters \
       bin/test-e2e-v2 \
         --ginkgo.label-filter="self-managed-azure-public" \
-        --ginkgo.skip="KAS allowed CIDRs" \
         --ginkgo.junit-report="${ARTIFACT_DIR}/junit_self_managed_azure_public.xml" \
         --ginkgo.v &
       PID_PUB=$!


### PR DESCRIPTION
## Summary

- Remove `--ginkgo.skip="KAS allowed CIDRs"` from the `hypershift-azure-run-e2e-v2-selfmanaged` step registry chain
- The upstream fix (wait for HCP propagation before checking KAS reachability) has landed on hypershift main

## Test plan

- [ ] Rehearsal of `hypershift-azure-e2e-v2-self-managed` passes with the KAS allowed CIDRs test enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR re-enables the KAS allowed CIDRs validation test in the HyperShift Azure v2 self-managed E2E test suite. The test was previously skipped via a `--ginkgo.skip="KAS allowed CIDRs"` flag in the CI step registry, pending an upstream fix in the HyperShift operator. That fix—which ensures HCP propagates before checking KAS reachability—has now landed on HyperShift main, making it safe to run this test.

## Changes

The modification removes the ginkgo skip directive from the `hypershift-azure-run-e2e-v2-selfmanaged` step registry chain, allowing the ValidateKASAllowedCIDRs test to execute as part of the standard E2E test suite. This validates that the Kubernetes API Server properly respects CIDR allowlist configurations in Azure self-managed deployments.

## Testing

The change will be validated through rehearsal of the `hypershift-azure-e2e-v2-self-managed` test job to confirm the previously-skipped test now passes with the upstream fix in place.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->