### PR TITLE
WINC-1926: Implement Windows Server 2022/2025 dual-version CI test matrix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ python-help:
 release-controllers: update_crt_crd
 	./hack/generators/release-controllers/generate-release-controllers.py .
 
-checkconfig: 
+checkconfig:
 	$(CONTAINER_ENGINE) run $(CONTAINER_ENGINE_OPTS) $(CONTAINER_USER) --rm -v "$(CURDIR):/release$(VOLUME_MOUNT_FLAGS)" us-docker.pkg.dev/k8s-infra-prow/images/checkconfig:v20260826-b9f26284d --config-path /release/core-services/prow/02_config/_config.yaml --supplemental-prow-config-dir=/release/core-services/prow/02_config --job-config-path /release/ci-operator/jobs/ --plugin-config /release/core-services/prow/02_config/_plugins.yaml --supplemental-plugin-config-dir /release/core-services/prow/02_config --strict --exclude-warning long-job-names --exclude-warning mismatched-tide
 
 jobs:  ci-operator-checkconfig

--- a/ci-operator/config/openshift-priv/openshift-tests-private/openshift-priv-openshift-tests-private-main.yaml
+++ b/ci-operator/config/openshift-priv/openshift-tests-private/openshift-priv-openshift-tests-private-main.yaml
@@ -204,6 +204,7 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: Windows_Server-2025-English-Core-Base
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-aws-ipi-ovn-winc
@@ -217,6 +218,7 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: projects/windows-cloud/global/images/family/windows-2025-core
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-gcp-ipi-ovn-winc
@@ -268,6 +270,7 @@ tests:
     cluster_profile: aws-qe
     env:
       BASE_DOMAIN: qe.devcluster.openshift.com
+      BYOH_WINDOWS_VERSION: "2025"
       FORCE_SUCCESS_EXIT: "no"
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers

--- a/ci-operator/config/openshift-priv/openshift-tests-private/openshift-priv-openshift-tests-private-main.yaml
+++ b/ci-operator/config/openshift-priv/openshift-tests-private/openshift-priv-openshift-tests-private-main.yaml
@@ -204,6 +204,7 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: Windows_Server-2025-English-Core-Base
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-aws-ipi-ovn-winc
@@ -217,6 +218,7 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: projects/windows-cloud/global/images/family/windows-2025-core
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-gcp-ipi-ovn-winc
@@ -234,6 +236,37 @@ tests:
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-azure-ipi-ovn-winc
+- as: debug-winc-vsphere-ipi-disconnected
+  optional: true
+  run_if_changed: test/extended/winc/
+  steps:
+    cluster_profile: vsphere-elastic
+    env:
+      FORCE_SUCCESS_EXIT: "no"
+      TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
+      TEST_SCENARIOS: Windows_Containers
+      TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: windows-golden-images/windows-server-2025-template-qe-ipv6-disabled
+    leases:
+    - env: VSPHERE_BASTION_LEASED_RESOURCE
+      resource_type: vsphere-connected-2-quota-slice
+    test:
+    - ref: openshift-extended-test
+    workflow: cucushift-installer-rehearse-vsphere-ipi-disconnected-ovn-winc
+- as: debug-winc-vsphere-ipi-proxy
+  optional: true
+  run_if_changed: test/extended/winc/
+  steps:
+    cluster_profile: vsphere-elastic
+    env:
+      FORCE_SUCCESS_EXIT: "no"
+      TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
+      TEST_SCENARIOS: Windows_Containers
+      TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: windows-golden-images/windows-server-2025-template-qe-ipv6-disabled
+    test:
+    - ref: openshift-extended-test
+    workflow: cucushift-installer-rehearse-vsphere-ipi-proxy-ovn-winc
 - as: debug-winc-aws-upi
   optional: true
   run_if_changed: test/extended/winc/
@@ -241,6 +274,7 @@ tests:
     cluster_profile: aws-qe
     env:
       BASE_DOMAIN: qe.devcluster.openshift.com
+      BYOH_WINDOWS_VERSION: "2025"
       FORCE_SUCCESS_EXIT: "no"
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers

--- a/ci-operator/config/openshift-priv/openshift-tests-private/openshift-priv-openshift-tests-private-release-4.22.yaml
+++ b/ci-operator/config/openshift-priv/openshift-tests-private/openshift-priv-openshift-tests-private-release-4.22.yaml
@@ -204,6 +204,7 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: Windows_Server-2025-English-Core-Base
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-aws-ipi-ovn-winc
@@ -217,6 +218,7 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: projects/windows-cloud/global/images/family/windows-2025-core
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-gcp-ipi-ovn-winc
@@ -257,6 +259,7 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: windows-golden-images/windows-server-2025-template-qe-ipv6-disabled
     leases:
     - env: VSPHERE_BASTION_LEASED_RESOURCE
       resource_type: vsphere-connected-2-quota-slice
@@ -284,6 +287,7 @@ tests:
     cluster_profile: aws-qe
     env:
       BASE_DOMAIN: qe.devcluster.openshift.com
+      BYOH_WINDOWS_VERSION: "2025"
       FORCE_SUCCESS_EXIT: "no"
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers

--- a/ci-operator/config/openshift-priv/openshift-tests-private/openshift-priv-openshift-tests-private-release-4.23.yaml
+++ b/ci-operator/config/openshift-priv/openshift-tests-private/openshift-priv-openshift-tests-private-release-4.23.yaml
@@ -204,6 +204,7 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: Windows_Server-2025-English-Core-Base
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-aws-ipi-ovn-winc
@@ -217,6 +218,7 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: projects/windows-cloud/global/images/family/windows-2025-core
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-gcp-ipi-ovn-winc
@@ -268,6 +270,7 @@ tests:
     cluster_profile: aws-qe
     env:
       BASE_DOMAIN: qe.devcluster.openshift.com
+      BYOH_WINDOWS_VERSION: "2025"
       FORCE_SUCCESS_EXIT: "no"
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers

--- a/ci-operator/config/openshift-priv/openshift-tests-private/openshift-priv-openshift-tests-private-release-4.23.yaml
+++ b/ci-operator/config/openshift-priv/openshift-tests-private/openshift-priv-openshift-tests-private-release-4.23.yaml
@@ -204,6 +204,7 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: Windows_Server-2025-English-Core-Base
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-aws-ipi-ovn-winc
@@ -217,6 +218,7 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: projects/windows-cloud/global/images/family/windows-2025-core
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-gcp-ipi-ovn-winc
@@ -234,6 +236,37 @@ tests:
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-azure-ipi-ovn-winc
+- as: debug-winc-vsphere-ipi-disconnected
+  optional: true
+  run_if_changed: test/extended/winc/
+  steps:
+    cluster_profile: vsphere-elastic
+    env:
+      FORCE_SUCCESS_EXIT: "no"
+      TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
+      TEST_SCENARIOS: Windows_Containers
+      TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: windows-golden-images/windows-server-2025-template-qe-ipv6-disabled
+    leases:
+    - env: VSPHERE_BASTION_LEASED_RESOURCE
+      resource_type: vsphere-connected-2-quota-slice
+    test:
+    - ref: openshift-extended-test
+    workflow: cucushift-installer-rehearse-vsphere-ipi-disconnected-ovn-winc
+- as: debug-winc-vsphere-ipi-proxy
+  optional: true
+  run_if_changed: test/extended/winc/
+  steps:
+    cluster_profile: vsphere-elastic
+    env:
+      FORCE_SUCCESS_EXIT: "no"
+      TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
+      TEST_SCENARIOS: Windows_Containers
+      TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: windows-golden-images/windows-server-2025-template-qe-ipv6-disabled
+    test:
+    - ref: openshift-extended-test
+    workflow: cucushift-installer-rehearse-vsphere-ipi-proxy-ovn-winc
 - as: debug-winc-aws-upi
   optional: true
   run_if_changed: test/extended/winc/
@@ -241,6 +274,7 @@ tests:
     cluster_profile: aws-qe
     env:
       BASE_DOMAIN: qe.devcluster.openshift.com
+      BYOH_WINDOWS_VERSION: "2025"
       FORCE_SUCCESS_EXIT: "no"
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers

--- a/ci-operator/config/openshift-priv/openshift-tests-private/openshift-priv-openshift-tests-private-release-5.0.yaml
+++ b/ci-operator/config/openshift-priv/openshift-tests-private/openshift-priv-openshift-tests-private-release-5.0.yaml
@@ -205,6 +205,7 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: Windows_Server-2025-English-Core-Base
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-aws-ipi-ovn-winc
@@ -218,6 +219,7 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: projects/windows-cloud/global/images/family/windows-2025-core
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-gcp-ipi-ovn-winc
@@ -269,6 +271,7 @@ tests:
     cluster_profile: aws-qe
     env:
       BASE_DOMAIN: qe.devcluster.openshift.com
+      BYOH_WINDOWS_VERSION: "2025"
       FORCE_SUCCESS_EXIT: "no"
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers

--- a/ci-operator/config/openshift-priv/openshift-tests-private/openshift-priv-openshift-tests-private-release-5.0.yaml
+++ b/ci-operator/config/openshift-priv/openshift-tests-private/openshift-priv-openshift-tests-private-release-5.0.yaml
@@ -204,6 +204,7 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: Windows_Server-2025-English-Core-Base
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-aws-ipi-ovn-winc
@@ -217,6 +218,7 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: projects/windows-cloud/global/images/family/windows-2025-core
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-gcp-ipi-ovn-winc
@@ -234,6 +236,37 @@ tests:
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-azure-ipi-ovn-winc
+- as: debug-winc-vsphere-ipi-disconnected
+  optional: true
+  run_if_changed: test/extended/winc/
+  steps:
+    cluster_profile: vsphere-elastic
+    env:
+      FORCE_SUCCESS_EXIT: "no"
+      TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
+      TEST_SCENARIOS: Windows_Containers
+      TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: windows-golden-images/windows-server-2025-template-qe-ipv6-disabled
+    leases:
+    - env: VSPHERE_BASTION_LEASED_RESOURCE
+      resource_type: vsphere-connected-2-quota-slice
+    test:
+    - ref: openshift-extended-test
+    workflow: cucushift-installer-rehearse-vsphere-ipi-disconnected-ovn-winc
+- as: debug-winc-vsphere-ipi-proxy
+  optional: true
+  run_if_changed: test/extended/winc/
+  steps:
+    cluster_profile: vsphere-elastic
+    env:
+      FORCE_SUCCESS_EXIT: "no"
+      TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
+      TEST_SCENARIOS: Windows_Containers
+      TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: windows-golden-images/windows-server-2025-template-qe-ipv6-disabled
+    test:
+    - ref: openshift-extended-test
+    workflow: cucushift-installer-rehearse-vsphere-ipi-proxy-ovn-winc
 - as: debug-winc-aws-upi
   optional: true
   run_if_changed: test/extended/winc/
@@ -241,6 +274,7 @@ tests:
     cluster_profile: aws-qe
     env:
       BASE_DOMAIN: qe.devcluster.openshift.com
+      BYOH_WINDOWS_VERSION: "2025"
       FORCE_SUCCESS_EXIT: "no"
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers

--- a/ci-operator/config/openshift-priv/openshift-tests-private/openshift-priv-openshift-tests-private-release-5.1.yaml
+++ b/ci-operator/config/openshift-priv/openshift-tests-private/openshift-priv-openshift-tests-private-release-5.1.yaml
@@ -204,6 +204,7 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: Windows_Server-2025-English-Core-Base
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-aws-ipi-ovn-winc
@@ -217,6 +218,7 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: projects/windows-cloud/global/images/family/windows-2025-core
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-gcp-ipi-ovn-winc
@@ -268,6 +270,7 @@ tests:
     cluster_profile: aws-qe
     env:
       BASE_DOMAIN: qe.devcluster.openshift.com
+      BYOH_WINDOWS_VERSION: "2025"
       FORCE_SUCCESS_EXIT: "no"
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers

