### PR TITLE
NO-ISSUE: add validation step to conformance iso-no-registry workflow

### DIFF
--- a/ci-operator/step-registry/agent/e2e/generic/conformance/iso-no-registry/agent-e2e-generic-conformance-iso-no-registry-workflow.yaml
+++ b/ci-operator/step-registry/agent/e2e/generic/conformance/iso-no-registry/agent-e2e-generic-conformance-iso-no-registry-workflow.yaml
@@ -8,6 +8,7 @@ workflow:
     pre:
       - chain: agent-pre
     test:
+      - ref: agent-e2e-compact-ipv4-iso-no-registry-validation
       - chain: agent-test-conformance-iso-no-registry
     post:
       - chain: agent-post


### PR DESCRIPTION
Required to properly run the conformance tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Adds validation step to Agent-based installer conformance workflow

This PR modifies the OpenShift CI configuration for Agent-based installer (IRI) testing by adding a validation step to the conformance ISO-no-registry workflow. 

**What changed:**
The `agent-e2e-generic-conformance-iso-no-registry` workflow now includes a `agent-e2e-compact-ipv4-iso-no-registry-validation` reference step that runs before the existing conformance test chain.

**Purpose:**
The validation step verifies that the cluster has been properly deployed before proceeding with conformance tests. It performs two checks:
1. Waits for the cluster to reach a stable state (verifying clusterversion availability, with conditions like `Available=True`, `Progressing=False`, and `Failing=False`)
2. Verifies that all installed ClusterServiceVersion (operator) resources have reached the "Succeeded" state

This ensures that conformance tests only run against a properly initialized cluster, preventing false test failures due to incomplete deployment.

**CI affected:**
Agent-based installer (IRI) conformance testing pipeline for ISO deployments without a container registry

<!-- end of auto-generated comment: release notes by coderabbit.ai -->