### PR TITLE
ARO-HCP: Add CI image builds and ACR push for mgmt-agent and kube-applier

### DIFF
--- a/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main.yaml
+++ b/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main.yaml
@@ -75,6 +75,24 @@ images:
       value: ci-sha
     - name: ARO_HCP_IMAGE_TAG
       value: ci-test-img
+    dockerfile_path: mgmt-agent/Dockerfile
+    to: aro-hcp-mgmt-agent
+  - build_args:
+    - name: PLATFORM
+      value: linux/amd64
+    - name: ARO_HCP_REVISION
+      value: ci-sha
+    - name: ARO_HCP_IMAGE_TAG
+      value: ci-test-img
+    dockerfile_path: kube-applier/Dockerfile
+    to: aro-hcp-kube-applier
+  - build_args:
+    - name: PLATFORM
+      value: linux/amd64
+    - name: ARO_HCP_REVISION
+      value: ci-sha
+    - name: ARO_HCP_IMAGE_TAG
+      value: ci-test-img
     dockerfile_path: hcp-recovery/Dockerfile
     from: src
     to: aro-hcp-hcp-recovery

--- a/ci-operator/jobs/Azure/ARO-HCP/Azure-ARO-HCP-main-postsubmits.yaml
+++ b/ci-operator/jobs/Azure/ARO-HCP/Azure-ARO-HCP-main-postsubmits.yaml
@@ -77,6 +77,8 @@ postsubmits:
       - frontend/Dockerfile
       - hcp-recovery/Dockerfile
       - image-sync/oc-mirror/Dockerfile
+      - kube-applier/Dockerfile
+      - mgmt-agent/Dockerfile
       - sessiongate/Dockerfile
       - test/Containerfile.e2e
       - tooling/aro-hcp-exporter/Dockerfile
@@ -405,6 +407,8 @@ postsubmits:
       - frontend/Dockerfile
       - hcp-recovery/Dockerfile
       - image-sync/oc-mirror/Dockerfile
+      - kube-applier/Dockerfile
+      - mgmt-agent/Dockerfile
       - sessiongate/Dockerfile
       - test/Containerfile.e2e
       - tooling/aro-hcp-exporter/Dockerfile
@@ -491,6 +495,8 @@ postsubmits:
       - frontend/Dockerfile
       - hcp-recovery/Dockerfile
       - image-sync/oc-mirror/Dockerfile
+      - kube-applier/Dockerfile
+      - mgmt-agent/Dockerfile
       - sessiongate/Dockerfile
       - test/Containerfile.e2e
       - tooling/aro-hcp-exporter/Dockerfile
@@ -560,6 +566,8 @@ postsubmits:
       - frontend/Dockerfile
       - hcp-recovery/Dockerfile
       - image-sync/oc-mirror/Dockerfile
+      - kube-applier/Dockerfile
+      - mgmt-agent/Dockerfile
       - sessiongate/Dockerfile
       - test/Containerfile.e2e
       - tooling/aro-hcp-exporter/Dockerfile

--- a/ci-operator/jobs/Azure/ARO-HCP/Azure-ARO-HCP-main-presubmits.yaml
+++ b/ci-operator/jobs/Azure/ARO-HCP/Azure-ARO-HCP-main-presubmits.yaml
@@ -15,6 +15,8 @@ presubmits:
       - frontend/Dockerfile
       - hcp-recovery/Dockerfile
       - image-sync/oc-mirror/Dockerfile
+      - kube-applier/Dockerfile
+      - mgmt-agent/Dockerfile
       - sessiongate/Dockerfile
       - test/Containerfile.e2e
       - tooling/aro-hcp-exporter/Dockerfile
@@ -157,6 +159,8 @@ presubmits:
       - frontend/Dockerfile
       - hcp-recovery/Dockerfile
       - image-sync/oc-mirror/Dockerfile
+      - kube-applier/Dockerfile
+      - mgmt-agent/Dockerfile
       - sessiongate/Dockerfile
       - test/Containerfile.e2e
       - tooling/aro-hcp-exporter/Dockerfile
@@ -239,6 +243,8 @@ presubmits:
       - frontend/Dockerfile
       - hcp-recovery/Dockerfile
       - image-sync/oc-mirror/Dockerfile
+      - kube-applier/Dockerfile
+      - mgmt-agent/Dockerfile
       - sessiongate/Dockerfile
       - test/Containerfile.e2e
       - tooling/aro-hcp-exporter/Dockerfile
