### PR TITLE
Revert "Add config-updater kubeconfig for build12"

### DIFF
--- a/core-services/ci-secret-bootstrap/_config.yaml
+++ b/core-services/ci-secret-bootstrap/_config.yaml
@@ -15,6 +15,7 @@ cluster_groups:
   - build09
   - build10
   - build11
+  - build12
   - core-ci
   - vsphere02
   managed_clusters:
@@ -30,6 +31,7 @@ cluster_groups:
   - build09
   - build10
   - build11
+  - build12
   - core-ci
   - hosted-mgmt
   non_app_ci:
@@ -44,6 +46,7 @@ cluster_groups:
   - build09
   - build10
   - build11
+  - build12
   - core-ci
   - vsphere02
   openshift_config_pull_secret:
@@ -58,6 +61,7 @@ cluster_groups:
   - build09
   - build10
   - build11
+  - build12
   - core-ci
   - hosted-mgmt
   - vsphere02
@@ -3045,6 +3049,9 @@ secret_configs:
     build11.config:
       field: sa.pod-scaler.build11.config
       item: pod-scaler
+    build12.config:
+      field: sa.pod-scaler.build12.config
+      item: pod-scaler
     core-ci.config:
       field: sa.pod-scaler.core-ci.config
       item: pod-scaler
@@ -3083,6 +3090,9 @@ secret_configs:
       item: pod-scaler
     sa.pod-scaler.build11.token.txt:
       field: sa.pod-scaler.build11.token.txt
+      item: pod-scaler
+    sa.pod-scaler.build12.token.txt:
+      field: sa.pod-scaler.build12.token.txt
       item: pod-scaler
     sa.pod-scaler.core-ci.token.txt:
       field: sa.pod-scaler.core-ci.token.txt
@@ -3448,6 +3458,12 @@ secret_configs:
     sa.crier.build11.token.txt:
       field: sa.crier.build11.token.txt
       item: build_farm
+    sa.crier.build12.config:
+      field: sa.crier.build12.config
+      item: build_farm
+    sa.crier.build12.token.txt:
+      field: sa.crier.build12.token.txt
+      item: build_farm
     sa.crier.core-ci.config:
       field: sa.crier.core-ci.config
       item: build_farm
@@ -3596,6 +3612,12 @@ secret_configs:
     sa.deck.build11.token.txt:
       field: sa.deck.build11.token.txt
       item: build_farm
+    sa.deck.build12.config:
+      field: sa.deck.build12.config
+      item: build_farm
+    sa.deck.build12.token.txt:
+      field: sa.deck.build12.token.txt
+      item: build_farm
     sa.deck.core-ci.config:
       field: sa.deck.core-ci.config
       item: build_farm
@@ -3684,6 +3706,12 @@ secret_configs:
       item: build_farm
     sa.hook.build11.token.txt:
       field: sa.hook.build11.token.txt
+      item: build_farm
+    sa.hook.build12.config:
+      field: sa.hook.build12.config
+      item: build_farm
+    sa.hook.build12.token.txt:
+      field: sa.hook.build12.token.txt
       item: build_farm
     sa.hook.core-ci.config:
       field: sa.hook.core-ci.config
@@ -3776,6 +3804,12 @@ secret_configs:
       item: build_farm
     sa.prow-controller-manager.build11.token.txt:
       field: sa.prow-controller-manager.build11.token.txt
+      item: build_farm
+    sa.prow-controller-manager.build12.config:
+      field: sa.prow-controller-manager.build12.config
+      item: build_farm
+    sa.prow-controller-manager.build12.token.txt:
+      field: sa.prow-controller-manager.build12.token.txt
       item: build_farm
     sa.prow-controller-manager.core-ci.config:
       field: sa.prow-controller-manager.core-ci.config
@@ -3892,6 +3926,12 @@ secret_configs:
     sa.sinker.build11.token.txt:
       field: sa.sinker.build11.token.txt
       item: build_farm
+    sa.sinker.build12.config:
+      field: sa.sinker.build12.config
+      item: build_farm
+    sa.sinker.build12.token.txt:
+      field: sa.sinker.build12.token.txt
+      item: build_farm
     sa.sinker.core-ci.config:
       field: sa.sinker.core-ci.config
       item: build_farm
