### PR TITLE
WINC: Use clusterbot-wait instead of cucushift-installer-wait in winc workflows

### DIFF
--- a/ci-operator/config/RedHatQE/interop-testing/RedHatQE-interop-testing-master__cnv-odf-ocp-4.22-lp-interop.yaml
+++ b/ci-operator/config/RedHatQE/interop-testing/RedHatQE-interop-testing-master__cnv-odf-ocp-4.22-lp-interop.yaml
@@ -107,7 +107,6 @@ tests:
       OCP_VERSION: "4.22"
       ODF_OPERATOR_CHANNEL: stable-4.20
       ODF_VERSION_MAJOR_MINOR: "4.20"
-      REPORT_TO_DR: "true"
       REPORTPORTAL_CMP: CNV-lp-interop
       USER_TAGS: |
         scenario cnv

--- a/ci-operator/config/RedHatQE/interop-testing/RedHatQE-interop-testing-master__cnv-odf-ocp-4.23-lp-interop.yaml
+++ b/ci-operator/config/RedHatQE/interop-testing/RedHatQE-interop-testing-master__cnv-odf-ocp-4.23-lp-interop.yaml
@@ -107,7 +107,6 @@ tests:
       OCP_VERSION: "4.23"
       ODF_OPERATOR_CHANNEL: stable-4.20
       ODF_VERSION_MAJOR_MINOR: "4.21"
-      REPORT_TO_DR: "true"
       REPORTPORTAL_CMP: CNV-lp-interop
       USER_TAGS: |
         scenario cnv

--- a/ci-operator/config/RedHatQE/interop-testing/RedHatQE-interop-testing-master__ibm-fusion-access-operator-ocp-4.21-lp-interop-cr.yaml
+++ b/ci-operator/config/RedHatQE/interop-testing/RedHatQE-interop-testing-master__ibm-fusion-access-operator-ocp-4.21-lp-interop-cr.yaml
@@ -50,7 +50,6 @@ tests:
       KMM_REGISTRY_URL: ""
       MAP_TESTS: "true"
       OCP_VERSION: "4.21"
-      REPORT_TO_DR: "true"
       REPORTPORTAL_CMP: Fusion-access-lp-interop
       STORAGE_SCALE_CLIENT_CPU: "2"
       STORAGE_SCALE_CLIENT_MEMORY: 4Gi

--- a/ci-operator/config/RedHatQE/interop-testing/RedHatQE-interop-testing-master__ibm-fusion-access-operator-ocp-4.23-lp-interop.yaml
+++ b/ci-operator/config/RedHatQE/interop-testing/RedHatQE-interop-testing-master__ibm-fusion-access-operator-ocp-4.23-lp-interop.yaml
@@ -50,7 +50,6 @@ tests:
       KMM_REGISTRY_URL: ""
       MAP_TESTS: "true"
       OCP_VERSION: "4.23"
-      REPORT_TO_DR: "true"
       REPORTPORTAL_CMP: Fusion-access-lp-interop
       STORAGE_SCALE_CLIENT_CPU: "2"
       STORAGE_SCALE_CLIENT_MEMORY: 4Gi
@@ -97,7 +96,6 @@ tests:
       KMM_REGISTRY_URL: ""
       MAP_TESTS: "true"
       OCP_VERSION: "4.23"
-      REPORT_TO_DR: "true"
       REPORTPORTAL_CMP: Fusion-access-lp-interop
       STORAGE_SCALE_CLIENT_CPU: "2"
       STORAGE_SCALE_CLIENT_MEMORY: 4Gi

--- a/ci-operator/config/oadp-qe/oadp-qe-automation/oadp-qe-oadp-qe-automation-oadp-1.5__oadp1.5-ocp-4.21-lp-interop-cr.yaml
+++ b/ci-operator/config/oadp-qe/oadp-qe-automation/oadp-qe-oadp-qe-automation-oadp-1.5__oadp1.5-ocp-4.21-lp-interop-cr.yaml
@@ -88,7 +88,6 @@ tests:
           {"name": "redhat-oadp-operator", "source": "redhat-operators", "channel": "stable", "install_namespace": "openshift-adp", "target_namespaces": "openshift-adp", "operator_group":"oadp-operator-group"}
         ]
       RE_TRIGGER_ON_FAILURE: "false"
