### PR TITLE
SPLAT-2753: splat/aws: routing jobs monitored to sub-channel

### DIFF
--- a/ci-operator/config/openshift/release/.config.prowgen
+++ b/ci-operator/config/openshift/release/.config.prowgen
@@ -503,7 +503,7 @@ slack_reporter:
   - stable-4.8-upgrade-from-stable-4.5
   - stable-4.y
   - stackrox-stackrox
-- channel: '#forum-ocp-splat-alerts'
+- channel: '#forum-ocp-splat-alerts-aws'
   job_states_to_report:
   - failure
   - error
@@ -516,6 +516,7 @@ slack_reporter:
   - e2e-aws-overlay-mtu-ovn-edge-1100
   - e2e-aws-ovn-edge-zones
   - e2e-aws-ovn-shared-vpc-edge-zones
+  - e2e-aws-public-ipv4-pool
   excluded_variants:
   - ci-4.10
   - ci-4.10-upgrade-from-stable-4.9
@@ -837,7 +838,7 @@ slack_reporter:
   - stable-4.8-upgrade-from-stable-4.5
   - stable-4.y
   - stackrox-stackrox
-- channel: '#forum-ocp-splat-alerts'
+- channel: '#forum-ocp-splat-alerts-aws'
   job_states_to_report:
   - failure
   - error
@@ -849,6 +850,172 @@ slack_reporter:
   job_names:
   - e2e-external-aws
   - e2e-external-aws-ccm
+  excluded_variants:
+  - ci-4.10
+  - ci-4.10-upgrade-from-stable-4.9
+  - ci-4.10-upgrade-from-stable-4.9-from-stable-4.8
+  - ci-4.11
+  - ci-4.11-upgrade-from-stable-4.10
+  - ci-4.11-upgrade-from-stable-4.10-from-stable-4.9
+  - ci-4.12
+  - ci-4.12-upgrade-from-stable-4.11
+  - ci-4.12-upgrade-from-stable-4.11-from-stable-4.10
+  - ci-4.13
+  - ci-4.13-upgrade-from-stable-4.12
+  - ci-4.13-upgrade-from-stable-4.12-from-stable-4.11
+  - ci-4.14
+  - ci-4.14-upgrade-from-stable-4.13
+  - ci-4.14-upgrade-from-stable-4.13-from-stable-4.12
+  - ci-4.15
+  - ci-4.15-upgrade-from-stable-4.14
+  - ci-4.15-upgrade-from-stable-4.14-from-stable-4.13
+  - ci-4.16
+  - ci-4.16-upgrade-from-stable-4.15
+  - ci-4.16-upgrade-from-stable-4.15-from-stable-4.14
+  - ci-4.17
+  - ci-4.17-upgrade-from-stable-4.16
+  - ci-4.17-upgrade-from-stable-4.16-from-stable-4.15
+  - ci-4.18
+  - ci-4.18-upgrade-from-stable-4.17
+  - ci-4.18-upgrade-from-stable-4.17-from-stable-4.16
+  - ci-4.19
+  - ci-4.19-upgrade-from-stable-4.18
+  - ci-4.19-upgrade-from-stable-4.18-from-stable-4.17
+  - ci-4.20
+  - ci-4.20-upgrade-from-stable-4.19
+  - ci-4.20-upgrade-from-stable-4.19-from-stable-4.18
+  - ci-4.21
+  - ci-4.21-upgrade-from-stable-4.20
+  - ci-4.21-upgrade-from-stable-4.20-from-stable-4.19
+  - ci-4.22
+  - ci-4.22-upgrade-from-stable-4.21
+  - ci-4.22-upgrade-from-stable-4.21-from-stable-4.20
+  - ci-4.6
+  - ci-4.6-upgrade-from-stable-4.5
+  - ci-4.7
+  - ci-4.7-upgrade-from-stable-4.6
+  - ci-4.8
+  - ci-4.8-upgrade-from-from-stable-4.7-from-stable-4.6
+  - ci-4.8-upgrade-from-stable-4.7
+  - ci-4.9
+  - ci-4.9-upgrade-from-stable-4.8
+  - ci-4.9-upgrade-from-stable-4.8-from-stable-4.7
+  - ci-5.0
+  - ci-5.0-upgrade-from-stable-4.22
+  - ci-5.0-upgrade-from-stable-4.22-from-stable-4.21
+  - cnv-nightly-4.16
+  - cnv-nightly-4.17
+  - cnv-nightly-4.18
+  - cnv-nightly-4.19
+  - cnv-nightly-4.20
+  - cnv-nightly-4.21
+  - cnv-nightly-4.22
+  - cnv-nightly-5.0
+  - hypershift-4.19
+  - hypershift-4.20
+  - hypershift-4.21
+  - nightly-4.10
+  - nightly-4.10-upgrade-from-stable-4.8
+  - nightly-4.10-upgrade-from-stable-4.9
+  - nightly-4.11
+  - nightly-4.11-upgrade-from-stable-4.10
+  - nightly-4.11-upgrade-from-stable-4.9
+  - nightly-4.12
+  - nightly-4.12-upgrade-from-stable-4.10
+  - nightly-4.12-upgrade-from-stable-4.11
+  - nightly-4.13
+  - nightly-4.13-upgrade-from-stable-4.11
+  - nightly-4.13-upgrade-from-stable-4.12
+  - nightly-4.14
+  - nightly-4.14-upgrade-from-stable-4.12
+  - nightly-4.14-upgrade-from-stable-4.13
+  - nightly-4.15
+  - nightly-4.15-upgrade-from-stable-4.13
+  - nightly-4.15-upgrade-from-stable-4.14
+  - nightly-4.16-upgrade-from-stable-4.14
+  - nightly-4.16-upgrade-from-stable-4.15
+  - nightly-4.17-upgrade-from-stable-4.15
+  - nightly-4.17-upgrade-from-stable-4.16
+  - nightly-4.18-upgrade-from-stable-4.16
+  - nightly-4.18-upgrade-from-stable-4.17
+  - nightly-4.19-upgrade-from-stable-4.17
+  - nightly-4.19-upgrade-from-stable-4.18
+  - nightly-4.20-upgrade-from-stable-4.18
+  - nightly-4.20-upgrade-from-stable-4.19
+  - nightly-4.21-upgrade-from-stable-4.19
+  - nightly-4.21-upgrade-from-stable-4.20
+  - nightly-4.22-upgrade-from-stable-4.20
+  - nightly-4.22-upgrade-from-stable-4.21
+  - nightly-4.6
+  - nightly-4.7
+  - nightly-4.7-upgrade-from-stable-4.6
+  - nightly-4.8
+  - nightly-4.8-upgrade-from-stable-4.7
+  - nightly-4.9
+  - nightly-4.9-upgrade-from-stable-4.8
+  - nightly-5.0-upgrade-from-stable-4.21
+  - nightly-5.0-upgrade-from-stable-4.22
+  - okd-4.10
+  - okd-4.10-upgrade-from-okd-4.9
+  - okd-4.11
+  - okd-4.11-upgrade-from-okd-4.10
+  - okd-4.12
+  - okd-4.12-upgrade-from-okd-4.11
+  - okd-4.13
+  - okd-4.13-upgrade-from-okd-4.12
+  - okd-4.14
+  - okd-4.14-upgrade-from-okd-4.13
+  - okd-4.15
+  - okd-4.15-upgrade-from-okd-4.14
+  - okd-4.16
+  - okd-4.16-upgrade-from-okd-4.15
+  - okd-4.17
+  - okd-4.17-upgrade-from-okd-4.16
+  - okd-4.18
+  - okd-4.18-upgrade-from-okd-4.17
+  - okd-4.6
+  - okd-4.7
+  - okd-4.7-upgrade-from-okd-4.6
+  - okd-4.8
+  - okd-4.8-upgrade-from-okd-4.7
+  - okd-4.9
+  - okd-4.9-upgrade-from-okd-4.8
+  - okd-scos-4.12
+  - okd-scos-4.13
+  - okd-scos-4.14
+  - okd-scos-4.15
+  - okd-scos-4.16
+  - okd-scos-4.17
+  - okd-scos-4.17-upgrade-from-okd-scos-4.16
+  - okd-scos-4.18
+  - okd-scos-4.18-upgrade-from-okd-scos-4.17
+  - okd-scos-4.19
+  - okd-scos-4.19-upgrade-from-okd-scos-4.18
+  - okd-scos-4.20
+  - okd-scos-4.20-upgrade-from-okd-scos-4.19
+  - okd-scos-4.21
+  - okd-scos-4.21-upgrade-from-okd-scos-4.20
+  - okd-scos-4.22
+  - okd-scos-4.22-upgrade-from-okd-scos-4.21
+  - okd-scos-5.0
+  - okd-scos-5.0-upgrade-from-okd-scos-4.22
+  - stable-4.7-upgrade-from-stable-4.6-from-stable-4.5
+  - stable-4.8-upgrade-from-stable-4.2
+  - stable-4.8-upgrade-from-stable-4.3
+  - stable-4.8-upgrade-from-stable-4.4
+  - stable-4.8-upgrade-from-stable-4.5
+  - stable-4.y
+  - stackrox-stackrox
+- channel: '#forum-opct-updates'
+  job_states_to_report:
+  - failure
+  - error
+  report_template: ':red_jenkins_circle: :external-link::aws: Periodical job *{{.Spec.Job}}* ended with *{{.Status.State}}*.
+    (<{{.Status.URL}}|View logs>) (<https://prow.ci.openshift.org/job-history/gs/test-platform-results/logs/{{.Spec.Job}}|View
+    history>)
+
+    '
+  job_names:
   - opct-external-aws-ccm
   - opct-platform-external-aws
   - opct-platform-external-aws-ccm
