### PR TITLE
acm business continuity 2.11 - use golang 1.25

### DIFF
--- a/ci-operator/config/stolostron/cluster-backup-operator/stolostron-cluster-backup-operator-release-2.11.yaml
+++ b/ci-operator/config/stolostron/cluster-backup-operator/stolostron-cluster-backup-operator-release-2.11.yaml
@@ -2,7 +2,7 @@ build_root:
   image_stream_tag:
     name: builder
     namespace: stolostron
-    tag: go1.24-linux
+    tag: go1.25-linux
 images:
   items:
   - dockerfile_path: Dockerfile

--- a/ci-operator/config/stolostron/volsync-addon-controller/stolostron-volsync-addon-controller-release-2.11.yaml
+++ b/ci-operator/config/stolostron/volsync-addon-controller/stolostron-volsync-addon-controller-release-2.11.yaml
@@ -2,7 +2,7 @@ build_root:
   image_stream_tag:
     name: builder
     namespace: stolostron
-    tag: go1.24-linux
+    tag: go1.25-linux
 images:
   items:
   - dockerfile_path: Dockerfile


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR updates the CI/CD build configuration for two Advanced Cluster Management (ACM) 2.11 release components to use Go 1.25, aligning with the broader platform effort to upgrade the Go toolchain across OpenShift's component builds.

## Changes

The build root Go version was upgraded for:
- **cluster-backup-operator** (2.11 release branch): Updated from `go1.24-linux` to `go1.25-linux`
- **volsync-addon-controller** (2.11 release branch): Updated from `go1.24-linux` to `go1.25-linux`

These changes affect the CI operator configuration for the public stolostron repositories, modifying the base builder image stream tag used during the build and test phases of the ACM 2.11 release pipelines. All unit tests, sonar code quality checks, and promotion workflows for these components will now execute with the updated Go 1.25 runtime and toolchain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->