### PR TITLE
Switch back to ci01

### DIFF
--- a/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main.yaml
+++ b/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main.yaml
@@ -487,7 +487,7 @@ tests:
   steps:
     env:
       ARO_HCP_CLOUD: dev
-      ARO_HCP_DEPLOY_ENV: prow
+      ARO_HCP_DEPLOY_ENV: ci01
       LOCATION: centralus
     leases:
     - count: 1


### PR DESCRIPTION
Switches ARO-HCP infra subscription for e2e-parallel job to "ARO HCP E2E Infrastructure (EA Subscription)"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Switches the ARO-HCP CI operator configuration so the component's e2e-parallel job deploys into the ci01 environment (ARO_HCP_DEPLOY_ENV=ci01) instead of the prow environment. This affects the Azure/ARO-HCP repository's CI operator config used by OpenShift CI, changing where e2e-parallel tests are deployed and executed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->