### PR TITLE
Fix NTO cleanup only related clusters

### DIFF
--- a/ci-operator/step-registry/telcov10n/functional/compute-nrop/ocp-deploy/telcov10n-functional-compute-nrop-ocp-deploy-commands.sh
+++ b/ci-operator/step-registry/telcov10n/functional/compute-nrop/ocp-deploy/telcov10n-functional-compute-nrop-ocp-deploy-commands.sh
@@ -37,6 +37,7 @@ cd /eco-ci-cd
 
 echo "Clean old clusters"
 ansible-playbook ./playbooks/compute/delete_old_clusters.yml \
+    -e "cluster_name=${CLUSTER_NAME}" \
     -i ./inventories/ocp-deployment/build-inventory.py
 
 EXTRA_VARS="kubeconfig=/home/telcov10n/project/generated/${CLUSTER_NAME}/auth/kubeconfig"

--- a/ci-operator/step-registry/telcov10n/functional/compute-nto/cleanup-old-clusters/telcov10n-functional-compute-nto-cleanup-old-clusters-commands.sh
+++ b/ci-operator/step-registry/telcov10n/functional/compute-nto/cleanup-old-clusters/telcov10n-functional-compute-nto-cleanup-old-clusters-commands.sh
@@ -69,6 +69,7 @@ main() {
 
     echo "Clean old clusters"
     ansible-playbook ./playbooks/compute/delete_old_clusters.yml \
+        -e "cluster_name=${CLUSTER_NAME}" \
         -i ./inventories/ocp-deployment/build-inventory.py
 }
 

--- a/ci-operator/step-registry/telcov10n/functional/compute-nto/ocp-deploy/telcov10n-functional-compute-nto-ocp-deploy-commands.sh
+++ b/ci-operator/step-registry/telcov10n/functional/compute-nto/ocp-deploy/telcov10n-functional-compute-nto-ocp-deploy-commands.sh
@@ -72,6 +72,7 @@ main() {
 
     echo "Clean old clusters"
     ansible-playbook ./playbooks/compute/delete_old_clusters.yml \
+        -e "cluster_name=${CLUSTER_NAME}" \
         -i ./inventories/ocp-deployment/build-inventory.py
 
     echo "Deploy OCP for compute-nto testing"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes the NTO (Node Tuning Operator) cluster cleanup configuration in the OpenShift CI infrastructure to ensure that old cluster cleanup operations only target the specific cluster being deployed, rather than all clusters.

### What Changed

The `telcov10n-functional-compute-nto-ocp-deploy-commands.sh` step registry command script was modified to pass the `cluster_name` variable as an extra argument to the Ansible playbook that cleans up old clusters. Specifically, the `delete_old_clusters.yml` playbook invocation now receives `-e "cluster_name=${CLUSTER_NAME}"`, which restricts the cleanup operation to only remove resources associated with the specific cluster being provisioned for the test run.

### Impact

This prevents unintended cleanup of clusters unrelated to the current NTO functional test deployment, ensuring that the cluster cleanup operation is scoped appropriately and only affects the relevant cluster resources. This improves the reliability and isolation of the Telco v10n (telecommunications v10n) functional testing infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->