@@ -3975,6 +4015,12 @@ secret_configs:
     sa.dptp-controller-manager.build11.token.txt:
       field: sa.dptp-controller-manager.build11.token.txt
       item: build_farm
+    sa.dptp-controller-manager.build12.config:
+      field: sa.dptp-controller-manager.build12.config
+      item: build_farm
+    sa.dptp-controller-manager.build12.token.txt:
+      field: sa.dptp-controller-manager.build12.token.txt
+      item: build_farm
     sa.dptp-controller-manager.core-ci.config:
       field: sa.dptp-controller-manager.core-ci.config
       item: build_farm
@@ -4057,6 +4103,12 @@ secret_configs:
       item: build_farm
     sa.promoted-image-governor.build11.token.txt:
       field: sa.promoted-image-governor.build11.token.txt
+      item: build_farm
+    sa.promoted-image-governor.build12.config:
+      field: sa.promoted-image-governor.build12.config
+      item: build_farm
+    sa.promoted-image-governor.build12.token.txt:
+      field: sa.promoted-image-governor.build12.token.txt
       item: build_farm
     sa.promoted-image-governor.core-ci.config:
       field: sa.promoted-image-governor.core-ci.config
@@ -4178,6 +4230,12 @@ secret_configs:
     sa.ci-chat-bot.build11.token.txt:
       field: sa.ci-chat-bot.build11.token.txt
       item: ci-chat-bot
+    sa.ci-chat-bot.build12.config:
+      field: sa.ci-chat-bot.build12.config
+      item: ci-chat-bot
+    sa.ci-chat-bot.build12.token.txt:
+      field: sa.ci-chat-bot.build12.token.txt
+      item: ci-chat-bot
     sa.ci-chat-bot.core-ci.config:
       field: sa.ci-chat-bot.core-ci.config
       item: ci-chat-bot
@@ -4266,6 +4324,12 @@ secret_configs:
       item: build_farm
     sa.github-ldap-user-group-creator.build11.token.txt:
       field: sa.github-ldap-user-group-creator.build11.token.txt
+      item: build_farm
+    sa.github-ldap-user-group-creator.build12.config:
+      field: sa.github-ldap-user-group-creator.build12.config
+      item: build_farm
+    sa.github-ldap-user-group-creator.build12.token.txt:
+      field: sa.github-ldap-user-group-creator.build12.token.txt
       item: build_farm
     sa.github-ldap-user-group-creator.core-ci.config:
       field: sa.github-ldap-user-group-creator.core-ci.config
@@ -5245,6 +5309,12 @@ secret_configs:
       item: build_farm
     sa.cluster-display.build11.token.txt:
       field: sa.cluster-display.build11.token.txt
+      item: build_farm
+    sa.cluster-display.build12.config:
+      field: sa.cluster-display.build12.config
+      item: build_farm
+    sa.cluster-display.build12.token.txt:
+      field: sa.cluster-display.build12.token.txt
       item: build_farm
     sa.cluster-display.core-ci.config:
       field: sa.cluster-display.core-ci.config
@@ -7232,6 +7302,90 @@ secret_configs:
     name: multi-arch-builder-controller-build11-registry-credentials
     namespace: ci
     type: kubernetes.io/dockerconfigjson
