### PR TITLE
CNF-22982: Add renovate.json to excluded files for cluster-group-upgr…

### DIFF
--- a/ci-operator/config/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-main.yaml
+++ b/ci-operator/config/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-main.yaml
@@ -21,7 +21,7 @@ images:
     to: cluster-group-upgrades-operator-recovery
   - dockerfile_path: bundle.Dockerfile
     to: cluster-group-upgrades-operator-bundle
-  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
 operator:
   bundles:
   - dockerfile_path: bundle.Dockerfile
@@ -67,9 +67,9 @@ tests:
   secrets:
   - mount_path: /etc/coveralls
     name: cluster-group-upgrades-operator-coverall
-  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
 - as: integration
-  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
   steps:
     cluster_profile: aws-telco
     env:
@@ -128,7 +128,7 @@ tests:
     workflow: optional-operators-ci-aws
 - as: security
   optional: true
-  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
   steps:
     env:
       PROJECT_NAME: cluster-group-upgrades-operator

--- a/ci-operator/config/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.12.yaml
+++ b/ci-operator/config/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.12.yaml
@@ -21,7 +21,7 @@ images:
     to: cluster-group-upgrades-operator-recovery
   - dockerfile_path: bundle.Dockerfile
     to: cluster-group-upgrades-operator-bundle
-  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
 operator:
   bundles:
   - dockerfile_path: bundle.Dockerfile
@@ -59,9 +59,9 @@ tests:
     make ci-job
   container:
     from: src
-  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
 - as: integration
-  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
   steps:
     cluster_profile: aws-telco
     env:

--- a/ci-operator/config/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.14.yaml
+++ b/ci-operator/config/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.14.yaml
@@ -21,7 +21,7 @@ images:
     to: cluster-group-upgrades-operator-recovery
   - dockerfile_path: bundle.Dockerfile
     to: cluster-group-upgrades-operator-bundle
-  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
 operator:
   bundles:
   - dockerfile_path: bundle.Dockerfile
@@ -61,9 +61,9 @@ tests:
     make ci-job
   container:
     from: src
-  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
 - as: integration
-  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
   steps:
     cluster_profile: aws-telco
     env:

--- a/ci-operator/config/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.16.yaml
+++ b/ci-operator/config/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.16.yaml
@@ -18,7 +18,7 @@ images:
     to: cluster-group-upgrades-operator-recovery
   - dockerfile_path: bundle.Dockerfile
     to: cluster-group-upgrades-operator-bundle
-  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
 operator:
   bundles:
   - dockerfile_path: bundle.Dockerfile
@@ -58,9 +58,9 @@ tests:
     make ci-job
   container:
     from: src
-  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
 - as: integration
-  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
   steps:
     cluster_profile: aws-telco
     env:
@@ -108,7 +108,7 @@ tests:
     workflow: optional-operators-ci-aws
 - as: security
   optional: true
-  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
   steps:
     env:
       PROJECT_NAME: cluster-group-upgrades-operator

--- a/ci-operator/config/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.18.yaml
+++ b/ci-operator/config/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.18.yaml
@@ -18,7 +18,7 @@ images:
     to: cluster-group-upgrades-operator-recovery
   - dockerfile_path: bundle.Dockerfile
     to: cluster-group-upgrades-operator-bundle
-  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
 operator:
   bundles:
   - dockerfile_path: bundle.Dockerfile
@@ -58,9 +58,9 @@ tests:
     make ci-job
   container:
     from: src
-  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
 - as: integration
-  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
   steps:
     cluster_profile: aws-telco
     env:
@@ -108,7 +108,7 @@ tests:
     workflow: optional-operators-ci-aws
 - as: security
   optional: true
-  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
   steps:
     env:
       PROJECT_NAME: cluster-group-upgrades-operator

--- a/ci-operator/config/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.19.yaml
+++ b/ci-operator/config/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.19.yaml
@@ -18,7 +18,7 @@ images:
     to: cluster-group-upgrades-operator-recovery
   - dockerfile_path: bundle.Dockerfile
     to: cluster-group-upgrades-operator-bundle
-  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
 operator:
   bundles:
   - dockerfile_path: bundle.Dockerfile
@@ -58,9 +58,9 @@ tests:
     make ci-job
   container:
     from: src
-  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
 - as: integration
-  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
   steps:
     cluster_profile: aws-telco
     env:
@@ -108,7 +108,7 @@ tests:
     workflow: optional-operators-ci-aws
 - as: security
   optional: true
-  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
   steps:
     env:
       PROJECT_NAME: cluster-group-upgrades-operator

