### PR TITLE
NO-JIRA: feat: use ci images now that we promote them in edge-tooling

### DIFF
--- a/ci-operator/step-registry/openshift/edge-tooling/gh-notifier/openshift-edge-tooling-gh-notifier-ref.yaml
+++ b/ci-operator/step-registry/openshift/edge-tooling/gh-notifier/openshift-edge-tooling-gh-notifier-ref.yaml
@@ -1,6 +1,9 @@
 ref:
   as: openshift-edge-tooling-gh-notifier
-  from: edge-tooling
+  from_image:
+    namespace: ci
+    name: edge-tooling-ai-helpers
+    tag: latest
   commands: openshift-edge-tooling-gh-notifier-commands.sh
   credentials:
   - namespace: test-credentials
@@ -48,10 +51,4 @@ ref:
   timeout: 30m0s
   grace_period: 5m0s
   documentation: |-
-    Runs the gh-notifier image built from openshift-eng/edge-tooling (pipeline image gh-notifier via
-    dockerfile_literal in ci-operator config), exports GitHub App and Slack credentials, and executes
-    GH_NOTIFIER_INVOKE. No runtime git clone—the src checkout is in the image; optional pip install of ./gh-notifier
-    runs at image build when pyproject.toml or setup.py exists. gh-token is installed in the image at build time.
-    After the notifier succeeds, ./gh-notifier/pr-dashboard.html is copied to
-    "${ARTIFACT_DIR}/edge-tooling-pr-summary.html" so Spyglass can show it (html lens *-summary*.html) and GCS/deck
-    can link the same path as in slack reporter templates (see ocp-ci-monitor / microshift ci-doctor patterns).
+    Runs gh-notifier a tool to notify about pull requests that need attention, see more in https://github.com/openshift-eng/edge-tooling/blob/main/gh-notifier/README.md.

--- a/ci-operator/step-registry/openshift/edge-tooling/gh-notifier/openshift-edge-tooling-gh-notifier-workflow.yaml
+++ b/ci-operator/step-registry/openshift/edge-tooling/gh-notifier/openshift-edge-tooling-gh-notifier-workflow.yaml
@@ -4,5 +4,4 @@ workflow:
     test:
     - ref: openshift-edge-tooling-gh-notifier
   documentation: |-
-    Builds and runs the gh-notifier image from openshift-eng/edge-tooling (dockerfile_literal in ci-operator config),
-    wires GitHub App and Slack credentials, and runs GH_NOTIFIER_INVOKE (no runtime clone; repo tree comes from src).
+    Runs gh-notifier a tool to notify about pull requests that need attention, see more in https://github.com/openshift-eng/edge-tooling/blob/main/gh-notifier/README.md.

--- a/ci-operator/step-registry/openshift/edge-tooling/microshift-ci/doctor/openshift-edge-tooling-microshift-ci-doctor-ref.yaml
+++ b/ci-operator/step-registry/openshift/edge-tooling/microshift-ci/doctor/openshift-edge-tooling-microshift-ci-doctor-ref.yaml
@@ -1,6 +1,9 @@
 ref:
   as: openshift-edge-tooling-microshift-ci-doctor
-  from: edge-tooling-ai-helpers
+  from_image:
+    namespace: ci
+    name: edge-tooling-ai-helpers
+    tag: latest
   commands: openshift-edge-tooling-microshift-ci-doctor-commands.sh
   credentials:
   - namespace: test-credentials


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR updates OpenShift Edge Tooling’s CI step-registry entries to explicitly use the promoted CI images from the ci namespace instead of implicit/local image references, making image sourcing explicit and reproducible.

Practical changes:
- Two step definitions (and the gh-notifier workflow) used by the edge-tooling CI pipeline now reference the promoted helper image via from_image: namespace: ci, name: edge-tooling-ai-helpers, tag: latest:
  - openshift-edge-tooling-gh-notifier (ref YAML + workflow): the gh-notifier step now pulls ci/edge-tooling-ai-helpers:latest and its workflow documentation was shortened to a concise README pointer.
  - openshift-edge-tooling-microshift-ci-doctor (ref YAML): the microshift-ci doctor step now pulls ci/edge-tooling-ai-helpers:latest; its behavior, environment, credentials, and resource settings are unchanged aside from the image spec.
- Documentation strings for the gh-notifier step/workflow were shortened (removed a longer build/run description); microshift-ci-doctor documentation remains as the concise analyzer description.

Why this matters:
- CI jobs for edge-tooling will now pull the explicitly promoted helper image from the CI registry (ci/edge-tooling-ai-helpers:latest), improving reproducibility and aligning with edge-tooling’s image promotion flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->