-      REPORT_TO_DR: "true"
       REPORTPORTAL_CMP: OADP-lp-interop
       STORAGE_CLASS: odf-operator-ceph-rbd-virtualization
       USER_TAGS: |

--- a/ci-operator/config/openshift-knative/serverless-operator/openshift-knative-serverless-operator-release-1.37__ocp-4.22-lp-interop.yaml
+++ b/ci-operator/config/openshift-knative/serverless-operator/openshift-knative-serverless-operator-release-1.37__ocp-4.22-lp-interop.yaml
@@ -157,7 +157,6 @@ tests:
       FIREWATCH_DEFAULT_JIRA_ASSIGNEE: maschmid@redhat.com
       FIREWATCH_DEFAULT_JIRA_PROJECT: SRVCOM
       OCP_VERSION: "4.22"
-      REPORT_TO_DR: "true"
       REPORTPORTAL_CMP: Serverless-lp-interop
       USER_TAGS: |
         scenario serverless
@@ -268,7 +267,6 @@ tests:
       FIREWATCH_DEFAULT_JIRA_ASSIGNEE: maschmid@redhat.com
       FIREWATCH_DEFAULT_JIRA_PROJECT: SRVCOM
       OCP_VERSION: "4.22"
-      REPORT_TO_DR: "true"
       REPORTPORTAL_CMP: Serverless-lp-interop
       USER_TAGS: |
         scenario serverless

--- a/ci-operator/config/quay/quay-tests/quay-quay-tests-master__ocp-4.21-quay-cr.yaml
+++ b/ci-operator/config/quay/quay-tests/quay-quay-tests-master__ocp-4.21-quay-cr.yaml
@@ -57,7 +57,6 @@ tests:
       QBO_CHANNEL: stable-3.14
       QUAY_OPERATOR_CHANNEL: stable-3.14
       QUAY_VERSION: "3.14"
-      REPORT_TO_DR: "true"
       REPORTPORTAL_CMP: Quay-lp-interop
       USER_TAGS: |
         scenario quay

--- a/ci-operator/config/quay/quay-tests/quay-quay-tests-master__ocp-4.22-quay-lp-interop.yaml
+++ b/ci-operator/config/quay/quay-tests/quay-quay-tests-master__ocp-4.22-quay-lp-interop.yaml
@@ -57,7 +57,6 @@ tests:
       QBO_CHANNEL: stable-3.16
       QUAY_OPERATOR_CHANNEL: stable-3.16
       QUAY_VERSION: "3.16"
-      REPORT_TO_DR: "true"
       REPORTPORTAL_CMP: Quay-lp-interop
       USER_TAGS: |
         scenario quay
@@ -96,7 +95,6 @@ tests:
       QBO_CHANNEL: stable-3.16
       QUAY_OPERATOR_CHANNEL: stable-3.16
       QUAY_VERSION: "3.16"
-      REPORT_TO_DR: "true"
       REPORTPORTAL_CMP: Quay-lp-interop
       USER_TAGS: |
         scenario quay

--- a/ci-operator/config/quay/quay-tests/quay-quay-tests-master__ocp-4.23-quay-lp-interop.yaml
+++ b/ci-operator/config/quay/quay-tests/quay-quay-tests-master__ocp-4.23-quay-lp-interop.yaml
@@ -57,7 +57,6 @@ tests:
       QBO_CHANNEL: stable-3.16
       QUAY_OPERATOR_CHANNEL: stable-3.16
       QUAY_VERSION: "3.16"
-      REPORT_TO_DR: "true"
       REPORTPORTAL_CMP: Quay-lp-interop
       USER_TAGS: |
         scenario quay
@@ -96,7 +95,6 @@ tests:
       QBO_CHANNEL: stable-3.16
       QUAY_OPERATOR_CHANNEL: stable-3.16
       QUAY_VERSION: "3.16"
-      REPORT_TO_DR: "true"
       REPORTPORTAL_CMP: Quay-lp-interop
       USER_TAGS: |
         scenario quay