--- a/ci-operator/config/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.20.yaml
+++ b/ci-operator/config/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.20.yaml
@@ -18,7 +18,7 @@ images:
     to: cluster-group-upgrades-operator-recovery
   - dockerfile_path: bundle.Dockerfile
     to: cluster-group-upgrades-operator-bundle
-  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
 operator:
   bundles:
   - dockerfile_path: bundle.Dockerfile
@@ -58,9 +58,9 @@ tests:
     make ci-job
   container:
     from: src
-  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
 - as: integration
-  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
   steps:
     cluster_profile: aws-telco
     env:
@@ -108,7 +108,7 @@ tests:
     workflow: optional-operators-ci-aws
 - as: security
   optional: true
-  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
   steps:
     env:
       PROJECT_NAME: cluster-group-upgrades-operator

--- a/ci-operator/config/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.21.yaml
+++ b/ci-operator/config/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.21.yaml
@@ -21,7 +21,7 @@ images:
     to: cluster-group-upgrades-operator-recovery
   - dockerfile_path: bundle.Dockerfile
     to: cluster-group-upgrades-operator-bundle
-  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
 operator:
   bundles:
   - dockerfile_path: bundle.Dockerfile
@@ -67,9 +67,9 @@ tests:
   secrets:
   - mount_path: /etc/coveralls
     name: cluster-group-upgrades-operator-coverall
-  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
 - as: integration
-  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
   steps:
     cluster_profile: aws-telco
     env:
@@ -128,7 +128,7 @@ tests:
     workflow: optional-operators-ci-aws
 - as: security
   optional: true
-  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
   steps:
     env:
       PROJECT_NAME: cluster-group-upgrades-operator

--- a/ci-operator/config/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.22.yaml
+++ b/ci-operator/config/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.22.yaml
@@ -21,7 +21,7 @@ images:
     to: cluster-group-upgrades-operator-recovery
   - dockerfile_path: bundle.Dockerfile
     to: cluster-group-upgrades-operator-bundle
-  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
 operator:
   bundles:
   - dockerfile_path: bundle.Dockerfile
@@ -67,9 +67,9 @@ tests:
   secrets:
   - mount_path: /etc/coveralls
     name: cluster-group-upgrades-operator-coverall
-  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
 - as: integration
-  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
   steps:
     cluster_profile: aws-telco
     env:
@@ -128,7 +128,7 @@ tests:
     workflow: optional-operators-ci-aws
 - as: security
   optional: true
-  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+  skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
   steps:
     env:
       PROJECT_NAME: cluster-group-upgrades-operator

--- a/ci-operator/jobs/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-main-presubmits.yaml
@@ -66,7 +66,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-main-ci-job
     rerun_command: /test ci-job
-    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
     spec:
       containers:
       - args:
@@ -135,7 +135,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-main-images
     rerun_command: /test images
-    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
     spec:
       containers:
       - args:
@@ -191,7 +191,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-main-integration
     rerun_command: /test integration
-    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
     spec:
       containers:
       - args:
@@ -271,7 +271,7 @@ presubmits:
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-main-security
     optional: true
     rerun_command: /test security
-    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.12-presubmits.yaml
+++ b/ci-operator/jobs/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.12-presubmits.yaml
@@ -70,7 +70,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-release-4.12-ci-job
     rerun_command: /test ci-job
-    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
     spec:
       containers:
       - args:
@@ -134,7 +134,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-release-4.12-images
     rerun_command: /test images
-    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
     spec:
       containers:
       - args:
@@ -192,7 +192,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-release-4.12-integration
     rerun_command: /test integration
-    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.14-presubmits.yaml
+++ b/ci-operator/jobs/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.14-presubmits.yaml
@@ -70,7 +70,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-release-4.14-ci-job
     rerun_command: /test ci-job
-    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
     spec:
       containers:
       - args:
@@ -134,7 +134,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-release-4.14-images
     rerun_command: /test images
-    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
     spec:
       containers:
       - args:
@@ -192,7 +192,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-release-4.14-integration
     rerun_command: /test integration
-    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.16-presubmits.yaml
+++ b/ci-operator/jobs/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.16-presubmits.yaml
@@ -66,7 +66,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-release-4.16-ci-job
     rerun_command: /test ci-job
-    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
     spec:
       containers:
       - args:
@@ -128,7 +128,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-release-4.16-images
     rerun_command: /test images
-    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
     spec:
       containers:
       - args:
@@ -184,7 +184,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-release-4.16-integration
     rerun_command: /test integration
-    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
     spec:
       containers:
       - args:
@@ -264,7 +264,7 @@ presubmits:
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-release-4.16-security
     optional: true
     rerun_command: /test security
-    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.18-presubmits.yaml
+++ b/ci-operator/jobs/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.18-presubmits.yaml
@@ -66,7 +66,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-release-4.18-ci-job
     rerun_command: /test ci-job
