### PR TITLE
Add jacobsee and jubittajohn to allowed users for cherry-pick-approved and backport-risk-assessed labels

### DIFF
--- a/core-services/prow/02_config/openshift/kubernetes/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/kubernetes/_pluginconfig.yaml
@@ -11,6 +11,8 @@ label:
       - gangwgr
       - duanwei33
       - lyman9966
+      - jacobsee
+      - jubittajohn
       assign_on:
       - label: backport-risk-assessed
       label: cherry-pick-approved
@@ -26,6 +28,8 @@ label:
       - tkashem
       - rphillips
       - mrunalp
+      - jacobsee
+      - jubittajohn
       label: backport-risk-assessed
     - allowed_teams:
       - openshift-staff-engineers


### PR DESCRIPTION
Add `jacobsee` and `jubittajohn` to allowed users for `cherry-pick-approved` and `backport-risk-assessed` labels

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Scope: OpenShift Prow configuration for the openshift/kubernetes repository.
- Change: Expanded the restricted label permissions so that “jacobsee” and “jubittajohn” can apply the “cherry-pick-approved” and “backport-risk-assessed” labels.
- Impact: Enables these maintainers to directly manage backport-related labels on openshift/kubernetes, reducing latency in backport triage and cherry-pick workflows. No changes to jobs, plugins, or other repos’ configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->