### PR TITLE
Change schedules for 4.21, 4.22 ppc64le jobs

### DIFF
--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.21__ppc64le-nightly.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.21__ppc64le-nightly.yaml
@@ -75,9 +75,9 @@ resources:
       cpu: "1"
       memory: 1Gi
 tests:
-- as: powervs-ipi-f7
+- as: powervs-ipi-f14
   cluster: build01
-  cron: 0 0 * * 3
+  cron: 10 22 2,16 * *
   steps:
     cluster_profile: powervs-4
     dependencies:
@@ -90,9 +90,9 @@ tests:
     - ref: enable-qe-catalogsource
     - chain: openshift-e2e-test-qe
     workflow: ipi-powervs
-- as: powervs-ipi-f7-destructive
+- as: powervs-ipi-f14-destructive
   cluster: build01
-  cron: 0 0 * * 4
+  cron: 15 22 6,20 * *
   steps:
     cluster_profile: powervs-4
     dependencies:

--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22__ppc64le-nightly.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22__ppc64le-nightly.yaml
@@ -77,7 +77,7 @@ resources:
 tests:
 - as: powervs-ipi-f7
   cluster: build01
-  cron: 0 0 * * 1
+  cron: 0 0 * * 3
   steps:
     cluster_profile: powervs-4
     dependencies:
@@ -92,7 +92,7 @@ tests:
     workflow: ipi-powervs
 - as: powervs-ipi-f7-destructive
   cluster: build01
-  cron: 0 0 * * 2
+  cron: 0 0 * * 4
   steps:
     cluster_profile: powervs-4
     dependencies:

--- a/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.21-periodics.yaml
+++ b/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.21-periodics.yaml
@@ -101459,7 +101459,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build01
-  cron: 0 0 * * 3
+  cron: 10 22 2,16 * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -101475,7 +101475,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.21"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-openshift-tests-private-release-4.21-ppc64le-nightly-powervs-ipi-f7
+  name: periodic-ci-openshift-openshift-tests-private-release-4.21-ppc64le-nightly-powervs-ipi-f14
   spec:
     containers:
     - args:
@@ -101485,7 +101485,7 @@ periodics:
       - --oauth-token-path=/usr/local/github-credentials/oauth
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=powervs-ipi-f7
+      - --target=powervs-ipi-f14
       - --variant=ppc64le-nightly
       command:
       - ci-operator
@@ -101550,7 +101550,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build01
-  cron: 0 0 * * 4
+  cron: 15 22 6,20 * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -101566,7 +101566,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.21"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-openshift-tests-private-release-4.21-ppc64le-nightly-powervs-ipi-f7-destructive
+  name: periodic-ci-openshift-openshift-tests-private-release-4.21-ppc64le-nightly-powervs-ipi-f14-destructive
   spec:
     containers:
     - args:
@@ -101576,7 +101576,7 @@ periodics:
       - --oauth-token-path=/usr/local/github-credentials/oauth
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=powervs-ipi-f7-destructive
+      - --target=powervs-ipi-f14-destructive
       - --variant=ppc64le-nightly
       command:
       - ci-operator

--- a/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22-periodics.yaml
+++ b/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22-periodics.yaml
@@ -109508,7 +109508,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build01
-  cron: 0 0 * * 1
+  cron: 0 0 * * 3
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -109599,7 +109599,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build01
-  cron: 0 0 * * 2
+  cron: 0 0 * * 4
   decorate: true
   decoration_config:
     skip_cloning: true


### PR DESCRIPTION
cc: @sajauddin 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR modifies the periodic test schedules for PowerVS IPI (Infrastructure as Code) test jobs on the ppc64le architecture for OpenShift 4.21 and 4.22 releases.

### OpenShift 4.21 ppc64le
The PR replaces two test jobs with updated versions and adjusted schedules:
- **Old jobs:** `powervs-ipi-f7` and `powervs-ipi-f7-destructive`
- **New jobs:** `powervs-ipi-f14` and `powervs-ipi-f14-destructive`
- The non-destructive test now runs at `10 22 2,16 * *` (10:22 PM on the 2nd and 16th of each month)
- The destructive test now runs at `15 22 6,20 * *` (10:15 PM on the 6th and 20th of each month)

### OpenShift 4.22 ppc64le
The PR updates the cron schedules for the existing `powervs-ipi-f7` test jobs:
- The non-destructive test shifts from running on Mondays (`0 0 * * 1`) to Wednesdays (`0 0 * * 3`)
- The destructive test shifts from running on Tuesdays (`0 0 * * 2`) to Thursdays (`0 0 * * 4`)

These changes adjust when the PowerShift infrastructure provider tests execute on the ppc64le build platform, likely to optimize CI resource utilization or align with maintenance schedules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->