--- a/ci-operator/config/openshift-priv/openshift-tests-private/openshift-priv-openshift-tests-private-release-5.1.yaml
+++ b/ci-operator/config/openshift-priv/openshift-tests-private/openshift-priv-openshift-tests-private-release-5.1.yaml
@@ -205,6 +205,7 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: Windows_Server-2025-English-Core-Base
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-aws-ipi-ovn-winc
@@ -218,6 +219,7 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: projects/windows-cloud/global/images/family/windows-2025-core
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-gcp-ipi-ovn-winc
@@ -235,6 +237,37 @@ tests:
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-azure-ipi-ovn-winc
+- as: debug-winc-vsphere-ipi-disconnected
+  optional: true
+  run_if_changed: test/extended/winc/
+  steps:
+    cluster_profile: vsphere-elastic
+    env:
+      FORCE_SUCCESS_EXIT: "no"
+      TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
+      TEST_SCENARIOS: Windows_Containers
+      TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: windows-golden-images/windows-server-2025-template-qe-ipv6-disabled
+    leases:
+    - env: VSPHERE_BASTION_LEASED_RESOURCE
+      resource_type: vsphere-connected-2-quota-slice
+    test:
+    - ref: openshift-extended-test
+    workflow: cucushift-installer-rehearse-vsphere-ipi-disconnected-ovn-winc
+- as: debug-winc-vsphere-ipi-proxy
+  optional: true
+  run_if_changed: test/extended/winc/
+  steps:
+    cluster_profile: vsphere-elastic
+    env:
+      FORCE_SUCCESS_EXIT: "no"
+      TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
+      TEST_SCENARIOS: Windows_Containers
+      TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: windows-golden-images/windows-server-2025-template-qe-ipv6-disabled
+    test:
+    - ref: openshift-extended-test
+    workflow: cucushift-installer-rehearse-vsphere-ipi-proxy-ovn-winc
 - as: debug-winc-aws-upi
   optional: true
   run_if_changed: test/extended/winc/
@@ -242,6 +275,7 @@ tests:
     cluster_profile: aws-qe
     env:
       BASE_DOMAIN: qe.devcluster.openshift.com
+      BYOH_WINDOWS_VERSION: "2025"
       FORCE_SUCCESS_EXIT: "no"
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers

--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-main.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-main.yaml
@@ -203,6 +203,7 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: Windows_Server-2025-English-Core-Base
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-aws-ipi-ovn-winc
@@ -216,6 +217,7 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: projects/windows-cloud/global/images/family/windows-2025-core
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-gcp-ipi-ovn-winc
@@ -267,6 +269,7 @@ tests:
     cluster_profile: aws-qe
     env:
       BASE_DOMAIN: qe.devcluster.openshift.com
+      BYOH_WINDOWS_VERSION: "2025"
       FORCE_SUCCESS_EXIT: "no"
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers

--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-main.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-main.yaml
@@ -203,6 +203,7 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: Windows_Server-2025-English-Core-Base
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-aws-ipi-ovn-winc
@@ -216,6 +217,7 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: projects/windows-cloud/global/images/family/windows-2025-core
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-gcp-ipi-ovn-winc
@@ -233,6 +235,37 @@ tests:
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-azure-ipi-ovn-winc
+- as: debug-winc-vsphere-ipi-disconnected
+  optional: true
+  run_if_changed: test/extended/winc/
+  steps:
+    cluster_profile: vsphere-elastic
+    env:
+      FORCE_SUCCESS_EXIT: "no"
+      TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
+      TEST_SCENARIOS: Windows_Containers
+      TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: windows-golden-images/windows-server-2025-template-qe-ipv6-disabled
+    leases:
+    - env: VSPHERE_BASTION_LEASED_RESOURCE
+      resource_type: vsphere-connected-2-quota-slice
+    test:
+    - ref: openshift-extended-test
+    workflow: cucushift-installer-rehearse-vsphere-ipi-disconnected-ovn-winc
+- as: debug-winc-vsphere-ipi-proxy
+  optional: true
+  run_if_changed: test/extended/winc/
+  steps:
+    cluster_profile: vsphere-elastic
+    env:
+      FORCE_SUCCESS_EXIT: "no"
+      TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
+      TEST_SCENARIOS: Windows_Containers
+      TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: windows-golden-images/windows-server-2025-template-qe-ipv6-disabled
+    test:
+    - ref: openshift-extended-test
+    workflow: cucushift-installer-rehearse-vsphere-ipi-proxy-ovn-winc
 - as: debug-winc-aws-upi
   optional: true
   run_if_changed: test/extended/winc/
@@ -240,6 +273,7 @@ tests:
     cluster_profile: aws-qe
     env:
       BASE_DOMAIN: qe.devcluster.openshift.com
+      BYOH_WINDOWS_VERSION: "2025"
       FORCE_SUCCESS_EXIT: "no"
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers

--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22.yaml
@@ -203,6 +203,7 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: Windows_Server-2025-English-Core-Base
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-aws-ipi-ovn-winc
@@ -216,6 +217,7 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: projects/windows-cloud/global/images/family/windows-2025-core
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-gcp-ipi-ovn-winc
@@ -256,6 +258,7 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: windows-golden-images/windows-server-2025-template-qe-ipv6-disabled
     leases:
     - env: VSPHERE_BASTION_LEASED_RESOURCE
       resource_type: vsphere-connected-2-quota-slice
@@ -283,6 +286,7 @@ tests:
     cluster_profile: aws-qe
     env:
       BASE_DOMAIN: qe.devcluster.openshift.com
+      BYOH_WINDOWS_VERSION: "2025"
       FORCE_SUCCESS_EXIT: "no"
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers

--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22__amd64-nightly.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22__amd64-nightly.yaml
@@ -3499,6 +3499,7 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WIN_SKU: 2025-datacenter
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-azure-ipi-ovn-winc
@@ -3524,6 +3525,7 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: windows-golden-images/windows-server-2025-template-qe-ipv6-disabled
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-vsphere-ipi-ovn-winc
@@ -3536,6 +3538,7 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: nutanix-windows-server-2025
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-nutanix-ipi-ovn-winc

--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.23.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.23.yaml
@@ -203,6 +203,7 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: Windows_Server-2025-English-Core-Base
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-aws-ipi-ovn-winc
@@ -216,6 +217,7 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: projects/windows-cloud/global/images/family/windows-2025-core
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-gcp-ipi-ovn-winc
@@ -267,6 +269,7 @@ tests:
     cluster_profile: aws-qe
     env:
       BASE_DOMAIN: qe.devcluster.openshift.com
+      BYOH_WINDOWS_VERSION: "2025"
       FORCE_SUCCESS_EXIT: "no"
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers

--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.23.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.23.yaml
@@ -203,6 +203,7 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: Windows_Server-2025-English-Core-Base
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-aws-ipi-ovn-winc
@@ -216,6 +217,7 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: projects/windows-cloud/global/images/family/windows-2025-core
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-gcp-ipi-ovn-winc
@@ -233,6 +235,37 @@ tests:
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-azure-ipi-ovn-winc
+- as: debug-winc-vsphere-ipi-disconnected
+  optional: true
+  run_if_changed: test/extended/winc/
+  steps:
+    cluster_profile: vsphere-elastic
+    env:
+      FORCE_SUCCESS_EXIT: "no"
+      TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
+      TEST_SCENARIOS: Windows_Containers
+      TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: windows-golden-images/windows-server-2025-template-qe-ipv6-disabled
+    leases:
+    - env: VSPHERE_BASTION_LEASED_RESOURCE
+      resource_type: vsphere-connected-2-quota-slice
+    test:
+    - ref: openshift-extended-test
+    workflow: cucushift-installer-rehearse-vsphere-ipi-disconnected-ovn-winc
+- as: debug-winc-vsphere-ipi-proxy
+  optional: true
+  run_if_changed: test/extended/winc/
+  steps:
+    cluster_profile: vsphere-elastic
+    env:
+      FORCE_SUCCESS_EXIT: "no"
+      TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
+      TEST_SCENARIOS: Windows_Containers
+      TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: windows-golden-images/windows-server-2025-template-qe-ipv6-disabled
+    test:
+    - ref: openshift-extended-test
+    workflow: cucushift-installer-rehearse-vsphere-ipi-proxy-ovn-winc
 - as: debug-winc-aws-upi
   optional: true
   run_if_changed: test/extended/winc/
@@ -240,6 +273,7 @@ tests:
     cluster_profile: aws-qe
     env:
       BASE_DOMAIN: qe.devcluster.openshift.com
+      BYOH_WINDOWS_VERSION: "2025"
       FORCE_SUCCESS_EXIT: "no"
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers

--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-5.0.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-5.0.yaml
@@ -204,6 +204,7 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: Windows_Server-2025-English-Core-Base
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-aws-ipi-ovn-winc
@@ -217,6 +218,7 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: projects/windows-cloud/global/images/family/windows-2025-core
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-gcp-ipi-ovn-winc
@@ -268,6 +270,7 @@ tests:
     cluster_profile: aws-qe
     env:
       BASE_DOMAIN: qe.devcluster.openshift.com
+      BYOH_WINDOWS_VERSION: "2025"
       FORCE_SUCCESS_EXIT: "no"
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers

--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-5.0.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-5.0.yaml
@@ -203,6 +203,7 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: Windows_Server-2025-English-Core-Base
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-aws-ipi-ovn-winc
@@ -216,6 +217,7 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: projects/windows-cloud/global/images/family/windows-2025-core
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-gcp-ipi-ovn-winc
@@ -233,6 +235,37 @@ tests:
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-azure-ipi-ovn-winc
+- as: debug-winc-vsphere-ipi-disconnected
+  optional: true
+  run_if_changed: test/extended/winc/
+  steps:
+    cluster_profile: vsphere-elastic
+    env:
+      FORCE_SUCCESS_EXIT: "no"
+      TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
+      TEST_SCENARIOS: Windows_Containers
+      TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: windows-golden-images/windows-server-2025-template-qe-ipv6-disabled
+    leases:
+    - env: VSPHERE_BASTION_LEASED_RESOURCE
+      resource_type: vsphere-connected-2-quota-slice
+    test:
+    - ref: openshift-extended-test
+    workflow: cucushift-installer-rehearse-vsphere-ipi-disconnected-ovn-winc
+- as: debug-winc-vsphere-ipi-proxy
+  optional: true
+  run_if_changed: test/extended/winc/
+  steps:
+    cluster_profile: vsphere-elastic
+    env:
+      FORCE_SUCCESS_EXIT: "no"
+      TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
+      TEST_SCENARIOS: Windows_Containers
+      TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: windows-golden-images/windows-server-2025-template-qe-ipv6-disabled
+    test:
+    - ref: openshift-extended-test
+    workflow: cucushift-installer-rehearse-vsphere-ipi-proxy-ovn-winc
 - as: debug-winc-aws-upi
   optional: true
   run_if_changed: test/extended/winc/
@@ -240,6 +273,7 @@ tests:
     cluster_profile: aws-qe
     env:
       BASE_DOMAIN: qe.devcluster.openshift.com
+      BYOH_WINDOWS_VERSION: "2025"
       FORCE_SUCCESS_EXIT: "no"
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers

--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-5.0__amd64-nightly-5.0-upgrade-from-stable-4.22.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-5.0__amd64-nightly-5.0-upgrade-from-stable-4.22.yaml
@@ -879,7 +879,7 @@ tests:
 - as: vsphere-ipi-compact-etcd-encryption-f28
   cron: 12 23 13 * *
   steps:
-    cluster_profile: vsphere-connected-2
+    cluster_profile: vsphere-elastic
     env:
       SIZE_VARIANT: compact
     test:
@@ -888,7 +888,7 @@ tests:
 - as: vsphere-ipi-disc-f28
   cron: 1 3 8 * *
   steps:
-    cluster_profile: vsphere-dis-2
+    cluster_profile: vsphere-elastic
     env:
       TEST_FILTERS: ~ConnectedOnly&;~HyperShiftMGMT&;~MicroShiftOnly&
     leases:
@@ -909,7 +909,7 @@ tests:
 - as: vsphere-ipi-external-lb-post-f28
   cron: 4 2 7 * *
   steps:
-    cluster_profile: vsphere-connected-2
+    cluster_profile: vsphere-elastic
     test:
     - chain: openshift-upgrade-qe-test
     workflow: cucushift-installer-rehearse-vsphere-ipi-external-lb-post
@@ -949,7 +949,7 @@ tests:
 - as: vsphere-ipi-ovn-ipsec-mininal-permission-f28
   cron: 49 14 10 * *
   steps:
-    cluster_profile: vsphere-connected-2
+    cluster_profile: vsphere-elastic
     test:
     - chain: openshift-upgrade-qe-test
     workflow: cucushift-installer-rehearse-vsphere-ipi-ovn-ipsec-minimal-permission
@@ -963,7 +963,7 @@ tests:
 - as: vsphere-ipi-proxy-fips-f28
   cron: 47 15 25 * *
   steps:
-    cluster_profile: vsphere-dis-2
+    cluster_profile: vsphere-elastic
     env:
       FIPS_ENABLED: "true"
     leases:
@@ -984,14 +984,14 @@ tests:
 - as: vsphere-ipi-static-ip-f28
   cron: 19 5 8 * *
   steps:
-    cluster_profile: vsphere-connected-2
+    cluster_profile: vsphere-elastic
     test:
     - chain: openshift-upgrade-qe-test
     workflow: cucushift-installer-rehearse-vsphere-ipi-static-ip
 - as: vsphere-ipi-template-usertags-f28
   cron: 26 9 9 * *
   steps:
-    cluster_profile: vsphere-connected-2
+    cluster_profile: vsphere-elastic
     test:
     - chain: openshift-upgrade-qe-test
     workflow: cucushift-installer-rehearse-vsphere-ipi-template-usertags
@@ -1021,7 +1021,7 @@ tests:
 - as: vsphere-upi-disc-secureboot-fips-f28
   cron: 32 1 13 * *
   steps:
-    cluster_profile: vsphere-dis-2
+    cluster_profile: vsphere-elastic
     env:
       FIPS_ENABLED: "true"
       TEST_FILTERS: ~ConnectedOnly&;~HyperShiftMGMT&;~MicroShiftOnly&
@@ -1034,7 +1034,7 @@ tests:
 - as: vsphere-upi-encrypt-f28
   cron: 29 14 3 * *
   steps:
-    cluster_profile: vsphere-connected-2
+    cluster_profile: vsphere-elastic
     test:
     - chain: openshift-upgrade-qe-test
     workflow: cucushift-installer-rehearse-vsphere-upi-encrypt

--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-5.0__amd64-nightly-5.0-upgrade-from-stable-5.0.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-5.0__amd64-nightly-5.0-upgrade-from-stable-5.0.yaml
@@ -960,7 +960,7 @@ tests:
 - as: vsphere-ipi-compact-etcd-encryption-f60
   cron: 24 13 22 2,4,6,8,10,12 *
   steps:
-    cluster_profile: vsphere-connected-2
+    cluster_profile: vsphere-elastic
     env:
       SIZE_VARIANT: compact
     test:
@@ -969,7 +969,7 @@ tests:
 - as: vsphere-ipi-disc-f28
   cron: 56 7 6 * *
   steps:
-    cluster_profile: vsphere-dis-2
+    cluster_profile: vsphere-elastic
     env:
       TEST_FILTERS: ~ChkUpgrade&;~NonPreRelease&;~Serial&;~Disruptive&;~ConnectedOnly&;~HyperShiftMGMT&;~MicroShiftOnly&
     leases:
@@ -990,7 +990,7 @@ tests:
 - as: vsphere-ipi-external-lb-post-f60
   cron: 27 23 17 1,3,5,7,9,11 *
   steps:
-    cluster_profile: vsphere-connected-2
+    cluster_profile: vsphere-elastic
     test:
     - chain: openshift-upgrade-qe-test
     workflow: cucushift-installer-rehearse-vsphere-ipi-external-lb-post
@@ -1032,7 +1032,7 @@ tests:
 - as: vsphere-ipi-ovn-ipsec-mininal-permission-f60
   cron: 12 5 4 2,4,6,8,10,12 *
   steps:
-    cluster_profile: vsphere-connected-2
+    cluster_profile: vsphere-elastic
     test:
     - chain: openshift-upgrade-qe-test
     workflow: cucushift-installer-rehearse-vsphere-ipi-ovn-ipsec-minimal-permission
@@ -1046,7 +1046,7 @@ tests:
 - as: vsphere-ipi-proxy-tp-f60
   cron: 16 8 25 2,4,6,8,10,12 *
   steps:
-    cluster_profile: vsphere-dis-2
+    cluster_profile: vsphere-elastic
     env:
       FEATURE_SET: TechPreviewNoUpgrade
     leases:
@@ -1067,14 +1067,14 @@ tests:
 - as: vsphere-ipi-static-ip-f60
   cron: 40 19 24 2,4,6,8,10,12 *
   steps:
-    cluster_profile: vsphere-connected-2
+    cluster_profile: vsphere-elastic
     test:
     - chain: openshift-upgrade-qe-test
     workflow: cucushift-installer-rehearse-vsphere-ipi-static-ip
 - as: vsphere-ipi-template-usertags-f60
   cron: 56 11 23 2,4,6,8,10,12 *
   steps:
-    cluster_profile: vsphere-connected-2
+    cluster_profile: vsphere-elastic
     test:
     - chain: openshift-upgrade-qe-test
     workflow: cucushift-installer-rehearse-vsphere-ipi-template-usertags
@@ -1106,7 +1106,7 @@ tests:
 - as: vsphere-upi-disc-secureboot-fips-f60
   cron: 41 2 3 2,4,6,8,10,12 *
   steps:
-    cluster_profile: vsphere-dis-2
+    cluster_profile: vsphere-elastic
     env:
       FIPS_ENABLED: "true"
     leases:
@@ -1118,7 +1118,7 @@ tests:
 - as: vsphere-upi-encrypt-f60
   cron: 37 2 6 2,4,6,8,10,12 *
   steps:
-    cluster_profile: vsphere-connected-2
+    cluster_profile: vsphere-elastic
     test:
     - chain: openshift-upgrade-qe-test
     workflow: cucushift-installer-rehearse-vsphere-upi-encrypt

--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-5.0__amd64-nightly.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-5.0__amd64-nightly.yaml
@@ -3073,6 +3073,7 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WIN_SKU: 2025-datacenter
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-azure-ipi-ovn-winc
@@ -3084,6 +3085,7 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: windows-golden-images/windows-server-2025-template-qe-ipv6-disabled
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-vsphere-ipi-ovn-winc
@@ -3096,6 +3098,7 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: nutanix-windows-server-2025
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-nutanix-ipi-ovn-winc

--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-5.0__amd64-nightly.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-5.0__amd64-nightly.yaml
@@ -3581,17 +3581,44 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WIN_SKU: 2025-datacenter-smalldisk
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-azure-ipi-ovn-winc
-- as: vsphere-ipi-ovn-winc-f7
-  cron: 23 2 5,12,19,26 * *
+- as: vsphere-ipi-disconnected-ovn-winc-f28
+  cron: 0 18 15 * *
   steps:
-    cluster_profile: vsphere-connected-2
+    cluster_profile: vsphere-elastic
     env:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+    leases:
+    - env: VSPHERE_BASTION_LEASED_RESOURCE
+      resource_type: vsphere-connected-2-quota-slice
+    test:
+    - ref: openshift-extended-test
+    workflow: cucushift-installer-rehearse-vsphere-ipi-disconnected-ovn-winc
+- as: vsphere-ipi-proxy-ovn-winc-f28
+  cron: 57 15 14 * *
+  steps:
+    cluster_profile: vsphere-elastic
+    env:
+      TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;Smokerun&
+      TEST_SCENARIOS: Windows_Containers
+      TEST_TIMEOUT: "50"
+    test:
+    - ref: openshift-extended-test
+    workflow: cucushift-installer-rehearse-vsphere-ipi-proxy-ovn-winc
+- as: vsphere-ipi-ovn-winc-f7
+  cron: 23 2 5,12,19,26 * *
+  steps:
+    cluster_profile: vsphere-elastic
+    env:
+      TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;Smokerun&
+      TEST_SCENARIOS: Windows_Containers
+      TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: windows-golden-images/windows-server-2025-template-qe-ipv6-disabled
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-vsphere-ipi-ovn-winc
@@ -4312,7 +4339,7 @@ tests:
 - as: vsphere-ipi-compact-etcd-encryption-f28
   cron: 11 2 27 * *
   steps:
-    cluster_profile: vsphere-connected-2
+    cluster_profile: vsphere-elastic
     env:
       SIZE_VARIANT: compact
     test:
@@ -4321,7 +4348,7 @@ tests:
 - as: vsphere-ipi-compact-etcd-encryption-f28-destructive
   cron: 32 7 1 * *
   steps:
-    cluster_profile: vsphere-connected-2
+    cluster_profile: vsphere-elastic
     env:
       SIZE_VARIANT: compact
     test:
@@ -4330,7 +4357,7 @@ tests:
 - as: vsphere-ipi-disc-f28
   cron: 26 1 14 * *
   steps:
-    cluster_profile: vsphere-dis-2
+    cluster_profile: vsphere-elastic
     env:
       E2E_RUN_TAGS: '@disconnected'
       TEST_FILTERS: ~ChkUpgrade&;~NonPreRelease&;~Serial&;~Disruptive&;~ConnectedOnly&;~HyperShiftMGMT&;~MicroShiftOnly&
@@ -4343,7 +4370,7 @@ tests:
 - as: vsphere-ipi-disc-f28-destructive
   cron: 36 6 13 * *
   steps:
-    cluster_profile: vsphere-dis-2
+    cluster_profile: vsphere-elastic
     env:
       E2E_RUN_TAGS: '@disconnected'
       TEST_FILTERS: ~ChkUpgrade&;~NonPreRelease&;Serial&;Disruptive&;~ConnectedOnly&;~HyperShiftMGMT&;~MicroShiftOnly&
@@ -4413,7 +4440,7 @@ tests:
 - as: vsphere-ipi-external-lb-post-f28
   cron: 30 11 24 * *
   steps:
-    cluster_profile: vsphere-connected-2
+    cluster_profile: vsphere-elastic
     test:
     - chain: openshift-e2e-test-qe-automated-release
     workflow: cucushift-installer-rehearse-vsphere-ipi-external-lb-post
@@ -4560,14 +4587,14 @@ tests:
 - as: vsphere-ipi-ovn-ipsec-mininal-permission-f28
   cron: 16 11 7 * *
   steps:
-    cluster_profile: vsphere-connected-2
+    cluster_profile: vsphere-elastic
     test:
     - chain: openshift-e2e-test-qe-automated-release
     workflow: cucushift-installer-rehearse-vsphere-ipi-ovn-ipsec-minimal-permission
 - as: vsphere-ipi-ovn-ipsec-mininal-permission-f28-destructive
   cron: 3 23 18 * *
   steps:
-    cluster_profile: vsphere-connected-2
+    cluster_profile: vsphere-elastic
     test:
     - chain: openshift-e2e-test-qe-destructive
     workflow: cucushift-installer-rehearse-vsphere-ipi-ovn-ipsec-minimal-permission
@@ -4595,7 +4622,7 @@ tests:
 - as: vsphere-ipi-proxy-fips-regen-cert-f14
   cron: 57 15 11,25 * *
   steps:
-    cluster_profile: vsphere-dis-2
+    cluster_profile: vsphere-elastic
     env:
       FIPS_ENABLED: "true"
     leases:
@@ -4608,7 +4635,7 @@ tests:
 - as: vsphere-ipi-proxy-f14-disasterrecovery
   cron: 26 18 16,30 * *
   steps:
-    cluster_profile: vsphere-dis-2
+    cluster_profile: vsphere-elastic
     leases:
     - env: VSPHERE_BASTION_LEASED_RESOURCE
       resource_type: vsphere-connected-2-quota-slice
@@ -4618,7 +4645,7 @@ tests:
 - as: vsphere-ipi-proxy-fips-f28
   cron: 50 14 2 * *
   steps:
-    cluster_profile: vsphere-dis-2
+    cluster_profile: vsphere-elastic
     env:
       FIPS_ENABLED: "true"
     leases:
@@ -4630,7 +4657,7 @@ tests:
 - as: vsphere-ipi-proxy-fips-f28-destructive
   cron: 3 7 21 * *
   steps:
-    cluster_profile: vsphere-dis-2
+    cluster_profile: vsphere-elastic
     env:
       FIPS_ENABLED: "true"
     leases:
@@ -4642,7 +4669,7 @@ tests:
 - as: vsphere-ipi-proxy-tp-f28
   cron: 17 21 6 * *
   steps:
-    cluster_profile: vsphere-dis-2
+    cluster_profile: vsphere-elastic
     env:
       FEATURE_SET: TechPreviewNoUpgrade
     leases:
@@ -4654,7 +4681,7 @@ tests:
 - as: vsphere-ipi-proxy-tp-f28-destructive
   cron: 14 7 21 * *
   steps:
-    cluster_profile: vsphere-dis-2
+    cluster_profile: vsphere-elastic
     env:
       FEATURE_SET: TechPreviewNoUpgrade
     leases:
@@ -4684,28 +4711,28 @@ tests:
 - as: vsphere-ipi-static-ip-f28
   cron: 8 5 4 * *
   steps:
-    cluster_profile: vsphere-connected-2
+    cluster_profile: vsphere-elastic
     test:
     - chain: openshift-e2e-test-qe-automated-release
     workflow: cucushift-installer-rehearse-vsphere-ipi-static-ip
 - as: vsphere-ipi-static-ip-f28-destructive
   cron: 11 4 22 * *
   steps:
-    cluster_profile: vsphere-connected-2
+    cluster_profile: vsphere-elastic
     test:
     - chain: openshift-e2e-test-qe-destructive
     workflow: cucushift-installer-rehearse-vsphere-ipi-static-ip
 - as: vsphere-ipi-template-usertags-f28
   cron: 23 13 25 * *
   steps:
-    cluster_profile: vsphere-connected-2
+    cluster_profile: vsphere-elastic
     test:
     - chain: openshift-e2e-test-qe-automated-release
     workflow: cucushift-installer-rehearse-vsphere-ipi-template-usertags
 - as: vsphere-ipi-template-usertags-f28-destructive
   cron: 36 10 22 * *
   steps:
-    cluster_profile: vsphere-connected-2
+    cluster_profile: vsphere-elastic
     test:
     - chain: openshift-e2e-test-qe-destructive
     workflow: cucushift-installer-rehearse-vsphere-ipi-template-usertags
@@ -4762,7 +4789,7 @@ tests:
 - as: vsphere-upi-disc-secureboot-fips-f28
   cron: 8 2 27 * *
   steps:
-    cluster_profile: vsphere-dis-2
+    cluster_profile: vsphere-elastic
     env:
       E2E_RUN_TAGS: '@disconnected'
       FIPS_ENABLED: "true"
@@ -4776,7 +4803,7 @@ tests:
 - as: vsphere-upi-disc-secureboot-fips-f28-destructive
   cron: 53 15 21 * *
   steps:
-    cluster_profile: vsphere-dis-2
+    cluster_profile: vsphere-elastic
     env:
       E2E_RUN_TAGS: '@disconnected'
       FIPS_ENABLED: "true"
@@ -4790,7 +4817,7 @@ tests:
 - as: vsphere-upi-disconnecting-network-f28
   cron: 12 5 20 * *
   steps:
-    cluster_profile: vsphere-connected-2
+    cluster_profile: vsphere-elastic
     env:
       E2E_RUN_TAGS: '@disconnected'
       TEST_FILTERS: ~ChkUpgrade&;~NonPreRelease&;~Serial&;~Disruptive&;~ConnectedOnly&;~HyperShiftMGMT&;~MicroShiftOnly&
@@ -4800,7 +4827,7 @@ tests:
 - as: vsphere-upi-disconnecting-network-f28-destructive
   cron: 20 14 15 * *
   steps:
-    cluster_profile: vsphere-connected-2
+    cluster_profile: vsphere-elastic
     env:
       E2E_RUN_TAGS: '@disconnected'
       TEST_FILTERS: ~ChkUpgrade&;~NonPreRelease&;Serial&;Disruptive&;~ConnectedOnly&;~HyperShiftMGMT&;~MicroShiftOnly&
@@ -4810,14 +4837,14 @@ tests:
 - as: vsphere-upi-encrypt-f28
   cron: 42 9 19 * *
   steps:
-    cluster_profile: vsphere-connected-2
+    cluster_profile: vsphere-elastic
     test:
     - chain: openshift-e2e-test-qe-automated-release
     workflow: cucushift-installer-rehearse-vsphere-upi-encrypt
 - as: vsphere-upi-encrypt-f28-destructive
   cron: 29 2 28 * *
   steps:
-    cluster_profile: vsphere-connected-2
+    cluster_profile: vsphere-elastic
     test:
     - chain: openshift-e2e-test-qe-destructive
     workflow: cucushift-installer-rehearse-vsphere-upi-encrypt

--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-5.0__amd64-stable-5.0-upgrade-from-stable-4.22.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-5.0__amd64-stable-5.0-upgrade-from-stable-4.22.yaml
@@ -204,7 +204,7 @@ tests:
 - as: vsphere-ipi-disc-f28
   cron: 11 16 11 * *
   steps:
-    cluster_profile: vsphere-dis-2
+    cluster_profile: vsphere-elastic
     env:
       ENABLE_OTA_TEST: OCP-30832
       OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY: ""
@@ -226,7 +226,7 @@ tests:
 - as: vsphere-ipi-proxy-fips-f28
   cron: 56 13 21 * *
   steps:
-    cluster_profile: vsphere-dis-2
+    cluster_profile: vsphere-elastic
     env:
       ENABLE_OTA_TEST: OCP-24358
       FIPS_ENABLED: "true"

--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-5.1.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-5.1.yaml
@@ -203,6 +203,7 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: Windows_Server-2025-English-Core-Base
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-aws-ipi-ovn-winc
@@ -216,6 +217,7 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: projects/windows-cloud/global/images/family/windows-2025-core
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-gcp-ipi-ovn-winc
@@ -267,6 +269,7 @@ tests:
     cluster_profile: aws-qe
     env:
       BASE_DOMAIN: qe.devcluster.openshift.com
+      BYOH_WINDOWS_VERSION: "2025"
       FORCE_SUCCESS_EXIT: "no"
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers

--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-5.1.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-5.1.yaml
@@ -204,6 +204,7 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: Windows_Server-2025-English-Core-Base
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-aws-ipi-ovn-winc
@@ -217,6 +218,7 @@ tests:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
       TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: projects/windows-cloud/global/images/family/windows-2025-core
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-gcp-ipi-ovn-winc
@@ -234,6 +236,37 @@ tests:
     test:
     - ref: openshift-extended-test
     workflow: cucushift-installer-rehearse-azure-ipi-ovn-winc
+- as: debug-winc-vsphere-ipi-disconnected
+  optional: true
+  run_if_changed: test/extended/winc/
+  steps:
+    cluster_profile: vsphere-elastic
+    env:
+      FORCE_SUCCESS_EXIT: "no"
+      TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
+      TEST_SCENARIOS: Windows_Containers
+      TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: windows-golden-images/windows-server-2025-template-qe-ipv6-disabled
+    leases:
+    - env: VSPHERE_BASTION_LEASED_RESOURCE
+      resource_type: vsphere-connected-2-quota-slice
+    test:
+    - ref: openshift-extended-test
+    workflow: cucushift-installer-rehearse-vsphere-ipi-disconnected-ovn-winc
+- as: debug-winc-vsphere-ipi-proxy
+  optional: true
+  run_if_changed: test/extended/winc/
+  steps:
+    cluster_profile: vsphere-elastic
+    env:
+      FORCE_SUCCESS_EXIT: "no"
+      TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
+      TEST_SCENARIOS: Windows_Containers
+      TEST_TIMEOUT: "50"
+      WINDOWS_OS_ID: windows-golden-images/windows-server-2025-template-qe-ipv6-disabled
+    test:
+    - ref: openshift-extended-test
+    workflow: cucushift-installer-rehearse-vsphere-ipi-proxy-ovn-winc
 - as: debug-winc-aws-upi
   optional: true
   run_if_changed: test/extended/winc/
@@ -241,6 +274,7 @@ tests:
     cluster_profile: aws-qe
     env:
       BASE_DOMAIN: qe.devcluster.openshift.com
+      BYOH_WINDOWS_VERSION: "2025"
       FORCE_SUCCESS_EXIT: "no"
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;~Disruptive&;~Serial&;Smokerun&
       TEST_SCENARIOS: Windows_Containers

--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-5.1__amd64-nightly.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-5.1__amd64-nightly.yaml
@@ -3587,7 +3587,7 @@ tests:
 - as: vsphere-ipi-ovn-winc-f7
   cron: 23 2 5,12,19,26 * *
   steps:
-    cluster_profile: vsphere-connected-2
+    cluster_profile: vsphere-elastic
     env:
       TEST_FILTERS: ~ChkUpgrade&;~ConnectedOnly&;Smokerun&
       TEST_SCENARIOS: Windows_Containers
@@ -4312,7 +4312,7 @@ tests:
 - as: vsphere-ipi-compact-etcd-encryption-f28
   cron: 11 2 27 * *
   steps:
-    cluster_profile: vsphere-connected-2
+    cluster_profile: vsphere-elastic
     env:
       SIZE_VARIANT: compact
     test:
@@ -4321,7 +4321,7 @@ tests:
 - as: vsphere-ipi-compact-etcd-encryption-f28-destructive
   cron: 32 7 1 * *
   steps:
-    cluster_profile: vsphere-connected-2
+    cluster_profile: vsphere-elastic
     env:
       SIZE_VARIANT: compact
     test:
@@ -4330,7 +4330,7 @@ tests:
 - as: vsphere-ipi-disc-f28
   cron: 26 1 14 * *
   steps:
-    cluster_profile: vsphere-dis-2
+    cluster_profile: vsphere-elastic
     env:
       E2E_RUN_TAGS: '@disconnected'
       TEST_FILTERS: ~ChkUpgrade&;~NonPreRelease&;~Serial&;~Disruptive&;~ConnectedOnly&;~HyperShiftMGMT&;~MicroShiftOnly&
@@ -4343,7 +4343,7 @@ tests:
 - as: vsphere-ipi-disc-f28-destructive
   cron: 36 6 13 * *
   steps:
-    cluster_profile: vsphere-dis-2
+    cluster_profile: vsphere-elastic
     env:
       E2E_RUN_TAGS: '@disconnected'
       TEST_FILTERS: ~ChkUpgrade&;~NonPreRelease&;Serial&;Disruptive&;~ConnectedOnly&;~HyperShiftMGMT&;~MicroShiftOnly&
@@ -4413,7 +4413,7 @@ tests:
 - as: vsphere-ipi-external-lb-post-f28
   cron: 30 11 24 * *
   steps:
-    cluster_profile: vsphere-connected-2
+    cluster_profile: vsphere-elastic
     test:
     - chain: openshift-e2e-test-qe-automated-release
     workflow: cucushift-installer-rehearse-vsphere-ipi-external-lb-post
