### PR TITLE
OCPBUGS-85346: Revert 4.22 and 4.23 from C4A to T2A instances to avoid hyperdisk costs

### DIFF
--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.22-upgrade-from-nightly-4.21.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.22-upgrade-from-nightly-4.21.yaml
@@ -101,7 +101,7 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_VM_TYPE: c4a-standard-4
+      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-4
       COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.22-upgrade-from-stable-4.21.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.22-upgrade-from-stable-4.21.yaml
@@ -108,8 +108,7 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_DISK_TYPE: hyperdisk-balanced
-      ADDITIONAL_WORKER_VM_TYPE: c4a-standard-4
+      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-4
       COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.22.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.22.yaml
@@ -777,8 +777,8 @@ tests:
   steps:
     cluster_profile: openshift-org-gcp
     env:
-      COMPUTE_NODE_TYPE: c4a-standard-2
-      CONTROL_PLANE_NODE_TYPE: c4a-standard-2
+      COMPUTE_NODE_TYPE: t2a-standard-4
+      CONTROL_PLANE_NODE_TYPE: t2a-standard-4
       OCP_ARCH: arm64
       ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)
     workflow: openshift-e2e-gcp-ovn
@@ -787,8 +787,8 @@ tests:
   steps:
     cluster_profile: openshift-org-gcp
     env:
-      MIGRATION_CP_MACHINE_TYPE: c4a-standard-2
-      MIGRATION_INFRA_MACHINE_TYPE: c4a-standard-2
+      MIGRATION_CP_MACHINE_TYPE: t2a-standard-4
+      MIGRATION_INFRA_MACHINE_TYPE: t2a-standard-4
       TEST_SKIPS: deploymentconfigs\| should expose cluster services outside the cluster\|
         FIPS TestFIPS\| Multi-stage image builds should succeed\| Optimized image
         builds should succeed\| build can reference a cluster service\| custom build
@@ -812,8 +812,8 @@ tests:
   steps:
     cluster_profile: openshift-org-gcp
     env:
-      COMPUTE_NODE_TYPE: c4a-standard-2
-      CONTROL_PLANE_NODE_TYPE: c4a-standard-2
+      COMPUTE_NODE_TYPE: t2a-standard-4
+      CONTROL_PLANE_NODE_TYPE: t2a-standard-4
       MIGRATION_ARCHITECTURE: x86_64
       MIGRATION_CP_MACHINE_TYPE: n2-standard-4
       MIGRATION_INFRA_MACHINE_TYPE: n2-standard-4
@@ -841,8 +841,8 @@ tests:
   steps:
     cluster_profile: openshift-org-gcp
     env:
-      COMPUTE_NODE_TYPE: c4a-standard-2
-      CONTROL_PLANE_NODE_TYPE: c4a-standard-2
+      COMPUTE_NODE_TYPE: t2a-standard-4
+      CONTROL_PLANE_NODE_TYPE: t2a-standard-4
       OCP_ARCH: arm64
       TEST_TYPE: upgrade-conformance
       ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)
@@ -853,8 +853,7 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_DISK_TYPE: hyperdisk-balanced
-      ADDITIONAL_WORKER_VM_TYPE: c4a-standard-2
+      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
       COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SKIPS: deploymentconfigs\| should expose cluster services outside the cluster\|
@@ -904,8 +903,7 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_DISK_TYPE: hyperdisk-balanced
-      ADDITIONAL_WORKER_VM_TYPE: c4a-standard-2
+      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
       COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.23-upgrade-from-nightly-4.22.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.23-upgrade-from-nightly-4.22.yaml
@@ -101,8 +101,7 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_DISK_TYPE: hyperdisk-balanced
-      ADDITIONAL_WORKER_VM_TYPE: c4a-standard-2
+      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
       COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.23-upgrade-from-stable-4.22.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.23-upgrade-from-stable-4.22.yaml
@@ -108,8 +108,7 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_DISK_TYPE: hyperdisk-balanced
-      ADDITIONAL_WORKER_VM_TYPE: c4a-standard-2
+      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
       COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.23.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.23.yaml
@@ -746,8 +746,8 @@ tests:
   steps:
     cluster_profile: openshift-org-gcp
     env:
-      COMPUTE_NODE_TYPE: c4a-standard-2
-      CONTROL_PLANE_NODE_TYPE: c4a-standard-2
+      COMPUTE_NODE_TYPE: t2a-standard-4
+      CONTROL_PLANE_NODE_TYPE: t2a-standard-4
       OCP_ARCH: arm64
       ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)
     workflow: openshift-e2e-gcp-ovn
@@ -756,8 +756,8 @@ tests:
   steps:
     cluster_profile: openshift-org-gcp
     env:
-      MIGRATION_CP_MACHINE_TYPE: c4a-standard-2
-      MIGRATION_INFRA_MACHINE_TYPE: c4a-standard-2
+      MIGRATION_CP_MACHINE_TYPE: t2a-standard-4
+      MIGRATION_INFRA_MACHINE_TYPE: t2a-standard-4
       TEST_SKIPS: deploymentconfigs\| should expose cluster services outside the cluster\|
         FIPS TestFIPS\| Multi-stage image builds should succeed\| Optimized image
         builds should succeed\| build can reference a cluster service\| custom build
@@ -781,8 +781,8 @@ tests:
   steps:
     cluster_profile: openshift-org-gcp
     env:
-      COMPUTE_NODE_TYPE: c4a-standard-2
-      CONTROL_PLANE_NODE_TYPE: c4a-standard-2
+      COMPUTE_NODE_TYPE: t2a-standard-4
+      CONTROL_PLANE_NODE_TYPE: t2a-standard-4
       MIGRATION_ARCHITECTURE: x86_64
       MIGRATION_CP_MACHINE_TYPE: n2-standard-4
       MIGRATION_INFRA_MACHINE_TYPE: n2-standard-4
@@ -810,8 +810,8 @@ tests:
   steps:
     cluster_profile: openshift-org-gcp
     env:
-      COMPUTE_NODE_TYPE: c4a-standard-2
-      CONTROL_PLANE_NODE_TYPE: c4a-standard-2
+      COMPUTE_NODE_TYPE: t2a-standard-4
+      CONTROL_PLANE_NODE_TYPE: t2a-standard-4
       OCP_ARCH: arm64
       TEST_TYPE: upgrade-conformance
       ZONES_EXCLUSION_PATTERN: (asia-southeast1-a|us-central1-c)
@@ -822,8 +822,7 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_DISK_TYPE: hyperdisk-balanced
-      ADDITIONAL_WORKER_VM_TYPE: c4a-standard-2
+      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
       COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SKIPS: deploymentconfigs\| should expose cluster services outside the cluster\|
@@ -873,8 +872,7 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_DISK_TYPE: hyperdisk-balanced
-      ADDITIONAL_WORKER_VM_TYPE: c4a-standard-2
+      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
       COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance


### PR DESCRIPTION
This reverts 4.22 and 4.23 multi-arch GCP jobs from C4A (Axion) instances back to T2A (Tau) instances to avoid the cost increase associated with hyperdisk-balanced storage.

## Root Cause of StatefulSet Failures

C4A instances only support Hyperdisk storage types and do NOT support Persistent Disk types (pd-standard, pd-balanced, pd-ssd). When StatefulSet tests create PVCs using the cluster's default StorageClass (standard-csi with pd-standard), volume attach fails on C4A nodes:

```
googleapi: Error 400: pd-standard disk type cannot be used by
c4a-standard-2 machine type., badRequest
```

## The Fix: Revert to T2A

Instead of adding hyperdisk-balanced StorageClass (which increases costs), revert 4.22 and 4.23 to T2A instances which support pd-standard.

### Cost Considerations

- **pd-standard:** ~$0.04/GB/month (T2A compatible)
- **hyperdisk-balanced:** ~$0.10-0.12/GB/month + IOPS charges (C4A required)

For CI jobs with many PVCs (monitoring, logging, registry, StatefulSets), using hyperdisk-balanced across all test runs would significantly increase costs. T2A with pd-standard is more cost-effective.

### Quota Mitigation

While reverting to T2A means 4.21, 4.22, and 4.23 will compete for the same T2A quota, PR #77809 included other mitigations that remain in place:

1. **Zone randomization** - Distributes instances across zones
2. **Interval scheduling (168h)** - Prevents simultaneous execution
3. **Smaller instances** - Uses t2a-standard-2 (not standard-4)
4. **Balanced worker layout** - 2+2 workers instead of 3+2

These mitigations should reduce quota pressure even with multiple releases using T2A.

## Changes Made

**4.22 nightly config (6 jobs):**
- ocp-e2e-gcp-ovn-multi-a-a: c4a-standard-2 → t2a-standard-2
- ocp-e2e-gcp-ovn-multi-x-x-to-a-x: c4a-standard-2 → t2a-standard-2
- ocp-e2e-gcp-ovn-multi-a-a-to-x-a: c4a-standard-2 → t2a-standard-2
- ocp-e2e-upgrade-gcp-ovn-multi-a-a: c4a-standard-2 → t2a-standard-2
- ocp-e2e-gcp-ovn-multi-x-ax: c4a-standard-2 → t2a-standard-2
- ocp-e2e-upgrade-gcp-ovn-multi-x-ax: c4a-standard-2 → t2a-standard-2

