### PR TITLE
Creating prow jobs for GitOps 1.21

### DIFF
--- a/ci-operator/config/openshift/openshift-docs/openshift-openshift-docs-gitops-docs-1.21.yaml
+++ b/ci-operator/config/openshift/openshift-docs/openshift-openshift-docs-gitops-docs-1.21.yaml
@@ -1,0 +1,38 @@
+build_root:
+  image_stream_tag:
+    name: openshift-docs-asciidoc
+    namespace: ocp
+    tag: latest
+  use_build_cache: true
+resources:
+  '*':
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 400m
+      memory: 800Mi
+tests:
+- as: validate-asciidoc
+  steps:
+    env:
+      DISTROS: openshift-gitops
+      PREVIEW_SITE: ocpdocs-pr
+    test:
+    - ref: openshift-docs-build-docs
+    - ref: openshift-docs-preview-comment-pages
+    - ref: openshift-docs-asciidoctor
+    - ref: openshift-docs-lint-topicmaps
+    - ref: openshift-docs-jira-links
+    - ref: openshift-docs-vale-review
+- as: validate-portal
+  steps:
+    env:
+      BUILD: build_for_portal.py
+      DISTROS: openshift-gitops
+      VERSION: "1.21"
+    test:
+    - ref: openshift-docs-portal
+zz_generated_metadata:
+  branch: gitops-docs-1.21
+  org: openshift
+  repo: openshift-docs

--- a/ci-operator/jobs/openshift/openshift-docs/openshift-openshift-docs-gitops-docs-1.21-presubmits.yaml
+++ b/ci-operator/jobs/openshift/openshift-docs/openshift-openshift-docs-gitops-docs-1.21-presubmits.yaml
@@ -1,0 +1,148 @@
+presubmits:
+  openshift/openshift-docs:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^gitops-docs-1\.21$
+    - ^gitops-docs-1\.21-
+    cluster: build01
+    context: ci/prow/validate-asciidoc
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-openshift-docs-gitops-docs-1.21-validate-asciidoc
+    rerun_command: /test validate-asciidoc
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --target=validate-asciidoc
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )validate-asciidoc,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^gitops-docs-1\.21$
+    - ^gitops-docs-1\.21-
+    cluster: build01
+    context: ci/prow/validate-portal
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-openshift-docs-gitops-docs-1.21-validate-portal
+    rerun_command: /test validate-portal
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --target=validate-portal
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )validate-portal,?($|\s.*)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR adds Prow job configuration for the openshift-docs repository's GitOps 1.21 documentation branch. It enables automated CI/CD testing for GitOps documentation by configuring two validation test suites:

1. **asciidoc validation** — validates the source documentation format with the `openshift-gitops` distribution
2. **portal build validation** — builds the documentation for the portal with GitOps 1.21 version

The configuration also sets up resource allocation (400m CPU and 800Mi memory per job), enables build caching, and specifies the documentation build image to use from the openshift namespace.

This change integrates the GitOps 1.21 documentation branch into the OpenShift CI infrastructure, ensuring documentation changes are automatically validated through the Prow job system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->