### PR TITLE
refactor: build_root points to a component specific build_root_image tag

### DIFF
--- a/ci-operator/config/openshift/apiserver-network-proxy/openshift-apiserver-network-proxy-release-4.12.yaml
+++ b/ci-operator/config/openshift/apiserver-network-proxy/openshift-apiserver-network-proxy-release-4.12.yaml
@@ -8,10 +8,7 @@ base_images:
     namespace: hypershift
     tag: latest
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-8-release-golang-1.17-openshift-4.11
+  from_repository: true
 images:
   items:
   - dockerfile_path: Dockerfile.openshift

--- a/ci-operator/config/openshift/apiserver-network-proxy/openshift-apiserver-network-proxy-release-4.13.yaml
+++ b/ci-operator/config/openshift/apiserver-network-proxy/openshift-apiserver-network-proxy-release-4.13.yaml
@@ -8,10 +8,7 @@ base_images:
     namespace: hypershift
     tag: latest
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-8-release-golang-1.17-openshift-4.11
+  from_repository: true
 images:
   items:
   - dockerfile_path: Dockerfile.openshift

--- a/ci-operator/config/openshift/bond-cni/openshift-bond-cni-release-4.12.yaml
+++ b/ci-operator/config/openshift/bond-cni/openshift-bond-cni-release-4.12.yaml
@@ -4,10 +4,7 @@ base_images:
     namespace: ocp
     tag: base
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-golang-1.12
+  from_repository: true
 images:
   items:
   - dockerfile_path: Dockerfile.openshift

--- a/ci-operator/config/openshift/bond-cni/openshift-bond-cni-release-4.13.yaml
+++ b/ci-operator/config/openshift/bond-cni/openshift-bond-cni-release-4.13.yaml
@@ -4,10 +4,7 @@ base_images:
     namespace: ocp
     tag: base
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-golang-1.12
+  from_repository: true
 images:
   items:
   - dockerfile_path: Dockerfile.openshift

--- a/ci-operator/config/openshift/bond-cni/openshift-bond-cni-release-4.14.yaml
+++ b/ci-operator/config/openshift/bond-cni/openshift-bond-cni-release-4.14.yaml
@@ -4,10 +4,7 @@ base_images:
     namespace: ocp
     tag: base
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-golang-1.12
+  from_repository: true
 images:
   items:
   - dockerfile_path: Dockerfile.openshift

--- a/ci-operator/config/openshift/bond-cni/openshift-bond-cni-release-4.15.yaml
+++ b/ci-operator/config/openshift/bond-cni/openshift-bond-cni-release-4.15.yaml
@@ -1,8 +1,5 @@
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-golang-1.12
+  from_repository: true
 images:
   items:
   - dockerfile_path: Dockerfile.openshift

--- a/ci-operator/config/openshift/cloud-provider-aws/openshift-cloud-provider-aws-release-4.12.yaml
+++ b/ci-operator/config/openshift/cloud-provider-aws/openshift-cloud-provider-aws-release-4.12.yaml
@@ -1,9 +1,6 @@
 binary_build_commands: make aws-cloud-controller-manager
 build_root:
-  image_stream_tag:
-    name: builder
-    namespace: ocp
-    tag: rhel-8-golang-1.18-openshift-4.11
+  from_repository: true
 canonical_go_repository: k8s.io/cloud-provider-aws
 images:
   items:

--- a/ci-operator/config/openshift/cloud-provider-aws/openshift-cloud-provider-aws-release-4.13.yaml
+++ b/ci-operator/config/openshift/cloud-provider-aws/openshift-cloud-provider-aws-release-4.13.yaml
@@ -1,9 +1,6 @@
 binary_build_commands: make aws-cloud-controller-manager
 build_root:
-  image_stream_tag:
-    name: builder
-    namespace: ocp
-    tag: rhel-8-golang-1.18-openshift-4.11
+  from_repository: true
 canonical_go_repository: k8s.io/cloud-provider-aws
 images:
   items:

--- a/ci-operator/config/openshift/cloud-provider-gcp/openshift-cloud-provider-gcp-release-4.12.yaml
+++ b/ci-operator/config/openshift/cloud-provider-gcp/openshift-cloud-provider-gcp-release-4.12.yaml
@@ -5,10 +5,7 @@ base_images:
     tag: base
 binary_build_commands: go build ./cmd/cloud-controller-manager
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-8-release-golang-1.17-openshift-4.11
+  from_repository: true
 canonical_go_repository: k8s.io/cloud-provider-gcp
 images:
   items:

--- a/ci-operator/config/openshift/cloud-provider-gcp/openshift-cloud-provider-gcp-release-4.13.yaml
+++ b/ci-operator/config/openshift/cloud-provider-gcp/openshift-cloud-provider-gcp-release-4.13.yaml
@@ -5,10 +5,7 @@ base_images:
     tag: base
 binary_build_commands: go build ./cmd/cloud-controller-manager
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-8-release-golang-1.17-openshift-4.11
+  from_repository: true
 canonical_go_repository: k8s.io/cloud-provider-gcp
 images:
   items:

--- a/ci-operator/config/openshift/cloud-provider-gcp/openshift-cloud-provider-gcp-release-4.14.yaml
+++ b/ci-operator/config/openshift/cloud-provider-gcp/openshift-cloud-provider-gcp-release-4.14.yaml
@@ -5,10 +5,7 @@ base_images:
     tag: base
 binary_build_commands: go build ./cmd/cloud-controller-manager
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-8-release-golang-1.17-openshift-4.11
+  from_repository: true
 canonical_go_repository: k8s.io/cloud-provider-gcp
 images:
   items:

--- a/ci-operator/config/openshift/cloud-provider-nutanix/openshift-cloud-provider-nutanix-release-4.12.yaml
+++ b/ci-operator/config/openshift/cloud-provider-nutanix/openshift-cloud-provider-nutanix-release-4.12.yaml
@@ -5,10 +5,7 @@ base_images:
     tag: base
 binary_build_commands: go build .
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-8-release-golang-1.17-openshift-4.11
+  from_repository: true
 canonical_go_repository: github.com/nutanix-cloud-native/cloud-provider-nutanix
 images:
   items:

--- a/ci-operator/config/openshift/cloud-provider-nutanix/openshift-cloud-provider-nutanix-release-4.13.yaml
+++ b/ci-operator/config/openshift/cloud-provider-nutanix/openshift-cloud-provider-nutanix-release-4.13.yaml
@@ -5,10 +5,7 @@ base_images:
     tag: base
 binary_build_commands: go build .
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-8-release-golang-1.19-openshift-4.13
+  from_repository: true
 canonical_go_repository: github.com/nutanix-cloud-native/cloud-provider-nutanix
 images:
   items:

--- a/ci-operator/config/openshift/cloud-provider-nutanix/openshift-cloud-provider-nutanix-release-4.14.yaml
+++ b/ci-operator/config/openshift/cloud-provider-nutanix/openshift-cloud-provider-nutanix-release-4.14.yaml
@@ -5,10 +5,7 @@ base_images:
     tag: base
 binary_build_commands: go build .
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-8-release-golang-1.20-openshift-4.14
+  from_repository: true
 canonical_go_repository: github.com/nutanix-cloud-native/cloud-provider-nutanix
 images:
   items:

--- a/ci-operator/config/openshift/cloud-provider-powervs/openshift-cloud-provider-powervs-release-4.12.yaml
+++ b/ci-operator/config/openshift/cloud-provider-powervs/openshift-cloud-provider-powervs-release-4.12.yaml
@@ -1,9 +1,6 @@
 binary_build_commands: go build .
 build_root:
