### PR TITLE
Adding OSSM 3.4 build

### DIFF
--- a/ci-operator/config/openshift/openshift-docs/openshift-openshift-docs-service-mesh-docs-3.4.yaml
+++ b/ci-operator/config/openshift/openshift-docs/openshift-openshift-docs-service-mesh-docs-3.4.yaml
@@ -1,0 +1,38 @@
+build_root:
+  image_stream_tag:
+    name: openshift-docs-asciidoc
+    namespace: ocp
+    tag: latest
+  use_build_cache: true
+resources:
+  '*':
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 400m
+      memory: 800Mi
+tests:
+- as: validate-asciidoc
+  steps:
+    env:
+      DISTROS: openshift-service-mesh
+      PREVIEW_SITE: ocpdocs-pr
+    test:
+    - ref: openshift-docs-build-docs
+    - ref: openshift-docs-preview-comment-pages
+    - ref: openshift-docs-asciidoctor
+    - ref: openshift-docs-lint-topicmaps
+    - ref: openshift-docs-jira-links
+    - ref: openshift-docs-vale-review
+- as: validate-portal
+  steps:
+    env:
+      BUILD: build_for_portal.py
+      DISTROS: openshift-service-mesh
+      VERSION: "3.4"
+    test:
+    - ref: openshift-docs-portal
+zz_generated_metadata:
+  branch: service-mesh-docs-3.4
+  org: openshift
+  repo: openshift-docs

--- a/ci-operator/jobs/openshift/openshift-docs/openshift-openshift-docs-service-mesh-docs-3.4-presubmits.yaml
+++ b/ci-operator/jobs/openshift/openshift-docs/openshift-openshift-docs-service-mesh-docs-3.4-presubmits.yaml
@@ -1,0 +1,148 @@
+presubmits:
+  openshift/openshift-docs:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^service-mesh-docs-3\.4$
+    - ^service-mesh-docs-3\.4-
+    cluster: build01
+    context: ci/prow/validate-asciidoc
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-openshift-docs-service-mesh-docs-3.4-validate-asciidoc
+    rerun_command: /test validate-asciidoc
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --target=validate-asciidoc
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )validate-asciidoc,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^service-mesh-docs-3\.4$
+    - ^service-mesh-docs-3\.4-
+    cluster: build01
+    context: ci/prow/validate-portal
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-openshift-docs-service-mesh-docs-3.4-validate-portal
+    rerun_command: /test validate-portal
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --target=validate-portal
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )validate-portal,?($|\s.*)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR adds OpenShift CI configuration for building and validating the OpenShift Service Mesh (OSSM) 3.4 documentation in the `openshift-docs` repository.

The new CI configuration defines the build pipeline for the `service-mesh-docs-3.4` branch with:

**Build Configuration:**
- Uses the `openshift-docs-asciidoc` image stream for documentation compilation
- Enables build caching and sets resource limits (4Gi memory limit, 400m CPU / 800Mi memory requests)

**Test Pipelines:**
- **validate-asciidoc**: Runs comprehensive documentation validation including building docs, generating preview comments, asciidoctor validation, topic map linting, JIRA link checking, and Vale style review for the Service Mesh distribution
- **validate-portal**: Builds the portal version specifically for OSSM 3.4

This enables automated testing of documentation changes for the Service Mesh 3.4 release on every pull request to that documentation branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->