### PR TITLE
[WIP]update the vault setup for oas-o

### DIFF
--- a/ci-operator/config/openshift/cluster-authentication-operator/openshift-cluster-authentication-operator-master.yaml
+++ b/ci-operator/config/openshift/cluster-authentication-operator/openshift-cluster-authentication-operator-master.yaml
@@ -3,6 +3,10 @@ base_images:
     name: test
     namespace: ocp-kni
     tag: dev-scripts
+  vault_kube_kms:
+    name: vault-kube-kms
+    namespace: control-plane_vault
+    tag: 0.0.1
 binary_build_commands: make build --warn-undefined-variables
 build_root:
   from_repository: true
@@ -304,11 +308,14 @@ tests:
 - always_run: false
   as: e2e-aws-operator-encryption-kms-ote
   optional: true
+  run_if_changed: ^(vendor/github.com/openshift/library-go/pkg/operator/encryption)|^(test/e2e-encryption-kms)|^(test/library/encryption)
   steps:
     cluster_profile: openshift-org-aws
     env:
+      FEATURE_SET: TechPreviewNoUpgrade
       TEST_SUITE: openshift/cluster-authentication-operator/encryption-kms
     test:
+    - chain: etcd-encryption-vault-setup
     - ref: openshift-e2e-test
     workflow: ipi-aws
   timeout: 4h0m0s

--- a/ci-operator/config/openshift/cluster-openshift-apiserver-operator/openshift-cluster-openshift-apiserver-operator-main.yaml
+++ b/ci-operator/config/openshift/cluster-openshift-apiserver-operator/openshift-cluster-openshift-apiserver-operator-main.yaml
@@ -1,3 +1,8 @@
+base_images:
+  vault_kube_kms:
+    name: vault-kube-kms
+    namespace: control-plane_vault
+    tag: 0.0.1
 binary_build_commands: make build --warn-undefined-variables
 build_root:
   from_repository: true
@@ -133,6 +138,7 @@ tests:
     env:
       FEATURE_SET: TechPreviewNoUpgrade
     test:
+    - chain: etcd-encryption-vault-setup
     - as: test
       cli: latest
       commands: |
@@ -142,6 +148,18 @@ tests:
         requests:
           cpu: 100m
       timeout: 4h0m0s
+    workflow: ipi-gcp
+- always_run: false
+  as: e2e-gcp-operator-encryption-kms-ote
+  run_if_changed: ^(vendor/github.com/openshift/library-go/pkg/operator/encryption)|^(test/e2e-encryption-kms)|^(test/library/encryption)
+  steps:
+    cluster_profile: openshift-org-gcp
+    env:
+      FEATURE_SET: TechPreviewNoUpgrade
+      TEST_SUITE: openshift/cluster-openshift-apiserver-operator/encryption-kms
+    test:
+    - chain: etcd-encryption-vault-setup
+    - ref: openshift-e2e-test
     workflow: ipi-gcp
 - as: verify-deps
   steps:

--- a/ci-operator/jobs/openshift/cluster-authentication-operator/openshift-cluster-authentication-operator-master-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-authentication-operator/openshift-cluster-authentication-operator-master-presubmits.yaml
@@ -8,6 +8,10 @@ presubmits:
     cluster: build01
     context: ci/prow/e2e-agnostic
     decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - .ci-operator.yaml
+      - Dockerfile.rhel7
     labels:
       ci-operator.openshift.io/cloud: azure4
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-azure
@@ -88,6 +92,10 @@ presubmits:
     cluster: build05
     context: ci/prow/e2e-agnostic-ipv6
     decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - .ci-operator.yaml
+      - Dockerfile.rhel7
     labels:
       capability/intranet: intranet
       ci-operator.openshift.io/cloud: equinix-ocp-metal
@@ -170,6 +178,10 @@ presubmits:
     cluster: build01
     context: ci/prow/e2e-agnostic-upgrade
     decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - .ci-operator.yaml
