### PR TITLE
ARO-HCP: add initial dev e2e slot to Boskos

### DIFF
--- a/core-services/prow/02_config/_boskos.yaml
+++ b/core-services/prow/02_config/_boskos.yaml
@@ -67,10 +67,14 @@ resources:
   min-count: 1
   state: free
   type: aro-hcp-dev-image-push-quota-slice
-- max-count: 15
-  min-count: 15
+- max-count: 14
+  min-count: 14
   state: free
   type: aro-hcp-dev-quota-slice
+- names:
+  - aro-hcp-dev-shard0-westus3-slot-00
+  state: free
+  type: aro-hcp-dev-shard0-westus3-slot
 - max-count: 1
   min-count: 1
   state: free

--- a/core-services/prow/02_config/generate-boskos.py
+++ b/core-services/prow/02_config/generate-boskos.py
@@ -286,7 +286,7 @@ CONFIG = {
         'default': 10
     },
     'aro-hcp-dev-quota-slice': {
-        'default': 15,
+        'default': 14,
     },
     'aro-hcp-dev-global-pipeline-quota-slice': {
         'default': 1,
@@ -301,6 +301,9 @@ CONFIG = {
     'aro-hcp-test-msi-containers-int': {},
     'aro-hcp-test-msi-containers-stg': {},
     'aro-hcp-test-msi-containers-prod': {},
+    # BEGIN ARO-HCP E2E SLOT TYPES
+    'aro-hcp-dev-shard0-westus3-slot': {},
+    # END ARO-HCP E2E SLOT TYPES
     'aro-hcp-msi-mock-cs-sp-dev': {},
     'equinix-ocp-metal-quota-slice': {
         'default': 140,
@@ -753,6 +756,10 @@ for i in range(150):
     CONFIG['aro-hcp-test-msi-containers-stg']['aro-hcp-test-msi-containers-stg-{}'.format(i)] = 1
     CONFIG['aro-hcp-test-msi-containers-prod']['aro-hcp-test-msi-containers-prod-{}'.format(i)] = 1
 
+# BEGIN ARO-HCP E2E SLOT RESOURCES
+for i in range(1):
+    CONFIG['aro-hcp-dev-shard0-westus3-slot']['aro-hcp-dev-shard0-westus3-slot-{i:0>2}'.format(i=i)] = 1
+# END ARO-HCP E2E SLOT RESOURCES
 for i in range(20):
     CONFIG['aro-hcp-msi-mock-cs-sp-dev']['aro-hcp-msi-mock-cs-sp-dev-{}'.format(i)] = 1
 


### PR DESCRIPTION
Add the `aro-hcp-dev-westus3-slot` Boskos resource type and seed a single `-00` resource for rehearsal testing. This enables early validation of the slot-based e2e lease flow in dev while legacy leases remain active during the migration.
Added comments around slot resources definition blocks in `generate-boskos.py` so our tooling can keep them in sync with the slot definitions in Azure/ARO-HCP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR modifies OpenShift CI Boskos configuration (core-services/prow/02_config) to add an initial slot-based E2E resource for ARO-HCP dev rehearsals and adjust the existing dev quota to account for it.

What changed
- core-services/prow/02_config/_boskos.yaml
  - Decreased the aro-hcp-dev-quota-slice count from 15 to 14.
  - Added a new slot-style Boskos resource type aro-hcp-dev-shard0-westus3-slot and seeded a single free resource name aro-hcp-dev-shard0-westus3-slot-00.
- core-services/prow/02_config/generate-boskos.py
  - Updated generator configuration to reflect the reduced aro-hcp-dev-quota-slice and to emit the new slot quota-slice (the generator populates exactly one slot resource name).

Why this matters
- Enables early validation of the slot-based e2e lease flow for ARO-HCP dev (rehearsal testing) by provisioning a named slot resource while leaving legacy quota-based leases active during migration.
- Affects how Boskos allocates ARO-HCP development cluster resources in the CI infrastructure; introduces a named slot alongside the existing quota-based slice to test the new allocation model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->