### PR TITLE
NO-JIRA: fix: declare OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY in baremetalds-sno-setup 

### DIFF
--- a/ci-operator/step-registry/baremetalds/sno/setup/baremetalds-sno-setup-ref.yaml
+++ b/ci-operator/step-registry/baremetalds/sno/setup/baremetalds-sno-setup-ref.yaml
@@ -11,6 +11,9 @@ ref:
   - name: "release:latest"
     env: OPENSHIFT_INSTALL_RELEASE_IMAGE
   env:
+  - name: OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY
+    default: "true"
+    documentation: "Set to true to disable the Sigstore image signature policy to allow the installation of an unsigned release image. This is for internal CI testing only"
   - name: SNO_CONFIG
     default: ""
     documentation: Additional single-node configuration, appended to the one defined by the step command. See https://github.com/openshift/assisted-test-infra/blob/master/README.md for more details about supported values.


### PR DESCRIPTION
The baremetalds-sno workflow was missing the env var declaration in its setup ref, causing SNO BiP installations to fail with operator timeout due to sigstore signing enforcement on unsigned nightly images.

The var was already set in the setup script (/root/config) but never declared in the ref YAML, so ci-operator did not inject it into the pod environment for reliable propagation through skipper.