### PR TITLE
WIP: Add workaround for creating LVM catalogsource

### DIFF
--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.19__amd64-nightly.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.19__amd64-nightly.yaml
@@ -2127,8 +2127,10 @@ tests:
     env:
       E2E_RUN_TAGS: '@fio'
       FILTERS_ADDITIONAL: ""
+      LVM_CATALOG_SOURCE: redhat-operators
       LVM_OPERATOR_SUB_CHANNEL: stable-4.19
       LVM_OPERATOR_SUB_SOURCE: lvm-catalogsource
+      REDHAT_OPERATORS_INDEX_TAG: v4.19
       TEST_FILTERS: ~HyperShiftMGMT&;~DEPRECATED&
       TEST_SCENARIOS: File_Integrity_Operator
       TEST_TIMEOUT: "30"

--- a/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.21__amd64-nightly.yaml
+++ b/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.21__amd64-nightly.yaml
@@ -2791,8 +2791,10 @@ tests:
     env:
       E2E_RUN_TAGS: '@fio'
       FILTERS_ADDITIONAL: ""
+      LVM_CATALOG_SOURCE: redhat-operators
       LVM_OPERATOR_SUB_CHANNEL: stable-4.21
       LVM_OPERATOR_SUB_SOURCE: lvm-catalogsource
+      REDHAT_OPERATORS_INDEX_TAG: v4.21
       TEST_FILTERS: ~HyperShiftMGMT&;~DEPRECATED&
       TEST_PARALLEL: "3"
       TEST_SCENARIOS: File_Integrity_Operator


### PR DESCRIPTION
DO NOT MERGE, please

Our jobs failed because the v4.19 and v4.21 tags were deleted or expired from quay.io/redhat-user-workloads/logical-volume-manag-tenant/lvm-operator-catalog. 

This change, created by Cursor should overcome this problem by creating a catalogsource. I am hestitant if this is going to work, but here we are.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# WIP: Add workaround for creating LVM catalogsource

## Overview
This PR adds a temporary workaround to fix failing LVM operator tests in OpenShift CI for versions 4.19 and 4.21. The tests were failing because the v4.19 and v4.21 container image tags had been deleted or expired from `quay.io/redhat-user-workloads/logical-volume-manag-tenant/lvm-operator-catalog`.

## Changes
The PR modifies CI test configurations for the private OpenShift test suite by adding environment variables to the `metal-ds-ipi-ovn-lvms-f999-file-integrity` test job:

- **4.19 nightly tests**: Added `LVM_CATALOG_SOURCE: redhat-operators` and `REDHAT_OPERATORS_INDEX_TAG: v4.19`
- **4.21 nightly tests**: Added `LVM_CATALOG_SOURCE: redhat-operators` and `REDHAT_OPERATORS_INDEX_TAG: v4.21`

These variables redirect the LVM operator to use the Red Hat Operators catalog instead of the deleted custom catalog, allowing the tests to proceed with a known good operator index version.

## Status
This is a draft PR marked "DO NOT MERGE". The author has expressed uncertainty about whether this workaround will be effective as a permanent solution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->