### PR TITLE
CNTRLPLANE-3364: adding the clusterbot workflow. Its optional.

### DIFF
--- a/ci-operator/config/openshift/cluster-kube-apiserver-operator/openshift-cluster-kube-apiserver-operator-main.yaml
+++ b/ci-operator/config/openshift/cluster-kube-apiserver-operator/openshift-cluster-kube-apiserver-operator-main.yaml
@@ -473,8 +473,7 @@ tests:
       FEATURE_SET: TechPreviewNoUpgrade
       TEST_SUITE: openshift/cluster-kube-apiserver-operator/encryption-kms
     test:
-    - ref: etcd-encryption-vault-install
-    - ref: etcd-encryption-vault-configure
+    - chain: etcd-encryption-vault-setup
     - ref: openshift-e2e-test
     workflow: ipi-gcp
 zz_generated_metadata:

--- a/ci-operator/step-registry/etcd-encryption/hashicorp-vault/OWNERS
+++ b/ci-operator/step-registry/etcd-encryption/hashicorp-vault/OWNERS
@@ -1,0 +1,18 @@
+approvers:
+- ardaguclu
+- benluddy
+- bertinatto
+- flavianmissi
+- gangwgr
+- p0lyn0mial
+- sandeepknd
+- tjungblu
+reviewers:
+- ardaguclu
+- benluddy
+- bertinatto
+- flavianmissi
+- gangwgr
+- p0lyn0mial
+- sandeepknd
+- tjungblu

--- a/ci-operator/step-registry/etcd-encryption/hashicorp-vault/aws/OWNERS
+++ b/ci-operator/step-registry/etcd-encryption/hashicorp-vault/aws/OWNERS
@@ -1,0 +1,18 @@
+approvers:
+- ardaguclu
+- benluddy
+- bertinatto
+- flavianmissi
+- gangwgr
+- p0lyn0mial
+- sandeepknd
+- tjungblu
+reviewers:
+- ardaguclu
+- benluddy
+- bertinatto
+- flavianmissi
+- gangwgr
+- p0lyn0mial
+- sandeepknd
+- tjungblu

--- a/ci-operator/step-registry/etcd-encryption/hashicorp-vault/aws/etcd-encryption-hashicorp-vault-aws-workflow.metadata.json
+++ b/ci-operator/step-registry/etcd-encryption/hashicorp-vault/aws/etcd-encryption-hashicorp-vault-aws-workflow.metadata.json
@@ -1,0 +1,25 @@
+{
+	"path": "etcd-encryption/hashicorp-vault/aws/etcd-encryption-hashicorp-vault-aws-workflow.yaml",
+	"owners": {
+		"approvers": [
+			"ardaguclu",
+			"benluddy",
+			"bertinatto",
+			"flavianmissi",
+			"gangwgr",
+			"p0lyn0mial",
+			"sandeepknd",
+			"tjungblu"
+		],
+		"reviewers": [
+			"ardaguclu",
+			"benluddy",
+			"bertinatto",
+			"flavianmissi",
+			"gangwgr",
+			"p0lyn0mial",
+			"sandeepknd",
+			"tjungblu"
+		]
+	}
+}

