### PR TITLE
neuron-ci: add KServe e2e tests for 4.19 and 4.20 stable variants

### DIFF
--- a/ci-operator/config/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main__4.19-stable.yaml
+++ b/ci-operator/config/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main__4.19-stable.yaml
@@ -88,6 +88,46 @@ tests:
       OPENSHIFT_VERSION: "4.19"
       REGION: us-west-2
     workflow: aws-neuron-operator-conditional-e2e-rosa
+- always_run: false
+  as: aws-neuron-operator-kserve-e2e
+  steps:
+    allow_best_effort_post_steps: true
+    cluster_profile: aws-edge-infra
+    env:
+      ECO_HWACCEL_NEURON_DEVICE_PLUGIN_IMAGE: public.ecr.aws/neuron/neuron-device-plugin:2.29.94.0
+      ECO_HWACCEL_NEURON_DRIVER_VERSION: 2.25.4.0
+      ECO_HWACCEL_NEURON_DRIVERS_IMAGE: public.ecr.aws/os-partners/neuron-openshift/neuron-kernel-module:2.25.4.0
+      ECO_HWACCEL_NEURON_KSERVE_MODEL_NAME: TinyLlama/TinyLlama-1.1B-Chat-v1.0
+      ECO_HWACCEL_NEURON_KSERVE_VLLM_IMAGE: registry.redhat.io/rhaiis/vllm-neuron-rhel9:3
+      ECO_HWACCEL_NEURON_NODE_METRICS_IMAGE: public.ecr.aws/neuron/neuron-monitor:1.3.0
+      ECO_HWACCEL_NEURON_SCHEDULER_EXTENSION_IMAGE: public.ecr.aws/neuron/neuron-scheduler:2.29.94.0
+      ECO_HWACCEL_NEURON_SCHEDULER_IMAGE: public.ecr.aws/eks-distro/kubernetes/kube-scheduler:v1.32.9-eks-1-32-24
+      OCM_LOGIN_ENV: production
+      OPENSHIFT_VERSION: "4.19"
+      REGION: us-west-2
+      RHOAI_CHANNEL: stable-3.x
+      VLLM_NEURON_IMAGE: registry.redhat.io/rhaiis/vllm-neuron-rhel9:3
+    workflow: aws-neuron-operator-kserve-e2e-rosa
+- as: aws-neuron-operator-kserve-e2e-weekly
+  cron: 0 6 * * 4
+  steps:
+    allow_best_effort_post_steps: true
+    cluster_profile: aws-edge-infra
+    env:
+      ECO_HWACCEL_NEURON_DEVICE_PLUGIN_IMAGE: public.ecr.aws/neuron/neuron-device-plugin:2.29.94.0
+      ECO_HWACCEL_NEURON_DRIVER_VERSION: 2.25.4.0
+      ECO_HWACCEL_NEURON_DRIVERS_IMAGE: public.ecr.aws/os-partners/neuron-openshift/neuron-kernel-module:2.25.4.0
+      ECO_HWACCEL_NEURON_KSERVE_MODEL_NAME: TinyLlama/TinyLlama-1.1B-Chat-v1.0
+      ECO_HWACCEL_NEURON_KSERVE_VLLM_IMAGE: registry.redhat.io/rhaiis/vllm-neuron-rhel9:3
+      ECO_HWACCEL_NEURON_NODE_METRICS_IMAGE: public.ecr.aws/neuron/neuron-monitor:1.3.0
+      ECO_HWACCEL_NEURON_SCHEDULER_EXTENSION_IMAGE: public.ecr.aws/neuron/neuron-scheduler:2.29.94.0
+      ECO_HWACCEL_NEURON_SCHEDULER_IMAGE: public.ecr.aws/eks-distro/kubernetes/kube-scheduler:v1.32.9-eks-1-32-24
+      OCM_LOGIN_ENV: production
+      OPENSHIFT_VERSION: "4.19"
+      REGION: us-west-2
+      RHOAI_CHANNEL: stable-3.x
+      VLLM_NEURON_IMAGE: registry.redhat.io/rhaiis/vllm-neuron-rhel9:3
+    workflow: aws-neuron-operator-kserve-e2e-rosa
 zz_generated_metadata:
   branch: main
   org: rh-ecosystem-edge

--- a/ci-operator/config/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main__4.20-stable.yaml
+++ b/ci-operator/config/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main__4.20-stable.yaml
@@ -89,6 +89,46 @@ tests:
       OPENSHIFT_VERSION: "4.20"
       REGION: us-west-2
     workflow: aws-neuron-operator-conditional-e2e-rosa
