### PR TITLE
Remove claude-payload-agent-opus-4-7 from release payload

### DIFF
--- a/core-services/release-controller/_releases/priv/release-ocp-5.0.json
+++ b/core-services/release-controller/_releases/priv/release-ocp-5.0.json
@@ -297,15 +297,6 @@
                 "name": "periodic-ci-openshift-release-main-claude-payload-agent-priv"
             }
         },
-        "claude-payload-agent-opus-4-7": {
-            "async": true,
-            "disabled": true,
-            "multiJobAnalysis": true,
-            "optional": true,
-            "prowJob": {
-                "name": "periodic-ci-openshift-release-main-claude-payload-agent-opus-4-7-priv"
-            }
-        },
         "cnv": {
             "disabled": true,
             "optional": true,

--- a/core-services/release-controller/_releases/release-ocp-5.0.json
+++ b/core-services/release-controller/_releases/release-ocp-5.0.json
@@ -133,14 +133,6 @@
         "name": "periodic-ci-openshift-release-main-claude-payload-agent"
       }
     },
-    "claude-payload-agent-opus-4-7": {
-      "async": true,
-      "optional": true,
-      "multiJobAnalysis": true,
-      "prowJob": {
-        "name": "periodic-ci-openshift-release-main-claude-payload-agent-opus-4-7"
-      }
-    },
     "driver-toolkit": {
       "optional": true,
       "maxRetries": 2,


### PR DESCRIPTION
## Summary
- Remove the `claude-payload-agent-opus-4-7` payload job from the 5.0 release controller (public and priv)
- Remove the bespoke periodic job definition from `openshift-release-main-periodics.yaml`

## Test plan
- [x] `make release-controllers` ran successfully
- [x] No remaining `opus-4-7` references in release controller or CI operator configs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## OpenShift Release Controller Configuration Update

This PR removes infrastructure related to the completed Claude Opus 4.7 model evaluation from the OpenShift CI infrastructure.

### Changes Made

**Release Controller Configurations:**
- Removed the `claude-payload-agent-opus-4-7` verification job entry from both the public and private OpenShift 5.0 release controller configurations
  - `core-services/release-controller/_releases/release-ocp-5.0.json` (-8 lines)
  - `core-services/release-controller/_releases/priv/release-ocp-5.0.json` (-9 lines)

The remaining `claude-payload-agent` verification job (without the opus-4-7 suffix) is preserved in both configurations and continues to run as a regular payload verification step.

### Rationale

The opus-4-7 model evaluation has completed, so the associated temporary payload job that was used for evaluation purposes is no longer needed and has been cleaned up from the release infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->