### PR TITLE
USHIFT-6976: Add close-duplicate rebase PRs to MicroShift CI Doctor

### DIFF
--- a/ci-operator/step-registry/openshift/edge-tooling/microshift-ci/doctor/openshift-edge-tooling-microshift-ci-doctor-commands.sh
+++ b/ci-operator/step-registry/openshift/edge-tooling/microshift-ci/doctor/openshift-edge-tooling-microshift-ci-doctor-commands.sh
@@ -256,9 +256,17 @@ timeout 600 claude \
     --verbose 2>&1 | tee "${CLAUDE_BUG_CREATION_LOG}"
 echo "Bug creation for failed jobs completed"
 
-# After the analysis, attempt to restart failed rebase PRs tests. If the
-# restarted tests complete successfully, the PR will be automatically
-# approved next time the analysis runs.
+# Close duplicate rebase PRs before attempting to restart failed test jobs.
+echo "Running automatic closing of duplicate rebase PRs..."
+"${PLUGIN_DIR}/scripts/prow-jobs-for-pull-requests.sh" \
+    --mode close-duplicates \
+    --execute \
+    --author 'microshift-rebase-script[bot]' \
+    --filter 'NO-ISSUE: rebase-release'
+echo "Automatic closing of duplicate rebase PRs completed"
+
+# Now attempt to restart failed rebase PRs tests. If the restarted tests
+# complete successfully, the PR will be automatically merged.
 echo "Running automatic restart of failed rebase PRs tests..."
 "${PLUGIN_DIR}/scripts/prow-jobs-for-pull-requests.sh" \
     --mode restart \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds functionality to the MicroShift CI Doctor to automatically close duplicate rebase pull requests. The change enhances the CI workflow by introducing a new step that runs before restarting failed rebase PR tests.

## Changes

**Modified file:**
- `ci-operator/step-registry/openshift/edge-tooling/microshift-ci/doctor/openshift-edge-tooling-microshift-ci-doctor-commands.sh`

The script now executes an additional cleanup phase that closes duplicate rebase PRs authored by the `microshift-rebase-script[bot]` using the `prow-jobs-for-pull-requests.sh` utility in `--mode close-duplicates`. This step runs after the "create bugs for failed jobs" dry-run and before restarting the failed rebase PR tests, filtering PRs by the `NO-ISSUE: rebase-release` label.

This change removes redundant PR artifacts that accumulate during the rebase process, improving the cleanliness of the repository and CI workflow.

Lines changed: +11/-3

<!-- end of auto-generated comment: release notes by coderabbit.ai -->