### PR TITLE
CNF-22981: Enable Tide auto-merge for red-hat-konflux[bot] on rh-ecos…

### DIFF
--- a/core-services/prow/02_config/_labels.yaml
+++ b/core-services/prow/02_config/_labels.yaml
@@ -1283,6 +1283,13 @@ repos:
         name: run-integration-tests
         target: prs
         addedBy: label
+  rh-ecosystem-edge/recert:
+    labels:
+      - color: 0ffa16
+        description: Allows Tide to automatically merge PRs from trusted authors
+        name: allow-automatic-merge
+        target: prs
+        addedBy: label
   ViaQ/vector:
     labels:
       - color: ffaa00

--- a/core-services/prow/02_config/rh-ecosystem-edge/recert/_prowconfig.yaml
+++ b/core-services/prow/02_config/rh-ecosystem-edge/recert/_prowconfig.yaml
@@ -21,6 +21,18 @@ branch-protection:
               protect: true
 tide:
   queries:
+  - author: red-hat-konflux[bot]
+    labels:
+    - allow-automatic-merge
+    missingLabels:
+    - backports/unvalidated-commits
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - jira/invalid-bug
+    - needs-rebase
+    repos:
+    - rh-ecosystem-edge/recert
   - labels:
     - approved
     - lgtm


### PR DESCRIPTION
…ystem-edge/recert

Add allow-automatic-merge label definition and Tide query with author: red-hat-konflux[bot] to enable automatic merging of Konflux dependency update PRs for rh-ecosystem-edge/recert.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This pull request enables automatic PR merging for the rh-ecosystem-edge/recert repository by configuring Prow's Tide service to accept PRs from the red-hat-konflux[bot] author.

The changes add a new `allow-automatic-merge` label definition for the recert repository and introduce a Tide query that automatically merges PRs authored by red-hat-konflux[bot] when they carry the `allow-automatic-merge` label and lack do-not-merge labels. This allows Konflux dependency update PRs to merge automatically without manual review, streamlining the dependency update workflow for this repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->