### PR TITLE
USHIFT-6935: MicroShift CI Doctor enables bug creation in dry-run mode (phase 1)

### DIFF
--- a/ci-operator/config/openshift-eng/edge-tooling/.config.prowgen
+++ b/ci-operator/config/openshift-eng/edge-tooling/.config.prowgen
@@ -15,8 +15,11 @@ slack_reporter:
   - failure
   - error
   report_template: >
-    :ai-intensifies: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*.
-    <https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/{{.Spec.Job}}/{{.Status.BuildID}}/artifacts/microshift-ci-doctor/openshift-edge-tooling-microshift-ci-doctor/artifacts/microshift-ci-doctor-report.html|View report>
-    <{{.Status.URL}}|View logs>
+    :ai-intensifies: *MicroShift CI Doctor* ended with *{{.Status.State}}*.
+
+    | <https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/{{.Spec.Job}}/{{.Status.BuildID}}/artifacts/microshift-ci-doctor/openshift-edge-tooling-microshift-ci-doctor/artifacts/microshift-ci-doctor-report.html|View report>
+    | <https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/{{.Spec.Job}}/{{.Status.BuildID}}/artifacts/microshift-ci-doctor/openshift-edge-tooling-microshift-ci-doctor/artifacts/analyze-ci-create-bugs-merged.txt|View bugs>
+    | <{{.Status.URL}}|View logs>
+    |
   job_names:
   - microshift-ci-doctor

--- a/ci-operator/jobs/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main-periodics.yaml
@@ -21,7 +21,8 @@ periodics:
       - failure
       - error
       report_template: |
-        :ai-intensifies: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/{{.Spec.Job}}/{{.Status.BuildID}}/artifacts/microshift-ci-doctor/openshift-edge-tooling-microshift-ci-doctor/artifacts/microshift-ci-doctor-report.html|View report> <{{.Status.URL}}|View logs>
+        :ai-intensifies: *MicroShift CI Doctor* ended with *{{.Status.State}}*.
+        | <https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/{{.Spec.Job}}/{{.Status.BuildID}}/artifacts/microshift-ci-doctor/openshift-edge-tooling-microshift-ci-doctor/artifacts/microshift-ci-doctor-report.html|View report> | <https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/{{.Spec.Job}}/{{.Status.BuildID}}/artifacts/microshift-ci-doctor/openshift-edge-tooling-microshift-ci-doctor/artifacts/analyze-ci-create-bugs-merged.txt|View bugs> | <{{.Status.URL}}|View logs> |
   spec:
     containers:
     - args:

--- a/ci-operator/step-registry/openshift/edge-tooling/microshift-ci/doctor/openshift-edge-tooling-microshift-ci-doctor-commands.sh
+++ b/ci-operator/step-registry/openshift/edge-tooling/microshift-ci/doctor/openshift-edge-tooling-microshift-ci-doctor-commands.sh
@@ -9,6 +9,9 @@ mkdir -p "${WORKDIR}"
 CLAUDE_HOME="/home/claude/.claude"
 mkdir -p "${CLAUDE_HOME}"
 
