### PR TITLE
ci-secret-bootstrap failing, drop build12 until reprovisioned

### DIFF
--- a/core-services/ci-secret-bootstrap/_config.yaml
+++ b/core-services/ci-secret-bootstrap/_config.yaml
@@ -15,7 +15,6 @@ cluster_groups:
   - build09
   - build10
   - build11
-  - build12
   - core-ci
   - vsphere02
   managed_clusters:
@@ -31,7 +30,6 @@ cluster_groups:
   - build09
   - build10
   - build11
-  - build12
   - core-ci
   - hosted-mgmt
   non_app_ci:
@@ -46,7 +44,6 @@ cluster_groups:
   - build09
   - build10
   - build11
-  - build12
   - core-ci
   - vsphere02
   openshift_config_pull_secret:
@@ -61,7 +58,6 @@ cluster_groups:
   - build09
   - build10
   - build11
-  - build12
   - core-ci
   - hosted-mgmt
   - vsphere02
@@ -3049,9 +3045,6 @@ secret_configs:
     build11.config:
       field: sa.pod-scaler.build11.config
       item: pod-scaler
-    build12.config:
-      field: sa.pod-scaler.build12.config
-      item: pod-scaler
     core-ci.config:
       field: sa.pod-scaler.core-ci.config
       item: pod-scaler
@@ -3090,9 +3083,6 @@ secret_configs:
       item: pod-scaler
     sa.pod-scaler.build11.token.txt:
       field: sa.pod-scaler.build11.token.txt
-      item: pod-scaler
-    sa.pod-scaler.build12.token.txt:
-      field: sa.pod-scaler.build12.token.txt
       item: pod-scaler
     sa.pod-scaler.core-ci.token.txt:
       field: sa.pod-scaler.core-ci.token.txt
@@ -3458,12 +3448,6 @@ secret_configs:
     sa.crier.build11.token.txt:
       field: sa.crier.build11.token.txt
       item: build_farm
-    sa.crier.build12.config:
-      field: sa.crier.build12.config
-      item: build_farm
-    sa.crier.build12.token.txt:
-      field: sa.crier.build12.token.txt
-      item: build_farm
     sa.crier.core-ci.config:
       field: sa.crier.core-ci.config
       item: build_farm
@@ -3516,9 +3500,6 @@ secret_configs:
       item: config-updater
     sa.config-updater.build11.config:
       field: sa.config-updater.build11.config
-      item: config-updater
-    sa.config-updater.build12.config:
-      field: sa.config-updater.build12.config
       item: config-updater
     sa.config-updater.core-ci.config:
       field: sa.config-updater.core-ci.config
@@ -3612,12 +3593,6 @@ secret_configs:
     sa.deck.build11.token.txt:
       field: sa.deck.build11.token.txt
       item: build_farm
-    sa.deck.build12.config:
-      field: sa.deck.build12.config
-      item: build_farm
-    sa.deck.build12.token.txt:
-      field: sa.deck.build12.token.txt
-      item: build_farm
     sa.deck.core-ci.config:
       field: sa.deck.core-ci.config
       item: build_farm
@@ -3706,12 +3681,6 @@ secret_configs:
       item: build_farm
     sa.hook.build11.token.txt:
       field: sa.hook.build11.token.txt
-      item: build_farm
-    sa.hook.build12.config:
-      field: sa.hook.build12.config
-      item: build_farm
-    sa.hook.build12.token.txt:
-      field: sa.hook.build12.token.txt
       item: build_farm
     sa.hook.core-ci.config:
       field: sa.hook.core-ci.config
@@ -3804,12 +3773,6 @@ secret_configs:
       item: build_farm
     sa.prow-controller-manager.build11.token.txt:
       field: sa.prow-controller-manager.build11.token.txt
-      item: build_farm
-    sa.prow-controller-manager.build12.config:
-      field: sa.prow-controller-manager.build12.config
-      item: build_farm
-    sa.prow-controller-manager.build12.token.txt:
-      field: sa.prow-controller-manager.build12.token.txt
       item: build_farm
     sa.prow-controller-manager.core-ci.config:
       field: sa.prow-controller-manager.core-ci.config
@@ -3926,12 +3889,6 @@ secret_configs:
     sa.sinker.build11.token.txt:
       field: sa.sinker.build11.token.txt
       item: build_farm
-    sa.sinker.build12.config:
-      field: sa.sinker.build12.config
-      item: build_farm
-    sa.sinker.build12.token.txt:
-      field: sa.sinker.build12.token.txt
-      item: build_farm
     sa.sinker.core-ci.config:
       field: sa.sinker.core-ci.config
       item: build_farm
