### PR TITLE
[ossm] Include CNI image to prepull phase

### DIFF
--- a/ci-operator/step-registry/servicemesh/sail-operator/e2e-lpinterop/servicemesh-sail-operator-e2e-lpinterop-commands.sh
+++ b/ci-operator/step-registry/servicemesh/sail-operator/e2e-lpinterop/servicemesh-sail-operator-e2e-lpinterop-commands.sh
@@ -225,8 +225,9 @@ mkdir ./test_artifacts
 ARTIFACTS="$(pwd)/test_artifacts"
 export ARTIFACTS
 
-# workaround for node instability, for now, ztunnel image only
+# workaround for a node network instability during test execution, prepull images which must be on each node
 prepull_image_on_nodes "ztunnel"
+prepull_image_on_nodes "cni"
 
 FIPS_CLUSTER=false
 # If fips cluster, patch network config to be able to run ambient tests


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR updates the E2E Limited Preview interoperability test script for the OpenShift Service Mesh Sail Operator to include CNI image pre-pulling during test execution.

## Changes
The test script that runs Sail Operator E2E Limited Preview interoperability tests now pre-pulls both the **ztunnel** and **CNI** container images on all OpenShift cluster nodes before test execution begins. Previously, only the ztunnel image was pre-pulled as part of a workaround for node instability.

## Practical Impact
This change ensures that both critical images required by the Sail Operator are available locally on all test cluster nodes before E2E tests begin. This addresses potential image pull delays or failures during test execution, which is particularly important for Limited Preview interoperability testing scenarios. The CNI (Container Network Interface) image is essential for the operator's networking functionality, and pre-pulling it reduces test flakiness related to image availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->