### PR TITLE
bump golang to 1.25 for fixing CLC MCE 2.6 CVEs

### DIFF
--- a/ci-operator/config/stolostron/cluster-curator-controller/stolostron-cluster-curator-controller-backplane-2.6.yaml
+++ b/ci-operator/config/stolostron/cluster-curator-controller/stolostron-cluster-curator-controller-backplane-2.6.yaml
@@ -1,13 +1,8 @@
-base_images:
-  stolostron_builder_go1.24-linux:
-    name: builder
-    namespace: stolostron
-    tag: go1.24-linux
 build_root:
   image_stream_tag:
     name: builder
     namespace: stolostron
-    tag: go1.24-linux
+    tag: go1.25-linux
 images:
   items:
   - dockerfile_path: Dockerfile.prow

--- a/ci-operator/config/stolostron/cluster-image-set-controller/stolostron-cluster-image-set-controller-backplane-2.6.yaml
+++ b/ci-operator/config/stolostron/cluster-image-set-controller/stolostron-cluster-image-set-controller-backplane-2.6.yaml
@@ -2,7 +2,7 @@ build_root:
   image_stream_tag:
     name: builder
     namespace: stolostron
-    tag: go1.21-linux
+    tag: go1.25-linux
 images:
   items:
   - dockerfile_path: Dockerfile

--- a/ci-operator/config/stolostron/clusterclaims-controller/stolostron-clusterclaims-controller-backplane-2.6.yaml
+++ b/ci-operator/config/stolostron/clusterclaims-controller/stolostron-clusterclaims-controller-backplane-2.6.yaml
@@ -2,7 +2,7 @@ build_root:
   image_stream_tag:
     name: builder
     namespace: stolostron
-    tag: go1.21-linux
+    tag: go1.25-linux
 images:
   items:
   - dockerfile_path: Dockerfile.prow

--- a/ci-operator/config/stolostron/provider-credential-controller/stolostron-provider-credential-controller-backplane-2.6.yaml
+++ b/ci-operator/config/stolostron/provider-credential-controller/stolostron-provider-credential-controller-backplane-2.6.yaml
@@ -2,7 +2,7 @@ build_root:
   image_stream_tag:
     name: builder
     namespace: stolostron
-    tag: go1.21-linux
+    tag: go1.25-linux
 images:
   items:
   - dockerfile_path: Dockerfile.prow


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Updates Go toolchain to 1.25 for CVE fixes in Stolostron MCE 2.6 backplane builds

This PR updates the Go builder image version across four Stolostron component CI configurations to address CVEs affecting the Management Cluster Engine (MCE) 2.6 backplane. The following components' CI pipelines are updated:

- **cluster-curator-controller** - Updated from `go1.24-linux` to `go1.25-linux`
- **cluster-image-set-controller** - Updated from `go1.21-linux` to `go1.25-linux`
- **clusterclaims-controller** - Updated from `go1.21-linux` to `go1.25-linux`
- **provider-credential-controller** - Updated from `go1.21-linux` to `go1.25-linux`

All changes are isolated to the `build_root.image_stream_tag` configuration in the respective backplane-2.6.yaml files, meaning only the builder image used for CI builds is affected. No changes to test configurations, build logic, or promotion strategies are included. These configuration updates will ensure that container images built by the CI pipeline for MCE 2.6 releases use the patched Go 1.25 toolchain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->