### PR TITLE
NO-JIRA: Schedule ocp-ci-monitor only Mon to Fri

### DIFF
--- a/ci-operator/config/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main.yaml
+++ b/ci-operator/config/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main.yaml
@@ -49,7 +49,7 @@ tests:
     from: shellcheck
   run_if_changed: .sh$
 - as: ocp-ci-monitor
-  cron: 0 7 * * *
+  cron: 0 7 * * 1-5
   steps:
     workflow: openshift-edge-tooling-ci-monitor
 - as: microshift-ci-doctor

--- a/ci-operator/jobs/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main-periodics.yaml
@@ -82,7 +82,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
-  cron: 0 7 * * *
+  cron: 0 7 * * 1-5
   decorate: true
   decoration_config:
     skip_cloning: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

This PR adjusts the schedule of the `ocp-ci-monitor` job in the edge-tooling CI configuration to run only on weekdays (Monday–Friday) instead of every day.

## Affected Component

The change applies to the **openshift-eng/edge-tooling** repository's CI configuration. The `ocp-ci-monitor` is a periodic job that monitors and reports CI health metrics via Slack to the `#team-ocp-edge-collab` channel.

## What Changed

The cron schedule for the `ocp-ci-monitor` test in `ci-operator/config/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main.yaml` was updated from `0 7 * * *` (daily at 7 AM UTC) to `0 7 * * 1-5` (weekdays only at 7 AM UTC). The job itself and its associated workflow remain unchanged.

## Practical Impact

The CI monitoring job will no longer execute on weekends, reducing unnecessary monitoring runs and Slack notifications outside of business hours while maintaining full weekday coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->