@@ -4015,12 +3972,6 @@ secret_configs:
     sa.dptp-controller-manager.build11.token.txt:
       field: sa.dptp-controller-manager.build11.token.txt
       item: build_farm
-    sa.dptp-controller-manager.build12.config:
-      field: sa.dptp-controller-manager.build12.config
-      item: build_farm
-    sa.dptp-controller-manager.build12.token.txt:
-      field: sa.dptp-controller-manager.build12.token.txt
-      item: build_farm
     sa.dptp-controller-manager.core-ci.config:
       field: sa.dptp-controller-manager.core-ci.config
       item: build_farm
@@ -4103,12 +4054,6 @@ secret_configs:
       item: build_farm
     sa.promoted-image-governor.build11.token.txt:
       field: sa.promoted-image-governor.build11.token.txt
-      item: build_farm
-    sa.promoted-image-governor.build12.config:
-      field: sa.promoted-image-governor.build12.config
-      item: build_farm
-    sa.promoted-image-governor.build12.token.txt:
-      field: sa.promoted-image-governor.build12.token.txt
       item: build_farm
     sa.promoted-image-governor.core-ci.config:
       field: sa.promoted-image-governor.core-ci.config
@@ -4230,12 +4175,6 @@ secret_configs:
     sa.ci-chat-bot.build11.token.txt:
       field: sa.ci-chat-bot.build11.token.txt
       item: ci-chat-bot
-    sa.ci-chat-bot.build12.config:
-      field: sa.ci-chat-bot.build12.config
-      item: ci-chat-bot
-    sa.ci-chat-bot.build12.token.txt:
-      field: sa.ci-chat-bot.build12.token.txt
-      item: ci-chat-bot
     sa.ci-chat-bot.core-ci.config:
       field: sa.ci-chat-bot.core-ci.config
       item: ci-chat-bot
@@ -4324,12 +4263,6 @@ secret_configs:
       item: build_farm
     sa.github-ldap-user-group-creator.build11.token.txt:
       field: sa.github-ldap-user-group-creator.build11.token.txt
-      item: build_farm
-    sa.github-ldap-user-group-creator.build12.config:
-      field: sa.github-ldap-user-group-creator.build12.config
-      item: build_farm
-    sa.github-ldap-user-group-creator.build12.token.txt:
-      field: sa.github-ldap-user-group-creator.build12.token.txt
       item: build_farm
     sa.github-ldap-user-group-creator.core-ci.config:
       field: sa.github-ldap-user-group-creator.core-ci.config
@@ -5309,12 +5242,6 @@ secret_configs:
       item: build_farm
     sa.cluster-display.build11.token.txt:
       field: sa.cluster-display.build11.token.txt
-      item: build_farm
-    sa.cluster-display.build12.config:
-      field: sa.cluster-display.build12.config
-      item: build_farm
-    sa.cluster-display.build12.token.txt:
-      field: sa.cluster-display.build12.token.txt
       item: build_farm
     sa.cluster-display.core-ci.config:
       field: sa.cluster-display.core-ci.config
@@ -7302,90 +7229,6 @@ secret_configs:
     name: multi-arch-builder-controller-build11-registry-credentials
     namespace: ci
     type: kubernetes.io/dockerconfigjson