@@ -378,6 +384,8 @@ presubmits:
       - frontend/Dockerfile
       - hcp-recovery/Dockerfile
       - image-sync/oc-mirror/Dockerfile
+      - kube-applier/Dockerfile
+      - mgmt-agent/Dockerfile
       - sessiongate/Dockerfile
       - test/Containerfile.e2e
       - tooling/aro-hcp-exporter/Dockerfile
@@ -518,6 +526,8 @@ presubmits:
       - frontend/Dockerfile
       - hcp-recovery/Dockerfile
       - image-sync/oc-mirror/Dockerfile
+      - kube-applier/Dockerfile
+      - mgmt-agent/Dockerfile
       - sessiongate/Dockerfile
       - test/Containerfile.e2e
       - tooling/aro-hcp-exporter/Dockerfile
@@ -582,6 +592,8 @@ presubmits:
       - frontend/Dockerfile
       - hcp-recovery/Dockerfile
       - image-sync/oc-mirror/Dockerfile
+      - kube-applier/Dockerfile
+      - mgmt-agent/Dockerfile
       - sessiongate/Dockerfile
       - test/Containerfile.e2e
       - tooling/aro-hcp-exporter/Dockerfile
@@ -664,6 +676,8 @@ presubmits:
       - frontend/Dockerfile
       - hcp-recovery/Dockerfile
       - image-sync/oc-mirror/Dockerfile
+      - kube-applier/Dockerfile
+      - mgmt-agent/Dockerfile
       - sessiongate/Dockerfile
       - test/Containerfile.e2e
       - tooling/aro-hcp-exporter/Dockerfile
@@ -754,6 +768,8 @@ presubmits:
       - frontend/Dockerfile
       - hcp-recovery/Dockerfile
       - image-sync/oc-mirror/Dockerfile
+      - kube-applier/Dockerfile
+      - mgmt-agent/Dockerfile
       - sessiongate/Dockerfile
       - test/Containerfile.e2e
       - tooling/aro-hcp-exporter/Dockerfile
@@ -836,6 +852,8 @@ presubmits:
       - frontend/Dockerfile
       - hcp-recovery/Dockerfile
       - image-sync/oc-mirror/Dockerfile
+      - kube-applier/Dockerfile
+      - mgmt-agent/Dockerfile
       - sessiongate/Dockerfile
       - test/Containerfile.e2e
       - tooling/aro-hcp-exporter/Dockerfile
@@ -918,6 +936,8 @@ presubmits:
       - frontend/Dockerfile
       - hcp-recovery/Dockerfile
       - image-sync/oc-mirror/Dockerfile
+      - kube-applier/Dockerfile
+      - mgmt-agent/Dockerfile
       - sessiongate/Dockerfile
       - test/Containerfile.e2e
       - tooling/aro-hcp-exporter/Dockerfile
@@ -1000,6 +1020,8 @@ presubmits:
       - frontend/Dockerfile
       - hcp-recovery/Dockerfile
       - image-sync/oc-mirror/Dockerfile
+      - kube-applier/Dockerfile
+      - mgmt-agent/Dockerfile
       - sessiongate/Dockerfile
       - test/Containerfile.e2e
       - tooling/aro-hcp-exporter/Dockerfile
@@ -1081,6 +1103,8 @@ presubmits:
       - frontend/Dockerfile
       - hcp-recovery/Dockerfile
       - image-sync/oc-mirror/Dockerfile
+      - kube-applier/Dockerfile
+      - mgmt-agent/Dockerfile
       - sessiongate/Dockerfile
       - test/Containerfile.e2e
       - tooling/aro-hcp-exporter/Dockerfile
@@ -1163,6 +1187,8 @@ presubmits:
       - frontend/Dockerfile
       - hcp-recovery/Dockerfile
       - image-sync/oc-mirror/Dockerfile
+      - kube-applier/Dockerfile
+      - mgmt-agent/Dockerfile
       - sessiongate/Dockerfile
       - test/Containerfile.e2e
       - tooling/aro-hcp-exporter/Dockerfile
@@ -1245,6 +1271,8 @@ presubmits:
       - frontend/Dockerfile
       - hcp-recovery/Dockerfile
       - image-sync/oc-mirror/Dockerfile