--- a/ci-operator/config/red-hat-storage/ocs-ci/red-hat-storage-ocs-ci-master__ocp-4.22-lp-interop.yaml
+++ b/ci-operator/config/red-hat-storage/ocs-ci/red-hat-storage-ocs-ci-master__ocp-4.22-lp-interop.yaml
@@ -52,7 +52,6 @@ tests:
         [
             {"name": "odf-operator", "install_namespace": "openshift-storage", "channel": "stable-4.21", "target_namespaces": "!install", "operator_group": "openshift-storage-operator-group"}
         ]
-      REPORT_TO_DR: "true"
       REPORTPORTAL_CMP: ODF-lp-interop
       USER_TAGS: |
         scenario odf
@@ -92,7 +91,6 @@ tests:
         [
             {"name": "odf-operator", "install_namespace": "openshift-storage", "channel": "stable-4.21","target_namespaces": "!install", "operator_group": "openshift-storage-operator-group"}
         ]
-      REPORT_TO_DR: "true"
       REPORTPORTAL_CMP: ODF-lp-interop
       USER_TAGS: |
         scenario odf

--- a/ci-operator/config/redhat-developer/gitops-operator/redhat-developer-gitops-operator-v1.20__gitops-ocp-4.22-lp-interop.yaml
+++ b/ci-operator/config/redhat-developer/gitops-operator/redhat-developer-gitops-operator-v1.20__gitops-ocp-4.22-lp-interop.yaml
@@ -86,7 +86,6 @@ tests:
         [
             {"name": "openshift-gitops-operator", "source": "redhat-operators", "channel": "latest", "install_namespace": "openshift-gitops-operator", "target_namespaces": "", "operator_group": "global-operators"}
         ]
-      REPORT_TO_DR: "true"
       REPORTPORTAL_CMP: Gitops-lp-interop
       USER_TAGS: |
         scenario gitops

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4.22-lp-interop-acs-latest.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-4.22-lp-interop-acs-latest.yaml
@@ -72,7 +72,6 @@ tests:
       FIREWATCH_FAIL_WITH_TEST_FAILURES: "true"
       MAP_TESTS: "true"
       OCP_VERSION: "4.22"
-      REPORT_TO_DR: "true"
       REPORTPORTAL_CMP: ACSLatest-lp-interop
       USER_TAGS: |
         scenario acs

--- a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-4.10__ocp-4-22-lp-interop.yaml
+++ b/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-4.10__ocp-4-22-lp-interop.yaml
@@ -43,7 +43,6 @@ tests:
       FIREWATCH_FAIL_WITH_TEST_FAILURES: "true"
       MAP_TESTS: "true"
       OCP_VERSION: "4.22"
-      REPORT_TO_DR: "true"
       REPORTPORTAL_CMP: ACS-lp-interop
       TEST_SUITE: ocp-compliance-e2e-tests
       USER_TAGS: |

--- a/ci-operator/step-registry/cucushift/installer/rehearse/aws/ipi/ovn/winc/cucushift-installer-rehearse-aws-ipi-ovn-winc-workflow.yaml
+++ b/ci-operator/step-registry/cucushift/installer/rehearse/aws/ipi/ovn/winc/cucushift-installer-rehearse-aws-ipi-ovn-winc-workflow.yaml
@@ -12,7 +12,8 @@ workflow:
       - chain: cucushift-installer-rehearse-aws-ipi-ovn-winc-provision
       - ref: cucushift-installer-reportportal-marker
     test:
-      - ref: cucushift-installer-wait
+      - ref: clusterbot-wait
+        timeout: 12h0m0s
     post:
       - chain: cucushift-installer-rehearse-aws-ipi-deprovision
       - ref: send-results-to-reportportal

--- a/ci-operator/step-registry/cucushift/installer/rehearse/aws/upi/ovn/winc/cucushift-installer-rehearse-aws-upi-ovn-winc-workflow.yaml
+++ b/ci-operator/step-registry/cucushift/installer/rehearse/aws/upi/ovn/winc/cucushift-installer-rehearse-aws-upi-ovn-winc-workflow.yaml
@@ -11,7 +11,8 @@ workflow:
       - chain: cucushift-installer-rehearse-aws-upi-ovn-winc-provision
       - ref: cucushift-installer-reportportal-marker
     test:
-      - ref: cucushift-installer-wait
+      - ref: clusterbot-wait
+        timeout: 12h0m0s
     post:
       - chain: cucushift-installer-rehearse-aws-upi-ovn-winc-deprovision
       - ref: send-results-to-reportportal

--- a/ci-operator/step-registry/cucushift/installer/rehearse/azure/ipi/ovn/winc/cucushift-installer-rehearse-azure-ipi-ovn-winc-workflow.yaml
+++ b/ci-operator/step-registry/cucushift/installer/rehearse/azure/ipi/ovn/winc/cucushift-installer-rehearse-azure-ipi-ovn-winc-workflow.yaml
@@ -12,7 +12,8 @@ workflow:
       - chain: cucushift-installer-rehearse-azure-ipi-ovn-winc-provision
       - ref: cucushift-installer-reportportal-marker
     test:
-      - ref: cucushift-installer-wait
+      - ref: clusterbot-wait
+        timeout: 12h0m0s
     post:
       - chain: cucushift-installer-rehearse-azure-ipi-ovn-winc-deprovision
       - ref: send-results-to-reportportal

--- a/ci-operator/step-registry/cucushift/installer/rehearse/gcp/ipi/ovn/winc/cucushift-installer-rehearse-gcp-ipi-ovn-winc-workflow.yaml
+++ b/ci-operator/step-registry/cucushift/installer/rehearse/gcp/ipi/ovn/winc/cucushift-installer-rehearse-gcp-ipi-ovn-winc-workflow.yaml
@@ -12,7 +12,8 @@ workflow:
       - chain: cucushift-installer-rehearse-gcp-ipi-ovn-winc-provision
       - ref: cucushift-installer-reportportal-marker
     test:
-      - ref: cucushift-installer-wait
+      - ref: clusterbot-wait
+        timeout: 12h0m0s
     post:
       - chain: cucushift-installer-rehearse-gcp-ipi-deprovision
       - ref: send-results-to-reportportal

--- a/ci-operator/step-registry/cucushift/installer/rehearse/nutanix/ipi/ovn/winc/cucushift-installer-rehearse-nutanix-ipi-ovn-winc-workflow.yaml
+++ b/ci-operator/step-registry/cucushift/installer/rehearse/nutanix/ipi/ovn/winc/cucushift-installer-rehearse-nutanix-ipi-ovn-winc-workflow.yaml
@@ -13,7 +13,8 @@ workflow:
       - chain: cucushift-installer-rehearse-nutanix-ipi-ovn-winc-provision
       - ref: cucushift-installer-reportportal-marker
     test:
-      - ref: cucushift-installer-wait
+      - ref: clusterbot-wait
+        timeout: 12h0m0s
     post:
       - chain: cucushift-installer-rehearse-nutanix-ipi-ovn-winc-deprovision
       - ref: send-results-to-reportportal

--- a/ci-operator/step-registry/cucushift/installer/rehearse/vsphere/ipi/disconnected/ovn/winc/cucushift-installer-rehearse-vsphere-ipi-disconnected-ovn-winc-workflow.yaml
+++ b/ci-operator/step-registry/cucushift/installer/rehearse/vsphere/ipi/disconnected/ovn/winc/cucushift-installer-rehearse-vsphere-ipi-disconnected-ovn-winc-workflow.yaml
@@ -6,7 +6,8 @@ workflow:
     pre:
     - chain: cucushift-installer-rehearse-vsphere-ipi-disconnected-ovn-winc-provision
     test:
-    - ref: cucushift-installer-wait
+    - ref: clusterbot-wait
+      timeout: 12h0m0s
     post:
     - chain: cucushift-installer-rehearse-vsphere-ipi-disconnected-ovn-winc-deprovision
   documentation: |-

