### PR TITLE
fix(core-ci): prevent highmem MachineSets from starving CI node scale-up

### DIFF
--- a/clusters/core-ci/machineset/worker-highmem.yaml
+++ b/clusters/core-ci/machineset/worker-highmem.yaml
@@ -6,7 +6,7 @@ metadata:
   name: master-64cvr-worker-highmem-aarch64-us-east-1a
   namespace: openshift-machine-api
 spec:
-  replicas: 0
+  replicas: 5
   selector:
     matchLabels:
       machine.openshift.io/cluster-api-cluster: master-64cvr
@@ -24,6 +24,8 @@ spec:
         value: worker-highmem
         effect: NoSchedule
       metadata:
+        annotations:
+          cluster-autoscaler.kubernetes.io/scale-down-disabled: "true"
         labels:
           node-role.kubernetes.io/worker-highmem: worker-highmem
       providerSpec:
@@ -65,19 +67,6 @@ spec:
           userDataSecret:
             name: worker-user-data-managed
 ---
-apiVersion: autoscaling.openshift.io/v1beta1
-kind: MachineAutoscaler
-metadata:
-  name: master-64cvr-worker-highmem-aarch64-us-east-1a
-  namespace: openshift-machine-api
-spec:
-  maxReplicas: 6
-  minReplicas: 0
-  scaleTargetRef:
-    apiVersion: machine.openshift.io/v1beta1
-    kind: MachineSet
-    name: master-64cvr-worker-highmem-aarch64-us-east-1a
----
 apiVersion: machine.openshift.io/v1beta1
 kind: MachineSet
 metadata:
@@ -86,7 +75,7 @@ metadata:
   name: master-64cvr-worker-highmem-aarch64-us-east-1b
   namespace: openshift-machine-api
 spec:
-  replicas: 0
+  replicas: 5
   selector:
     matchLabels:
       machine.openshift.io/cluster-api-cluster: master-64cvr
@@ -104,6 +93,8 @@ spec:
         value: worker-highmem
         effect: NoSchedule
       metadata:
+        annotations:
+          cluster-autoscaler.kubernetes.io/scale-down-disabled: "true"
         labels:
           node-role.kubernetes.io/worker-highmem: worker-highmem
       providerSpec:
@@ -145,19 +136,6 @@ spec:
           userDataSecret:
             name: worker-user-data-managed
 ---
-apiVersion: autoscaling.openshift.io/v1beta1
-kind: MachineAutoscaler
-metadata:
-  name: master-64cvr-worker-highmem-aarch64-us-east-1b
-  namespace: openshift-machine-api
-spec:
-  maxReplicas: 6
-  minReplicas: 0
-  scaleTargetRef:
-    apiVersion: machine.openshift.io/v1beta1
-    kind: MachineSet
-    name: master-64cvr-worker-highmem-aarch64-us-east-1b
----
 apiVersion: machine.openshift.io/v1beta1
 kind: MachineSet
 metadata:
@@ -166,7 +144,7 @@ metadata:
   name: master-64cvr-worker-highmem-aarch64-us-east-1c
   namespace: openshift-machine-api
 spec:
-  replicas: 0
+  replicas: 5
   selector:
     matchLabels:
       machine.openshift.io/cluster-api-cluster: master-64cvr
@@ -184,6 +162,8 @@ spec:
         value: worker-highmem
         effect: NoSchedule
       metadata:
+        annotations:
+          cluster-autoscaler.kubernetes.io/scale-down-disabled: "true"
         labels:
           node-role.kubernetes.io/worker-highmem: worker-highmem
       providerSpec:
@@ -224,16 +204,3 @@ spec:
             value: owned
           userDataSecret:
             name: worker-user-data-managed
