### PR TITLE
Add claude-payload-agent to 4.12-4.19 nightlies

### DIFF
--- a/core-services/release-controller/_releases/priv/release-ocp-4.12.json
+++ b/core-services/release-controller/_releases/priv/release-ocp-4.12.json
@@ -35,6 +35,15 @@
             },
             "upgrade": true
         },
+        "claude-payload-agent": {
+            "async": true,
+            "disabled": true,
+            "multiJobAnalysis": true,
+            "optional": true,
+            "prowJob": {
+                "name": "periodic-ci-openshift-release-main-claude-payload-agent-no-slack-priv"
+            }
+        },
         "driver-toolkit": {
             "disabled": true,
             "maxRetries": 2,

--- a/core-services/release-controller/_releases/priv/release-ocp-4.13.json
+++ b/core-services/release-controller/_releases/priv/release-ocp-4.13.json
@@ -34,6 +34,15 @@
             },
             "upgrade": true
         },
+        "claude-payload-agent": {
+            "async": true,
+            "disabled": true,
+            "multiJobAnalysis": true,
+            "optional": true,
+            "prowJob": {
+                "name": "periodic-ci-openshift-release-main-claude-payload-agent-no-slack-priv"
+            }
+        },
         "driver-toolkit": {
             "disabled": true,
             "maxRetries": 2,

--- a/core-services/release-controller/_releases/priv/release-ocp-4.14.json
+++ b/core-services/release-controller/_releases/priv/release-ocp-4.14.json
@@ -42,6 +42,15 @@
             },
             "upgrade": true
         },
+        "claude-payload-agent": {
+            "async": true,
+            "disabled": true,
+            "multiJobAnalysis": true,
+            "optional": true,
+            "prowJob": {
+                "name": "periodic-ci-openshift-release-main-claude-payload-agent-no-slack-priv"
+            }
+        },
         "driver-toolkit": {
             "disabled": true,
             "maxRetries": 2,

--- a/core-services/release-controller/_releases/priv/release-ocp-4.15.json
+++ b/core-services/release-controller/_releases/priv/release-ocp-4.15.json
@@ -42,6 +42,15 @@
             },
             "upgrade": true
         },
+        "claude-payload-agent": {
+            "async": true,
+            "disabled": true,
+            "multiJobAnalysis": true,
+            "optional": true,
+            "prowJob": {
+                "name": "periodic-ci-openshift-release-main-claude-payload-agent-no-slack-priv"
+            }
+        },
         "driver-toolkit": {
             "disabled": true,
             "maxRetries": 2,

--- a/core-services/release-controller/_releases/priv/release-ocp-4.16.json
+++ b/core-services/release-controller/_releases/priv/release-ocp-4.16.json
@@ -42,6 +42,15 @@
             },
             "upgrade": true
         },
+        "claude-payload-agent": {
+            "async": true,
+            "disabled": true,
+            "multiJobAnalysis": true,
+            "optional": true,
+            "prowJob": {
+                "name": "periodic-ci-openshift-release-main-claude-payload-agent-no-slack-priv"
+            }
+        },
         "driver-toolkit": {
             "disabled": true,
             "maxRetries": 2,

--- a/core-services/release-controller/_releases/priv/release-ocp-4.17.json
+++ b/core-services/release-controller/_releases/priv/release-ocp-4.17.json
@@ -42,6 +42,15 @@
             },
             "upgrade": true
         },
+        "claude-payload-agent": {
+            "async": true,
+            "disabled": true,
+            "multiJobAnalysis": true,
+            "optional": true,
+            "prowJob": {
+                "name": "periodic-ci-openshift-release-main-claude-payload-agent-no-slack-priv"
+            }
+        },
         "driver-toolkit": {
             "disabled": true,
             "maxRetries": 2,

--- a/core-services/release-controller/_releases/priv/release-ocp-4.18.json
+++ b/core-services/release-controller/_releases/priv/release-ocp-4.18.json
@@ -42,6 +42,15 @@
             },
             "upgrade": true
         },