--- a/ci-operator/step-registry/cucushift/installer/rehearse/vsphere/ipi/ovn/winc/cucushift-installer-rehearse-vsphere-ipi-ovn-winc-workflow.yaml
+++ b/ci-operator/step-registry/cucushift/installer/rehearse/vsphere/ipi/ovn/winc/cucushift-installer-rehearse-vsphere-ipi-ovn-winc-workflow.yaml
@@ -14,7 +14,8 @@ workflow:
       - chain: cucushift-installer-rehearse-vsphere-ipi-ovn-winc-provision
       - ref: cucushift-installer-reportportal-marker
     test:
-      - ref: cucushift-installer-wait
+      - ref: clusterbot-wait
+        timeout: 12h0m0s
     post:
       - chain: cucushift-installer-rehearse-vsphere-ipi-ovn-winc-deprovision
       - ref: send-results-to-reportportal

--- a/ci-operator/step-registry/cucushift/installer/rehearse/vsphere/ipi/proxy/ovn/winc/cucushift-installer-rehearse-vsphere-ipi-proxy-ovn-winc-workflow.yaml
+++ b/ci-operator/step-registry/cucushift/installer/rehearse/vsphere/ipi/proxy/ovn/winc/cucushift-installer-rehearse-vsphere-ipi-proxy-ovn-winc-workflow.yaml
@@ -12,7 +12,8 @@ workflow:
       - chain: cucushift-installer-rehearse-vsphere-ipi-proxy-ovn-winc-provision
       - ref: cucushift-installer-reportportal-marker
     test:
-      - ref: cucushift-installer-wait
+      - ref: clusterbot-wait
+        timeout: 12h0m0s
     post:
       - chain: cucushift-installer-rehearse-vsphere-ipi-proxy-deprovision
       - ref: send-results-to-reportportal

--- a/ci-operator/step-registry/firewatch/ipi/aws/cr/firewatch-ipi-aws-cr-workflow.yaml
+++ b/ci-operator/step-registry/firewatch/ipi/aws/cr/firewatch-ipi-aws-cr-workflow.yaml
@@ -1,8 +1,6 @@
 workflow:
   as: firewatch-ipi-aws-cr
   steps:
-    env:
-        REPORT_TO_DR: "true"
     pre:
       - chain: ipi-aws-pre
     post:

--- a/ci-operator/step-registry/mpiit/data-router-reporter/mpiit-data-router-reporter-commands.sh
+++ b/ci-operator/step-registry/mpiit/data-router-reporter/mpiit-data-router-reporter-commands.sh
@@ -1,59 +1,37 @@
 #!/bin/bash
-set -o nounset
-set -o errexit
-set -o pipefail
+set -euxo pipefail; shopt -s inherit_errexit
 
+# Legacy backward compatibility. TODO: To be removed once all caller are migrated.
+: "${DR__RP__CR_COMP_NAME:=${REPORTPORTAL_CMP}}"
 
-function reportToDataRouter() {
-    if [[ $REPORT_TO_DR == "true" ]]; then
-        if [[ $REPORTPORTAL_CMP == "" ]]; then
-            echo "Required variable 'REPORTPORTAL_CMP' is missing!"
-            exit 1
-        fi
-      datarouter-openshift-ci
+[ -n "${DR__RP__CR_COMP_NAME}" ]
+
+# If `OCP_VERSION` is not set, try to extract it form `JOB_NAME`.
+if [ -z "${OCP_VERSION}" ]; then
+    if [[ "${JOB_NAME}" =~ ocp-([0-9]+\.[0-9]+) ]]; then
+        OCP_VERSION="${BASH_REMATCH[1]}"
+    else
+        OCP_VERSION="unknown"
     fi
-}
+fi
 
