### PR TITLE
no-jira: ipi-install-install-aws: extract installer from release image

### DIFF
--- a/ci-operator/step-registry/ipi/install/install/aws/ipi-install-install-aws-commands.sh
+++ b/ci-operator/step-registry/ipi/install/install/aws/ipi-install-install-aws-commands.sh
@@ -390,6 +390,10 @@ elif [[ "${USE_ORIGINAL_OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE:-}" == "true" ]
   ORIGINAL_OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE=$(KUBECONFIG="" oc get is release -o jsonpath='{range .status.tags[*].items[*]}{.image}{" "}{.dockerImageReference}{"\n"}{end}' | grep "^$(echo "$OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE" | sed 's/.*@//')" | awk '{print $2}')
   echo "User want the original payload for cluster install, overwrite OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE to ${ORIGINAL_OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE}"
   export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE=${ORIGINAL_OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE}
+else
+  echo "Extracting openshift-install from release image ${OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE}"
+  oc adm release extract -a "${CLUSTER_PROFILE_DIR}/pull-secret" "${OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE}" --command=openshift-install --to="/tmp" || exit 1
+  export INSTALLER_BINARY="/tmp/openshift-install"
 fi
 
 if [[ -z "$OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE" ]]; then


### PR DESCRIPTION
The step was using the openshift-install binary baked into the upi-installer container image, which does not include changes from installer PRs during rehearsals. Extract the binary from OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE instead, which points to the CI-built release image containing PR changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR modifies the AWS IPI (Infrastructure Provider Integration) cluster installation step in the OpenShift CI infrastructure to extract the `openshift-install` binary from the CI-built release image instead of using a pre-baked binary.

## What Changed

The `ipi-install-install-aws` step in `ci-operator/step-registry/ipi/install/install/aws/ipi-install-install-aws-commands.sh` now dynamically extracts the `openshift-install` binary from `OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE` using `oc adm release extract` when neither a custom override nor the original image flag is specified.

**Key modification:** When `USE_ORIGINAL_OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE` is not set to `"true"`, the script now extracts the binary from the release image to `/tmp/openshift-install` and uses that path for the installation, instead of relying on a baked-in binary from the container image.

## Why It Matters

Previously, the installer binary came from the upi-installer container image, which was static and didn't reflect changes from pull requests being tested during rehearsals. By extracting the binary from the CI-built release image (which `OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE` points to), the step now uses installer versions that include pending PR changes, enabling proper testing and validation of installer modifications during the rehearsal process before they merge to main.

This ensures that AWS cluster installation tests accurately reflect the actual installer code under review rather than using stale, pre-baked binaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->