### PR TITLE
Add required-contexts for Tests check to odh-dashboard Tide config

### DIFF
--- a/core-services/prow/02_config/_config.yaml
+++ b/core-services/prow/02_config/_config.yaml
@@ -727,6 +727,8 @@ tide:
       opendatahub-io:
         repos:
           odh-dashboard:
+            required-contexts:
+            - Tests
             skip-unknown-contexts: true
           opendatahub-operator:
             optional-regex-contexts:


### PR DESCRIPTION
## Problem

PR [opendatahub-io/odh-dashboard#7498](https://github.com/opendatahub-io/odh-dashboard/pull/7498) was merged with a failing `Tests` GitHub Actions check, even though `Tests` is a required status check in GitHub's branch protection rules.

The Tide merge pool UI even displayed `Tests` as failed (along with two `Cypress-Mock-Tests` jobs), but because these were "unknown" contexts to Tide, they were not blocking — Tide merged the PR anyway.

This happened because of how Tide and the existing configuration interact:

1. **GitHub branch protection requires `Tests`**, but `openshift-merge-bot[bot]` has admin permissions on the repo, which allows it to bypass branch protection entirely. Tide and GitHub branch protection are [two separate systems](https://docs.prow.k8s.io/docs/components/core/tide/maintainers/) that must be kept in sync manually (see best practice #3).
2. **Tide drives the merge bot** and has its own independent merge criteria — it checks for `lgtm` + `approved` labels and passing Prow jobs, but it does not automatically inherit GitHub's branch protection requirements. The `branch-protection` config for this repo is set to [`unmanaged: true`](https://github.com/openshift/release/blob/main/core-services/prow/02_config/opendatahub-io/odh-dashboard/_prowconfig.yaml), meaning Prow's [branchprotector](https://docs.prow.k8s.io/docs/components/optional/branchprotector/) does not manage this repo — branch protection is configured manually in GitHub by repo admins.
3. **The existing `skip-unknown-contexts: true`** setting in `core-services/prow/02_config/_config.yaml` tells Tide to ignore any status checks it doesn't recognize. Since `Tests` is a GitHub Actions check (not a Prow job), Tide considers it an "unknown" context and ignores it — even though the merge pool UI shows it as failed.
4. **The net effect**: Tide saw `lgtm`, `approved`, and all Prow jobs passing, treated the unknown `Tests` context as irrelevant due to `skip-unknown-contexts: true`, and merged the PR — completely unaware that `Tests` had failed.

### Prior attempt and why it failed

This was previously attempted in [#73690](https://github.com/openshift/release/pull/73690) (Jan 2026) using `required-if-present-contexts: [Tests]`, but it was [reverted in #77797](https://github.com/openshift/release/pull/77797) (Apr 2026) because it didn't work.

The root cause was in how Tide processes check run conclusions. In [`checkRunToContext`](https://github.com/kubernetes-sigs/prow/blob/main/pkg/tide/tide.go#L2272-L2290), Tide maps GitHub Actions check run conclusions to internal states:

```go
func checkRunToContext(checkRun CheckRun) Context {
    context := Context{
        Context: checkRun.Name,
    }
    if checkRun.Status != githubql.String(githubql.CheckStatusStateCompleted) {
        context.State = githubql.StatusStatePending
        return context
    }

    if checkRun.Conclusion == githubql.String(githubql.CheckConclusionStateNeutral) ||
       checkRun.Conclusion == githubql.String(githubql.CheckConclusionStateSkipped) ||  // <-- skipped = success
       checkRun.Conclusion == githubql.String(githubql.StatusStateSuccess) {
        context.State = githubql.StatusStateSuccess
        return context
    }

    context.State = githubql.StatusStateFailure
    return context
}
```

**Line 2283 is the key**: Tide treats `CheckConclusionStateSkipped` as `StatusStateSuccess`. Before the companion fix ([odh-dashboard#7489](https://github.com/opendatahub-io/odh-dashboard/pull/7489)), when an upstream CI job (e.g. Cypress tests) failed, the dependent `Tests` summary job was **skipped** by GitHub Actions rather than explicitly failing. So:

1. `Tests` job was skipped → GitHub reported `conclusion: "skipped"`
2. Tide mapped `skipped` → `StatusStateSuccess` (line 2283)
3. `required-if-present-contexts` saw a "passing" context → no block
4. PR merged despite real test failures

## Change

Adds `required-contexts: ["Tests"]` to the existing `context_options` entry for `opendatahub-io/odh-dashboard` in `core-services/prow/02_config/_config.yaml`. The `required-contexts` field takes precedence over `skip-unknown-contexts`, meaning:

- **`Tests` GitHub Actions check**: now explicitly required by Tide — merges will be blocked if it fails
- **Prow CI jobs** (images, e2e tests, etc.): still required as always — Prow jobs are "known" contexts unaffected by `skip-unknown-contexts`
- **Other unknown non-Prow checks**: still ignored via `skip-unknown-contexts: true`

This is placed in the global `_config.yaml` because supplemental per-repo `_prowconfig.yaml` files only support `branch-protection`, `slack_reporter_configs`, `tide.merge_method`, and `tide.queries` — `context_options` has no merging logic in the supplemental config system.

### Why this will work when #73690 didn't

Two things are different now:

1. **`required-contexts`** instead of `required-if-present-contexts` — Tide will require `Tests` to **exist AND pass**, not silently skip the check when the context is absent

2. **[opendatahub-io/odh-dashboard#7489](https://github.com/opendatahub-io/odh-dashboard/pull/7489)** (already merged) fixed the GitHub Actions workflow so the `Tests` summary job always runs and explicitly reports failure. The fix adds `if: always()` to the `Tests` job and checks dependency outcomes:

```yaml
Tests:
    if: always()  # Always run, even if dependencies fail
    needs: [Lint, Unit-Tests, Cypress-E2E-Tests, Cypress-Mock-Tests, ...]
    steps:
      - name: Check for failures
        run: |
          if [[ "${{ contains(needs.*.result, 'failure') || ... }}" == "true" ]]; then
            echo "One or more required jobs failed, were cancelled, or were skipped."
            exit 1
          fi
```

**Before #7489**: upstream failure → `Tests` skipped → `conclusion: "skipped"` → Tide treats as success (line 2283) → PR merges
**After #7489**: upstream failure → `Tests` always runs → `exit 1` → `conclusion: "failure"` → Tide treats as failure → PR blocked

Together, these two changes close the gap: `#7489` ensures `Tests` always reports a real pass/fail conclusion, and this PR ensures Tide actually requires it.

## Verification

### How Tide reads GitHub Actions check runs

Tide queries the GitHub Check Runs API via [`ListCheckRuns`](https://github.com/kubernetes-sigs/prow/blob/main/pkg/github/client.go#L4938-L4962), which calls `GET /repos/{org}/{repo}/commits/{ref}/check-runs`. It then converts each check run into a context using [`checkRunToContext`](https://github.com/kubernetes-sigs/prow/blob/main/pkg/tide/tide.go#L2272-L2290), which maps `checkRun.Name` directly to `Context.Context`:

```go
func checkRunToContext(checkRun CheckRun) Context {
    context := Context{
        Context: checkRun.Name,
    }
    ...
}
```

### Confirming the check run name matches our config

Querying the same API that Tide uses on the PR that was wrongly merged (#7498):

```bash
$ gh api repos/opendatahub-io/odh-dashboard/commits/8dfd3994/check-runs \
    --jq '.check_runs[] | select(.name == "Tests")'
```

Returns (trimmed):

```json
{
  "name": "Tests",
  "status": "completed",
  "conclusion": "failure",
  "head_sha": "8dfd3994ded69764759d9fd6fe1db764d9d6c24d",
  "app": {
    "name": "GitHub Actions",
    "slug": "github-actions"
  },
  "details_url": "https://github.com/opendatahub-io/odh-dashboard/actions/runs/25569482337/job/75067245491"
}
```

Our config uses `required-contexts: Tests`, which matches the `name` field exactly. Note: the GitHub UI displays this as `Test / Tests (pull_request)` but the API returns just `Tests` — Tide uses the API value.

## References

- [Tide Context Policy Options documentation](https://docs.prow.k8s.io/docs/components/core/tide/config/#context-policy-options) — describes `required-contexts`, `skip-unknown-contexts`, and how Tide determines which checks must pass before merging
- [Tide Maintainer's Guide](https://docs.prow.k8s.io/docs/components/core/tide/maintainers/) — best practice #3: "Ensure that merge requirements configured in GitHub match the merge requirements configured for Tide"
- [`checkRunToContext` source](https://github.com/kubernetes-sigs/prow/blob/main/pkg/tide/tide.go#L2272-L2290) — maps check run `Name` to context; **line 2283 treats `skipped` as `success`**
- [`ListCheckRuns` source](https://github.com/kubernetes-sigs/prow/blob/main/pkg/github/client.go#L4938-L4962) — calls `GET /repos/{org}/{repo}/commits/{ref}/check-runs`
- [Branchprotector docs](https://docs.prow.k8s.io/docs/components/optional/branchprotector/) — explains that branchprotector pushes config to GitHub, does not pull from it
- [Prior attempt #73690](https://github.com/openshift/release/pull/73690) — used `required-if-present-contexts` (reverted in [#77797](https://github.com/openshift/release/pull/77797) because Tide treated skipped `Tests` as passing)
- [Companion fix odh-dashboard#7489](https://github.com/opendatahub-io/odh-dashboard/pull/7489) — adds `if: always()` to `Tests` job so it reports `failure` instead of `skipped`