### PR TITLE
USHIFT-6972: Add MicroShift CI Doctor continue-session instructions in the spy-glass

### DIFF
--- a/ci-operator/step-registry/openshift/edge-tooling/microshift-ci/doctor/openshift-edge-tooling-microshift-ci-doctor-workflow.yaml
+++ b/ci-operator/step-registry/openshift/edge-tooling/microshift-ci/doctor/openshift-edge-tooling-microshift-ci-doctor-workflow.yaml
@@ -5,7 +5,6 @@ workflow:
     - ref: openshift-edge-tooling-microshift-ci-doctor
     post:
     - ref: openshift-edge-tooling-microshift-ci-post
-    - ref: openshift-claude-post
   documentation: |-
     Analyzes MicroShift periodic jobs and pull requests using Claude AI.
     Runs the microshift-ci:doctor command to analyze the releases and pull requests.

--- a/ci-operator/step-registry/openshift/edge-tooling/microshift-ci/post/openshift-edge-tooling-microshift-ci-post-commands.sh
+++ b/ci-operator/step-registry/openshift/edge-tooling/microshift-ci/post/openshift-edge-tooling-microshift-ci-post-commands.sh
@@ -3,19 +3,60 @@ set -euo pipefail
 set -x
 
 if [ "${JOB_TYPE:-}" = "presubmit" ]; then
-    PROW_JOB_URL="https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/${REPO_OWNER}_${REPO_NAME}/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
+    GCSWEB_JOB_URL="https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/${REPO_OWNER}_${REPO_NAME}/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
+    PROW_JOB_URL="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/${REPO_OWNER}_${REPO_NAME}/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
 else
-    PROW_JOB_URL="https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/${JOB_NAME}/${BUILD_ID}"
+    GCSWEB_JOB_URL="https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/${JOB_NAME}/${BUILD_ID}"
+    PROW_JOB_URL="https://prow.ci.openshift.org/view/gs/test-platform-results/logs/${JOB_NAME}/${BUILD_ID}"
 fi
 
 download_report() {
     local -r report_name="microshift-ci-doctor-report.html"
-    local -r report_url="${PROW_JOB_URL}/artifacts/microshift-ci-doctor/openshift-edge-tooling-microshift-ci-doctor/artifacts/${report_name}"
+    local -r report_url="${GCSWEB_JOB_URL}/artifacts/microshift-ci-doctor/openshift-edge-tooling-microshift-ci-doctor/artifacts/${report_name}"
     local -r output_file="${ARTIFACT_DIR}/0-${report_name%.html}-summary.html"
 
     echo "Downloading report from artifacts..."
     curl -sSfL --retry 3 --max-time 300 -o "${output_file}" "${report_url}"
     echo "Report downloaded successfully."
+}
+
+generate_continue_session_page() {
+    local -r summary_name="${ARTIFACT_DIR}/1-continue-session-summary.html"
+    cat > "${summary_name}" <<HTMLEOF
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Continue This MicroShift CI Session Locally</title>
+<style>
+  body { font-family: system-ui, sans-serif; background: #1a1a2e; color: #e0e0e0; max-width: 960px; margin: 0 auto; padding: 3rem 2rem; }
+  h1 { text-align: center; }
+  .subtitle { text-align: center; color: #888; margin-bottom: 2rem; }
+  pre { background: #111; border: 1px solid #333; border-radius: 8px; padding: 1rem; color: #b39ddb; word-break: break-all; white-space: pre-wrap; cursor: pointer; position: relative; }
+  pre:hover { border-color: #7c4dff; }
+  ol { color: #aaa; margin: 2rem 0; padding-left: 1.5rem; }
+  li { padding: 0.25rem 0; }
+  a { color: #b39ddb; }
+</style>
+</head>
+<body>
+<h1>Continue This MicroShift CI Session Locally</h1>
+<p class="subtitle">Pick up right where the MicroShift CI agent left off. Click below to copy.</p>
+<pre id="cmd" onclick="navigator.clipboard.writeText(this.textContent).then(()=>{this.style.borderColor='#4caf50';setTimeout(()=>this.style.borderColor='',1500)})">/microshift-ci:continue-session ${PROW_JOB_URL}</pre>
+<ol>
+  <li>Install the <strong>microshift-ci</strong> plugin: <code>claude plugin add openshift-eng/edge-tooling/plugins/microshift-ci</code></li>
+  <li>Open Claude Code in your terminal</li>
+  <li>Paste the command above and press Enter</li>
+  <li>Claude will download the CI artifacts to a local work directory so you can use <code>/microshift-ci:*</code> skills on them</li>
+</ol>
+<p>&nbsp;</p>
+<p>&nbsp;</p>
+<p>&nbsp;</p>
+<p>&nbsp;</p>
+</body>
+</html>
+HTMLEOF
+    echo "Continue-session page written to ${summary_name}"
 }
 
 #
@@ -27,4 +68,10 @@ if [[ -f "${SHARED_DIR}/claude-report-available" ]]; then
     download_report
 else
     echo "No Claude report found. Skipping."
+fi
+
+if [[ -f "${SHARED_DIR}/claude-session-available" ]]; then
+    generate_continue_session_page
+else
+    echo "No Claude session archive found. Skipping continue-session page."
 fi

--- a/ci-operator/step-registry/openshift/edge-tooling/microshift-ci/post/openshift-edge-tooling-microshift-ci-post-ref.yaml
+++ b/ci-operator/step-registry/openshift/edge-tooling/microshift-ci/post/openshift-edge-tooling-microshift-ci-post-ref.yaml
@@ -15,4 +15,4 @@ ref:
     Post step that exposes the HTML report and generates a continue-session
     HTML page in the artifact directory when a Claude session archive is present.
     The continue-session page provides a one-click copy command for resuming the
-    CI session locally using the ai-helpers marketplace.
+    CI session locally using the edge-tooling marketplace.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR extends the MicroShift CI infrastructure in OpenShift's release configuration to enable users to continue failed or partial CI sessions locally.

## Changes to MicroShift CI Post-Step

The PR modifies the post-step workflow and script that runs after MicroShift CI test execution:

1. **Workflow routing**: Updated the workflow to reference the correct post-step (`openshift-edge-tooling-microshift-ci-post`) instead of a deprecated one.

2. **Enhanced post-step reporting**: The post-step script now generates a new "Continue This MicroShift CI Session Locally" HTML page alongside existing CI reports. This page displays a command that developers can copy and run locally to reproduce the CI session using the edge-tooling marketplace.

3. **Artifact URL handling**: Adjusted how doctor report artifact URLs are constructed to use the correct GCS web URL (`GCSWEB_JOB_URL`) for proper accessibility in the spy-glass dashboard.

The overall effect is that CI users can now easily continue their MicroShift CI sessions locally without manually reconstructing the test environment, improving developer productivity when debugging CI failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->