### PR TITLE
[openshift-psap/topsail] New nightly test for remoting

### DIFF
--- a/ci-operator/config/openshift-psap/topsail/openshift-psap-topsail-main__mac_ai.yaml
+++ b/ci-operator/config/openshift-psap/topsail/openshift-psap-topsail-main__mac_ai.yaml
@@ -400,6 +400,149 @@ tests:
           cpu: 1000m
           memory: 500Mi
       timeout: 23h0m0s
+- as: jump-ci-cpt-remoting
+  capabilities:
+  - intranet
+  cron: 0 10 * * *
+  restrict_network_access: false
+  steps:
+    allow_skip_on_success: true
+    post:
+    - as: 006-post-cleanup
+      commands: |
+        export CRC_MAC_AI_SECRET_PATH=/var/run/crc-mac-ai-secret
+        git -C $HOME fetch --quiet origin main
+        git -C $HOME reset --hard FETCH_HEAD
+        run jump_ci test post_cleanup_ci
+      credentials:
+      - mount_path: /var/run/crc-mac-ai-secret
+        name: crc-mac-ai-secret
+        namespace: test-credentials
+      from_image:
+        name: topsail-light
+        namespace: ci
+        tag: latest
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 500Mi
+    - as: 007-unlock-cluster
+      commands: |
+        export CRC_MAC_AI_SECRET_PATH=/var/run/crc-mac-ai-secret
+        git -C $HOME fetch --quiet origin main
+        git -C $HOME reset --hard FETCH_HEAD
+        run jump_ci run unlock_cluster
+      credentials:
+      - mount_path: /var/run/crc-mac-ai-secret
+        name: crc-mac-ai-secret
+        namespace: test-credentials
+      from_image:
+        name: topsail-light
+        namespace: ci
+        tag: latest
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 500Mi
+    pre:
+    - as: 001-lock-cluster
+      commands: |
+        export CRC_MAC_AI_SECRET_PATH=/var/run/crc-mac-ai-secret
+        git -C $HOME fetch --quiet origin main
+        git -C $HOME reset --hard FETCH_HEAD
+        cat <<EOF > variable_overrides.yaml
+        ci_presets.to_apply: [cpt_nightly]
+        EOF
+        run jump_ci run lock_cluster
+      credentials:
+      - mount_path: /var/run/crc-mac-ai-secret
+        name: crc-mac-ai-secret
+        namespace: test-credentials
+      from_image:
+        name: topsail-light
+        namespace: ci
+        tag: latest
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 500Mi
+      timeout: 10h0m0s
+    - as: 002-prepare-jump-ci
+      commands: |
+        export CRC_MAC_AI_SECRET_PATH=/var/run/crc-mac-ai-secret
+        git -C $HOME fetch --quiet origin main
+        git -C $HOME reset --hard FETCH_HEAD
+        run jump_ci run prepare_jump_ci
+      credentials:
+      - mount_path: /var/run/crc-mac-ai-secret
+        name: crc-mac-ai-secret
+        namespace: test-credentials
+      from_image:
+        name: topsail-light
+        namespace: ci
+        tag: latest
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 500Mi
+      timeout: 1h0m0s
+    - as: 003-pre-cleanup
+      commands: |
+        export CRC_MAC_AI_SECRET_PATH=/var/run/crc-mac-ai-secret
+        git -C $HOME fetch --quiet origin main
+        git -C $HOME reset --hard FETCH_HEAD
+        run jump_ci test pre_cleanup_ci
+      credentials:
+      - mount_path: /var/run/crc-mac-ai-secret
+        name: crc-mac-ai-secret
+        namespace: test-credentials
+      from_image:
+        name: topsail-light
+        namespace: ci
+        tag: latest
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 500Mi
+    - as: 004-prepare
+      commands: |
+        export CRC_MAC_AI_SECRET_PATH=/var/run/crc-mac-ai-secret
+        git -C $HOME fetch --quiet origin main
+        git -C $HOME reset --hard FETCH_HEAD
+        run jump_ci test prepare_ci
+      credentials:
+      - mount_path: /var/run/crc-mac-ai-secret
+        name: crc-mac-ai-secret
+        namespace: test-credentials
+      from_image:
+        name: topsail-light
+        namespace: ci
+        tag: latest
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 500Mi
+      timeout: 3h0m0s
+    test:
+    - as: 005-test
+      commands: |
+        export CRC_MAC_AI_SECRET_PATH=/var/run/crc-mac-ai-secret
+        git -C $HOME fetch --quiet origin main
+        git -C $HOME reset --hard FETCH_HEAD
+        run jump_ci test test_ci
+      credentials:
+      - mount_path: /var/run/crc-mac-ai-secret
+        name: crc-mac-ai-secret
+        namespace: test-credentials
+      from_image:
+        name: topsail-light
+        namespace: ci
+        tag: latest
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 500Mi
+      timeout: 23h0m0s
 - as: jump-ci-cpt-lightspeed
   capabilities:
   - intranet

--- a/ci-operator/jobs/openshift-psap/topsail/openshift-psap-topsail-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-psap/topsail/openshift-psap-topsail-main-periodics.yaml
@@ -145,3 +145,76 @@ periodics:
     - name: result-aggregator
       secret:
         secretName: result-aggregator
+- agent: kubernetes
+  cluster: build03
+  cron: 0 10 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-psap
+    repo: topsail
+  labels:
+    capability/intranet: intranet
+    ci-operator.openshift.io/variant: mac_ai
+    ci.openshift.io/generator: prowgen
+  name: periodic-ci-openshift-psap-topsail-main-mac_ai-jump-ci-cpt-remoting
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --target=jump-ci-cpt-remoting
+      - --variant=mac_ai
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds a new scheduled nightly CI job to the OpenShift CI configuration for the OpenShift PSAP Topsail repository. It introduces a Mac AI scheduled test entry (as: jump-ci-cpt-remoting) in ci-operator/config/openshift-psap/topsail/openshift-psap-topsail-main__mac_ai.yaml that runs daily at 10:00 UTC (cron: 0 10 * * *).

In practical terms:
- A new Topsail CI job (jump-ci-cpt-remoting) will run on Mac AI hardware and requires intranet capability.
- It reuses the shared crc-mac-ai-secret (mounted at /var/run/crc-mac-ai-secret) for credentials.
- The job follows the existing jump_ci workflow used by other scheduled jobs: lock_cluster (creates variable_overrides.yaml to apply the cpt_nightly preset), prepare_jump_ci, pre_cleanup_ci, prepare_ci, then the main test_ci step (timeout 23h), followed by post_cleanup_ci and unlock_cluster.
- Per-step resource requests and timeouts match the other mac_ai jobs (e.g., lock 10h, prepare_jump_ci 1h, prepare 3h; CPU/memory requests mirror existing entries).

No source code or public API changes are included—only CI YAML configuration is modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->