### PR TITLE
rosa-e2e: Exclude Access:MC tests from HCP nightly jobs

### DIFF
--- a/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__periodics.yaml
+++ b/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__periodics.yaml
@@ -38,6 +38,7 @@ tests:
       CHANNEL_GROUP: nightly
       ENABLE_BILLING_ACCOUNT: "yes"
       HOSTED_CP: "true"
+      LABEL_FILTER: '!Access:MC'
       OCM_LOGIN_ENV: staging
       OPENSHIFT_VERSION: "4.19"
       REPLICAS: "3"
@@ -50,6 +51,7 @@ tests:
       CHANNEL_GROUP: nightly
       ENABLE_BILLING_ACCOUNT: "yes"
       HOSTED_CP: "true"
+      LABEL_FILTER: '!Access:MC'
       OCM_LOGIN_ENV: staging
       OPENSHIFT_VERSION: "4.20"
       REPLICAS: "3"
@@ -62,6 +64,7 @@ tests:
       CHANNEL_GROUP: nightly
       ENABLE_BILLING_ACCOUNT: "yes"
       HOSTED_CP: "true"
+      LABEL_FILTER: '!Access:MC'
       OCM_LOGIN_ENV: staging
       OPENSHIFT_VERSION: "4.21"
       REPLICAS: "3"
@@ -74,6 +77,7 @@ tests:
       CHANNEL_GROUP: nightly
       ENABLE_BILLING_ACCOUNT: "yes"
       HOSTED_CP: "true"
+      LABEL_FILTER: '!Access:MC'
       OCM_LOGIN_ENV: staging
       OPENSHIFT_VERSION: "4.22"
       REPLICAS: "3"
@@ -86,6 +90,7 @@ tests:
       CHANNEL_GROUP: nightly
       ENABLE_BILLING_ACCOUNT: "yes"
       HOSTED_CP: "true"
+      LABEL_FILTER: '!Access:MC'
       OCM_LOGIN_ENV: staging
       OPENSHIFT_VERSION: "5.0"
       REPLICAS: "3"


### PR DESCRIPTION
## Summary

Excludes MC-dependent tests from rosa-e2e HCP nightly jobs until a dedicated e2e sector with bastion access is provisioned ([ROSAENG-1082](https://redhat.atlassian.net/browse/ROSAENG-1082)).

Adds `LABEL_FILTER: "!Access:MC"` to all 5 HCP nightly jobs (4.19, 4.20, 4.21, 4.22, 5.0). The `Access:MC` label was added to MC-dependent test Describe blocks in openshift-online/rosa-e2e#40.

MC API hostnames are in private Route53 zones and cannot be resolved from CI pods. Tests tagged with `Access:MC` require management cluster API access via a bastion proxy, which is not yet available in CI.

## Test plan

- [ ] Verify `LABEL_FILTER` is consumed by `rosa-e2e-test-commands.sh` and passed to `--ginkgo.label-filter`
- [ ] Confirm MC tests (management_cluster_test.go, hostedcluster_health_test.go, managed_operators_test.go MC Components) are excluded
- [ ] Confirm non-MC tests continue to run normally

Jira: https://redhat.atlassian.net/browse/ROSAENG-1082

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR modifies the ROSA e2e test infrastructure configuration to exclude management cluster (MC) dependent tests from nightly HCP (Hosted Control Plane) jobs.

## Changes

Updates `ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__periodics.yaml` to add `LABEL_FILTER: '!Access:MC'` environment variable to five nightly periodic test jobs running across ROSA OpenShift versions:
- rosa-hcp-e2e-nightly-4-19
- rosa-hcp-e2e-nightly-4-20
- rosa-hcp-e2e-nightly-4-21
- rosa-hcp-e2e-nightly-4-22
- rosa-hcp-e2e-nightly-5-0

## Rationale

Tests labeled `Access:MC` require direct management cluster API access via bastion proxy. These API hostnames are located in private Route53 zones that are not resolvable from standard CI pods. Until a dedicated e2e sector with bastion access is provisioned (tracked under [ROSAENG-1082](https://redhat.atlassian.net/browse/ROSAENG-1082)), these tests cannot run in the current CI environment and are being excluded to prevent test failures and job delays.

The `Access:MC` label was previously added to affected test blocks in the rosa-e2e repository to identify MC-dependent tests (management_cluster_test.go, hostedcluster_health_test.go, and the MC Components sections of managed_operators_test.go).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->