-function extractOCPVersion() {
-    # If OCP_VERSION is not set, we don't want to fail the entire launch report process
-    # The version attribute is not essentially required, so extract it from the JOB_NAME
-    if [[ -z "${OCP_VERSION}" ]]; then
-        if [[ "${JOB_NAME}" =~ ocp-([0-9]+\.[0-9]+) ]]; then
-            export OCP_VERSION="${BASH_REMATCH[1]}"
-        else
-            export OCP_VERSION="unknown"
-        fi
-    fi
-    true
-}
+DATAROUTER_RESULTS="${SHARED_DIR}/*.xml" \
+    REPORTPORTAL_LAUNCH_NAME="${DR__RP__CR_COMP_NAME}" \
+    REPORTPORTAL_LAUNCH_ATTRIBUTES="$(
+        jq -nc \
+            --arg jobName "${JOB_NAME}" \
+            --arg buildID "${BUILD_ID}" \
+            --arg ocpVer "${OCP_VERSION}" \
+            --arg crCompName "${DR__RP__CR_COMP_NAME}" \
+            --arg fipsEnabled "${FIPS_ENABLED}" \
+            '[
+                {key: "job_name", value: $jobName},
+                {key: "build_id", value: $buildID},
+                {key: "ocp_release", value: $ocpVer},
+                {key: "ComponentReadiness_ComponentName", value: $crCompName},
+                {key: "fips_enabled", value: $fipsEnabled}
+            ]'
+    )" \
+    datarouter-openshift-ci
 
-export DATAROUTER_RESULTS="${SHARED_DIR}/*.xml"
-export REPORTPORTAL_APPLY_TFA="${APPLY_TFA}"
-export REPORTPORTAL_CMP
-export REPORTPORTAL_HOSTNAME
-export REPORTPORTAL_PROJECT="lp-interop-dr_personal"
-export REPORTPORTAL_LAUNCH_NAME="${REPORTPORTAL_CMP}"
-
-extractOCPVersion
-
-typeset version="${OCP_VERSION}"
-typeset fips="${FIPS_ENABLED}"
-
-REPORTPORTAL_LAUNCH_ATTRIBUTES="$(
-    jq -nc \
-        --arg jobName "${JOB_NAME}" \
-        --arg buildID "${BUILD_ID}" \
-        --arg ocpVer "${version}" \
-        --arg rpCompName "${REPORTPORTAL_CMP}" \
-        --arg fipsEnabled "${fips}" \
-        '[
-            {key: "job_name", value: $jobName},
-            {key: "build_id", value: $buildID},
-            {key: "ocp_release", value: $ocpVer},
-            {key: "component_name", value: $rpCompName},
-            {key: "fips_enabled", value: $fipsEnabled}
-        ]'
-)"
-export REPORTPORTAL_LAUNCH_ATTRIBUTES
-
-reportToDataRouter
+true

--- a/ci-operator/step-registry/mpiit/data-router-reporter/mpiit-data-router-reporter-ref.yaml
+++ b/ci-operator/step-registry/mpiit/data-router-reporter/mpiit-data-router-reporter-ref.yaml
@@ -19,21 +19,27 @@ ref:
       name: mpiit-dr-creds
       mount_path: /datarouter/secrets
   env:
-  - name: REPORT_TO_DR
-    default: "false"
-  - name: APPLY_TFA
+  - name: REPORTPORTAL_APPLY_TFA
     default: "true"
-    documentation: Whether to apply TFA (Test Failure Analysis)
+    documentation: Instructs the Report Portal whether to perform Test Failure Analysis (TFA).
   - name: REPORTPORTAL_HOSTNAME
     default: "reportportal-lp-interop.apps.dno.ocp-hub.prod.psi.redhat.com"
-  - name: OCP_VERSION
-    default: ""
-    documentation: If exists, will be injected as an attribute
+    documentation: Hostname of the Report Portal instance that the Data Router client uses when publishing results.
+  - name: REPORTPORTAL_PROJECT
+    default: "lp-interop-dr_personal"
+    documentation: Report Portal project that receives the uploads produced by this step.
   - name: REPORTPORTAL_CMP
     default: ""
-    documentation: Component (Layered Product) mention for metadata attributes
+    documentation: Deprecated component or launch identifier. See DR__RP__CR_COMP_NAME instead.
+  - name: DR__RP__CR_COMP_NAME
+    default: ""
+    documentation: Layered Product name for Component Readiness (CR), injected into Report Portal launch attributes, and sets launch name.
   - name: FIPS_ENABLED
     default: "false"
-    documentation: Whether FIPS is enabled (true/false); will be injected as an attribute
+    documentation: This information is set as a metadata attribute of the report.
+  - name: OCP_VERSION
+    default: ""
+    documentation: If this is set to an empty string, the Step will attempt to determine the OCP version by parsing the job name (`ocp-*.*`). This information is set as a metadata attribute of the report.
   documentation: |-
