### PR TITLE
Adjust slack notifications to only ping on a failure

### DIFF
--- a/core-services/prow/02_config/openshift-online/rosa-e2e/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift-online/rosa-e2e/_prowconfig.yaml
@@ -7,10 +7,10 @@ slack_reporter_configs:
     - error
     job_types_to_report:
     - periodic
-    report_template: '<!subteam^S06F39XKT6K> {{if eq .Status.State "success"}} :green_jenkins_circle:
-      Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs>
-      :rainbow: {{else}} :red_jenkins_circle: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*.
-      <{{.Status.URL}}|View logs> :volcano: {{end}}'
+    report_template: '{{if eq .Status.State "success"}} :green_jenkins_circle: Job
+      *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs>
+      :rainbow: {{else}} <!subteam^S06F39XKT6K> :red_jenkins_circle: Job *{{.Spec.Job}}*
+      ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :volcano: {{end}}'
 tide:
   queries:
   - labels:


### PR DESCRIPTION
Need to reduce ping fatigue a bit and only notify on failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adjusts Slack notifications for the OpenShift Online ROSA E2E CI pipeline to reduce notification fatigue. The change modifies the `slack_reporter_configs` for `openshift-online/rosa-e2e` in the Prow configuration to ensure that Slack subteam mentions (pings) are only sent when jobs **fail**, not on successful runs.

## What Changed

The Slack message template for the ROSA E2E periodic jobs now only includes the subteam mention (`<!subteam^S06F39XKT6K>`) in the failure branch of the conditional template. Successful job completions no longer generate a mention/ping, while failure and error states continue to notify the team with the red circle indicator.

## Impact

This reduces unnecessary Slack notifications to the OCM FVT team (`#ocm-fvt-prow` channel) by eliminating pings on successful runs, keeping the team focused on actual failures that require attention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->