### PR TITLE
Update odf release

### DIFF
--- a/core-services/jira-lifecycle-plugin/config.yaml
+++ b/core-services/jira-lifecycle-plugin/config.yaml
@@ -1091,28 +1091,28 @@ orgs:
         target_version: odf-4.15.28
         validate_by_default: true
       release-4.16:
-        target_version: odf-4.16.26
+        target_version: odf-4.16.28
         validate_by_default: true
       release-4.16-compatibility:
-        target_version: odf-4.16.26
+        target_version: odf-4.16.28
         validate_by_default: true
       release-4.17:
-        target_version: odf-4.17.24
+        target_version: odf-4.17.26
         validate_by_default: true
       release-4.17-compatibility:
-        target_version: odf-4.17.24
+        target_version: odf-4.17.26
         validate_by_default: true
       release-4.18:
-        target_version: odf-4.18.20
+        target_version: odf-4.18.22
         validate_by_default: true
       release-4.18-compatibility:
-        target_version: odf-4.18.20
+        target_version: odf-4.18.22
         validate_by_default: true
       release-4.19:
-        target_version: odf-4.19.16
+        target_version: odf-4.19.17
         validate_by_default: true
       release-4.19-compatibility:
-        target_version: odf-4.19.16
+        target_version: odf-4.19.17
         validate_by_default: true
       release-4.20:
         target_version: odf-4.20.12


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR updates the Jira lifecycle plugin configuration for the red-hat-storage organization so Jira target versions for several OpenShift Data Foundation (ODF) release branches are bumped.

Changes
- File modified: core-services/jira-lifecycle-plugin/config.yaml
- For red-hat-storage repo entries (both release-* and release-*-compatibility branches where present) the ODF Jira target versions were advanced:
  - release-4.16 / release-4.16-compatibility: odf-4.16.26 → odf-4.16.28
  - release-4.17 / release-4.17-compatibility: odf-4.17.24 → odf-4.17.26
  - release-4.18 / release-4.18-compatibility: odf-4.18.20 → odf-4.18.22
  - release-4.19 / release-4.19-compatibility: odf-4.19.16 → odf-4.19.17

Impact
- YAML-only configuration change that updates how the Jira lifecycle plugin maps issue targets for the listed ODF branches, ensuring issues are associated with the newer ODF minor release targets.

Metadata
- Lines changed: +8 / -8
- Estimated review effort: Medium
<!-- end of auto-generated comment: release notes by coderabbit.ai -->