### PR TITLE
Adding ARO post submit jobs

### DIFF
--- a/ci-operator/config/Azure/ARO-RP/Azure-ARO-RP-master.yaml
+++ b/ci-operator/config/Azure/ARO-RP/Azure-ARO-RP-master.yaml
@@ -44,7 +44,7 @@ tests:
     cluster_profile: aro-classic-int
     env:
       E2E_TYPE: miwi
-      LOCATION: uksouth
+      LOCATION: eastus
     workflow: aro-classic-e2e
 - always_run: false
   as: stage-e2e-parallel-miwi
@@ -53,7 +53,7 @@ tests:
     cluster_profile: aro-classic-stg
     env:
       E2E_TYPE: miwi
-      LOCATION: uksouth
+      LOCATION: westus2
     workflow: aro-classic-e2e
 - always_run: false
   as: prod-e2e-parallel-miwi
@@ -79,7 +79,7 @@ tests:
     cluster_profile: aro-classic-int
     env:
       E2E_TYPE: csp
-      LOCATION: uksouth
+      LOCATION: eastus
     workflow: aro-classic-e2e
 - always_run: false
   as: stage-e2e-parallel-csp
@@ -88,7 +88,7 @@ tests:
     cluster_profile: aro-classic-stg
     env:
       E2E_TYPE: csp
-      LOCATION: uksouth
+      LOCATION: westus2
     workflow: aro-classic-e2e
 - always_run: false
   as: prod-e2e-parallel-csp

--- a/ci-operator/config/Azure/ARO-RP/Azure-ARO-RP-master__e2e.yaml
+++ b/ci-operator/config/Azure/ARO-RP/Azure-ARO-RP-master__e2e.yaml
@@ -21,54 +21,54 @@ resources:
       cpu: 100m
       memory: 200Mi
 tests:
-- always_run: false
-  as: integration-e2e-parallel-miwi
-  cron: 0 0 1 1 *
+- as: integration-e2e-parallel-miwi
+  postsubmit: true
+  run_if_changed: ^$
   steps:
     cluster_profile: aro-classic-int
     env:
       E2E_TYPE: miwi
       LOCATION: eastus
     workflow: aro-classic-e2e
-- always_run: false
-  as: stage-e2e-parallel-miwi
-  cron: 0 0 1 1 *
+- as: stage-e2e-parallel-miwi
+  postsubmit: true
+  run_if_changed: ^$
   steps:
     cluster_profile: aro-classic-stg
     env:
       E2E_TYPE: miwi
       LOCATION: westus2
     workflow: aro-classic-e2e
-- always_run: false
-  as: prod-e2e-parallel-miwi
-  cron: 0 0 1 1 *
+- as: prod-e2e-parallel-miwi
+  postsubmit: true
+  run_if_changed: ^$
   steps:
     cluster_profile: aro-classic-prod
     env:
       E2E_TYPE: miwi
       LOCATION: uksouth
     workflow: aro-classic-e2e
-- always_run: false
-  as: integration-e2e-parallel-csp
-  cron: 0 0 1 1 *
+- as: integration-e2e-parallel-csp
+  postsubmit: true
+  run_if_changed: ^$
   steps:
     cluster_profile: aro-classic-int
     env:
       E2E_TYPE: csp
       LOCATION: eastus
     workflow: aro-classic-e2e
-- always_run: false
-  as: stage-e2e-parallel-csp
-  cron: 0 0 1 1 *
+- as: stage-e2e-parallel-csp
+  postsubmit: true
+  run_if_changed: ^$
   steps:
     cluster_profile: aro-classic-stg
     env:
       E2E_TYPE: csp
       LOCATION: westus2
     workflow: aro-classic-e2e
-- always_run: false
-  as: prod-e2e-parallel-csp
-  cron: 0 0 1 1 *
+- as: prod-e2e-parallel-csp
+  postsubmit: true
+  run_if_changed: ^$
   steps:
     cluster_profile: aro-classic-prod
     env:
@@ -79,4 +79,4 @@ zz_generated_metadata:
   branch: master
   org: Azure
   repo: ARO-RP
-  variant: periodic
+  variant: e2e

--- a/ci-operator/jobs/Azure/ARO-RP/Azure-ARO-RP-master-postsubmits.yaml
+++ b/ci-operator/jobs/Azure/ARO-RP/Azure-ARO-RP-master-postsubmits.yaml
@@ -1,6 +1,492 @@
 postsubmits:
   Azure/ARO-RP:
   - agent: kubernetes
