### PR TITLE
telco5g: Fix nightly info jobs for 5.0

### DIFF
--- a/ci-operator/step-registry/telco5g/jobs-router/telco5g-jobs-router-commands.sh
+++ b/ci-operator/step-registry/telco5g/jobs-router/telco5g-jobs-router-commands.sh
@@ -34,7 +34,11 @@ if [[ "$PROW_JOB_ID" = *"nightly"* ]] && [[ "$JOB_TYPE" == "periodic" ]]; then
     else
         export IMG=${PROW_JOB_ID/-telco5g/}
     fi
-    IMG_URL="registry.ci.openshift.org/ocp/release:$IMG"
+    if [[ "$IMG" == "5"* ]]; then
+        IMG_URL="registry.ci.openshift.org/ocp/release-5:$IMG"
+    else
+        IMG_URL="registry.ci.openshift.org/ocp/release:$IMG"
+    fi
 
     echo "export T5_JOB_TRIGGER=nightly" >> "$MAINENV"
     echo "export T5_JOB_DESC='nightly-${T5CI_JOB_TYPE}'" >> "$MAINENV"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Telco5g Nightly Job Configuration Fix for OpenShift 5.0

This PR fixes the telco5g periodic nightly job configuration to correctly reference OpenShift release images for version 5.0.

### What Changed

The `telco5g-jobs-router-commands.sh` script now conditionally selects the appropriate OpenShift release image registry based on the release version:

- **For 5.0 releases**: Uses `registry.ci.openshift.org/ocp/release-5:$IMG`
- **For other versions**: Uses `registry.ci.openshift.org/ocp/release:$IMG`

The logic checks if the image version string starts with `"5"` and routes accordingly. This ensures that nightly telco5g jobs running on OpenShift 5.0 releases can correctly resolve their release image URLs, which are stored in a separate registry path than 4.x releases.

### Impact

The telco5g CI infrastructure's nightly jobs (triggered by periodic Prow jobs with "nightly" in the job ID) will now properly construct the release image environment variable (`T5_JOB_RELEASE_IMAGE`) when running against 5.0 release streams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->