+- from:
+    .dockerconfigjson:
+      dockerconfigJSON:
+      - auth_field: token_image-puller_build12_reg_auth_value.txt
+        item: build_farm
+        registry_url: image-registry.openshift-image-registry.svc.cluster.local:5000
+      - auth_field: token_image-puller_build12_reg_auth_value.txt
+        item: build_farm
+        registry_url: image-registry.openshift-image-registry.svc:5000
+      - auth_field: token_image-puller_build12_reg_auth_value.txt
+        item: build_farm
+        registry_url: registry.build12.ci.openshift.org
+      - auth_field: token_image-pusher_app.ci_reg_auth_value.txt
+        item: build_farm
+        registry_url: registry.ci.openshift.org
+      - auth_field: auth
+        item: quay-io-push-credentials
+        registry_url: quay.io/openshift/ci
+  to:
+  - cluster: build12
+    name: registry-push-credentials-ci-central
+    namespace: ci
+    type: kubernetes.io/dockerconfigjson
+  - cluster: build12
+    name: registry-push-credentials-ci-central
+    namespace: test-credentials
+    type: kubernetes.io/dockerconfigjson
+- from:
+    .dockerconfigjson:
+      dockerconfigJSON:
+      - auth_field: token_image-pusher_build12_reg_auth_value.txt
+        item: build_farm
+        registry_url: image-registry.openshift-image-registry.svc:5000
+      - auth_field: token_multi-arch-builder-controller_build12_reg_auth_value.txt
+        item: build_farm
+        registry_url: registry.multi-build01.arm-build.devcluster.openshift.com
+      - auth_field: token_image-pusher_app.ci_reg_auth_value.txt
+        item: build_farm
+        registry_url: registry.ci.openshift.org
+  to:
+  - cluster: build12
+    name: multi-arch-builder-controller-build12-registry-credentials
+    namespace: ci
+    type: kubernetes.io/dockerconfigjson
+- from:
+    build12-id:
+      field: build12-id
+      item: dex
+    build12-secret:
+      field: build12-secret
+      item: dex
+  to:
+  - cluster: app.ci
+    name: build12-secret
+    namespace: dex
+  - cluster: app.ci
+    name: build12-dex-oidc
+    namespace: ci
+- from:
+    clientSecret:
+      field: build12-secret
+      item: dex
+  to:
+  - cluster: build12
+    name: dex-rh-sso
+    namespace: openshift-config
+- from:
+    .dockerconfigjson:
+      dockerconfigJSON:
+      - auth_field: token_image-pusher_build12_reg_auth_value.txt
+        item: build_farm
+        registry_url: image-registry.openshift-image-registry.svc:5000
+      - auth_field: token_image-pusher_build12_reg_auth_value.txt
+        item: build_farm
+        registry_url: registry.build12.ci.openshift.org
+  to:
+  - cluster: build12
+    name: manifest-tool-local-pusher
+    namespace: ci
+    type: kubernetes.io/dockerconfigjson
+  - cluster: build12
+    name: manifest-tool-local-pusher
+    namespace: test-credentials
+    type: kubernetes.io/dockerconfigjson
 user_secrets_target_clusters:
 - app.ci
 - build01
@@ -7245,6 +7399,7 @@ user_secrets_target_clusters:
 - build09
 - build10
 - build11
+- build12
 - core-ci
 - hosted-mgmt
 - vsphere02

--- a/core-services/ci-secret-bootstrap/gsm-config.yaml
+++ b/core-services/ci-secret-bootstrap/gsm-config.yaml
@@ -16,6 +16,7 @@ cluster_groups:
     - build09
     - build10
     - build11
+    - build12
     - core-ci
     - vsphere02
   managed_clusters:
@@ -31,6 +32,7 @@ cluster_groups:
     - build09
     - build10
     - build11
+    - build12
     - core-ci
     - hosted-mgmt
   non_app_ci:
@@ -45,6 +47,7 @@ cluster_groups:
     - build09
     - build10
     - build11
+    - build12
     - core-ci
     - vsphere02
   standard_build_clusters:
@@ -59,6 +62,7 @@ cluster_groups:
     - build09
     - build10
     - build11
+    - build12
 
 dptp_collection: test-platform-infra
 
@@ -121,6 +125,8 @@ bundles:
           - sa--dot--cluster-init--dot--build10--dot--token--dot--txt
           - sa--dot--cluster-init--dot--build11--dot--config
           - sa--dot--cluster-init--dot--build11--dot--token--dot--txt
+          - sa--dot--cluster-init--dot--build12--dot--config
+          - sa--dot--cluster-init--dot--build12--dot--token--dot--txt
           - sa--dot--cluster-init--dot--core-ci--dot--config
           - sa--dot--cluster-init--dot--core-ci--dot--token--dot--txt
           - sa--dot--cluster-init--dot--vsphere02--dot--config
@@ -650,6 +656,51 @@ bundles:
         namespace: ocp
         type: kubernetes.io/dockerconfigjson
 
