### PR TITLE
NO-JIRA: Swap PowerVS CI dal10 and lon04 profiles for pre-4.20 compatibility

### DIFF
--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.16.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.16.yaml
@@ -553,7 +553,7 @@ tests:
   - sshd-bastion
   cron: 0 0 25 1 *
   steps:
-    cluster_profile: powervs-6
+    cluster_profile: powervs-3
     dependencies:
       OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: release:multi-latest
     env:

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.18.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.18.yaml
@@ -605,7 +605,7 @@ tests:
   - sshd-bastion
   cron: 0 7 * * *
   steps:
-    cluster_profile: powervs-6
+    cluster_profile: powervs-3
     env:
       ARCH: ppc64le
       BRANCH: "4.18"

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.19.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.19.yaml
@@ -605,7 +605,7 @@ tests:
   - sshd-bastion
   cron: 0 15 * * *
   steps:
-    cluster_profile: powervs-6
+    cluster_profile: powervs-3
     env:
       ARCH: ppc64le
       BRANCH: "4.19"

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.20.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.20.yaml
@@ -609,7 +609,7 @@ tests:
   - sshd-bastion
   cron: 0 1,13 * * *
   steps:
-    cluster_profile: powervs-3
+    cluster_profile: powervs-6
     env:
       ARCH: ppc64le
       BRANCH: "4.20"

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.21.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.21.yaml
@@ -642,7 +642,7 @@ tests:
   - sshd-bastion
   cron: 0 7,19 * * *
   steps:
-    cluster_profile: powervs-3
+    cluster_profile: powervs-6
     env:
       ARCH: ppc64le
       BRANCH: "4.21"

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.22.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.22.yaml
@@ -715,7 +715,7 @@ tests:
   - sshd-bastion
   cron: 0 4,16 * * *
   steps:
-    cluster_profile: powervs-3
+    cluster_profile: powervs-6
     env:
       ARCH: ppc64le
       BRANCH: "4.22"

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-5.0.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-5.0.yaml
@@ -653,7 +653,7 @@ tests:
 - as: ocp-e2e-ovn-powervs-capi-multi-p-p
   capabilities:
   - sshd-bastion
-  cron: 0 19 * * 1,3,5
+  cron: 0 22 * * 1,3,5
   steps:
     cluster_profile: powervs-6
     env:

--- a/ci-operator/jobs/openshift/multiarch/openshift-multiarch-main-periodics.yaml
+++ b/ci-operator/jobs/openshift/multiarch/openshift-multiarch-main-periodics.yaml
@@ -18840,8 +18840,8 @@ periodics:
     repo: multiarch
   labels:
     capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: powervs-6
-    ci-operator.openshift.io/cloud-cluster-profile: powervs-6
+    ci-operator.openshift.io/cloud: powervs-3
+    ci-operator.openshift.io/cloud-cluster-profile: powervs-3
     ci-operator.openshift.io/variant: nightly-4.16
     ci.openshift.io/generator: prowgen
     job-release: "4.16"
@@ -27920,8 +27920,8 @@ periodics:
     repo: multiarch
   labels:
     capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: powervs-6
-    ci-operator.openshift.io/cloud-cluster-profile: powervs-6
+    ci-operator.openshift.io/cloud: powervs-3
+    ci-operator.openshift.io/cloud-cluster-profile: powervs-3
     ci-operator.openshift.io/variant: nightly-4.18
     ci.openshift.io/generator: prowgen
     job-release: "4.18"
@@ -32668,8 +32668,8 @@ periodics:
     repo: multiarch
   labels:
     capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: powervs-6
-    ci-operator.openshift.io/cloud-cluster-profile: powervs-6
+    ci-operator.openshift.io/cloud: powervs-3
+    ci-operator.openshift.io/cloud-cluster-profile: powervs-3
     ci-operator.openshift.io/variant: nightly-4.19
     ci.openshift.io/generator: prowgen
     job-release: "4.19"
@@ -37834,8 +37834,8 @@ periodics:
     repo: multiarch
   labels:
     capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: powervs-3
-    ci-operator.openshift.io/cloud-cluster-profile: powervs-3
+    ci-operator.openshift.io/cloud: powervs-6
+    ci-operator.openshift.io/cloud-cluster-profile: powervs-6
     ci-operator.openshift.io/variant: nightly-4.20
     ci.openshift.io/generator: prowgen
     job-release: "4.20"
@@ -43253,8 +43253,8 @@ periodics:
     repo: multiarch
   labels:
     capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: powervs-3
-    ci-operator.openshift.io/cloud-cluster-profile: powervs-3
+    ci-operator.openshift.io/cloud: powervs-6
+    ci-operator.openshift.io/cloud-cluster-profile: powervs-6
     ci-operator.openshift.io/variant: nightly-4.21
     ci.openshift.io/generator: prowgen
     job-release: "4.21"
@@ -48672,8 +48672,8 @@ periodics:
     repo: multiarch
   labels:
     capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: powervs-3
-    ci-operator.openshift.io/cloud-cluster-profile: powervs-3
+    ci-operator.openshift.io/cloud: powervs-6
+    ci-operator.openshift.io/cloud-cluster-profile: powervs-6
     ci-operator.openshift.io/variant: nightly-4.22
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
@@ -61682,7 +61682,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build01
-  cron: 0 19 * * 1,3,5
+  cron: 0 22 * * 1,3,5
   decorate: true
   decoration_config:
     skip_cloning: true


### PR DESCRIPTION
This PR updates the cluster profile assignments for our PowerVS OpenShift CI jobs by swapping `lon04` and `dal10` across specific OpenShift versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## PowerVS Cluster Profile Realignment for Version Compatibility

This PR updates PowerVS cluster profile assignments across OpenShift multiarch nightly CI configurations to align PowerVS test infrastructure with version-specific requirements:

**Pre-4.20 releases (4.16, 4.18, 4.19):** PowerVS tests switched to the `powervs-3` profile (dal10/US region), affecting:
- `ocp-e2e-ovn-ppc64le-powervs-original` test in the 4.16 configuration  
- `ocp-e2e-ovn-powervs-capi-multi-p-p` test job in 4.18 and 4.19 configurations

**4.20+ releases (4.20, 4.21, 4.22):** PowerVS tests use the `powervs-6` profile (lon04/EU region), affecting the `ocp-e2e-ovn-powervs-capi-multi-p-p` test job across these versions

**5.0 release:** In addition to the profile swap, the scheduled cron timing for `ocp-e2e-ovn-powervs-capi-multi-p-p` was adjusted from `0 19 * * 1,3,5` to `0 22 * * 1,3,5` (3-hour delay).

These changes ensure that pre-4.20 OpenShift releases test against the appropriate IBM PowerVS infrastructure region while 4.20 and later versions use a different region, maintaining compatibility constraints across the release lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->