+    always_run: false
+    branches:
+    - ^master$
+    cluster: build08
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: aro-classic-int
+      ci-operator.openshift.io/cloud-cluster-profile: aro-classic-int
+      ci-operator.openshift.io/variant: e2e
+      ci.openshift.io/generator: prowgen
+    max_concurrency: 1
+    name: branch-ci-Azure-ARO-RP-master-e2e-integration-e2e-parallel-csp
+    run_if_changed: ^$
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=integration-e2e-parallel-csp
+        - --variant=e2e
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^master$
+    cluster: build08
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: aro-classic-int
+      ci-operator.openshift.io/cloud-cluster-profile: aro-classic-int
+      ci-operator.openshift.io/variant: e2e
+      ci.openshift.io/generator: prowgen
+    max_concurrency: 1
+    name: branch-ci-Azure-ARO-RP-master-e2e-integration-e2e-parallel-miwi
+    run_if_changed: ^$
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=integration-e2e-parallel-miwi
+        - --variant=e2e
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^master$
+    cluster: build08
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: aro-classic-prod
+      ci-operator.openshift.io/cloud-cluster-profile: aro-classic-prod
+      ci-operator.openshift.io/variant: e2e
+      ci.openshift.io/generator: prowgen
+    max_concurrency: 1
+    name: branch-ci-Azure-ARO-RP-master-e2e-prod-e2e-parallel-csp
+    run_if_changed: ^$
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=prod-e2e-parallel-csp
+        - --variant=e2e
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^master$
+    cluster: build08
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: aro-classic-prod
+      ci-operator.openshift.io/cloud-cluster-profile: aro-classic-prod
+      ci-operator.openshift.io/variant: e2e
+      ci.openshift.io/generator: prowgen
+    max_concurrency: 1
+    name: branch-ci-Azure-ARO-RP-master-e2e-prod-e2e-parallel-miwi
+    run_if_changed: ^$
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=prod-e2e-parallel-miwi
+        - --variant=e2e
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^master$
+    cluster: build08
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: aro-classic-stg
+      ci-operator.openshift.io/cloud-cluster-profile: aro-classic-stg
+      ci-operator.openshift.io/variant: e2e
+      ci.openshift.io/generator: prowgen
+    max_concurrency: 1
+    name: branch-ci-Azure-ARO-RP-master-e2e-stage-e2e-parallel-csp
+    run_if_changed: ^$
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=stage-e2e-parallel-csp
+        - --variant=e2e
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^master$
+    cluster: build08
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: aro-classic-stg
+      ci-operator.openshift.io/cloud-cluster-profile: aro-classic-stg
+      ci-operator.openshift.io/variant: e2e
+      ci.openshift.io/generator: prowgen
+    max_concurrency: 1
+    name: branch-ci-Azure-ARO-RP-master-e2e-stage-e2e-parallel-miwi
+    run_if_changed: ^$
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=stage-e2e-parallel-miwi
+        - --variant=e2e
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+  - agent: kubernetes
     always_run: true
     branches:
     - ^master$


### PR DESCRIPTION
Adding ARO post submit jobs. I believe this is the more correct type of test to invoke post-deployment. Also pointing the int and stg jobs to the correct environment by default because it's been bothering me.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This pull request adds CI/CD configuration for Azure ARO-RP (Azure Red Hat OpenShift Resource Provider) end-to-end testing in the OpenShift release repository.

The PR introduces three new CI configuration files:

**Azure-ARO-RP-master.yaml** (base configuration)
- Establishes the base CI configuration for ARO-RP testing
- Defines E2E test steps for two test suites: MIWI and CSP (Cloud Service Provider)
- Configures tests across multiple cluster profiles (dev, integration, staging, and production)
- Specifies Azure regions via the LOCATION environment variable appropriate to each environment: `eastus` for integration, `westus2` for staging, and `uksouth` for production and dev clusters

**Azure-ARO-RP-master__e2e.yaml** (postsubmit jobs)
- Adds 6 new postsubmit E2E jobs that run after code is merged to the master branch
- Tests both MIWI and CSP suites across integration, staging, and production cluster profiles
- Configured with `run_if_changed: ^$` to ensure they run regardless of what files changed
- Each job uses the same region configuration as the base setup

**Azure-ARO-RP-master__periodic.yaml** (periodic jobs)
- Adds 6 periodic E2E tests scheduled to run on January 1st each year
- Same structure and region configuration as the postsubmit variant
- Provides scheduled testing cadence for both test suites across all environments

The configuration ensures that ARO-RP tests run in environment-appropriate Azure regions and against the correct cluster profiles, with postsubmit jobs validating changes immediately after merge and periodic jobs providing scheduled validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->