@@ -4560,14 +4560,14 @@ tests:
 - as: vsphere-ipi-ovn-ipsec-mininal-permission-f28
   cron: 16 11 7 * *
   steps:
-    cluster_profile: vsphere-connected-2
+    cluster_profile: vsphere-elastic
     test:
     - chain: openshift-e2e-test-qe-automated-release
     workflow: cucushift-installer-rehearse-vsphere-ipi-ovn-ipsec-minimal-permission
 - as: vsphere-ipi-ovn-ipsec-mininal-permission-f28-destructive
   cron: 3 23 18 * *
   steps:
-    cluster_profile: vsphere-connected-2
+    cluster_profile: vsphere-elastic
     test:
     - chain: openshift-e2e-test-qe-destructive
     workflow: cucushift-installer-rehearse-vsphere-ipi-ovn-ipsec-minimal-permission
@@ -4595,7 +4595,7 @@ tests:
 - as: vsphere-ipi-proxy-fips-regen-cert-f14
   cron: 57 15 11,25 * *
   steps:
-    cluster_profile: vsphere-dis-2
+    cluster_profile: vsphere-elastic
     env:
       FIPS_ENABLED: "true"
     leases:
@@ -4608,7 +4608,7 @@ tests:
 - as: vsphere-ipi-proxy-f14-disasterrecovery
   cron: 26 18 16,30 * *
   steps:
-    cluster_profile: vsphere-dis-2
+    cluster_profile: vsphere-elastic
     leases:
     - env: VSPHERE_BASTION_LEASED_RESOURCE
       resource_type: vsphere-connected-2-quota-slice
@@ -4618,7 +4618,7 @@ tests:
 - as: vsphere-ipi-proxy-fips-f28
   cron: 50 14 2 * *
   steps:
-    cluster_profile: vsphere-dis-2
+    cluster_profile: vsphere-elastic
     env:
       FIPS_ENABLED: "true"
     leases:
@@ -4630,7 +4630,7 @@ tests:
 - as: vsphere-ipi-proxy-fips-f28-destructive
   cron: 3 7 21 * *
   steps:
-    cluster_profile: vsphere-dis-2
+    cluster_profile: vsphere-elastic
     env:
       FIPS_ENABLED: "true"
     leases:
@@ -4642,7 +4642,7 @@ tests:
 - as: vsphere-ipi-proxy-tp-f28
   cron: 17 21 6 * *
   steps:
-    cluster_profile: vsphere-dis-2
+    cluster_profile: vsphere-elastic
     env:
       FEATURE_SET: TechPreviewNoUpgrade
     leases:
@@ -4654,7 +4654,7 @@ tests:
 - as: vsphere-ipi-proxy-tp-f28-destructive
   cron: 14 7 21 * *
   steps:
-    cluster_profile: vsphere-dis-2
+    cluster_profile: vsphere-elastic
     env:
       FEATURE_SET: TechPreviewNoUpgrade
     leases:
@@ -4684,28 +4684,28 @@ tests:
 - as: vsphere-ipi-static-ip-f28
   cron: 8 5 4 * *
   steps:
-    cluster_profile: vsphere-connected-2
+    cluster_profile: vsphere-elastic
     test:
     - chain: openshift-e2e-test-qe-automated-release
     workflow: cucushift-installer-rehearse-vsphere-ipi-static-ip
 - as: vsphere-ipi-static-ip-f28-destructive
   cron: 11 4 22 * *
   steps:
-    cluster_profile: vsphere-connected-2
+    cluster_profile: vsphere-elastic
     test:
     - chain: openshift-e2e-test-qe-destructive
     workflow: cucushift-installer-rehearse-vsphere-ipi-static-ip
 - as: vsphere-ipi-template-usertags-f28
   cron: 23 13 25 * *
   steps:
-    cluster_profile: vsphere-connected-2
+    cluster_profile: vsphere-elastic
     test:
     - chain: openshift-e2e-test-qe-automated-release
     workflow: cucushift-installer-rehearse-vsphere-ipi-template-usertags
 - as: vsphere-ipi-template-usertags-f28-destructive
   cron: 36 10 22 * *
   steps:
-    cluster_profile: vsphere-connected-2
+    cluster_profile: vsphere-elastic
     test:
     - chain: openshift-e2e-test-qe-destructive
     workflow: cucushift-installer-rehearse-vsphere-ipi-template-usertags
@@ -4762,7 +4762,7 @@ tests:
 - as: vsphere-upi-disc-secureboot-fips-f28
   cron: 8 2 27 * *
   steps:
-    cluster_profile: vsphere-dis-2
+    cluster_profile: vsphere-elastic
     env:
       E2E_RUN_TAGS: '@disconnected'
       FIPS_ENABLED: "true"
@@ -4776,7 +4776,7 @@ tests:
 - as: vsphere-upi-disc-secureboot-fips-f28-destructive
   cron: 53 15 21 * *
   steps:
-    cluster_profile: vsphere-dis-2
+    cluster_profile: vsphere-elastic
     env:
       E2E_RUN_TAGS: '@disconnected'
       FIPS_ENABLED: "true"
@@ -4790,7 +4790,7 @@ tests:
 - as: vsphere-upi-disconnecting-network-f28
   cron: 12 5 20 * *
   steps:
-    cluster_profile: vsphere-connected-2
+    cluster_profile: vsphere-elastic
     env:
       E2E_RUN_TAGS: '@disconnected'
       TEST_FILTERS: ~ChkUpgrade&;~NonPreRelease&;~Serial&;~Disruptive&;~ConnectedOnly&;~HyperShiftMGMT&;~MicroShiftOnly&
@@ -4800,7 +4800,7 @@ tests:
 - as: vsphere-upi-disconnecting-network-f28-destructive
   cron: 20 14 15 * *
   steps:
-    cluster_profile: vsphere-connected-2
+    cluster_profile: vsphere-elastic
     env:
       E2E_RUN_TAGS: '@disconnected'
       TEST_FILTERS: ~ChkUpgrade&;~NonPreRelease&;Serial&;Disruptive&;~ConnectedOnly&;~HyperShiftMGMT&;~MicroShiftOnly&
@@ -4810,14 +4810,14 @@ tests:
 - as: vsphere-upi-encrypt-f28
   cron: 42 9 19 * *
   steps:
-    cluster_profile: vsphere-connected-2
+    cluster_profile: vsphere-elastic
     test:
     - chain: openshift-e2e-test-qe-automated-release
     workflow: cucushift-installer-rehearse-vsphere-upi-encrypt
 - as: vsphere-upi-encrypt-f28-destructive
   cron: 29 2 28 * *
   steps:
-    cluster_profile: vsphere-connected-2
+    cluster_profile: vsphere-elastic
     test:
     - chain: openshift-e2e-test-qe-destructive
     workflow: cucushift-installer-rehearse-vsphere-upi-encrypt

--- a/ci-operator/jobs/openshift-priv/openshift-tests-private/openshift-priv-openshift-tests-private-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/openshift-tests-private/openshift-priv-openshift-tests-private-main-presubmits.yaml
@@ -151,7 +151,7 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build09
+    cluster: build06
     context: ci/prow/debug-disasterrecovery-aws-ipi
     decorate: true
     decoration_config:
@@ -338,7 +338,7 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build09
+    cluster: build06
     context: ci/prow/debug-winc-aws-ipi
     decorate: true
     decoration_config:
@@ -431,7 +431,7 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build09
+    cluster: build06
     context: ci/prow/debug-winc-aws-upi
     decorate: true
     decoration_config:
@@ -710,7 +710,193 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build09
+    cluster: vsphere02
+    context: ci/prow/debug-winc-vsphere-ipi-disconnected
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: vsphere
+      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+      ci.openshift.io/generator: prowgen
+      job-release: "5.1"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-priv-openshift-tests-private-main-debug-winc-vsphere-ipi-disconnected
+    optional: true
+    path_alias: github.com/openshift/openshift-tests-private
+    rerun_command: /test debug-winc-vsphere-ipi-disconnected
+    run_if_changed: test/extended/winc/
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=debug-winc-vsphere-ipi-disconnected
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: github-credentials-openshift-ci-robot-private-git-cloner
+        secret:
+          secretName: github-credentials-openshift-ci-robot-private-git-cloner
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )debug-winc-vsphere-ipi-disconnected,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: vsphere02
+    context: ci/prow/debug-winc-vsphere-ipi-proxy
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: vsphere
+      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+      ci.openshift.io/generator: prowgen
+      job-release: "5.1"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-priv-openshift-tests-private-main-debug-winc-vsphere-ipi-proxy
+    optional: true
+    path_alias: github.com/openshift/openshift-tests-private
+    rerun_command: /test debug-winc-vsphere-ipi-proxy
+    run_if_changed: test/extended/winc/
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=debug-winc-vsphere-ipi-proxy
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: github-credentials-openshift-ci-robot-private-git-cloner
+        secret:
+          secretName: github-credentials-openshift-ci-robot-private-git-cloner
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )debug-winc-vsphere-ipi-proxy,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build06
     context: ci/prow/e2e-aws
     decorate: true
     decoration_config:

--- a/ci-operator/jobs/openshift-priv/openshift-tests-private/openshift-priv-openshift-tests-private-release-4.23-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/openshift-tests-private/openshift-priv-openshift-tests-private-release-4.23-presubmits.yaml
@@ -151,7 +151,7 @@ presubmits:
     branches:
     - ^release-4\.23$
     - ^release-4\.23-
-    cluster: build07
+    cluster: build06
     context: ci/prow/debug-disasterrecovery-aws-ipi
     decorate: true
     decoration_config:
@@ -338,7 +338,7 @@ presubmits:
     branches:
     - ^release-4\.23$
     - ^release-4\.23-
-    cluster: build07
+    cluster: build06
     context: ci/prow/debug-winc-aws-ipi
     decorate: true
     decoration_config:
@@ -431,7 +431,7 @@ presubmits:
     branches:
     - ^release-4\.23$
     - ^release-4\.23-
-    cluster: build07
+    cluster: build06
     context: ci/prow/debug-winc-aws-upi
     decorate: true
     decoration_config:
@@ -617,7 +617,7 @@ presubmits:
     branches:
     - ^release-4\.23$
     - ^release-4\.23-
-    cluster: build13
+    cluster: build08
     context: ci/prow/debug-winc-gcp-ipi
     decorate: true
     decoration_config:
@@ -710,7 +710,193 @@ presubmits:
     branches:
     - ^release-4\.23$
     - ^release-4\.23-
-    cluster: build07
+    cluster: vsphere02
+    context: ci/prow/debug-winc-vsphere-ipi-disconnected
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: vsphere
+      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+      ci.openshift.io/generator: prowgen
+      job-release: "4.23"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-priv-openshift-tests-private-release-4.23-debug-winc-vsphere-ipi-disconnected
+    optional: true
+    path_alias: github.com/openshift/openshift-tests-private
+    rerun_command: /test debug-winc-vsphere-ipi-disconnected
+    run_if_changed: test/extended/winc/
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=debug-winc-vsphere-ipi-disconnected
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: github-credentials-openshift-ci-robot-private-git-cloner
+        secret:
+          secretName: github-credentials-openshift-ci-robot-private-git-cloner
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )debug-winc-vsphere-ipi-disconnected,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.23$
+    - ^release-4\.23-
+    cluster: vsphere02
+    context: ci/prow/debug-winc-vsphere-ipi-proxy
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: vsphere
+      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+      ci.openshift.io/generator: prowgen
+      job-release: "4.23"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-priv-openshift-tests-private-release-4.23-debug-winc-vsphere-ipi-proxy
+    optional: true
+    path_alias: github.com/openshift/openshift-tests-private
+    rerun_command: /test debug-winc-vsphere-ipi-proxy
+    run_if_changed: test/extended/winc/
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=debug-winc-vsphere-ipi-proxy
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: github-credentials-openshift-ci-robot-private-git-cloner
+        secret:
+          secretName: github-credentials-openshift-ci-robot-private-git-cloner
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )debug-winc-vsphere-ipi-proxy,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.23$
+    - ^release-4\.23-
+    cluster: build06
     context: ci/prow/e2e-aws
     decorate: true
     decoration_config:
@@ -802,7 +988,7 @@ presubmits:
     branches:
     - ^release-4\.23$
     - ^release-4\.23-
-    cluster: build13
+    cluster: build08
     context: ci/prow/e2e-console
     decorate: true
     decoration_config:

--- a/ci-operator/jobs/openshift-priv/openshift-tests-private/openshift-priv-openshift-tests-private-release-5.0-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/openshift-tests-private/openshift-priv-openshift-tests-private-release-5.0-presubmits.yaml
@@ -5,7 +5,7 @@ presubmits:
     branches:
     - ^release-5\.0$
     - ^release-5\.0-
-    cluster: build10
+    cluster: build11
     context: ci/prow/bindata-check
     decorate: true
     decoration_config:
@@ -78,7 +78,7 @@ presubmits:
     branches:
     - ^release-5\.0$
     - ^release-5\.0-
-    cluster: build10
+    cluster: build11
     context: ci/prow/code-check
     decorate: true
     decoration_config:
@@ -151,7 +151,7 @@ presubmits:
     branches:
     - ^release-5\.0$
     - ^release-5\.0-
-    cluster: build06
+    cluster: build05
     context: ci/prow/debug-disasterrecovery-aws-ipi
     decorate: true
     decoration_config:
@@ -338,7 +338,7 @@ presubmits:
     branches:
     - ^release-5\.0$
     - ^release-5\.0-
-    cluster: build06
+    cluster: build05
     context: ci/prow/debug-winc-aws-ipi
     decorate: true
     decoration_config:
@@ -431,7 +431,7 @@ presubmits:
     branches:
     - ^release-5\.0$
     - ^release-5\.0-
-    cluster: build06
+    cluster: build05
     context: ci/prow/debug-winc-aws-upi
     decorate: true
     decoration_config:
@@ -524,7 +524,7 @@ presubmits:
     branches:
     - ^release-5\.0$
     - ^release-5\.0-
-    cluster: build10
+    cluster: build11
     context: ci/prow/debug-winc-azure-ipi
     decorate: true
     decoration_config:
@@ -617,7 +617,7 @@ presubmits:
     branches:
     - ^release-5\.0$
     - ^release-5\.0-
-    cluster: build08
+    cluster: build04
     context: ci/prow/debug-winc-gcp-ipi
     decorate: true
     decoration_config:
@@ -710,7 +710,193 @@ presubmits:
     branches:
     - ^release-5\.0$
     - ^release-5\.0-
-    cluster: build06
+    cluster: vsphere02
+    context: ci/prow/debug-winc-vsphere-ipi-disconnected
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: vsphere
+      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+      ci.openshift.io/generator: prowgen
+      job-release: "5.0"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-priv-openshift-tests-private-release-5.0-debug-winc-vsphere-ipi-disconnected
+    optional: true
+    path_alias: github.com/openshift/openshift-tests-private
+    rerun_command: /test debug-winc-vsphere-ipi-disconnected
+    run_if_changed: test/extended/winc/
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=debug-winc-vsphere-ipi-disconnected
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: github-credentials-openshift-ci-robot-private-git-cloner
+        secret:
+          secretName: github-credentials-openshift-ci-robot-private-git-cloner
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )debug-winc-vsphere-ipi-disconnected,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-5\.0$
+    - ^release-5\.0-
+    cluster: vsphere02
+    context: ci/prow/debug-winc-vsphere-ipi-proxy
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: vsphere
+      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+      ci.openshift.io/generator: prowgen
+      job-release: "5.0"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-priv-openshift-tests-private-release-5.0-debug-winc-vsphere-ipi-proxy
+    optional: true
+    path_alias: github.com/openshift/openshift-tests-private
+    rerun_command: /test debug-winc-vsphere-ipi-proxy
+    run_if_changed: test/extended/winc/
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=debug-winc-vsphere-ipi-proxy
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: github-credentials-openshift-ci-robot-private-git-cloner
+        secret:
+          secretName: github-credentials-openshift-ci-robot-private-git-cloner
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )debug-winc-vsphere-ipi-proxy,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-5\.0$
+    - ^release-5\.0-
+    cluster: build05
     context: ci/prow/e2e-aws
     decorate: true
     decoration_config:
@@ -802,7 +988,7 @@ presubmits:
     branches:
     - ^release-5\.0$
     - ^release-5\.0-
-    cluster: build08
+    cluster: build04
     context: ci/prow/e2e-console
     decorate: true
     decoration_config:
@@ -895,7 +1081,7 @@ presubmits:
     branches:
     - ^release-5\.0$
     - ^release-5\.0-
-    cluster: build10
+    cluster: build11
     context: ci/prow/images
     decorate: true
     decoration_config:
@@ -959,7 +1145,7 @@ presubmits:
     branches:
     - ^release-5\.0$
     - ^release-5\.0-
-    cluster: build10
+    cluster: build11
     context: ci/prow/title-check
     decorate: true
     decoration_config:

--- a/ci-operator/jobs/openshift-priv/openshift-tests-private/openshift-priv-openshift-tests-private-release-5.1-presubmits.yaml
+++ b/ci-operator/jobs/openshift-priv/openshift-tests-private/openshift-priv-openshift-tests-private-release-5.1-presubmits.yaml
@@ -710,6 +710,192 @@ presubmits:
     branches:
     - ^release-5\.1$
     - ^release-5\.1-
+    cluster: vsphere02
+    context: ci/prow/debug-winc-vsphere-ipi-disconnected
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: vsphere
+      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+      ci.openshift.io/generator: prowgen
+      job-release: "5.1"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-priv-openshift-tests-private-release-5.1-debug-winc-vsphere-ipi-disconnected
+    optional: true
+    path_alias: github.com/openshift/openshift-tests-private
+    rerun_command: /test debug-winc-vsphere-ipi-disconnected
+    run_if_changed: test/extended/winc/
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=debug-winc-vsphere-ipi-disconnected
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: github-credentials-openshift-ci-robot-private-git-cloner
+        secret:
+          secretName: github-credentials-openshift-ci-robot-private-git-cloner
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )debug-winc-vsphere-ipi-disconnected,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-5\.1$
+    - ^release-5\.1-
+    cluster: vsphere02
+    context: ci/prow/debug-winc-vsphere-ipi-proxy
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: vsphere
+      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+      ci.openshift.io/generator: prowgen
+      job-release: "5.1"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-priv-openshift-tests-private-release-5.1-debug-winc-vsphere-ipi-proxy
+    optional: true
+    path_alias: github.com/openshift/openshift-tests-private
+    rerun_command: /test debug-winc-vsphere-ipi-proxy
+    run_if_changed: test/extended/winc/
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=debug-winc-vsphere-ipi-proxy
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: github-credentials-openshift-ci-robot-private-git-cloner
+        secret:
+          secretName: github-credentials-openshift-ci-robot-private-git-cloner
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )debug-winc-vsphere-ipi-proxy,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-5\.1$
+    - ^release-5\.1-
     cluster: build06
     context: ci/prow/e2e-aws
     decorate: true

--- a/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-main-presubmits.yaml
@@ -5,7 +5,7 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build12
+    cluster: build04
     context: ci/prow/bindata-check
     decorate: true
     decoration_config:
@@ -77,7 +77,7 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build12
+    cluster: build04
     context: ci/prow/code-check
     decorate: true
     decoration_config:
@@ -149,7 +149,7 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build01
+    cluster: build10
     context: ci/prow/debug-disasterrecovery-aws-ipi
     decorate: true
     decoration_config:
@@ -334,7 +334,7 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build01
+    cluster: build10
     context: ci/prow/debug-winc-aws-ipi
     decorate: true
     decoration_config:
@@ -426,7 +426,7 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build01
+    cluster: build10
     context: ci/prow/debug-winc-aws-upi
     decorate: true
     decoration_config:
@@ -518,7 +518,7 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build12
+    cluster: build04
     context: ci/prow/debug-winc-azure-ipi
     decorate: true
     decoration_config:
@@ -610,7 +610,7 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build08
+    cluster: build13
     context: ci/prow/debug-winc-gcp-ipi
     decorate: true
     decoration_config:
@@ -702,7 +702,191 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build01
+    cluster: vsphere02
+    context: ci/prow/debug-winc-vsphere-ipi-disconnected
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: vsphere
+      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+      ci.openshift.io/generator: prowgen
+      job-release: "5.1"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-openshift-tests-private-main-debug-winc-vsphere-ipi-disconnected
+    optional: true
+    rerun_command: /test debug-winc-vsphere-ipi-disconnected
+    run_if_changed: test/extended/winc/
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=debug-winc-vsphere-ipi-disconnected
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: github-credentials-openshift-ci-robot-private-git-cloner
+        secret:
+          secretName: github-credentials-openshift-ci-robot-private-git-cloner
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )debug-winc-vsphere-ipi-disconnected,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: vsphere02
+    context: ci/prow/debug-winc-vsphere-ipi-proxy
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: vsphere
+      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+      ci.openshift.io/generator: prowgen
+      job-release: "5.1"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-openshift-tests-private-main-debug-winc-vsphere-ipi-proxy
+    optional: true
+    rerun_command: /test debug-winc-vsphere-ipi-proxy
+    run_if_changed: test/extended/winc/
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=debug-winc-vsphere-ipi-proxy
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: github-credentials-openshift-ci-robot-private-git-cloner
+        secret:
+          secretName: github-credentials-openshift-ci-robot-private-git-cloner
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )debug-winc-vsphere-ipi-proxy,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build10
     context: ci/prow/e2e-aws
     decorate: true
     decoration_config:
@@ -793,7 +977,7 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build08
+    cluster: build13
     context: ci/prow/e2e-console
     decorate: true
     decoration_config:
@@ -885,7 +1069,7 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build12
+    cluster: build04
     context: ci/prow/images
     decorate: true
     decoration_config:
@@ -949,7 +1133,7 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build12
+    cluster: build04
     context: ci/prow/images-images
     decorate: true
     decoration_config:
@@ -1014,7 +1198,7 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build12
+    cluster: build04
     context: ci/prow/title-check
     decorate: true
     decoration_config:

--- a/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.23-presubmits.yaml
+++ b/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.23-presubmits.yaml
@@ -5,7 +5,7 @@ presubmits:
     branches:
     - ^release-4\.23$
     - ^release-4\.23-
-    cluster: build10
+    cluster: build04
     context: ci/prow/bindata-check
     decorate: true
     decoration_config:
@@ -77,7 +77,7 @@ presubmits:
     branches:
     - ^release-4\.23$
     - ^release-4\.23-
-    cluster: build10
+    cluster: build04
     context: ci/prow/code-check
     decorate: true
     decoration_config:
@@ -149,7 +149,7 @@ presubmits:
     branches:
     - ^release-4\.23$
     - ^release-4\.23-
-    cluster: build12
+    cluster: build10
     context: ci/prow/debug-disasterrecovery-aws-ipi
     decorate: true
     decoration_config:
@@ -334,7 +334,7 @@ presubmits:
     branches:
     - ^release-4\.23$
     - ^release-4\.23-
-    cluster: build12
+    cluster: build10
     context: ci/prow/debug-winc-aws-ipi
     decorate: true
     decoration_config:
@@ -426,7 +426,7 @@ presubmits:
     branches:
     - ^release-4\.23$
     - ^release-4\.23-
-    cluster: build12
+    cluster: build10
     context: ci/prow/debug-winc-aws-upi
     decorate: true
     decoration_config:
@@ -518,7 +518,7 @@ presubmits:
     branches:
     - ^release-4\.23$
     - ^release-4\.23-
-    cluster: build10
+    cluster: build04
     context: ci/prow/debug-winc-azure-ipi
     decorate: true
     decoration_config:
@@ -702,7 +702,191 @@ presubmits:
     branches:
     - ^release-4\.23$
     - ^release-4\.23-
-    cluster: build12
+    cluster: vsphere02
+    context: ci/prow/debug-winc-vsphere-ipi-disconnected
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: vsphere
+      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+      ci.openshift.io/generator: prowgen
+      job-release: "4.23"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-openshift-tests-private-release-4.23-debug-winc-vsphere-ipi-disconnected
+    optional: true
+    rerun_command: /test debug-winc-vsphere-ipi-disconnected
+    run_if_changed: test/extended/winc/
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=debug-winc-vsphere-ipi-disconnected
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: github-credentials-openshift-ci-robot-private-git-cloner
+        secret:
+          secretName: github-credentials-openshift-ci-robot-private-git-cloner
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )debug-winc-vsphere-ipi-disconnected,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.23$
+    - ^release-4\.23-
+    cluster: vsphere02
+    context: ci/prow/debug-winc-vsphere-ipi-proxy
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: vsphere
+      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+      ci.openshift.io/generator: prowgen
+      job-release: "4.23"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-openshift-tests-private-release-4.23-debug-winc-vsphere-ipi-proxy
+    optional: true
+    rerun_command: /test debug-winc-vsphere-ipi-proxy
+    run_if_changed: test/extended/winc/
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=debug-winc-vsphere-ipi-proxy
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: github-credentials-openshift-ci-robot-private-git-cloner
+        secret:
+          secretName: github-credentials-openshift-ci-robot-private-git-cloner
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )debug-winc-vsphere-ipi-proxy,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.23$
+    - ^release-4\.23-
+    cluster: build10
     context: ci/prow/e2e-aws
     decorate: true
     decoration_config:
@@ -885,7 +1069,7 @@ presubmits:
     branches:
     - ^release-4\.23$
     - ^release-4\.23-
-    cluster: build10
+    cluster: build04
     context: ci/prow/images
     decorate: true
     decoration_config:
@@ -949,7 +1133,7 @@ presubmits:
     branches:
     - ^release-4\.23$
     - ^release-4\.23-
-    cluster: build10
+    cluster: build04
     context: ci/prow/title-check
     decorate: true
     decoration_config:

--- a/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-5.0-periodics.yaml
+++ b/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-5.0-periodics.yaml
@@ -6125,7 +6125,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-connected-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly-5.0-upgrade-from-stable-4.22
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -6214,7 +6214,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-dis-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly-5.0-upgrade-from-stable-4.22
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -6392,7 +6392,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-connected-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly-5.0-upgrade-from-stable-4.22
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -6837,7 +6837,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-connected-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly-5.0-upgrade-from-stable-4.22
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -7015,7 +7015,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-dis-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly-5.0-upgrade-from-stable-4.22
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -7193,7 +7193,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-connected-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly-5.0-upgrade-from-stable-4.22
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -7282,7 +7282,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-connected-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly-5.0-upgrade-from-stable-4.22
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -7638,7 +7638,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-dis-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly-5.0-upgrade-from-stable-4.22
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -7727,7 +7727,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-connected-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly-5.0-upgrade-from-stable-4.22
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -14301,7 +14301,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-connected-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly-5.0-upgrade-from-stable-5.0
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -14390,7 +14390,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-dis-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly-5.0-upgrade-from-stable-5.0
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -14568,7 +14568,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-connected-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly-5.0-upgrade-from-stable-5.0
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -15013,7 +15013,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-connected-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly-5.0-upgrade-from-stable-5.0
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -15191,7 +15191,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-dis-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly-5.0-upgrade-from-stable-5.0
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -15369,7 +15369,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-connected-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly-5.0-upgrade-from-stable-5.0
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -15458,7 +15458,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-connected-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly-5.0-upgrade-from-stable-5.0
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -15814,7 +15814,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-dis-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly-5.0-upgrade-from-stable-5.0
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -15903,7 +15903,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-connected-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly-5.0-upgrade-from-stable-5.0
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -42114,7 +42114,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-connected-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -42204,7 +42204,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-connected-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -42294,7 +42294,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-dis-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -42384,7 +42384,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-dis-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -42400,6 +42400,96 @@ periodics:
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
       - --target=vsphere-ipi-disc-f28-destructive
+      - --variant=amd64-nightly
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /usr/local/github-credentials
+        name: github-credentials-openshift-ci-robot-private-git-cloner
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: github-credentials-openshift-ci-robot-private-git-cloner
+      secret:
+        secretName: github-credentials-openshift-ci-robot-private-git-cloner
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: vsphere02
+  cron: 0 18 15 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: release-5.0
+    org: openshift
+    repo: openshift-tests-private
+  labels:
+    ci-operator.openshift.io/cloud: vsphere
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+    ci-operator.openshift.io/variant: amd64-nightly
+    ci.openshift.io/generator: prowgen
+    job-release: "5.0"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-openshift-tests-private-release-5.0-amd64-nightly-vsphere-ipi-disconnected-ovn-winc-f28
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --oauth-token-path=/usr/local/github-credentials/oauth
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=vsphere-ipi-disconnected-ovn-winc-f28
       - --variant=amd64-nightly
       command:
       - ci-operator
@@ -42654,7 +42744,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-connected-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -44598,7 +44688,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-connected-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -44688,7 +44778,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-connected-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -45048,7 +45138,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-connected-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -45138,7 +45228,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-dis-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -45228,7 +45318,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-dis-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -45318,7 +45408,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-dis-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -45408,7 +45498,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-dis-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -45488,6 +45578,96 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: vsphere02
+  cron: 57 15 14 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: release-5.0
+    org: openshift
+    repo: openshift-tests-private
+  labels:
+    ci-operator.openshift.io/cloud: vsphere
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+    ci-operator.openshift.io/variant: amd64-nightly
+    ci.openshift.io/generator: prowgen
+    job-release: "5.0"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-openshift-tests-private-release-5.0-amd64-nightly-vsphere-ipi-proxy-ovn-winc-f28
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --oauth-token-path=/usr/local/github-credentials/oauth
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=vsphere-ipi-proxy-ovn-winc-f28
+      - --variant=amd64-nightly
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /usr/local/github-credentials
+        name: github-credentials-openshift-ci-robot-private-git-cloner
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: github-credentials-openshift-ci-robot-private-git-cloner
+      secret:
+        secretName: github-credentials-openshift-ci-robot-private-git-cloner
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: vsphere02
   cron: 17 21 6 * *
   decorate: true
   decoration_config:
@@ -45498,7 +45678,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-dis-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -45588,7 +45768,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-dis-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -45858,7 +46038,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-connected-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -45948,7 +46128,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-connected-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -46038,7 +46218,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-connected-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -46128,7 +46308,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-connected-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -46848,7 +47028,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-dis-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -46938,7 +47118,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-dis-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -47028,7 +47208,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-connected-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -47118,7 +47298,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-connected-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -47208,7 +47388,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-connected-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -47298,7 +47478,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-connected-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -49359,7 +49539,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-dis-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-stable-5.0-upgrade-from-stable-4.22
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -49537,7 +49717,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-dis-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-stable-5.0-upgrade-from-stable-4.22
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"

--- a/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-5.0-presubmits.yaml
+++ b/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-5.0-presubmits.yaml
@@ -5,7 +5,7 @@ presubmits:
     branches:
     - ^release-5\.0$
     - ^release-5\.0-
-    cluster: build12
+    cluster: build11
     context: ci/prow/bindata-check
     decorate: true
     decoration_config:
@@ -77,7 +77,7 @@ presubmits:
     branches:
     - ^release-5\.0$
     - ^release-5\.0-
-    cluster: build12
+    cluster: build11
     context: ci/prow/code-check
     decorate: true
     decoration_config:
@@ -149,7 +149,7 @@ presubmits:
     branches:
     - ^release-5\.0$
     - ^release-5\.0-
-    cluster: build11
+    cluster: build09
     context: ci/prow/debug-disasterrecovery-aws-ipi
     decorate: true
     decoration_config:
@@ -334,7 +334,7 @@ presubmits:
     branches:
     - ^release-5\.0$
     - ^release-5\.0-
-    cluster: build11
+    cluster: build09
     context: ci/prow/debug-winc-aws-ipi
     decorate: true
     decoration_config:
@@ -426,7 +426,7 @@ presubmits:
     branches:
     - ^release-5\.0$
     - ^release-5\.0-
-    cluster: build11
+    cluster: build09
     context: ci/prow/debug-winc-aws-upi
     decorate: true
     decoration_config:
@@ -518,7 +518,7 @@ presubmits:
     branches:
     - ^release-5\.0$
     - ^release-5\.0-
-    cluster: build12
+    cluster: build11
     context: ci/prow/debug-winc-azure-ipi
     decorate: true
     decoration_config:
@@ -702,7 +702,191 @@ presubmits:
     branches:
     - ^release-5\.0$
     - ^release-5\.0-
-    cluster: build11
+    cluster: vsphere02
+    context: ci/prow/debug-winc-vsphere-ipi-disconnected
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: vsphere
+      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+      ci.openshift.io/generator: prowgen
+      job-release: "5.0"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-openshift-tests-private-release-5.0-debug-winc-vsphere-ipi-disconnected
+    optional: true
+    rerun_command: /test debug-winc-vsphere-ipi-disconnected
+    run_if_changed: test/extended/winc/
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=debug-winc-vsphere-ipi-disconnected
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: github-credentials-openshift-ci-robot-private-git-cloner
+        secret:
+          secretName: github-credentials-openshift-ci-robot-private-git-cloner
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )debug-winc-vsphere-ipi-disconnected,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-5\.0$
+    - ^release-5\.0-
+    cluster: vsphere02
+    context: ci/prow/debug-winc-vsphere-ipi-proxy
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: vsphere
+      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+      ci.openshift.io/generator: prowgen
+      job-release: "5.0"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-openshift-tests-private-release-5.0-debug-winc-vsphere-ipi-proxy
+    optional: true
+    rerun_command: /test debug-winc-vsphere-ipi-proxy
+    run_if_changed: test/extended/winc/
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=debug-winc-vsphere-ipi-proxy
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: github-credentials-openshift-ci-robot-private-git-cloner
+        secret:
+          secretName: github-credentials-openshift-ci-robot-private-git-cloner
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )debug-winc-vsphere-ipi-proxy,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-5\.0$
+    - ^release-5\.0-
+    cluster: build09
     context: ci/prow/e2e-aws
     decorate: true
     decoration_config:
@@ -885,7 +1069,7 @@ presubmits:
     branches:
     - ^release-5\.0$
     - ^release-5\.0-
-    cluster: build12
+    cluster: build11
     context: ci/prow/images
     decorate: true
     decoration_config:
@@ -949,7 +1133,7 @@ presubmits:
     branches:
     - ^release-5\.0$
     - ^release-5\.0-
-    cluster: build12
+    cluster: build11
     context: ci/prow/images-images
     decorate: true
     decoration_config:
@@ -1014,7 +1198,7 @@ presubmits:
     branches:
     - ^release-5\.0$
     - ^release-5\.0-
-    cluster: build12
+    cluster: build11
     context: ci/prow/title-check
     decorate: true
     decoration_config:

--- a/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-5.1-periodics.yaml
+++ b/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-5.1-periodics.yaml
@@ -25777,7 +25777,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-connected-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly
     ci.openshift.io/generator: prowgen
     job-release: "5.1"
@@ -25867,7 +25867,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-connected-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly
     ci.openshift.io/generator: prowgen
     job-release: "5.1"
@@ -25957,7 +25957,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-dis-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly
     ci.openshift.io/generator: prowgen
     job-release: "5.1"
@@ -26047,7 +26047,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-dis-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly
     ci.openshift.io/generator: prowgen
     job-release: "5.1"
@@ -26317,7 +26317,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-connected-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly
     ci.openshift.io/generator: prowgen
     job-release: "5.1"
