### PR TITLE
onboard openshift-virtualization/virt-platform-autopilot to Prow

### DIFF
--- a/ci-operator/config/openshift-virtualization/virt-platform-autopilot/OWNERS
+++ b/ci-operator/config/openshift-virtualization/virt-platform-autopilot/OWNERS
@@ -1,0 +1,12 @@
+approvers:
+  - tiraboschi
+  - fabiand
+  - dominikholler
+reviewers:
+  - tiraboschi
+  - fabiand
+  - dominikholler
+  - Barakmor1
+  - tal-hason
+  - nirdothan
+  - enp0s3

--- a/ci-operator/config/openshift-virtualization/virt-platform-autopilot/openshift-virtualization-virt-platform-autopilot-main.yaml
+++ b/ci-operator/config/openshift-virtualization/virt-platform-autopilot/openshift-virtualization-virt-platform-autopilot-main.yaml
@@ -1,0 +1,36 @@
+binary_build_commands: make build
+build_root:
+  image_stream_tag:
+    name: release
+    namespace: openshift
+    tag: rhel-9-release-golang-1.25-openshift-5.0
+promotion:
+  to:
+  - name: "5.0"
+    namespace: ocp
+releases:
+  initial:
+    integration:
+      name: "5.0"
+      namespace: ocp
+  latest:
+    integration:
+      include_built_images: true
+      name: "5.0"
+      namespace: ocp
+resources:
+  '*':
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: unit
+  commands: go test ./pkg/... -coverprofile cover.out
+  container:
+    from: src
+zz_generated_metadata:
+  branch: main
+  org: openshift-virtualization
+  repo: virt-platform-autopilot

--- a/ci-operator/config/openshift-virtualization/virt-platform-autopilot/openshift-virtualization-virt-platform-autopilot-release-4.22.yaml
+++ b/ci-operator/config/openshift-virtualization/virt-platform-autopilot/openshift-virtualization-virt-platform-autopilot-release-4.22.yaml
@@ -1,0 +1,36 @@
+binary_build_commands: make build
+build_root:
+  image_stream_tag:
+    name: release
+    namespace: openshift
+    tag: rhel-9-release-golang-1.25-openshift-4.22
+promotion:
+  to:
+  - name: "4.22"
+    namespace: ocp
+releases:
+  initial:
+    integration:
+      name: "4.22"
+      namespace: ocp
+  latest:
+    integration:
+      include_built_images: true
+      name: "4.22"
+      namespace: ocp
+resources:
+  '*':
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: unit
+  commands: go test ./pkg/... -coverprofile cover.out
+  container:
+    from: src
+zz_generated_metadata:
+  branch: release-4.22
+  org: openshift-virtualization
+  repo: virt-platform-autopilot

--- a/ci-operator/jobs/openshift-virtualization/virt-platform-autopilot/OWNERS
+++ b/ci-operator/jobs/openshift-virtualization/virt-platform-autopilot/OWNERS
@@ -1,0 +1,12 @@
+approvers:
+  - tiraboschi
+  - fabiand
+  - dominikholler
+reviewers:
+  - tiraboschi
+  - fabiand
+  - dominikholler
+  - Barakmor1
+  - tal-hason
+  - nirdothan
+  - enp0s3

--- a/ci-operator/jobs/openshift-virtualization/virt-platform-autopilot/openshift-virtualization-virt-platform-autopilot-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-virtualization/virt-platform-autopilot/openshift-virtualization-virt-platform-autopilot-main-presubmits.yaml
@@ -1,0 +1,65 @@
+presubmits:
+  openshift-virtualization/virt-platform-autopilot:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build01
+    context: ci/prow/unit
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-virtualization-virt-platform-autopilot-main-unit
+    rerun_command: /test unit
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=unit
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )unit,?($|\s.*)

--- a/ci-operator/jobs/openshift-virtualization/virt-platform-autopilot/openshift-virtualization-virt-platform-autopilot-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift-virtualization/virt-platform-autopilot/openshift-virtualization-virt-platform-autopilot-release-4.22-presubmits.yaml
@@ -1,0 +1,65 @@
+presubmits:
+  openshift-virtualization/virt-platform-autopilot:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^release-4\.22$
+    - ^release-4\.22-
+    cluster: build01
+    context: ci/prow/unit
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-virtualization-virt-platform-autopilot-release-4.22-unit
+    rerun_command: /test unit
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=unit
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )unit,?($|\s.*)