----
-apiVersion: autoscaling.openshift.io/v1beta1
-kind: MachineAutoscaler
-metadata:
-  name: master-64cvr-worker-highmem-aarch64-us-east-1c
-  namespace: openshift-machine-api
-spec:
-  maxReplicas: 6
-  minReplicas: 0
-  scaleTargetRef:
-    apiVersion: machine.openshift.io/v1beta1
-    kind: MachineSet
-    name: master-64cvr-worker-highmem-aarch64-us-east-1c


### PR DESCRIPTION
## Summary

- Remove MachineAutoscalers from worker-highmem-aarch64 MachineSets on core-ci, eliminating them from ClusterAutoscaler's scale-up candidate pool
- Set fixed replicas to 5 per AZ (15 total) to match the 15 thanos-receive-ingester pods
- Add `cluster-autoscaler.kubernetes.io/scale-down-disabled` annotation to prevent CA from scaling down highmem nodes

## Root Cause

The worker-highmem-aarch64 MachineSets (added in [DPTP-4738](https://redhat.atlassian.net/browse/DPTP-4738) / #77551) had MachineAutoscalers with `minReplicas: 0`. When thanos-receive-ingester pods (15 replicas × 110Gi memory each) were pending alongside CI workload pods, the ClusterAutoscaler's waste-based expander always picked highmem MachineSets (30% blended waste) over CI MachineSets (56%+ blended waste). This caused:

1. CA exclusively scales up highmem nodes for thanos pods
2. ci-scheduling-webhook scales down idle CI nodes to 0 (working as designed)
3. CA never scales up CI MachineSets because highmem always wins the waste calculation
4. CI pods permanently starved — 70+ pending pods with zero CI nodes

The fix removes highmem MachineSets from CA's autoscaling pool entirely by deleting MachineAutoscalers and using fixed replica counts. This ensures CA only considers CI MachineSets for scale-up decisions.

## Test plan

- [ ] Verify ArgoCD syncs the MachineSet changes to core-ci
- [ ] Verify 15 worker-highmem-aarch64 nodes provision (5 per AZ)
- [ ] Verify thanos-receive-ingester pods schedule on highmem nodes
- [ ] Verify CA scale-up logs show CI MachineSets being selected (not highmem)
- [ ] Verify CI pods schedule normally after fix
- [ ] Monitor for ~1 hour to confirm ci-scheduling-webhook scale-down/CA scale-up cycle works for CI MachineSets

/cc @bear-redhat


Made with [Cursor](https://cursor.com)

[DPTP-4738]: https://redhat.atlassian.net/browse/DPTP-4738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fix core-ci highmem node scaling starvation

This change prevents worker-highmem-aarch64 MachineSets on the core-ci cluster from blocking scale-up of CI workload nodes.

### Problem
The core-ci cluster was experiencing CI pod starvation caused by ClusterAutoscaler preferring to scale up highmem nodes over CI nodes. When 15 thanos-receive-ingester pods (110Gi each) and many CI workload pods were pending simultaneously, ClusterAutoscaler's waste-based expander consistently selected highmem MachineSets (with ~30% blended waste) over CI MachineSets (~56%+ waste). This triggered a problematic cycle: CA would scale up only highmem nodes to accommodate the thanos pods, the ci-scheduling-webhook would scale down idle CI nodes to zero, and CA would never select CI MachineSets because highmem continued winning the waste calculation—leaving 70+ CI pods permanently pending.

### Solution
The fix removes highmem MachineSets from ClusterAutoscaler's consideration and provisions them at fixed capacity:

- **Removed MachineAutoscalers** from all three highmem MachineSets (us-east-1a/b/c), eliminating their minReplicas: 0 / maxReplicas: 6 configuration
- **Set fixed replicas to 5 per AZ** (15 total across three zones) to statically accommodate the 15 thanos-receive-ingester pods
- **Added scale-down-disabled annotation** to prevent ClusterAutoscaler from scaling down highmem nodes

With highmem nodes removed from CA's scaling pool, CA will now properly select CI MachineSets for scale-up when CI workload pods are pending, allowing normal pod scheduling and CI operations to resume.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->