-    The step analysis the tests and upload the results to ReportPortal
+    This step uploads the results to [Data Router Report Portal](https://redhat.atlassian.net/wiki/display/CentralCI/D%26O+Data+Router).
+    It supplies Report Portal launch metadata, including the launch name and attributes derived from the job context and from the environment variables documented above.


### PR DESCRIPTION
## Summary
- Replaces `cucushift-installer-wait` with `clusterbot-wait` (timeout extended to 12h) in the test section of all 8 winc workflows
- Fixes cluster-bot `workflow-test` failing with ImagePullBackOff because `cucushift-installer-wait` requires the `tests-private` image which is not available in cluster-bot context

## Problem
PR #78899 added `cucushift-installer-wait` to winc workflow test sections, but that ref uses `from: tests-private` which is only available in openshift-tests-private CI jobs. In cluster-bot context, the image does not exist:
```
Failed to pull image ".../stable:tests-private": manifest unknown
Back-off pulling image "image-registry...stable:tests-private"
```

`clusterbot-wait` uses `from: cli` which is always available from the release payload.

## Usage
Use `workflow-test` (not `workflow-launch`) to control cluster duration. Do not use quotes around the parameter (Slack smart quotes break config resolution):
```
workflow-test cucushift-installer-rehearse-vsphere-ipi-proxy-ovn-winc 4.22 CLUSTER_DURATION=36000
```

`CLUSTER_DURATION` is in seconds (36000 = 10h). The step timeout is extended to 12h.

Note: `workflow-launch` always replaces the test section with its own `clusterbot-wait` step (default 2.5h, capped at 4h). Use `workflow-test` to preserve the workflow's test section with the extended 12h timeout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR makes two primary sets of changes to OpenShift CI infrastructure:

## WINC Workflow Refactoring (Primary Objective)

Updates eight WINC (Windows Machine Config) workflow configurations to replace the `cucushift-installer-wait` step with `clusterbot-wait` and extends the test phase timeout to 12 hours. The affected workflows cover multiple infrastructure platforms (AWS IPI/UPI, Azure IPI, GCP IPI, Nutanix IPI, and vSphere IPI/disconnected/proxy variants).

**Reason for change:** `cucushift-installer-wait` references the `tests-private` image from a private source, which is unavailable in cluster-bot contexts and causes ImagePullBackOff errors. The `clusterbot-wait` step uses the `cli` image from the release payload, which is always available. The 12-hour timeout accommodates longer test execution windows in cluster-bot environments.

**Usage impact:** Workflows should be invoked via `workflow-test` (not `workflow-launch`) to preserve the extended 12-hour timeout in the test section.

## Data Router Reporter Refactoring

Removes the `REPORT_TO_DR: "true"` environment variable as a gating mechanism from 12 CI configuration files across multiple component repositories (RedHatQE interop-testing, IBM Fusion Access, OADP, Knative Serverless, Quay, OCS, GitOps Operator, and StackRox). Additionally, removes the same flag from the firewatch workflow base configuration.

Simultaneously refactors the `mpiit-data-router-reporter` step to unconditionally perform data router reporting when the component name is configured (via `DR__RP__CR_COMP_NAME`). The step's configuration is updated to:
- Remove the `REPORT_TO_DR` variable entirely
- Rename `APPLY_TFA` to `REPORTPORTAL_APPLY_TFA`
- Add explicit variables for `REPORTPORTAL_PROJECT` and `DR__RP__CR_COMP_NAME`
- Mark `REPORTPORTAL_CMP` as deprecated with reference to the new `DR__RP__CR_COMP_NAME` variable (legacy fallback provided in script)
- Refactor the shell script to directly invoke `datarouter-openshift-ci` with updated JSON attribute formatting (component name handling via `ComponentReadiness_ComponentName`, OCP release metadata, and FIPS status)

This represents a shift from optional to always-on data router reporting for component readiness tracking in interop-testing CI jobs, decoupled from a boolean flag in individual job configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->