--- a/ci-operator/step-registry/etcd-encryption/hashicorp-vault/aws/etcd-encryption-hashicorp-vault-aws-workflow.yaml
+++ b/ci-operator/step-registry/etcd-encryption/hashicorp-vault/aws/etcd-encryption-hashicorp-vault-aws-workflow.yaml
@@ -1,0 +1,39 @@
+workflow:
+  as: etcd-encryption-hashicorp-vault-aws
+  steps:
+    allow_best_effort_post_steps: true
+    pre:
+    - chain: ipi-aws-pre
+    - chain: etcd-encryption-vault-setup
+    test:
+    - ref: clusterbot-wait
+    post:
+    - chain: gather-core-dump
+    - chain: ipi-aws-post
+  documentation: |-
+    Provisions an AWS cluster with HashiCorp Vault Enterprise installed and
+    configured for KMS encryption testing.
+
+    This workflow is designed for use with clusterbot to provide interactive access
+    to a cluster with Vault pre-installed and configured.
+
+    What's installed:
+    - OpenShift cluster on AWS (IPI)
+    - HashiCorp Vault Enterprise (via Helm) in namespace: vault-kms
+    - Vault initialized and configured with:
+      * Transit secret engine enabled
+      * KMS encryption key created
+      * AppRole authentication configured
+      * Credentials stored in vault-credentials secret
+
+    Access details:
+    - Vault service: vault.vault-kms.svc:8200
+    - Vault pod: vault-0
+    - Credentials secret: vault-credentials (namespace: vault-kms)
+
+    Vault installation uses the following environment variables with default values:
+    - VAULT_VERSION: 2.0.0-ent (Vault Enterprise version)
+    - VAULT_NAMESPACE: vault-kms (namespace for Vault installation)
+    - VAULT_KMS_KEY_NAME: kms-key (transit encryption key name)
+
+    Note: These Vault configuration values are not configurable via cluster-bot.

--- a/ci-operator/step-registry/etcd-encryption/hashicorp-vault/azure/OWNERS
+++ b/ci-operator/step-registry/etcd-encryption/hashicorp-vault/azure/OWNERS
@@ -1,0 +1,18 @@
+approvers:
+- ardaguclu
+- benluddy
+- bertinatto
+- flavianmissi
+- gangwgr
+- p0lyn0mial
+- sandeepknd
+- tjungblu
+reviewers:
+- ardaguclu
+- benluddy
+- bertinatto
+- flavianmissi
+- gangwgr
+- p0lyn0mial
+- sandeepknd
+- tjungblu

--- a/ci-operator/step-registry/etcd-encryption/hashicorp-vault/azure/etcd-encryption-hashicorp-vault-azure-workflow.metadata.json
+++ b/ci-operator/step-registry/etcd-encryption/hashicorp-vault/azure/etcd-encryption-hashicorp-vault-azure-workflow.metadata.json
@@ -1,0 +1,25 @@
+{
+	"path": "etcd-encryption/hashicorp-vault/azure/etcd-encryption-hashicorp-vault-azure-workflow.yaml",
+	"owners": {
+		"approvers": [
+			"ardaguclu",
+			"benluddy",
+			"bertinatto",
+			"flavianmissi",
+			"gangwgr",
+			"p0lyn0mial",
+			"sandeepknd",
+			"tjungblu"
+		],
+		"reviewers": [
+			"ardaguclu",
+			"benluddy",
+			"bertinatto",
+			"flavianmissi",
+			"gangwgr",
+			"p0lyn0mial",
+			"sandeepknd",
+			"tjungblu"
+		]
+	}
+}

--- a/ci-operator/step-registry/etcd-encryption/hashicorp-vault/azure/etcd-encryption-hashicorp-vault-azure-workflow.yaml
+++ b/ci-operator/step-registry/etcd-encryption/hashicorp-vault/azure/etcd-encryption-hashicorp-vault-azure-workflow.yaml
@@ -1,0 +1,39 @@
+workflow:
+  as: etcd-encryption-hashicorp-vault-azure
+  steps:
+    allow_best_effort_post_steps: true
+    pre:
+    - chain: ipi-azure-pre
+    - chain: etcd-encryption-vault-setup
+    test:
+    - ref: clusterbot-wait
+    post:
+    - chain: gather-core-dump
+    - chain: ipi-azure-post
+  documentation: |-
+    Provisions an Azure cluster with HashiCorp Vault Enterprise installed and
+    configured for KMS encryption testing.
+
+    This workflow is designed for use with clusterbot to provide interactive access
+    to a cluster with Vault pre-installed and configured.
+
+    What's installed:
+    - OpenShift cluster on Azure (IPI)
+    - HashiCorp Vault Enterprise (via Helm) in namespace: vault-kms
+    - Vault initialized and configured with:
+      * Transit secret engine enabled
+      * KMS encryption key created
+      * AppRole authentication configured
+      * Credentials stored in vault-credentials secret
+
+    Access details:
+    - Vault service: vault.vault-kms.svc:8200
+    - Vault pod: vault-0
+    - Credentials secret: vault-credentials (namespace: vault-kms)
+
+    Vault installation uses the following environment variables with default values:
+    - VAULT_VERSION: 2.0.0-ent (Vault Enterprise version)
+    - VAULT_NAMESPACE: vault-kms (namespace for Vault installation)
+    - VAULT_KMS_KEY_NAME: kms-key (transit encryption key name)
+
+    Note: These Vault configuration values are not configurable via cluster-bot.

