### PR TITLE
installer: set BUILD_VERSION arg

### DIFF
--- a/ci-operator/config/openshift/installer/openshift-installer-main.yaml
+++ b/ci-operator/config/openshift/installer/openshift-installer-main.yaml
@@ -63,6 +63,9 @@ build_root:
   from_repository: true
   use_build_cache: true
 images:
+  build_args:
+  - name: BUILD_VERSION
+    value: "5.0.0"
   items:
   - dockerfile_path: images/installer/Dockerfile.ci
     to: installer


### PR DESCRIPTION
Sets BUILD_VERSION similar to nightlies. We will use this to distinguish between 5.0+ behavior and 4.23.
set a build version to be able

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds a `BUILD_VERSION` build argument to the OpenShift installer's CI configuration. The `BUILD_VERSION` is set to `"5.0.0"` and will be passed to all Docker image builds in the installer's CI pipeline.

## What Changed

The change modifies `ci-operator/config/openshift/installer/openshift-installer-main.yaml` to add a `build_args` section in the image build configuration:

```yaml
images:
  build_args:
  - name: BUILD_VERSION
    value: "5.0.0"
  items:
    - dockerfile_path: images/installer/Dockerfile.ci
      to: installer
    - ...
```

## Why It Matters

The `BUILD_VERSION` environment variable will be available during the Docker image builds for all installer container images (installer, libvirt-installer, upi-installer, baremetal-installer, etc.). This allows the build process and the resulting binaries to:

- Distinguish between 5.0+ behavior and 4.23 behavior
- Apply version-specific logic or features during builds
- Mirror the approach already used in nightly builds

This is foundational infrastructure change that enables version-aware behavior in the OpenShift installer CI pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->