### PR TITLE
onboard lightspeed-agentic-alerts-adapter

### DIFF
--- a/ci-operator/config/openshift/lightspeed-agentic-alerts-adapter/OWNERS
+++ b/ci-operator/config/openshift/lightspeed-agentic-alerts-adapter/OWNERS
@@ -1,0 +1,15 @@
+# DO NOT EDIT; this file is auto-generated using https://github.com/openshift/ci-tools.
+# Fetched from https://github.com/openshift/lightspeed-agentic-alerts-adapter root OWNERS
+# If the repo had OWNERS_ALIASES then the aliases were expanded
+# Logins who are not members of 'openshift' organization were filtered out
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+- falox
+- rioloc
+- tremes
+options: {}
+reviewers:
+- falox
+- rioloc
+- tremes

--- a/core-services/prow/02_config/openshift/lightspeed-agentic-alerts-adapter/OWNERS
+++ b/core-services/prow/02_config/openshift/lightspeed-agentic-alerts-adapter/OWNERS
@@ -1,0 +1,15 @@
+# DO NOT EDIT; this file is auto-generated using https://github.com/openshift/ci-tools.
+# Fetched from https://github.com/openshift/cluster-health-analyzer root OWNERS
+# If the repo had OWNERS_ALIASES then the aliases were expanded
+# Logins who are not members of 'openshift' organization were filtered out
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+- falox
+- rioloc
+- tremes
+options: {}
+reviewers:
+- falox
+- rioloc
+- tremes

--- a/core-services/prow/02_config/openshift/lightspeed-agentic-alerts-adapter/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/lightspeed-agentic-alerts-adapter/_pluginconfig.yaml
@@ -1,0 +1,12 @@
+approve:
+- repos:
+  - openshift/lightspeed-agentic-alerts-adapter
+  require_self_approval: false
+lgtm:
+- repos:
+  - openshift/lightspeed-agentic-alerts-adapter
+  review_acts_as_lgtm: true
+plugins:
+  openshift/lightspeed-agentic-alerts-adapter:
+    plugins:
+    - approve

--- a/core-services/prow/02_config/openshift/lightspeed-agentic-alerts-adapter/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift/lightspeed-agentic-alerts-adapter/_prowconfig.yaml
@@ -1,0 +1,14 @@
+tide:
+  queries:
+  - labels:
+    - approved
+    - lgtm
+    missingLabels:
+    - backports/unvalidated-commits
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - jira/invalid-bug
+    - needs-rebase
+    repos:
+    - openshift/lightspeed-agentic-alerts-adapter


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR onboards the `openshift/lightspeed-agentic-alerts-adapter` repository to the OpenShift CI infrastructure by establishing its CI/CD configuration and approval workflows.

The changes establish foundational CI infrastructure for the new repository:

**Code Review Configuration**: OWNERS files are added in both the CI operator config and Prow config directories, designating three approvers and reviewers (`falox`, `rioloc`, `tremes`) for changes related to this repository's CI configuration.

**Approval Workflow**: Prow plugin configuration is set up to require both `approved` and `lgtm` labels on pull requests before they can be merged via Prow's `tide` automation. The approval process is configured to not require self-approval, allowing any designated approver to sign off on changes.

**Merge Requirements**: The Prow tide configuration defines merge criteria for the repository, specifying which labels must be present (`approved`, `lgtm`) and which labels block merging (backports, unvalidated-commits, do-not-merge, invalid JIRA bugs, and rebasing issues).

In practical terms, this PR enables automated CI testing and pull request management for the lightspeed-agentic-alerts-adapter component through the OpenShift CI infrastructure, with proper code review gates in place.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->