### PR TITLE
WINC: Replace cucushift-installer-wait with clusterbot-wait in winc workflows

### DIFF
--- a/ci-operator/step-registry/cucushift/installer/rehearse/aws/ipi/ovn/winc/cucushift-installer-rehearse-aws-ipi-ovn-winc-workflow.yaml
+++ b/ci-operator/step-registry/cucushift/installer/rehearse/aws/ipi/ovn/winc/cucushift-installer-rehearse-aws-ipi-ovn-winc-workflow.yaml
@@ -12,7 +12,7 @@ workflow:
       - chain: cucushift-installer-rehearse-aws-ipi-ovn-winc-provision
       - ref: cucushift-installer-reportportal-marker
     test:
-      - ref: cucushift-installer-wait
+      - ref: clusterbot-wait
     post:
       - chain: cucushift-installer-rehearse-aws-ipi-deprovision
       - ref: send-results-to-reportportal

--- a/ci-operator/step-registry/cucushift/installer/rehearse/aws/upi/ovn/winc/cucushift-installer-rehearse-aws-upi-ovn-winc-workflow.yaml
+++ b/ci-operator/step-registry/cucushift/installer/rehearse/aws/upi/ovn/winc/cucushift-installer-rehearse-aws-upi-ovn-winc-workflow.yaml
@@ -11,7 +11,7 @@ workflow:
       - chain: cucushift-installer-rehearse-aws-upi-ovn-winc-provision
       - ref: cucushift-installer-reportportal-marker
     test:
-      - ref: cucushift-installer-wait
+      - ref: clusterbot-wait
     post:
       - chain: cucushift-installer-rehearse-aws-upi-ovn-winc-deprovision
       - ref: send-results-to-reportportal

--- a/ci-operator/step-registry/cucushift/installer/rehearse/azure/ipi/ovn/winc/cucushift-installer-rehearse-azure-ipi-ovn-winc-workflow.yaml
+++ b/ci-operator/step-registry/cucushift/installer/rehearse/azure/ipi/ovn/winc/cucushift-installer-rehearse-azure-ipi-ovn-winc-workflow.yaml
@@ -12,7 +12,7 @@ workflow:
       - chain: cucushift-installer-rehearse-azure-ipi-ovn-winc-provision
       - ref: cucushift-installer-reportportal-marker
     test:
-      - ref: cucushift-installer-wait
+      - ref: clusterbot-wait
     post:
       - chain: cucushift-installer-rehearse-azure-ipi-ovn-winc-deprovision
       - ref: send-results-to-reportportal

--- a/ci-operator/step-registry/cucushift/installer/rehearse/gcp/ipi/ovn/winc/cucushift-installer-rehearse-gcp-ipi-ovn-winc-workflow.yaml
+++ b/ci-operator/step-registry/cucushift/installer/rehearse/gcp/ipi/ovn/winc/cucushift-installer-rehearse-gcp-ipi-ovn-winc-workflow.yaml
@@ -12,7 +12,7 @@ workflow:
       - chain: cucushift-installer-rehearse-gcp-ipi-ovn-winc-provision
       - ref: cucushift-installer-reportportal-marker
     test:
-      - ref: cucushift-installer-wait
+      - ref: clusterbot-wait
     post:
       - chain: cucushift-installer-rehearse-gcp-ipi-deprovision
       - ref: send-results-to-reportportal

--- a/ci-operator/step-registry/cucushift/installer/rehearse/nutanix/ipi/ovn/winc/cucushift-installer-rehearse-nutanix-ipi-ovn-winc-workflow.yaml
+++ b/ci-operator/step-registry/cucushift/installer/rehearse/nutanix/ipi/ovn/winc/cucushift-installer-rehearse-nutanix-ipi-ovn-winc-workflow.yaml
@@ -13,7 +13,7 @@ workflow:
       - chain: cucushift-installer-rehearse-nutanix-ipi-ovn-winc-provision
       - ref: cucushift-installer-reportportal-marker
     test:
-      - ref: cucushift-installer-wait
+      - ref: clusterbot-wait
     post:
       - chain: cucushift-installer-rehearse-nutanix-ipi-ovn-winc-deprovision
       - ref: send-results-to-reportportal

--- a/ci-operator/step-registry/cucushift/installer/rehearse/vsphere/ipi/disconnected/ovn/winc/cucushift-installer-rehearse-vsphere-ipi-disconnected-ovn-winc-workflow.yaml
+++ b/ci-operator/step-registry/cucushift/installer/rehearse/vsphere/ipi/disconnected/ovn/winc/cucushift-installer-rehearse-vsphere-ipi-disconnected-ovn-winc-workflow.yaml
@@ -6,7 +6,7 @@ workflow:
     pre:
     - chain: cucushift-installer-rehearse-vsphere-ipi-disconnected-ovn-winc-provision
     test:
-    - ref: cucushift-installer-wait
+    - ref: clusterbot-wait
     post:
     - chain: cucushift-installer-rehearse-vsphere-ipi-disconnected-ovn-winc-deprovision
   documentation: |-

--- a/ci-operator/step-registry/cucushift/installer/rehearse/vsphere/ipi/ovn/winc/cucushift-installer-rehearse-vsphere-ipi-ovn-winc-workflow.yaml
+++ b/ci-operator/step-registry/cucushift/installer/rehearse/vsphere/ipi/ovn/winc/cucushift-installer-rehearse-vsphere-ipi-ovn-winc-workflow.yaml
@@ -14,7 +14,7 @@ workflow:
       - chain: cucushift-installer-rehearse-vsphere-ipi-ovn-winc-provision
       - ref: cucushift-installer-reportportal-marker
     test:
-      - ref: cucushift-installer-wait
+      - ref: clusterbot-wait
     post:
       - chain: cucushift-installer-rehearse-vsphere-ipi-ovn-winc-deprovision
       - ref: send-results-to-reportportal

--- a/ci-operator/step-registry/cucushift/installer/rehearse/vsphere/ipi/proxy/ovn/winc/cucushift-installer-rehearse-vsphere-ipi-proxy-ovn-winc-workflow.yaml
+++ b/ci-operator/step-registry/cucushift/installer/rehearse/vsphere/ipi/proxy/ovn/winc/cucushift-installer-rehearse-vsphere-ipi-proxy-ovn-winc-workflow.yaml
@@ -12,7 +12,7 @@ workflow:
       - chain: cucushift-installer-rehearse-vsphere-ipi-proxy-ovn-winc-provision
       - ref: cucushift-installer-reportportal-marker
     test:
-      - ref: cucushift-installer-wait
+      - ref: clusterbot-wait
     post:
       - chain: cucushift-installer-rehearse-vsphere-ipi-proxy-deprovision
       - ref: send-results-to-reportportal


### PR DESCRIPTION
## Summary
- Replaces `cucushift-installer-wait` with `clusterbot-wait` in the test section of all 8 winc workflows
- Fixes cluster-bot `workflow-test` failing with ImagePullBackOff

## Problem
PR #78899 added `cucushift-installer-wait` to winc workflow test sections to enable `SLEEP_DURATION` override via cluster-bot. However, `cucushift-installer-wait` uses `from: tests-private`, an image that does not exist in cluster-bot context:
```
Failed to pull image "...stable:tests-private": manifest unknown
Back-off pulling image "...stable:tests-private"
```

`tests-private` is built from the openshift-tests-private repository during CI. It only exists in the `stable` image stream when a CI job is running against that repo. Cluster-bot doesn't build any repo -- it just provisions a cluster using a workflow, so only release payload images (`cli`, `installer`, etc.) are available.

## Fix
Replace with `clusterbot-wait`, which uses `from: cli` (always available from the release payload). No test image is needed -- the cluster just needs to sit and wait. The test section exists only so cluster-bot has a step that declares `CLUSTER_DURATION`, allowing the parameter override to pass config resolution. The step itself just runs `sleep $(CLUSTER_DURATION) & wait`, and uses `cli` because every step needs some image to run in.

## Affected workflows
- cucushift-installer-rehearse-aws-ipi-ovn-winc
- cucushift-installer-rehearse-aws-upi-ovn-winc
- cucushift-installer-rehearse-azure-ipi-ovn-winc
- cucushift-installer-rehearse-gcp-ipi-ovn-winc
- cucushift-installer-rehearse-nutanix-ipi-ovn-winc
- cucushift-installer-rehearse-vsphere-ipi-ovn-winc
- cucushift-installer-rehearse-vsphere-ipi-proxy-ovn-winc
- cucushift-installer-rehearse-vsphere-ipi-disconnected-ovn-winc

## Usage
```
workflow-launch cucushift-installer-rehearse-vsphere-ipi-proxy-ovn-winc 4.22 CLUSTER_DURATION=14400
```
`CLUSTER_DURATION` is in seconds (14400 = 4h). Default is 9000 (2.5h). Max is limited by the 4h step timeout and 8h ProwJob decoration timeout.

## Existing CI jobs
Unaffected -- all existing CI jobs define their own test sections (with `openshift-extended-test`), which override the workflow's test section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR updates eight winc-related CI workflows to use `clusterbot-wait` instead of `cucushift-installer-wait` in their test phases. The change enables these workflows to accept `CLUSTER_DURATION` overrides when launched via cluster-bot.

## Problem Addressed

The existing `cucushift-installer-wait` step references an image from `tests-private`, which is not available in the cluster-bot execution context. This causes `ImagePullBackOff` errors (manifest unknown) since `tests-private` is only produced when CI runs against the openshift-tests-private repository, whereas cluster-bot only has access to images in the release payload.

## Solution

Replace `cucushift-installer-wait` with `clusterbot-wait`, which:
- Uses `from: cli` (available in the release payload)
- Executes a no-op wait command: `sleep $(CLUSTER_DURATION) & wait`
- Allows workflows to accept `CLUSTER_DURATION` overrides without requiring test images
- Supports a default of 9000 seconds with a maximum limited by step timeout (4h) and ProwJob decoration timeout (8h)

## Affected Workflows

Eight winc-enabled workflows across multiple cloud platforms:
- cucushift-installer-rehearse-aws-ipi-ovn-winc
- cucushift-installer-rehearse-aws-upi-ovn-winc
- cucushift-installer-rehearse-azure-ipi-ovn-winc
- cucushift-installer-rehearse-gcp-ipi-ovn-winc
- cucushift-installer-rehearse-nutanix-ipi-ovn-winc
- cucushift-installer-rehearse-vsphere-ipi-ovn-winc
- cucushift-installer-rehearse-vsphere-ipi-proxy-ovn-winc
- cucushift-installer-rehearse-vsphere-ipi-disconnected-ovn-winc

## Impact

- **Existing CI jobs:** Unaffected, as they define their own test sections (with `openshift-extended-test`) that override the workflow's test section
- **Cluster-bot users:** Can now override cluster duration via command line, e.g., `workflow-launch cucushift-installer-rehearse-vsphere-ipi-proxy-ovn-winc 4.22 CLUSTER_DURATION=14400`

## Changes

Configuration-only updates: each workflow file updated with one line changed (+1/-1) in the test phase step reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->