-- from:
-    .dockerconfigjson:
-      dockerconfigJSON:
-      - auth_field: token_image-puller_build12_reg_auth_value.txt
-        item: build_farm
-        registry_url: image-registry.openshift-image-registry.svc.cluster.local:5000
-      - auth_field: token_image-puller_build12_reg_auth_value.txt
-        item: build_farm
-        registry_url: image-registry.openshift-image-registry.svc:5000
-      - auth_field: token_image-puller_build12_reg_auth_value.txt
-        item: build_farm
-        registry_url: registry.build12.ci.openshift.org
-      - auth_field: token_image-pusher_app.ci_reg_auth_value.txt
-        item: build_farm
-        registry_url: registry.ci.openshift.org
-      - auth_field: auth
-        item: quay-io-push-credentials
-        registry_url: quay.io/openshift/ci
-  to:
-  - cluster: build12
-    name: registry-push-credentials-ci-central
-    namespace: ci
-    type: kubernetes.io/dockerconfigjson
-  - cluster: build12
-    name: registry-push-credentials-ci-central
-    namespace: test-credentials
-    type: kubernetes.io/dockerconfigjson
-- from:
-    .dockerconfigjson:
-      dockerconfigJSON:
-      - auth_field: token_image-pusher_build12_reg_auth_value.txt
-        item: build_farm
-        registry_url: image-registry.openshift-image-registry.svc:5000
-      - auth_field: token_multi-arch-builder-controller_build12_reg_auth_value.txt
-        item: build_farm
-        registry_url: registry.multi-build01.arm-build.devcluster.openshift.com
-      - auth_field: token_image-pusher_app.ci_reg_auth_value.txt
-        item: build_farm
-        registry_url: registry.ci.openshift.org
-  to:
-  - cluster: build12
-    name: multi-arch-builder-controller-build12-registry-credentials
-    namespace: ci
-    type: kubernetes.io/dockerconfigjson
-- from:
-    build12-id:
-      field: build12-id
-      item: dex
-    build12-secret:
-      field: build12-secret
-      item: dex
-  to:
-  - cluster: app.ci
-    name: build12-secret
-    namespace: dex
-  - cluster: app.ci
-    name: build12-dex-oidc
-    namespace: ci
-- from:
-    clientSecret:
-      field: build12-secret
-      item: dex
-  to:
-  - cluster: build12
-    name: dex-rh-sso
-    namespace: openshift-config
-- from:
-    .dockerconfigjson:
-      dockerconfigJSON:
-      - auth_field: token_image-pusher_build12_reg_auth_value.txt
-        item: build_farm
-        registry_url: image-registry.openshift-image-registry.svc:5000
-      - auth_field: token_image-pusher_build12_reg_auth_value.txt
-        item: build_farm
-        registry_url: registry.build12.ci.openshift.org
-  to:
-  - cluster: build12
-    name: manifest-tool-local-pusher
-    namespace: ci
-    type: kubernetes.io/dockerconfigjson
-  - cluster: build12
-    name: manifest-tool-local-pusher
-    namespace: test-credentials
-    type: kubernetes.io/dockerconfigjson
 user_secrets_target_clusters:
 - app.ci
 - build01
@@ -7399,7 +7242,6 @@ user_secrets_target_clusters:
 - build09
 - build10
 - build11
-- build12
 - core-ci
 - hosted-mgmt
 - vsphere02

--- a/core-services/ci-secret-bootstrap/gsm-config.yaml
+++ b/core-services/ci-secret-bootstrap/gsm-config.yaml
@@ -16,7 +16,6 @@ cluster_groups:
     - build09
     - build10
     - build11
-    - build12
     - core-ci
     - vsphere02
   managed_clusters:
@@ -32,7 +31,6 @@ cluster_groups:
     - build09
     - build10
     - build11
-    - build12
     - core-ci
     - hosted-mgmt
   non_app_ci:
@@ -47,7 +45,6 @@ cluster_groups:
     - build09
     - build10
     - build11
-    - build12
     - core-ci
     - vsphere02
   standard_build_clusters:
@@ -62,7 +59,6 @@ cluster_groups:
     - build09
     - build10
     - build11
-    - build12
 
 dptp_collection: test-platform-infra
 
@@ -125,8 +121,6 @@ bundles:
           - sa--dot--cluster-init--dot--build10--dot--token--dot--txt
           - sa--dot--cluster-init--dot--build11--dot--config
           - sa--dot--cluster-init--dot--build11--dot--token--dot--txt
-          - sa--dot--cluster-init--dot--build12--dot--config
-          - sa--dot--cluster-init--dot--build12--dot--token--dot--txt
           - sa--dot--cluster-init--dot--core-ci--dot--config
           - sa--dot--cluster-init--dot--core-ci--dot--token--dot--txt
           - sa--dot--cluster-init--dot--vsphere02--dot--config
@@ -656,51 +650,6 @@ bundles:
         namespace: ocp
         type: kubernetes.io/dockerconfigjson
 
