### PR TITLE
RHDH: Fix AKS spot VM creation by switching to Standard_D4as_v5

### DIFF
--- a/ci-operator/step-registry/redhat-developer/rhdh/aks/mapt/create/redhat-developer-rhdh-aks-mapt-create-commands.sh
+++ b/ci-operator/step-registry/redhat-developer/rhdh/aks/mapt/create/redhat-developer-rhdh-aks-mapt-create-commands.sh
@@ -63,7 +63,7 @@ mapt azure aks create \
   --backed-url "azblob://${AZURE_STORAGE_BLOB}/${CORRELATE_MAPT}" \
   --conn-details-output "${SHARED_DIR}" \
   --version "${MAPT_KUBERNETES_VERSION}" \
-  --vmsize "Standard_D4as_v6" \
+  --vmsize "Standard_D4as_v5" \
   --spot \
   --spot-eviction-tolerance "low" \
   --spot-excluded-regions "centralindia" \


### PR DESCRIPTION
## Summary

- Switch AKS MAPT VM size from `Standard_D4as_v6` to `Standard_D4as_v5` to fix spot VM selection failure

`Standard_D4as_v5` has the same specs (4 vCPUs, 16 GB RAM, AMD-based) for a comparable price.

Failure log: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_release/79129/rehearse-79129-periodic-ci-redhat-developer-rhdh-main-e2e-aks-helm-nightly/2054133366562754560/artifacts/e2e-aks-helm-nightly/redhat-developer-rhdh-aks-mapt-create/build-log.txt

Jira: https://redhat.atlassian.net/browse/RHIDP-13580