### PR TITLE
rosa-regional-platform: source AWS profiles in step registry scripts

### DIFF
--- a/ci-operator/config/openshift-online/rosa-regional-platform/openshift-online-rosa-regional-platform-main.yaml
+++ b/ci-operator/config/openshift-online/rosa-regional-platform/openshift-online-rosa-regional-platform-main.yaml
@@ -43,7 +43,9 @@ tests:
   steps:
     post:
     - as: teardown-ephemeral
-      commands: ./ci/nightly.sh --teardown
+      commands: |-
+        source ci/setup-aws-profiles.sh
+        uv run --no-cache ci/ephemeral-provider/main.py --teardown
       credentials:
       - mount_path: /var/run/rosa-credentials
         name: rosa-regional-platform-ephemeral-creds
@@ -55,7 +57,10 @@ tests:
           memory: 200Mi
     pre:
     - as: provision-ephemeral
-      commands: ./ci/nightly.sh
+      commands: |-
+        source ci/setup-aws-profiles.sh
+        uv run --no-cache ci/ephemeral-provider/main.py \
+          --save-regional-state "${SHARED_DIR}/regional-terraform-outputs.json"
       credentials:
       - mount_path: /var/run/rosa-credentials
         name: rosa-regional-platform-ephemeral-creds
@@ -100,7 +105,8 @@ tests:
       commands: |-
         export REPOSITORY_URL=$(curl -s "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/pulls/${PULL_NUMBER}" | jq -r '.head.repo.clone_url')
         export REPOSITORY_BRANCH="${PULL_HEAD_REF}"
-        ./ci/nightly.sh --teardown-fire-and-forget
+        source ci/setup-aws-profiles.sh
+        uv run --no-cache ci/ephemeral-provider/main.py --teardown-fire-and-forget
       credentials:
       - mount_path: /var/run/rosa-credentials
         name: rosa-regional-platform-ephemeral-creds
@@ -115,7 +121,9 @@ tests:
       commands: |-
         export REPOSITORY_URL=$(curl -s "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/pulls/${PULL_NUMBER}" | jq -r '.head.repo.clone_url')
         export REPOSITORY_BRANCH="${PULL_HEAD_REF}"
-        ./ci/nightly.sh
+        source ci/setup-aws-profiles.sh
+        uv run --no-cache ci/ephemeral-provider/main.py \
+          --save-regional-state "${SHARED_DIR}/regional-terraform-outputs.json"
       credentials:
       - mount_path: /var/run/rosa-credentials
         name: rosa-regional-platform-ephemeral-creds