+      - kube-applier/Dockerfile
+      - mgmt-agent/Dockerfile
       - sessiongate/Dockerfile
       - test/Containerfile.e2e
       - tooling/aro-hcp-exporter/Dockerfile
@@ -1327,6 +1355,8 @@ presubmits:
       - frontend/Dockerfile
       - hcp-recovery/Dockerfile
       - image-sync/oc-mirror/Dockerfile
+      - kube-applier/Dockerfile
+      - mgmt-agent/Dockerfile
       - sessiongate/Dockerfile
       - test/Containerfile.e2e
       - tooling/aro-hcp-exporter/Dockerfile
@@ -1417,6 +1447,8 @@ presubmits:
       - frontend/Dockerfile
       - hcp-recovery/Dockerfile
       - image-sync/oc-mirror/Dockerfile
+      - kube-applier/Dockerfile
+      - mgmt-agent/Dockerfile
       - sessiongate/Dockerfile
       - test/Containerfile.e2e
       - tooling/aro-hcp-exporter/Dockerfile
@@ -1499,6 +1531,8 @@ presubmits:
       - frontend/Dockerfile
       - hcp-recovery/Dockerfile
       - image-sync/oc-mirror/Dockerfile
+      - kube-applier/Dockerfile
+      - mgmt-agent/Dockerfile
       - sessiongate/Dockerfile
       - test/Containerfile.e2e
       - tooling/aro-hcp-exporter/Dockerfile
@@ -1589,6 +1623,8 @@ presubmits:
       - frontend/Dockerfile
       - hcp-recovery/Dockerfile
       - image-sync/oc-mirror/Dockerfile
+      - kube-applier/Dockerfile
+      - mgmt-agent/Dockerfile
       - sessiongate/Dockerfile
       - test/Containerfile.e2e
       - tooling/aro-hcp-exporter/Dockerfile
@@ -1671,6 +1707,8 @@ presubmits:
       - frontend/Dockerfile
       - hcp-recovery/Dockerfile
       - image-sync/oc-mirror/Dockerfile
+      - kube-applier/Dockerfile
+      - mgmt-agent/Dockerfile
       - sessiongate/Dockerfile
       - test/Containerfile.e2e
       - tooling/aro-hcp-exporter/Dockerfile
@@ -1753,6 +1791,8 @@ presubmits:
       - frontend/Dockerfile
       - hcp-recovery/Dockerfile
       - image-sync/oc-mirror/Dockerfile
+      - kube-applier/Dockerfile
+      - mgmt-agent/Dockerfile
       - sessiongate/Dockerfile
       - test/Containerfile.e2e
       - tooling/aro-hcp-exporter/Dockerfile
@@ -1843,6 +1883,8 @@ presubmits:
       - frontend/Dockerfile
       - hcp-recovery/Dockerfile
       - image-sync/oc-mirror/Dockerfile
+      - kube-applier/Dockerfile
+      - mgmt-agent/Dockerfile
       - sessiongate/Dockerfile
       - test/Containerfile.e2e
       - tooling/aro-hcp-exporter/Dockerfile
@@ -1925,6 +1967,8 @@ presubmits:
       - frontend/Dockerfile
       - hcp-recovery/Dockerfile
       - image-sync/oc-mirror/Dockerfile
+      - kube-applier/Dockerfile
+      - mgmt-agent/Dockerfile
       - sessiongate/Dockerfile
       - test/Containerfile.e2e
       - tooling/aro-hcp-exporter/Dockerfile
@@ -2015,6 +2059,8 @@ presubmits:
       - frontend/Dockerfile
       - hcp-recovery/Dockerfile
       - image-sync/oc-mirror/Dockerfile
+      - kube-applier/Dockerfile
+      - mgmt-agent/Dockerfile
       - sessiongate/Dockerfile
       - test/Containerfile.e2e
       - tooling/aro-hcp-exporter/Dockerfile
@@ -2097,6 +2143,8 @@ presubmits:
       - frontend/Dockerfile
       - hcp-recovery/Dockerfile
       - image-sync/oc-mirror/Dockerfile
+      - kube-applier/Dockerfile
+      - mgmt-agent/Dockerfile
       - sessiongate/Dockerfile
       - test/Containerfile.e2e
       - tooling/aro-hcp-exporter/Dockerfile
@@ -2178,6 +2226,8 @@ presubmits:
       - frontend/Dockerfile
       - hcp-recovery/Dockerfile
       - image-sync/oc-mirror/Dockerfile
