### PR TITLE
OCPBUGS-85344: enable karpenter tests for hypershift e2e-aws on 4.22

### DIFF
--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-main.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-main.yaml
@@ -321,6 +321,7 @@ tests:
     env:
       ENABLE_HYPERSHIFT_CERT_ROTATION_SCALE: "true"
       REQUEST_SERVING_COMPONENT_TEST: "true"
+      RUN_KARPENTER_TESTS: "true"
     workflow: hypershift-aws-e2e-nested
 - always_run: false
   as: e2e-kubevirt-aws-ovn-reduced

--- a/ci-operator/step-registry/hypershift/aws/run-e2e/nested/hypershift-aws-run-e2e-nested-ref.yaml
+++ b/ci-operator/step-registry/hypershift/aws/run-e2e/nested/hypershift-aws-run-e2e-nested-ref.yaml
@@ -48,6 +48,8 @@ ref:
     - default: "false"
       name: REQUEST_SERVING_COMPONENT_TEST
     - default: "false"
+      name: RUN_KARPENTER_TESTS
+    - default: "false"
       name: RUN_UPGRADE_TEST
     - default: "0"
       name: TEST_CPO_OVERRIDE


### PR DESCRIPTION
## Summary
- Add `RUN_KARPENTER_TESTS=true` env var to the `e2e-aws` test in the hypershift release-4.22 CI config
- This enables karpenter e2e tests to run against 4.22 hosted clusters when the HyperShift operator is built from main
- The karpenter API (`karpenter.hypershift.openshift.io/v1`) only exists on main, but can be tested against 4.22 clusters with this gate

## Context
Depends on https://github.com/openshift/hypershift/pull/8466 which adds the `RUN_KARPENTER_TESTS` env var check to lower the version gate from 4.23 to 4.22 for karpenter tests.

Fixes https://issues.redhat.com/browse/OCPBUGS-85344

## Test plan
- [ ] Verify CI presubmit checks pass
- [ ] Confirm e2e-aws job picks up `RUN_KARPENTER_TESTS=true` and runs karpenter tests against 4.22 clusters

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Enables running Karpenter e2e tests for HyperShift 4.22 in the OpenShift CI configuration. The PR updates HyperShift CI to set RUN_KARPENTER_TESTS: "true" for the e2e-aws-4-22 job (ci-operator/config/openshift/hypershift/openshift-hypershift-main.yaml), and adds the RUN_KARPENTER_TESTS environment variable (default "false") in the hypershift AWS nested e2e step definition (ci-operator/step-registry/hypershift/aws/run-e2e/nested/hypershift-aws-run-e2e-nested-ref.yaml). Practically, this lets the OpenShift CI run Karpenter e2e tests against 4.22 hosted clusters when the HyperShift operator is built from main — relying on the dependent HyperShift change that implements the gate and lowers the version requirement from 4.23 to 4.22. Fixes OCPBUGS-85344.

Test plan: ensure presubmit CI passes and verify the e2e-aws job picks up RUN_KARPENTER_TESTS=true and executes Karpenter tests against 4.22 clusters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->