### PR TITLE
Adding ARO post submit jobs

### DIFF
--- a/ci-operator/config/Azure/ARO-RP/Azure-ARO-RP-master.yaml
+++ b/ci-operator/config/Azure/ARO-RP/Azure-ARO-RP-master.yaml
@@ -44,7 +44,7 @@ tests:
     cluster_profile: aro-classic-int
     env:
       E2E_TYPE: miwi
-      LOCATION: uksouth
+      LOCATION: eastus
     workflow: aro-classic-e2e
 - always_run: false
   as: stage-e2e-parallel-miwi
@@ -53,7 +53,7 @@ tests:
     cluster_profile: aro-classic-stg
     env:
       E2E_TYPE: miwi
-      LOCATION: uksouth
+      LOCATION: westus2
     workflow: aro-classic-e2e
 - always_run: false
   as: prod-e2e-parallel-miwi
@@ -79,7 +79,7 @@ tests:
     cluster_profile: aro-classic-int
     env:
       E2E_TYPE: csp
-      LOCATION: uksouth
+      LOCATION: eastus
     workflow: aro-classic-e2e
 - always_run: false
   as: stage-e2e-parallel-csp
@@ -88,7 +88,7 @@ tests:
     cluster_profile: aro-classic-stg
     env:
       E2E_TYPE: csp
-      LOCATION: uksouth
+      LOCATION: westus2
     workflow: aro-classic-e2e
 - always_run: false
   as: prod-e2e-parallel-csp

--- a/ci-operator/config/Azure/ARO-RP/Azure-ARO-RP-master__e2e.yaml
+++ b/ci-operator/config/Azure/ARO-RP/Azure-ARO-RP-master__e2e.yaml
@@ -21,54 +21,54 @@ resources:
       cpu: 100m
       memory: 200Mi
 tests:
-- always_run: false
-  as: integration-e2e-parallel-miwi
-  cron: 0 0 1 1 *
+- as: integration-e2e-parallel-miwi
+  postsubmit: true
+  run_if_changed: ^$
   steps:
     cluster_profile: aro-classic-int
     env:
       E2E_TYPE: miwi
       LOCATION: eastus
     workflow: aro-classic-e2e
-- always_run: false
-  as: stage-e2e-parallel-miwi
-  cron: 0 0 1 1 *
+- as: stage-e2e-parallel-miwi
+  postsubmit: true
+  run_if_changed: ^$
   steps:
     cluster_profile: aro-classic-stg
     env:
       E2E_TYPE: miwi
       LOCATION: westus2
     workflow: aro-classic-e2e
-- always_run: false
-  as: prod-e2e-parallel-miwi
-  cron: 0 0 1 1 *
+- as: prod-e2e-parallel-miwi
+  postsubmit: true
+  run_if_changed: ^$
   steps:
     cluster_profile: aro-classic-prod
     env:
       E2E_TYPE: miwi
       LOCATION: uksouth
     workflow: aro-classic-e2e
-- always_run: false
-  as: integration-e2e-parallel-csp
-  cron: 0 0 1 1 *
+- as: integration-e2e-parallel-csp
+  postsubmit: true
+  run_if_changed: ^$
   steps:
     cluster_profile: aro-classic-int
     env:
       E2E_TYPE: csp
       LOCATION: eastus
     workflow: aro-classic-e2e
-- always_run: false
-  as: stage-e2e-parallel-csp
-  cron: 0 0 1 1 *
+- as: stage-e2e-parallel-csp
+  postsubmit: true
+  run_if_changed: ^$
   steps:
     cluster_profile: aro-classic-stg
     env:
       E2E_TYPE: csp
       LOCATION: westus2
     workflow: aro-classic-e2e
-- always_run: false
-  as: prod-e2e-parallel-csp
-  cron: 0 0 1 1 *
+- as: prod-e2e-parallel-csp
+  postsubmit: true
+  run_if_changed: ^$
   steps:
     cluster_profile: aro-classic-prod
     env:
@@ -79,4 +79,4 @@ zz_generated_metadata:
   branch: master
   org: Azure
   repo: ARO-RP
-  variant: periodic
+  variant: e2e

--- a/ci-operator/jobs/Azure/ARO-RP/Azure-ARO-RP-master-postsubmits.yaml
+++ b/ci-operator/jobs/Azure/ARO-RP/Azure-ARO-RP-master-postsubmits.yaml
@@ -1,6 +1,492 @@
 postsubmits:
   Azure/ARO-RP:
   - agent: kubernetes