+      - kube-applier/Dockerfile
+      - mgmt-agent/Dockerfile
       - sessiongate/Dockerfile
       - test/Containerfile.e2e
       - tooling/aro-hcp-exporter/Dockerfile

--- a/ci-operator/step-registry/aro-hcp/cspr/services-svc/aro-hcp-cspr-services-svc-commands.sh
+++ b/ci-operator/step-registry/aro-hcp/cspr/services-svc/aro-hcp-cspr-services-svc-commands.sh
@@ -47,11 +47,21 @@ SESSIONGATE_REPOSITORY=$(echo "${SESSIONGATE_IMAGE}" | cut -d'@' -f1 | cut -d '/
 SESSIONGATE_SOURCE_REGISTRY=$(echo "${SESSIONGATE_IMAGE}" | cut -d'@' -f1 | cut -d '/' -f1)
 echo "source registry set to ${SESSIONGATE_SOURCE_REGISTRY} and repo ${SESSIONGATE_REPOSITORY} for SessionGate Image"
 
+MGMT_AGENT_DIGEST=$(echo "${MGMT_AGENT_IMAGE}" | cut -d'@' -f2)
+MGMT_AGENT_REPOSITORY=$(echo "${MGMT_AGENT_IMAGE}" | cut -d'@' -f1 | cut -d '/' -f2-)
+MGMT_AGENT_SOURCE_REGISTRY=$(echo "${MGMT_AGENT_IMAGE}" | cut -d'@' -f1 | cut -d '/' -f1)
+echo "source registry set to ${MGMT_AGENT_SOURCE_REGISTRY} and repo ${MGMT_AGENT_REPOSITORY} for Mgmt Agent Image"
+
+KUBE_APPLIER_DIGEST=$(echo "${KUBE_APPLIER_IMAGE}" | cut -d'@' -f2)
+KUBE_APPLIER_REPOSITORY=$(echo "${KUBE_APPLIER_IMAGE}" | cut -d'@' -f1 | cut -d '/' -f2-)
+KUBE_APPLIER_SOURCE_REGISTRY=$(echo "${KUBE_APPLIER_IMAGE}" | cut -d'@' -f1 | cut -d '/' -f1)
+echo "source registry set to ${KUBE_APPLIER_SOURCE_REGISTRY} and repo ${KUBE_APPLIER_REPOSITORY} for Kube Applier Image"
+
 # Set up registries that require oc login for ImageMirror to pull from CI registry
 if [[ -n "${USE_OC_LOGIN_REGISTRIES}" ]]; then
-    USE_OC_LOGIN_REGISTRIES="${USE_OC_LOGIN_REGISTRIES} ${BACKEND_SOURCE_REGISTRY} ${FRONTEND_SOURCE_REGISTRY} ${ADMIN_API_SOURCE_REGISTRY} ${SESSIONGATE_SOURCE_REGISTRY}"
+    USE_OC_LOGIN_REGISTRIES="${USE_OC_LOGIN_REGISTRIES} ${BACKEND_SOURCE_REGISTRY} ${FRONTEND_SOURCE_REGISTRY} ${ADMIN_API_SOURCE_REGISTRY} ${SESSIONGATE_SOURCE_REGISTRY} ${MGMT_AGENT_SOURCE_REGISTRY} ${KUBE_APPLIER_SOURCE_REGISTRY}"
 else
-    USE_OC_LOGIN_REGISTRIES="${BACKEND_SOURCE_REGISTRY} ${FRONTEND_SOURCE_REGISTRY} ${ADMIN_API_SOURCE_REGISTRY} ${SESSIONGATE_SOURCE_REGISTRY}"
+    USE_OC_LOGIN_REGISTRIES="${BACKEND_SOURCE_REGISTRY} ${FRONTEND_SOURCE_REGISTRY} ${ADMIN_API_SOURCE_REGISTRY} ${SESSIONGATE_SOURCE_REGISTRY} ${MGMT_AGENT_SOURCE_REGISTRY} ${KUBE_APPLIER_SOURCE_REGISTRY}"
 fi
 echo "USE_OC_LOGIN_REGISTRIES set to: ${USE_OC_LOGIN_REGISTRIES}"
 export USE_OC_LOGIN_REGISTRIES
@@ -73,7 +83,13 @@ yq eval -n "
   .clouds.dev.environments.${DEPLOY_ENV}.defaults.adminApi.image.digest = \"${ADMIN_API_DIGEST}\" |
   .clouds.dev.environments.${DEPLOY_ENV}.defaults.sessiongate.image.registry = \"${SESSIONGATE_SOURCE_REGISTRY}\" |
   .clouds.dev.environments.${DEPLOY_ENV}.defaults.sessiongate.image.repository = \"${SESSIONGATE_REPOSITORY}\" |
-  .clouds.dev.environments.${DEPLOY_ENV}.defaults.sessiongate.image.digest = \"${SESSIONGATE_DIGEST}\"
+  .clouds.dev.environments.${DEPLOY_ENV}.defaults.sessiongate.image.digest = \"${SESSIONGATE_DIGEST}\" |
+  .clouds.dev.environments.${DEPLOY_ENV}.defaults.mgmtAgent.image.registry = \"${MGMT_AGENT_SOURCE_REGISTRY}\" |
+  .clouds.dev.environments.${DEPLOY_ENV}.defaults.mgmtAgent.image.repository = \"${MGMT_AGENT_REPOSITORY}\" |
+  .clouds.dev.environments.${DEPLOY_ENV}.defaults.mgmtAgent.image.digest = \"${MGMT_AGENT_DIGEST}\" |
+  .clouds.dev.environments.${DEPLOY_ENV}.defaults.kubeApplier.image.registry = \"${KUBE_APPLIER_SOURCE_REGISTRY}\" |
+  .clouds.dev.environments.${DEPLOY_ENV}.defaults.kubeApplier.image.repository = \"${KUBE_APPLIER_REPOSITORY}\" |
+  .clouds.dev.environments.${DEPLOY_ENV}.defaults.kubeApplier.image.digest = \"${KUBE_APPLIER_DIGEST}\"
 " > "${OVERRIDE_CONFIG_FILE}"
 echo "Created override config at: ${OVERRIDE_CONFIG_FILE}"
 cat "${OVERRIDE_CONFIG_FILE}"

--- a/ci-operator/step-registry/aro-hcp/cspr/services-svc/aro-hcp-cspr-services-svc-ref.yaml
+++ b/ci-operator/step-registry/aro-hcp/cspr/services-svc/aro-hcp-cspr-services-svc-ref.yaml
@@ -27,6 +27,10 @@ ref:
     env: ADMIN_API_IMAGE
   - name: "pipeline:aro-hcp-sessiongate"
     env: SESSIONGATE_IMAGE
+  - name: "pipeline:aro-hcp-mgmt-agent"
+    env: MGMT_AGENT_IMAGE
+  - name: "pipeline:aro-hcp-kube-applier"
+    env: KUBE_APPLIER_IMAGE
   resources:
     requests:
       cpu: "1"

--- a/ci-operator/step-registry/aro-hcp/images-push/aro-hcp-images-push-commands.sh
+++ b/ci-operator/step-registry/aro-hcp/images-push/aro-hcp-images-push-commands.sh
@@ -27,8 +27,10 @@ ADMIN_API_REPO=$(yq '.adminApi.image.repository' "${CONFIG_FILE}")
 SESSIONGATE_REPO=$(yq '.sessiongate.image.repository' "${CONFIG_FILE}")
 EXPORTER_REPO=$(yq '.customExporter.image.repository' "${CONFIG_FILE}")
 OC_MIRROR_REPO=$(yq '.imageSync.ocMirror.image.repository' "${CONFIG_FILE}")
+MGMT_AGENT_REPO=$(yq '.mgmtAgent.image.repository' "${CONFIG_FILE}")
+KUBE_APPLIER_REPO=$(yq '.kubeApplier.image.repository' "${CONFIG_FILE}")
 echo "Target ACR: ${ACR_URL}"
-echo "Repos: backend=${BACKEND_REPO}, frontend=${FRONTEND_REPO}, admin-api=${ADMIN_API_REPO}, sessiongate=${SESSIONGATE_REPO}, exporter=${EXPORTER_REPO}, oc-mirror=${OC_MIRROR_REPO}"
+echo "Repos: backend=${BACKEND_REPO}, frontend=${FRONTEND_REPO}, admin-api=${ADMIN_API_REPO}, sessiongate=${SESSIONGATE_REPO}, exporter=${EXPORTER_REPO}, oc-mirror=${OC_MIRROR_REPO}, mgmt-agent=${MGMT_AGENT_REPO}, kube-applier=${KUBE_APPLIER_REPO}"
 
 # Authenticate to CI registry
 export XDG_RUNTIME_DIR="/tmp/run"
@@ -76,5 +78,11 @@ retry oc image mirror "${ARO_HCP_OC_MIRROR}" "${ACR_URL}/${OC_MIRROR_REPO}:${IMA
 
 echo "Pushing oc-mirror latest: ${ARO_HCP_OC_MIRROR} -> ${ACR_URL}/${OC_MIRROR_REPO}:latest"
 retry oc image mirror "${ARO_HCP_OC_MIRROR}" "${ACR_URL}/${OC_MIRROR_REPO}:latest"
+
+echo "Pushing mgmt-agent: ${ARO_HCP_MGMT_AGENT} -> ${ACR_URL}/${MGMT_AGENT_REPO}:${IMAGE_TAG}"
+retry oc image mirror "${ARO_HCP_MGMT_AGENT}" "${ACR_URL}/${MGMT_AGENT_REPO}:${IMAGE_TAG}"
+
+echo "Pushing kube-applier: ${ARO_HCP_KUBE_APPLIER} -> ${ACR_URL}/${KUBE_APPLIER_REPO}:${IMAGE_TAG}"
+retry oc image mirror "${ARO_HCP_KUBE_APPLIER}" "${ACR_URL}/${KUBE_APPLIER_REPO}:${IMAGE_TAG}"
 
 echo "All images pushed successfully."

--- a/ci-operator/step-registry/aro-hcp/images-push/aro-hcp-images-push-ref.yaml
+++ b/ci-operator/step-registry/aro-hcp/images-push/aro-hcp-images-push-ref.yaml
@@ -29,6 +29,10 @@ ref:
     env: ARO_HCP_OC_MIRROR
   - name: aro-hcp-exporter
     env: ARO_HCP_EXPORTER
+  - name: aro-hcp-mgmt-agent
+    env: ARO_HCP_MGMT_AGENT
+  - name: aro-hcp-kube-applier
+    env: ARO_HCP_KUBE_APPLIER
   resources:
     requests:
       cpu: "1"

--- a/ci-operator/step-registry/aro-hcp/provision/environment/aro-hcp-provision-environment-commands.sh
+++ b/ci-operator/step-registry/aro-hcp/provision/environment/aro-hcp-provision-environment-commands.sh
@@ -43,11 +43,21 @@ HCP_RECOVERY_REPOSITORY=$(echo ${HCP_RECOVERY_IMAGE} | cut -d'@' -f1 | cut -d '/
 HCP_RECOVERY_SOURCE_REGISTRY=$(echo ${HCP_RECOVERY_IMAGE} | cut -d'@' -f1 | cut -d '/' -f1)
 echo "source registry set to ${HCP_RECOVERY_SOURCE_REGISTRY} and repo ${HCP_RECOVERY_REPOSITORY} for HCP Recovery Image"
 
+MGMT_AGENT_DIGEST=$(echo ${MGMT_AGENT_IMAGE} | cut -d'@' -f2)
+MGMT_AGENT_REPOSITORY=$(echo ${MGMT_AGENT_IMAGE} | cut -d'@' -f1 | cut -d '/' -f2-)
+MGMT_AGENT_SOURCE_REGISTRY=$(echo ${MGMT_AGENT_IMAGE} | cut -d'@' -f1 | cut -d '/' -f1)
+echo "source registry set to ${MGMT_AGENT_SOURCE_REGISTRY} and repo ${MGMT_AGENT_REPOSITORY} for Mgmt Agent Image"
+
+KUBE_APPLIER_DIGEST=$(echo ${KUBE_APPLIER_IMAGE} | cut -d'@' -f2)
+KUBE_APPLIER_REPOSITORY=$(echo ${KUBE_APPLIER_IMAGE} | cut -d'@' -f1 | cut -d '/' -f2-)
+KUBE_APPLIER_SOURCE_REGISTRY=$(echo ${KUBE_APPLIER_IMAGE} | cut -d'@' -f1 | cut -d '/' -f1)
+echo "source registry set to ${KUBE_APPLIER_SOURCE_REGISTRY} and repo ${KUBE_APPLIER_REPOSITORY} for Kube Applier Image"
+
 # Set up registries that require oc login - append backend and frontend registries
 if [[ -n "${USE_OC_LOGIN_REGISTRIES}" ]]; then
-    USE_OC_LOGIN_REGISTRIES="${USE_OC_LOGIN_REGISTRIES} ${BACKEND_SOURCE_REGISTRY} ${FRONTEND_SOURCE_REGISTRY} ${ADMIN_API_SOURCE_REGISTRY} ${SESSIONGATE_SOURCE_REGISTRY} ${HCP_RECOVERY_SOURCE_REGISTRY}"
+    USE_OC_LOGIN_REGISTRIES="${USE_OC_LOGIN_REGISTRIES} ${BACKEND_SOURCE_REGISTRY} ${FRONTEND_SOURCE_REGISTRY} ${ADMIN_API_SOURCE_REGISTRY} ${SESSIONGATE_SOURCE_REGISTRY} ${HCP_RECOVERY_SOURCE_REGISTRY} ${MGMT_AGENT_SOURCE_REGISTRY} ${KUBE_APPLIER_SOURCE_REGISTRY}"
 else
-    USE_OC_LOGIN_REGISTRIES="${BACKEND_SOURCE_REGISTRY} ${FRONTEND_SOURCE_REGISTRY} ${ADMIN_API_SOURCE_REGISTRY} ${SESSIONGATE_SOURCE_REGISTRY} ${HCP_RECOVERY_SOURCE_REGISTRY}"
+    USE_OC_LOGIN_REGISTRIES="${BACKEND_SOURCE_REGISTRY} ${FRONTEND_SOURCE_REGISTRY} ${ADMIN_API_SOURCE_REGISTRY} ${SESSIONGATE_SOURCE_REGISTRY} ${HCP_RECOVERY_SOURCE_REGISTRY} ${MGMT_AGENT_SOURCE_REGISTRY} ${KUBE_APPLIER_SOURCE_REGISTRY}"
 fi
 echo "USE_OC_LOGIN_REGISTRIES set to: ${USE_OC_LOGIN_REGISTRIES}"
 
@@ -77,6 +87,12 @@ yq eval -n "
   .clouds.dev.environments.${DEPLOY_ENV}.defaults.hcpRecovery.image.registry = \"${HCP_RECOVERY_SOURCE_REGISTRY}\" |
   .clouds.dev.environments.${DEPLOY_ENV}.defaults.hcpRecovery.image.repository = \"${HCP_RECOVERY_REPOSITORY}\" |
   .clouds.dev.environments.${DEPLOY_ENV}.defaults.hcpRecovery.image.digest = \"${HCP_RECOVERY_DIGEST}\" |
+  .clouds.dev.environments.${DEPLOY_ENV}.defaults.mgmtAgent.image.registry = \"${MGMT_AGENT_SOURCE_REGISTRY}\" |
+  .clouds.dev.environments.${DEPLOY_ENV}.defaults.mgmtAgent.image.repository = \"${MGMT_AGENT_REPOSITORY}\" |
+  .clouds.dev.environments.${DEPLOY_ENV}.defaults.mgmtAgent.image.digest = \"${MGMT_AGENT_DIGEST}\" |
+  .clouds.dev.environments.${DEPLOY_ENV}.defaults.kubeApplier.image.registry = \"${KUBE_APPLIER_SOURCE_REGISTRY}\" |
+  .clouds.dev.environments.${DEPLOY_ENV}.defaults.kubeApplier.image.repository = \"${KUBE_APPLIER_REPOSITORY}\" |
+  .clouds.dev.environments.${DEPLOY_ENV}.defaults.kubeApplier.image.digest = \"${KUBE_APPLIER_DIGEST}\" |
   .clouds.dev.environments.${DEPLOY_ENV}.defaults.svc.aks.systemAgentPool.vmSize = \"Standard_D4ds_v6\" |
   .clouds.dev.environments.${DEPLOY_ENV}.defaults.svc.aks.userAgentPool.vmSize = \"Standard_D8ds_v6\" |
   .clouds.dev.environments.${DEPLOY_ENV}.defaults.svc.aks.infraAgentPool.vmSize = \"Standard_D4ds_v6\" |

--- a/ci-operator/step-registry/aro-hcp/provision/environment/aro-hcp-provision-environment-ref.yaml
+++ b/ci-operator/step-registry/aro-hcp/provision/environment/aro-hcp-provision-environment-ref.yaml
@@ -41,5 +41,9 @@ ref:
     env: SESSIONGATE_IMAGE
   - name: "pipeline:aro-hcp-hcp-recovery"
     env: HCP_RECOVERY_IMAGE
+  - name: "pipeline:aro-hcp-mgmt-agent"
+    env: MGMT_AGENT_IMAGE
+  - name: "pipeline:aro-hcp-kube-applier"
+    env: KUBE_APPLIER_IMAGE
   documentation: |-
     Create ARO HCP development environment.


### PR DESCRIPTION
Companion to https://github.com/Azure/ARO-HCP/pull/5234

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Updates OpenShift CI configuration in this repository for the Azure/ARO-HCP pipeline to build two additional images (mgmt-agent and kube-applier) and to publish + consume those images end-to-end through the pipeline, image-push, provisioning, and CSPR service steps.

## What this changes practically

- ci-operator build config (ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main.yaml)
  - Adds two new ci-operator image items:
    - aro-hcp-mgmt-agent (mgmt-agent/Dockerfile)
    - aro-hcp-kube-applier (kube-applier/Dockerfile)
  - Both builds set PLATFORM=linux/amd64 and CI build args (ARO_HCP_REVISION=ci-sha, ARO_HCP_IMAGE_TAG=ci-test-img).

- Image push step (step-registry/aro-hcp/images-push)
  - images-push commands now resolve mgmtAgent and kubeApplier repository names from the rendered config and include them in the "Repos:" log.
  - The script mirrors/pushes the pipeline-built aro-hcp-mgmt-agent and aro-hcp-kube-applier into the target ACR (oc image mirror) with the same retry logic used for other images.
  - images-push ref adds pipeline dependencies for aro-hcp-mgmt-agent and aro-hcp-kube-applier (env: ARO_HCP_MGMT_AGENT, ARO_HCP_KUBE_APPLIER).

- Pipeline dependency wiring (cspr & provision steps)
  - cspr/services-svc and provision/environment step refs now declare pipeline dependencies for pipeline:aro-hcp-mgmt-agent and pipeline:aro-hcp-kube-applier, exposing MGMT_AGENT_IMAGE and KUBE_APPLIER_IMAGE to downstream steps.

- Provisioning / ImageMirror and override generation
  - cspr/services-svc and provision/environment commands parse MGMT_AGENT_IMAGE and KUBE_APPLIER_IMAGE (IMAGE@sha) into registry/repository/digest components.
  - Both scripts append the mgmt-agent and kube-applier source registries into USE_OC_LOGIN_REGISTRIES (when present) so ImageMirror can authenticate to pull from CI registries.
  - The generated override configs populate clouds.dev.environments.${DEPLOY_ENV}.defaults.mgmtAgent.image.* and ...kubeApplier.image.* (registry/repository/digest) so ImageMirror/pipeline overrides include these components.

## Files / areas touched (high level)
- ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main.yaml
- ci-operator/step-registry/aro-hcp/images-push/{aro-hcp-images-push-commands.sh,aro-hcp-images-push-ref.yaml}
- ci-operator/step-registry/aro-hcp/cspr/services-svc/{aro-hcp-cspr-services-svc-commands.sh,aro-hcp-cspr-services-svc-ref.yaml}
- ci-operator/step-registry/aro-hcp/provision/environment/{aro-hcp-provision-environment-commands.sh,aro-hcp-provision-environment-ref.yaml}

## Impact & review focus

- Ensure environment/dependency variable names are consistent and correctly wired:
  - Pipeline dependency envs: ARO_HCP_MGMT_AGENT / ARO_HCP_KUBE_APPLIER (images-push ref)
  - Downstream image coordinates: MGMT_AGENT_IMAGE / KUBE_APPLIER_IMAGE (cspr/provision refs)
- Verify parsing of IMAGE@sha values yields correct registry/repository/digest parts for ImageMirror and override generation.
- Validate USE_OC_LOGIN_REGISTRIES composition so oc registry login is performed for the required CI source registries.
- Confirm ACR auth and oc image mirror usage in images-push (token acquisition, oc registry login, retry behavior) matches security/operational expectations.
- Confirm generated override YAML structure (clouds.dev.environments.<env>.defaults.{mgmtAgent,kubeApplier}.image.*) matches the pipelines that consume those overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->