### PR TITLE
USHIFT-6935: Redirect JIRA MCP output to a log file

### DIFF
--- a/ci-operator/step-registry/openshift/edge-tooling/microshift-ci/doctor/openshift-edge-tooling-microshift-ci-doctor-commands.sh
+++ b/ci-operator/step-registry/openshift/edge-tooling/microshift-ci/doctor/openshift-edge-tooling-microshift-ci-doctor-commands.sh
@@ -11,6 +11,7 @@ mkdir -p "${CLAUDE_HOME}"
 
 CLAUDE_ANALYSIS_LOG="${WORKDIR}/claude-analysis.log"
 CLAUDE_BUG_CREATION_LOG="${WORKDIR}/claude-bug-creation.log"
+JIRA_MCP_LOG="${WORKDIR}/jira-mcp.log"
 
 # The procedure to copy reports and session logs to artifacts, executed at exit
 atexit_handler() {
@@ -185,16 +186,18 @@ EOF
     echo "Claude permissions configured."
     cat "${CLAUDE_HOME}/settings.json"
 
-    # Configure JIRA MCP
+    # Configure JIRA MCP, redirecting stderr to the JIRA MCP log file.
+    # Set MCP_VERBOSE=true to enable verbose logging.
     if [[ -n "${JIRA_API_TOKEN:-}" ]] && [[ -n "${JIRA_USERNAME:-}" ]]; then
         echo "Configuring JIRA MCP..."
         claude mcp add \
             -e JIRA_URL="${JIRA_URL}" \
             -e JIRA_API_TOKEN="${JIRA_API_TOKEN}" \
             -e JIRA_USERNAME="${JIRA_USERNAME}" \
+            -e MCP_VERBOSE=true \
             --scope user \
             --transport stdio \
-            jira -- uvx mcp-atlassian@0.21.0
+            jira -- bash -c "uvx mcp-atlassian@0.21.0 2>>${JIRA_MCP_LOG}"
 
         echo "Waiting for JIRA MCP to become available..."
         wait_for_mcp_status "jira" "Connected"


### PR DESCRIPTION
## Sample [JIRA MPC Log](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_release/79104/rehearse-79104-periodic-ci-openshift-eng-edge-tooling-main-microshift-ci-doctor/2053796024081715200/artifacts/microshift-ci-doctor/openshift-edge-tooling-microshift-ci-doctor/artifacts/jira-mcp.log)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR updates the MicroShift CI Doctor step in the OpenShift CI release repository to capture JIRA MCP (Model Context Protocol) diagnostic output in a dedicated log file.

## Changes

File modified:
- ci-operator/step-registry/openshift/edge-tooling/microshift-ci/doctor/openshift-edge-tooling-microshift-ci-doctor-commands.sh

What changed practically:
- Introduces JIRA_MCP_LOG="${WORKDIR}/jira-mcp.log" to store MCP output.
- Runs the JIRA MCP initializer (uvx mcp-atlassian@0.21.0) via bash with stderr redirected into the new log file (using 2>>${JIRA_MCP_LOG}).
- Enables very verbose MCP logging by setting MCP_VERY_VERBOSE=true in the MCP environment.

## Practical impact

JIRA MCP stderr and verbose diagnostics are now captured separately in jira-mcp.log and archived with job artifacts, improving post-run troubleshooting for JIRA-related failures or misconfigurations in the MicroShift CI Doctor step. A sample artifact produced by a rehearse run is linked in the PR (jira-mcp.log).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->