### PR TITLE
ART-14263: Migrate OCP 4.13 RPM repos to R2 CloudFlare

### DIFF
--- a/core-services/release-controller/_repos/ocp-4.13-default.repo
+++ b/core-services/release-controller/_repos/ocp-4.13-default.repo
@@ -30,7 +30,7 @@ gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release ht
 
 [rhel-server-ose]
 name = rhel-server-ose
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.13/rhel-server-ose-rpms/
+baseurl = https://openshift-mirror-list.ci-systems.workers.dev/enterprise/reposync/4.13/rhel-server-ose-rpms/
 sslverify = false
 username_file = /tmp/mirror-enterprise-basic-auth/username
 password_file = /tmp/mirror-enterprise-basic-auth/password

--- a/core-services/release-controller/_repos/ocp-4.13-openstack-beta.repo
+++ b/core-services/release-controller/_repos/ocp-4.13-openstack-beta.repo
@@ -1,6 +1,6 @@
 [openstack-beta-rhel8]
 name = rhel-openstack
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.13/openstack-beta-for-rhel-8-rpms
+baseurl = https://openshift-mirror-list.ci-systems.workers.dev/enterprise/reposync/4.13/openstack-beta-for-rhel-8-rpms
 sslverify = false
 username_file = /tmp/mirror-enterprise-basic-auth/username
 password_file = /tmp/mirror-enterprise-basic-auth/password

--- a/core-services/release-controller/_repos/ocp-4.13-openstack.repo
+++ b/core-services/release-controller/_repos/ocp-4.13-openstack.repo
@@ -1,6 +1,6 @@
 [openstack-16-rhel8]
 name = rhel-openstack
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.13/openstack-16-for-rhel-8-rpms
+baseurl = https://openshift-mirror-list.ci-systems.workers.dev/enterprise/reposync/4.13/openstack-16-for-rhel-8-rpms
 sslverify = false
 username_file = /tmp/mirror-enterprise-basic-auth/username
 password_file = /tmp/mirror-enterprise-basic-auth/password

--- a/core-services/release-controller/_repos/ocp-4.13-ppc64le.repo
+++ b/core-services/release-controller/_repos/ocp-4.13-ppc64le.repo
@@ -30,7 +30,7 @@ gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release ht
 
 [rhel-server-ose]
 name = rhel-server-ose
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.13_ppc64le/rhel-server-ose-rpms/
+baseurl = https://openshift-mirror-list.ci-systems.workers.dev/enterprise/reposync/4.13_ppc64le/rhel-server-ose-rpms/
 sslverify = false
 username_file = /tmp/mirror-enterprise-basic-auth/username
 password_file = /tmp/mirror-enterprise-basic-auth/password

--- a/core-services/release-controller/_repos/ocp-4.13-rhel-8-ironic-prevalidation.repo
+++ b/core-services/release-controller/_repos/ocp-4.13-rhel-8-ironic-prevalidation.repo
@@ -1,6 +1,6 @@
 [rhel-8-ironic-prevalidation]
 name = rhel-8-ironic-prevalidation
-baseurl = https://mirror2.openshift.com/enterprise/reposync/ci-ironic/rhaos-4.13-rhel-8-ironic-prevalidation/x86_64/os/
+baseurl = https://openshift-mirror-list.ci-systems.workers.dev/enterprise/reposync/ci-ironic/rhaos-4.13-rhel-8-ironic-prevalidation/x86_64/os/
 enabled = 0
 sslverify = false
 username_file = /tmp/mirror-enterprise-basic-auth/username

--- a/core-services/release-controller/_repos/ocp-4.13-rhel-8-server-ironic.repo
+++ b/core-services/release-controller/_repos/ocp-4.13-rhel-8-server-ironic.repo
@@ -1,6 +1,6 @@
 [rhel-8-server-ironic-rpms]
 name = rhel-8-server-ironic-rpms
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.13/rhel-8-server-ironic-rpms/
+baseurl = https://openshift-mirror-list.ci-systems.workers.dev/enterprise/reposync/4.13/rhel-8-server-ironic-rpms/
 enabled = 1
 sslverify = false
 username_file = /tmp/mirror-enterprise-basic-auth/username

