### PR TITLE
Use new Helm chart location for NVIDIA DRA tests

### DIFF
--- a/ci-operator/config/rh-ecosystem-edge/nvidia-ci/rh-ecosystem-edge-nvidia-ci-main__4.21-dra.yaml
+++ b/ci-operator/config/rh-ecosystem-edge/nvidia-ci/rh-ecosystem-edge-nvidia-ci-main__4.21-dra.yaml
@@ -50,9 +50,8 @@ tests:
         export TEST_FEATURES=nvidiagpu
         make run-tests
 
-        export READ_PACKAGES_GITHUB_TOKEN_FILE=/var/run/nvidia-ci/github_read_packages_token
         export DRA_CHART_VERSION=$(./scripts/get-latest-dra-chart.sh)
-        export DRA_CHART_SOURCE=oci://ghcr.io/nvidia/k8s-dra-driver-gpu
+        export DRA_CHART_SOURCE=oci://us-central1-docker.pkg.dev/k8s-staging-images/dra-driver-nvidia/charts/dra-driver-nvidia-gpu
         export TEST_FEATURES=dra
 
         export TEST_LABELS=dra-imex
@@ -60,10 +59,6 @@ tests:
 
         export TEST_LABELS=dra-gpu
         make run-tests
-      credentials:
-      - mount_path: /var/run/nvidia-ci
-        name: nvidia-ci
-        namespace: test-credentials
       from: nvidia-ci
       resources:
         requests:


### PR DESCRIPTION
Depends on https://github.com/rh-ecosystem-edge/nvidia-ci/pull/530

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR updates OpenShift CI job configuration for the rh-ecosystem-edge/nvidia-ci repository (the 4.21 DRA test variant) to change how the NVIDIA DRA Helm chart is sourced for GPU E2E tests.

What changed
- Affects: ci-operator config for rh-ecosystem-edge/nvidia-ci — the nvidia-dra-gpu-e2e test step in rh-ecosystem-edge-nvidia-ci-main__4.21-dra.yaml.
- The job now sets DRA_CHART_SOURCE to oci://us-central1-docker.pkg.dev/k8s-staging-images/dra-driver-nvidia/charts/dra-driver-nvidia-gpu (previously the chart was referenced from oci://ghcr.io/nvidia/k8s-dra-driver-gpu).
- DRA_CHART_VERSION is still obtained via ./scripts/get-latest-dra-chart.sh; the test step sequence (nvidiagpu run, then dra-imex and dra-gpu runs) is unchanged.
- The change removes the prior explicit export of a GitHub packages read token (the job no longer sets READ_PACKAGES_GITHUB_TOKEN_FILE).

Notes
- The PR is held pending rh-ecosystem-edge/nvidia-ci#528 (author requested /hold until that PR is merged).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->