### PR TITLE
OSAC-856: require up-to-date branches for osac-installer

### DIFF
--- a/core-services/prow/02_config/osac-project/osac-installer/_prowconfig.yaml
+++ b/core-services/prow/02_config/osac-project/osac-installer/_prowconfig.yaml
@@ -1,3 +1,13 @@
+branch-protection:
+  orgs:
+    osac-project:
+      repos:
+        osac-installer:
+          branches:
+            main:
+              protect: true
+              required_status_checks:
+                strict: true
 tide:
   queries:
   - labels:


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OSAC-856

Add branch-protection config with `required_status_checks.strict: true`
for osac-installer main branch. Prevents Tide from merging stale PRs
that haven't been rebased on latest main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds branch protection configuration to enforce strict status checks on the `osac-installer` repository's main branch. The change requires that branches be up-to-date with main before allowing merges, preventing Tide from auto-merging PRs that are stale and have not been rebased on the latest main commit.

## Changes

**File: `core-services/prow/02_config/osac-project/osac-installer/_prowconfig.yaml`**

Added branch protection rule for the `osac-project/osac-installer` repository main branch:
- Enabled `required_status_checks.strict: true` to enforce up-to-date branch requirement

The existing Tide configuration (label-based merge criteria and exclusion labels) remains unchanged.

## Impact

This configuration change tightens merge requirements for the osac-installer repository, ensuring that all pull requests must be rebased to the latest main before they can be merged through the automated merge system. This addresses [OSAC-856](https://redhat.atlassian.net/browse/OSAC-856) to prevent merging of stale pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[OSAC-856]: https://redhat.atlassian.net/browse/OSAC-856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