### PR TITLE
NO-JIRA: upkeep: streamline build images and promotion

### DIFF
--- a/ci-operator/config/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main.yaml
+++ b/ci-operator/config/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main.yaml
@@ -14,65 +14,26 @@ build_root:
     tag: rhel-9-release-golang-1.25-openshift-4.22
 images:
   items:
-  - dockerfile_literal: |
-      FROM root
-      ARG GH_TOKEN_VER=2.0.8
-      ARG GH_TOKEN_SHA=867d9ebf7dd18e67e2599f0f890f3f41b8673e88c4394a32a05476024c41ea0f
-      RUN set -eu; \
-            f=/tmp/gh-token.download; rm -f "$f"; \
-            n=1; max=5; delay=1; \
-            until curl -sSL --fail --connect-timeout 10 --max-time 120 \
-              --retry 3 --retry-delay 2 \
-              "https://github.com/Link-/gh-token/releases/download/v${GH_TOKEN_VER}/linux-amd64" \
-              -o "$f"; do \
-              rm -f "$f"; \
-              [ "$n" -ge "$max" ] && exit 1; \
-              sleep "$delay"; \
-              delay=$((delay * 2)); \
-              n=$((n+1)); \
-            done; \
-            echo "${GH_TOKEN_SHA}  $f" | sha256sum -c -; \
-            install -m 0755 "$f" /usr/local/bin/gh-token; \
-            rm -f "$f"
+  - dockerfile_path: images/Containerfile.tooling
     from: root
     to: gh-token
-  - dockerfile_literal: |
-      FROM src
-      USER 0:0
-      COPY ghtoken/gh-token /usr/local/bin/gh-token
-      RUN chmod +x /usr/local/bin/gh-token
-      COPY . /opt/app-root/src/
-      WORKDIR /opt/app-root/src/
-    from: src
-    inputs:
-      gh-token:
-        paths:
-        - destination_dir: ghtoken
-          source_path: /usr/local/bin/gh-token
-    to: edge-tooling
-  - dockerfile_literal: |
-      FROM pipeline:claude-ai-helpers
-      USER 0:0
-      COPY ghtoken/gh-token /usr/local/bin/gh-token
-      RUN chmod +x /usr/local/bin/gh-token
-      COPY repo/ /opt/app-root/src/edge-tooling
-      ENV EDGE_TOOLING_DIR=/opt/app-root/src/edge-tooling
-      WORKDIR /opt/app-root/src/edge-tooling
+  - dockerfile_path: images/Containerfile.markdownlint
+    from: root
+    to: markdownlint-cli2
+  - dockerfile_path: images/Containerfile.ci
     from: claude-ai-helpers
     inputs:
       gh-token:
         paths:
         - destination_dir: ghtoken
           source_path: /usr/local/bin/gh-token
-      src:
-        paths:
-        - destination_dir: repo
-          source_path: /go/src/github.com/openshift-eng/edge-tooling/.
     to: edge-tooling-ai-helpers
 promotion:
   to:
   - additional_images:
+      edge-tooling-ai-helpers: edge-tooling-ai-helpers
       gh-token: gh-token
+      markdownlint-cli2: markdownlint-cli2
     excluded_images:
     - '*'
     namespace: ci
@@ -82,30 +43,12 @@ resources:
     requests:
       cpu: 100m
       memory: 200Mi
-test_binary_build_commands: |-
-  dnf -y module reset nodejs || true
-  dnf -y module enable nodejs:20
-  dnf -y install nodejs
-
-  npm install -g \
-  markdownlint@v0.40.0 \
-  markdownlint-cli2@v0.22.1 \
-  markdownlint-cli2-formatter-json \
-  markdownlint-cli2-formatter-pretty \
-  markdownlint-cli2-formatter-junit
 tests:
 - always_run: false
   as: markdownlint
-  commands: |
-    set +e
-    make lint-markdown
-    rc=$?
-    if [[ -n "${ARTIFACT_DIR:-}" && -f markdownlint-cli2-junit.xml ]]; then
-      cp -f markdownlint-cli2-junit.xml "${ARTIFACT_DIR}/"
-    fi
-    exit "${rc}"
+  commands: make lint-markdown
   container:
-    from: test-bin
+    from: markdownlint-cli2
   run_if_changed: (\.md|^Makefile|^hack/.*markdown.*|^\.markdown.*)$
 - as: shellcheck
   commands: make lint-shellcheck

--- a/ci-operator/config/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main.yaml
+++ b/ci-operator/config/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main.yaml
@@ -14,25 +14,16 @@ build_root:
     tag: rhel-9-release-golang-1.25-openshift-4.22
 images:
   items:
-  - dockerfile_path: images/Containerfile.tooling
-    from: root
-    to: gh-token
   - dockerfile_path: images/Containerfile.markdownlint
     from: root
     to: markdownlint-cli2
   - dockerfile_path: images/Containerfile.ci
     from: claude-ai-helpers
-    inputs:
-      gh-token:
-        paths:
-        - destination_dir: ghtoken
-          source_path: /usr/local/bin/gh-token
     to: edge-tooling-ai-helpers
 promotion:
   to:
   - additional_images:
       edge-tooling-ai-helpers: edge-tooling-ai-helpers
-      gh-token: gh-token
       markdownlint-cli2: markdownlint-cli2
     excluded_images:
     - '*'
@@ -48,11 +39,13 @@ tests:
   as: markdownlint
   commands: make lint-markdown
   container:
+    clone: true
     from: markdownlint-cli2
   run_if_changed: (\.md|^Makefile|^hack/.*markdown.*|^\.markdown.*)$
 - as: shellcheck
   commands: make lint-shellcheck
   container:
+    clone: true
     from: shellcheck
   run_if_changed: .sh$
 - as: ocp-ci-monitor

--- a/ci-operator/jobs/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main-postsubmits.yaml
@@ -22,7 +22,9 @@ postsubmits:
         - --promote
         - --report-credentials-file=/etc/report/credentials
         - --target=[images]
+        - --target=edge-tooling-ai-helpers
         - --target=gh-token
+        - --target=markdownlint-cli2
         command:
         - ci-operator
         image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest

--- a/ci-operator/jobs/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main-postsubmits.yaml
@@ -23,7 +23,6 @@ postsubmits:
         - --report-credentials-file=/etc/report/credentials
         - --target=[images]
         - --target=edge-tooling-ai-helpers
-        - --target=gh-token
         - --target=markdownlint-cli2
         command:
         - ci-operator

--- a/ci-operator/jobs/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main-presubmits.yaml
@@ -22,7 +22,9 @@ presubmits:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --report-credentials-file=/etc/report/credentials
         - --target=[images]
+        - --target=edge-tooling-ai-helpers
         - --target=gh-token
+        - --target=markdownlint-cli2
         command:
         - ci-operator
         image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest

--- a/ci-operator/jobs/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main-presubmits.yaml
@@ -23,7 +23,6 @@ presubmits:
         - --report-credentials-file=/etc/report/credentials
         - --target=[images]
         - --target=edge-tooling-ai-helpers
-        - --target=gh-token
         - --target=markdownlint-cli2
         command:
         - ci-operator

--- a/ci-operator/step-registry/openshift/edge-tooling/microshift-ci/doctor/openshift-edge-tooling-microshift-ci-doctor-commands.sh
+++ b/ci-operator/step-registry/openshift/edge-tooling/microshift-ci/doctor/openshift-edge-tooling-microshift-ci-doctor-commands.sh
@@ -114,23 +114,6 @@ load_secrets() {
     fi
 }
 
-install_prerequisites() {
-    # Export the PATH to include the local bin directory
-    export PATH="${HOME}/.local/bin:${PATH}"
-
-    echo "Installing gcloud CLI..."
-    curl -sSL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-linux-x86_64.tar.gz | tar -xz -C /tmp
-    /tmp/google-cloud-sdk/install.sh --quiet --path-update true
-    export PATH="/tmp/google-cloud-sdk/bin:${PATH}"
-    echo "gcloud CLI installed."
-
-    echo "Installing Python package dependencies..."
-    pip install --user \
-        'uv==0.11.6' \
-        'matplotlib==3.9.4'
-    echo "Python package dependencies installed."
-}
-
 wait_for_mcp_status() {
     local -r service="$1"
     local -r status="$2"
@@ -218,7 +201,6 @@ fi
 trap atexit_handler EXIT TERM INT
 
 load_secrets
-install_prerequisites
 configure_claude
 
 # Use the edge-tooling source pre-installed in the image


### PR DESCRIPTION
updated to build from repo container files
updated to promote the tooling to be used by other periodics 
added linter image instead of test build image

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Updates CI configuration for the openshift-eng/edge-tooling repository to build and promote reusable tooling images from Containerfiles, simplify tests to run inside those images, and remove in-script prerequisite installation in the microshift-ci doctor step so the execution image must provide required tooling.

## What changed (practical impact)

- ci-operator now builds tooling images from Containerfile paths in the repo instead of embedding Dockerfile literals:
  - markdownlint-cli2 from images/Containerfile.markdownlint
  - edge-tooling-ai-helpers from images/Containerfile.ci
- Image promotion updated to publish tooling into the ci namespace:
  - edge-tooling-ai-helpers and markdownlint-cli2 are promoted to ci:latest so other periodics can consume them
- Tests/jobs simplified to rely on built images:
  - markdownlint job now runs in the markdownlint-cli2 image (container.from: markdownlint-cli2, clone: true) and invokes make lint-markdown directly
  - shellcheck job runs from the shellcheck base image with clone: true
  - removed prior inline test_binary_build_commands and previous shell-return/artefact-copying logic from the markdownlint test
- microshift-ci doctor step script no longer installs prerequisites:
  - the script no longer performs in-script installation of gcloud/Python/other helpers and assumes the execution image contains required tools (install_prerequisites was removed)
  - it continues to load secrets, generate GitHub installation tokens, configure Claude (including optional JIRA MCP), run the doctor analysis with timeout and turn limits, attempt automatic restart of failed rebase PR tests, and copy/archive reports and Claude session logs into artifacts

## Files/areas affected

- ci-operator/config/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main.yaml — switch to dockerfile_path build entries, promotion to ci namespace for tooling images, base images entries for claude-ai-helpers and shellcheck, and simplified test container/commands.
- ci-operator/step-registry/openshift/edge-tooling/microshift-ci/doctor/openshift-edge-tooling-microshift-ci-doctor-commands.sh — removed internal prerequisite installation; retained secrets handling, Claude/JIRA configuration, analysis run, automatic restart logic, and artifact/session archival.

These changes centralize Containerfile maintenance, make tooling images reusable across CI jobs, and reduce runtime setup by depending on more fully provisioned execution images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->