### PR TITLE
Fix storageClassName for GCP build clusters (build02/04/08) to standard-csi

### DIFF
--- a/clusters/_cluster-install/build02.yaml
+++ b/clusters/_cluster-install/build02.yaml
@@ -64,7 +64,7 @@ onboard:
                 effect: NoExecute
               volumeClaimTemplate:
                 spec:
-                  storageClassName: gp2
+                  storageClassName: standard-csi
                   resources:
                     requests:
                       storage: 10Gi
@@ -98,7 +98,7 @@ onboard:
                 effect: NoExecute
               volumeClaimTemplate:
                 spec:
-                  storageClassName: gp2
+                  storageClassName: standard-csi
                   resources:
                     requests:
                       storage: 400Gi

--- a/clusters/_cluster-install/build04.yaml
+++ b/clusters/_cluster-install/build04.yaml
@@ -64,7 +64,7 @@ onboard:
                 effect: NoExecute
               volumeClaimTemplate:
                 spec:
-                  storageClassName: gp2
+                  storageClassName: standard-csi
                   resources:
                     requests:
                       storage: 10Gi
@@ -98,7 +98,7 @@ onboard:
                 effect: NoExecute
               volumeClaimTemplate:
                 spec:
-                  storageClassName: gp2
+                  storageClassName: standard-csi
                   resources:
                     requests:
                       storage: 400Gi

--- a/clusters/_cluster-install/build08.yaml
+++ b/clusters/_cluster-install/build08.yaml
@@ -64,7 +64,7 @@ onboard:
                 effect: NoExecute
               volumeClaimTemplate:
                 spec:
-                  storageClassName: gp2
+                  storageClassName: standard-csi
                   resources:
                     requests:
                       storage: 10Gi
@@ -98,7 +98,7 @@ onboard:
                 effect: NoExecute
               volumeClaimTemplate:
                 spec:
-                  storageClassName: gp2
+                  storageClassName: standard-csi
                   resources:
                     requests:
                       storage: 400Gi

--- a/clusters/build-clusters/build02/openshift-monitoring/cluster-monitoring-config.yaml
+++ b/clusters/build-clusters/build02/openshift-monitoring/cluster-monitoring-config.yaml
@@ -19,7 +19,7 @@ data:
         effect: NoExecute
       volumeClaimTemplate:
         spec:
-          storageClassName: standard
+          storageClassName: standard-csi
           resources:
             requests:
               storage: 10Gi
@@ -54,7 +54,7 @@ data:
         effect: NoExecute
       volumeClaimTemplate:
         spec:
-          storageClassName: standard
+          storageClassName: standard-csi
           resources:
             requests:
               storage: 400Gi


### PR DESCRIPTION
/cc @bear-redhat 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR fixes incorrect storage class definitions for the OpenShift monitoring infrastructure across three GCP build clusters (build02, build04, and build08).

## Changes

The PR updates storage class references in monitoring configurations across these clusters:
- **build02**: Updates both `alertmanagerMain` and `prometheusK8s` volume claim templates in two configuration locations
- **build04**: Updates volume claim templates for monitoring components (with 10Gi and 400Gi storage allocations)
- **build08**: Updates alertmanager and prometheus-related volume claim templates

## What's being fixed

The changes correct the storage class name from `gp2` (AWS-specific) and `standard` (generic) to `standard-csi` (the correct GCP storage class). This ensures that monitoring components in GCP build clusters use the appropriate persistent volume storage class for their infrastructure environment. The volume allocations and all other monitoring configuration remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->