### PR TITLE
Updated odf-4.20.12 release

### DIFF
--- a/core-services/jira-lifecycle-plugin/config.yaml
+++ b/core-services/jira-lifecycle-plugin/config.yaml
@@ -1115,10 +1115,10 @@ orgs:
         target_version: odf-4.19.16
         validate_by_default: true
       release-4.20:
-        target_version: odf-4.20.11
+        target_version: odf-4.20.12
         validate_by_default: true
       release-4.20-compatibility:
-        target_version: odf-4.20.11
+        target_version: odf-4.20.12
         validate_by_default: true
       release-4.21:
         target_version: odf-4.21.3


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR updates the JIRA lifecycle plugin configuration to track the ODF 4.20.12 release in the OpenShift CI infrastructure.

Specifically, the target version is updated for the OpenShift Data Foundation (ODF) project's `release-4.20` and `release-4.20-compatibility` branches from `odf-4.20.11` to `odf-4.20.12`. The JIRA lifecycle plugin uses this target version to automatically set the resolved version in JIRA issues when code is merged to these branches.

This change ensures that issues fixed in the ODF 4.20.12 release are properly tracked and marked in the project's issue management system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->