### PR TITLE
NO-ISSUE: change dpf-hcp-provisioner-operator-e2e-aws-single-replica job to always run

### DIFF
--- a/ci-operator/config/rh-ecosystem-edge/dpf-hcp-provisioner-operator/rh-ecosystem-edge-dpf-hcp-provisioner-operator-main__4.22.yaml
+++ b/ci-operator/config/rh-ecosystem-edge/dpf-hcp-provisioner-operator/rh-ecosystem-edge-dpf-hcp-provisioner-operator-main__4.22.yaml
@@ -23,7 +23,7 @@ resources:
       cpu: 2000m
       memory: 2Gi
 tests:
-- always_run: false
+- always_run: true
   as: dpf-hcp-provisioner-operator-e2e-aws-single-replica
   steps:
     cluster_profile: aws-edge-infra

--- a/ci-operator/jobs/rh-ecosystem-edge/dpf-hcp-provisioner-operator/rh-ecosystem-edge-dpf-hcp-provisioner-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/rh-ecosystem-edge/dpf-hcp-provisioner-operator/rh-ecosystem-edge-dpf-hcp-provisioner-operator-main-presubmits.yaml
@@ -1,7 +1,7 @@
 presubmits:
   rh-ecosystem-edge/dpf-hcp-provisioner-operator:
   - agent: kubernetes
-    always_run: false
+    always_run: true
     branches:
     - ^main$
     - ^main-
@@ -84,7 +84,7 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )(4.22-dpf-hcp-provisioner-operator-e2e-aws-single-replica|remaining-required),?($|\s.*)
+    trigger: (?m)^/test( | .* )4.22-dpf-hcp-provisioner-operator-e2e-aws-single-replica,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:


### PR DESCRIPTION
change dpf-hcp-provisioner-operator-e2e-aws-single-replica job to always run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changes

This PR updates the OpenShift CI configuration for the rh-ecosystem-edge/dpf-hcp-provisioner-operator repository by changing the 4.22 ci-operator test definition so the e2e job always runs.

## Practical impact

The dpf-hcp-provisioner-operator-e2e-aws-single-replica test (configured in ci-operator/config/rh-ecosystem-edge/dpf-hcp-provisioner-operator/rh-ecosystem-edge-dpf-hcp-provisioner-operator-main__4.22.yaml) now has always_run: true. As a result, this AWS single-replica end-to-end test will execute on every CI build of the main branch for the 4.22 variant instead of running only when certain changes trigger it, providing consistent validation of the operator on every build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->