### PR TITLE
CNTRLPLANE-2207: allow conversion webhooks on GCP

### DIFF
--- a/ci-operator/step-registry/hypershift/install/hypershift-install-commands.sh
+++ b/ci-operator/step-registry/hypershift/install/hypershift-install-commands.sh
@@ -147,7 +147,6 @@ case "${CLOUD_PROVIDER}" in
   # Install HyperShift operator
   # The --pull-secret flag creates the pull-secret in the hypershift namespace
   "${HCP_CLI}" install --hypershift-image="${OPERATOR_IMAGE}" \
-  --enable-conversion-webhook=false \
   --external-dns-provider=google \
   --external-dns-domain-filter="${HYPERSHIFT_CI_DNS_DOMAIN}" \
   --external-dns-google-project="${HYPERSHIFT_CI_PROJECT}" \


### PR DESCRIPTION
## Summary

- Removes `--enable-conversion-webhook=false` from the GCP HyperShift install command
- Mirrors the same change done for Azure in #76413

For the upgrade to CAPI 1.11, conversion between v1beta1 and v1beta2 is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Removes the `--enable-conversion-webhook=false` flag from the GCP HyperShift install command in the OpenShift CI infrastructure, enabling conversion webhook support for GCP-based HyperShift test deployments. This change mirrors a previously applied fix for Azure (PR #76413) and is required to support Cluster API (CAPI) 1.11's conversion between v1beta1 and v1beta2 schemas.

## Impact

**Affected CI infrastructure**: HyperShift operator installation for GCP-hosted test environments (`ci-operator/step-registry/hypershift/install/hypershift-install-commands.sh`)

By allowing conversion webhooks on GCP HyperShift deployments, the CI infrastructure will now support the API schema conversions needed for upcoming CAPI releases during cluster upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->