### PR TITLE
Try Standard_D*ads_v6

### DIFF
--- a/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main.yaml
+++ b/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main.yaml
@@ -452,7 +452,7 @@ tests:
   steps:
     env:
       ARO_HCP_CLOUD: dev
-      ARO_HCP_DEPLOY_ENV: prow
+      ARO_HCP_DEPLOY_ENV: ci01
       LOCATION: westus3
     leases:
     - count: 1

--- a/ci-operator/step-registry/aro-hcp/provision/environment/aro-hcp-provision-environment-commands.sh
+++ b/ci-operator/step-registry/aro-hcp/provision/environment/aro-hcp-provision-environment-commands.sh
@@ -76,7 +76,14 @@ yq eval -n "
   .clouds.dev.environments.${DEPLOY_ENV}.defaults.miMockCertName = \"${MSI_MOCK_CERT_NAME}\" |
   .clouds.dev.environments.${DEPLOY_ENV}.defaults.hcpRecovery.image.registry = \"${HCP_RECOVERY_SOURCE_REGISTRY}\" |
   .clouds.dev.environments.${DEPLOY_ENV}.defaults.hcpRecovery.image.repository = \"${HCP_RECOVERY_REPOSITORY}\" |
-  .clouds.dev.environments.${DEPLOY_ENV}.defaults.hcpRecovery.image.digest = \"${HCP_RECOVERY_DIGEST}\"
+  .clouds.dev.environments.${DEPLOY_ENV}.defaults.hcpRecovery.image.digest = \"${HCP_RECOVERY_DIGEST}\" |
+  .clouds.dev.environments.${DEPLOY_ENV}.defaults.svc.aks.systemAgentPool.vmSize = \"Standard_D4ads_v6\" |
+  .clouds.dev.environments.${DEPLOY_ENV}.defaults.svc.aks.userAgentPool.vmSize = \"Standard_D8ads_v6\" |
+  .clouds.dev.environments.${DEPLOY_ENV}.defaults.svc.aks.userAgentPool.name = \"u64d8adsv6\" |
+  .clouds.dev.environments.${DEPLOY_ENV}.defaults.svc.aks.infraAgentPool.vmSize = \"Standard_D4ads_v6\" |
+  .clouds.dev.environments.${DEPLOY_ENV}.defaults.mgmt.aks.systemAgentPool.vmSize = \"Standard_D4ads_v6\" |
+  .clouds.dev.environments.${DEPLOY_ENV}.defaults.mgmt.aks.userAgentPool.vmSize = \"Standard_D16ads_v6\" |
+  .clouds.dev.environments.${DEPLOY_ENV}.defaults.mgmt.aks.infraAgentPool.vmSize = \"Standard_D4ads_v6\"
 " > "${OVERRIDE_CONFIG_FILE}"
 echo "Created override config at: ${OVERRIDE_CONFIG_FILE}"
 cat "${OVERRIDE_CONFIG_FILE}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ARO HCP CI Provisioning: Introduce Standard_D*ads_v6 Azure VM Sizes

This PR updates the ARO HCP (Azure Red Hat OpenShift Hosted Control Plane) development environment provisioning step to configure Azure AKS node pool VM sizes using the newer `Standard_D*ads_v6` generation of instance types.

### What Changed

The `aro-hcp-provision-environment` step—which provisions test infrastructure for ARO HCP CI jobs—now explicitly sets VM size overrides for both the service cluster (`svc.aks`) and management cluster (`mgmt.aks`):

**Service Cluster (svc.aks):**
- System agent pool: `Standard_D4ads_v6`
- User agent pool: `Standard_D8ads_v6` (with pool name updated to `u64d8adsv6`)
- Infrastructure agent pool: `Standard_D4ads_v6`

**Management Cluster (mgmt.aks):**
- System agent pool: `Standard_D4ads_v6`
- User agent pool: `Standard_D16ads_v6`
- Infrastructure agent pool: `Standard_D4ads_v6`

These overrides are added to the configuration YAML file (`config-override.yaml`) that is used by the provisioning workflow in the `westus3` region.

### Impact

This changes the underlying compute resources used for ARO HCP test environments in OpenShift CI, moving from an unspecified VM type to explicitly using the memory-optimized `Standard_D*ads_v6` instance family (which provides AMD EPYC CPUs with premium memory).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->