--- a/core-services/release-controller/_repos/ocp-4.13-rhel-9-ironic-prevalidation.repo
+++ b/core-services/release-controller/_repos/ocp-4.13-rhel-9-ironic-prevalidation.repo
@@ -1,6 +1,6 @@
 [rhel-9-ironic-prevalidation]
 name = rhel-9-ironic-prevalidation
-baseurl = https://mirror2.openshift.com/enterprise/reposync/ci-ironic/rhaos-4.13-ironic-rhel-9-prevalidation/x86_64/os/
+baseurl = https://openshift-mirror-list.ci-systems.workers.dev/enterprise/reposync/ci-ironic/rhaos-4.13-ironic-rhel-9-prevalidation/x86_64/os/
 enabled = 0
 sslverify = false
 username_file = /tmp/mirror-enterprise-basic-auth/username

--- a/core-services/release-controller/_repos/ocp-4.13-rhel-9-server-ironic.repo
+++ b/core-services/release-controller/_repos/ocp-4.13-rhel-9-server-ironic.repo
@@ -1,6 +1,6 @@
 [rhel-9-server-ironic-rpms]
 name = rhel-9-server-ironic-rpms
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.13/rhel-9-server-ironic-rpms/
+baseurl = https://openshift-mirror-list.ci-systems.workers.dev/enterprise/reposync/4.13/rhel-9-server-ironic-rpms/
 enabled = 1
 sslverify = false
 username_file = /tmp/mirror-enterprise-basic-auth/username

--- a/core-services/release-controller/_repos/ocp-4.13-rhel8-aarch64.repo
+++ b/core-services/release-controller/_repos/ocp-4.13-rhel8-aarch64.repo
@@ -38,7 +38,7 @@ failovermethod = priority
 name = rhel-8-server-ose
 # Using mirror until aarch64 content released to CDN
 # See: https://github.com/openshift/release/pull/23111#discussion_r739417374
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.13_aarch64/rhel-8-server-ose-rpms
+baseurl = https://openshift-mirror-list.ci-systems.workers.dev/enterprise/reposync/4.13_aarch64/rhel-8-server-ose-rpms
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false
 gpgcheck = 0

--- a/core-services/release-controller/_repos/ocp-4.13-rhel8.repo
+++ b/core-services/release-controller/_repos/ocp-4.13-rhel8.repo
@@ -48,7 +48,7 @@ failovermethod = priority
 
 [rhel-8-server-ose]
 name = rhel-8-server-ose
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.13/rhel-8-server-ose-rpms
+baseurl = https://openshift-mirror-list.ci-systems.workers.dev/enterprise/reposync/4.13/rhel-8-server-ose-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false

--- a/core-services/release-controller/_repos/ocp-4.13-rhel810.repo
+++ b/core-services/release-controller/_repos/ocp-4.13-rhel810.repo
@@ -48,7 +48,7 @@ failovermethod = priority
 
 [rhel-8.6-server-ose-4.13]
 name = rhel-8.6-server-ose-4.13
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.13/rhel-8-server-ose-rpms
+baseurl = https://openshift-mirror-list.ci-systems.workers.dev/enterprise/reposync/4.13/rhel-8-server-ose-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false

--- a/core-services/release-controller/_repos/ocp-4.13-rhel9.repo
+++ b/core-services/release-controller/_repos/ocp-4.13-rhel9.repo
@@ -48,7 +48,7 @@ failovermethod = priority
 
 [rhel-9-server-ose]
 name = rhel-9-server-ose
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.13/rhel-9-server-ose-rpms
+baseurl = https://openshift-mirror-list.ci-systems.workers.dev/enterprise/reposync/4.13/rhel-9-server-ose-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false

