### PR TITLE
feat: tune ClusterAutoscaler to reduce waste and churn on build farms

### DIFF
--- a/clusters/build-clusters/common/machineset/cluster-autoscaler-priority-expander.yaml
+++ b/clusters/build-clusters/common/machineset/cluster-autoscaler-priority-expander.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-autoscaler-priority-expander
+  namespace: kube-system
+data:
+  priorities: |-
+    100:
+      - .*ci-.*
+    50:
+      - .*worker.*
+      - .*highmem.*
+    10:
+      - .*infra.*
+      - .*

--- a/clusters/build-clusters/common/machineset/clusterautoscaler.yaml
+++ b/clusters/build-clusters/common/machineset/clusterautoscaler.yaml
@@ -10,7 +10,13 @@ metadata:
   name: default
 spec:
   balanceSimilarNodeGroups: true
-  maxNodeProvisionTime: 30m
+  expanders:
+  - Priority
+  - LeastWaste
+  ignoreDaemonsetsUtilization: true
+  maxNodeProvisionTime: 15m
   podPriorityThreshold: -10
   scaleDown:
+    delayAfterAdd: 15m
     enabled: true
+    unneededTime: 15m


### PR DESCRIPTION
Tune CA params: ignore DaemonSet utilization, reduce provision timeout, increase scale-down delays to prevent node churn during bursty CI workloads.
https://github.com/openshift/kubernetes-autoscaler/blob/main/cluster-autoscaler/FAQ.md#what-are-the-parameters-to-ca

/cc @bear-redhat 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR tunes the ClusterAutoscaler configuration used by OpenShift's build-farm clusters (common configuration under clusters/build-clusters/common) to reduce node churn and resource waste during bursty CI/build-farm workloads.

## Changes

1. clusters/build-clusters/common/machineset/clusterautoscaler.yaml
- Enables ignoreDaemonsetsUtilization: true so DaemonSet resource usage is not considered for scale-down decisions (avoids retaining nodes solely for infra/monitoring DaemonSets).
- Reduces spec.maxNodeProvisionTime from 30m to 15m to detect provisioning failures faster.
- Adjusts scaleDown timing:
  - delayAfterAdd: 15m — prevents newly added nodes from being immediately scaled down.
  - unneededTime: 15m — nodes must be idle for 15 minutes before eligible for scale-down.
  - ensures scaleDown.enabled remains true.
- Adds spec.expanders to prefer Priority and LeastWaste expanders (affects how node groups are chosen when scaling up).

2. clusters/build-clusters/common/machineset/cluster-autoscaler-priority-expander.yaml
- Adds a kube-system ConfigMap named cluster-autoscaler-priority-expander that defines regex-based priority buckets for the priority expander used by ClusterAutoscaler.

## Impact

Applies to the shared build-cluster autoscaler configuration (affects all build farms using that common manifest). The changes aim to reduce oscillation and wasted capacity during bursty CI runs by ignoring DaemonSet usage, preventing immediate scale-down of recently provisioned nodes, and preferring expansion strategies that minimize waste; shortening the node provisioning timeout helps surface provisioning failures faster for quicker remediation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->