### PR TITLE
Add Prow onboarding for medik8s/system-tests

### DIFF
--- a/ci-operator/config/medik8s/system-tests/OWNERS
+++ b/ci-operator/config/medik8s/system-tests/OWNERS
@@ -9,6 +9,7 @@ filters:
     approvers:
     - beekhof
     - clobrano
+    - maximunited
     - mshitrit
     - razo7
     - slintes
@@ -16,6 +17,7 @@ filters:
     reviewers:
     - beekhof
     - clobrano
+    - maximunited
     - mshitrit
     - razo7
     - slintes

--- a/ci-operator/config/medik8s/system-tests/OWNERS
+++ b/ci-operator/config/medik8s/system-tests/OWNERS
@@ -1,0 +1,23 @@
+# DO NOT EDIT; this file is auto-generated using https://github.com/openshift/ci-tools.
+# Fetched from https://github.com/medik8s/system-tests root OWNERS
+# If the repo had OWNERS_ALIASES then the aliases were expanded
+# Logins who are not members of 'openshift' organization were filtered out
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+filters:
+  .*:
+    approvers:
+    - beekhof
+    - clobrano
+    - mshitrit
+    - razo7
+    - slintes
+    - ugreener
+    reviewers:
+    - beekhof
+    - clobrano
+    - mshitrit
+    - razo7
+    - slintes
+    - ugreener
+options: {}

--- a/ci-operator/config/medik8s/system-tests/medik8s-system-tests-main.yaml
+++ b/ci-operator/config/medik8s/system-tests/medik8s-system-tests-main.yaml
@@ -1,0 +1,24 @@
+build_root:
+  from_repository: true
+releases:
+  latest:
+    candidate:
+      product: ocp
+      stream: ci
+      version: "4.22"
+resources:
+  '*':
+    requests:
+      cpu: 500m
+      memory: 1000Mi
+tests:
+- as: lint
+  commands: make lint
+  container:
+    from: src
+  skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|OWNERS_ALIASES|PROJECT|LICENSE)$
+- as: unit
+  commands: make test
+  container:
+    from: src
+  skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|OWNERS_ALIASES|PROJECT|LICENSE)$

--- a/ci-operator/config/medik8s/system-tests/medik8s-system-tests-main.yaml
+++ b/ci-operator/config/medik8s/system-tests/medik8s-system-tests-main.yaml
@@ -22,3 +22,7 @@ tests:
   container:
     from: src
   skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|OWNERS_ALIASES|PROJECT|LICENSE)$
+zz_generated_metadata:
+  branch: main
+  org: medik8s
+  repo: system-tests

--- a/ci-operator/jobs/medik8s/system-tests/OWNERS
+++ b/ci-operator/jobs/medik8s/system-tests/OWNERS
@@ -9,6 +9,7 @@ filters:
     approvers:
     - beekhof
     - clobrano
+    - maximunited
     - mshitrit
     - razo7
     - slintes
@@ -16,6 +17,7 @@ filters:
     reviewers:
     - beekhof
     - clobrano
+    - maximunited
     - mshitrit
     - razo7
     - slintes

--- a/ci-operator/jobs/medik8s/system-tests/OWNERS
+++ b/ci-operator/jobs/medik8s/system-tests/OWNERS
@@ -1,0 +1,23 @@
+# DO NOT EDIT; this file is auto-generated using https://github.com/openshift/ci-tools.
+# Fetched from https://github.com/medik8s/system-tests root OWNERS
+# If the repo had OWNERS_ALIASES then the aliases were expanded
+# Logins who are not members of 'openshift' organization were filtered out
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+filters:
+  .*:
+    approvers:
+    - beekhof
+    - clobrano
+    - mshitrit
+    - razo7
+    - slintes
+    - ugreener
+    reviewers:
+    - beekhof
+    - clobrano
+    - mshitrit
+    - razo7
+    - slintes
+    - ugreener
+options: {}

--- a/ci-operator/jobs/medik8s/system-tests/medik8s-system-tests-main-presubmits.yaml
+++ b/ci-operator/jobs/medik8s/system-tests/medik8s-system-tests-main-presubmits.yaml
@@ -8,6 +8,9 @@ presubmits:
     cluster: build01
     context: ci/prow/lint
     decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - .ci-operator.yaml
     labels:
       ci.openshift.io/generator: prowgen
       job-release: "4.22"
@@ -71,6 +74,9 @@ presubmits:
     cluster: build01
     context: ci/prow/unit
     decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - .ci-operator.yaml
     labels:
       ci.openshift.io/generator: prowgen
       job-release: "4.22"

