### PR TITLE
WIP: Migrate power CI to use cis.ibm.net

### DIFF
--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.22.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.22.yaml
@@ -575,7 +575,7 @@ tests:
     workflow: openshift-e2e-libvirt-vpn-fips
 - as: ocp-e2e-ovn-remote-s2s-libvirt-ppc64le
   capabilities:
-  - power-s2s-dns
+  - intranet
   cron: 0 7 * * 6
   steps:
     cluster_profile: libvirt-ppc64le-s2s
@@ -587,6 +587,7 @@ tests:
       DOMAIN_MEMORY: "34816"
       ETCD_DISK_SPEED: slow
       TEST_TYPE: conformance-parallel
+      USE_EXTERNAL_DNS: "true"
       USE_RAMFS: "true"
     workflow: openshift-e2e-libvirt-upi
 - as: ocp-e2e-ovn-remote-s2s-libvirt-multi-p-p

--- a/ci-operator/jobs/openshift/multiarch/openshift-multiarch-main-periodics.yaml
+++ b/ci-operator/jobs/openshift/multiarch/openshift-multiarch-main-periodics.yaml
@@ -49091,7 +49091,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
+    capability/intranet: intranet
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.22


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Migrate Power CI to external DNS (cis.ibm.net)

This PR updates the multiarch OpenShift CI configuration (ci-operator config for the multiarch nightly 4.22 jobs) to move Power-based testing toward using the external IBM DNS (cis.ibm.net).

Practical changes:
- A POWER ppc64le nightly test (ocp-e2e-ovn-remote-s2s-libvirt-ppc64le) is reconfigured to stop requiring the legacy power-specific DNS capability and use the intranet capability instead.
- The test environment now enables external DNS by setting USE_EXTERNAL_DNS: "true" (so jobs will use cis.ibm.net / the unified external DNS for Power testing).
- Affects CI for the multiarch OpenShift nightly 4.22 jobs in this repository (openshift/release) — specifically the OpenShift multiarch CI job definitions that run POWER (ppc64le) e2e tests.

Intent: shift Power CI away from the prior custom Power DNS setup to the shared external DNS (cis.ibm.net) while preserving existing nightly test execution on POWER hosts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->