@@ -870,7 +1037,8 @@ slack_reporter:
   - ci-4.14-upgrade-from-stable-4.13-from-stable-4.12
   - ci-4.15
   - ci-4.15-upgrade-from-stable-4.14
-  - ci-4.15-upgrade-from-stable-4.14-from-stable-4.13  - ci-4.16
+  - ci-4.15-upgrade-from-stable-4.14-from-stable-4.13
+  - ci-4.16
   - ci-4.16-upgrade-from-stable-4.15
   - ci-4.16-upgrade-from-stable-4.15-from-stable-4.14
   - ci-4.17


### PR DESCRIPTION
Move the SPLAT monitored jobs for AWS to a dedicated channel to isolate tracking issues as well focusing in platform specific ci job;

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR updates OpenShift CI's prowgen Slack reporter configuration (ci-operator/config/openshift/release/.config.prowgen) to segregate AWS-specific SPLAT monitored job alerts into a dedicated Slack channel.

Changes
- Routes AWS SPLAT job failure/error alerts from the generic #forum-ocp-splat-alerts channel to a new AWS-specific channel #forum-ocp-splat-alerts-aws.
- Adds e2e-aws-public-ipv4-pool to the AWS job list alongside the existing AWS e2e jobs.
- Mirrors the channel change for the second AWS alert entry (so both AWS-focused alert groups now target #forum-ocp-splat-alerts-aws).
- Retains the existing excluded_variants filtering to limit which release/test variants trigger alerts.

Impact
- Splits AWS platform CI noise out of the generic SPLAT alerts channel, improving focused tracking and reducing cross-platform alert noise for OpenShift CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->