### PR TITLE
Revert e2e-parallel back to prow deployment env

### DIFF
--- a/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main.yaml
+++ b/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main.yaml
@@ -452,7 +452,7 @@ tests:
   steps:
     env:
       ARO_HCP_CLOUD: dev
-      ARO_HCP_DEPLOY_ENV: ci01
+      ARO_HCP_DEPLOY_ENV: prow
       LOCATION: westus3
     leases:
     - count: 1


### PR DESCRIPTION
Reverts the deployment environment for e2e-parallel back to `prow` due to Azure capacity issues in the subscription that `ci01` targets.