### PR TITLE
[WIP] Provision cluster for OTEL tests

### DIFF
--- a/ci-operator/config/openshift/open-telemetry-opentelemetry-operator/openshift-open-telemetry-opentelemetry-operator-main__upstream-ocp-4.22-amd64.yaml
+++ b/ci-operator/config/openshift/open-telemetry-opentelemetry-operator/openshift-open-telemetry-opentelemetry-operator-main__upstream-ocp-4.22-amd64.yaml
@@ -117,8 +117,7 @@ tests:
             {"name": "amq-streams", "source": "redhat-operators", "channel": "stable", "install_namespace": "openshift-operators", "target_namespaces": ""},
             {"name": "cluster-observability-operator", "source": "redhat-operators", "channel": "stable", "install_namespace": "openshift-operators", "target_namespaces": ""}
         ]
-      SKIP_TESTS: tests/e2e/smoke-ip-families tests/e2e-otel/*aws* tests/e2e-otel/google*
-        tests/e2e-openshift/export-to-cluster-logging-lokistack
+      TIMEOUT: +14 hours
     test:
     - as: install
       cli: latest
@@ -136,7 +135,7 @@ tests:
           cpu: 1000m
           memory: 400Mi
     - ref: install-operators
-    - ref: distributed-tracing-tests-opentelemetry-upstream
+    - ref: wait
     workflow: cucushift-installer-rehearse-gcp-ipi
 zz_generated_metadata:
   branch: main

--- a/ci-operator/config/openshift/open-telemetry-opentelemetry-operator/openshift-open-telemetry-opentelemetry-operator-main__upstream-ocp-4.22-amd64.yaml
+++ b/ci-operator/config/openshift/open-telemetry-opentelemetry-operator/openshift-open-telemetry-opentelemetry-operator-main__upstream-ocp-4.22-amd64.yaml
@@ -7,8 +7,10 @@ base_images:
     name: "4.19"
     namespace: origin
     tag: operator-sdk
-binary_build_commands: export GOTOOLCHAIN=auto && unset GOFLAGS && make manager &&
-  make targetallocator && make operator-opamp-bridge
+binary_build_commands: unset GOFLAGS && mkdir -p bin cmd/operator-opamp-bridge/bin
+  && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/manager_amd64 -trimpath
+  main.go && make targetallocator && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build
+  -o cmd/operator-opamp-bridge/bin/opampbridge_amd64 -trimpath ./cmd/operator-opamp-bridge
 build_root:
   image_stream_tag:
     name: builder

--- a/ci-operator/config/openshift/open-telemetry-opentelemetry-operator/openshift-open-telemetry-opentelemetry-operator-main__upstream-ocp-4.22-amd64.yaml
+++ b/ci-operator/config/openshift/open-telemetry-opentelemetry-operator/openshift-open-telemetry-opentelemetry-operator-main__upstream-ocp-4.22-amd64.yaml
@@ -7,8 +7,8 @@ base_images:
     name: "4.19"
     namespace: origin
     tag: operator-sdk
-binary_build_commands: unset GOFLAGS && make manager && make targetallocator && make
-  operator-opamp-bridge
+binary_build_commands: export GOTOOLCHAIN=auto && unset GOFLAGS && make manager &&
+  make targetallocator && make operator-opamp-bridge
 build_root:
   image_stream_tag:
     name: builder


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR updates the OpenShift CI operator job for the open-telemetry/opentelemetry-operator upstream OCP 4.22 (amd64) pipeline. It changes how CI builds the operator binaries, adjusts the test/job environment, and re-wires the test step sequence used when provisioning clusters and running upstream e2e tests.

Practical changes and impact:
- Build steps:
  - Replaces the previous single make sequence with explicit binary build commands: unsets GOFLAGS, ensures bin directories, cross-builds the operator manager (bin/manager_amd64) and the operator-opamp-bridge (cmd/operator-opamp-bridge/bin/opampbridge_amd64) with CGO disabled for linux/amd64, and runs make targetallocator. This alters how built artifacts are produced and injected into image builds.
  - Image inputs reference those built artifacts (manager_amd64, targetallocator_amd64, opampbridge_amd64) for the operator and test images.
- Test environment and provisioning:
  - The opentelemetry-upstream-tests job uses cluster_profile: gcp-observability.
  - Adds an OPERATORS JSON env that installs three operators (tempo-product, amq-streams, cluster-observability-operator) from redhat-operators into specified namespaces before tests run.
  - Sets TIMEOUT to "+14 hours" (increasing allowed runtime) and removes use of SKIP_TESTS.
- Test step wiring:
  - Keeps an explicit install step that creates the opentelemetry-operator namespace, deploys the bundle via operator-sdk, and waits for the controller-manager to be Available.
  - After install-operators, the job now references the shared "wait" step (ref: wait) instead of the previous distributed-tracing-tests-opentelemetry ref.
  - The job runs under the cucushift-installer-rehearse-gcp-ipi workflow.

Overall effect: CI cluster provisioning and test runs for the upstream OpenTelemetry operator will now build explicit cross-compiled binaries into the images, ensure additional operator dependencies are installed, run with a longer timeout, and use the centralized wait step and gcp-observability profile for provisioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->