### PR TITLE
Add 'do-not-merge/jira-invalid' label to config

### DIFF
--- a/core-services/prow/02_config/kubevirt-ui/kubevirt-plugin/_prowconfig.yaml
+++ b/core-services/prow/02_config/kubevirt-ui/kubevirt-plugin/_prowconfig.yaml
@@ -7,6 +7,7 @@ tide:
     - backports/unvalidated-commits
     - do-not-merge/hold
     - do-not-merge/invalid-owners-file
+    - do-not-merge/jira-invalid
     - do-not-merge/work-in-progress
     - jira/invalid-bug
     - needs-rebase


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds the `do-not-merge/jira-invalid` label to the Prow tide auto-merge blocklist for the KubeVirt UI plugin repository's CI configuration.

### What Changed

The tide query configuration for the `kubevirt-ui/kubevirt-plugin` repository now includes `do-not-merge/jira-invalid` in its `missingLabels` list. This means pull requests with this label will be blocked from automatic merging by the Prow tide bot.

### Practical Impact

This change extends the KubeVirt UI plugin's CI gate to prevent automatic merging of PRs tagged with the `do-not-merge/jira-invalid` label, which is typically applied when a PR references an invalid or missing JIRA issue. This adds an additional validation checkpoint for the KubeVirt UI plugin component's CI pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->