### PR TITLE
Add exceptional labelling powers for repo admins

### DIFF
--- a/core-services/prow/02_config/Azure/ARO-HCP/_pluginconfig.yaml
+++ b/core-services/prow/02_config/Azure/ARO-HCP/_pluginconfig.yaml
@@ -37,6 +37,13 @@ external_plugins:
     events:
     - issue_comment
     name: multi-pr-prow-plugin
+label:
+  restricted_labels:
+    Azure/ARO-HCP:
+    - allowed_users:
+      - deads2k
+      - stevekuznetsov
+      label: lgtm
 plugins:
   Azure/ARO-HCP:
     plugins:


### PR DESCRIPTION
We have a couple repo admins in Azure/ARO-HCP and this allows relabelling and self-labeling in extreme circumstances to avoid using the green button and accidentally bypassing "works on top of master" checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds Prow plugin configuration for the `Azure/ARO-HCP` repository, establishing a restricted labeling policy for repository administrators.

## Changes

The configuration creates a new `restricted_labels` rule in Prow's label plugin that permits only two designated users (`deads2k` and `stevekuznetsov`) to apply the `lgtm` label to pull requests in the Azure/ARO-HCP repository. This allows repo admins to relabel and self-label PRs in exceptional circumstances through Prow commands, providing an alternative to manual GitHub approvals while ensuring proper authorization controls.

The change is motivated by avoiding accidental bypasses of "works on top of master" checks when using direct approval mechanisms. The configuration also enables all standard Prow plugins and external integrations (refresh, cherrypick, needs-rebase, backport-verifier, pipeline-controller, and others) for the repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->