### PR TITLE
Bump peribolos image to include --ignore-enterprise-teams flag

### DIFF
--- a/ci-operator/jobs/infra-periodics.yaml
+++ b/ci-operator/jobs/infra-periodics.yaml
@@ -1401,7 +1401,7 @@ periodics:
           --github-allowed-burst=600 \
           --allow-repo-archival \
           --ignore-enterprise-teams
-      image: us-docker.pkg.dev/k8s-infra-prow/images/peribolos:v20260507-f8cedc561
+      image: us-docker.pkg.dev/k8s-infra-prow/images/peribolos:v20260508-77c4e0541
       imagePullPolicy: Always
       name: ""
       resources:


### PR DESCRIPTION
The previous image tag (v20260507-f8cedc561) predates the merge of kubernetes-sigs/prow#710 which adds the flag. Update to v20260508-77c4e0541 which includes it, fixing the runtime failure.