-  image_stream_tag:
-    name: builder
-    namespace: ocp
-    tag: rhel-8-golang-1.18-openshift-4.11
+  from_repository: true
 images:
   items:
   - dockerfile_path: openshift-hack/images/Dockerfile.openshift

--- a/ci-operator/config/openshift/cloud-provider-powervs/openshift-cloud-provider-powervs-release-4.13.yaml
+++ b/ci-operator/config/openshift/cloud-provider-powervs/openshift-cloud-provider-powervs-release-4.13.yaml
@@ -1,9 +1,6 @@
 binary_build_commands: go build .
 build_root:
-  image_stream_tag:
-    name: builder
-    namespace: ocp
-    tag: rhel-8-golang-1.18-openshift-4.11
+  from_repository: true
 images:
   items:
   - dockerfile_path: openshift-hack/images/Dockerfile.openshift

--- a/ci-operator/config/openshift/cluster-api-operator/openshift-cluster-api-operator-release-4.12.yaml
+++ b/ci-operator/config/openshift/cluster-api-operator/openshift-cluster-api-operator-release-4.12.yaml
@@ -5,10 +5,7 @@ base_images:
     tag: base
 binary_build_commands: make operator
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-8-release-golang-1.17-openshift-4.11
+  from_repository: true
 canonical_go_repository: sigs.k8s.io/cluster-api-operator
 images:
   items:

--- a/ci-operator/config/openshift/cluster-api-operator/openshift-cluster-api-operator-release-4.13.yaml
+++ b/ci-operator/config/openshift/cluster-api-operator/openshift-cluster-api-operator-release-4.13.yaml
@@ -5,10 +5,7 @@ base_images:
     tag: base
 binary_build_commands: make operator
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-8-release-golang-1.17-openshift-4.11
+  from_repository: true
 canonical_go_repository: sigs.k8s.io/cluster-api-operator
 images:
   items:

--- a/ci-operator/config/openshift/cluster-api-operator/openshift-cluster-api-operator-release-4.14.yaml
+++ b/ci-operator/config/openshift/cluster-api-operator/openshift-cluster-api-operator-release-4.14.yaml
@@ -5,10 +5,7 @@ base_images:
     tag: base
 binary_build_commands: make operator
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-8-release-golang-1.17-openshift-4.11
+  from_repository: true
 canonical_go_repository: sigs.k8s.io/cluster-api-operator
 images:
   items:

--- a/ci-operator/config/openshift/cluster-api-operator/openshift-cluster-api-operator-release-4.15.yaml
+++ b/ci-operator/config/openshift/cluster-api-operator/openshift-cluster-api-operator-release-4.15.yaml
@@ -5,10 +5,7 @@ base_images:
     tag: latest
 binary_build_commands: make operator
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-8-release-golang-1.17-openshift-4.11
+  from_repository: true
 canonical_go_repository: sigs.k8s.io/cluster-api-operator
 images:
   items:

--- a/ci-operator/config/openshift/csi-operator/openshift-csi-operator-release-4.12.yaml
+++ b/ci-operator/config/openshift/csi-operator/openshift-csi-operator-release-4.12.yaml
@@ -4,10 +4,7 @@ base_images:
     namespace: ocp
     tag: base
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-8-release-golang-1.25-openshift-4.23
+  from_repository: true
 promotion:
   to:
   - name: "4.12"

--- a/ci-operator/config/openshift/csi-operator/openshift-csi-operator-release-4.13.yaml
+++ b/ci-operator/config/openshift/csi-operator/openshift-csi-operator-release-4.13.yaml
@@ -4,10 +4,7 @@ base_images:
     namespace: ocp
     tag: base
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-8-release-golang-1.25-openshift-4.23
+  from_repository: true
 promotion:
   to:
   - name: "4.13"

--- a/ci-operator/config/openshift/csi-operator/openshift-csi-operator-release-4.14.yaml
+++ b/ci-operator/config/openshift/csi-operator/openshift-csi-operator-release-4.14.yaml
@@ -4,10 +4,7 @@ base_images:
     namespace: ocp
     tag: base
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-8-release-golang-1.25-openshift-4.23
+  from_repository: true
 promotion:
   to:
   - name: "4.14"

--- a/ci-operator/config/openshift/etcd/openshift-etcd-openshift-4.12.yaml
+++ b/ci-operator/config/openshift/etcd/openshift-etcd-openshift-4.12.yaml
@@ -5,10 +5,7 @@ base_images:
     tag: base
 binary_build_commands: GOFLAGS=-mod=readonly make build --warn-undefined-variables
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-8-release-golang-1.19-openshift-4.12
+  from_repository: true
 canonical_go_repository: go.etcd.io/etcd
 images:
   items:

--- a/ci-operator/config/openshift/frr/openshift-frr-release-4.12.yaml
+++ b/ci-operator/config/openshift/frr/openshift-frr-release-4.12.yaml
@@ -8,10 +8,7 @@ base_images:
     namespace: ocp
     tag: rhel-8-base-openshift-4.10
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-8-release-golang-1.16-openshift-4.10
+  from_repository: true
 images:
   items:
   - dockerfile_path: Dockerfile.openshift

--- a/ci-operator/config/openshift/frr/openshift-frr-release-4.13.yaml
+++ b/ci-operator/config/openshift/frr/openshift-frr-release-4.13.yaml
@@ -8,10 +8,7 @@ base_images:
     namespace: ocp
     tag: rhel-8-base-openshift-4.10
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-8-release-golang-1.16-openshift-4.10
+  from_repository: true
 images:
   items:
   - dockerfile_path: Dockerfile.openshift

--- a/ci-operator/config/openshift/frr/openshift-frr-release-4.14.yaml
+++ b/ci-operator/config/openshift/frr/openshift-frr-release-4.14.yaml
@@ -8,10 +8,7 @@ base_images:
     namespace: ocp
     tag: rhel-9-base-openshift-4.14
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-8-release-golang-1.16-openshift-4.9
+  from_repository: true
 images:
   items:
   - dockerfile_path: Dockerfile.openshift

--- a/ci-operator/config/openshift/frr/openshift-frr-release-4.15.yaml
+++ b/ci-operator/config/openshift/frr/openshift-frr-release-4.15.yaml
@@ -8,10 +8,7 @@ base_images:
     namespace: ocp
     tag: rhel-9-base-openshift-4.14
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-8-release-golang-1.16-openshift-4.9
+  from_repository: true
 images:
   items:
   - dockerfile_path: Dockerfile.openshift

--- a/ci-operator/config/openshift/frr/openshift-frr-release-4.16.yaml
+++ b/ci-operator/config/openshift/frr/openshift-frr-release-4.16.yaml
@@ -8,10 +8,7 @@ base_images:
     namespace: ocp
     tag: rhel-9-base-openshift-4.16
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-8-release-golang-1.16-openshift-4.9
+  from_repository: true
 images:
   items:
   - dockerfile_path: Dockerfile.openshift

--- a/ci-operator/config/openshift/frr/openshift-frr-release-4.17.yaml
+++ b/ci-operator/config/openshift/frr/openshift-frr-release-4.17.yaml
@@ -8,10 +8,7 @@ base_images:
     namespace: ocp
     tag: rhel-9-base-openshift-4.17
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-8-release-golang-1.16-openshift-4.9
+  from_repository: true
 images:
   items:
   - dockerfile_path: Dockerfile.openshift

--- a/ci-operator/config/openshift/frr/openshift-frr-release-4.18.yaml
+++ b/ci-operator/config/openshift/frr/openshift-frr-release-4.18.yaml
@@ -8,10 +8,7 @@ base_images:
     namespace: ocp
     tag: rhel-9-base-openshift-4.17
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-8-release-golang-1.16-openshift-4.9
+  from_repository: true
 images:
   items:
   - dockerfile_path: Dockerfile.openshift

