### PR TITLE
CNF-22981: Enable Tide allow-automatic-merge on scheduler-plugins

### DIFF
--- a/core-services/prow/02_config/openshift-kni/scheduler-plugins/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift-kni/scheduler-plugins/_prowconfig.yaml
@@ -1,0 +1,12 @@
+tide:
+  queries:
+  - author: red-hat-konflux[bot]
+    labels:
+    - allow-automatic-merge
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/hold
+    - do-not-merge/work-in-progress
+    - needs-rebase
+    repos:
+    - openshift-kni/scheduler-plugins


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR enables automatic merge (Tide auto-merge) for the `red-hat-konflux[bot]` user on the `openshift-kni/scheduler-plugins` repository.

## What's changing

A new Prow Tide configuration file is added that allows pull requests from `red-hat-konflux[bot]` to be automatically merged when they have the `allow-automatic-merge` label and lack any blocking labels (`do-not-merge`, `do-not-merge/hold`, `do-not-merge/work-in-progress`, or `needs-rebase`).

## Practical impact

The scheduler-plugins CI infrastructure will now automatically merge qualifying PRs from the red-hat-konflux bot without requiring manual merge operations, streamlining the automated contribution workflow for this bot on that specific repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->