--- a/core-services/prow/02_config/openshift-virtualization/virt-platform-autopilot/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-virtualization/virt-platform-autopilot/_pluginconfig.yaml
@@ -1,0 +1,43 @@
+approve:
+- commandHelpLink: https://go.k8s.io/bot-commands
+  ignore_review_state: true
+  repos:
+  - openshift-virtualization/virt-platform-autopilot
+  require_self_approval: true
+external_plugins:
+  openshift-virtualization/virt-platform-autopilot:
+  - endpoint: http://cherrypick
+    events:
+    - issue_comment
+    - pull_request
+    name: cherrypick
+  - endpoint: http://needs-rebase
+    events:
+    - issue_comment
+    - pull_request
+    name: needs-rebase
+lgtm:
+- repos:
+  - openshift-virtualization/virt-platform-autopilot
+  review_acts_as_lgtm: true
+plugins:
+  openshift-virtualization/virt-platform-autopilot:
+    plugins:
+    - assign
+    - golint
+    - help
+    - hold
+    - label
+    - lgtm
+    - trigger
+    - owners-label
+    - approve
+    - wip
+    - verify-owners
+triggers:
+- org_invite:
+    prominent: {}
+  repos:
+  - openshift-virtualization/virt-platform-autopilot
+  trusted_apps:
+  - openshift-merge-bot

--- a/core-services/prow/02_config/openshift-virtualization/virt-platform-autopilot/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift-virtualization/virt-platform-autopilot/_prowconfig.yaml
@@ -1,0 +1,12 @@
+tide:
+  queries:
+  - labels:
+    - approved
+    - lgtm
+    missingLabels:
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - needs-rebase
+    repos:
+    - openshift-virtualization/virt-platform-autopilot


### PR DESCRIPTION
Add CI operator configs for main (Go 1.25 / OCP 5.0) and release-4.22, with a unit test presubmit job. Configure Prow plugins (approve, lgtm, cherry-pick, needs-rebase, hold) and Tide merge gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Onboards the openshift-virtualization/virt-platform-autopilot repository into OpenShift's Prow-based CI. Adds ci-operator pipelines for main and release-4.22, Prow plugin configuration, Tide merge gating, and repository OWNERS to enable automated builds, tests, image promotion and merge automation.

## What changed (practical impact)

- Wires CI for openshift-virtualization/virt-platform-autopilot into OpenShift CI.
- ci-operator configurations (two branches):
  - main: builds using Go 1.25 on an RHEL9 Go image targeted at OCP 5.0; binary build via `make build`; unit test declared.
  - release-4.22: builds via `make build` on an OCP 4.22 RHEL9 Go image; unit test declared.
- Build/test/job behavior:
  - Build command: make build
  - Unit test job: go test ./pkg/... -coverprofile cover.out (configured as a ci-operator test)
  - Default resource requests/limits applied (requests: 100m CPU / 200Mi memory; memory limit: 4Gi where specified).
  - Image promotion configured to the appropriate ocp release namespaces and release integration wiring (initial/latest) so built images can be published into release streams.
- Prow/plugin configuration:
  - Enables standard plugins for the repo including approve, lgtm, hold, assign, label, trigger, owners-label, wip, verify-owners, golint, help, and others.
  - Approve configured with repo-specific settings (require_self_approval: true, ignore_review_state: true).
  - External plugin hooks registered for cherrypick and needs-rebase (issue_comment and pull_request events).
- Merge automation:
  - Tide configured to require both approved and lgtm labels for merging and to block merges when do-not-merge/hold, do-not-merge/invalid-owners-file, do-not-merge/work-in-progress, or needs-rebase are present.
- Repository ownership:
  - OWNERS updated to set approvers: tiraboschi, fabiand, dominikholler
  - Reviewers: tiraboschi, fabiand, dominikholler, Barakmor1, tal-hason, nirdothan, enp0s3

## Net effect

The repository is connected to OpenShift CI with automated builds and unit tests, configured image promotion into release streams, GitHub approval/LGTM workflows and external integrations for cherry-pick/rebase, and Tide-driven merge gating. The OWNERS file is added/updated to define approvers and reviewers for the repo.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->