--- a/ci-operator/config/openshift/frr/openshift-frr-release-4.19.yaml
+++ b/ci-operator/config/openshift/frr/openshift-frr-release-4.19.yaml
@@ -8,10 +8,7 @@ base_images:
     namespace: ocp
     tag: rhel-9-base-openshift-4.17
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-8-release-golang-1.22-openshift-4.17
+  from_repository: true
 images:
   items:
   - dockerfile_path: Dockerfile.openshift

--- a/ci-operator/config/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.12.yaml
+++ b/ci-operator/config/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.12.yaml
@@ -5,10 +5,7 @@ base_images:
     tag: base
 binary_build_commands: make build
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-8-release-golang-1.18-openshift-4.12
+  from_repository: true
 canonical_go_repository: github.com/kubevirt/csi-driver
 images:
   items:

--- a/ci-operator/config/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.13.yaml
+++ b/ci-operator/config/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.13.yaml
@@ -5,10 +5,7 @@ base_images:
     tag: base
 binary_build_commands: make build
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-8-release-golang-1.18-openshift-4.12
+  from_repository: true
 canonical_go_repository: github.com/kubevirt/csi-driver
 images:
   items:

--- a/ci-operator/config/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.14.yaml
+++ b/ci-operator/config/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.14.yaml
@@ -9,10 +9,7 @@ base_images:
     tag: cli
 binary_build_commands: make build
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-8-release-golang-1.19-openshift-4.14
+  from_repository: true
 canonical_go_repository: github.com/kubevirt/csi-driver
 images:
   items:

--- a/ci-operator/config/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.15.yaml
+++ b/ci-operator/config/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.15.yaml
@@ -9,10 +9,7 @@ base_images:
     tag: latest
 binary_build_commands: make build
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-8-release-golang-1.19-openshift-4.15
+  from_repository: true
 canonical_go_repository: github.com/kubevirt/csi-driver
 images:
   items:

--- a/ci-operator/config/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.16.yaml
+++ b/ci-operator/config/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.16.yaml
@@ -9,10 +9,7 @@ base_images:
     tag: latest
 binary_build_commands: make build
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-9-release-golang-1.19-openshift-4.15
+  from_repository: true
 canonical_go_repository: github.com/kubevirt/csi-driver
 images:
   items:

--- a/ci-operator/config/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.17.yaml
+++ b/ci-operator/config/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.17.yaml
@@ -9,10 +9,7 @@ base_images:
     tag: latest
 binary_build_commands: make build
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-9-release-golang-1.22-openshift-4.17
+  from_repository: true
 canonical_go_repository: github.com/kubevirt/csi-driver
 images:
   items:

--- a/ci-operator/config/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.18.yaml
+++ b/ci-operator/config/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.18.yaml
@@ -9,10 +9,7 @@ base_images:
     tag: latest
 binary_build_commands: make build
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-9-release-golang-1.22-openshift-4.17
+  from_repository: true
 canonical_go_repository: github.com/kubevirt/csi-driver
 images:
   items:

--- a/ci-operator/config/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.19.yaml
+++ b/ci-operator/config/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.19.yaml
@@ -9,10 +9,7 @@ base_images:
     tag: latest
 binary_build_commands: make build
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-9-release-golang-1.22-openshift-4.17
+  from_repository: true
 canonical_go_repository: github.com/kubevirt/csi-driver
 images:
   items:

--- a/ci-operator/config/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.20.yaml
+++ b/ci-operator/config/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.20.yaml
@@ -9,10 +9,7 @@ base_images:
     tag: latest
 binary_build_commands: make build
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-9-release-golang-1.22-openshift-4.17
+  from_repository: true
 canonical_go_repository: github.com/kubevirt/csi-driver
 images:
   items:

--- a/ci-operator/config/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.21.yaml
+++ b/ci-operator/config/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.21.yaml
@@ -9,10 +9,7 @@ base_images:
     tag: latest
 binary_build_commands: make build
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-9-release-golang-1.22-openshift-4.17
+  from_repository: true
 canonical_go_repository: github.com/kubevirt/csi-driver
 images:
   items:

--- a/ci-operator/config/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.22.yaml
+++ b/ci-operator/config/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.22.yaml
@@ -9,10 +9,7 @@ base_images:
     tag: latest
 binary_build_commands: make build
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-9-release-golang-1.22-openshift-4.17
+  from_repository: true
 canonical_go_repository: github.com/kubevirt/csi-driver
 images:
   items:

--- a/ci-operator/config/openshift/kuryr-kubernetes/openshift-kuryr-kubernetes-release-4.12.yaml
+++ b/ci-operator/config/openshift/kuryr-kubernetes/openshift-kuryr-kubernetes-release-4.12.yaml
@@ -4,10 +4,7 @@ base_rpm_images:
     namespace: ocp
     tag: "8"
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-8-release-golang-1.19-openshift-4.12
+  from_repository: true
 images:
   items:
   - dockerfile_path: openshift-kuryr-tester-rhel8.Dockerfile

--- a/ci-operator/config/openshift/kuryr-kubernetes/openshift-kuryr-kubernetes-release-4.13.yaml
+++ b/ci-operator/config/openshift/kuryr-kubernetes/openshift-kuryr-kubernetes-release-4.13.yaml
@@ -4,10 +4,7 @@ base_rpm_images:
     namespace: ocp
     tag: "8"
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-8-release-golang-1.19-openshift-4.13
+  from_repository: true
 images:
   items:
   - dockerfile_path: openshift-kuryr-tester-rhel8.Dockerfile

--- a/ci-operator/config/openshift/kuryr-kubernetes/openshift-kuryr-kubernetes-release-4.14.yaml
+++ b/ci-operator/config/openshift/kuryr-kubernetes/openshift-kuryr-kubernetes-release-4.14.yaml
@@ -4,10 +4,7 @@ base_rpm_images:
     namespace: ocp
     tag: "8"
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-8-release-golang-1.19-openshift-4.14
+  from_repository: true
 images:
   items:
   - dockerfile_path: openshift-kuryr-tester-rhel8.Dockerfile

--- a/ci-operator/config/openshift/monitoring-plugin/openshift-monitoring-plugin-release-4.14.yaml
+++ b/ci-operator/config/openshift/monitoring-plugin/openshift-monitoring-plugin-release-4.14.yaml
@@ -1,8 +1,5 @@
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-8-release-golang-1.25-openshift-4.23
+  from_repository: true
 images:
   items:
   - dockerfile_path: Dockerfile

--- a/ci-operator/config/openshift/monitoring-plugin/openshift-monitoring-plugin-release-4.15.yaml
+++ b/ci-operator/config/openshift/monitoring-plugin/openshift-monitoring-plugin-release-4.15.yaml
@@ -1,8 +1,5 @@
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-8-release-golang-1.25-openshift-4.23
+  from_repository: true
 images:
   items:
   - dockerfile_path: Dockerfile

--- a/ci-operator/config/openshift/monitoring-plugin/openshift-monitoring-plugin-release-4.16.yaml
+++ b/ci-operator/config/openshift/monitoring-plugin/openshift-monitoring-plugin-release-4.16.yaml
@@ -1,8 +1,5 @@
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-8-release-golang-1.25-openshift-4.23
+  from_repository: true
 images:
   items:
   - dockerfile_path: Dockerfile

--- a/ci-operator/config/openshift/monitoring-plugin/openshift-monitoring-plugin-release-4.17.yaml
+++ b/ci-operator/config/openshift/monitoring-plugin/openshift-monitoring-plugin-release-4.17.yaml
@@ -1,8 +1,5 @@
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-8-release-golang-1.25-openshift-4.23
+  from_repository: true
 images:
   items:
   - dockerfile_path: Dockerfile

