### PR TITLE
Increase nightly job step timeout to 2h45m for IQE full profile

### DIFF
--- a/ci-operator/config/insights-onprem/cost-onprem-chart/insights-onprem-cost-onprem-chart-main__periodics.yaml
+++ b/ci-operator/config/insights-onprem/cost-onprem-chart/insights-onprem-cost-onprem-chart-main__periodics.yaml
@@ -60,6 +60,7 @@ tests:
     test:
     - ref: insights-onprem-cost-onprem-chart-e2e
     workflow: insights-onprem-cost-onprem-chart-claim
+  timeout: 2h45m0s
 - as: nightly-rc
   cluster_claim:
     architecture: amd64
@@ -77,6 +78,7 @@ tests:
     test:
     - ref: insights-onprem-cost-onprem-chart-e2e
     workflow: insights-onprem-cost-onprem-chart-claim
+  timeout: 2h45m0s
 zz_generated_metadata:
   branch: main
   org: insights-onprem

--- a/ci-operator/jobs/insights-onprem/cost-onprem-chart/insights-onprem-cost-onprem-chart-main-periodics.yaml
+++ b/ci-operator/jobs/insights-onprem/cost-onprem-chart/insights-onprem-cost-onprem-chart-main-periodics.yaml
@@ -5,6 +5,7 @@ periodics:
   decorate: true
   decoration_config:
     skip_cloning: true
+    timeout: 2h45m0s
   extra_refs:
   - base_ref: main
     org: insights-onprem
@@ -102,6 +103,7 @@ periodics:
   decorate: true
   decoration_config:
     skip_cloning: true
+    timeout: 2h45m0s
   extra_refs:
   - base_ref: main
     org: insights-onprem


### PR DESCRIPTION
The `nightly-release` job was failing with:
```
Process did not finish before 2h0m0s timeout
```

**Timeline breakdown:**
| Phase | Duration |
|-------|----------|
| Deployment + chart tests | ~50 min |
| IQE `full` profile | 60-90+ min |
| **Total needed** | ~110-140 min |

The default 2-hour step timeout was insufficient. The cluster claim timeout (3h) was not the bottleneck—the step timeout was.

## Changes

```yaml
# Both nightly-release and nightly-rc jobs:
timeout: 2h45m0s  # Added (was: 2h default)
```

This provides 45 minutes of headroom while staying under the 3-hour cluster claim limit.

## Test Plan

- [ ] Verify `make jobs` regenerates without errors (if applicable)
- [ ] Monitor next `nightly-release` run completes without timeout
- [ ] Monitor next `nightly-rc` run completes without timeout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## CI job timeout adjustment for insights-onprem cost chart nightly tests

This PR adjusts the step execution timeout for two periodic CI jobs in the **insights-onprem/cost-onprem-chart** repository. The `nightly-release` and `nightly-rc` jobs, which run nightly at 2 AM and 5 AM respectively, now have a step timeout of **2 hours 45 minutes** (up from the default 2 hours).

The change addresses a recurring issue where these jobs exceed the 2-hour step timeout when running the IQE `full` profile test suite. Based on observed timing patterns, the tests require approximately 110–140 minutes to complete (including ~50 minutes for deployment and chart validation, plus 60–90+ minutes for the IQE full profile). The 2h45m timeout provides ~45 minutes of buffer while remaining under the cluster claim timeout of 3 hours.

Both jobs continue to use OpenShift 4.20 on AWS with the same test workflow (`insights-onprem-cost-onprem-chart-claim` workflow with `insights-onprem-cost-onprem-chart-e2e` test reference).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->