--- a/core-services/release-controller/_repos/ocp-4.13-rhel92.repo
+++ b/core-services/release-controller/_repos/ocp-4.13-rhel92.repo
@@ -48,7 +48,7 @@ failovermethod = priority
 
 [rhel-9.2-server-ose-4.13]
 name = rhel-9.2-server-ose-4.13
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.13/rhel-9-server-ose-rpms
+baseurl = https://openshift-mirror-list.ci-systems.workers.dev/enterprise/reposync/4.13/rhel-9-server-ose-rpms
 enabled = 1
 gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
 sslverify = false

--- a/core-services/release-controller/_repos/ocp-4.13-s390x.repo
+++ b/core-services/release-controller/_repos/ocp-4.13-s390x.repo
@@ -30,7 +30,7 @@ gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release ht
 
 [rhel-server-ose]
 name = rhel-server-ose
-baseurl = https://mirror2.openshift.com/enterprise/reposync/4.13_s390x/rhel-server-ose-rpms/
+baseurl = https://openshift-mirror-list.ci-systems.workers.dev/enterprise/reposync/4.13_s390x/rhel-server-ose-rpms/
 sslverify = false
 username_file = /tmp/mirror-enterprise-basic-auth/username
 password_file = /tmp/mirror-enterprise-basic-auth/password


### PR DESCRIPTION
## Summary

Migrates OCP 4.13 RPM repository downloads from `mirror2.openshift.com` to the Cloudflare Workers R2 endpoint (`openshift-mirror-list.ci-systems.workers.dev`) to eliminate CloudFront egress costs.

## Changes

- Updated `baseurl` in 14 `ocp-4.13-*.repo` files under `core-services/release-controller/_repos/`
- Replaced `https://mirror2.openshift.com` with `https://openshift-mirror-list.ci-systems.workers.dev`
- Preserved all path structures and authentication configuration (username_file/password_file)
- CDN (`cdn.redhat.com`) baseurls are unchanged

## Scope

Follows the same pattern as #78292 (OCP 4.12 pilot migration).

## Related

- Jira: https://redhat.atlassian.net/browse/ART-14263
- Pilot PR: #78292

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR migrates OCP 4.13 RPM repository downloads from mirror2.openshift.com to the Cloudflare Workers R2 endpoint at openshift-mirror-list.ci-systems.workers.dev to reduce CloudFront egress costs. This follows the successful pilot migration for OCP 4.12 (PR #78292).

## Changes

Updated the repository `baseurl` in 14 OCP 4.13 repo configuration files located in `core-services/release-controller/_repos/`:
- `ocp-4.13-default.repo`
- `ocp-4.13-openstack.repo`
- `ocp-4.13-openstack-beta.repo`
- `ocp-4.13-ppc64le.repo`
- `ocp-4.13-rhel8.repo`
- `ocp-4.13-rhel8-aarch64.repo`
- `ocp-4.13-rhel810.repo`
- `ocp-4.13-rhel9.repo`
- `ocp-4.13-rhel92.repo`
- `ocp-4.13-s390x.repo`
- `ocp-4.13-rhel-8-ironic-prevalidation.repo`
- `ocp-4.13-rhel-8-server-ironic.repo`
- `ocp-4.13-rhel-9-ironic-prevalidation.repo`
- `ocp-4.13-rhel-9-server-ironic.repo`

Each file's `baseurl` was changed from `https://mirror2.openshift.com/enterprise/reposync/...` to `https://openshift-mirror-list.ci-systems.workers.dev/enterprise/reposync/...`, preserving all path structures and authentication configuration (username_file/password_file settings). CDN-based baseurls (cdn.redhat.com) remain unchanged.

## Impact

This configuration change affects OCP 4.13 CI builds and release processes, redirecting RPM downloads for multiple architectures (x86_64, ppc64le, aarch64, s390x) and environments (RHEL 8, RHEL 9, ironic, OpenStack) to use the R2 endpoint instead of the CloudFront mirror, reducing infrastructure costs while maintaining availability and package authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->