--- a/ci-operator/config/openshift/monitoring-plugin/openshift-monitoring-plugin-release-4.18.yaml
+++ b/ci-operator/config/openshift/monitoring-plugin/openshift-monitoring-plugin-release-4.18.yaml
@@ -4,10 +4,7 @@ base_images:
     namespace: hypershift
     tag: latest
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-8-release-golang-1.25-openshift-4.23
+  from_repository: true
 images:
   items:
   - dockerfile_path: Dockerfile

--- a/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-sandbox-release-4.16.yaml
+++ b/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-sandbox-release-4.16.yaml
@@ -12,10 +12,7 @@ base_images:
     namespace: ci
     tag: "4.16"
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-8-release-golang-1.21-openshift-4.16
+  from_repository: true
 images:
   items:
   - dockerfile_path: Dockerfile.base

--- a/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-sandbox-release-4.17.yaml
+++ b/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-sandbox-release-4.17.yaml
@@ -12,10 +12,7 @@ base_images:
     namespace: ci
     tag: latest
 build_root:
-  image_stream_tag:
-    name: release
-    namespace: openshift
-    tag: rhel-8-release-golang-1.22-openshift-4.17
+  from_repository: true
 images:
   items:
   - dockerfile_path: Dockerfile.base

--- a/ci-operator/jobs/openshift/apiserver-network-proxy/openshift-apiserver-network-proxy-release-4.12-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/apiserver-network-proxy/openshift-apiserver-network-proxy-release-4.12-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci-operator.openshift.io/is-promotion: "true"

--- a/ci-operator/jobs/openshift/apiserver-network-proxy/openshift-apiserver-network-proxy-release-4.12-presubmits.yaml
+++ b/ci-operator/jobs/openshift/apiserver-network-proxy/openshift-apiserver-network-proxy-release-4.12-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: hypershift-aws
@@ -93,6 +94,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -150,6 +152,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -214,6 +217,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen

--- a/ci-operator/jobs/openshift/apiserver-network-proxy/openshift-apiserver-network-proxy-release-4.13-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/apiserver-network-proxy/openshift-apiserver-network-proxy-release-4.13-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci-operator.openshift.io/is-promotion: "true"

--- a/ci-operator/jobs/openshift/apiserver-network-proxy/openshift-apiserver-network-proxy-release-4.13-presubmits.yaml
+++ b/ci-operator/jobs/openshift/apiserver-network-proxy/openshift-apiserver-network-proxy-release-4.13-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: hypershift-aws
@@ -93,6 +94,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -150,6 +152,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -214,6 +217,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen

--- a/ci-operator/jobs/openshift/bond-cni/openshift-bond-cni-release-4.12-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/bond-cni/openshift-bond-cni-release-4.12-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci-operator.openshift.io/is-promotion: "true"

--- a/ci-operator/jobs/openshift/bond-cni/openshift-bond-cni-release-4.12-presubmits.yaml
+++ b/ci-operator/jobs/openshift/bond-cni/openshift-bond-cni-release-4.12-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen

--- a/ci-operator/jobs/openshift/bond-cni/openshift-bond-cni-release-4.13-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/bond-cni/openshift-bond-cni-release-4.13-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci-operator.openshift.io/is-promotion: "true"

--- a/ci-operator/jobs/openshift/bond-cni/openshift-bond-cni-release-4.13-presubmits.yaml
+++ b/ci-operator/jobs/openshift/bond-cni/openshift-bond-cni-release-4.13-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen

--- a/ci-operator/jobs/openshift/bond-cni/openshift-bond-cni-release-4.14-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/bond-cni/openshift-bond-cni-release-4.14-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci-operator.openshift.io/is-promotion: "true"

--- a/ci-operator/jobs/openshift/bond-cni/openshift-bond-cni-release-4.14-presubmits.yaml
+++ b/ci-operator/jobs/openshift/bond-cni/openshift-bond-cni-release-4.14-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen

--- a/ci-operator/jobs/openshift/bond-cni/openshift-bond-cni-release-4.15-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/bond-cni/openshift-bond-cni-release-4.15-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci-operator.openshift.io/is-promotion: "true"

--- a/ci-operator/jobs/openshift/bond-cni/openshift-bond-cni-release-4.15-presubmits.yaml
+++ b/ci-operator/jobs/openshift/bond-cni/openshift-bond-cni-release-4.15-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen

--- a/ci-operator/jobs/openshift/cloud-provider-aws/openshift-cloud-provider-aws-release-4.12-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-aws/openshift-cloud-provider-aws-release-4.12-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci-operator.openshift.io/is-promotion: "true"

--- a/ci-operator/jobs/openshift/cloud-provider-aws/openshift-cloud-provider-aws-release-4.12-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-aws/openshift-cloud-provider-aws-release-4.12-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: aws
@@ -94,6 +95,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: aws
@@ -178,6 +180,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: aws
@@ -262,6 +265,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: aws
@@ -347,6 +351,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -405,6 +410,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: aws

--- a/ci-operator/jobs/openshift/cloud-provider-aws/openshift-cloud-provider-aws-release-4.13-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-aws/openshift-cloud-provider-aws-release-4.13-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci-operator.openshift.io/is-promotion: "true"

--- a/ci-operator/jobs/openshift/cloud-provider-aws/openshift-cloud-provider-aws-release-4.13-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-aws/openshift-cloud-provider-aws-release-4.13-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: aws
@@ -95,6 +96,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: aws
@@ -180,6 +182,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: aws
@@ -265,6 +268,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: aws
@@ -350,6 +354,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -408,6 +413,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: aws

--- a/ci-operator/jobs/openshift/cloud-provider-gcp/openshift-cloud-provider-gcp-release-4.12-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-gcp/openshift-cloud-provider-gcp-release-4.12-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift-hack/images/Dockerfile.openshift
     labels:
       ci-operator.openshift.io/is-promotion: "true"

--- a/ci-operator/jobs/openshift/cloud-provider-gcp/openshift-cloud-provider-gcp-release-4.12-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-gcp/openshift-cloud-provider-gcp-release-4.12-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift-hack/images/Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: gcp
@@ -95,6 +96,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift-hack/images/Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: gcp
@@ -179,6 +181,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift-hack/images/Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -244,6 +247,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift-hack/images/Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -302,6 +306,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift-hack/images/Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: gcp

--- a/ci-operator/jobs/openshift/cloud-provider-gcp/openshift-cloud-provider-gcp-release-4.13-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-gcp/openshift-cloud-provider-gcp-release-4.13-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift-hack/images/Dockerfile.openshift
     labels:
       ci-operator.openshift.io/is-promotion: "true"

--- a/ci-operator/jobs/openshift/cloud-provider-gcp/openshift-cloud-provider-gcp-release-4.13-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-gcp/openshift-cloud-provider-gcp-release-4.13-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift-hack/images/Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: gcp
@@ -95,6 +96,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift-hack/images/Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: gcp
@@ -180,6 +182,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift-hack/images/Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -245,6 +248,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift-hack/images/Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -303,6 +307,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift-hack/images/Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: gcp

--- a/ci-operator/jobs/openshift/cloud-provider-gcp/openshift-cloud-provider-gcp-release-4.14-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-gcp/openshift-cloud-provider-gcp-release-4.14-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift-hack/images/Dockerfile.openshift
     labels:
       ci-operator.openshift.io/is-promotion: "true"

