### PR TITLE
[WIP] TEST PR: Add network configuration manifest for PowerVS routingViaHost and ipForwarding

### DIFF
--- a/ci-operator/step-registry/ipi/conf/powervs/ipi-conf-powervs-commands.sh
+++ b/ci-operator/step-registry/ipi/conf/powervs/ipi-conf-powervs-commands.sh
@@ -540,23 +540,6 @@ spec:
 EOF
 fi
 
-
-# This configures the network operator with routingViaHost and ipForwarding
-# before the cluster is created, avoiding pod restarts during installation
-echo "Saving Network patch to shared dir..."
-cat >> "${SHARED_DIR}/manifest_cluster-network-03-config.yml" << EOF
-apiVersion: operator.openshift.io/v1
-kind: Network
-metadata:
-  name: cluster
-spec:
-  defaultNetwork:
-    ovnKubernetesConfig:
-      gatewayConfig:
-        routingViaHost: true
-        ipForwarding: Global
-EOF
-
 echo "OPTIONAL_INSTALL_CONFIG_PARMS=\"${OPTIONAL_INSTALL_CONFIG_PARMS}\""
 read -ra PARAMETERS <<< "${OPTIONAL_INSTALL_CONFIG_PARMS}"
 echo "count = ${#PARAMETERS[*]}"

--- a/ci-operator/step-registry/ipi/conf/powervs/ipi-conf-powervs-commands.sh
+++ b/ci-operator/step-registry/ipi/conf/powervs/ipi-conf-powervs-commands.sh
@@ -540,6 +540,23 @@ spec:
 EOF
 fi
 
+
+# This configures the network operator with routingViaHost and ipForwarding
+# before the cluster is created, avoiding pod restarts during installation
+echo "Saving Network patch to shared dir..."
+cat >> "${SHARED_DIR}/manifest_cluster-network-03-config.yml" << EOF
+apiVersion: operator.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+spec:
+  defaultNetwork:
+    ovnKubernetesConfig:
+      gatewayConfig:
+        routingViaHost: true
+        ipForwarding: Global
+EOF
+
 echo "OPTIONAL_INSTALL_CONFIG_PARMS=\"${OPTIONAL_INSTALL_CONFIG_PARMS}\""
 read -ra PARAMETERS <<< "${OPTIONAL_INSTALL_CONFIG_PARMS}"
 echo "count = ${#PARAMETERS[*]}"

--- a/ci-operator/step-registry/ipi/install/powervs/install/ipi-install-powervs-install-commands.sh
+++ b/ci-operator/step-registry/ipi/install/powervs/install/ipi-install-powervs-install-commands.sh
@@ -814,6 +814,12 @@ fi
 echo "DATE=$(date --utc '+%Y-%m-%dT%H:%M:%S%:z')"
 openshift-install --dir="${dir}" create manifests
 
+
+# This adds routingViaHost and ipForwarding to the existing network config
+# without overwriting the critical CIDR configurations
+echo "Patching network operator config for PowerVS..."
+yq-v4 eval '.spec.defaultNetwork.ovnKubernetesConfig.gatewayConfig.routingViaHost = true | .spec.defaultNetwork.ovnKubernetesConfig.gatewayConfig.ipForwarding = "Global"' -i "${dir}/manifests/cluster-network-03-config.yml"
+
 # copy ccoctl files
 cat > "${dir}/manifests/openshift-cloud-controller-manager-ibm-cloud-credentials-credentials.yaml" << EOF
 apiVersion: v1


### PR DESCRIPTION
## Summary
This is a TEST PR which patches network configuration manifest to enable `routingViaHost` and `ipForwarding: Global` for PowerVS clusters before installation completes, which might prevent  monitor test failures.

## Problem
When applying network configuration changes via `oc patch` after cluster installation, the Cluster Network Operator restarts network pods across all nodes, causing:
- `alert/KubePodNotReady` monitor failures
- `apiserver-incluster-availability` disruptions
- Test flakes during CI runs

