### PR TITLE
ROSAENG-855: Add presubmit e2e smoke tests for rosa-e2e PRs

### DIFF
--- a/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main.yaml
+++ b/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main.yaml
@@ -40,6 +40,33 @@ tests:
     make lint
   container:
     from: src
+- as: e2e-rosa-hcp-smoke
+  run_if_changed: ^(pkg/|test/|Containerfile|go\.(mod|sum))
+  steps:
+    cluster_profile: rosa-e2e-01
+    env:
+      CHANNEL_GROUP: stable
+      ENABLE_BILLING_ACCOUNT: "yes"
+      HOSTED_CP: "true"
+      LABEL_FILTER: Importance:Critical && Platform:HCP && (Area:ClusterLifecycle
+        || Area:DataPlane || Area:ManagementPlane || Area:Upgrade)
+      OCM_LOGIN_ENV: staging
+      OPENSHIFT_VERSION: "4.21"
+      REPLICAS: "3"
+    workflow: rosa-e2e-hcp
+- as: e2e-rosa-classic-smoke
+  run_if_changed: ^(pkg/|test/|Containerfile|go\.(mod|sum))
+  steps:
+    cluster_profile: rosa-e2e-01
+    env:
+      CHANNEL_GROUP: stable
+      HOSTED_CP: "false"
+      LABEL_FILTER: Importance:Critical && Platform:Classic && (Area:ClusterLifecycle
+        || Area:DataPlane || Area:ManagementPlane || Area:Upgrade)
+      OCM_LOGIN_ENV: staging
+      OPENSHIFT_VERSION: "4.21"
+      REPLICAS: "3"
+    workflow: rosa-e2e-classic
 - as: rosa-ci-daily-status
   commands: scripts/ci-status-report.sh
   container:

--- a/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-presubmits.yaml
@@ -1,6 +1,174 @@
 presubmits:
   openshift-online/rosa-e2e:
   - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build10
+    context: ci/prow/e2e-rosa-classic-smoke
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: rosa-e2e-01
+      ci.openshift.io/generator: prowgen
+      job-release: "4.22"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-online-rosa-e2e-main-e2e-rosa-classic-smoke
+    rerun_command: /test e2e-rosa-classic-smoke
+    run_if_changed: ^(pkg/|test/|Containerfile|go\.(mod|sum))
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-rosa-classic-smoke
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-rosa-classic-smoke,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build10
+    context: ci/prow/e2e-rosa-hcp-smoke
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: rosa-e2e-01
+      ci.openshift.io/generator: prowgen
+      job-release: "4.22"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-online-rosa-e2e-main-e2e-rosa-hcp-smoke
+    rerun_command: /test e2e-rosa-hcp-smoke
+    run_if_changed: ^(pkg/|test/|Containerfile|go\.(mod|sum))
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-rosa-hcp-smoke
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-rosa-hcp-smoke,?($|\s.*)
+  - agent: kubernetes
     always_run: true
     branches:
     - ^main$

--- a/ci-operator/step-registry/rosa/e2e/test/rosa-e2e-test-commands.sh
+++ b/ci-operator/step-registry/rosa/e2e/test/rosa-e2e-test-commands.sh
@@ -68,9 +68,10 @@ if [[ "${CLUSTER_TOPOLOGY}" == "hcp" ]]; then
 fi
 
 # Run tests
-GINKGO_FLAGS="--ginkgo.junit-report=${ARTIFACT_DIR}/junit-rosa-e2e.xml --ginkgo.v"
+GINKGO_ARGS=(--ginkgo.junit-report="${ARTIFACT_DIR}/junit-rosa-e2e.xml" --ginkgo.v)
 if [[ -n "${LABEL_FILTER}" ]]; then
-  GINKGO_FLAGS="${GINKGO_FLAGS} --ginkgo.label-filter=${LABEL_FILTER}"
+  log "Label filter: ${LABEL_FILTER}"
+  GINKGO_ARGS+=(--ginkgo.label-filter="${LABEL_FILTER}")
 fi
 
 if [[ -n "${EXCLUDE_CLUSTER_OPERATORS}" ]]; then
@@ -78,6 +79,6 @@ if [[ -n "${EXCLUDE_CLUSTER_OPERATORS}" ]]; then
 fi
 
 log "Running rosa-e2e tests..."