--- a/ci-operator/jobs/openshift/cloud-provider-gcp/openshift-cloud-provider-gcp-release-4.14-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-gcp/openshift-cloud-provider-gcp-release-4.14-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift-hack/images/Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: gcp
@@ -95,6 +96,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift-hack/images/Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: gcp
@@ -180,6 +182,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift-hack/images/Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -245,6 +248,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift-hack/images/Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -303,6 +307,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift-hack/images/Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: gcp

--- a/ci-operator/jobs/openshift/cloud-provider-nutanix/openshift-cloud-provider-nutanix-release-4.12-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-nutanix/openshift-cloud-provider-nutanix-release-4.12-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift/Dockerfile.openshift
     labels:
       ci-operator.openshift.io/is-promotion: "true"

--- a/ci-operator/jobs/openshift/cloud-provider-nutanix/openshift-cloud-provider-nutanix-release-4.12-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-nutanix/openshift-cloud-provider-nutanix-release-4.12-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift/Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: nutanix
@@ -95,6 +96,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift/Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -160,6 +162,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift/Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -218,6 +221,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift/Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen

--- a/ci-operator/jobs/openshift/cloud-provider-nutanix/openshift-cloud-provider-nutanix-release-4.13-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-nutanix/openshift-cloud-provider-nutanix-release-4.13-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift/Dockerfile.openshift
     labels:
       ci-operator.openshift.io/is-promotion: "true"

--- a/ci-operator/jobs/openshift/cloud-provider-nutanix/openshift-cloud-provider-nutanix-release-4.13-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-nutanix/openshift-cloud-provider-nutanix-release-4.13-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift/Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: nutanix
@@ -96,6 +97,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift/Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -161,6 +163,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift/Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -219,6 +222,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift/Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen

--- a/ci-operator/jobs/openshift/cloud-provider-nutanix/openshift-cloud-provider-nutanix-release-4.14-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-nutanix/openshift-cloud-provider-nutanix-release-4.14-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift/Dockerfile.openshift
     labels:
       ci-operator.openshift.io/is-promotion: "true"

--- a/ci-operator/jobs/openshift/cloud-provider-nutanix/openshift-cloud-provider-nutanix-release-4.14-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-nutanix/openshift-cloud-provider-nutanix-release-4.14-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift/Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: nutanix
@@ -96,6 +97,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift/Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: nutanix
@@ -182,6 +184,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift/Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -247,6 +250,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift/Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -305,6 +309,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift/Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen

--- a/ci-operator/jobs/openshift/cloud-provider-powervs/openshift-cloud-provider-powervs-release-4.12-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-powervs/openshift-cloud-provider-powervs-release-4.12-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift-hack/images/Dockerfile.openshift
     labels:
       ci-operator.openshift.io/is-promotion: "true"

--- a/ci-operator/jobs/openshift/cloud-provider-powervs/openshift-cloud-provider-powervs-release-4.12-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-powervs/openshift-cloud-provider-powervs-release-4.12-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift-hack/images/Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -74,6 +75,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift-hack/images/Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -131,6 +133,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift-hack/images/Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -195,6 +198,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift-hack/images/Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen

--- a/ci-operator/jobs/openshift/cloud-provider-powervs/openshift-cloud-provider-powervs-release-4.13-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-powervs/openshift-cloud-provider-powervs-release-4.13-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift-hack/images/Dockerfile.openshift
     labels:
       ci-operator.openshift.io/is-promotion: "true"

--- a/ci-operator/jobs/openshift/cloud-provider-powervs/openshift-cloud-provider-powervs-release-4.13-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cloud-provider-powervs/openshift-cloud-provider-powervs-release-4.13-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift-hack/images/Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -74,6 +75,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift-hack/images/Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -131,6 +133,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift-hack/images/Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -195,6 +198,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift-hack/images/Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen

--- a/ci-operator/jobs/openshift/cluster-api-operator/openshift-cluster-api-operator-release-4.12-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-operator/openshift-cluster-api-operator-release-4.12-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift/Dockerfile.openshift
     labels:
       ci-operator.openshift.io/is-promotion: "true"

--- a/ci-operator/jobs/openshift/cluster-api-operator/openshift-cluster-api-operator-release-4.12-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-operator/openshift-cluster-api-operator-release-4.12-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift/Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: aws
@@ -94,6 +95,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift/Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen

--- a/ci-operator/jobs/openshift/cluster-api-operator/openshift-cluster-api-operator-release-4.13-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-operator/openshift-cluster-api-operator-release-4.13-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift/Dockerfile.openshift
     labels:
       ci-operator.openshift.io/is-promotion: "true"

--- a/ci-operator/jobs/openshift/cluster-api-operator/openshift-cluster-api-operator-release-4.13-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-operator/openshift-cluster-api-operator-release-4.13-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift/Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: aws
@@ -95,6 +96,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift/Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: aws
@@ -180,6 +182,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift/Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: azure4
@@ -265,6 +268,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift/Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: gcp
@@ -350,6 +354,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift/Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen

--- a/ci-operator/jobs/openshift/cluster-api-operator/openshift-cluster-api-operator-release-4.14-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-operator/openshift-cluster-api-operator-release-4.14-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift/Dockerfile.openshift
     labels:
       ci-operator.openshift.io/is-promotion: "true"

--- a/ci-operator/jobs/openshift/cluster-api-operator/openshift-cluster-api-operator-release-4.14-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-operator/openshift-cluster-api-operator-release-4.14-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift/Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: aws
@@ -95,6 +96,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift/Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: aws
@@ -180,6 +182,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift/Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: azure4
@@ -265,6 +268,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift/Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: azure4
@@ -350,6 +354,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift/Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: gcp
@@ -435,6 +440,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift/Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen

--- a/ci-operator/jobs/openshift/cluster-api-operator/openshift-cluster-api-operator-release-4.15-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-operator/openshift-cluster-api-operator-release-4.15-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift/Dockerfile.openshift
     labels:
       ci-operator.openshift.io/is-promotion: "true"

--- a/ci-operator/jobs/openshift/cluster-api-operator/openshift-cluster-api-operator-release-4.15-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-api-operator/openshift-cluster-api-operator-release-4.15-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift/Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: aws
@@ -95,6 +96,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift/Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: aws
@@ -180,6 +182,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift/Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: azure4
@@ -265,6 +268,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift/Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: azure4
@@ -350,6 +354,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift/Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: gcp
@@ -435,6 +440,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift/Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -493,6 +499,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift/Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen

--- a/ci-operator/jobs/openshift/csi-operator/openshift-csi-operator-release-4.12-presubmits.yaml
+++ b/ci-operator/jobs/openshift/csi-operator/openshift-csi-operator-release-4.12-presubmits.yaml
@@ -9,7 +9,8 @@ presubmits:
     context: ci/prow/e2e-aws-operator
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - .ci-operator.yaml
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -91,7 +92,8 @@ presubmits:
     context: ci/prow/unit
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - .ci-operator.yaml
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -154,7 +156,8 @@ presubmits:
     context: ci/prow/verify
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - .ci-operator.yaml
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"

--- a/ci-operator/jobs/openshift/csi-operator/openshift-csi-operator-release-4.13-presubmits.yaml
+++ b/ci-operator/jobs/openshift/csi-operator/openshift-csi-operator-release-4.13-presubmits.yaml
@@ -9,7 +9,8 @@ presubmits:
     context: ci/prow/e2e-aws-operator
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - .ci-operator.yaml
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -91,7 +92,8 @@ presubmits:
     context: ci/prow/unit
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - .ci-operator.yaml
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -154,7 +156,8 @@ presubmits:
     context: ci/prow/verify
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - .ci-operator.yaml
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"

