### PR TITLE
osac-project: add edge04 unified vmaas test job

### DIFF
--- a/ci-operator/config/osac-project/osac-test-infra/osac-project-osac-test-infra-main.yaml
+++ b/ci-operator/config/osac-project/osac-test-infra/osac-project-osac-test-infra-main.yaml
@@ -58,6 +58,11 @@ resources:
       cpu: 100m
       memory: 200Mi
 tests:
+- as: e2e-edge04-vmaas-all-pr
+  capabilities:
+  - intranet
+  steps:
+    workflow: osac-project-edge04
 - as: e2e-metal-vmaas-compute-instance-creation-pr
   capabilities:
   - intranet

--- a/ci-operator/jobs/osac-project/osac-test-infra/osac-project-osac-test-infra-main-presubmits.yaml
+++ b/ci-operator/jobs/osac-project/osac-test-infra/osac-project-osac-test-infra-main-presubmits.yaml
@@ -6,6 +6,88 @@ presubmits:
     - ^main$
     - ^main-
     cluster: build03
+    context: ci/prow/e2e-edge04-vmaas-all-pr
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      capability/intranet: intranet
+      ci.openshift.io/generator: prowgen
+      job-release: "4.20"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-osac-project-osac-test-infra-main-e2e-edge04-vmaas-all-pr
+    rerun_command: /test e2e-edge04-vmaas-all-pr
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-edge04-vmaas-all-pr
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-edge04-vmaas-all-pr,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build03
     context: ci/prow/e2e-metal-vmaas-compute-instance-api-fields-pr
     decorate: true
     decoration_config:

--- a/ci-operator/step-registry/osac-project/edge04/OWNERS
+++ b/ci-operator/step-registry/osac-project/edge04/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+- osac-cicd
+options: {}
+reviewers:
+- osac-cicd

--- a/ci-operator/step-registry/osac-project/edge04/osac-project-edge04-workflow.metadata.json
+++ b/ci-operator/step-registry/osac-project/edge04/osac-project-edge04-workflow.metadata.json
@@ -1,0 +1,11 @@
+{
+	"path": "osac-project/edge04/osac-project-edge04-workflow.yaml",
+	"owners": {
+		"approvers": [
+			"osac-cicd"
+		],
+		"reviewers": [
+			"osac-cicd"
+		]
+	}
+}

--- a/ci-operator/step-registry/osac-project/edge04/osac-project-edge04-workflow.yaml
+++ b/ci-operator/step-registry/osac-project/edge04/osac-project-edge04-workflow.yaml
@@ -1,0 +1,14 @@
+workflow:
+  as: osac-project-edge04
+  steps:
+    allow_best_effort_post_steps: true
+    allow_skip_on_success: true
+    test:
+      - ref: osac-project-edge04-test
+    post:
+      - ref: osac-project-gather
+  documentation: |-
+    Runs the full vmaas test suite on the persistent edge-04 baremetal host
+    (edge-04.edge.lab.eng.rdu2.redhat.com) via SSH. No cluster provisioning is
+    required — the environment is already set up on edge-04. All tests run
+    sequentially in a single environment.

--- a/ci-operator/step-registry/osac-project/edge04/osac-project-edge04-workflow.yaml
+++ b/ci-operator/step-registry/osac-project/edge04/osac-project-edge04-workflow.yaml
@@ -4,6 +4,7 @@ workflow:
     allow_best_effort_post_steps: true
     allow_skip_on_success: true
     test:
+      - ref: wait
       - ref: osac-project-edge04-test
     post:
       - ref: osac-project-gather

--- a/ci-operator/step-registry/osac-project/edge04/osac-project-edge04-workflow.yaml
+++ b/ci-operator/step-registry/osac-project/edge04/osac-project-edge04-workflow.yaml
@@ -4,9 +4,9 @@ workflow:
     allow_best_effort_post_steps: true
     allow_skip_on_success: true
     test:
-      - ref: wait
       - ref: osac-project-edge04-test
     post:
+      - ref: wait
       - ref: osac-project-gather
   documentation: |-
     Runs the full vmaas test suite on the persistent edge-04 baremetal host

--- a/ci-operator/step-registry/osac-project/edge04/test/OWNERS
+++ b/ci-operator/step-registry/osac-project/edge04/test/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+- osac-cicd
+options: {}
+reviewers:
+- osac-cicd

--- a/ci-operator/step-registry/osac-project/edge04/test/osac-project-edge04-test-commands.sh
+++ b/ci-operator/step-registry/osac-project/edge04/test/osac-project-edge04-test-commands.sh
@@ -19,18 +19,24 @@ E2E_VM_TEMPLATE="$2"
 E2E_CLUSTER_TEMPLATE="$3"
 OSAC_TEST_IMAGE="$4"
 
-KUBECONFIG=$(find /root -name "kubeconfig" -type f -print -quit 2>/dev/null || echo "")
-[[ -z "${KUBECONFIG}" ]] && KUBECONFIG="/root/.kube/config"
+KUBECONFIG="${KUBECONFIG:-/root/.kube/config}"
 [[ ! -f "${KUBECONFIG}" ]] && echo "ERROR: No kubeconfig found at ${KUBECONFIG}" && exit 1
 
 PULL_SECRET_PATH="/root/pull-secret"
 WORK_DIR=$(mktemp -d /tmp/osac-test-XXXXXX)
 
