### PR TITLE
Testindividualcases

### DIFF
--- a/ci-operator/config/openshift/hive/openshift-hive-master__periodic.yaml
+++ b/ci-operator/config/openshift/hive/openshift-hive-master__periodic.yaml
@@ -253,7 +253,7 @@ tests:
     env:
       BASE_DOMAIN: qe.devcluster.openshift.com
       FILTERS_ADDITIONAL: ~CPaasrunOnly&;HiveSDRosa&;
-      TEST_IMPORTANCE: OCP-40825
+      TEST_IMPORTANCE: "40825"
       TEST_SCENARIOS: Cluster_Operator
       TEST_TIMEOUT: "90"
     test:

--- a/ci-operator/config/openshift/hive/openshift-hive-master__periodic.yaml
+++ b/ci-operator/config/openshift/hive/openshift-hive-master__periodic.yaml
@@ -253,6 +253,7 @@ tests:
     env:
       BASE_DOMAIN: qe.devcluster.openshift.com
       FILTERS_ADDITIONAL: ~CPaasrunOnly&;HiveSDRosa&;
+      TEST_IMPORTANCE: OCP-40825
       TEST_SCENARIOS: Cluster_Operator
       TEST_TIMEOUT: "90"
     test:

--- a/ci-operator/config/openshift/hive/openshift-hive-master__periodic.yaml
+++ b/ci-operator/config/openshift/hive/openshift-hive-master__periodic.yaml
@@ -260,7 +260,7 @@ tests:
     - as: deploy-hive
       cli: latest
       commands: |
-        make deploy
+        IMG="${HIVE_IMAGE}" make deploy
       dependencies:
       - env: HIVE_IMAGE
         name: hive


### PR DESCRIPTION
/hold

40825

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR updates the OpenShift Hive CI configuration (ci-operator config for openshift/hive) and adjusts the newly added periodic job's runtime behavior.

## Scope
- Affects: ci-operator configuration for the OpenShift Hive project's periodic jobs (ci-operator/config/openshift/hive/openshift-hive-master__periodic.yaml).

## What changed (practical impact)
- The existing periodic job aws-ipi-f7-longduration-hive-sd-rosa (the long-duration AWS IPI job added for Hive SD/ROSA testing) now passes the built Hive image explicitly into the deploy step by running:
  IMG="${HIVE_IMAGE}" make deploy
  instead of invoking make deploy with no explicit image. This ensures the job deploys the exact Hive image produced by the CI pipeline rather than relying on any default image lookup.
- The job environment adds TEST_IMPORTANCE: "40825" (in addition to existing TEST_SCENARIOS: Cluster_Operator and TEST_TIMEOUT: "90"), which may be used by test tooling/filters to categorize or prioritize the test run.
- Other previously described repository-level changes remain: base images and release version alignment to 4.22, and the aws-ipi-f7-longduration-hive-sd-rosa periodic job configuration (schedule, cluster profile, workflows, timeouts, etc.).

## Metadata / status
- PR description contains "/hold", references [HIVE-3153](https://redhat.atlassian.net/browse/HIVE-3153) (https://redhat.atlassian.net/browse/HIVE-3153), and includes the string "40825".
- Labels: do-not-merge/hold.
- Comments: two identical rehearse invocations to re-run periodic-ci-openshift-hive-master-periodic-aws-ipi-f7-longduration-hive-sd-rosa.
- Reviewers: dlom, jstuever.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[HIVE-3153]: https://redhat.atlassian.net/browse/HIVE-3153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