### PR TITLE
[DO NOT MERGE] Rerun 4.14.65 multiarch failures

### DIFF
--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.14-upgrade-from-nightly-4.13.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.14-upgrade-from-nightly-4.13.yaml
@@ -136,7 +136,7 @@ tests:
       OCP_ARCH: arm64
       TEST_TYPE: upgrade-conformance
     workflow: openshift-upgrade-aws
-- as: ocp-ovn-remote-libvirt-s390x
+- as: ocp-ovn-remote-libvirt-s390x-test
   capabilities:
   - sshd-bastion
   cron: 0 2 * * 5
@@ -151,7 +151,7 @@ tests:
       NODE_TUNING: "true"
       TEST_TYPE: upgrade
     workflow: openshift-e2e-libvirt
-- as: ocp-ovn-remote-s2s-libvirt-ppc64le
+- as: ocp-ovn-remote-s2s-libvirt-ppc64le-test
   capabilities:
   - power-s2s-dns
   cron: 0 2 * * 5

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.14.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.14.yaml
@@ -370,7 +370,7 @@ tests:
       OCP_ARCH: arm64
       TEST_SUITE: upgrade-conformance
     workflow: openshift-upgrade-azure
-- as: ocp-e2e-ovn-remote-libvirt-s390x
+- as: ocp-e2e-ovn-remote-libvirt-s390x-test
   capabilities:
   - sshd-bastion
   cron: 0 0 * * 5
@@ -437,7 +437,7 @@ tests:
       BRANCH: "4.14"
       TEST_TYPE: conformance-serial
     workflow: openshift-e2e-libvirt
-- as: ocp-fips-ovn-remote-libvirt-s390x
+- as: ocp-fips-ovn-remote-libvirt-s390x-test
   capabilities:
   - sshd-bastion
   cron: 0 4 * * 5
@@ -452,7 +452,7 @@ tests:
       NODE_TUNING: "true"
       TEST_TYPE: conformance-parallel
     workflow: openshift-e2e-libvirt-fips
-- as: ocp-e2e-ovn-remote-s2s-libvirt-ppc64le
+- as: ocp-e2e-ovn-remote-s2s-libvirt-ppc64le-test
   capabilities:
   - power-s2s-dns
   cron: 0 0 * * 5
@@ -493,7 +493,7 @@ tests:
       BRANCH: "4.14"
       TEST_TYPE: conformance-serial
     workflow: openshift-e2e-libvirt
-- as: ocp-fips-ovn-remote-s2s-libvirt-ppc64le
+- as: ocp-fips-ovn-remote-s2s-libvirt-ppc64le-test
   capabilities:
   - power-s2s-dns
   cron: 0 4 * * 5

--- a/ci-operator/jobs/openshift/multiarch/openshift-multiarch-main-periodics.yaml
+++ b/ci-operator/jobs/openshift/multiarch/openshift-multiarch-main-periodics.yaml
@@ -10603,7 +10603,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.14"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-multiarch-main-nightly-4.14-ocp-e2e-ovn-remote-libvirt-s390x
+  name: periodic-ci-openshift-multiarch-main-nightly-4.14-ocp-e2e-ovn-remote-libvirt-s390x-test
   spec:
     containers:
     - args:
@@ -10612,7 +10612,7 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=ocp-e2e-ovn-remote-libvirt-s390x
+      - --target=ocp-e2e-ovn-remote-libvirt-s390x-test
       - --variant=nightly-4.14
       command:
       - ci-operator
@@ -10687,7 +10687,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.14"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-multiarch-main-nightly-4.14-ocp-e2e-ovn-remote-s2s-libvirt-ppc64le
+  name: periodic-ci-openshift-multiarch-main-nightly-4.14-ocp-e2e-ovn-remote-s2s-libvirt-ppc64le-test
   spec:
     containers:
     - args:
@@ -10696,7 +10696,7 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=ocp-e2e-ovn-remote-s2s-libvirt-ppc64le
+      - --target=ocp-e2e-ovn-remote-s2s-libvirt-ppc64le-test
       - --variant=nightly-4.14
       command:
       - ci-operator
