### PR TITLE
Remove aws-splat-quota-slice

### DIFF
--- a/core-services/prow/02_config/_boskos.yaml
+++ b/core-services/prow/02_config/_boskos.yaml
@@ -2749,19 +2749,6 @@ resources:
   state: free
   type: aws-serverless-quota-slice
 - names:
-  - us-east-1--aws-splat-quota-slice-0
-  - us-east-1--aws-splat-quota-slice-1
-  - us-east-1--aws-splat-quota-slice-2
-  - us-east-1--aws-splat-quota-slice-3
-  - us-east-1--aws-splat-quota-slice-4
-  - us-west-2--aws-splat-quota-slice-0
-  - us-west-2--aws-splat-quota-slice-1
-  - us-west-2--aws-splat-quota-slice-2
-  - us-west-2--aws-splat-quota-slice-3
-  - us-west-2--aws-splat-quota-slice-4
-  state: free
-  type: aws-splat-quota-slice
-- names:
   - us-east-1--aws-stackrox-quota-slice-00
   - us-east-1--aws-stackrox-quota-slice-01
   - us-east-1--aws-stackrox-quota-slice-02

--- a/core-services/prow/02_config/generate-boskos.py
+++ b/core-services/prow/02_config/generate-boskos.py
@@ -90,10 +90,6 @@ CONFIG = {
         'us-east-1': 10,
         'us-west-2': 10,
     },
-    'aws-splat-quota-slice': {
-        'us-east-1': 5,
-        'us-west-2': 5
-    },
     'aws-perfscale-qe-quota-slice': {
         'us-west-2': 20,
     },


### PR DESCRIPTION
Follow up after https://github.com/openshift/ci-tools/pull/5175

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR removes the aws-splat-quota-slice quota-slice from the OpenShift CI Boskos configuration generation. It updates the generator and the generated _boskos.yaml so Boskos will no longer create or manage resources under the aws-splat-quota-slice type.

## Scope / affected area

- Repository: openshift/release — CI/infrastructure configuration for OpenShift CI (Boskos resource generation).
- Affects Boskos resource provisioning used by CI jobs that consume AWS quota-slice resources.

## What changed (practical terms)

- core-services/prow/02_config/generate-boskos.py
  - Removed the CONFIG entry for "aws-splat-quota-slice". As a result generate-boskos.py will no longer emit Boskos resource entries for that type.
- core-services/prow/02_config/_boskos.yaml (generated)
  - The entire aws-splat-quota-slice resource group was removed from the generated Boskos config.
  - The aws-serverless-quota-slice names list was extended to include an additional name in us-east-2 (us-east-2--aws-serverless-quota-slice-4).

## Impact

- CI jobs relying on Boskos-managed resources of type aws-splat-quota-slice will no longer find those resources; they must be migrated to a different quota-slice type or otherwise handled.
- This is a follow-up to changes in ci-tools (reference: ci-tools PR 5175) that removed or renamed the resource type upstream; the release repo is being aligned to that change.

## Notes / reviewer feedback

- A reviewer observed a failing rehearsal job and linked the prow log, noting that `make boskos-config` appears to be missing from whatever workflow ran the tests. The commit message ("make boskos-config") indicates intent to (re)run or ensure the boskos config generation step; ensure release jobs or CI workflows that regenerate _boskos.yaml call `make boskos-config` as appropriate before validating generated artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->