+      - Dockerfile.rhel7
     labels:
       ci-operator.openshift.io/cloud: azure4
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-azure
@@ -251,6 +263,9 @@ presubmits:
     context: ci/prow/e2e-aws-external-oidc-conformance-parallel
     decorate: true
     decoration_config:
+      sparse_checkout_files:
+      - .ci-operator.yaml
+      - Dockerfile.rhel7
       timeout: 8h0m0s
     labels:
       ci-operator.openshift.io/cloud: aws
@@ -334,6 +349,9 @@ presubmits:
     context: ci/prow/e2e-aws-external-oidc-conformance-serial
     decorate: true
     decoration_config:
+      sparse_checkout_files:
+      - .ci-operator.yaml
+      - Dockerfile.rhel7
       timeout: 8h0m0s
     labels:
       ci-operator.openshift.io/cloud: aws
@@ -414,92 +432,12 @@ presubmits:
     - ^master$
     - ^master-
     cluster: build01
-    context: ci/prow/e2e-aws-operator-encryption-kms-ote
-    decorate: true
-    decoration_config:
-      timeout: 4h0m0s
-    labels:
-      ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-authentication-operator-master-e2e-aws-operator-encryption-kms-ote
-    optional: true
-    rerun_command: /test e2e-aws-operator-encryption-kms-ote
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-aws-operator-encryption-kms-ote
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-aws-operator-encryption-kms-ote,?($|\s.*)
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - ^master$
-    - ^master-
-    cluster: build01
     context: ci/prow/e2e-aws-operator-encryption-perf-serial-ote-1of2
     decorate: true
     decoration_config:
+      sparse_checkout_files:
+      - .ci-operator.yaml
+      - Dockerfile.rhel7
       timeout: 2h0m0s
     labels:
       ci-operator.openshift.io/cloud: aws
@@ -584,6 +522,9 @@ presubmits:
     context: ci/prow/e2e-aws-operator-encryption-perf-serial-ote-2of2
     decorate: true
     decoration_config:
+      sparse_checkout_files:
+      - .ci-operator.yaml
+      - Dockerfile.rhel7
       timeout: 2h0m0s
     labels:
       ci-operator.openshift.io/cloud: aws
@@ -668,6 +609,9 @@ presubmits:
     context: ci/prow/e2e-aws-operator-encryption-rotation-serial-ote-1of2
     decorate: true
     decoration_config:
+      sparse_checkout_files:
+      - .ci-operator.yaml
+      - Dockerfile.rhel7
       timeout: 4h0m0s
     labels:
       ci-operator.openshift.io/cloud: aws
@@ -752,6 +696,9 @@ presubmits:
     context: ci/prow/e2e-aws-operator-encryption-rotation-serial-ote-2of2
     decorate: true
     decoration_config:
+      sparse_checkout_files:
+      - .ci-operator.yaml
+      - Dockerfile.rhel7
       timeout: 4h0m0s
     labels:
       ci-operator.openshift.io/cloud: aws
@@ -836,6 +783,9 @@ presubmits:
     context: ci/prow/e2e-aws-operator-encryption-serial-ote-1of2
     decorate: true
     decoration_config:
+      sparse_checkout_files:
+      - .ci-operator.yaml
+      - Dockerfile.rhel7
       timeout: 4h0m0s
     labels:
       ci-operator.openshift.io/cloud: aws
@@ -920,6 +870,9 @@ presubmits:
     context: ci/prow/e2e-aws-operator-encryption-serial-ote-2of2
     decorate: true
     decoration_config:
+      sparse_checkout_files:
+      - .ci-operator.yaml
+      - Dockerfile.rhel7
       timeout: 4h0m0s
     labels:
       ci-operator.openshift.io/cloud: aws
@@ -1003,6 +956,10 @@ presubmits:
     cluster: build01
     context: ci/prow/e2e-aws-operator-parallel-ote
     decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - .ci-operator.yaml