--- a/ci-operator/jobs/openshift/csi-operator/openshift-csi-operator-release-4.14-presubmits.yaml
+++ b/ci-operator/jobs/openshift/csi-operator/openshift-csi-operator-release-4.14-presubmits.yaml
@@ -9,7 +9,8 @@ presubmits:
     context: ci/prow/unit
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - .ci-operator.yaml
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -72,7 +73,8 @@ presubmits:
     context: ci/prow/verify
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - .ci-operator.yaml
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"

--- a/ci-operator/jobs/openshift/etcd/openshift-etcd-openshift-4.12-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/etcd/openshift-etcd-openshift-4.12-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.rhel
     labels:
       ci-operator.openshift.io/is-promotion: "true"

--- a/ci-operator/jobs/openshift/etcd/openshift-etcd-openshift-4.12-presubmits.yaml
+++ b/ci-operator/jobs/openshift/etcd/openshift-etcd-openshift-4.12-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.rhel
     labels:
       ci-operator.openshift.io/cloud: aws
@@ -94,6 +95,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.rhel
     labels:
       ci-operator.openshift.io/cloud: aws
@@ -179,6 +181,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.rhel
     labels:
       ci-operator.openshift.io/cloud: aws
@@ -263,6 +266,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.rhel
     labels:
       ci-operator.openshift.io/cloud: aws
@@ -347,6 +351,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.rhel
     labels:
       ci-operator.openshift.io/cloud: aws
@@ -431,6 +436,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.rhel
     labels:
       ci.openshift.io/generator: prowgen
@@ -489,6 +495,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.rhel
     labels:
       ci.openshift.io/generator: prowgen

--- a/ci-operator/jobs/openshift/frr/openshift-frr-release-4.12-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/frr/openshift-frr-release-4.12-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci-operator.openshift.io/is-promotion: "true"

--- a/ci-operator/jobs/openshift/frr/openshift-frr-release-4.12-presubmits.yaml
+++ b/ci-operator/jobs/openshift/frr/openshift-frr-release-4.12-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -67,6 +68,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       capability/intranet: intranet
@@ -151,6 +153,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       capability/intranet: intranet

--- a/ci-operator/jobs/openshift/frr/openshift-frr-release-4.13-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/frr/openshift-frr-release-4.13-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci-operator.openshift.io/is-promotion: "true"

--- a/ci-operator/jobs/openshift/frr/openshift-frr-release-4.13-presubmits.yaml
+++ b/ci-operator/jobs/openshift/frr/openshift-frr-release-4.13-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -67,6 +68,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       capability/intranet: intranet
@@ -151,6 +153,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       capability/intranet: intranet

--- a/ci-operator/jobs/openshift/frr/openshift-frr-release-4.14-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/frr/openshift-frr-release-4.14-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci-operator.openshift.io/is-promotion: "true"

--- a/ci-operator/jobs/openshift/frr/openshift-frr-release-4.14-presubmits.yaml
+++ b/ci-operator/jobs/openshift/frr/openshift-frr-release-4.14-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -67,6 +68,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       capability/intranet: intranet
@@ -151,6 +153,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       capability/intranet: intranet

--- a/ci-operator/jobs/openshift/frr/openshift-frr-release-4.15-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/frr/openshift-frr-release-4.15-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci-operator.openshift.io/is-promotion: "true"

--- a/ci-operator/jobs/openshift/frr/openshift-frr-release-4.15-presubmits.yaml
+++ b/ci-operator/jobs/openshift/frr/openshift-frr-release-4.15-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -67,6 +68,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       capability/intranet: intranet
@@ -151,6 +153,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       capability/intranet: intranet

--- a/ci-operator/jobs/openshift/frr/openshift-frr-release-4.16-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/frr/openshift-frr-release-4.16-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci-operator.openshift.io/is-promotion: "true"

--- a/ci-operator/jobs/openshift/frr/openshift-frr-release-4.16-presubmits.yaml
+++ b/ci-operator/jobs/openshift/frr/openshift-frr-release-4.16-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -67,6 +68,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       capability/intranet: intranet
@@ -151,6 +153,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       capability/intranet: intranet
@@ -235,6 +238,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen

--- a/ci-operator/jobs/openshift/frr/openshift-frr-release-4.17-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/frr/openshift-frr-release-4.17-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci-operator.openshift.io/is-promotion: "true"

--- a/ci-operator/jobs/openshift/frr/openshift-frr-release-4.17-presubmits.yaml
+++ b/ci-operator/jobs/openshift/frr/openshift-frr-release-4.17-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -67,6 +68,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       capability/intranet: intranet
@@ -151,6 +153,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       capability/intranet: intranet
@@ -235,6 +238,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen

--- a/ci-operator/jobs/openshift/frr/openshift-frr-release-4.18-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/frr/openshift-frr-release-4.18-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci-operator.openshift.io/is-promotion: "true"

--- a/ci-operator/jobs/openshift/frr/openshift-frr-release-4.18-presubmits.yaml
+++ b/ci-operator/jobs/openshift/frr/openshift-frr-release-4.18-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       capability/intranet: intranet
@@ -94,6 +95,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       capability/intranet: intranet
@@ -178,6 +180,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -235,6 +238,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       capability/intranet: intranet
@@ -319,6 +323,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen

--- a/ci-operator/jobs/openshift/frr/openshift-frr-release-4.19-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/frr/openshift-frr-release-4.19-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci-operator.openshift.io/is-promotion: "true"

--- a/ci-operator/jobs/openshift/frr/openshift-frr-release-4.19-presubmits.yaml
+++ b/ci-operator/jobs/openshift/frr/openshift-frr-release-4.19-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       capability/intranet: intranet
@@ -94,6 +95,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -151,6 +153,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       capability/intranet: intranet
@@ -235,6 +238,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -317,6 +321,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen

--- a/ci-operator/jobs/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.12-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.12-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci-operator.openshift.io/is-promotion: "true"

--- a/ci-operator/jobs/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.12-presubmits.yaml
+++ b/ci-operator/jobs/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.12-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -68,6 +69,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen

--- a/ci-operator/jobs/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.13-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.13-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci-operator.openshift.io/is-promotion: "true"

--- a/ci-operator/jobs/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.13-presubmits.yaml
+++ b/ci-operator/jobs/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.13-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -68,6 +69,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen

--- a/ci-operator/jobs/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.14-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.14-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci-operator.openshift.io/is-promotion: "true"

--- a/ci-operator/jobs/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.14-presubmits.yaml
+++ b/ci-operator/jobs/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.14-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: aws
@@ -94,6 +95,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -152,6 +154,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen

--- a/ci-operator/jobs/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.15-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.15-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci-operator.openshift.io/is-promotion: "true"

--- a/ci-operator/jobs/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.15-presubmits.yaml
+++ b/ci-operator/jobs/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.15-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: aws
@@ -94,6 +95,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -152,6 +154,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen

--- a/ci-operator/jobs/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.16-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.16-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci-operator.openshift.io/is-promotion: "true"

--- a/ci-operator/jobs/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.16-presubmits.yaml
+++ b/ci-operator/jobs/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.16-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: aws
@@ -94,6 +95,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -152,6 +154,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen

--- a/ci-operator/jobs/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.17-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.17-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci-operator.openshift.io/is-promotion: "true"

--- a/ci-operator/jobs/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.17-presubmits.yaml
+++ b/ci-operator/jobs/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.17-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: aws
@@ -94,6 +95,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -152,6 +154,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen

--- a/ci-operator/jobs/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.18-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.18-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci-operator.openshift.io/is-promotion: "true"

--- a/ci-operator/jobs/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.18-presubmits.yaml
+++ b/ci-operator/jobs/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.18-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: aws
@@ -94,6 +95,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -152,6 +154,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen

--- a/ci-operator/jobs/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.19-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.19-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci-operator.openshift.io/is-promotion: "true"

--- a/ci-operator/jobs/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.19-presubmits.yaml
+++ b/ci-operator/jobs/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.19-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: aws
@@ -94,6 +95,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -152,6 +154,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -217,6 +220,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen

--- a/ci-operator/jobs/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.20-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.20-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci-operator.openshift.io/is-promotion: "true"

--- a/ci-operator/jobs/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.20-presubmits.yaml
+++ b/ci-operator/jobs/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.20-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: aws
@@ -94,6 +95,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -152,6 +154,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -217,6 +220,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen

--- a/ci-operator/jobs/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.21-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.21-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci-operator.openshift.io/is-promotion: "true"

--- a/ci-operator/jobs/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.21-presubmits.yaml
+++ b/ci-operator/jobs/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.21-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: aws
@@ -94,6 +95,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -297,6 +299,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -362,6 +365,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen

--- a/ci-operator/jobs/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.22-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.22-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci-operator.openshift.io/is-promotion: "true"

--- a/ci-operator/jobs/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift/kubevirt-csi-driver/openshift-kubevirt-csi-driver-release-4.22-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci-operator.openshift.io/cloud: aws
@@ -94,6 +95,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -152,6 +154,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen
@@ -217,6 +220,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile.openshift
     labels:
       ci.openshift.io/generator: prowgen

--- a/ci-operator/jobs/openshift/kuryr-kubernetes/openshift-kuryr-kubernetes-release-4.12-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/kuryr-kubernetes/openshift-kuryr-kubernetes-release-4.12-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift-kuryr-cni-rhel8.Dockerfile
       - openshift-kuryr-controller-rhel8.Dockerfile
       - openshift-kuryr-tester-rhel8.Dockerfile

--- a/ci-operator/jobs/openshift/kuryr-kubernetes/openshift-kuryr-kubernetes-release-4.12-presubmits.yaml
+++ b/ci-operator/jobs/openshift/kuryr-kubernetes/openshift-kuryr-kubernetes-release-4.12-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift-kuryr-cni-rhel8.Dockerfile
       - openshift-kuryr-controller-rhel8.Dockerfile
       - openshift-kuryr-tester-rhel8.Dockerfile
@@ -70,6 +71,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift-kuryr-cni-rhel8.Dockerfile
       - openshift-kuryr-controller-rhel8.Dockerfile
       - openshift-kuryr-tester-rhel8.Dockerfile
@@ -136,6 +138,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift-kuryr-cni-rhel8.Dockerfile
       - openshift-kuryr-controller-rhel8.Dockerfile
       - openshift-kuryr-tester-rhel8.Dockerfile

--- a/ci-operator/jobs/openshift/kuryr-kubernetes/openshift-kuryr-kubernetes-release-4.13-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/kuryr-kubernetes/openshift-kuryr-kubernetes-release-4.13-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift-kuryr-cni-rhel8.Dockerfile
       - openshift-kuryr-controller-rhel8.Dockerfile
       - openshift-kuryr-tester-rhel8.Dockerfile

--- a/ci-operator/jobs/openshift/kuryr-kubernetes/openshift-kuryr-kubernetes-release-4.13-presubmits.yaml
+++ b/ci-operator/jobs/openshift/kuryr-kubernetes/openshift-kuryr-kubernetes-release-4.13-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift-kuryr-cni-rhel8.Dockerfile
       - openshift-kuryr-controller-rhel8.Dockerfile
       - openshift-kuryr-tester-rhel8.Dockerfile
@@ -70,6 +71,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift-kuryr-cni-rhel8.Dockerfile
       - openshift-kuryr-controller-rhel8.Dockerfile
       - openshift-kuryr-tester-rhel8.Dockerfile
@@ -136,6 +138,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift-kuryr-cni-rhel8.Dockerfile
       - openshift-kuryr-controller-rhel8.Dockerfile
       - openshift-kuryr-tester-rhel8.Dockerfile

--- a/ci-operator/jobs/openshift/kuryr-kubernetes/openshift-kuryr-kubernetes-release-4.14-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/kuryr-kubernetes/openshift-kuryr-kubernetes-release-4.14-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift-kuryr-cni-rhel8.Dockerfile
       - openshift-kuryr-controller-rhel8.Dockerfile
       - openshift-kuryr-tester-rhel8.Dockerfile

--- a/ci-operator/jobs/openshift/kuryr-kubernetes/openshift-kuryr-kubernetes-release-4.14-presubmits.yaml
+++ b/ci-operator/jobs/openshift/kuryr-kubernetes/openshift-kuryr-kubernetes-release-4.14-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift-kuryr-cni-rhel8.Dockerfile
       - openshift-kuryr-controller-rhel8.Dockerfile
       - openshift-kuryr-tester-rhel8.Dockerfile
@@ -70,6 +71,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift-kuryr-cni-rhel8.Dockerfile
       - openshift-kuryr-controller-rhel8.Dockerfile
       - openshift-kuryr-tester-rhel8.Dockerfile
@@ -136,6 +138,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - openshift-kuryr-cni-rhel8.Dockerfile
       - openshift-kuryr-controller-rhel8.Dockerfile
       - openshift-kuryr-tester-rhel8.Dockerfile

--- a/ci-operator/jobs/openshift/monitoring-plugin/openshift-monitoring-plugin-release-4.14-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/monitoring-plugin/openshift-monitoring-plugin-release-4.14-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.test
     labels:

--- a/ci-operator/jobs/openshift/monitoring-plugin/openshift-monitoring-plugin-release-4.14-presubmits.yaml
+++ b/ci-operator/jobs/openshift/monitoring-plugin/openshift-monitoring-plugin-release-4.14-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.test
     labels:
@@ -68,6 +69,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.test
     labels:

--- a/ci-operator/jobs/openshift/monitoring-plugin/openshift-monitoring-plugin-release-4.15-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/monitoring-plugin/openshift-monitoring-plugin-release-4.15-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.test
     labels:

--- a/ci-operator/jobs/openshift/monitoring-plugin/openshift-monitoring-plugin-release-4.15-presubmits.yaml
+++ b/ci-operator/jobs/openshift/monitoring-plugin/openshift-monitoring-plugin-release-4.15-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.test
     labels:
@@ -68,6 +69,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.test
     labels:

--- a/ci-operator/jobs/openshift/monitoring-plugin/openshift-monitoring-plugin-release-4.16-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/monitoring-plugin/openshift-monitoring-plugin-release-4.16-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.test
     labels:

--- a/ci-operator/jobs/openshift/monitoring-plugin/openshift-monitoring-plugin-release-4.16-presubmits.yaml
+++ b/ci-operator/jobs/openshift/monitoring-plugin/openshift-monitoring-plugin-release-4.16-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.test
     labels:
@@ -68,6 +69,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.test
     labels:

--- a/ci-operator/jobs/openshift/monitoring-plugin/openshift-monitoring-plugin-release-4.17-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/monitoring-plugin/openshift-monitoring-plugin-release-4.17-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.test
     labels:

--- a/ci-operator/jobs/openshift/monitoring-plugin/openshift-monitoring-plugin-release-4.17-presubmits.yaml
+++ b/ci-operator/jobs/openshift/monitoring-plugin/openshift-monitoring-plugin-release-4.17-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.test
     labels:
@@ -68,6 +69,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.test
     labels:

--- a/ci-operator/jobs/openshift/monitoring-plugin/openshift-monitoring-plugin-release-4.18-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/monitoring-plugin/openshift-monitoring-plugin-release-4.18-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.test
       - web/cypress/Dockerfile

