### PR TITLE
Add taint to bm node in vsphere hybrid to prevent e2e scheduling

### DIFF
--- a/ci-operator/step-registry/ipi/install/vsphere/virt/ipi-install-vsphere-virt-commands.sh
+++ b/ci-operator/step-registry/ipi/install/vsphere/virt/ipi-install-vsphere-virt-commands.sh
@@ -174,6 +174,12 @@ for (( i=0; i<${BM_COUNT}; i++ )); do
   oc adm taint nodes "${VM_NAME}-${i}" node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule- --kubeconfig="${CLUSTER_KUBECONFIG}"
 done
 
+# add custom taint to prevent e2e from running on it due to current networking limitations.  Metrics do not seem to work when making calls from BM to ingress for data, but
+# everything else seems fine.
+for (( i=0; i<${BM_COUNT}; i++ )); do
+  oc adm taint nodes "${VM_NAME}-${i}" vsphere.openshift.io/e2e=true:NoSchedule --kubeconfig="${CLUSTER_KUBECONFIG}"
+done
+
 # Wait for node to be ready to prevent any interruption during the e2e tests
 wait_for_node_ready
 


### PR DESCRIPTION
### Changes
- Changed vsphere virt step to put taint on BM nodes so e2e pods wont run there for now.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR updates the vSphere hybrid environment setup in OpenShift CI to prevent e2e test pods from being scheduled on newly created bare-metal nodes.

## Changes

**Modified file:** `ci-operator/step-registry/ipi/install/vsphere/virt/ipi-install-vsphere-virt-commands.sh`

The vSphere virtualization installation step script now adds a custom taint (`vsphere.openshift.io/e2e=true:NoSchedule`) to bare-metal nodes after removing the provider initialization taint. This taint prevents e2e test workloads from being scheduled on these nodes due to current networking limitations—specifically, metrics collection fails when bare-metal nodes attempt to reach ingress services for data retrieval. The taint is applied before waiting for nodes to become ready, ensuring it's in place before the cluster stability checks and CSI driver configuration.

## Impact

This configuration change affects the vSphere hybrid test cluster setup in OpenShift CI infrastructure, ensuring e2e tests skip bare-metal nodes where they would otherwise fail due to networking constraints while other workloads can still run normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->