### PR TITLE
[WIP] Test cluster for Tempo

### DIFF
--- a/ci-operator/config/openshift/grafana-tempo-operator/openshift-grafana-tempo-operator-main__upstream-ocp-4.22-amd64.yaml
+++ b/ci-operator/config/openshift/grafana-tempo-operator/openshift-grafana-tempo-operator-main__upstream-ocp-4.22-amd64.yaml
@@ -7,6 +7,10 @@ base_images:
     name: "4.19"
     namespace: origin
     tag: operator-sdk
+  tests-private:
+    name: tests-private
+    namespace: ci
+    tag: "4.22"
   upi-installer:
     name: "4.12"
     namespace: ocp
@@ -66,7 +70,7 @@ tests:
             {"name": "lightspeed-operator", "source": "redhat-operators", "channel": "stable", "install_namespace": "openshift-lightspeed", "target_namespaces": "openshift-lightspeed", "operator_group": "openshift-lightspeed"},
             {"name": "serverless-operator", "source": "redhat-operators", "channel": "stable", "install_namespace": "openshift-serverless", "target_namespaces": "", "operator_group": "openshift-serverless"}
         ]
-      SKIP_TESTS: tests/e2e-openshift-object-stores/*
+      SLEEP_DURATION: 6h
     test:
     - as: install
       cli: latest
@@ -83,8 +87,7 @@ tests:
           cpu: 1000m
           memory: 400Mi
     - ref: install-operators
-    - ref: distributed-tracing-tests-tempo-upstream
-    - ref: distributed-tracing-tests-tracing-ui-integration
+    - ref: cucushift-installer-wait
     workflow: cucushift-installer-rehearse-azure-ipi
 zz_generated_metadata:
   branch: main


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updates CI configuration for the openshift/grafana-tempo-operator repository's upstream-ocp-4.22-amd64 job to change how the Tempo operator is tested on OpenShift CI.

Practical changes:
- Adds a new base image entry tests-private (namespace: ci, tag: "4.22") used by the job.
- For the tempo-upstream-tests job (cluster_profile: azure-observability / upstream OCP 4.22):
  - Sets SLEEP_DURATION=6h in the test environment to allow more time for cluster/resources to stabilize before tests run.
  - The tempo install step runs the operator bundle via operator-sdk and waits for the tempo-operator deployment to become Available.
  - Replaces prior distributed-tracing test dependencies with a simpler installer wait by removing distributed-tracing-tests-tempo-upstream and distributed-tracing-tests-tracing-ui-integration and adding cucushift-installer-wait (workflow: cucushift-installer-rehearse-azure-ipi).
- Keeps the Azure observability cluster profile and existing operator install/installer workflow but shifts focus from running specialized distributed-tracing prereqs to ensuring the installer has finished/provisioning is stable before executing Tempo tests.

Impact: Simplifies the test cluster setup for Tempo by relying on a longer stabilization period and an installer-wait step rather than chaining separate distributed tracing test jobs; affects the Grafana Tempo operator’s OpenShift CI job for upstream-ocp-4.22-amd64.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->