### PR TITLE
patterns-operator: Upgrade golang from 1.24 to 1.25

### DIFF
--- a/ci-operator/config/validatedpatterns/patterns-operator/validatedpatterns-patterns-operator-main.yaml
+++ b/ci-operator/config/validatedpatterns/patterns-operator/validatedpatterns-patterns-operator-main.yaml
@@ -3,7 +3,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: rhel-9-release-golang-1.24-openshift-4.21
+    tag: rhel-9-release-golang-1.25-openshift-4.21
 promotion:
   to:
   - name: "5.0"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Upgrade Go version for patterns-operator CI builds

This PR updates the ci-operator build configuration for the Validated Patterns "patterns-operator" repository's main-branch CI to use Go 1.25. Concretely, the build root image stream tag used by ci-operator was changed from rhel-9-release-golang-1.24-openshift-4.21 to rhel-9-release-golang-1.25-openshift-4.21. 

Practical effect: CI jobs for the patterns-operator component will run in a RHEL 9-based builder image that contains Go 1.25 instead of Go 1.24. No other CI logic, job definitions, resource requests/limits, promotion settings, or test commands were modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->