@@ -11770,7 +11770,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.14"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-multiarch-main-nightly-4.14-ocp-fips-ovn-remote-libvirt-s390x
+  name: periodic-ci-openshift-multiarch-main-nightly-4.14-ocp-fips-ovn-remote-libvirt-s390x-test
   spec:
     containers:
     - args:
@@ -11779,7 +11779,7 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=ocp-fips-ovn-remote-libvirt-s390x
+      - --target=ocp-fips-ovn-remote-libvirt-s390x-test
       - --variant=nightly-4.14
       command:
       - ci-operator
@@ -11854,7 +11854,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.14"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-multiarch-main-nightly-4.14-ocp-fips-ovn-remote-s2s-libvirt-ppc64le
+  name: periodic-ci-openshift-multiarch-main-nightly-4.14-ocp-fips-ovn-remote-s2s-libvirt-ppc64le-test
   spec:
     containers:
     - args:
@@ -11863,7 +11863,7 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=ocp-fips-ovn-remote-s2s-libvirt-ppc64le
+      - --target=ocp-fips-ovn-remote-s2s-libvirt-ppc64le-test
       - --variant=nightly-4.14
       command:
       - ci-operator
@@ -12689,7 +12689,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.14"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-multiarch-main-nightly-4.14-upgrade-from-nightly-4.13-ocp-ovn-remote-libvirt-s390x
+  name: periodic-ci-openshift-multiarch-main-nightly-4.14-upgrade-from-nightly-4.13-ocp-ovn-remote-libvirt-s390x-test
   spec:
     containers:
     - args:
@@ -12698,7 +12698,7 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=ocp-ovn-remote-libvirt-s390x
+      - --target=ocp-ovn-remote-libvirt-s390x-test
       - --variant=nightly-4.14-upgrade-from-nightly-4.13
       command:
       - ci-operator
@@ -12773,7 +12773,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.14"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-multiarch-main-nightly-4.14-upgrade-from-nightly-4.13-ocp-ovn-remote-s2s-libvirt-ppc64le
+  name: periodic-ci-openshift-multiarch-main-nightly-4.14-upgrade-from-nightly-4.13-ocp-ovn-remote-s2s-libvirt-ppc64le-test
   spec:
     containers:
     - args:
@@ -12782,7 +12782,7 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=ocp-ovn-remote-s2s-libvirt-ppc64le
+      - --target=ocp-ovn-remote-s2s-libvirt-ppc64le-test
       - --variant=nightly-4.14-upgrade-from-nightly-4.13
       command:
       - ci-operator


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR renames multiarch CI test jobs for OpenShift 4.14 to facilitate re-running tests that previously failed for the 4.14.65 release on non-x86 architectures.

## Changes

The PR modifies two multiarch CI configuration files:

**openshift-multiarch-main__nightly-4.14.yaml:**
- Renames four scheduled test jobs by adding a `-test` suffix:
  - S390x tests: `ocp-e2e-ovn-remote-libvirt-s390x` and `ocp-fips-ovn-remote-libvirt-s390x`
  - PPC64le tests: `ocp-e2e-ovn-remote-s2s-libvirt-ppc64le` and `ocp-fips-ovn-remote-s2s-libvirt-ppc64le`

**openshift-multiarch-main__nightly-4.14-upgrade-from-nightly-4.13.yaml:**
- Renames two upgrade test jobs with the `-test` suffix:
  - S390x upgrade test: `ocp-ovn-remote-libvirt-s390x`
  - PPC64le upgrade test: `ocp-ovn-remote-s2s-libvirt-ppc64le`

The test configurations (cluster profiles, cron schedules, capabilities, and environment variables) remain unchanged.

## Context

The "[DO NOT MERGE]" tag in the PR title indicates this is a temporary branch for re-running specific multiarch test failures for the 4.14.65 release on s390x and ppc64le platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->