### PR TITLE
Aligned playbook name

### DIFF
--- a/ci-operator/step-registry/telcov10n/functional/cnf-ran/cleanup-compact-post/telcov10n-functional-cnf-ran-cleanup-compact-post-commands.sh
+++ b/ci-operator/step-registry/telcov10n/functional/cnf-ran/cleanup-compact-post/telcov10n-functional-cnf-ran-cleanup-compact-post-commands.sh
@@ -78,6 +78,6 @@ HUB_KUBECONFIG="/home/telcov10n/project/generated/${HUB_CLUSTER}/auth/kubeconfig
 cd /eco-ci-cd
 
 echo "Running spoke cleanup for compact cluster ${SPOKE_CLUSTER}"
-ansible-playbook playbooks/ran/spoke_cleanup.yml \
+ansible-playbook playbooks/ran/spoke-cleanup.yml \
   -i inventories/ocp-deployment/build-inventory.py \
   --extra-vars "hub_kubeconfig=${HUB_KUBECONFIG} spoke_cluster=${SPOKE_CLUSTER}"

--- a/ci-operator/step-registry/telcov10n/functional/cnf-ran/cleanup-compact/telcov10n-functional-cnf-ran-cleanup-compact-commands.sh
+++ b/ci-operator/step-registry/telcov10n/functional/cnf-ran/cleanup-compact/telcov10n-functional-cnf-ran-cleanup-compact-commands.sh
@@ -78,6 +78,6 @@ HUB_KUBECONFIG="/home/telcov10n/project/generated/${HUB_CLUSTER}/auth/kubeconfig
 cd /eco-ci-cd
 
 echo "Running spoke cleanup for compact cluster ${SPOKE_CLUSTER}"
-ansible-playbook playbooks/ran/spoke_cleanup.yml \
+ansible-playbook playbooks/ran/spoke-cleanup.yml \
   -i inventories/ocp-deployment/build-inventory.py \
   --extra-vars "hub_kubeconfig=${HUB_KUBECONFIG} spoke_cluster=${SPOKE_CLUSTER}"

--- a/ci-operator/step-registry/telcov10n/functional/cnf-ran/cleanup-standard-post/telcov10n-functional-cnf-ran-cleanup-standard-post-commands.sh
+++ b/ci-operator/step-registry/telcov10n/functional/cnf-ran/cleanup-standard-post/telcov10n-functional-cnf-ran-cleanup-standard-post-commands.sh
@@ -78,6 +78,6 @@ HUB_KUBECONFIG="/home/telcov10n/project/generated/${HUB_CLUSTER}/auth/kubeconfig
 cd /eco-ci-cd
 
 echo "Running spoke cleanup for ${SPOKE_CLUSTER}"
-ansible-playbook playbooks/ran/spoke_cleanup.yml \
+ansible-playbook playbooks/ran/spoke-cleanup.yml \
   -i inventories/ocp-deployment/build-inventory.py \
   --extra-vars "hub_kubeconfig=${HUB_KUBECONFIG} spoke_cluster=${SPOKE_CLUSTER}"

--- a/ci-operator/step-registry/telcov10n/functional/cnf-ran/cleanup-standard/telcov10n-functional-cnf-ran-cleanup-standard-commands.sh
+++ b/ci-operator/step-registry/telcov10n/functional/cnf-ran/cleanup-standard/telcov10n-functional-cnf-ran-cleanup-standard-commands.sh
@@ -78,6 +78,6 @@ HUB_KUBECONFIG="/home/telcov10n/project/generated/${HUB_CLUSTER}/auth/kubeconfig
 cd /eco-ci-cd
 
 echo "Running spoke cleanup for ${SPOKE_CLUSTER}"
-ansible-playbook playbooks/ran/spoke_cleanup.yml \
+ansible-playbook playbooks/ran/spoke-cleanup.yml \
   -i inventories/ocp-deployment/build-inventory.py \
   --extra-vars "hub_kubeconfig=${HUB_KUBECONFIG} spoke_cluster=${SPOKE_CLUSTER}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR aligns the Ansible playbook filename references across four CNF RAN cleanup CI step configurations. The playbook reference used in these steps is updated from `playbooks/ran/spoke_cleanup.yml` (underscore) to `playbooks/ran/spoke-cleanup.yml` (hyphen) for consistency.

The following cleanup step registries are affected:
- `telcov10n-functional-cnf-ran-cleanup-compact`
- `telcov10n-functional-cnf-ran-cleanup-compact-post`
- `telcov10n-functional-cnf-ran-cleanup-standard`
- `telcov10n-functional-cnf-ran-cleanup-standard-post`

This naming convention change appears to be a standardization effort to adopt consistent hyphen-based naming in the Ansible playbook filenames used by the RAN (Radio Access Network) functional test cleanup procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->