+- always_run: false
+  as: aws-neuron-operator-kserve-e2e
+  steps:
+    allow_best_effort_post_steps: true
+    cluster_profile: aws-edge-infra
+    env:
+      ECO_HWACCEL_NEURON_DEVICE_PLUGIN_IMAGE: public.ecr.aws/neuron/neuron-device-plugin:2.29.94.0
+      ECO_HWACCEL_NEURON_DRIVER_VERSION: 2.25.4.0
+      ECO_HWACCEL_NEURON_DRIVERS_IMAGE: public.ecr.aws/os-partners/neuron-openshift/neuron-kernel-module:2.25.4.0
+      ECO_HWACCEL_NEURON_KSERVE_MODEL_NAME: TinyLlama/TinyLlama-1.1B-Chat-v1.0
+      ECO_HWACCEL_NEURON_KSERVE_VLLM_IMAGE: registry.redhat.io/rhaiis/vllm-neuron-rhel9:3
+      ECO_HWACCEL_NEURON_NODE_METRICS_IMAGE: public.ecr.aws/neuron/neuron-monitor:1.3.0
+      ECO_HWACCEL_NEURON_SCHEDULER_EXTENSION_IMAGE: public.ecr.aws/neuron/neuron-scheduler:2.29.94.0
+      ECO_HWACCEL_NEURON_SCHEDULER_IMAGE: public.ecr.aws/eks-distro/kubernetes/kube-scheduler:v1.32.9-eks-1-32-24
+      OCM_LOGIN_ENV: production
+      OPENSHIFT_VERSION: "4.20"
+      REGION: us-west-2
+      RHOAI_CHANNEL: stable-3.x
+      VLLM_NEURON_IMAGE: registry.redhat.io/rhaiis/vllm-neuron-rhel9:3
+    workflow: aws-neuron-operator-kserve-e2e-rosa
+- as: aws-neuron-operator-kserve-e2e-weekly
+  cron: 0 6 * * 5
+  steps:
+    allow_best_effort_post_steps: true
+    cluster_profile: aws-edge-infra
+    env:
+      ECO_HWACCEL_NEURON_DEVICE_PLUGIN_IMAGE: public.ecr.aws/neuron/neuron-device-plugin:2.29.94.0
+      ECO_HWACCEL_NEURON_DRIVER_VERSION: 2.25.4.0
+      ECO_HWACCEL_NEURON_DRIVERS_IMAGE: public.ecr.aws/os-partners/neuron-openshift/neuron-kernel-module:2.25.4.0
+      ECO_HWACCEL_NEURON_KSERVE_MODEL_NAME: TinyLlama/TinyLlama-1.1B-Chat-v1.0
+      ECO_HWACCEL_NEURON_KSERVE_VLLM_IMAGE: registry.redhat.io/rhaiis/vllm-neuron-rhel9:3
+      ECO_HWACCEL_NEURON_NODE_METRICS_IMAGE: public.ecr.aws/neuron/neuron-monitor:1.3.0
+      ECO_HWACCEL_NEURON_SCHEDULER_EXTENSION_IMAGE: public.ecr.aws/neuron/neuron-scheduler:2.29.94.0
+      ECO_HWACCEL_NEURON_SCHEDULER_IMAGE: public.ecr.aws/eks-distro/kubernetes/kube-scheduler:v1.32.9-eks-1-32-24
+      OCM_LOGIN_ENV: production
+      OPENSHIFT_VERSION: "4.20"
+      REGION: us-west-2
+      RHOAI_CHANNEL: stable-3.x
+      VLLM_NEURON_IMAGE: registry.redhat.io/rhaiis/vllm-neuron-rhel9:3
+    workflow: aws-neuron-operator-kserve-e2e-rosa
 zz_generated_metadata:
   branch: main
   org: rh-ecosystem-edge

--- a/ci-operator/jobs/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main-periodics.yaml
+++ b/ci-operator/jobs/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main-periodics.yaml
@@ -82,6 +82,87 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
+  cron: 0 6 * * 4
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: rh-ecosystem-edge
+    repo: neuron-ci
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-edge-infra
+    ci-operator.openshift.io/variant: 4.19-stable
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-rh-ecosystem-edge-neuron-ci-main-4.19-stable-aws-neuron-operator-kserve-e2e-weekly
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=aws-neuron-operator-kserve-e2e-weekly
+      - --variant=4.19-stable
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
   cluster: build11
   cron: 0 6 * * 1
   decorate: true
@@ -107,6 +188,87 @@ periodics:
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
       - --target=aws-neuron-operator-e2e-weekly
+      - --variant=4.20-stable
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cron: 0 6 * * 5
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: rh-ecosystem-edge
+    repo: neuron-ci
+  labels:
+    ci-operator.openshift.io/cloud: aws
+    ci-operator.openshift.io/cloud-cluster-profile: aws-edge-infra
+    ci-operator.openshift.io/variant: 4.20-stable
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-rh-ecosystem-edge-neuron-ci-main-4.20-stable-aws-neuron-operator-kserve-e2e-weekly
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=aws-neuron-operator-kserve-e2e-weekly
       - --variant=4.20-stable
       command:
       - ci-operator

