### PR TITLE
Deploy openshift-eng/ship-hook to app.ci

### DIFF
--- a/clusters/app.ci/openshift-user-workload-monitoring/ship-hook_servicemonitor.yaml
+++ b/clusters/app.ci/openshift-user-workload-monitoring/ship-hook_servicemonitor.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app: prow
+    component: ship-hook
+    prow-app: ship-hook
+  name: ship-hook
+  namespace: ci
+spec:
+  endpoints:
+  - interval: 30s
+    port: metrics
+    scheme: http
+  selector:
+    matchLabels:
+      app: prow
+      component: ship-hook

--- a/clusters/app.ci/prow/03_deployment/ship-hook.yaml
+++ b/clusters/app.ci/prow/03_deployment/ship-hook.yaml
@@ -1,0 +1,160 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ship-hook
+  namespace: ci
+---
+# TODO: Replace this inline ConfigMap with config file fragments managed
+# directly in the repo (similar to how Prow plugin configs are split per-repo).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ship-hook-config
+  labels:
+    app: prow
+    component: ship-hook
+  namespace: ci
+data:
+  config.yaml: |
+    orgs:
+      openshift:
+        repos:
+          sippy:
+            plugins:
+            - name: ready-for-humans
+          origin:
+            plugins:
+            - name: ready-for-humans
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ship-hook
+  namespace: ci
+  labels:
+    app: prow
+    component: ship-hook
+spec:
+  selector:
+    app: prow
+    component: ship-hook
+  ports:
+  - name: main
+    port: 80
+    targetPort: 8888
+  - name: metrics
+    port: 9090
+    targetPort: 9090
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ship-hook
+  labels:
+    app: prow
+    component: ship-hook
+  annotations:
+    keel.sh/policy: force
+    keel.sh/matchTag: "true"
+    keel.sh/trigger: poll
+    keel.sh/pollSchedule: "@every 5m"
+  namespace: ci
+spec:
+  replicas: 2
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: prow
+      component: ship-hook
+  template:
+    metadata:
+      labels:
+        app: prow
+        component: ship-hook
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  component: ship-hook
+              topologyKey: kubernetes.io/hostname
+      containers:
+      - name: ship-hook
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ship-hook_latest
+        imagePullPolicy: Always
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
+          capabilities:
+            drop:
+            - ALL
+        args:
+        - --dry-run=false
+        - --log-level=debug
+        - --endpoint=/
+        - --hmac-secret-file=/etc/webhook/hmac.yaml
+        - --github-endpoint=http://ghproxy
+        - --github-endpoint=https://api.github.com
+        - --github-app-id=$(GITHUB_APP_ID)
+        - --github-app-private-key-path=/etc/github/cert
+        - --config-path=/etc/ship-hook/config.yaml
+        env:
+        - name: GITHUB_APP_ID
+          valueFrom:
+            secretKeyRef:
+              name: openshift-prow-github-app
+              key: appid
+        ports:
+        - name: http
+          containerPort: 8888
+        - name: metrics
+          containerPort: 9090
+        - name: health
+          containerPort: 8081
+        volumeMounts:
+        - name: hmac
+          mountPath: /etc/webhook
+          readOnly: true
+        - name: github-app-credentials
+          mountPath: /etc/github
+          readOnly: true
+        - name: ship-hook-config
+          mountPath: /etc/ship-hook
+          readOnly: true
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "100m"
+          limits:
+            memory: "256Mi"
+            cpu: "500m"
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: health
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /healthz/ready
+            port: health
+          initialDelaySeconds: 5
+          periodSeconds: 10
+      serviceAccountName: ship-hook
+      volumes:
+      - name: hmac
+        secret:
+          secretName: github-webhook-credentials
+      - name: github-app-credentials
+        secret:
+          secretName: openshift-prow-github-app
+      - name: ship-hook-config
+        configMap:
+          name: ship-hook-config

--- a/core-services/prow/02_config/openshift/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/_pluginconfig.yaml
@@ -43,6 +43,12 @@ external_plugins:
     events:
     - issue_comment
     name: multi-pr-prow-plugin
+  - endpoint: http://ship-hook
+    events:
+    - pull_request
+    - issue_comment
+    - pull_request_review
+    name: ship-hook
 plugins:
   openshift:
     excluded_repos:


### PR DESCRIPTION
Deploys [openshift-eng/ship-hook](https://github.com/openshift-eng/ship-hook) as a Prow external plugin on the app.ci cluster. This adds a Deployment, Service, ServiceAccount, ConfigMap, and ServiceMonitor in the `ci` namespace, and registers ship-hook as an org-level external plugin for the `openshift` organization. The CI build and image promotion is set up in #78840.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR deploys the openshift-eng/ship-hook service to the app.ci cluster and wires it into Prow as an external plugin for the openshift org. Image build/promotion was configured in PR #78840.

What this changes in practical terms
- Installs ship-hook into app.ci (namespace: ci) so it can receive GitHub webhooks and act as an external Prow plugin for openshift.
- Registers ship-hook in the openshift Prow plugin config so Prow will forward pull_request, issue_comment, and pull_request_review events to the service.

Cluster manifests and runtime
- ServiceAccount: ci/ship-hook.
- ConfigMap: ci/ship-hook-config containing config.yaml that enables the ready-for-humans plugin for openshift/repos sippy and origin.
- Service: ci/ship-hook (ClusterIP) selecting app: prow, component: ship-hook
  - Ports: main (80 → container 8888), metrics (9090 → container 9090).
- Deployment: ci/ship-hook
  - replicas: 2 with Keel annotations for automated image updates.
  - image: quay-proxy.ci.openshift.org/openshift/ci:ci_ship-hook_latest (Always pull).
  - Container args include HMAC secret path, GitHub endpoints, GITHUB_APP_ID (from secret openshift-prow-github-app), GitHub app private key path, and config path.
  - Volume mounts:
    - github-webhook-credentials → /etc/webhook (secret github-webhook-credentials)
    - openshift-prow-github-app → /etc/github (secret openshift-prow-github-app)
    - ship-hook-config → /etc/ship-hook (ConfigMap)
  - Security: runAsNonRoot, allowPrivilegeEscalation: false, readOnlyRootFilesystem, seccomp RuntimeDefault, drop ALL capabilities.
  - Resources: requests 100m CPU / 128Mi memory; limits 500m CPU / 256Mi memory.
  - Health probes: liveness /healthz and readiness /healthz/ready on port 8081.
  - Pod anti-affinity preferred across hostnames.

Monitoring
- ServiceMonitor: monitoring.coreos.com/v1 ServiceMonitor named ship-hook in namespace ci
  - Selects services with labels app: prow, component: ship-hook
  - Scrapes port named metrics over HTTP every 30s.

Prow configuration
- core-services/prow/02_config/openshift/_pluginconfig.yaml: adds external_plugins.openshift entry:
  - name: ship-hook, endpoint: http://ship-hook
  - events: [pull_request, issue_comment, pull_request_review]

Effect
- ship-hook will run on app.ci, be discoverable by Prometheus, and receive PR, comment, and review events from Prow for the openshift organization using the specified secrets and ConfigMap-driven plugin configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->