### PR TITLE
Add user_secrets_target_clusters cluster group

### DIFF
--- a/core-services/ci-secret-bootstrap/gsm-config.yaml
+++ b/core-services/ci-secret-bootstrap/gsm-config.yaml
@@ -63,6 +63,23 @@ cluster_groups:
     - build10
     - build11
     - build12
+  user_secrets_target_clusters:
+    - app.ci
+    - build01
+    - build02
+    - build03
+    - build04
+    - build05
+    - build06
+    - build07
+    - build08
+    - build09
+    - build10
+    - build11
+    - build12
+    - core-ci
+    - hosted-mgmt
+    - vsphere02
 
 dptp_collection: test-platform-infra
 


### PR DESCRIPTION
This is present in _config.yaml. It's used for the secrets in Vault that have the secretsync/* metadata which cause those secrets to be synced to our clusters, but don't have a secret entry in _config.yaml. To be able to migrate those secrets from Vault, and create bundles for them in gsm-config.yaml, this `user_secrets_target_clusters` needs to be added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds a new `user_secrets_target_clusters` cluster group to the Google Secret Manager (GSM) configuration, enabling support for Vault-stored secrets marked with `secretsync/*` metadata that don't have explicit entries in the legacy `_config.yaml` file.

## Changes

**Modified:** `core-services/ci-secret-bootstrap/gsm-config.yaml`

Added a new cluster group defining the target clusters for user secrets syncing: `app.ci`, `build01`–`build12`, `core-ci`, `hosted-mgmt`, and `vsphere02`. This cluster group aligns with the OpenShift CI infrastructure's managed cluster topology.

## Practical Impact

This change enables the secret bootstrap tooling to migrate and manage Vault secrets that are tagged for synchronization across the build farm and managed clusters. Previously, such secrets without a corresponding configuration entry would have been skipped. With this cluster group defined, the system can now create bundles for these user-managed secrets in the GSM configuration, facilitating a smoother transition from the legacy Vault-based secret management to the newer Google Secret Manager system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->