--- a/ci-operator/jobs/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main-periodics.yaml
+++ b/ci-operator/jobs/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main-periodics.yaml
@@ -82,6 +82,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
+  cluster: build11
   cron: 0 6 * * 4
   decorate: true
   decoration_config:
@@ -245,6 +246,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
+  cluster: build11
   cron: 0 6 * * 5
   decorate: true
   decoration_config:

--- a/ci-operator/jobs/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main-presubmits.yaml
+++ b/ci-operator/jobs/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main-presubmits.yaml
@@ -89,6 +89,7 @@ presubmits:
     branches:
     - ^main$
     - ^main-
+    cluster: build01
     context: ci/prow/4.19-stable-aws-neuron-operator-kserve-e2e
     decorate: true
     decoration_config:
@@ -313,6 +314,7 @@ presubmits:
     branches:
     - ^main$
     - ^main-
+    cluster: build01
     context: ci/prow/4.20-stable-aws-neuron-operator-kserve-e2e
     decorate: true
     decoration_config:

--- a/ci-operator/jobs/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main-presubmits.yaml
+++ b/ci-operator/jobs/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main-presubmits.yaml
@@ -85,6 +85,89 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )(4.19-stable-aws-neuron-operator-e2e|remaining-required),?($|\s.*)
   - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    context: ci/prow/4.19-stable-aws-neuron-operator-kserve-e2e
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: aws-edge-infra
+      ci-operator.openshift.io/variant: 4.19-stable
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-rh-ecosystem-edge-neuron-ci-main-4.19-stable-aws-neuron-operator-kserve-e2e
+    rerun_command: /test 4.19-stable-aws-neuron-operator-kserve-e2e
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=aws-neuron-operator-kserve-e2e
+        - --variant=4.19-stable
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )(4.19-stable-aws-neuron-operator-kserve-e2e|remaining-required),?($|\s.*)
+  - agent: kubernetes
     always_run: true
     branches:
     - ^main$
@@ -225,6 +308,89 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )(4.20-stable-aws-neuron-operator-e2e|remaining-required),?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    context: ci/prow/4.20-stable-aws-neuron-operator-kserve-e2e
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: aws-edge-infra
+      ci-operator.openshift.io/variant: 4.20-stable
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-rh-ecosystem-edge-neuron-ci-main-4.20-stable-aws-neuron-operator-kserve-e2e
+    rerun_command: /test 4.20-stable-aws-neuron-operator-kserve-e2e
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=aws-neuron-operator-kserve-e2e
+        - --variant=4.20-stable
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )(4.20-stable-aws-neuron-operator-kserve-e2e|remaining-required),?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:


### PR DESCRIPTION
## Summary
- Add KServe on-demand and weekly periodic e2e tests to the 4.19-stable and 4.20-stable neuron-ci variants
- KServe tests were previously only configured for 4.21-stable, but the workflow (`aws-neuron-operator-kserve-e2e-rosa`) already handles OCP version differences (Serverless mode for <4.21, RawDeployment for >=4.21)
- Weekly cron jobs staggered: Thu for 4.19, Fri for 4.20 (existing: Sun-Tue for e2e-weekly, Wed for 4.21 kserve-weekly)

## Test plan
- [ ] Validate kserve job is triggerable via `/test 4.21-stable-aws-neuron-operator-kserve-e2e` on [neuron-ci PR #19](https://github.com/rh-ecosystem-edge/neuron-ci/pull/19) (already defined, verifies workflow works)
- [ ] After merge, trigger `/test 4.19-stable-aws-neuron-operator-kserve-e2e` and `/test 4.20-stable-aws-neuron-operator-kserve-e2e` to validate new jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request extends KServe end-to-end testing to the OpenShift 4.19 and 4.20 stable variants in the neuron-ci component repository's CI configuration.

## Changes

The PR adds KServe on-demand and weekly periodic e2e test jobs to two neuron-ci CI configuration files:

- **4.19-stable configuration**: Adds `aws-neuron-operator-kserve-e2e` (on-demand) and `aws-neuron-operator-kserve-e2e-weekly` (scheduled weekly on Thursdays) test jobs
- **4.20-stable configuration**: Adds the same test jobs with the weekly schedule shifted to Fridays

Both configurations:
- Use the existing `aws-neuron-operator-kserve-e2e-rosa` workflow, which automatically handles the differences between OpenShift versions (Serverless mode for <4.21, RawDeployment for >=4.21)
- Configure environment variables for Neuron device/plugin configuration and KServe-specific settings (model names, VLLM images, RHOAI channel)
- Run on the `aws-edge-infra` cluster profile

## Testing

The test jobs can be triggered on PRs using `/test 4.19-stable-aws-neuron-operator-kserve-e2e` and `/test 4.20-stable-aws-neuron-operator-kserve-e2e` after merge to validate the new configurations are working correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->