### PR TITLE
snc: Add new line char if missing at the end of priv key

### DIFF
--- a/ci-operator/step-registry/code-ready/snc/e2e/test/code-ready-snc-e2e-test-commands.sh
+++ b/ci-operator/step-registry/code-ready/snc/e2e/test/code-ready-snc-e2e-test-commands.sh
@@ -17,8 +17,13 @@ mkdir -p "${HOME}"/.ssh
 mock-nss.sh
 
 # gcloud compute will use this key rather than create a new one
-cp "${CLUSTER_PROFILE_DIR}"/ssh-privatekey "${HOME}"/.ssh/google_compute_engine
-chmod 0600 "${HOME}"/.ssh/google_compute_engine
+PRIVATE_KEY_PATH="${HOME}"/.ssh/google_compute_engine
+cp "${CLUSTER_PROFILE_DIR}"/ssh-privatekey "${PRIVATE_KEY_PATH}"
+chmod 0600 "${PRIVATE_KEY_PATH}"
+lastchar=$(tail -c1 "${PRIVATE_KEY_PATH}")
+if [ -n "$lastchar" ]; then
+    echo >> "${PRIVATE_KEY_PATH}"
+fi
 cp "${CLUSTER_PROFILE_DIR}"/ssh-publickey "${HOME}"/.ssh/google_compute_engine.pub
 echo 'ServerAliveInterval 30' | tee -a "${HOME}"/.ssh/config
 echo 'ServerAliveCountMax 1200' | tee -a "${HOME}"/.ssh/config

--- a/ci-operator/step-registry/code-ready/snc/microshift-arm/test/code-ready-snc-microshift-arm-test-commands.sh
+++ b/ci-operator/step-registry/code-ready/snc/microshift-arm/test/code-ready-snc-microshift-arm-test-commands.sh
@@ -17,8 +17,13 @@ mkdir -p "${HOME}"/.ssh
 mock-nss.sh
 
 # gcloud compute will use this key rather than create a new one
-cp "${CLUSTER_PROFILE_DIR}"/ssh-privatekey "${HOME}"/.ssh/google_compute_engine
-chmod 0600 "${HOME}"/.ssh/google_compute_engine
+PRIVATE_KEY_PATH="${HOME}"/.ssh/google_compute_engine
+cp "${CLUSTER_PROFILE_DIR}"/ssh-privatekey "${PRIVATE_KEY_PATH}"
+chmod 0600 "${PRIVATE_KEY_PATH}"
+lastchar=$(tail -c1 "${PRIVATE_KEY_PATH}")
+if [ -n "$lastchar" ]; then
+    echo >> "${PRIVATE_KEY_PATH}"
+fi
 cp "${CLUSTER_PROFILE_DIR}"/ssh-publickey "${HOME}"/.ssh/google_compute_engine.pub
 echo 'ServerAliveInterval 30' | tee -a "${HOME}"/.ssh/config
 echo 'ServerAliveCountMax 1200' | tee -a "${HOME}"/.ssh/config

--- a/ci-operator/step-registry/code-ready/snc/microshift/test/code-ready-snc-microshift-test-commands.sh
+++ b/ci-operator/step-registry/code-ready/snc/microshift/test/code-ready-snc-microshift-test-commands.sh
@@ -17,8 +17,13 @@ mkdir -p "${HOME}"/.ssh
 mock-nss.sh
 
 # gcloud compute will use this key rather than create a new one
-cp "${CLUSTER_PROFILE_DIR}"/ssh-privatekey "${HOME}"/.ssh/google_compute_engine
-chmod 0600 "${HOME}"/.ssh/google_compute_engine
+PRIVATE_KEY_PATH="${HOME}"/.ssh/google_compute_engine
+cp "${CLUSTER_PROFILE_DIR}"/ssh-privatekey "${PRIVATE_KEY_PATH}"
+chmod 0600 "${PRIVATE_KEY_PATH}"
+lastchar=$(tail -c1 "${PRIVATE_KEY_PATH}")
+if [ -n "$lastchar" ]; then
+    echo >> "${PRIVATE_KEY_PATH}"
+fi
 cp "${CLUSTER_PROFILE_DIR}"/ssh-publickey "${HOME}"/.ssh/google_compute_engine.pub
 echo 'ServerAliveInterval 30' | tee -a "${HOME}"/.ssh/config
 echo 'ServerAliveCountMax 1200' | tee -a "${HOME}"/.ssh/config

