### PR TITLE
vcf-migration-operator config retry

### DIFF
--- a/ci-operator/config/openshift/vcf-migration-operator/OWNERS
+++ b/ci-operator/config/openshift/vcf-migration-operator/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+- vsphere-approvers

--- a/ci-operator/config/openshift/vcf-migration-operator/openshift-vcf-migration-operator-main.yaml
+++ b/ci-operator/config/openshift/vcf-migration-operator/openshift-vcf-migration-operator-main.yaml
@@ -1,0 +1,28 @@
+build_root:
+  from_repository: true
+images:
+  items:
+  - dockerfile_path: Dockerfile
+    to: vcf-migration-operator
+releases:
+  latest:
+    candidate:
+      product: ocp
+      stream: nightly
+      version: "5.0"
+resources:
+  '*':
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: unit
+  commands: make test
+  container:
+    from: src
+zz_generated_metadata:
+  branch: main
+  org: openshift
+  repo: vcf-migration-operator

--- a/ci-operator/jobs/openshift/vcf-migration-operator/OWNERS
+++ b/ci-operator/jobs/openshift/vcf-migration-operator/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+- vsphere-approvers

--- a/ci-operator/jobs/openshift/vcf-migration-operator/openshift-vcf-migration-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/vcf-migration-operator/openshift-vcf-migration-operator-main-presubmits.yaml
@@ -1,0 +1,118 @@
+presubmits:
+  openshift/vcf-migration-operator:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build01
+    context: ci/prow/images
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      job-release: "5.0"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-vcf-migration-operator-main-images
+    rerun_command: /test images
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=[images]
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )images,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build01
+    context: ci/prow/unit
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      job-release: "5.0"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-vcf-migration-operator-main-unit
+    rerun_command: /test unit
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=unit
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )unit,?($|\s.*)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds OpenShift CI Operator configuration and OWNERS for the openshift/vcf-migration-operator repository (main branch) to enable automated builds, bundle creation, unit tests, and release metadata.

## What this changes in practical terms

- Enables the CI Operator pipeline for openshift/vcf-migration-operator on branch main:
  - Builds the main image from Dockerfile and publishes it as vcf-migration-operator.
  - Builds an operator bundle from bundle.Dockerfile as vcf-migration-operator-bundle and skips building an index.
  - Applies a substitution mapping controller:latest -> pipeline:vcf-migration-operator for bundle/pullspecs.
  - Declares a releases.latest candidate for product=ocp, stream=nightly, version="5.0" (used by promotion/release plumbing).
  - Applies global resource defaults for all components: CPU request 100m, memory request 200Mi, memory limit 4Gi.
  - Runs unit tests via a "unit" test step executing "make test" in a container sourced from src.
  - Generated metadata pins branch: main, org: openshift, repo: vcf-migration-operator.
- Grants approval responsibility to the vsphere-approvers group via OWNERS.

## Files added
- ci-operator/config/openshift/vcf-migration-operator/openshift-vcf-migration-operator-main.yaml
- ci-operator/config/openshift/vcf-migration-operator/OWNERS

## Notes from PR comments
- The author triggered CI/test jobs multiple times:
  - /test pull-ci-openshift-vcf-migration-operator-main-images pull-ci-openshift-vcf-migration-operator-main-unit
  - /pj-rehearse pull-ci-openshift-vcf-migration-operator-main-images pull-ci-openshift-vcf-migration-operator-main-unit (issued three times)
- A comment block includes the assistant username: coderabbitai.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->