+    always_run: false
+    branches:
+    - ^master$
+    cluster: build08
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: aro-classic-int
+      ci-operator.openshift.io/cloud-cluster-profile: aro-classic-int
+      ci-operator.openshift.io/variant: e2e
+      ci.openshift.io/generator: prowgen
+    max_concurrency: 1
+    name: branch-ci-Azure-ARO-RP-master-e2e-integration-e2e-parallel-csp
+    run_if_changed: ^$
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=integration-e2e-parallel-csp
+        - --variant=e2e
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^master$
+    cluster: build08
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: aro-classic-int
+      ci-operator.openshift.io/cloud-cluster-profile: aro-classic-int
+      ci-operator.openshift.io/variant: e2e
+      ci.openshift.io/generator: prowgen
+    max_concurrency: 1
+    name: branch-ci-Azure-ARO-RP-master-e2e-integration-e2e-parallel-miwi
+    run_if_changed: ^$
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=integration-e2e-parallel-miwi
+        - --variant=e2e
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^master$
+    cluster: build08
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: aro-classic-prod
+      ci-operator.openshift.io/cloud-cluster-profile: aro-classic-prod
+      ci-operator.openshift.io/variant: e2e
+      ci.openshift.io/generator: prowgen
+    max_concurrency: 1
+    name: branch-ci-Azure-ARO-RP-master-e2e-prod-e2e-parallel-csp
+    run_if_changed: ^$
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=prod-e2e-parallel-csp
+        - --variant=e2e
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^master$
+    cluster: build08
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: aro-classic-prod
+      ci-operator.openshift.io/cloud-cluster-profile: aro-classic-prod
+      ci-operator.openshift.io/variant: e2e
+      ci.openshift.io/generator: prowgen
+    max_concurrency: 1
+    name: branch-ci-Azure-ARO-RP-master-e2e-prod-e2e-parallel-miwi
+    run_if_changed: ^$
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=prod-e2e-parallel-miwi
+        - --variant=e2e
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^master$
+    cluster: build08
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: aro-classic-stg
+      ci-operator.openshift.io/cloud-cluster-profile: aro-classic-stg
+      ci-operator.openshift.io/variant: e2e
+      ci.openshift.io/generator: prowgen
+    max_concurrency: 1
+    name: branch-ci-Azure-ARO-RP-master-e2e-stage-e2e-parallel-csp
+    run_if_changed: ^$
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=stage-e2e-parallel-csp
+        - --variant=e2e
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^master$
+    cluster: build08
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: aro-classic-stg
+      ci-operator.openshift.io/cloud-cluster-profile: aro-classic-stg
+      ci-operator.openshift.io/variant: e2e
+      ci.openshift.io/generator: prowgen
+    max_concurrency: 1
+    name: branch-ci-Azure-ARO-RP-master-e2e-stage-e2e-parallel-miwi
+    run_if_changed: ^$
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=stage-e2e-parallel-miwi
+        - --variant=e2e
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+  - agent: kubernetes
     always_run: true
     branches:
     - ^master$


### PR DESCRIPTION
Adding ARO post submit jobs. I believe this is the more correct type of test to invoke post-deployment. Also pointing the int and stg jobs to the correct environment by default because it's been bothering me.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ARO Post-Submit E2E Jobs

This PR adds CI infrastructure for Azure Red Hat OpenShift (ARO) by introducing postsubmit end-to-end test jobs.

### What's Being Added

The PR creates a new CI configuration for the ARO-RP (Azure Red Hat OpenShift - Resource Provider) repository master branch, establishing post-submit testing across three deployment environments:

- **Integration environment** - Uses `eastus` Azure region
- **Staging environment** - Uses `westus2` Azure region  
- **Production environment** - Uses `uksouth` Azure region

### Job Structure

Two test variants are configured to run after merges:
- **miwi** test variant
- **csp** test variant

Each variant runs across all three environments (6 postsubmit jobs total), using the `aro-classic-e2e` workflow to execute end-to-end tests with OCP 4.22. The tests include resource limits and requests (`100m` CPU / `200Mi` memory request, `4Gi` memory limit) to control execution footprint.

The configuration also defines corresponding periodic job variants (scheduled with cron `0 0 1 1 *`) for the same test combinations.

### Files Modified

- `ci-operator/config/Azure/ARO-RP/Azure-ARO-RP-master__e2e.yaml` - New postsubmit test configuration (82 lines)
- `ci-operator/config/Azure/ARO-RP/Azure-ARO-RP-master__periodic.yaml` - New periodic test configuration (82 lines)  
- `ci-operator/config/Azure/ARO-RP/Azure-ARO-RP-master.yaml` - Main ARO-RP CI configuration (113 lines)
- Generated Prow job YAML files in `ci-operator/jobs/Azure/ARO-RP/` (postsubmits, periodics, presubmits)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->