--- a/ci-operator/step-registry/etcd-encryption/hashicorp-vault/gcp/OWNERS
+++ b/ci-operator/step-registry/etcd-encryption/hashicorp-vault/gcp/OWNERS
@@ -1,0 +1,18 @@
+approvers:
+- ardaguclu
+- benluddy
+- bertinatto
+- flavianmissi
+- gangwgr
+- p0lyn0mial
+- sandeepknd
+- tjungblu
+reviewers:
+- ardaguclu
+- benluddy
+- bertinatto
+- flavianmissi
+- gangwgr
+- p0lyn0mial
+- sandeepknd
+- tjungblu

--- a/ci-operator/step-registry/etcd-encryption/hashicorp-vault/gcp/etcd-encryption-hashicorp-vault-gcp-workflow.metadata.json
+++ b/ci-operator/step-registry/etcd-encryption/hashicorp-vault/gcp/etcd-encryption-hashicorp-vault-gcp-workflow.metadata.json
@@ -1,0 +1,25 @@
+{
+	"path": "etcd-encryption/hashicorp-vault/gcp/etcd-encryption-hashicorp-vault-gcp-workflow.yaml",
+	"owners": {
+		"approvers": [
+			"ardaguclu",
+			"benluddy",
+			"bertinatto",
+			"flavianmissi",
+			"gangwgr",
+			"p0lyn0mial",
+			"sandeepknd",
+			"tjungblu"
+		],
+		"reviewers": [
+			"ardaguclu",
+			"benluddy",
+			"bertinatto",
+			"flavianmissi",
+			"gangwgr",
+			"p0lyn0mial",
+			"sandeepknd",
+			"tjungblu"
+		]
+	}
+}

--- a/ci-operator/step-registry/etcd-encryption/hashicorp-vault/gcp/etcd-encryption-hashicorp-vault-gcp-workflow.yaml
+++ b/ci-operator/step-registry/etcd-encryption/hashicorp-vault/gcp/etcd-encryption-hashicorp-vault-gcp-workflow.yaml
@@ -1,0 +1,39 @@
+workflow:
+  as: etcd-encryption-hashicorp-vault-gcp
+  steps:
+    allow_best_effort_post_steps: true
+    pre:
+    - chain: ipi-gcp-pre
+    - chain: etcd-encryption-vault-setup
+    test:
+    - ref: clusterbot-wait
+    post:
+    - chain: gather-core-dump
+    - chain: ipi-gcp-post
+  documentation: |-
+    Provisions a GCP cluster with HashiCorp Vault Enterprise installed and
+    configured for KMS encryption testing.
+
+    This workflow is designed for use with clusterbot to provide interactive access
+    to a cluster with Vault pre-installed and configured.
+
+    What's installed:
+    - OpenShift cluster on GCP (IPI)
+    - HashiCorp Vault Enterprise (via Helm) in namespace: vault-kms
+    - Vault initialized and configured with:
+      * Transit secret engine enabled
+      * KMS encryption key created
+      * AppRole authentication configured
+      * Credentials stored in vault-credentials secret
+
+    Access details:
+    - Vault service: vault.vault-kms.svc:8200
+    - Vault pod: vault-0
+    - Credentials secret: vault-credentials (namespace: vault-kms)
+
+    Vault installation uses the following environment variables with default values:
+    - VAULT_VERSION: 2.0.0-ent (Vault Enterprise version)
+    - VAULT_NAMESPACE: vault-kms (namespace for Vault installation)
+    - VAULT_KMS_KEY_NAME: kms-key (transit encryption key name)
+
+    Note: These Vault configuration values are not configurable via cluster-bot.

