### PR TITLE
Add Tide query for cloud-event-proxy release-4.22 branch

### DIFF
--- a/core-services/prow/02_config/redhat-cne/cloud-event-proxy/_prowconfig.yaml
+++ b/core-services/prow/02_config/redhat-cne/cloud-event-proxy/_prowconfig.yaml
@@ -33,6 +33,7 @@ tide:
     - release-4.18
     - release-4.19
     - release-4.20
+    - release-4.21
     - release-4.9
     labels:
     - approved
@@ -50,7 +51,7 @@ tide:
     repos:
     - redhat-cne/cloud-event-proxy
   - includedBranches:
-    - release-4.21
+    - release-4.22
     labels:
     - approved
     - backport-risk-assessed


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Tide Query Configuration for cloud-event-proxy release-4.22 Branch

This PR adds Prow tide merge automation support for the new `release-4.22` branch of the RedHat CNE cloud-event-proxy repository.

**Changes:**
- Added a new dedicated Prow tide query targeting the `release-4.22` branch with the same label requirements as other release branches (`approved`, `backport-risk-assessed`, `jira/valid-bug`, `lgtm`, and `verified`)
- Updated the catch-all query's `excludedBranches` list to include `release-4.22`, ensuring PRs on that branch are handled by the dedicated query rather than the generic configuration

**Impact:**
This enables automated PR merging for the `release-4.22` release branch, allowing the cloud-event-proxy component to participate in OpenShift's downstream release automation workflow for the 4.22 release cycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->