+        "claude-payload-agent": {
+            "async": true,
+            "disabled": true,
+            "multiJobAnalysis": true,
+            "optional": true,
+            "prowJob": {
+                "name": "periodic-ci-openshift-release-main-claude-payload-agent-no-slack-priv"
+            }
+        },
         "driver-toolkit": {
             "disabled": true,
             "maxRetries": 2,

--- a/core-services/release-controller/_releases/priv/release-ocp-4.19.json
+++ b/core-services/release-controller/_releases/priv/release-ocp-4.19.json
@@ -42,6 +42,15 @@
             },
             "upgrade": true
         },
+        "claude-payload-agent": {
+            "async": true,
+            "disabled": true,
+            "multiJobAnalysis": true,
+            "optional": true,
+            "prowJob": {
+                "name": "periodic-ci-openshift-release-main-claude-payload-agent-no-slack-priv"
+            }
+        },
         "driver-toolkit": {
             "disabled": true,
             "maxRetries": 1,

--- a/core-services/release-controller/_releases/release-ocp-4.12.json
+++ b/core-services/release-controller/_releases/release-ocp-4.12.json
@@ -88,6 +88,14 @@
         "name": "periodic-ci-openshift-release-main-nightly-4.12-e2e-metal-ipi-ovn-ipv6"
       }
     },
+    "claude-payload-agent": {
+      "async": true,
+      "optional": true,
+      "multiJobAnalysis": true,
+      "prowJob": {
+        "name": "periodic-ci-openshift-release-main-claude-payload-agent-no-slack"
+      }
+    },
     "fips-scan": {
       "maxRetries": 2,
       "prowJob": {

--- a/core-services/release-controller/_releases/release-ocp-4.13.json
+++ b/core-services/release-controller/_releases/release-ocp-4.13.json
@@ -89,6 +89,14 @@
         "name": "periodic-ci-openshift-release-main-nightly-4.13-e2e-metal-ipi-sdn-bm"
       }
     },
+    "claude-payload-agent": {
+      "async": true,
+      "optional": true,
+      "multiJobAnalysis": true,
+      "prowJob": {
+        "name": "periodic-ci-openshift-release-main-claude-payload-agent-no-slack"
+      }
+    },
     "fips-scan": {
       "maxRetries": 2,
       "prowJob": {

--- a/core-services/release-controller/_releases/release-ocp-4.14.json
+++ b/core-services/release-controller/_releases/release-ocp-4.14.json
@@ -109,6 +109,14 @@
         "name": "periodic-ci-openshift-release-main-nightly-4.14-e2e-metal-ipi-sdn-bm"
       }
     },
+    "claude-payload-agent": {
+      "async": true,
+      "optional": true,
+      "multiJobAnalysis": true,
+      "prowJob": {
+        "name": "periodic-ci-openshift-release-main-claude-payload-agent-no-slack"
+      }
+    },
     "fips-scan": {
       "maxRetries": 2,
       "prowJob": {

--- a/core-services/release-controller/_releases/release-ocp-4.15.json
+++ b/core-services/release-controller/_releases/release-ocp-4.15.json
@@ -120,6 +120,14 @@
         "name": "periodic-ci-openshift-hypershift-release-4.15-periodics-e2e-aws-ovn-conformance"
       }
     },
+    "claude-payload-agent": {
+      "async": true,
+      "optional": true,
+      "multiJobAnalysis": true,
+      "prowJob": {
+        "name": "periodic-ci-openshift-release-main-claude-payload-agent-no-slack"
+      }
+    },
     "fips-scan": {
       "maxRetries": 2,
       "prowJob": {

--- a/core-services/release-controller/_releases/release-ocp-4.16.json
+++ b/core-services/release-controller/_releases/release-ocp-4.16.json
@@ -114,6 +114,14 @@
         "name": "periodic-ci-openshift-release-main-nightly-4.16-overall-analysis-all"
       }
     },
+    "claude-payload-agent": {
+      "async": true,
+      "optional": true,
+      "multiJobAnalysis": true,
+      "prowJob": {
+        "name": "periodic-ci-openshift-release-main-claude-payload-agent-no-slack"
+      }
+    },
     "fips-scan": {
       "maxRetries": 1,
       "prowJob": {

--- a/core-services/release-controller/_releases/release-ocp-4.17.json
+++ b/core-services/release-controller/_releases/release-ocp-4.17.json
@@ -114,6 +114,14 @@
         "name": "periodic-ci-openshift-release-main-nightly-4.17-overall-analysis-all"
       }
     },
