### PR TITLE
fix: remove spec.replicas from core-ci highmem MachineSets to stop ArgoCD fighting CA

### DIFF
--- a/clusters/core-ci/machineset/worker-highmem.yaml
+++ b/clusters/core-ci/machineset/worker-highmem.yaml
@@ -6,7 +6,6 @@ metadata:
   name: master-64cvr-worker-highmem-aarch64-us-east-1a
   namespace: openshift-machine-api
 spec:
-  replicas: 0
   selector:
     matchLabels:
       machine.openshift.io/cluster-api-cluster: master-64cvr
@@ -86,7 +85,6 @@ metadata:
   name: master-64cvr-worker-highmem-aarch64-us-east-1b
   namespace: openshift-machine-api
 spec:
-  replicas: 0
   selector:
     matchLabels:
       machine.openshift.io/cluster-api-cluster: master-64cvr
@@ -166,7 +164,6 @@ metadata:
   name: master-64cvr-worker-highmem-aarch64-us-east-1c
   namespace: openshift-machine-api
 spec:
-  replicas: 0
   selector:
     matchLabels:
       machine.openshift.io/cluster-api-cluster: master-64cvr


### PR DESCRIPTION
/cc @bear-redhat 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

Removes the explicit `spec.replicas` field from three high-memory aarch64 MachineSet resources in the core-ci OpenShift cluster infrastructure:
- `master-64cvr-worker-highmem-aarch64-us-east-1a`
- `master-64cvr-worker-highmem-aarch64-us-east-1b`
- `master-64cvr-worker-highmem-aarch64-us-east-1c`

These MachineSets provision large memory worker nodes (r6g.4xlarge instances) used by the CI infrastructure and are managed in `clusters/core-ci/machineset/worker-highmem.yaml`.

## Rationale

Removes a configuration conflict between ArgoCD (which manages cluster state via GitOps) and the Cluster Autoscaler. Previously, the explicit `spec.replicas: 0` directives were constantly being reconciled by ArgoCD, preventing the Cluster Autoscaler from dynamically scaling these high-memory worker nodes up when needed. With the replicas field removed, the paired MachineAutoscaler resources (configured with `minReplicas: 0` and `maxReplicas: 6`) can now properly manage scaling based on actual CI workload demand without GitOps interference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->