### PR TITLE
Update SKIP_INTERFACES in PTP test commands script

### DIFF
--- a/ci-operator/step-registry/telco5g/ptp/tests/telco5g-ptp-tests-commands.sh
+++ b/ci-operator/step-registry/telco5g/ptp/tests/telco5g-ptp-tests-commands.sh
@@ -469,7 +469,7 @@ mkdir -p $LOG_ARTIFACTS_DIR
 export JUNIT_OUTPUT_DIR=${ARTIFACT_DIR}
 
 export PTP_LOG_LEVEL=debug
-export SKIP_INTERFACES=eno8303np0,eno8403np1,eno8503np2,eno8603np3,eno12409,eno8303,ens7f0np0,ens7f1np1,eno8403,ens6f0np0,ens6f1np1,eno8303np0,eno8403np1,eno8503np2,eno8603np3
+export SKIP_INTERFACES=eno8303np0,eno8403np1,eno8503np2,eno8603np3,eno12409,eno8303,ens7f0np0,ens7f1np1,eno8403,ens6f0np0,ens6f1np1,eno8303np0,eno8403np1,eno8503np2,eno8603np3,eno12399
 export PTP_TEST_CONFIG_FILE=${SHARED_DIR}/test-config.yaml
 
 # wait before first run


### PR DESCRIPTION
## Summary
- Add `eno12399` to the `SKIP_INTERFACES` variable in the telco5g PTP test commands script because this interface cannot be used for PTP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR updates the CI test configuration for telco5g (5G for Telco) PTP (Precision Time Protocol) testing in the OpenShift release repository's step registry.

**Change:** Adds the network interface `eno12399` to the `SKIP_INTERFACES` environment variable in the PTP test commands script.

**Why:** The `eno12399` interface cannot be used for PTP operations and needs to be excluded from PTP test execution to prevent test failures.

**Impact:** The telco5g PTP test CI pipeline will now automatically skip the `eno12399` network interface when running PTP tests, ensuring that testing only targets valid PTP-capable interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->