@@ -28261,7 +28261,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-connected-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly
     ci.openshift.io/generator: prowgen
     job-release: "5.1"
@@ -28351,7 +28351,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-connected-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly
     ci.openshift.io/generator: prowgen
     job-release: "5.1"
@@ -28711,7 +28711,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-connected-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly
     ci.openshift.io/generator: prowgen
     job-release: "5.1"
@@ -28801,7 +28801,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-dis-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly
     ci.openshift.io/generator: prowgen
     job-release: "5.1"
@@ -28891,7 +28891,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-dis-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly
     ci.openshift.io/generator: prowgen
     job-release: "5.1"
@@ -28981,7 +28981,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-dis-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly
     ci.openshift.io/generator: prowgen
     job-release: "5.1"
@@ -29071,7 +29071,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-dis-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly
     ci.openshift.io/generator: prowgen
     job-release: "5.1"
@@ -29161,7 +29161,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-dis-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly
     ci.openshift.io/generator: prowgen
     job-release: "5.1"
@@ -29251,7 +29251,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-dis-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly
     ci.openshift.io/generator: prowgen
     job-release: "5.1"
@@ -29521,7 +29521,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-connected-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly
     ci.openshift.io/generator: prowgen
     job-release: "5.1"
@@ -29611,7 +29611,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-connected-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly
     ci.openshift.io/generator: prowgen
     job-release: "5.1"
@@ -29701,7 +29701,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-connected-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly
     ci.openshift.io/generator: prowgen
     job-release: "5.1"
@@ -29791,7 +29791,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-connected-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly
     ci.openshift.io/generator: prowgen
     job-release: "5.1"
@@ -30511,7 +30511,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-dis-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly
     ci.openshift.io/generator: prowgen
     job-release: "5.1"
@@ -30601,7 +30601,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-dis-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly
     ci.openshift.io/generator: prowgen
     job-release: "5.1"
@@ -30691,7 +30691,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-connected-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly
     ci.openshift.io/generator: prowgen
     job-release: "5.1"
@@ -30781,7 +30781,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-connected-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly
     ci.openshift.io/generator: prowgen
     job-release: "5.1"
@@ -30871,7 +30871,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-connected-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly
     ci.openshift.io/generator: prowgen
     job-release: "5.1"
@@ -30961,7 +30961,7 @@ periodics:
     repo: openshift-tests-private
   labels:
     ci-operator.openshift.io/cloud: vsphere
-    ci-operator.openshift.io/cloud-cluster-profile: vsphere-connected-2
+    ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
     ci-operator.openshift.io/variant: amd64-nightly
     ci.openshift.io/generator: prowgen
     job-release: "5.1"

--- a/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-5.1-presubmits.yaml
+++ b/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-5.1-presubmits.yaml
@@ -702,6 +702,190 @@ presubmits:
     branches:
     - ^release-5\.1$
     - ^release-5\.1-
+    cluster: vsphere02
+    context: ci/prow/debug-winc-vsphere-ipi-disconnected
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: vsphere
+      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+      ci.openshift.io/generator: prowgen
+      job-release: "5.1"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-openshift-tests-private-release-5.1-debug-winc-vsphere-ipi-disconnected
+    optional: true
+    rerun_command: /test debug-winc-vsphere-ipi-disconnected
+    run_if_changed: test/extended/winc/
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=debug-winc-vsphere-ipi-disconnected
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: github-credentials-openshift-ci-robot-private-git-cloner
+        secret:
+          secretName: github-credentials-openshift-ci-robot-private-git-cloner
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )debug-winc-vsphere-ipi-disconnected,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-5\.1$
+    - ^release-5\.1-
+    cluster: vsphere02
+    context: ci/prow/debug-winc-vsphere-ipi-proxy
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/cloud: vsphere
+      ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
+      ci.openshift.io/generator: prowgen
+      job-release: "5.1"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-openshift-tests-private-release-5.1-debug-winc-vsphere-ipi-proxy
+    optional: true
+    rerun_command: /test debug-winc-vsphere-ipi-proxy
+    run_if_changed: test/extended/winc/
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=debug-winc-vsphere-ipi-proxy
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: github-credentials-openshift-ci-robot-private-git-cloner
+        secret:
+          secretName: github-credentials-openshift-ci-robot-private-git-cloner
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )debug-winc-vsphere-ipi-proxy,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-5\.1$
+    - ^release-5\.1-
     cluster: build11
     context: ci/prow/e2e-aws
     decorate: true

--- a/ci-operator/step-registry/aws/windows/ami-discover/aws-windows-ami-discover-ref.yaml
+++ b/ci-operator/step-registry/aws/windows/ami-discover/aws-windows-ami-discover-ref.yaml
@@ -9,7 +9,7 @@ ref:
   env:
     - name: BYOH_WINDOWS_VERSION
       default: "2022"
-      documentation: "Windows Server version to discover (2019 or 2022)"
+      documentation: "Windows Server version to discover (2022 or 2025)"
   documentation: |-
     Discovers the latest Windows Server AMI ID in the target AWS region.
 

--- a/ci-operator/step-registry/cucushift/winc/prepare/byoh/cucushift-winc-prepare-byoh-commands.sh
+++ b/ci-operator/step-registry/cucushift/winc/prepare/byoh/cucushift-winc-prepare-byoh-commands.sh
@@ -34,9 +34,8 @@ function setup_image_mirroring()
 
   # Create ImageTagMirrorSet to redirect Windows images to mirror
   # Includes PowerShell containers and CSI driver images for storage tests
-  # PowerShell: Server 2019 (1809), Server 2022 (ltsc2022)
+  # PowerShell: Server 2022 (ltsc2022), Server 2025 (ltsc2022 until Microsoft publishes ltsc2025)
   # CSI: Azure File and vSphere drivers for OCP-66352
-  # TODO: Remove Server 2019 support after AMI/image upgrades to Server 2022
   cat <<EOF | oc create -f -
 apiVersion: config.openshift.io/v1
 kind: ImageTagMirrorSet
@@ -244,11 +243,8 @@ fi
 # installed on the Windows workers
 os_version=$(oc get nodes -l 'kubernetes.io/os=windows' -o=jsonpath="{.items[0].status.nodeInfo.osImage}")
 
+# Server 2022 and 2025 both use ltsc2022 until Microsoft publishes lts-nanoserver-ltsc2025
 windows_container_image="mcr.microsoft.com/powershell:lts-nanoserver-ltsc2022"
-if [[ "$os_version" == *"2019"* ]]
-then
-    windows_container_image="mcr.microsoft.com/powershell:lts-nanoserver-1809"
-fi
 
 echo "Windows OS version: ${os_version}"
 echo "Windows OS image ID: ${windows_os_image_id}"

--- a/ci-operator/step-registry/cucushift/winc/prepare/byoh/cucushift-winc-prepare-byoh-commands.sh
+++ b/ci-operator/step-registry/cucushift/winc/prepare/byoh/cucushift-winc-prepare-byoh-commands.sh
@@ -34,9 +34,8 @@ function setup_image_mirroring()
 
   # Create ImageTagMirrorSet to redirect Windows images to mirror
   # Includes PowerShell containers and CSI driver images for storage tests
-  # PowerShell: Server 2019 (1809), Server 2022 (ltsc2022)
+  # PowerShell: Server 2022 (ltsc2022), Server 2025 (ltsc2022 until Microsoft publishes ltsc2025)
   # CSI: Azure File and vSphere drivers for OCP-66352
-  # TODO: Remove Server 2019 support after AMI/image upgrades to Server 2022
   cat <<EOF | oc create -f -
 apiVersion: config.openshift.io/v1
 kind: ImageTagMirrorSet
@@ -245,10 +244,6 @@ fi
 os_version=$(oc get nodes -l 'kubernetes.io/os=windows' -o=jsonpath="{.items[0].status.nodeInfo.osImage}")
 
 windows_container_image="mcr.microsoft.com/powershell:lts-nanoserver-ltsc2022"
-if [[ "$os_version" == *"2019"* ]]
-then
-    windows_container_image="mcr.microsoft.com/powershell:lts-nanoserver-1809"
-fi
 
 echo "Windows OS version: ${os_version}"
 echo "Windows OS image ID: ${windows_os_image_id}"

--- a/ci-operator/step-registry/windows/byoh/provision/windows-byoh-provision-ref.yaml
+++ b/ci-operator/step-registry/windows/byoh/provision/windows-byoh-provision-ref.yaml
@@ -18,7 +18,7 @@ ref:
       documentation: "Number of Windows workers to provision"
     - name: BYOH_WINDOWS_VERSION
       default: "2022"
-      documentation: "Windows Server version (2019 or 2022)"
+      documentation: "Windows Server version (2022 or 2025)"
     - name: WINC_ADMIN_PASSWORD
       default: ""
       documentation: "Windows administrator password (auto-generated if not provided)"


### PR DESCRIPTION
[WINC-1926](https://redhat.atlassian.net/browse/WINC-1926): Implement Windows Server 2022/2025 dual-version CI test matrix

## Summary

Implement the dual-version test matrix that alternates Server 2022 and
Server 2025 between debug/presubmit and periodic jobs across all platforms.
This ensures both versions are tested without doubling job count.

Step-registry defaults remain at Server 2022. Jobs override env vars
(WINDOWS_OS_ID, WIN_SKU, BYOH_WINDOWS_VERSION) where Server 2025 is needed.
Server 2019 references are removed from BYOH prepare script and step
documentation.

Applied to: main, release-4.23, release-5.0 (both openshift and openshift-priv).
Periodic overrides in 5.0 amd64-nightly only (4.23 has no nightly config).

## Support Matrix

| Workflow | Debug/Presubmit | Periodic |
|----------|----------------|----------|
| AWS IPI | Server 2025 | Server 2022 |
| Azure IPI | Server 2022 | Server 2025 |
| GCP IPI | Server 2025 | Server 2022 |
| vSphere IPI* | -- | Server 2025 |
| vSphere IPI Proxy | Server 2025 | Server 2022 |
| vSphere IPI Disconnected | Server 2025 | Server 2022 |
| Nutanix IPI | -- | Server 2025 |
| AWS UPI | Server 2025 | Server 2022 |

vSphere IPI* connected debug removed per [WINC-1881](https://redhat.atlassian.net/browse/WINC-1881). Periodic retained.
Nutanix debug removed -- periodic coverage with Server 2025 is sufficient.

## Dependencies

1. PR #78406 ([WINC-1708](https://redhat.atlassian.net/browse/WINC-1708)): Drop Server 2019, update AWS default to 2022 -- merged
2. PR #78735 ([WINC-1881](https://redhat.atlassian.net/browse/WINC-1881)): Remove vSphere connected debug jobs -- merged
3. [WINC-1879](https://redhat.atlassian.net/browse/WINC-1879): Add Nutanix Server 2025 support -- merged

## Test Plan

- [ ] Validate via /pj-rehearse that all affected jobs pass
- [ ] Verify debug/presubmit jobs use the correct Server version per matrix
- [ ] Verify periodic jobs use the correct Server version per matrix
- [ ] Confirm no unexpected increase in total job count

[WINC-1926]: https://redhat.atlassian.net/browse/WINC-1926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WINC-1881]: https://redhat.atlassian.net/browse/WINC-1881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Updates OpenShift CI configurations across supported release branches to add Windows Server 2025 coverage for AWS, Azure, GCP, and vSphere Windows container tests.
- Adds vSphere disconnected and proxy test jobs with Server 2025 images and required leases, workflows, and cluster profiles.
- Uses `WINDOWS_OS_ID`, `WIN_SKU`, and `BYOH_WINDOWS_VERSION` overrides while retaining Windows Server 2022 defaults.
- Removes Windows Server 2019 references from BYOH preparation logic and documentation.
- Removes trailing whitespace from the `Makefile` `checkconfig` target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->