-  - name: registry-pull-credentials
-    dockerconfig:
-      registries:
-        - auth_field: token_image-puller_build12_reg_auth_value--dot--txt
-          group: build_farm
-          registry_url: image-registry.openshift-image-registry.svc.cluster.local:5000
-        - auth_field: token_image-puller_build12_reg_auth_value--dot--txt
-          group: build_farm
-          registry_url: image-registry.openshift-image-registry.svc:5000
-        - auth_field: token_image-puller_build12_reg_auth_value--dot--txt
-          group: build_farm
-          registry_url: registry.build12.ci.openshift.org
-        - auth_field: token_image-puller_app--dot--ci_reg_auth_value--dot--txt
-          group: build_farm
-          registry_url: registry.ci.openshift.org
-        - auth_field: auth
-          email_field: email
-          group: quay--dot--io-pull-secret
-          registry_url: quay.io
-        - auth_field: auth
-          group: quayio-ci-read-only-robot
-          registry_url: quay-proxy.ci.openshift.org
-        - auth_field: auth
-          group: quayio-ci-read-only-robot
-          registry_url: quay.io/openshift/ci
-        - auth_field: auth
-          group: quayio-ci-read-only-robot
-          registry_url: quay.io/openshift/network-edge-testing
-        - auth_field: auth
-          group: quayio-ci-read-only-robot
-          registry_url: qci-pull-through-cache-us-east-1-ci.apps.ci.l2s4.p1.openshiftapps.com
-    sync_to_cluster: true
-    targets:
-      - cluster: build12
-        namespace: ci
-        type: kubernetes.io/dockerconfigjson
-      - cluster: build12
-        namespace: test-credentials
-        type: kubernetes.io/dockerconfigjson
-      - cluster: build12
-        namespace: keel
-        type: kubernetes.io/dockerconfigjson
-      - cluster: build12
-        namespace: ocp
-        type: kubernetes.io/dockerconfigjson
 
   - name: registry-pull-credentials
     dockerconfig:

--- a/core-services/ci-secret-generator/_config.yaml
+++ b/core-services/ci-secret-generator/_config.yaml
@@ -20,7 +20,6 @@
     - build09
     - build10
     - build11
-    - build12
     - core-ci
     - vsphere02
     service_account:
@@ -117,7 +116,6 @@
     - build09
     - build10
     - build11
-    - build12
     - core-ci
     - vsphere02
     service_account:
@@ -145,7 +143,6 @@
     - build09
     - build10
     - build11
-    - build12
     - core-ci
     - vsphere02
     service_account:
@@ -173,7 +170,6 @@
     - build09
     - build10
     - build11
-    - build12
     - core-ci
     service_account:
     - pod-scaler
@@ -281,7 +277,6 @@
     - build09
     - build10
     - build11
-    - build12
 - fields:
   - cmd: /usr/bin/generate_thanos_tls.sh /tmp/thanos-tls /tmp/build-farm-credentials/sa.config-updater.$(cluster).config
       thanos-receive.core.ci.devcluster.openshift.com && cat /tmp/thanos-tls/server.crt


### PR DESCRIPTION
https://prow.ci.openshift.org/view/gs/test-platform-results/logs/openshift-release-main-config-bootstrapper/2053789611171254272#1:build-log.txt%3A76542

/cc @openshift/test-platform 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR temporarily removes the build12 cluster from OpenShift CI secret management and generation until the cluster is reprovisioned. Practically, secrets and generated service-account tokens that were being synchronized to build12 are no longer produced or pushed; all build12 targets and bundle entries were removed from ci-secret-bootstrap and ci-secret-generator configuration and from GSM bundling.

## What changed (practical effect)

- ci-secret-bootstrap/_config.yaml
  - Removed build12 from cluster group definitions and from user_secrets_target_clusters.
  - Deleted all secret targets/mappings that referenced cluster: build12 (this stops syncing existing secrets — service account tokens, kubeconfigs, registry dockerconfigs and other component secrets — to build12).

- ci-secret-bootstrap/gsm-config.yaml
  - Removed build12 from cluster_groups (build_farm, managed_clusters, non_app_ci, standard_build_clusters).
  - Removed build12-specific entries from bundles (cluster-init and registry/manifest dockerconfig bundle targets), so GSM no longer includes or syncs build12 service-account secrets or registry credentials.

- ci-secret-generator/_config.yaml
  - Removed build12 from params.cluster lists used to generate service-account tokens and registry auth values (so token generation and related secret artifacts for build12 will not be produced).

## Affected infrastructure

- Secret management and token generation for CI components (prow components, ci-operator, pod-scaler, registry/manifest push/pull creds, multi-arch builder tokens, Dex/registry-push credentials, etc.) will no longer target build12.
- All other build clusters (build01–build11), app.ci, core-ci and other configured clusters continue to receive secrets and generated tokens as before.

## Rationale & next steps

- This is a temporary measure to avoid CI errors while build12 is reprovisioned. Once build12 is reprovisioned, the removed entries should be reintroduced to resume secret sync and token generation for that cluster.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->