+    "claude-payload-agent": {
+      "async": true,
+      "optional": true,
+      "multiJobAnalysis": true,
+      "prowJob": {
+        "name": "periodic-ci-openshift-release-main-claude-payload-agent-no-slack"
+      }
+    },
     "fips-scan": {
       "maxRetries": 1,
       "prowJob": {

--- a/core-services/release-controller/_releases/release-ocp-4.18.json
+++ b/core-services/release-controller/_releases/release-ocp-4.18.json
@@ -121,6 +121,14 @@
         "name": "periodic-ci-openshift-release-main-nightly-4.18-overall-analysis-all"
       }
     },
+    "claude-payload-agent": {
+      "async": true,
+      "optional": true,
+      "multiJobAnalysis": true,
+      "prowJob": {
+        "name": "periodic-ci-openshift-release-main-claude-payload-agent-no-slack"
+      }
+    },
     "fips-scan": {
       "maxRetries": 1,
       "prowJob": {

--- a/core-services/release-controller/_releases/release-ocp-4.19.json
+++ b/core-services/release-controller/_releases/release-ocp-4.19.json
@@ -134,6 +134,14 @@
         "name": "periodic-ci-openshift-release-main-nightly-4.19-e2e-rosa-sts-ovn"
       }
     },
+    "claude-payload-agent": {
+      "async": true,
+      "optional": true,
+      "multiJobAnalysis": true,
+      "prowJob": {
+        "name": "periodic-ci-openshift-release-main-claude-payload-agent-no-slack"
+      }
+    },
     "fips-scan": {
       "maxRetries": 1,
       "prowJob": {


### PR DESCRIPTION
## Summary
- Adds the claude payload agent as an async, optional, informing job on OCP 4.12 through 4.19 nightly release controllers
- Uses the no-slack variant, matching the existing 4.20/4.21 configuration
- Priv variants auto-generated with `disabled: true`

## Test plan
- [ ] Verify release controller configs pass validation
- [ ] Payload agent will run on next rejected nightly for each version

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR updates OpenShift release-controller configuration (openshift/release) to add the claude-payload-agent as an informational verification job for nightly release controllers (OCP 4.14 → 4.19). The changes are JSON manifest updates used by the release-controller to drive nightly release validation.

## Practical impact

- Adds an async, optional, informational verification job named "claude-payload-agent" that references the "no-slack" Prow job variant.
- The job is configured with async: true and multiJobAnalysis: true and is optional so it will not block releases.
- Privileged (priv) release-controller manifests receive equivalent entries with disabled: true (these priv entries are auto-generated and remain disabled).
- After these manifests are deployed, the non-privileged job will run on the next rejected nightly for each affected version to provide payload analysis.

## Files / scope changed

Updated release-controller manifests under:
- core-services/release-controller/_releases/release-ocp-4.14.json
- core-services/release-controller/_releases/release-ocp-4.15.json
- core-services/release-controller/_releases/release-ocp-4.16.json
- core-services/release-controller/_releases/release-ocp-4.17.json
- core-services/release-controller/_releases/release-ocp-4.18.json
- core-services/release-controller/_releases/release-ocp-4.19.json
- core-services/release-controller/_releases/priv/release-ocp-4.14.json
- core-services/release-controller/_releases/priv/release-ocp-4.15.json
- core-services/release-controller/_releases/priv/release-ocp-4.16.json
- core-services/release-controller/_releases/priv/release-ocp-4.17.json
- core-services/release-controller/_releases/priv/release-ocp-4.18.json
- core-services/release-controller/_releases/priv/release-ocp-4.19.json

## Configuration details

- Non-priv entries: async: true, optional: true, multiJobAnalysis: true, prowJob.name: "periodic-ci-openshift-release-main-claude-payload-agent-no-slack"
- Priv entries: same as above plus disabled: true, prowJob.name: "periodic-ci-openshift-release-main-claude-payload-agent-no-slack-priv"

## Notes

- Uses the "no-slack" variant to match existing configuration on later branches.
- Changes are limited to release-controller JSON manifests; no runtime code changes.
- Test plan: validate release-controller configs and observe the payload agent run on the next rejected nightly for each affected version.
- PR body indicates it was generated with Claude Code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->