--- a/ci-operator/jobs/openshift/monitoring-plugin/openshift-monitoring-plugin-release-4.18-presubmits.yaml
+++ b/ci-operator/jobs/openshift/monitoring-plugin/openshift-monitoring-plugin-release-4.18-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.test
       - web/cypress/Dockerfile
@@ -95,6 +96,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.test
       - web/cypress/Dockerfile
@@ -180,6 +182,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.test
       - web/cypress/Dockerfile
@@ -265,6 +268,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.test
       - web/cypress/Dockerfile
@@ -367,6 +371,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.test
       - web/cypress/Dockerfile
@@ -426,6 +431,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.test
       - web/cypress/Dockerfile

--- a/ci-operator/jobs/openshift/ovn-kubernetes/openshift-ovn-kubernetes-sandbox-release-4.16-periodics.yaml
+++ b/ci-operator/jobs/openshift/ovn-kubernetes/openshift-ovn-kubernetes-sandbox-release-4.16-periodics.yaml
@@ -5,6 +5,7 @@ periodics:
   decorate: true
   decoration_config:
     sparse_checkout_files:
+    - .ci-operator.yaml
     - Dockerfile
     - Dockerfile.base
     - Dockerfile.microshift
@@ -13,6 +14,7 @@ periodics:
     org: openshift
     repo: ovn-kubernetes
     sparse_checkout_files:
+    - .ci-operator.yaml
     - Dockerfile
     - Dockerfile.base
     - Dockerfile.microshift
@@ -92,6 +94,7 @@ periodics:
   decorate: true
   decoration_config:
     sparse_checkout_files:
+    - .ci-operator.yaml
     - Dockerfile
     - Dockerfile.base
     - Dockerfile.microshift
@@ -100,6 +103,7 @@ periodics:
     org: openshift
     repo: ovn-kubernetes
     sparse_checkout_files:
+    - .ci-operator.yaml
     - Dockerfile
     - Dockerfile.base
     - Dockerfile.microshift
@@ -179,6 +183,7 @@ periodics:
   decorate: true
   decoration_config:
     sparse_checkout_files:
+    - .ci-operator.yaml
     - Dockerfile
     - Dockerfile.base
     - Dockerfile.microshift
@@ -187,6 +192,7 @@ periodics:
     org: openshift
     repo: ovn-kubernetes
     sparse_checkout_files:
+    - .ci-operator.yaml
     - Dockerfile
     - Dockerfile.base
     - Dockerfile.microshift

--- a/ci-operator/jobs/openshift/ovn-kubernetes/openshift-ovn-kubernetes-sandbox-release-4.16-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/ovn-kubernetes/openshift-ovn-kubernetes-sandbox-release-4.16-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift

--- a/ci-operator/jobs/openshift/ovn-kubernetes/openshift-ovn-kubernetes-sandbox-release-4.16-presubmits.yaml
+++ b/ci-operator/jobs/openshift/ovn-kubernetes/openshift-ovn-kubernetes-sandbox-release-4.16-presubmits.yaml
@@ -306,6 +306,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -393,6 +394,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -478,6 +480,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -564,6 +567,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -649,6 +653,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -735,6 +740,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -821,6 +827,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -906,6 +913,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -992,6 +1000,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -1077,6 +1086,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -1162,6 +1172,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -1248,6 +1259,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -1333,6 +1345,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -1418,6 +1431,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -1503,6 +1517,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -1588,6 +1603,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -1673,6 +1689,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -1759,6 +1776,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -1844,6 +1862,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -1929,6 +1948,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -2015,6 +2035,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -2102,6 +2123,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -2189,6 +2211,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -2275,6 +2298,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -2361,6 +2385,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -2447,6 +2472,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -2533,6 +2559,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -2619,6 +2646,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -2685,6 +2713,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -2744,6 +2773,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -2810,6 +2840,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -2896,6 +2927,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -2982,6 +3014,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -3068,6 +3101,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -3154,6 +3188,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -3238,6 +3273,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift

--- a/ci-operator/jobs/openshift/ovn-kubernetes/openshift-ovn-kubernetes-sandbox-release-4.17-periodics.yaml
+++ b/ci-operator/jobs/openshift/ovn-kubernetes/openshift-ovn-kubernetes-sandbox-release-4.17-periodics.yaml
@@ -5,6 +5,7 @@ periodics:
   decorate: true
   decoration_config:
     sparse_checkout_files:
+    - .ci-operator.yaml
     - Dockerfile
     - Dockerfile.base
     - Dockerfile.microshift
@@ -13,6 +14,7 @@ periodics:
     org: openshift
     repo: ovn-kubernetes
     sparse_checkout_files:
+    - .ci-operator.yaml
     - Dockerfile
     - Dockerfile.base
     - Dockerfile.microshift
@@ -92,6 +94,7 @@ periodics:
   decorate: true
   decoration_config:
     sparse_checkout_files:
+    - .ci-operator.yaml
     - Dockerfile
     - Dockerfile.base
     - Dockerfile.microshift
@@ -100,6 +103,7 @@ periodics:
     org: openshift
     repo: ovn-kubernetes
     sparse_checkout_files:
+    - .ci-operator.yaml
     - Dockerfile
     - Dockerfile.base
     - Dockerfile.microshift
@@ -179,6 +183,7 @@ periodics:
   decorate: true
   decoration_config:
     sparse_checkout_files:
+    - .ci-operator.yaml
     - Dockerfile
     - Dockerfile.base
     - Dockerfile.microshift
@@ -187,6 +192,7 @@ periodics:
     org: openshift
     repo: ovn-kubernetes
     sparse_checkout_files:
+    - .ci-operator.yaml
     - Dockerfile
     - Dockerfile.base
     - Dockerfile.microshift

--- a/ci-operator/jobs/openshift/ovn-kubernetes/openshift-ovn-kubernetes-sandbox-release-4.17-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/ovn-kubernetes/openshift-ovn-kubernetes-sandbox-release-4.17-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift

--- a/ci-operator/jobs/openshift/ovn-kubernetes/openshift-ovn-kubernetes-sandbox-release-4.17-presubmits.yaml
+++ b/ci-operator/jobs/openshift/ovn-kubernetes/openshift-ovn-kubernetes-sandbox-release-4.17-presubmits.yaml
@@ -396,6 +396,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -483,6 +484,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -568,6 +570,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -654,6 +657,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -740,6 +744,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -825,6 +830,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -911,6 +917,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -996,6 +1003,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -1081,6 +1089,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -1166,6 +1175,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -1251,6 +1261,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -1337,6 +1348,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -1422,6 +1434,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -1507,6 +1520,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -1592,6 +1606,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -1678,6 +1693,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -1764,6 +1780,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -1849,6 +1866,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -1934,6 +1952,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -2019,6 +2038,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -2105,6 +2125,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -2192,6 +2213,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -2279,6 +2301,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -2366,6 +2389,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -2452,6 +2476,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -2539,6 +2564,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -2626,6 +2652,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -2712,6 +2739,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -2798,6 +2826,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -2884,6 +2913,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -2970,6 +3000,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -3056,6 +3087,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -3122,6 +3154,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -3181,6 +3214,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -3247,6 +3281,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -3333,6 +3368,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -3419,6 +3455,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -3505,6 +3542,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -3591,6 +3629,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -3677,6 +3716,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift
@@ -3761,6 +3801,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
+      - .ci-operator.yaml
       - Dockerfile
       - Dockerfile.base
       - Dockerfile.microshift


### PR DESCRIPTION
This PR is an effort to bring on a consistency between the CI and build images used by OpenShift components.