### PR TITLE
Add claude-payload-agent to 4.14 nightlies

### DIFF
--- a/ci-operator/config/openshift/release/openshift-release-main__payload-analysis-test.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__payload-analysis-test.yaml
@@ -1,0 +1,17 @@
+resources:
+  '*':
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: claude-payload-analysis-test
+  cron: '@yearly'
+  steps:
+    env:
+      PAYLOAD_TAG: 4.14.0-0.nightly-2026-05-10-173114
+    workflow: openshift-claude-payload
+zz_generated_metadata:
+  branch: main
+  org: openshift
+  repo: release
+  variant: payload-analysis-test

--- a/core-services/release-controller/_releases/priv/release-ocp-4.14.json
+++ b/core-services/release-controller/_releases/priv/release-ocp-4.14.json
@@ -42,6 +42,15 @@
             },
             "upgrade": true
         },
+        "claude-payload-agent": {
+            "async": true,
+            "disabled": true,
+            "multiJobAnalysis": true,
+            "optional": true,
+            "prowJob": {
+                "name": "periodic-ci-openshift-release-main-claude-payload-agent-no-slack-priv"
+            }
+        },
         "driver-toolkit": {
             "disabled": true,
             "maxRetries": 2,

--- a/core-services/release-controller/_releases/release-ocp-4.14.json
+++ b/core-services/release-controller/_releases/release-ocp-4.14.json
@@ -109,6 +109,14 @@
         "name": "periodic-ci-openshift-release-main-nightly-4.14-e2e-metal-ipi-sdn-bm"
       }
     },
+    "claude-payload-agent": {
+      "async": true,
+      "optional": true,
+      "multiJobAnalysis": true,
+      "prowJob": {
+        "name": "periodic-ci-openshift-release-main-claude-payload-agent-no-slack"
+      }
+    },
     "fips-scan": {
       "maxRetries": 2,
       "prowJob": {


### PR DESCRIPTION
## Summary
- Adds the claude payload agent as an async, optional, informing job on the OCP 4.14 nightly release controller (no-slack variant, matching 4.20/4.21)
- Includes a temporary one-off rehearsable job targeting rejected nightly `4.14.0-0.nightly-2026-05-11-095134` for validation — will be removed before or after merge

## Test plan
- [ ] CI rehearsal runs the one-off `claude-payload-analysis-test` job against the rejected 4.14 nightly
- [ ] Verify the payload agent successfully analyzes the 4.14 payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds the Claude payload analysis agent to the OpenShift 4.14 nightly release pipeline and introduces a temporary rehearsable CI job to validate the agent.

What changed (practical impact)
- Release controller (core-services/release-controller/_releases/release-ocp-4.14.json and the private variant):
  - Adds a new verify entry named claude-payload-agent configured as async: true, optional: true, multiJobAnalysis: true.
  - The public config points to prow job periodic-ci-openshift-release-main-claude-payload-agent-no-slack.
  - The private config points to periodic-ci-openshift-release-main-claude-payload-agent-no-slack-priv and sets disabled: true (so the private release-controller entry is present but not active).
  - Effect: the agent will run informatively (non-blocking) against 4.14 nightlies when enabled, matching the pattern used on newer branches.

- CI test config (ci-operator/config/openshift/release/openshift-release-main__payload-analysis-test.yaml):
  - Adds a test "claude-payload-analysis-test" (cron: '@yearly') that runs the openshift-claude-payload workflow.
  - The job sets env.PAYLOAD_TAG=4.14.0-0.nightly-2026-05-10-173114 and uses small resource requests (cpu: 100m, memory: 200Mi).
  - This test is a temporary, rehearsable validation intended to confirm the payload agent can analyze a real 4.14 payload.

Why
- Enables automated, non-blocking payload analysis for OCP 4.14 nightlies using the Claude payload agent (bringing 4.14 in line with patterns on branches like 4.20/4.21).
- The rehearsable CI job validates the agent against an actual nightly payload before continuous use.

Test plan
- Rehearse the one-off claude-payload-analysis-test job and verify the openshift-claude-payload workflow successfully analyzes the specified 4.14 payload.

Notes
- The public verify entry is configured to run informatively; the private entry is currently disabled (disabled: true) in the private release configuration.
- The ci-operator job's PAYLOAD_TAG in the added file is 4.14.0-0.nightly-2026-05-10-173114; the PR description notes the one-off rehearsal intent and the rehearsal command was requested via comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->