+CLAUDE_ANALYSIS_LOG="${WORKDIR}/claude-analysis.log"
+CLAUDE_BUG_CREATION_LOG="${WORKDIR}/claude-bug-creation.log"
+
 # The procedure to copy reports and session logs to artifacts, executed at exit
 atexit_handler() {
     if [[ -d "${WORKDIR:-}" ]]; then
@@ -16,6 +19,7 @@ atexit_handler() {
         find "${WORKDIR}" -maxdepth 1 -name "*.html" -exec cp {} "${ARTIFACT_DIR}/" \; || true
         find "${WORKDIR}" -maxdepth 1 -name "*.json" -exec cp {} "${ARTIFACT_DIR}/" \; || true
         find "${WORKDIR}" -maxdepth 1 -name "*.txt"  -exec cp {} "${ARTIFACT_DIR}/" \; || true
+        find "${WORKDIR}" -maxdepth 1 -name "*.log"  -exec cp {} "${ARTIFACT_DIR}/" \; || true
     fi
 
     # Archive the full Claude session directory (including subagent logs) for session continuation.
@@ -27,7 +31,7 @@ atexit_handler() {
         fi
     fi
 
-    # Check if the report was produced
+    # Check if the HTML report was produced
     if ls "${WORKDIR}"/*.html &>/dev/null; then
         touch "${SHARED_DIR}/claude-report-available"
         echo "Analysis complete"
@@ -36,14 +40,24 @@ atexit_handler() {
         return 1
     fi
 
-    # Check if the Claude session completed successfully
-    local result_line
-    result_line=$(grep '"type":"result"' "${WORKDIR}/claude-output.log" | tail -1)
-    if ! echo "$result_line" | grep -q '"subtype":"success"' ||
-       ! echo "$result_line" | grep -q '"is_error":false'; then
-        echo "ERROR: Claude session did not complete successfully"
-        return 1
-    fi
+    # Check if the Claude sessions were completed successfully
+    for log_file in "${CLAUDE_ANALYSIS_LOG}" "${CLAUDE_BUG_CREATION_LOG}"; do
+        # If a session was terminated due to a timeout, report lack of
+        # subsequent session log files as a warning and continue not
+        # to mask the actual error
+        if [ ! -f "${log_file}" ]; then
+            echo "WARNING: Log file '${log_file}' not found"
+            continue
+        fi
+
+        local result_line
+        result_line=$(grep '"type":"result"' "${log_file}" | tail -1)
+        if ! echo "$result_line" | grep -q '"subtype":"success"' ||
+           ! echo "$result_line" | grep -q '"is_error":false'; then
+            echo "ERROR: Claude session in '${log_file}' did not complete successfully"
+            return 1
+        fi
+    done
 }
 
 github_app_token() {
@@ -232,13 +246,26 @@ cd "${SRC_DIR}"
 # Run analysis on all releases and open rebase PRs.
 # Time-box analysis and limit turns to avoid uncontrolled billable minutes.
 echo "Running Claude to analyze MicroShift CI jobs and pull requests..."
-timeout 3600 claude \
+timeout 3000 claude \
     --model "${CLAUDE_MODEL}" \
     --max-turns 100 \
     --output-format stream-json \
     --plugin-dir "${PLUGIN_DIR}" \
     -p "/microshift-ci:doctor ${RELEASE_VERSIONS}" \
-    --verbose 2>&1 | tee "${WORKDIR}/claude-output.log"
+    --verbose 2>&1 | tee "${CLAUDE_ANALYSIS_LOG}"
+echo "Analysis for MicroShift CI jobs and pull requests completed"
+
+# Run bug creation for failed jobs (dry-run mode).
+# Time-box bug creation and limit turns to avoid uncontrolled billable minutes.
+echo "Running Claude to create bugs for failed jobs..."
+timeout 600 claude \
+    --model "${CLAUDE_MODEL}" \
+    --max-turns 50 \
+    --output-format stream-json \
+    --plugin-dir "${PLUGIN_DIR}" \
+    -p "/microshift-ci:create-bugs ${RELEASE_VERSIONS}" \
+    --verbose 2>&1 | tee "${CLAUDE_BUG_CREATION_LOG}"
+echo "Bug creation for failed jobs completed"
 
 # After the analysis, attempt to restart failed rebase PRs tests. If the
 # restarted tests complete successfully, the PR will be automatically

--- a/ci-operator/step-registry/openshift/edge-tooling/microshift-ci/doctor/openshift-edge-tooling-microshift-ci-doctor-commands.sh
+++ b/ci-operator/step-registry/openshift/edge-tooling/microshift-ci/doctor/openshift-edge-tooling-microshift-ci-doctor-commands.sh
@@ -51,7 +51,11 @@ atexit_handler() {
         fi
 
         local result_line
-        result_line=$(grep '"type":"result"' "${log_file}" | tail -1)
+        result_line="$(grep '"type":"result"' "${log_file}" | tail -1 || true)"
+        if [[ -z "${result_line}" ]]; then
+            echo "ERROR: No Claude result event found in '${log_file}'"
+            return 1
+        fi
         if ! echo "$result_line" | grep -q '"subtype":"success"' ||
            ! echo "$result_line" | grep -q '"is_error":false'; then
             echo "ERROR: Claude session in '${log_file}' did not complete successfully"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR implements phase 1 of [USHIFT-6935](https://redhat.atlassian.net/browse/USHIFT-6935) to enable the MicroShift CI Doctor's bug-creation procedure in dry-run mode. It updates the edge-tooling CI configuration and the MicroShift CI Doctor step used by OpenShift CI so the doctor executes an analysis pass and a separate, dry-run bug-creation pass and reports both results to artifacts and Slack.

## Changes

- Affects OpenShift CI configuration for the openshift-eng/edge-tooling repository and the MicroShift CI Doctor step used by the edge-tooling job.

- ci-operator/config/openshift-eng/edge-tooling/.config.prowgen
  - Tailors the second slack_reporter entry’s report_template for MicroShift CI Doctor wording.
  - Adds a new "View bugs" action link that points at the bug-creation report artifact (analyze-ci-create-bugs-merged.txt), alongside existing "View report" and "View logs" links.

- ci-operator/step-registry/openshift/edge-tooling/microshift-ci/doctor/openshift-edge-tooling-microshift-ci-doctor-commands.sh
  - Splits Claude output into separate logs for analysis and bug-creation runs (CLAUDE_ANALYSIS_LOG and CLAUDE_BUG_CREATION_LOG).
  - Runs two Claude invocations in sequence: the analysis/doctor run (longer timeout, primary analysis) and a second bug-creation run executed in dry-run mode under a shorter timeout (phase 1 behavior).
  - Enhances the exit handler to collect additional artifacts (*.log, *.txt, *.json, *.html) and to validate both Claude log outputs for success indicators ("subtype":"success" and "is_error":false), emitting warnings for missing log files rather than failing the handler.
  - Adds more robust shell handling for cases like grep producing no matches (fix for set -euo pipefail behavior).

## Impact

The CI Doctor now performs both analysis and a simulated bug-creation workflow and publishes distinct artifacts for each step. Slack notifications are improved to surface the bug-creation report link so reviewers can inspect the dry-run bug results before enabling full automated bug filing in later phases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[USHIFT-6935]: https://redhat.atlassian.net/browse/USHIFT-6935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