### PR TITLE
increase 4.22-e2e-metal-ipi-serial-ovn-dualstack timeout

### DIFF
--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22.yaml
@@ -321,7 +321,7 @@ tests:
       enable:
       - observers-resource-watch
     workflow: baremetalds-e2e-serial-ovn-dualstack
-  timeout: 5h0m0s
+  timeout: 5h30m0s
 - as: e2e-metal-ipi-ovn-upgrade
   capabilities:
   - intranet


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This pull request increases the timeout for the OpenShift 4.22 nightly CI job that tests bare metal deployments with OVN networking and dual-stack (IPv4 + IPv6) support.

**Impact:**
The `e2e-metal-ipi-serial-ovn-dualstack` test job in the OpenShift 4.22 nightly CI pipeline will now be allowed up to 5 hours and 30 minutes to complete, an increase of 30 minutes from the previous 5-hour timeout. This job runs weekly on Equinix bare metal infrastructure and tests OpenShift cluster provisioning and functionality on physical hardware with OVN networking enabled for both IPv4 and IPv6 traffic.

This timeout adjustment helps prevent test failures due to timeout conditions, allowing the job more time to complete its serial test execution on bare metal environments where provisioning and test execution can be more time-intensive than cloud-based alternatives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->