--- a/ci-operator/jobs/medik8s/system-tests/medik8s-system-tests-main-presubmits.yaml
+++ b/ci-operator/jobs/medik8s/system-tests/medik8s-system-tests-main-presubmits.yaml
@@ -1,0 +1,128 @@
+presubmits:
+  medik8s/system-tests:
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build01
+    context: ci/prow/lint
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      job-release: "4.22"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-medik8s-system-tests-main-lint
+    rerun_command: /test lint
+    skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|OWNERS_ALIASES|PROJECT|LICENSE)$
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=lint
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )lint,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build01
+    context: ci/prow/unit
+    decorate: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      job-release: "4.22"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-medik8s-system-tests-main-unit
+    rerun_command: /test unit
+    skip_if_only_changed: ^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|OWNERS_ALIASES|PROJECT|LICENSE)$
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=unit
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )unit,?($|\s.*)


### PR DESCRIPTION
## Summary
Register the `medik8s/system-tests` repository with OpenShift CI (Prow). This is the shared E2E testing repo for all medik8s/RHWA operators (SBR, FAR, SNR, NHC, MDR, NMO), recently forked from eco-gotests.

## Changes
- Add `ci-operator/config/medik8s/system-tests/medik8s-system-tests-main.yaml` with lint and unit presubmit jobs
- Generated presubmit job definitions via `make jobs`
- Add OWNERS files and `zz_generated_metadata`

## Presubmit Jobs
- `lint`: runs `make lint` (golangci-lint)
- `unit`: runs `make test` (Go unit tests)
- Both skip docs-only changes

## OWNERS
The OWNERS files include the 7 team members who are currently in the `openshift` GitHub organization: beekhof, clobrano, maximunited, mshitrit, razo7, slintes, ugreener.

4 additional QE members (mhabashrh, lyfofvipin, rbartal, swgoswam) are not yet in the openshift org. Once they join, the `autoowners` periodic Prow job will automatically update the OWNERS files to include them. This is tracked in [RHWA-983](https://redhat.atlassian.net/browse/RHWA-983).

## Context
- Repo: https://github.com/medik8s/system-tests
- Phase 3 of the [system-tests migration plan](https://docs.google.com/document/d/1Xh_oakZmn_xTDHWqRhJMwUGRPPeIYO0Ied8CQxBbbwU/edit)
- Periodic/e2e jobs will be added in follow-up PRs

Jira: [RHWA-979](https://redhat.atlassian.net/browse/RHWA-979)

[RHWA-979]: https://redhat.atlassian.net/browse/RHWA-979
[RHWA-983]: https://redhat.atlassian.net/browse/RHWA-983

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR registers the medik8s/system-tests repository with OpenShift CI (Prow), adding initial presubmit CI for the shared E2E testing repo used by medik8s RHWA operators (SBR, FAR, SNR, NHC, MDR, NMO). This is part of Phase 3 of the system-tests migration; periodic and full E2E jobs will follow in subsequent PRs.

## Changes
- Added ci-operator config: ci-operator/config/medik8s/system-tests/medik8s-system-tests-main.yaml
  - Configures builds from repository sources, targets the OCP candidate stream `ci` (4.22), and sets default pod resource requests (cpu: 500m, memory: 1000Mi).
  - Defines two presubmit container steps:
    - lint — runs `make lint` (golangci-lint)
    - unit — runs `make test` (Go unit tests)
  - Both presubmits are configured to skip for docs/OWNERS/license-only changes.
  - Includes generated metadata (org: medik8s, repo: system-tests, branch: main).
- Added OWNERS and generated metadata (zz_generated_metadata) and generated presubmit job definitions via `make jobs`.
  - OWNERS lists seven current OpenShift org members as approvers/reviewers: beekhof, clobrano, maximunited, mshitrit, razo7, slintes, ugreener.
  - Four additional QE members (mhabashrh, lyfofvipin, rbartal, swgoswam) are tracked to be added once they join the openshift org; the `autoowners` periodic job will add them automatically (tracked in [RHWA-983](https://redhat.atlassian.net/browse/RHWA-983)).

## Impact
- Pull requests to medik8s/system-tests will now run automated lint and unit presubmits, improving CI feedback early in the migration.
- No runtime/e2e periodic jobs are added yet; those will be introduced in follow-up PRs as part of the migration plan.
- PR activity includes customary Prow/rehearse commands and a brief hold/unhold review flow; reviewers deems ready (labels: lgtm, approved, rehearsals-ack).

## Jira / Tracking
- Migration tracked under [RHWA-979](https://redhat.atlassian.net/browse/RHWA-979) (this PR) and [RHWA-983](https://redhat.atlassian.net/browse/RHWA-983) (OWNERS auto-update follow-up).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->