### PR TITLE
[DO NOT MERGE] Rerun job for 4.15.64 multiarch failures

### DIFF
--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.15-upgrade-from-nightly-4.14.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.15-upgrade-from-nightly-4.14.yaml
@@ -188,7 +188,7 @@ tests:
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance
     workflow: openshift-upgrade-gcp-heterogeneous
-- as: ocp-ovn-remote-libvirt-s390x
+- as: ocp-ovn-remote-libvirt-s390x-test
   capabilities:
   - sshd-bastion
   cron: 0 2 * * 5
@@ -203,7 +203,7 @@ tests:
       NODE_TUNING: "true"
       TEST_TYPE: upgrade
     workflow: openshift-e2e-libvirt
-- as: ocp-ovn-remote-s2s-libvirt-ppc64le
+- as: ocp-ovn-remote-s2s-libvirt-ppc64le-test
   capabilities:
   - power-s2s-dns
   cron: 0 2 * * 5

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.15.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.15.yaml
@@ -380,7 +380,7 @@ tests:
       OCP_ARCH: arm64
       TEST_SUITE: upgrade-conformance
     workflow: openshift-upgrade-azure
-- as: ocp-e2e-ovn-remote-libvirt-s390x
+- as: ocp-e2e-ovn-remote-libvirt-s390x-test
   capabilities:
   - sshd-bastion
   cron: 0 0 * * 5
@@ -462,7 +462,7 @@ tests:
       BRANCH: "4.15"
       TEST_TYPE: conformance-serial
     workflow: openshift-e2e-libvirt
-- as: ocp-fips-ovn-remote-libvirt-s390x
+- as: ocp-fips-ovn-remote-libvirt-s390x-test
   capabilities:
   - sshd-bastion
   cron: 0 10 * * 5
@@ -477,7 +477,7 @@ tests:
       NODE_TUNING: "true"
       TEST_TYPE: conformance-parallel
     workflow: openshift-e2e-libvirt-fips
-- as: ocp-e2e-ovn-remote-s2s-libvirt-ppc64le
+- as: ocp-e2e-ovn-remote-s2s-libvirt-ppc64le-test
   capabilities:
   - power-s2s-dns
   cron: 0 6 * * 5
@@ -518,7 +518,7 @@ tests:
       BRANCH: "4.15"
       TEST_TYPE: conformance-serial
     workflow: openshift-e2e-libvirt
-- as: ocp-fips-ovn-remote-s2s-libvirt-ppc64le
+- as: ocp-fips-ovn-remote-s2s-libvirt-ppc64le-test
   capabilities:
   - power-s2s-dns
   cron: 0 10 * * 5

--- a/ci-operator/jobs/openshift/multiarch/openshift-multiarch-main-periodics.yaml
+++ b/ci-operator/jobs/openshift/multiarch/openshift-multiarch-main-periodics.yaml
@@ -14434,7 +14434,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.15"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-multiarch-main-nightly-4.15-ocp-e2e-ovn-remote-libvirt-s390x
+  name: periodic-ci-openshift-multiarch-main-nightly-4.15-ocp-e2e-ovn-remote-libvirt-s390x-test
   spec:
     containers:
     - args:
@@ -14443,7 +14443,7 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=ocp-e2e-ovn-remote-libvirt-s390x
+      - --target=ocp-e2e-ovn-remote-libvirt-s390x-test
       - --variant=nightly-4.15
       command:
       - ci-operator
@@ -14602,7 +14602,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.15"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-multiarch-main-nightly-4.15-ocp-e2e-ovn-remote-s2s-libvirt-ppc64le
+  name: periodic-ci-openshift-multiarch-main-nightly-4.15-ocp-e2e-ovn-remote-s2s-libvirt-ppc64le-test
   spec:
     containers:
     - args:
@@ -14611,7 +14611,7 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=ocp-e2e-ovn-remote-s2s-libvirt-ppc64le
+      - --target=ocp-e2e-ovn-remote-s2s-libvirt-ppc64le-test
       - --variant=nightly-4.15
       command:
       - ci-operator
@@ -15601,7 +15601,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.15"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-multiarch-main-nightly-4.15-ocp-fips-ovn-remote-libvirt-s390x
+  name: periodic-ci-openshift-multiarch-main-nightly-4.15-ocp-fips-ovn-remote-libvirt-s390x-test
   spec:
     containers:
     - args:
@@ -15610,7 +15610,7 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=ocp-fips-ovn-remote-libvirt-s390x
+      - --target=ocp-fips-ovn-remote-libvirt-s390x-test
       - --variant=nightly-4.15
       command:
       - ci-operator
@@ -15685,7 +15685,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.15"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-multiarch-main-nightly-4.15-ocp-fips-ovn-remote-s2s-libvirt-ppc64le
+  name: periodic-ci-openshift-multiarch-main-nightly-4.15-ocp-fips-ovn-remote-s2s-libvirt-ppc64le-test
   spec:
     containers:
     - args:
@@ -15694,7 +15694,7 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=ocp-fips-ovn-remote-s2s-libvirt-ppc64le
+      - --target=ocp-fips-ovn-remote-s2s-libvirt-ppc64le-test
       - --variant=nightly-4.15
       command:
       - ci-operator
@@ -16852,7 +16852,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.15"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-multiarch-main-nightly-4.15-upgrade-from-nightly-4.14-ocp-ovn-remote-libvirt-s390x
+  name: periodic-ci-openshift-multiarch-main-nightly-4.15-upgrade-from-nightly-4.14-ocp-ovn-remote-libvirt-s390x-test
   spec:
     containers:
     - args:
@@ -16861,7 +16861,7 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=ocp-ovn-remote-libvirt-s390x
+      - --target=ocp-ovn-remote-libvirt-s390x-test
       - --variant=nightly-4.15-upgrade-from-nightly-4.14
       command:
       - ci-operator
@@ -16936,7 +16936,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.15"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-multiarch-main-nightly-4.15-upgrade-from-nightly-4.14-ocp-ovn-remote-s2s-libvirt-ppc64le
+  name: periodic-ci-openshift-multiarch-main-nightly-4.15-upgrade-from-nightly-4.14-ocp-ovn-remote-s2s-libvirt-ppc64le-test
   spec:
     containers:
     - args:
@@ -16945,7 +16945,7 @@ periodics:
       - --lease-server-credentials-file=/etc/boskos/credentials
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
-      - --target=ocp-ovn-remote-s2s-libvirt-ppc64le
+      - --target=ocp-ovn-remote-s2s-libvirt-ppc64le-test
       - --variant=nightly-4.15-upgrade-from-nightly-4.14
       command:
       - ci-operator


### PR DESCRIPTION
This PR renames multiarch CI test jobs for OpenShift 4.15 to facilitate re-running tests that previously failed for the 4.15.64 release on non-x86 architectures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR updates OpenShift's multiarch CI configurations for OpenShift 4.15 by renaming several test job variants to include a `-test` suffix. These changes affect the remote libvirt testing infrastructure for s390x (IBM System Z) and ppc64le (IBM Power) architectures.

### Changes Made

**File: `openshift-multiarch-main__nightly-4.15-upgrade-from-nightly-4.14.yaml`**
- Renamed upgrade test job for s390x: `ocp-ovn-remote-libvirt-s390x` → `ocp-ovn-remote-libvirt-s390x-test`
- Renamed upgrade test job for ppc64le: `ocp-ovn-remote-s2s-libvirt-ppc64le` → `ocp-ovn-remote-s2s-libvirt-ppc64le-test`

**File: `openshift-multiarch-main__nightly-4.15.yaml`**
- Renamed e2e test job for s390x: `ocp-e2e-ovn-remote-libvirt-s390x` → `ocp-e2e-ovn-remote-libvirt-s390x-test`
- Renamed FIPS test job for s390x: `ocp-fips-ovn-remote-libvirt-s390x` → `ocp-fips-ovn-remote-libvirt-s390x-test`
- Renamed e2e test job for ppc64le: `ocp-e2e-ovn-remote-s2s-libvirt-ppc64le` → `ocp-e2e-ovn-remote-s2s-libvirt-ppc64le-test`
- Renamed FIPS test job for ppc64le: `ocp-fips-ovn-remote-s2s-libvirt-ppc64le` → `ocp-fips-ovn-remote-s2s-libvirt-ppc64le-test`

All renamed jobs retain their original schedules, cluster profiles, environment variables, and test workflows. The changes target multiarch test infrastructure in libvirt environments for both upgrade scenarios and standard nightly conformance testing.

**Note:** This PR is marked "[DO NOT MERGE]" and appears to be a temporary solution for addressing failures in the 4.15.64 multiarch release by rerunning the affected tests with renamed job variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->