### PR TITLE
add FPA credentials from OpenShift CI Vault for SAL deletion

### DIFF
--- a/ci-operator/step-registry/aro-hcp/deprovision/expired-resource-groups/aro-hcp-deprovision-expired-resource-groups-commands.sh
+++ b/ci-operator/step-registry/aro-hcp/deprovision/expired-resource-groups/aro-hcp-deprovision-expired-resource-groups-commands.sh
@@ -19,7 +19,7 @@ echo "Using subscription name='${CUSTOMER_SUBSCRIPTION}'"
 cmd="./test/aro-hcp-tests cleanup resource-groups --expired"
 
 # Add FPA credentials if available (needed for SAL deletion in no-rp mode)
-FPA_CLIENT_ID_FILE="${CLUSTER_PROFILE_DIR}/fpa-cert2-id"
+FPA_CLIENT_ID_FILE="${CLUSTER_PROFILE_DIR}/first-party-app-client-id"
 FPA_CERT_FILE="${CLUSTER_PROFILE_DIR}/fpa-cert2-value"
 
 if [ -s "${FPA_CLIENT_ID_FILE}" ] && [ -s "${FPA_CERT_FILE}" ]; then

--- a/ci-operator/step-registry/aro-hcp/deprovision/expired-resource-groups/aro-hcp-deprovision-expired-resource-groups-commands.sh
+++ b/ci-operator/step-registry/aro-hcp/deprovision/expired-resource-groups/aro-hcp-deprovision-expired-resource-groups-commands.sh
@@ -16,6 +16,30 @@ az login --service-principal -u "${AZURE_CLIENT_ID}" -p "${AZURE_CLIENT_SECRET}"
 az account set --subscription "${CUSTOMER_SUBSCRIPTION}"
 echo "Using subscription name='${CUSTOMER_SUBSCRIPTION}'"
 
+echo "DEBUG: VAULT_SECRET_PROFILE=${VAULT_SECRET_PROFILE}"
+echo "DEBUG: CLUSTER_PROFILE_DIR=${CLUSTER_PROFILE_DIR}"
+echo "DEBUG: AZURE_CLIENT_ID=${AZURE_CLIENT_ID}"
+echo "DEBUG: AZURE_TENANT_ID=${AZURE_TENANT_ID}"
+
+echo "DEBUG: Azure account context:"
+az account show \
+  --query "{user:user.name, tenantId:tenantId, subscriptionId:id, subscriptionName:name}" \
+  -o table
+
+echo "DEBUG: Checking Key Vault access to aro-hcp-dev-svc-kv/firstPartyCert2"
+if az keyvault secret show \
+  --vault-name aro-hcp-dev-svc-kv \
+  --name firstPartyCert2 \
+  --query id \
+  -o tsv; then
+  echo "DEBUG: SUCCESS: Prow identity can access aro-hcp-dev-svc-kv/firstPartyCert2"
+else
+  echo "DEBUG: FAILURE: Prow identity cannot access aro-hcp-dev-svc-kv/firstPartyCert2"
+fi
+
+echo "DEBUG: stopping before cleanup for rehearsal"
+exit 0
+
 cmd="./test/aro-hcp-tests cleanup resource-groups --expired"
 
 if [ -n "${CLEANUP_MODE}" ]; then


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

This PR updates the OpenShift CI step script in the `openshift/release` repository that runs the ARO HCP periodic cleanup for expired resource groups. It adds support to optionally perform SAL (Service Account Lifecycle) deletion using First-Party Azure (FPA) credentials sourced from the CI cluster profile when those credentials are available.

### Practical effect
- **Target script:** `ci-operator/step-registry/aro-hcp/deprovision/expired-resource-groups/aro-hcp-deprovision-expired-resource-groups-commands.sh`
- **New conditional behavior (SAL deletion via FPA):**
  - The script checks for **non-empty** files under `CLUSTER_PROFILE_DIR`:
    - `fpa-cert2-id`
    - `fpa-cert2-value`
  - When both are present:
    - It reads the **FPA client ID** from `fpa-cert2-id`.
    - It **base64-decodes** the PFX blob from `fpa-cert2-value` into a temporary `.pfx` file.
    - It converts the PFX to **PEM** using `openssl pkcs12`.
    - It appends `--fpa-client-id` and `--fpa-cert-path` to the deprovision command, and reports that SAL deletion is **enabled**.
  - If either file is missing/empty, the command is left unchanged and the script reports SAL deletion is **disabled**.
- **Logging/safety adjustment:**
  - Removes the log line that echoed the full command (`echo "Running: ${cmd}"`) to avoid leaking sensitive credential-related arguments; the script executes using `eval "${cmd}"` instead.

No public interfaces, manifests, or exported declarations are changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->