--- a/ci-operator/step-registry/etcd-encryption/vault-setup/OWNERS
+++ b/ci-operator/step-registry/etcd-encryption/vault-setup/OWNERS
@@ -1,0 +1,18 @@
+approvers:
+- ardaguclu
+- benluddy
+- bertinatto
+- flavianmissi
+- gangwgr
+- p0lyn0mial
+- sandeepknd
+- tjungblu
+reviewers:
+- ardaguclu
+- benluddy
+- bertinatto
+- flavianmissi
+- gangwgr
+- p0lyn0mial
+- sandeepknd
+- tjungblu

--- a/ci-operator/step-registry/etcd-encryption/vault-setup/etcd-encryption-vault-setup-chain.metadata.json
+++ b/ci-operator/step-registry/etcd-encryption/vault-setup/etcd-encryption-vault-setup-chain.metadata.json
@@ -1,0 +1,25 @@
+{
+	"path": "etcd-encryption/vault-setup/etcd-encryption-vault-setup-chain.yaml",
+	"owners": {
+		"approvers": [
+			"ardaguclu",
+			"benluddy",
+			"bertinatto",
+			"flavianmissi",
+			"gangwgr",
+			"p0lyn0mial",
+			"sandeepknd",
+			"tjungblu"
+		],
+		"reviewers": [
+			"ardaguclu",
+			"benluddy",
+			"bertinatto",
+			"flavianmissi",
+			"gangwgr",
+			"p0lyn0mial",
+			"sandeepknd",
+			"tjungblu"
+		]
+	}
+}

--- a/ci-operator/step-registry/etcd-encryption/vault-setup/etcd-encryption-vault-setup-chain.yaml
+++ b/ci-operator/step-registry/etcd-encryption/vault-setup/etcd-encryption-vault-setup-chain.yaml
@@ -1,0 +1,44 @@
+chain:
+  as: etcd-encryption-vault-setup
+  steps:
+  - ref: etcd-encryption-vault-install
+  - ref: etcd-encryption-vault-configure
+  documentation: |-
+    Installs and configures HashiCorp Vault Enterprise for KMS encryption testing.
+
+    This chain combines the vault installation and configuration steps into a single
+    reusable component that can be used across different platform workflows.
+
+    What this chain does:
+    1. Installs HashiCorp Vault Enterprise via Helm (vault-install step)
+       - Deploys Vault in dev mode to vault-kms namespace
+       - Creates vault-license secret from mounted credentials
+       - Waits for Vault pod to be ready
+
+    2. Configures Vault for KMS encryption (vault-configure step)
+       - Enables transit secret engine
+       - Creates KMS encryption key
+       - Configures AppRole authentication
+       - Stores credentials in vault-credentials secret
+
+    Prerequisites:
+    - OpenShift cluster with adequate resources
+    - Vault Enterprise license secret named 'tests-private-account' in test-credentials namespace
+      containing the license file at key 'kms-vault-license'
+
+    Outputs:
+    - Vault service: vault.vault-kms.svc:8200
+    - Vault pod: vault-0 (Ready state)
+    - Credentials secret: vault-credentials in vault-kms namespace
+      * role-id: AppRole role ID for KMS plugin
+      * secret-id: AppRole secret ID for KMS plugin
+      * root-token: Vault root token (dev mode)
+
+    Environment variables (inherited from vault-install step):
+    - VAULT_VERSION: Vault Enterprise version (default: 2.0.0-ent)
+    - VAULT_CHART_VERSION: Helm chart version (default: 0.28.1)
+    - VAULT_NAMESPACE: Vault namespace (default: vault-kms)
+    - VAULT_IMAGE_REPOSITORY: Container image repo (default: docker.io/hashicorp/vault-enterprise)
+
+    Environment variables (inherited from vault-configure step):
+    - VAULT_KMS_KEY_NAME: Transit encryption key name (default: kms-key)

--- a/core-services/ci-chat-bot/workflows-config.yaml
+++ b/core-services/ci-chat-bot/workflows-config.yaml
@@ -721,6 +721,12 @@ workflows:
     platform: nutanix
   cucushift-installer-rehearse-ibmcloud-ipi:
     platform: ibmcloud
