### PR TITLE
Test cluster profile bundle creation

### DIFF
--- a/core-services/ci-secret-bootstrap/gsm-config.yaml
+++ b/core-services/ci-secret-bootstrap/gsm-config.yaml
@@ -1625,3 +1625,41 @@ bundles:
     targets:
       - cluster: build01  # todo: change to cluster_groups: [non_app_ci]
         namespace: ci
+
+  - dockerconfig:
+      as: pull-secret
+      registries:
+      - auth_field: token_image-puller_app--dot--ci_reg_auth_value--dot--txt
+        group: build_farm
+        registry_url: registry.ci.openshift.org
+      - auth_field: auth
+        email_field: email
+        group: cloud--dot--openshift--dot--com-pull-secret
+        registry_url: cloud.openshift.com
+      - auth_field: auth
+        email_field: email
+        group: quay--dot--io-pull-secret
+        registry_url: quay.io
+      - auth_field: auth
+        group: quayio-ci-read-only-robot
+        registry_url: quay-proxy.ci.openshift.org
+      - auth_field: auth
+        group: quayio-ci-read-only-robot
+        registry_url: quay.io/openshift/ci
+      - auth_field: auth
+        email_field: email
+        group: registry--dot--connect--dot--redhat--dot--com-pull-secret
+        registry_url: registry.connect.redhat.com
+      - auth_field: auth
+        email_field: email
+        group: registry--dot--redhat--dot--io-pull-secret
+        registry_url: registry.redhat.io
+    gsm_secrets:
+    - collection: psalajova-first-secret
+      group: ibmcloud-rhoai-qe-collection/cluster-secrets
+    name: cluster-secrets-ibmcloud-rhoai-qe-psalajova-test
+    sync_to_cluster: true
+    targets:
+    - cluster_groups:
+      - non_app_ci
+      namespace: ci


### PR DESCRIPTION
I'd like to merge this to test some mechanisms of how the secret will be created from this bundle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changes to CI secret bootstrap configuration

This PR adds a test secret bundle to core-services/ci-secret-bootstrap/gsm-config.yaml to exercise OpenShift CI's GSM-based secret bundle and cluster-profile secret creation/sync mechanisms.

Key points:
- Introduces a new bundle named cluster-secrets-ibmcloud-rhoai-qe-psalajova-test.
- The bundle defines a dockerconfig-style pull secret (as: pull-secret) with multiple registry auth entries and sources GSM secrets from the ibmcloud-rhoai-qe-collection (group: cluster-secrets).
- The bundle is configured sync_to_cluster: true and targets the non_app_ci cluster group, placing the secret into the ci namespace on those clusters.

Impact:
- Affects core-services/ci-secret-bootstrap configuration which controls how secrets from Google Secret Manager are packaged and distributed across OpenShift CI clusters.
- Used to validate/test the end-to-end creation and distribution of a cluster profile bundle and the resulting Kubernetes secret(s) on the targeted clusters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->