### PR TITLE
STS conformance: Skip CSR approver test failing with 401 on 4.22+

### DIFF
--- a/ci-operator/step-registry/rosa/aws/sts/conformance/rosa-aws-sts-conformance-workflow.yaml
+++ b/ci-operator/step-registry/rosa/aws/sts/conformance/rosa-aws-sts-conformance-workflow.yaml
@@ -31,7 +31,8 @@ workflow:
         sig-auth.*SCC.*should not have pod creation failures during install\|
         sig-imageregistry.*should redirect on blob pull\|
         CSI Mock volume expansion.*should record target size in allocated resources\|
-        Conntrack proxy implementation should not be vulnerable to the invalid conntrack state bug
+        Conntrack proxy implementation should not be vulnerable to the invalid conntrack state bug\|
+        CSRs from machines that are not recognized by the cloud provider are not approved
     pre:
       - chain: rosa-aws-sts-provision
       - ref: osd-ccs-conf-idp-htpasswd-multi-users


### PR DESCRIPTION
## Summary

- Skip-list the test `CSRs from machines that are not recognized by the cloud provider are not approved` in STS conformance jobs
- This test returns 401 Unauthorized on ROSA Classic STS clusters starting in OCP 4.22 due to stricter SA token handling in the platform
- The test passes on 4.21 but consistently fails on 4.22, 4.23, and 5.0
- Upstream bug: https://github.com/openshift/origin/issues/31163

## Test plan

- [ ] pj-rehearse affected STS conformance periodic jobs
- [ ] Verify skip pattern matches correctly (no YAML folding issues)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## STS Conformance Test Skip List Update

This PR updates the ROSA AWS STS conformance workflow configuration to skip a test that fails on OpenShift 4.22 and later versions.

**What changed:**
The `rosa-aws-sts-conformance-workflow.yaml` file adds a new skip pattern to the `TEST_SKIPS` environment variable: "CSRs from machines that are not recognized by the cloud provider are not approved". This test is now excluded from the STS conformance test suite.

**Why it matters:**
The targeted test returns 401 Unauthorized errors on ROSA Classic STS clusters starting with OCP 4.22 due to stricter service account token validation in the platform. The test was passing on OCP 4.21 but fails consistently on 4.22, 4.23, and 5.0. An upstream bug will be filed separately to address the root cause, but this skip list entry prevents false test failures in the CI pipeline until the issue is resolved upstream.

**Impact:**
This affects the periodic STS conformance testing jobs for ROSA clusters in the OpenShift CI infrastructure. Tests will continue to run, but this specific test will be excluded from validation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->