--- a/ci-operator/step-registry/code-ready/snc/subscription/code-ready-snc-subscription-commands.sh
+++ b/ci-operator/step-registry/code-ready/snc/subscription/code-ready-snc-subscription-commands.sh
@@ -17,8 +17,13 @@ mkdir -p "${HOME}"/.ssh
 mock-nss.sh
 
 # gcloud compute will use this key rather than create a new one
-cp "${CLUSTER_PROFILE_DIR}"/ssh-privatekey "${HOME}"/.ssh/google_compute_engine
-chmod 0600 "${HOME}"/.ssh/google_compute_engine
+PRIVATE_KEY_PATH="${HOME}"/.ssh/google_compute_engine
+cp "${CLUSTER_PROFILE_DIR}"/ssh-privatekey "${PRIVATE_KEY_PATH}"
+chmod 0600 "${PRIVATE_KEY_PATH}"
+lastchar=$(tail -c1 "${PRIVATE_KEY_PATH}")
+if [ -n "$lastchar" ]; then
+    echo >> "${PRIVATE_KEY_PATH}"
+fi
 cp "${CLUSTER_PROFILE_DIR}"/ssh-publickey "${HOME}"/.ssh/google_compute_engine.pub
 echo 'ServerAliveInterval 30' | tee -a "${HOME}"/.ssh/config
 echo 'ServerAliveCountMax 1200' | tee -a "${HOME}"/.ssh/config

--- a/ci-operator/step-registry/gather/snc/gather-snc-commands.sh
+++ b/ci-operator/step-registry/gather/snc/gather-snc-commands.sh
@@ -16,8 +16,13 @@ mkdir -p "${HOME}"/.ssh
 mock-nss.sh
 
 # gcloud compute will use this key rather than create a new one
-cp "${CLUSTER_PROFILE_DIR}"/ssh-privatekey "${HOME}"/.ssh/google_compute_engine
-chmod 0600 "${HOME}"/.ssh/google_compute_engine
+PRIVATE_KEY_PATH="${HOME}"/.ssh/google_compute_engine
+cp "${CLUSTER_PROFILE_DIR}"/ssh-privatekey "${PRIVATE_KEY_PATH}"
+chmod 0600 "${PRIVATE_KEY_PATH}"
+lastchar=$(tail -c1 "${PRIVATE_KEY_PATH}")
+if [ -n "$lastchar" ]; then
+    echo >> "${PRIVATE_KEY_PATH}"
+fi
 cp "${CLUSTER_PROFILE_DIR}"/ssh-publickey "${HOME}"/.ssh/google_compute_engine.pub
 
 gcloud auth activate-service-account --quiet --key-file "${CLUSTER_PROFILE_DIR}"/gce.json


### PR DESCRIPTION
It is observed that the priv key which is part of secret is missing the new line char at the end and causing the ssh fail with following error

```
Load key "/tmp/secret/.ssh/google_compute_engine": error in libcrypto
```

Filled Jira issue https://redhat.atlassian.net/browse/DPTP-4864

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes an SSH key formatting issue in the OpenShift CI infrastructure that was causing SSH authentication to fail with libcrypto errors. The issue occurs when SSH private keys stored in CI secrets are missing a trailing newline character, which SSH clients require for proper key parsing.

## Changes

The fix is applied consistently across five test scripts in the SNC (Simple Node Creation) step registry:
- E2E tests
- Microshift tests (both ARM and standard architectures)
- Subscription tests  
- Gather (log collection) steps

**What Changed:**
Each affected script now:
1. Copies the SSH private key from the cluster profile directory to `~/.ssh/google_compute_engine`
2. Sets restrictive file permissions (`chmod 0600`)
3. **Checks the last byte of the key file and appends a newline if it's missing**

This ensures that all SSH keys are properly formatted with a trailing newline, preventing the `Load key: error in libcrypto` failures that were occurring when SSH tried to authenticate using keys that lacked this required formatting.

## Impact

These changes affect the OpenShift CI testing infrastructure for SNC-based clusters, ensuring that SSH authentication works reliably across various test scenarios (e2e tests, microshift deployments, and log collection) regardless of how the private key was originally formatted in the secret store.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->