### PR TITLE
Migrate networking-console-plugin 4.16 branch from yarn to npm

### DIFF
--- a/ci-operator/config/openshift/networking-console-plugin/openshift-networking-console-plugin-release-4.16.yaml
+++ b/ci-operator/config/openshift/networking-console-plugin/openshift-networking-console-plugin-release-4.16.yaml
@@ -2,7 +2,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: console-plugin-test-cypress
+    tag: tectonic-console-builder-v29
 images:
   items:
   - dockerfile_path: Dockerfile
@@ -33,7 +33,7 @@ tests:
   steps:
     test:
     - as: lint
-      commands: yarn install && yarn run lint && yarn build
+      commands: npm ci && npm run lint && npm run build
       from: src
       resources:
         requests:
@@ -41,7 +41,7 @@ tests:
           memory: 200Mi
     - as: i18n
       commands: |
-        yarn install && yarn i18n
+        npm ci && npm run i18n
         GIT_STATUS="$(git status --short --untracked-files locales)"
         if [ -n "$GIT_STATUS" ]; then
           echo "i18n files are not up to date. Commit them to fix."


### PR DESCRIPTION
## Summary

- Update `build_root` image tag to `tectonic-console-builder-v29` for `networking-console-plugin` release-4.16 CI configurations
- Replace `yarn` commands with `npm` equivalents in lint and i18n test steps as part of the yarn to npm migration

## Details

The networking-console-plugin repository is migrating from yarn to npm. This PR updates the CI configurations to:

1. Use the `tectonic-console-builder-v29` base image which includes npm support
2. Replace all yarn commands with their npm counterparts (`yarn install` -> `npm install`, `yarn run lint` -> `npm run lint`, `yarn build` -> `npm run build`, `yarn i18n` -> `npm i18n`)