+cleanup() {
+  if compgen -G "${WORK_DIR}/*" > /dev/null; then
+    cp -r "${WORK_DIR}"/* /tmp/
+  fi
+  rm -rf "${WORK_DIR}"
+}
+trap cleanup EXIT
+
 echo "Using kubeconfig: ${KUBECONFIG}"
 echo "Work dir: ${WORK_DIR}"
 echo "Test image: ${OSAC_TEST_IMAGE}"
 
-set +x
 podman run --authfile "${PULL_SECRET_PATH}" --rm --network=host \
   -v "${KUBECONFIG}:/root/.kube/config:z" \
   -v "${PULL_SECRET_PATH}:/root/pull-secret:z" \
@@ -43,9 +49,6 @@ podman run --authfile "${PULL_SECRET_PATH}" --rm --network=host \
   -e OSAC_PULL_SECRET_PATH=/root/pull-secret \
   "${OSAC_TEST_IMAGE}" \
   make test-vmaas
-
-echo "Copying reports"
-cp -r "${WORK_DIR}"/* /tmp/ 2>/dev/null || true
 REMOTE_EOF
 
 echo "Test suite completed"

--- a/ci-operator/step-registry/osac-project/edge04/test/osac-project-edge04-test-commands.sh
+++ b/ci-operator/step-registry/osac-project/edge04/test/osac-project-edge04-test-commands.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+SSH_KEY="/tmp/secrets/edge04/ssh-privatekey"
+SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ${SSH_KEY}"
+
+echo "Running full vmaas test suite on ${EDGE04_USER}@${EDGE04_HOST}"
+
+timeout -s 9 150m ssh ${SSH_OPTS} "${EDGE04_USER}@${EDGE04_HOST}" bash -s \
+  "${E2E_NAMESPACE}" "${E2E_VM_TEMPLATE}" "${E2E_CLUSTER_TEMPLATE}" "${OSAC_TEST_IMAGE}" <<'REMOTE_EOF'
+set -euo pipefail
+
+E2E_NAMESPACE="$1"
+E2E_VM_TEMPLATE="$2"
+E2E_CLUSTER_TEMPLATE="$3"
+OSAC_TEST_IMAGE="$4"
+
+KUBECONFIG=$(find /root -name "kubeconfig" -type f -print -quit 2>/dev/null || echo "")
+[[ -z "${KUBECONFIG}" ]] && KUBECONFIG="/root/.kube/config"
+[[ ! -f "${KUBECONFIG}" ]] && echo "ERROR: No kubeconfig found at ${KUBECONFIG}" && exit 1
+
+PULL_SECRET_PATH="/root/pull-secret"
+WORK_DIR=$(mktemp -d /tmp/osac-test-XXXXXX)
+
+echo "Using kubeconfig: ${KUBECONFIG}"
+echo "Work dir: ${WORK_DIR}"
+echo "Test image: ${OSAC_TEST_IMAGE}"
+
+set +x
+podman run --authfile "${PULL_SECRET_PATH}" --rm --network=host \
+  -v "${KUBECONFIG}:/root/.kube/config:z" \
+  -v "${PULL_SECRET_PATH}:/root/pull-secret:z" \
+  -v "${WORK_DIR}:/reports:z" \
+  -e KUBECONFIG=/root/.kube/config \
+  -e OSAC_VM_KUBECONFIG=/root/.kube/config \
+  -e OSAC_NAMESPACE="${E2E_NAMESPACE}" \
+  -e OSAC_VM_TEMPLATE="${E2E_VM_TEMPLATE}" \
+  -e OSAC_CLUSTER_TEMPLATE="${E2E_CLUSTER_TEMPLATE}" \
+  -e OSAC_PULL_SECRET_PATH=/root/pull-secret \
+  "${OSAC_TEST_IMAGE}" \
+  make test-vmaas
+
+echo "Copying reports"
+cp -r "${WORK_DIR}"/* /tmp/ 2>/dev/null || true
+REMOTE_EOF
+
+echo "Test suite completed"

--- a/ci-operator/step-registry/osac-project/edge04/test/osac-project-edge04-test-commands.sh
+++ b/ci-operator/step-registry/osac-project/edge04/test/osac-project-edge04-test-commands.sh
@@ -5,9 +5,6 @@ set -o errexit
 set -o pipefail
 
 
-echo "DEBUG: sleeping 1h for interactive debugging via oc rsh"
-sleep 3600
-
 SSH_KEY="/tmp/secrets/edge04/ssh-privatekey"
 SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ${SSH_KEY}"
 

--- a/ci-operator/step-registry/osac-project/edge04/test/osac-project-edge04-test-commands.sh
+++ b/ci-operator/step-registry/osac-project/edge04/test/osac-project-edge04-test-commands.sh
@@ -4,6 +4,10 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
+
+echo "DEBUG: sleeping 1h for interactive debugging via oc rsh"
+sleep 3600
+
 SSH_KEY="/tmp/secrets/edge04/ssh-privatekey"
 SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ${SSH_KEY}"
 

--- a/ci-operator/step-registry/osac-project/edge04/test/osac-project-edge04-test-ref.metadata.json
+++ b/ci-operator/step-registry/osac-project/edge04/test/osac-project-edge04-test-ref.metadata.json
@@ -1,0 +1,11 @@
+{
+	"path": "osac-project/edge04/test/osac-project-edge04-test-ref.yaml",
+	"owners": {
+		"approvers": [
+			"osac-cicd"
+		],
+		"reviewers": [
+			"osac-cicd"
+		]
+	}
+}

--- a/ci-operator/step-registry/osac-project/edge04/test/osac-project-edge04-test-ref.yaml
+++ b/ci-operator/step-registry/osac-project/edge04/test/osac-project-edge04-test-ref.yaml
@@ -1,0 +1,36 @@
+ref:
+  as: osac-project-edge04-test
+  from: dev-scripts
+  dependencies:
+  - name: osac-test-infra
+    env: OSAC_TEST_IMAGE
+  grace_period: 10m
+  timeout: 3h0m0s
+  commands: osac-project-edge04-test-commands.sh
+  resources:
+    requests:
+      cpu: 100m
+      memory: 200Mi
+  credentials:
+  - namespace: test-credentials
+    name: edge04key
+    mount_path: /tmp/secrets/edge04
+  env:
+  - name: EDGE04_HOST
+    default: "edge-04.edge.lab.eng.rdu2.redhat.com"
+    documentation: The edge-04 baremetal host to run tests on
+  - name: EDGE04_USER
+    default: "root"
+    documentation: SSH user for edge-04
+  - name: E2E_NAMESPACE
+    default: "osac-e2e-ci"
+    documentation: The namespace to use for the e2e tests
+  - name: E2E_VM_TEMPLATE
+    default: "osac.templates.ocp_virt_vm"
+    documentation: The VM template to use for the e2e tests
+  - name: E2E_CLUSTER_TEMPLATE
+    default: "osac.templates.ocp_4_17_small"
+    documentation: The cluster template to use for CaaS e2e tests
+  documentation: |-
+    Runs the full vmaas test suite on a persistent edge-04 baremetal host via SSH,
+    without provisioning a new cluster. All tests run sequentially in a single environment.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# osac-project: Add edge04 unified vmaas test job

This PR updates the OpenShift CI configuration (openshift/release → osac-project) to add a new PR presubmit that runs the full vMAAS test suite against the persistent [edge-04](https://redhat.atlassian.net/browse/edge-04) baremetal host.

What changed, in practical terms
- Added a new presubmit test: e2e-edge04-vmaas-all-pr in ci-operator/config/osac-project/osac-test-infra/osac-project-osac-test-infra-main.yaml. The job requires the intranet capability and uses the new osac-project-edge04 workflow.
- Added a new workflow (ci-operator/step-registry/osac-project/edge04/osac-project-edge04-workflow.yaml) that sequences a wait step then the osac-project-edge04-test step and runs osac-project-gather as a post step. (The PR replaces an inline sleep with a wait step to improve debug access timing.)
- Added a test step ref (ci-operator/step-registry/osac-project/edge04/test/osac-project-edge04-test-ref.yaml) that:
  - Runs a dev-scripts-based command with a 3h timeout and 10m grace period.
  - Mounts credentials (edge04key) at /tmp/secrets/edge04.
  - Exposes env vars for EDGE04_HOST/EDGE04_USER and vMAAS test configuration (namespace, VM/cluster templates).
- Added the remote execution script (ci-operator/step-registry/osac-project/edge04/test/osac-project-edge04-test-commands.sh) which SSHes to the configured [edge-04](https://redhat.atlassian.net/browse/edge-04) host, validates kubeconfig, then runs the specified OSAC test image via podman (passing kubeconfig, pull secret, workdir) to execute make test-vmaas and copy test reports back.
- Ownership metadata: added OWNERS and metadata.json files to set osac-cicd as approvers/reviewers for the new workflow, step registry, and test ref.

Why this matters
- The new job validates vMAAS behavior directly against an existing persistent [edge-04](https://redhat.atlassian.net/browse/edge-04) baremetal host ([edge-04](https://redhat.atlassian.net/browse/edge-04).edge.lab.eng.rdu2.redhat.com) over SSH, without provisioning a temporary cluster. This provides faster end-to-end validation of the full vMAAS suite for PRs that affect the osac-project test infra.
- Clear ownership (osac-cicd) and a wait step for debug improve maintainability and interactive debugging during presubmit runs.

Files added/updated (high-level)
- ci-operator/config/osac-project/osac-test-infra/osac-project-osac-test-infra-main.yaml — add e2e-edge04-vmaas-all-pr
- ci-operator/step-registry/osac-project/edge04/ — added workflow YAML + metadata, test ref YAML + metadata, test commands script, and OWNERS files

Behavioral notes
- Job runs sequential tests inside a single persistent environment; it uses SSH keys from the test-credentials secret and expects kubeconfig & pull secret to be available on the remote host.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->