### PR TITLE
Update ODF release 4.15.28

### DIFF
--- a/core-services/jira-lifecycle-plugin/config.yaml
+++ b/core-services/jira-lifecycle-plugin/config.yaml
@@ -1085,10 +1085,10 @@ orgs:
         target_version: odf-4.14.29
         validate_by_default: true
       release-4.15:
-        target_version: odf-4.15.25
+        target_version: odf-4.15.28
         validate_by_default: true
       release-4.15-compatibility:
-        target_version: odf-4.15.25
+        target_version: odf-4.15.28
         validate_by_default: true
       release-4.16:
         target_version: odf-4.16.26


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR updates the OpenShift CI infrastructure configuration to advance the ODF (Red Hat OpenShift Data Foundation) release target version from 4.15.25 to 4.15.28 for the `red-hat-storage` organization's release branches.

## Infrastructure Impact

The change modifies the Jira lifecycle plugin configuration, which automates issue version tracking in Jira during CI/CD workflows. Specifically, it updates two branch configurations under the `red-hat-storage` organization:
- `release-4.15`: now targets ODF version 4.15.28 (previously 4.15.25)
- `release-4.15-compatibility`: now targets ODF version 4.15.28 (previously 4.15.25)

When code is merged into these release branches, the Jira plugin will automatically reflect this updated ODF release version for issue lifecycle management and version tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->