### PR TITLE
Skip deprovisioning VPC with orphaned ENI

### DIFF
--- a/core-services/ipi-deprovision/aws.sh
+++ b/core-services/ipi-deprovision/aws.sh
@@ -36,6 +36,59 @@ function deprovision() {
 	fi
 }
 
+function vpc_has_only_orphaned_eni() {
+	local region="${1}" vpc_id="${2}"
+
+	local enis
+	enis="$(aws ec2 describe-network-interfaces \
+		--region "${region}" \
+		--filters "Name=vpc-id,Values=${vpc_id}" \
+		--query 'NetworkInterfaces[].{Id:NetworkInterfaceId,Status:Status,Desc:Description,Subnet:SubnetId,Type:InterfaceType,RequesterManaged:RequesterManaged}' \
+		--output json)"
+
+	local total
+	total="$(echo "${enis}" | jq 'length')"
+	if [[ "${total}" -ne 1 ]]; then
+		return 1
+	fi
+
+	local requester_managed
+	requester_managed="$(echo "${enis}" | jq -r '.[0].RequesterManaged')"
+	if [[ "${requester_managed}" != "true" ]]; then
+		return 1
+	fi
+
+	local interface_type
+	interface_type="$(echo "${enis}" | jq -r '.[0].Type')"
+
+	local owner_gone=false
+	case "${interface_type}" in
+		network_load_balancer|gateway_load_balancer)
+			local lb_count
+			lb_count="$(aws elbv2 describe-load-balancers \
+				--region "${region}" \
+				--query "length(LoadBalancers[?VpcId=='${vpc_id}'])" \
+				--output text)"
+			if [[ "${lb_count}" -eq 0 ]]; then
+				owner_gone=true
+			fi
+			;;
+		*)
+			return 1
+			;;
+	esac
+
+	if [[ "${owner_gone}" != "true" ]]; then
+		return 1
+	fi
+
+	echo "WARNING: Known AWS bug -- orphaned ENI in VPC ${vpc_id} (region ${region})."
+	echo "WARNING: The ENI is RequesterManaged but its owning resource (${interface_type}) no longer exists:"
+	echo "${enis}" | jq -r '.[0] | "  ENI: \(.Id)  Type: \(.Type)  Status: \(.Status)  Subnet: \(.Subnet)  Description: \(.Desc)"'
+	echo "WARNING: Skipping deprovision for this VPC."
+	return 0
+}
+
 if [[ -n ${HYPERSHIFT_PRUNER:-} ]]; then
 	had_failure=0
 	if [[ -n ${HYPERSHIFT_PRUNER_ALL_NAMESPACES:-} ]]; then
@@ -63,8 +116,11 @@ echo "deprovisioning clusters with an expirationDate before ${aws_cluster_age_cu
 # --region is necessary when there is no profile customization
 for region in $( aws ec2 describe-regions --region us-east-1 --query "Regions[].{Name:RegionName}" --output text ); do
 	echo "deprovisioning in AWS region ${region} ..."
-	aws ec2 describe-vpcs --output json --region ${region} | jq --arg date "${aws_cluster_age_cutoff}" -r '.Vpcs[] | select(.Tags[]? | select(.Key == "expirationDate" and .Value < $date)) | .Tags[]? | select((.Key | startswith("kubernetes.io/cluster/")) and (.Value == "owned")) | .Key' > /tmp/clusters
-	while read cluster; do
+	aws ec2 describe-vpcs --output json --region ${region} | jq --arg date "${aws_cluster_age_cutoff}" -r '.Vpcs[] | select(.Tags[]? | select(.Key == "expirationDate" and .Value < $date)) | . as $vpc | .Tags[]? | select((.Key | startswith("kubernetes.io/cluster/")) and (.Value == "owned")) | "\($vpc.VpcId) \(.Key)"' > /tmp/clusters
+	while read vpc_id cluster; do
+		if vpc_has_only_orphaned_eni "${region}" "${vpc_id}"; then
+			continue
+		fi
 		workdir="${logdir}/${cluster:22}"
 		mkdir -p "${workdir}"
 		cat <<-EOF >"${workdir}/metadata.json"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## AWS cluster deprovisioning now skips VPCs with orphaned load balancer ENIs

This PR modifies the AWS cluster deprovisioning logic to handle a known AWS edge case where VPCs contain orphaned Elastic Network Interfaces (ENIs) belonging to load balancers that no longer exist.

**What changed:**

The `core-services/ipi-deprovision/aws.sh` script now includes logic to detect and skip deprovisioning for VPCs that contain only a single "orphaned" RequesterManaged ENI of type `network_load_balancer` or `gateway_load_balancer` where the owning load balancer resource no longer exists.

A new helper function `vpc_has_only_orphaned_eni(region, vpc_id)` was added that:
- Queries AWS EC2 for network interfaces in the VPC using `describe-network-interfaces`
- Identifies RequesterManaged ENIs
- For NLB/GLB type ENIs, verifies via the ELBv2 API that no load balancer exists in that VPC
- Prints diagnostic warnings about the orphaned ENI when detected, including details like ID, type, status, subnet, and description
- Signals to skip deprovisioning by returning successfully

When an orphaned ENI is detected, the script now skips creating the per-cluster working directory and any deprovisioning steps for that VPC, allowing the process to continue gracefully rather than failing.

The VPC discovery query was also updated to output both `vpc_id` and the Kubernetes cluster tag key alongside the existing data, enabling the main loop to read and check each VPC before proceeding.

**Practical impact:**

This prevents AWS deprovisioning jobs from failing on the known AWS edge case of orphaned load balancer ENIs. Affected clusters will be skipped gracefully with informative warnings, rather than causing deprovisioning to hang or fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->