### PR TITLE
fix(hypershift-kubevirt): grant networkpolicies RBAC to external infra SA

### DIFF
--- a/ci-operator/step-registry/hypershift/kubevirt/install/create-external-infra-kubeconfig/hypershift-kubevirt-install-create-external-infra-kubeconfig-commands.sh
+++ b/ci-operator/step-registry/hypershift/kubevirt/install/create-external-infra-kubeconfig/hypershift-kubevirt-install-create-external-infra-kubeconfig-commands.sh
@@ -85,6 +85,12 @@ rules:
     verbs:
       - '*'
   - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - '*'
+  - apiGroups:
       - k8s.ovn.org
     resources:
       - egressfirewalls
@@ -114,6 +120,36 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: kv-external-infra-role
+EOF
+
+# ClusterRole to read cluster network config (needed for virt-launcher NetworkPolicy CIDR-based egress rules)
+oc apply -f - <<EOF
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kv-external-infra-network-reader
+rules:
+  - apiGroups:
+      - config.openshift.io
+    resources:
+      - networks
+    verbs:
+      - get
+EOF
+
+oc apply -f - <<EOF
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kv-external-infra-network-reader-binding
+subjects:
+  - kind: ServiceAccount
+    name: ${SA_NAME}
+    namespace: ${EXTERNAL_INFRA_NS}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kv-external-infra-network-reader
 EOF
 
 


### PR DESCRIPTION
The hypershift-operator now creates a virt-launcher NetworkPolicy on the external infrastructure cluster to enforce network isolation for KubeVirt guest VMs (openshift/hypershift#8056, OCPBUGS-78575). A new ValidKubeVirtInfraNetworkPolicyRBAC condition was added that requires the external infra service account to have networking.k8s.io/networkpolicies permissions.

The CI step that provisions the restricted infra kubeconfig was not updated to include this permission, so the e2e-hypershift-kubevirt job fails with:
```
  networkpolicies.networking.k8s.io "virt-launcher" is forbidden:
  User "`system:serviceaccount:guest-external-infra-ns:kv-external-infra-sa"
  cannot get resource "networkpolicies" in API group "networking.k8s.io"
```
Add networking.k8s.io/networkpolicies with full verbs to the kv-external-infra-role so the operator can manage the virt-launcher NetworkPolicy on the infra cluster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## KubeVirt external infrastructure RBAC update (openshift/release CI)

**What changed:** The CI step that creates the external infra kubeconfig for hypershift-kubevirt (ci-operator/step-registry/hypershift/kubevirt/install/create-external-infra-kubeconfig/hypershift-kubevirt-install-create-external-infra-kubeconfig-commands.sh) now grants the kv-external-infra service account additional RBAC:
- Adds a Role rule allowing full verbs ("*") on networking.k8s.io/networkpolicies in the external infra namespace so the hypershift operator can create/manage the virt-launcher NetworkPolicy.
- Adds a ClusterRole (kv-external-infra-network-reader) and ClusterRoleBinding giving the same service account get access to config.openshift.io/networks (used for CIDR-based egress rules).

**Why it matters:** The hypershift operator was updated to enforce network isolation for KubeVirt VMs by creating virt-launcher NetworkPolicy objects on the external infra cluster. A new ValidKubeVirtInfraNetworkPolicyRBAC validation requires the external infra service account to have networkpolicy permissions; the previous CI-provisioned restricted kubeconfig lacked them, causing e2e-hypershift-kubevirt runs to fail with forbidden errors.

**Impact:** Aligns the CI-provisioned infra kubeconfig's permissions with operator runtime needs and fixes the e2e-hypershift-kubevirt test failures by enabling the operator to manage NetworkPolicies and read cluster network configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->