+      - Dockerfile.rhel7
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -1084,6 +1041,10 @@ presubmits:
     cluster: build01
     context: ci/prow/e2e-aws-operator-serial-ote
     decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - .ci-operator.yaml
+      - Dockerfile.rhel7
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -1165,6 +1126,10 @@ presubmits:
     cluster: build01
     context: ci/prow/e2e-aws-single-node
     decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - .ci-operator.yaml
+      - Dockerfile.rhel7
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -1246,6 +1211,10 @@ presubmits:
     cluster: build04
     context: ci/prow/e2e-console-login
     decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - .ci-operator.yaml
+      - Dockerfile.rhel7
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -1326,6 +1295,10 @@ presubmits:
     cluster: build04
     context: ci/prow/e2e-gcp-operator-disruptive
     decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - .ci-operator.yaml
+      - Dockerfile.rhel7
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -1406,6 +1379,10 @@ presubmits:
     cluster: build04
     context: ci/prow/e2e-gcp-operator-encryption-kms
     decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - .ci-operator.yaml
+      - Dockerfile.rhel7
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -1486,8 +1463,99 @@ presubmits:
     - ^master$
     - ^master-
     cluster: build04
+    context: ci/prow/e2e-gcp-operator-encryption-kms-ote
+    decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - .ci-operator.yaml
+      - Dockerfile.rhel7
+      timeout: 4h0m0s
+    labels:
+      ci-operator.openshift.io/cloud: gcp
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-authentication-operator-master-e2e-gcp-operator-encryption-kms-ote
+    optional: true
+    rerun_command: /test e2e-gcp-operator-encryption-kms-ote
+    run_if_changed: ^(vendor/github.com/openshift/library-go/pkg/operator/encryption)|^(test/e2e-encryption-kms)|^(test/library/encryption)
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-gcp-operator-encryption-kms-ote
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-gcp-operator-encryption-kms-ote,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^master$
+    - ^master-
+    cluster: build04
     context: ci/prow/e2e-gcp-operator-encryption-perf
     decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - .ci-operator.yaml
+      - Dockerfile.rhel7
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -1569,6 +1637,10 @@ presubmits:
     cluster: build04
     context: ci/prow/e2e-gcp-operator-encryption-rotation
     decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - .ci-operator.yaml
+      - Dockerfile.rhel7
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -1650,6 +1722,10 @@ presubmits:
     cluster: build04
     context: ci/prow/e2e-oidc
     decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - .ci-operator.yaml
+      - Dockerfile.rhel7
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -1730,6 +1806,10 @@ presubmits:
     cluster: build04
     context: ci/prow/e2e-oidc-techpreview
     decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - .ci-operator.yaml
+      - Dockerfile.rhel7
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -1811,6 +1891,10 @@ presubmits:
     cluster: build04
     context: ci/prow/e2e-operator
     decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - .ci-operator.yaml
+      - Dockerfile.rhel7
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -1891,6 +1975,10 @@ presubmits:
     cluster: build04
     context: ci/prow/e2e-operator-encryption
     decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - .ci-operator.yaml
+      - Dockerfile.rhel7
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -1972,6 +2060,10 @@ presubmits:
     cluster: build01
     context: ci/prow/images
     decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - .ci-operator.yaml
+      - Dockerfile.rhel7
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -2027,7 +2119,8 @@ presubmits:
     context: ci/prow/okd-scos-e2e-aws-ovn
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile.rhel7
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -2112,7 +2205,8 @@ presubmits:
     context: ci/prow/okd-scos-images
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile.rhel7
     labels:
       ci-operator.openshift.io/variant: okd-scos
       ci.openshift.io/generator: prowgen
@@ -2169,6 +2263,10 @@ presubmits:
     cluster: build01
     context: ci/prow/test-operator-integration
     decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - .ci-operator.yaml