**4.23 nightly config (5 jobs):**
- ocp-e2e-gcp-ovn-multi-a-a: c4a-standard-2 → t2a-standard-2
- ocp-e2e-gcp-ovn-multi-x-x-to-a-x: c4a-standard-2 → t2a-standard-2
- ocp-e2e-gcp-ovn-multi-a-a-to-x-a: c4a-standard-2 → t2a-standard-2
- ocp-e2e-upgrade-gcp-ovn-multi-a-a: c4a-standard-2 → t2a-standard-2
- Heterogeneous jobs: c4a-standard-2 → t2a-standard-2

**4.22 upgrade configs (2 files):**
- nightly-4.22-upgrade-from-nightly-4.21: c4a-standard-4 → t2a-standard-4
- nightly-4.22-upgrade-from-stable-4.21: c4a-standard-4 → t2a-standard-4

**4.23 upgrade configs (2 files):**
- nightly-4.23-upgrade-from-nightly-4.22: c4a-standard-2 → t2a-standard-2
- nightly-4.23-upgrade-from-stable-4.22: c4a-standard-2 → t2a-standard-2

Removed `ADDITIONAL_WORKER_DISK_TYPE: hyperdisk-balanced` from all heterogeneous jobs (no longer needed as T2A supports pd-standard).

## Release Distribution After This Change

- **4.21:** T2A standard-2
- **4.22:** T2A standard-2 (reverted from C4A)
- **4.23:** T2A standard-2 (reverted from C4A)
- **5.0:** T2A standard-4

## References

- JIRA: https://redhat.atlassian.net/browse/OCPBUGS-85346
- Failed job: periodic-ci-openshift-multiarch-main-nightly-4.22-ocp-e2e-gcp-ovn-multi-x-ax
- Original PR #77809: https://github.com/openshift/release/pull/77809
- GCP C4A disk requirements: https://cloud.google.com/blog/products/compute/first-google-axion-processor-c4a-now-ga-with-titanium-ssd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## OpenShift CI (openshift/release): Revert GCP multi-arch jobs from C4A → T2A for 4.22 & 4.23

This PR updates ci-operator job configurations in the openshift/release repository to stop using GCP C4A (Axion) machine types for multi-architecture OpenShift CI for releases 4.22 and 4.23 and use T2A (Tau) machine types instead. The practical effect is that multi-arch GCP CI jobs and related upgrade jobs will schedule on T2A instances (which support pd-standard disks) instead of C4A instances (which require higher-cost hyperdisk storage), restoring compatibility with cluster default StorageClasses and avoiding hyperdisk cost/IOPS requirements.

What changed (practical summary)
- Affected area: ci-operator configuration under ci-operator/config/openshift/multiarch/ in the openshift/release repo (nightly and upgrade job definitions for 4.22 and 4.23).
- Instance-type changes:
  - 4.22 nightly and related upgrade jobs: several jobs changed from c4a-standard-2/4 → t2a-standard-2/4 as appropriate (heterogeneous worker jobs and some migration/AMD64 combos). The heterogeneous jobs also had ADDITIONAL_WORKER_DISK_TYPE: hyperdisk-balanced removed.
  - 4.23 nightly and related upgrade jobs: similar changes from c4a-standard-2 → t2a-standard-2/4; removals of ADDITIONAL_WORKER_DISK_TYPE where present.
- Files updated include the 4.22 and 4.23 nightly CI job YAMLs and their upgrade-from-{nightly,stable} counterparts under ci-operator/config/openshift/multiarch/.

Reason
- C4A machine types do not accept pd-standard/pd-balanced/pd-ssd disks (they require hyperdisk), causing PVC attach failures in StatefulSet tests that use the cluster default StorageClass (standard-csi/pd-standard). Reverting to T2A restores pd-standard compatibility and avoids adding higher-cost hyperdisk storage classes to CI.

Cost, quota, and mitigations
- Cost: pd-standard ≈ $0.04/GB/mo (T2A) vs hyperdisk-balanced ≈ $0.10–0.12/GB/mo + IOPS (C4A).
- Quota impact: This increases demand on T2A quota across 4.21–4.23. Existing mitigations from prior work remain: zone randomization, 168h scheduling intervals, smaller instances (t2a-standard-2 where feasible), and balanced worker layout (2+2).

Known follow-up / risks
- Rehearsal failure observed when t2a-standard-2 was used for control-plane in rehearsals: t2a-standard-2 does not meet control-plane minimums (requires ≥4 vCPUs, ≥15360 MB RAM). Ensure control-plane machine types remain sized to meet minimum requirements (use t2a-standard-4 where control-plane minimums apply).
- Monitor T2A quota pressure after merge; consider further scheduling/instance adjustments or quota requests if failures appear.

References
- JIRA OCPBUGS-85346 and failing job evidence cited in the PR description; previous PR #77809 mitigations noted in PR discussion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->