### PR TITLE
Revert "Testing config-updater"

### DIFF
--- a/core-services/ci-secret-bootstrap/_config.yaml
+++ b/core-services/ci-secret-bootstrap/_config.yaml
@@ -3529,9 +3529,6 @@ secret_configs:
     sa.config-updater.vsphere02.config:
       field: sa.config-updater.vsphere02.config
       item: config-updater
-    sa.config-updater.hvidosil.config:
-      field: sa.config-updater.hvidosil.config
-      item: config-updater
   to:
   - cluster: app.ci
     name: config-updater


### PR DESCRIPTION
Reverts openshift/release#79148

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR reverts PR #79148, which had been a temporary test of the config-updater secret distribution system.

The change removes a test configuration entry (`sa.config-updater.hvidosil.config`) from the `core-services/ci-secret-bootstrap/_config.yaml` file. This entry had been added to test how the CI secret bootstrap system distributes the config-updater service account kubeconfig across clusters. The actual production configuration for distributing config-updater secrets to the standard cluster set (app.ci, build01-12, core-ci, hosted-mgmt, and vsphere02) remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->