+  - name: registry-pull-credentials
+    dockerconfig:
+      registries:
+        - auth_field: token_image-puller_build12_reg_auth_value--dot--txt
+          group: build_farm
+          registry_url: image-registry.openshift-image-registry.svc.cluster.local:5000
+        - auth_field: token_image-puller_build12_reg_auth_value--dot--txt
+          group: build_farm
+          registry_url: image-registry.openshift-image-registry.svc:5000
+        - auth_field: token_image-puller_build12_reg_auth_value--dot--txt
+          group: build_farm
+          registry_url: registry.build12.ci.openshift.org
+        - auth_field: token_image-puller_app--dot--ci_reg_auth_value--dot--txt
+          group: build_farm
+          registry_url: registry.ci.openshift.org
+        - auth_field: auth
+          email_field: email
+          group: quay--dot--io-pull-secret
+          registry_url: quay.io
+        - auth_field: auth
+          group: quayio-ci-read-only-robot
+          registry_url: quay-proxy.ci.openshift.org
+        - auth_field: auth
+          group: quayio-ci-read-only-robot
+          registry_url: quay.io/openshift/ci
+        - auth_field: auth
+          group: quayio-ci-read-only-robot
+          registry_url: quay.io/openshift/network-edge-testing
+        - auth_field: auth
+          group: quayio-ci-read-only-robot
+          registry_url: qci-pull-through-cache-us-east-1-ci.apps.ci.l2s4.p1.openshiftapps.com
+    sync_to_cluster: true
+    targets:
+      - cluster: build12
+        namespace: ci
+        type: kubernetes.io/dockerconfigjson
+      - cluster: build12
+        namespace: test-credentials
+        type: kubernetes.io/dockerconfigjson
+      - cluster: build12
+        namespace: keel
+        type: kubernetes.io/dockerconfigjson
+      - cluster: build12
+        namespace: ocp
+        type: kubernetes.io/dockerconfigjson
 
   - name: registry-pull-credentials
     dockerconfig:

--- a/core-services/ci-secret-generator/_config.yaml
+++ b/core-services/ci-secret-generator/_config.yaml
@@ -20,6 +20,7 @@
     - build09
     - build10
     - build11
+    - build12
     - core-ci
     - vsphere02
     service_account:
@@ -116,6 +117,7 @@
     - build09
     - build10
     - build11
+    - build12
     - core-ci
     - vsphere02
     service_account:
@@ -143,6 +145,7 @@
     - build09
     - build10
     - build11
+    - build12
     - core-ci
     - vsphere02
     service_account:
@@ -170,6 +173,7 @@
     - build09
     - build10
     - build11
+    - build12
     - core-ci
     service_account:
     - pod-scaler
@@ -277,6 +281,7 @@
     - build09
     - build10
     - build11
+    - build12
 - fields:
   - cmd: /usr/bin/generate_thanos_tls.sh /tmp/thanos-tls /tmp/build-farm-credentials/sa.config-updater.$(cluster).config
       thanos-receive.core.ci.devcluster.openshift.com && cat /tmp/thanos-tls/server.crt


### PR DESCRIPTION
Reverts openshift/release#79134

config-updater is already working as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR reverts PR #79134, which had removed build12 from the OpenShift CI infrastructure configuration. The revert restores build12 cluster integration because "config-updater is already working as expected," suggesting the previous removal was either unnecessary or caused operational issues.

## Changes

The PR re-adds build12 across three critical CI secret management systems:

**core-services/ci-secret-bootstrap/_config.yaml**
- Restores build12 to core cluster group definitions (`build_farm`, `managed_clusters`, `non_app_ci`, `openshift_config_pull_secret`)
- Re-establishes build12 as a target for component secrets and configurations including pod-scaler, component-monitor, crier, deck, hook, prow-controller-manager, sinker, dptp-controller-manager, promoted-image-governor, ci-chat-bot, github-ldap-user-group-creator, and cluster-display
- Restores build12-specific registry push credentials (ci-central image registry, multi-arch builder controller), dex OIDC integration secrets, and manifest-tool credentials
- Adds build12 to `user_secrets_target_clusters` for expanded secret propagation

**core-services/ci-secret-bootstrap/gsm-config.yaml**
- Restores build12 to cluster group definitions for Google Secret Manager integration
- Re-adds build12 config and token bundles for cluster initialization
- Restores registry pull credential configuration for build12 across multiple namespaces

**core-services/ci-secret-generator/_config.yaml**
- Re-adds build12 to secret and token generation configurations for multiple components

## Impact

This change fully restores the build12 cluster's integration with OpenShift CI's secret management, credential distribution, and configuration synchronization systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->