### PR TITLE
OCM-24587| feat:  OSDFM HCcreation-integration-canary Prow migration from Jenkins

### DIFF
--- a/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__ocm-fvt-osdfm-integration.yaml
+++ b/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__ocm-fvt-osdfm-integration.yaml
@@ -1,0 +1,66 @@
+base_images:
+  nested-podman:
+    name: nested-podman
+    namespace: ci
+    tag: latest
+build_root:
+  image_stream_tag:
+    name: builder
+    namespace: ocp
+    tag: rhel-9-golang-1.24-openshift-4.22
+releases:
+  latest:
+    candidate:
+      product: ocp
+      stream: nightly
+      version: "4.22"
+resources:
+  '*':
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: ocm-fvt-periodic-osdfm-hc-creation-integration-canary
+  capabilities:
+  - nested-podman
+  commands: |
+    JOB_LINK="https://prow.ci.openshift.org/view/gs/test-platform-results/"
+    if [ -n "${PULL_NUMBER:-}" ]; then
+      JOB_LINK="${JOB_LINK}pr-logs/pull/openshift_release/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
+    else
+      JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
+    fi
+
+    env -i bash --norc --noprofile << EOF > /tmp/podman.env
+    export OCM_ENV=integration
+    export SECTOR=canary
+    export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
+    export AWS_SHARED_VPC_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
+    export JOB_LINK="${JOB_LINK}"
+    source /usr/local/cs-qe-credentials/ocm-tokens
+    env | grep -v '^_='
+    EOF
+
+    podman run \
+    --authfile /usr/local/cs-qe-credentials/.dockerconfigjson \
+    --env-file /tmp/podman.env \
+    -v /usr/local/cs-qe-credentials:/credentials:ro,z \
+    --rm \
+    quay.io/redhat-services-prod/ocmci/ocmci:latest \
+    ocmtest test --service osdfm --job osdfm-basic-on-demand
+  container:
+    from: nested-podman
+    memory_backed_volume:
+      size: 1Gi
+  cron: 0 12 * * 1-5
+  nested_podman: true
+  secrets:
+  - mount_path: /usr/local/cs-qe-credentials
+    name: cs-qe-credentials
+zz_generated_metadata:
+  branch: main
+  org: openshift-online
+  repo: rosa-e2e
+  variant: ocm-fvt-osdfm-integration

--- a/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-periodics.yaml
@@ -217,6 +217,78 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build06
+  cron: 0 12 * * 1-5
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift-online
+    repo: rosa-e2e
+  labels:
+    capability/nested-podman: nested-podman
+    ci-operator.openshift.io/variant: ocm-fvt-osdfm-integration
+    ci.openshift.io/generator: prowgen
+    job-release: "4.22"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-online-rosa-e2e-main-ocm-fvt-osdfm-integration-ocm-fvt-periodic-osdfm-hc-creation-integration-canary
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/cs-qe-credentials
+      - --target=ocm-fvt-periodic-osdfm-hc-creation-integration-canary
+      - --variant=ocm-fvt-osdfm-integration
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /secrets/cs-qe-credentials
+        name: cs-qe-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: cs-qe-credentials
+      secret:
+        secretName: cs-qe-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build06
   cron: 0 8 * * *
   decorate: true
   decoration_config:


### PR DESCRIPTION
Migrate the  OCM job from Jenkins to a Prow periodic.
Add a Prow periodic for OSDFM hosted-cluster creation aligned with Jenkins osdfm-hc-creation integration + canary (OCM_ENV=integration, SECTOR=canary).
New ci-operator variant ocm-fvt-osdfm-integration and test ocm-fvt-periodic-osdfm-hc-creation-integration-canary.

Env: Integration 
sector : canary
cron: 0 12 * * 1-5 

Files:
ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__ocm-fvt-osdfm-integration.yaml (new)
ci-operator/jobs/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main-periodics.yaml (generated)


Follow-ups (out of scope for this PR)
Jenkins cutover / disable duplicate osdfm-hc-creation int canary in app-interface after this job is green and team agrees.
Optional: Jira reporting parity (jira-cred, --reportJiraTicket) like other CS jobs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new integration test configuration for OSDFM functionality.
  * Configured automated periodic testing on weekdays to ensure continuous reliability and stability of OSDFM features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->