### PR TITLE
Remove taint to bm node in vsphere hybrid

### DIFF
--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22.yaml
@@ -1298,6 +1298,7 @@ tests:
       NETWORK_TYPE: multi-tenant
       PERSISTENT_MONITORING: "false"
       SETUP_IMAGE_REGISTRY_WITH_PVC: "false"
+      TEST_ARGS: ' --disable-monitor=legacy-cvo-invariants --cluster-stability=Disruptive '
       TEST_SKIPS: \[FeatureGate:VSphereDriverConfiguration\]\|\[sig-arch\]\[Early\]
         Operators low level operators
       TEST_SUITE: openshift/conformance/serial

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.23.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.23.yaml
@@ -1275,6 +1275,7 @@ tests:
       NETWORK_TYPE: multi-tenant
       PERSISTENT_MONITORING: "false"
       SETUP_IMAGE_REGISTRY_WITH_PVC: "false"
+      TEST_ARGS: ' --disable-monitor=legacy-cvo-invariants --cluster-stability=Disruptive '
       TEST_SKIPS: \[FeatureGate:VSphereDriverConfiguration\]\|\[sig-arch\]\[Early\]
         Operators low level operators
       TEST_SUITE: openshift/conformance/serial

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
@@ -1382,6 +1382,7 @@ tests:
       NETWORK_TYPE: multi-tenant
       PERSISTENT_MONITORING: "false"
       SETUP_IMAGE_REGISTRY_WITH_PVC: "false"
+      TEST_ARGS: ' --disable-monitor=legacy-cvo-invariants --cluster-stability=Disruptive '
       TEST_SKIPS: \[FeatureGate:VSphereDriverConfiguration\]\|\[sig-arch\]\[Early\]
         Operators low level operators
       TEST_SUITE: openshift/conformance/serial

--- a/ci-operator/step-registry/ipi/install/vsphere/virt/ipi-install-vsphere-virt-commands.sh
+++ b/ci-operator/step-registry/ipi/install/vsphere/virt/ipi-install-vsphere-virt-commands.sh
@@ -174,12 +174,6 @@ for (( i=0; i<${BM_COUNT}; i++ )); do
   oc adm taint nodes "${VM_NAME}-${i}" node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule- --kubeconfig="${CLUSTER_KUBECONFIG}"
 done
 
-# add custom taint to prevent e2e from running on it due to current networking limitations.  Metrics do not seem to work when making calls from BM to ingress for data, but
-# everything else seems fine.
-for (( i=0; i<${BM_COUNT}; i++ )); do
-  oc adm taint nodes "${VM_NAME}-${i}" vsphere.openshift.io/e2e=true:NoSchedule --kubeconfig="${CLUSTER_KUBECONFIG}"
-done
-
 # Wait for node to be ready to prevent any interruption during the e2e tests
 wait_for_node_ready
 


### PR DESCRIPTION
### Changes
- Removed the taint due to some e2e wanting to do tests on all detected nodes.  

### Notes
Need to investigate how to better prevent this.  I am guessing some of these e2e tests have logic on determining which nodes to run their tests on.  The real issue we are trying to resolve is why some tests from our SNO cluster with virt on it for the BM node are unable to do some of the metrics tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Removes a custom taint from bare-metal nodes in the vSphere hybrid cluster configuration CI setup.

## Changes
The PR removes the application of a custom `vsphere.openshift.io/e2e=true:NoSchedule` taint to bare-metal (BM) nodes in the vSphere hybrid cluster installation workflow. This taint was previously added in PR #79111 to prevent end-to-end (e2e) tests from running on those nodes due to networking limitations that caused metrics tests to fail.

## Impact
By removing this taint, bare-metal nodes in vSphere hybrid configurations will now be available for scheduling e2e tests and other workloads, allowing them to participate in all detected node deployments during testing rather than being excluded. The script continues to remove the Kubernetes provider initialization taint as before.

The author notes they plan to investigate better solutions to address the underlying metrics test failures that occur when the BM node is included with virtualization enabled, rather than completely preventing test scheduling on those nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->