### PR TITLE
Remove unused secret definitions

### DIFF
--- a/core-services/ci-secret-bootstrap/_config.yaml
+++ b/core-services/ci-secret-bootstrap/_config.yaml
@@ -838,54 +838,6 @@ secret_configs:
     name: cluster-secrets-aws
     namespace: ci
 - from:
-    insights-live.yaml:
-      field: insights-live.yaml
-      item: insights-ci-account
-    ops-mirror.pem:
-      field: cert-key.pem
-      item: mirror.openshift.com
-    pull-secret:
-      dockerconfigJSON:
-      - auth_field: token_image-puller_app.ci_reg_auth_value.txt
-        item: build_farm
-        registry_url: registry.ci.openshift.org
-      - auth_field: auth
-        email_field: email
-        item: cloud.openshift.com-pull-secret
-        registry_url: cloud.openshift.com
-      - auth_field: auth
-        email_field: email
-        item: quay.io-pull-secret
-        registry_url: quay.io
-      - auth_field: auth
-        item: quay.io/multi-arch
-        registry_url: quay.io/multi-arch
-      - auth_field: auth
-        item: quayio-ci-read-only-robot
-        registry_url: quay-proxy.ci.openshift.org
-      - auth_field: auth
-        item: quayio-ci-read-only-robot
-        registry_url: quay.io/openshift/ci
-      - auth_field: auth
-        email_field: email
-        item: registry.connect.redhat.com-pull-secret
-        registry_url: registry.connect.redhat.com
-      - auth_field: auth
-        email_field: email
-        item: registry.redhat.io-pull-secret
-        registry_url: registry.redhat.io
-    ssh-privatekey:
-      field: ssh-privatekey
-      item: openshift-ci-aws-credentials
-    ssh-publickey:
-      field: ssh-publickey
-      item: openshift-ci-aws-credentials
-  to:
-  - cluster_groups:
-    - non_app_ci
-    name: cluster-secrets-aws-arm64
-    namespace: ci
-- from:
     pull-secret:
       dockerconfigJSON:
       - auth_field: token_image-puller_app.ci_reg_auth_value.txt
@@ -2961,10 +2913,6 @@ secret_configs:
   - cluster_groups:
     - non_app_ci
     name: cluster-secrets-azure-confidential-qe
-    namespace: ci
-  - cluster_groups:
-    - non_app_ci
-    name: cluster-secrets-azure-perfscale-qe
     namespace: ci
 - from:
     osServicePrincipal.json:
@@ -6514,42 +6462,6 @@ secret_configs:
     - managed_clusters
     name: cloudability-api-key
     namespace: cloudability
-- from:
-    pull-secret:
-      dockerconfigJSON:
-      - auth_field: token_image-puller_app.ci_reg_auth_value.txt
-        item: build_farm
-        registry_url: registry.ci.openshift.org
-      - auth_field: auth
-        email_field: email
-        item: cloud.openshift.com-pull-secret
-        registry_url: cloud.openshift.com
-      - auth_field: auth
-        email_field: email
-        item: quay.io-pull-secret
-        registry_url: quay.io
-      - auth_field: auth
-        item: quay.io/multi-arch
-        registry_url: quay.io/multi-arch
-      - auth_field: auth
-        item: quayio-ci-read-only-robot
-        registry_url: quay-proxy.ci.openshift.org
-      - auth_field: auth
-        item: quayio-ci-read-only-robot
-        registry_url: quay.io/openshift/ci
-      - auth_field: auth
-        email_field: email
-        item: registry.connect.redhat.com-pull-secret
-        registry_url: registry.connect.redhat.com
-      - auth_field: auth
-        email_field: email
-        item: registry.redhat.io-pull-secret
-        registry_url: registry.redhat.io
-  to:
-  - cluster_groups:
-    - non_app_ci
-    name: cluster-secrets-vsphere-qe
-    namespace: ci
 - from:
     .dockerconfigjson:
       dockerconfigJSON:


### PR DESCRIPTION
These 3 entries are old and not used in any tests. Their naming suggests that they at some point had served as cluster profile secrets, but now are not associated with any actual cluster profiles defined in `ci-tools/pkg/api/types.go`.

- `cluster-secrets-aws-arm64` -- not used anywhere in release repo, references vault secret `selfservice/arm/arm-ci-awscred` which has last been updated in Jun 25, 2021
- `cluster-secrets-vsphere-qe` - not used anywhere, no user secrets attached
- `cluster-secrets-azure-perfscale-qe` - not used anywhere, no user secrets attached

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Remove unused secret definitions

This PR removes three unused secret mappings from the OpenShift CI infrastructure's secret bootstrap configuration. These secrets were mapped to the `non_app_ci` cluster group but are no longer in use:

- **cluster-secrets-aws-arm64**: AWS credentials secret last updated in 2021, referenced an old Vault secret for ARM CI environments
- **cluster-secrets-vsphere-qe**: vSphere QE cluster secret with pull-secret credentials
- **cluster-secrets-azure-perfscale-qe**: Azure performance scale QE secret mapping Azure service principal and pull-secrets

The changes reduce the secret bootstrap configuration file from 7,519 to 7,431 lines (88 lines removed), cleaning up legacy secret definitions that are no longer associated with any active cluster profiles in the CI infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->