### PR TITLE
Prepare jobs for testing 4.22 with ROSACLI

### DIFF
--- a/ci-operator/config/openshift/rosa/openshift-rosa-master__e2e.yaml
+++ b/ci-operator/config/openshift/rosa/openshift-rosa-master__e2e.yaml
@@ -27,10 +27,12 @@ tests:
   steps:
     cluster_profile: oex-aws-qe
     env:
+      CHANNEL_GROUP: candidate
       CLUSTER_TIMEOUT: "120"
       IMPORTANCE: (Critical,High)
       NAME_PREFIX: rosa-sts-f3
       TEST_PROFILE: rosa-advanced
+      VERSION: 4.22.0-rc.3
     test:
     - chain: rosa-tests-e2e-fullcycle
     workflow: rosa-lifecycle
@@ -39,10 +41,12 @@ tests:
   steps:
     cluster_profile: oex-aws-qe
     env:
+      CHANNEL_GROUP: candidate
       CLUSTER_TIMEOUT: "120"
       IMPORTANCE: (Critical,High)
       NAME_PREFIX: rosa-sv-f3
       TEST_PROFILE: rosa-shared-vpc
+      VERSION: 4.22.0-rc.3
     test:
     - chain: rosa-tests-e2e-fullcycle
     workflow: rosa-lifecycle
@@ -76,10 +80,12 @@ tests:
   steps:
     cluster_profile: oex-aws-qe
     env:
+      CHANNEL_GROUP: candidate
       CLUSTER_TIMEOUT: "120"
       IMPORTANCE: (Medium,Low)
       NAME_PREFIX: rosa-sts-f7
       TEST_PROFILE: rosa-advanced
+      VERSION: 4.22.0-rc.3
     test:
     - chain: rosa-tests-e2e-fullcycle
     workflow: rosa-lifecycle
@@ -88,9 +94,11 @@ tests:
   steps:
     cluster_profile: oex-aws-qe
     env:
+      CHANNEL_GROUP: candidate
       IMPORTANCE: (Critical,High)
       NAME_PREFIX: hcp-sv-f3
       TEST_PROFILE: rosa-hcp-shared-vpc-advanced
+      VERSION: 4.22.0-rc.3
     test:
     - chain: rosa-tests-e2e-fullcycle
     workflow: rosa-lifecycle
@@ -110,10 +118,12 @@ tests:
   steps:
     cluster_profile: oex-aws-qe
     env:
+      CHANNEL_GROUP: candidate
       CLUSTER_TIMEOUT: "120"
       IMPORTANCE: (Critical,High)
       NAME_PREFIX: rosa-pl-f3
       TEST_PROFILE: rosa-private-link
+      VERSION: 4.22.0-rc.3
     test:
     - chain: rosa-tests-e2e-fullcycle
     workflow: rosa-lifecycle
@@ -134,10 +144,12 @@ tests:
   steps:
     cluster_profile: oex-aws-qe
     env:
+      CHANNEL_GROUP: candidate
       CLUSTER_TIMEOUT: "100"
       IMPORTANCE: (Critical,High)
       NAME_PREFIX: rosa-nsts-f3
       TEST_PROFILE: rosa-non-sts-advanced
+      VERSION: 4.22.0-rc.3
     test:
     - chain: rosa-tests-e2e-fullcycle
     workflow: rosa-lifecycle
@@ -157,9 +169,11 @@ tests:
   steps:
     cluster_profile: oex-aws-qe
     env:
+      CHANNEL_GROUP: candidate
       IMPORTANCE: (Critical,High)
       NAME_PREFIX: rosa-auth-f3
       TEST_PROFILE: rosa-hcp-external-auth
+      VERSION: 4.22.0-rc.3
     test:
     - chain: rosa-tests-e2e-fullcycle
     workflow: rosa-lifecycle
@@ -168,9 +182,11 @@ tests:
   steps:
     cluster_profile: oex-aws-qe
     env:
+      CHANNEL_GROUP: candidate
       IMPORTANCE: (Critical,High)
       NAME_PREFIX: rosa-hcp-f3
       TEST_PROFILE: rosa-hcp-advanced
+      VERSION: 4.22.0-rc.3
     test:
     - chain: rosa-tests-e2e-fullcycle
     workflow: rosa-lifecycle
@@ -191,9 +207,11 @@ tests:
   steps:
     cluster_profile: oex-aws-qe
     env:
+      CHANNEL_GROUP: candidate
       IMPORTANCE: (Medium,Low)
       NAME_PREFIX: rosa-hcp-f7
       TEST_PROFILE: rosa-hcp-advanced
+      VERSION: 4.22.0-rc.3
     test:
     - chain: rosa-tests-e2e-fullcycle
     workflow: rosa-lifecycle
@@ -216,9 +234,11 @@ tests:
   steps:
     cluster_profile: oex-aws-qe
     env:
+      CHANNEL_GROUP: candidate
       IMPORTANCE: (Critical,High)
       NAME_PREFIX: rosa-hcppl-f3
       TEST_PROFILE: rosa-hcp-pl
+      VERSION: 4.22.0-rc.3
     test:
     - chain: rosa-tests-e2e-fullcycle
     workflow: rosa-lifecycle


### PR DESCRIPTION
DO NOT MERGE. This is only for triggering automated tests for the new OCP version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR configures the OpenShift CI infrastructure to prepare ROSA (Red Hat OpenShift Service on AWS) E2E test jobs for testing OCP 4.22 release candidates.

The changes modify the scheduled test configuration in `ci-operator/config/openshift/rosa/openshift-rosa-master__e2e.yaml` by adding environment variables to 10 E2E test job variants:
- Setting `CHANNEL_GROUP: candidate` to specify the release channel for the cluster
- Setting `VERSION: 4.22.0-rc.3` to designate the specific OCP version under test

The affected test jobs span both STS (Security Token Service) and HCP (Hosted Control Plane) ROSA deployment modes, covering critical-high and medium-low importance test suites. These scheduled jobs will now run periodic E2E tests against the 4.22 release candidate to validate the ROSA offering before the final release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->