### PR TITLE
Remove pj-rehearse-plugin-alpha from user-fork pluginconfigs

### DIFF
--- a/core-services/prow/02_config/Prucek/release/_pluginconfig.yaml
+++ b/core-services/prow/02_config/Prucek/release/_pluginconfig.yaml
@@ -32,12 +32,6 @@ external_plugins:
     - issue_comment
     - pull_request
     name: jira-lifecycle-plugin
-  - endpoint: http://pj-rehearse-plugin-alpha
-    events:
-    - issue_comment
-    - pull_request
-    - push
-    name: pj-rehearse-plugin-alpha
   - endpoint: http://ai-plugin
     events:
     - issue_comment

--- a/core-services/prow/02_config/smg247/release/_pluginconfig.yaml
+++ b/core-services/prow/02_config/smg247/release/_pluginconfig.yaml
@@ -32,12 +32,6 @@ external_plugins:
     - issue_comment
     - pull_request
     name: jira-lifecycle-plugin
-  - endpoint: http://pj-rehearse-plugin-alpha
-    events:
-    - issue_comment
-    - pull_request
-    - push
-    name: pj-rehearse-plugin-alpha
   - endpoint: http://multi-pr-prow-plugin
     events:
     - issue_comment


### PR DESCRIPTION
`pj-rehearse-alpha` are consuming too much memory affecting other important services to wait/pending schedule

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR removes the `pj-rehearse-plugin-alpha` external plugin configuration from Prow's plugin settings for two user-fork repositories: `Prucek/release` and `smg247/release`.

The pj-rehearse tool is used within OpenShift CI infrastructure to enable developers to test CI job configuration changes before merging them to the release repository. By commenting commands like `/test pj-rehearse`, developers can simulate how jobs would execute with proposed configuration changes.

The PR specifically removes the alpha version of this plugin endpoint from both repositories' external plugin configurations. Along with these removals, the configurations were updated to add alternative plugin integrations (ai-plugin for Prucek/release and multi-pr-prow-plugin for smg247/release), indicating a transition away from the alpha version of the pj-rehearse plugin for these user-fork environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->