+      - Dockerfile.rhel7
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -2230,6 +2328,10 @@ presubmits:
     cluster: build01
     context: ci/prow/unit
     decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - .ci-operator.yaml
+      - Dockerfile.rhel7
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -2291,6 +2393,10 @@ presubmits:
     cluster: build01
     context: ci/prow/verify
     decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - .ci-operator.yaml
+      - Dockerfile.rhel7
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -2352,6 +2458,10 @@ presubmits:
     cluster: build01
     context: ci/prow/verify-bindata
     decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - .ci-operator.yaml
+      - Dockerfile.rhel7
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -2413,6 +2523,10 @@ presubmits:
     cluster: build01
     context: ci/prow/verify-deps
     decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - .ci-operator.yaml
+      - Dockerfile.rhel7
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"

--- a/ci-operator/jobs/openshift/cluster-openshift-apiserver-operator/openshift-cluster-openshift-apiserver-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-openshift-apiserver-operator/openshift-cluster-openshift-apiserver-operator-main-presubmits.yaml
@@ -412,6 +412,87 @@ presubmits:
     - ^main$
     - ^main-
     cluster: build08
+    context: ci/prow/e2e-gcp-operator-encryption-kms-ote
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: gcp
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-openshift-apiserver-operator-main-e2e-gcp-operator-encryption-kms-ote
+    rerun_command: /test e2e-gcp-operator-encryption-kms-ote
+    run_if_changed: ^(vendor/github.com/openshift/library-go/pkg/operator/encryption)|^(test/e2e-encryption-kms)|^(test/library/encryption)
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-gcp-operator-encryption-kms-ote
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-gcp-operator-encryption-kms-ote,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build08
     context: ci/prow/e2e-gcp-operator-encryption-rotation-aescbc
     decorate: true
     labels:


### PR DESCRIPTION
update the missing vault setup for oas.
Please refer this for more details.
https://redhat-internal.slack.com/archives/C0A0DMK3N7K/p1778488432410269?thread_ts=1778485365.758369&cid=C0A0DMK3N7K

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
OpenShift CI config — add Vault KMS helper image and wire Vault setup into encryption KMS jobs

What changed (practical impact)
- A Vault helper image was added to CI base_images so jobs can provision/configure Vault for KMS-backed etcd encryption tests:
  - Added vault_kube_kms -> name: vault-kube-kms, namespace: control-plane_vault, tag: 0.0.1 (present in ci-operator configs and mirrored in core-services image-mirroring).

- The etcd-encryption Vault setup is now invoked as a prerequisite for operator encryption-KMS tests across CI jobs:
  - cluster-openshift-apiserver-operator: the e2e-gcp-operator-encryption-kms presubmit now runs chain: etcd-encryption-vault-setup before make test-e2e-encryption-kms. A new OTE-style presubmit e2e-gcp-operator-encryption-kms-ote was added that chains etcd-encryption-vault-setup then runs the openshift e2e test (TEST_SUITE set to openshift/cluster-openshift-apiserver-operator/encryption-kms and FEATURE_SET: TechPreviewNoUpgrade).
  - cluster-authentication-operator: vault_kube_kms was added to base_images and the operator encryption OTE presubmits were updated to run etcd-encryption-vault-setup before the openshift e2e test (OTE jobs set FEATURE_SET: TechPreviewNoUpgrade and use the encryption-kms TEST_SUITE).

- Jobs are gated to run only for relevant changes by run_if_changed patterns that match library-go operator/encryption and the encryption test paths; presubmit contexts and retry/rehearse commands (e.g., /test e2e-gcp-operator-encryption-kms and /test e2e-gcp-operator-encryption-kms-ote) were added/updated for various release branches.

Scope and notes
- Changes are limited to ci-operator job/YAML configuration and image-mirroring configuration (CI infra only); no runtime or operator source code changes.
- Author has triggered CI/rehearse/test commands in PR comments to validate job behavior; reviewers will likely validate via rehearsal or CI runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->