+  etcd-encryption-hashicorp-vault-aws:
+    platform: aws
+  etcd-encryption-hashicorp-vault-azure:
+    platform: azure
+  etcd-encryption-hashicorp-vault-gcp:
+    platform: gcp
   hypershift-aws-e2e-external:
     platform: aws
   hypershift-aws-e2e-nested:


### PR DESCRIPTION
Introduces three new clusterbot workflows that enable users to launch OpenShift clusters with HashiCorp Vault Enterprise pre-installed and configured for KMS encryption testing via Slack

  Basic Commands:
  Launch a cluster with Vault on AWS:
```
  workflow-launch etcd-encryption-hashicorp-vault-aws 5.0
```

  Launch a cluster with Vault on GCP:
```
  workflow-launch etcd-encryption-hashicorp-vault-gcp 5.0
```

  Launch a cluster with Vault on Azure:
```
  workflow-launch etcd-encryption-hashicorp-vault-azure 5.0
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds optional cluster-bot workflows and a reusable step-registry chain to OpenShift CI to let operators provision IPI clusters with HashiCorp Vault Enterprise pre-installed and configured for KMS-based etcd encryption testing. Affects core-services/ci-chat-bot (workflow registration), ci-operator step-registry (new workflows, new vault-setup chain and metadata), and multiple OWNERS files under the etcd-encryption step-registry. PR is marked WIP.

## Practical impact

- New clusterbot workflows (ci-operator step-registry)
  - etcd-encryption-hashicorp-vault-aws
  - etcd-encryption-hashicorp-vault-gcp
  - etcd-encryption-hashicorp-vault-azure
  Each workflow provisions an IPI cluster on the given cloud, installs Vault Enterprise via Helm into namespace vault-kms, enables the Transit secret engine, creates a KMS key, configures AppRole auth, stores credentials in a vault-credentials secret, exposes Vault endpoints, waits for cluster readiness (clusterbot-wait), and runs platform post/cleanup chains (gather-core-dump, ipi-*-post). Documented defaults include VAULT_VERSION, VAULT_NAMESPACE, and VAULT_KMS_KEY_NAME. Workflows are intended for interactive/manual testing and are launched via the CI chat-bot (example Slack commands provided in the PR).

- New reusable chain: etcd-encryption-vault-setup
  - Composes etcd-encryption-vault-install and etcd-encryption-vault-configure into a single chain with documentation of responsibilities, prerequisites, outputs, and inherited environment variables.

- CI chat-bot registration
  - Registers the three workflows in core-services/ci-chat-bot/workflows-config.yaml (platform: aws/gcp/azure) so cluster-bot can launch them.

- Ownership and metadata
  - Added/updated OWNERS for:
    - ci-operator/step-registry/etcd-encryption/hashicorp-vault (root) and per-platform (aws, gcp, azure)
    - ci-operator/step-registry/etcd-encryption/vault-setup
    Approvers/reviewers lists include: ardaguclu, benluddy, bertinatto, flavianmissi, gangwgr, p0lyn0mial, sandeepknd, tjungblu.
  - Added workflow and chain metadata JSON files mapping YAML paths to owners.

- CI job config change
  - Updated ci-operator config for openshift/cluster-kube-apiserver-operator to use the new etcd-encryption-vault-setup chain instead of separate install/configure refs.

## Notes for reviewers/operators

- These changes are optional/manual and do not modify production controllers.
- The vault-setup chain groups install + configure; confirm the referenced etcd-encryption-vault-install and etcd-encryption-vault-configure steps exist and behave as documented before merging.
- PR is WIP and the author wrapped install+configure into a chain per reviewer guidance and plans a follow-up PR to invoke this chain in CI tests (author references PR #78947).
- openshift-ci-robot validated Jira [CNTRLPLANE-3364](https://redhat.atlassian.net/browse/CNTRLPLANE-3364) but flagged the Jira issue has no target version set (expected 5.0.0 for main).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[CNTRLPLANE-3364]: https://redhat.atlassian.net/browse/CNTRLPLANE-3364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