### PR TITLE
RHDH: Bump AKS and EKS K8s version from 1.34 to 1.35

### DIFF
--- a/ci-operator/step-registry/redhat-developer/rhdh/aks/mapt/create/redhat-developer-rhdh-aks-mapt-create-commands.sh
+++ b/ci-operator/step-registry/redhat-developer/rhdh/aks/mapt/create/redhat-developer-rhdh-aks-mapt-create-commands.sh
@@ -56,7 +56,7 @@ mapt azure aks create \
   --project-name "aks" \
   --backed-url "azblob://${AZURE_STORAGE_BLOB}/${CORRELATE_MAPT}" \
   --conn-details-output "${SHARED_DIR}" \
-  --version 1.34 \
+  --version 1.35 \
   --vmsize "Standard_D4as_v6" \
   --spot \
   --spot-eviction-tolerance "low" \

--- a/ci-operator/step-registry/redhat-developer/rhdh/eks/mapt/create/redhat-developer-rhdh-eks-mapt-create-commands.sh
+++ b/ci-operator/step-registry/redhat-developer/rhdh/eks/mapt/create/redhat-developer-rhdh-eks-mapt-create-commands.sh
@@ -54,7 +54,7 @@ mapt aws eks create \
   --project-name "eks" \
   --backed-url "s3://${AWS_S3_BUCKET}/${CORRELATE_MAPT}" \
   --conn-details-output "${SHARED_DIR}" \
-  --version 1.34 \
+  --version 1.35 \
   --workers-max 3 \
   --workers-desired 3 \
   --cpus 2 \


### PR DESCRIPTION
## Summary

- Bump AKS Kubernetes version from 1.34 to 1.35 (GA on AKS)
- Bump EKS Kubernetes version from 1.34 to 1.35 (Standard support on EKS)
- GKE is aligned (uses static cluster, not managed in CI config)

Both platforms now support K8s 1.35 as the newest generally available version.
This updates the MAPT create scripts to provision clusters with the latest version.

Produced by agent skills from https://github.com/openshift/release/pull/79129.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR updates the Red Hat Developer Hub (RHDH) CI infrastructure to use Kubernetes 1.35 for both Azure AKS and AWS EKS cluster provisioning, aligned with the availability of stable versions on these platforms.

## Changes

The PR modifies two MAPT (cluster provisioning tool) scripts used in the RHDH CI pipeline:

- **AKS cluster creation**: Updates the MAPT Azure AKS provisioning command to target Kubernetes 1.35 (up from 1.34)
- **EKS cluster creation**: Updates the MAPT AWS EKS provisioning command to target Kubernetes 1.35 (up from 1.34)

Both scripts continue to perform their existing operations—loading cloud credentials, setting up infrastructure correlation, handling cleanup, and verifying the kubeconfig—with only the Kubernetes version parameter changing.

This ensures that RHDH's test infrastructure across both cloud providers uses the latest generally available Kubernetes version, improving compatibility testing and alignment with current platform offerings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->