-/usr/local/bin/e2e.test ${GINKGO_FLAGS}
+/usr/local/bin/e2e.test "${GINKGO_ARGS[@]}"
 
 log "Tests complete. Results at ${ARTIFACT_DIR}/junit-rosa-e2e.xml"

--- a/ci-operator/step-registry/rosa/e2e/test/rosa-e2e-test-ref.yaml
+++ b/ci-operator/step-registry/rosa/e2e/test/rosa-e2e-test-ref.yaml
@@ -11,6 +11,9 @@ ref:
   - name: OCM_LOGIN_ENV
     default: "staging"
     documentation: The environment for OCM login.
+  - name: HOSTED_CP
+    default: "true"
+    documentation: Whether the cluster is HCP (true) or Classic (false). Controls topology detection and MC access.
   - name: LABEL_FILTER
     default: ""
     documentation: Ginkgo label filter for test selection (e.g. "Area:ManagedService").


### PR DESCRIPTION
## Summary

Add presubmit e2e smoke tests for rosa-e2e PRs that validate code changes against both ROSA HCP and Classic STS clusters in parallel.

- **e2e-rosa-hcp-smoke**: Provisions HCP cluster, runs `Importance:Critical` tests
- **e2e-rosa-classic-smoke**: Provisions Classic STS cluster, runs `Importance:Critical && Platform:Classic` tests
- Both use `run_if_changed` to trigger only on Go code, test, or Containerfile changes
- Uses `rosa-e2e-01` cluster profile, stable channel, OCP 4.22

Jira: https://redhat.atlassian.net/browse/ROSAENG-855

## Test plan

- [x] `make jobs` generates presubmit job definitions
- [ ] After merge, open a test PR to rosa-e2e with a code change and verify both jobs trigger
- [ ] Verify docs-only PRs do not trigger the e2e jobs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR updates OpenShift CI configuration in the openshift/release repo for the openshift-online/rosa-e2e project by adding two presubmit end-to-end smoke jobs that run in parallel to validate critical ROSA scenarios on Hosted Control Plane (HCP) and Classic STS clusters.

### Changes made
- Adds two presubmit jobs to ci-operator config for openshift-online/rosa-e2e:
  - e2e-rosa-hcp-smoke — provisions an HCP cluster and runs tests filtered by LABEL_FILTER: Importance:Critical && Platform:HCP && (Area:ClusterLifecycle || Area:DataPlane || Area:ManagementPlane || Area:Upgrade). ENABLE_BILLING_ACCOUNT is set to "yes" and HOSTED_CP = "true".
  - e2e-rosa-classic-smoke — provisions a Classic STS cluster and runs tests filtered by LABEL_FILTER: Importance:Critical && Platform:Classic && (Area:ClusterLifecycle || Area:DataPlane || Area:ManagementPlane || Area:Upgrade). HOSTED_CP = "false".
- Both jobs:
  - Use cluster_profile: rosa-e2e-01.
  - Use run_if_changed: ^(pkg/|test/|Containerfile|go\.(mod|sum)) so they only trigger for code, tests, Containerfile, or Go module changes (avoids docs-only PRs).
  - Set CHANNEL_GROUP: stable, OCM_LOGIN_ENV: staging, REPLICAS: "3".
  - Reference workflow names rosa-e2e-hcp and rosa-e2e-classic.
- The repository's ci-operator releases section indicates nightly candidate version "4.22", but the new presubmit job env OPENSHIFT_VERSION is set to "4.21" in the committed YAML (discrepancy noted).

### Metadata, validation & notes
- Jira: [ROSAENG-855](https://redhat.atlassian.net/browse/ROSAENG-855) (openshift-ci-robot validated the Jira reference and warned the issue lacks a target version).
- The author and reviewers used multiple /pj-rehearse commands to rehearse the new presubmits; make jobs was used to generate job definitions.
- Commit message refines the smoke-filtering to exclude machine-config-dependent test areas (i.e., the LABEL_FILTER enumerates areas to avoid MC-dependent tests).
- Pending verification after merge: open a test PR in rosa-e2e to confirm both jobs trigger on code changes and confirm docs-only PRs do not trigger them.

### Impact
- Affects CI presubmit behavior for the openshift-online/rosa-e2e repository only (adds lightweight smoke presubmits to catch critical regressions on HCP and Classic STS variants without running full e2e suites).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[ROSAENG-855]: https://redhat.atlassian.net/browse/ROSAENG-855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