-    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
     spec:
       containers:
       - args:
@@ -128,7 +128,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-release-4.18-images
     rerun_command: /test images
-    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
     spec:
       containers:
       - args:
@@ -184,7 +184,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-release-4.18-integration
     rerun_command: /test integration
-    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
     spec:
       containers:
       - args:
@@ -264,7 +264,7 @@ presubmits:
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-release-4.18-security
     optional: true
     rerun_command: /test security
-    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.19-presubmits.yaml
+++ b/ci-operator/jobs/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.19-presubmits.yaml
@@ -66,7 +66,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-release-4.19-ci-job
     rerun_command: /test ci-job
-    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
     spec:
       containers:
       - args:
@@ -128,7 +128,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-release-4.19-images
     rerun_command: /test images
-    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
     spec:
       containers:
       - args:
@@ -184,7 +184,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-release-4.19-integration
     rerun_command: /test integration
-    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
     spec:
       containers:
       - args:
@@ -264,7 +264,7 @@ presubmits:
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-release-4.19-security
     optional: true
     rerun_command: /test security
-    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.20-presubmits.yaml
+++ b/ci-operator/jobs/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.20-presubmits.yaml
@@ -66,7 +66,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-release-4.20-ci-job
     rerun_command: /test ci-job
-    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
     spec:
       containers:
       - args:
@@ -128,7 +128,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-release-4.20-images
     rerun_command: /test images
-    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
     spec:
       containers:
       - args:
@@ -184,7 +184,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-release-4.20-integration
     rerun_command: /test integration
-    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
     spec:
       containers:
       - args:
@@ -264,7 +264,7 @@ presubmits:
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-release-4.20-security
     optional: true
     rerun_command: /test security
-    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.21-presubmits.yaml
+++ b/ci-operator/jobs/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.21-presubmits.yaml
@@ -66,7 +66,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-release-4.21-ci-job
     rerun_command: /test ci-job
-    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
     spec:
       containers:
       - args:
@@ -135,7 +135,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-release-4.21-images
     rerun_command: /test images
-    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
     spec:
       containers:
       - args:
@@ -191,7 +191,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-release-4.21-integration
     rerun_command: /test integration
-    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
     spec:
       containers:
       - args:
@@ -271,7 +271,7 @@ presubmits:
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-release-4.21-security
     optional: true
     rerun_command: /test security
-    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift-kni/cluster-group-upgrades-operator/openshift-kni-cluster-group-upgrades-operator-release-4.22-presubmits.yaml
@@ -66,7 +66,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-release-4.22-ci-job
     rerun_command: /test ci-job
-    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
     spec:
       containers:
       - args:
@@ -135,7 +135,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-release-4.22-images
     rerun_command: /test images
-    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
     spec:
       containers:
       - args:
@@ -191,7 +191,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-release-4.22-integration
     rerun_command: /test integration
-    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
     spec:
       containers:
       - args:
@@ -271,7 +271,7 @@ presubmits:
     name: pull-ci-openshift-kni-cluster-group-upgrades-operator-release-4.22-security
     optional: true
     rerun_command: /test security
-    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE)$
+    skip_if_only_changed: ^(?:.*/)?(?:\.gitignore|\.tekton/.*|\.konflux/.*|.*\.md|OWNERS|OWNERS_ALIASES|LICENSE|renovate\.json)$
     spec:
       containers:
       - args:


### PR DESCRIPTION
…ades-operator ci triggers

- the renovate.json file should not cause any prow tests to run as it is only used for Mintmaker configuration

Assisted-by: Cursor/auto
AI-attribution: AIA,Primarily AI-generated,Human-initiated,Reviewed,Cursor/auto,v1.0
For more information on AI attribution statements, see: https://aiattribution.github.io/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds `renovate.json` to the list of excluded files in CI trigger configurations for the OpenShift KNI cluster-group-upgrades-operator component. This prevents Prow CI jobs from running when only `renovate.json` is modified, since this file is used exclusively for Mintmaker configuration and does not require any test validation.

## Changes

Updated the `skip_if_only_changed` glob patterns across all cluster-group-upgrades-operator CI configuration files to exclude `renovate.json`:

- **Main branch configuration** (`openshift-kni-cluster-group-upgrades-operator-main.yaml`): Updated skip patterns in base CI job config, integration, and security test sections
- **Release branch configurations** (4.12, 4.14, 4.16, 4.18, 4.19, 4.20, 4.21, 4.22): Applied consistent skip pattern updates across corresponding CI job and test definitions

The changes ensure that both primary CI jobs and optional test stages (integration, security) consistently skip execution when only renovate configuration files are modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->