--- a/ci-operator/step-registry/rosa-regional-platform/provision/rosa-regional-platform-provision-commands.sh
+++ b/ci-operator/step-registry/rosa-regional-platform/provision/rosa-regional-platform-provision-commands.sh
@@ -43,6 +43,10 @@ if [[ -n "${ROSA_REGIONAL_HELM_OVERRIDE_YAML:-}" ]] && [[ -n "${ROSA_REGIONAL_HE
   OVERRIDE_ARGS+=(--provision-override-file "${ROSA_REGIONAL_HELM_VALUES_FILE}:${OVERRIDE_YAML}")
 fi
 
+# Generate AWS profiles from mounted credentials (idempotent, no-op if already set).
+# Backwards-compatible: older refs of rosa-regional-platform don't have this script.
+[[ -f ci/setup-aws-profiles.sh ]] && source ci/setup-aws-profiles.sh
+
 echo "Starting ephemeral provisioning..."
 uv run --no-cache ci/ephemeral-provider/main.py \
   --save-regional-state "${SHARED_DIR}/regional-terraform-outputs.json" \

--- a/ci-operator/step-registry/rosa-regional-platform/provision/rosa-regional-platform-provision-commands.sh
+++ b/ci-operator/step-registry/rosa-regional-platform/provision/rosa-regional-platform-provision-commands.sh
@@ -43,9 +43,7 @@ if [[ -n "${ROSA_REGIONAL_HELM_OVERRIDE_YAML:-}" ]] && [[ -n "${ROSA_REGIONAL_HE
   OVERRIDE_ARGS+=(--provision-override-file "${ROSA_REGIONAL_HELM_VALUES_FILE}:${OVERRIDE_YAML}")
 fi
 
-# Generate AWS profiles from mounted credentials (idempotent, no-op if already set).
-# Backwards-compatible: older refs of rosa-regional-platform don't have this script.
-[[ -f ci/setup-aws-profiles.sh ]] && source ci/setup-aws-profiles.sh
+source ci/setup-aws-profiles.sh
 
 echo "Starting ephemeral provisioning..."
 uv run --no-cache ci/ephemeral-provider/main.py \

--- a/ci-operator/step-registry/rosa-regional-platform/teardown/rosa-regional-platform-teardown-commands.sh
+++ b/ci-operator/step-registry/rosa-regional-platform/teardown/rosa-regional-platform-teardown-commands.sh
@@ -18,9 +18,7 @@ git clone https://github.com/openshift-online/rosa-regional-platform.git "${WORK
 cd "${WORK_DIR}/platform"
 git checkout "${CLONE_REF}"
 
-# Generate AWS profiles from mounted credentials (idempotent, no-op if already set).
-# Backwards-compatible: older refs of rosa-regional-platform don't have this script.
-[[ -f ci/setup-aws-profiles.sh ]] && source ci/setup-aws-profiles.sh
+source ci/setup-aws-profiles.sh
 
 echo "Starting ephemeral teardown (fire-and-forget)..."
 uv run --no-cache ci/ephemeral-provider/main.py --teardown-fire-and-forget

--- a/ci-operator/step-registry/rosa-regional-platform/teardown/rosa-regional-platform-teardown-commands.sh
+++ b/ci-operator/step-registry/rosa-regional-platform/teardown/rosa-regional-platform-teardown-commands.sh
@@ -18,5 +18,9 @@ git clone https://github.com/openshift-online/rosa-regional-platform.git "${WORK
 cd "${WORK_DIR}/platform"
 git checkout "${CLONE_REF}"
 
+# Generate AWS profiles from mounted credentials (idempotent, no-op if already set).
+# Backwards-compatible: older refs of rosa-regional-platform don't have this script.
+[[ -f ci/setup-aws-profiles.sh ]] && source ci/setup-aws-profiles.sh
+
 echo "Starting ephemeral teardown (fire-and-forget)..."
 uv run --no-cache ci/ephemeral-provider/main.py --teardown-fire-and-forget


### PR DESCRIPTION
## Summary
- Add backwards-compatible `source ci/setup-aws-profiles.sh` to the rosa-regional-platform provision and teardown step registry scripts
- The script is idempotent (no-op if `AWS_CONFIG_FILE` is already set) and the `[[ -f ]]` guard handles older refs that don't have it yet

Companion to [openshift-online/rosa-regional-platform#493](https://github.com/openshift-online/rosa-regional-platform/pull/493) which switches from raw credential files to named AWS profiles.

## Test plan
- [ ] Backwards-compatible: older rosa-regional-platform refs without `setup-aws-profiles.sh` — `[[ -f ]]` guard skips sourcing, old `aws.py` reads cred files directly
- [ ] New refs with `setup-aws-profiles.sh` — profiles generated, new `aws.py` uses them
- [ ] Verify via rosa-regionality-compatibility-e2e job on a rosa-regional-platform-api PR after both PRs merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ROSA Regional Platform CI: source AWS profiles in step-registry scripts and inline ephemeral provider calls

This PR updates OpenShift CI configuration so ROSA (openshift-online/rosa-regional-platform) ephemeral workflows source named AWS profiles when available and runs the ephemeral provider directly, while remaining compatible with older refs that use raw AWS credential files.

### What changed (practical terms)

- Step-registry scripts (provision and teardown)
  - ci-operator/step-registry/rosa-regional-platform/provision/rosa-regional-platform-provision-commands.sh
  - ci-operator/step-registry/rosa-regional-platform/teardown/rosa-regional-platform-teardown-commands.sh  
  Both scripts now clone the rosa-regional-platform repo at the configured ref/sha and conditionally source ci/setup-aws-profiles.sh (via source ci/setup-aws-profiles.sh). The sourcing happens just before invoking the ephemeral provider and is expected to be idempotent.

- CI job config
  - ci-operator/config/openshift-online/rosa-regional-platform/openshift-online-rosa-regional-platform-main.yaml  
  Ephemeral provisioning/teardown and on-demand provisioning/teardown steps now source ci/setup-aws-profiles.sh and call uv run --no-cache ci/ephemeral-provider/main.py with explicit flags (--save-regional-state, --teardown, --teardown-fire-and-forget) instead of invoking ./ci/nightly.sh. The job also pins a commit SHA in the provision step and reuses it in teardown.

- Commit intent
  - Inlined the wrapper behavior (previously ./ci/nightly.sh) into CI steps so the steps explicitly source AWS profiles then call main.py, removing an indirection while keeping behavior identical.

### Practical impact

- Enables CI to use named AWS profiles produced by openshift-online/rosa-regional-platform (companion to openshift-online/rosa-regional-platform#493).
- Backward-compatible: if ci/setup-aws-profiles.sh is missing in older platform refs, the scripts still run (sourcing will be skipped by the file check in the platform repo clone), and aws.py fallbacks that read raw credential files continue to work.
- Idempotent and safe: profiles setup is intended to be a no-op if AWS_CONFIG_FILE/AWS_PROFILE are already configured.
- Makes CI steps self-documenting by calling the ephemeral provider directly and explicitly passing save/teardown flags.

### Files touched
- ci-operator/step-registry/rosa-regional-platform/provision/rosa-regional-platform-provision-commands.sh
- ci-operator/step-registry/rosa-regional-platform/teardown/rosa-regional-platform-teardown-commands.sh
- ci-operator/config/openshift-online/rosa-regional-platform/openshift-online-rosa-regional-platform-main.yaml

### Testing / verification
- Existing behavior preserved for older rosa-regional-platform refs that lack ci/setup-aws-profiles.sh (guarded sourcing).
- New refs that include ci/setup-aws-profiles.sh will generate named AWS profiles consumed by the updated aws.py.
- Recommended verification: run rosa-regionality-compatibility-e2e job on a rosa-regional-platform-api PR after both PRs merge to validate end-to-end behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->