### PR TITLE
OLS-2887 - adding vertex credentials to both evaluation and e2e tests

### DIFF
--- a/ci-operator/config/openshift/lightspeed-service/openshift-lightspeed-service-main.yaml
+++ b/ci-operator/config/openshift/lightspeed-service/openshift-lightspeed-service-main.yaml
@@ -90,6 +90,7 @@ tests:
         export OPENAI_PROVIDER_KEY_PATH=/var/run/openai/token
         export WATSONX_PROVIDER_KEY_PATH=/var/run/watsonx/token
         export RHAIIS_PROVIDER_KEY_PATH=/var/run/rhaiis
+        export VERTEX_PROVIDER_KEY_PATH=/var/run/vertex
 
         export PROVIDER_KEY_PATH=/var/run/openai/token
         export PROVIDER=openai
@@ -116,6 +117,9 @@ tests:
         namespace: test-credentials
       - mount_path: /var/run/rhaiis
         name: rhaiis-apitoken
+        namespace: test-credentials
+      - mount_path: /var/run/vertex
+        name: vertex-apitoken
         namespace: test-credentials
       - mount_path: /var/run/insights-stage-upload-offline-token
         name: insights-stage-upload-offline-token
@@ -151,6 +155,7 @@ tests:
         export AZUREOPENAI_PROVIDER_KEY_PATH=/var/run/azure_openai/token
         export OPENAI_PROVIDER_KEY_PATH=/var/run/openai/token
         export WATSONX_PROVIDER_KEY_PATH=/var/run/watsonx/token
+        export VERTEX_PROVIDER_KEY_PATH=/var/run/vertex
 
         tests/scripts/test-evaluation.sh
       credentials:
@@ -162,6 +167,9 @@ tests:
         namespace: test-credentials
       - mount_path: /var/run/watsonx
         name: watsonx-apitoken
+        namespace: test-credentials
+      - mount_path: /var/run/vertex
+        name: vertex-apitoken
         namespace: test-credentials
       dependencies:
       - env: OLS_IMAGE

--- a/ci-operator/config/openshift/lightspeed-service/openshift-lightspeed-service-main__4.16.yaml
+++ b/ci-operator/config/openshift/lightspeed-service/openshift-lightspeed-service-main__4.16.yaml
@@ -51,6 +51,7 @@ tests:
         export OPENAI_PROVIDER_KEY_PATH=/var/run/openai/token
         export WATSONX_PROVIDER_KEY_PATH=/var/run/watsonx/token
         export RHAIIS_PROVIDER_KEY_PATH=/var/run/rhaiis
+        export VERTEX_PROVIDER_KEY_PATH=/var/run/vertex
 
         export PROVIDER_KEY_PATH=/var/run/openai/token
         export PROVIDER=openai
@@ -77,6 +78,9 @@ tests:
         namespace: test-credentials
       - mount_path: /var/run/rhaiis
         name: rhaiis-apitoken
+        namespace: test-credentials
+      - mount_path: /var/run/vertex
+        name: vertex-apitoken
         namespace: test-credentials
       - mount_path: /var/run/insights-stage-upload-offline-token
         name: insights-stage-upload-offline-token

--- a/ci-operator/config/openshift/lightspeed-service/openshift-lightspeed-service-main__4.17.yaml
+++ b/ci-operator/config/openshift/lightspeed-service/openshift-lightspeed-service-main__4.17.yaml
@@ -59,6 +59,7 @@ tests:
         export OPENAI_PROVIDER_KEY_PATH=/var/run/openai/token
         export WATSONX_PROVIDER_KEY_PATH=/var/run/watsonx/token
         export RHAIIS_PROVIDER_KEY_PATH=/var/run/rhaiis
+        export VERTEX_PROVIDER_KEY_PATH=/var/run/vertex
 
         export PROVIDER_KEY_PATH=/var/run/openai/token
         export PROVIDER=openai
@@ -85,6 +86,9 @@ tests:
         namespace: test-credentials
       - mount_path: /var/run/rhaiis
         name: rhaiis-apitoken
+        namespace: test-credentials
+      - mount_path: /var/run/vertex
+        name: vertex-apitoken
         namespace: test-credentials
       - mount_path: /var/run/insights-stage-upload-offline-token
         name: insights-stage-upload-offline-token

--- a/ci-operator/config/openshift/lightspeed-service/openshift-lightspeed-service-main__4.18.yaml
+++ b/ci-operator/config/openshift/lightspeed-service/openshift-lightspeed-service-main__4.18.yaml
@@ -55,6 +55,7 @@ tests:
         export OPENAI_PROVIDER_KEY_PATH=/var/run/openai/token
         export WATSONX_PROVIDER_KEY_PATH=/var/run/watsonx/token
         export RHAIIS_PROVIDER_KEY_PATH=/var/run/rhaiis
+        export VERTEX_PROVIDER_KEY_PATH=/var/run/vertex
 
         export PROVIDER_KEY_PATH=/var/run/openai/token
         export PROVIDER=openai
@@ -81,6 +82,9 @@ tests:
         namespace: test-credentials
       - mount_path: /var/run/rhaiis
         name: rhaiis-apitoken
+        namespace: test-credentials
+      - mount_path: /var/run/vertex
+        name: vertex-apitoken
         namespace: test-credentials
       - mount_path: /var/run/insights-stage-upload-offline-token
         name: insights-stage-upload-offline-token

--- a/ci-operator/config/openshift/lightspeed-service/openshift-lightspeed-service-main__4.19.yaml
+++ b/ci-operator/config/openshift/lightspeed-service/openshift-lightspeed-service-main__4.19.yaml
@@ -51,6 +51,7 @@ tests:
         export OPENAI_PROVIDER_KEY_PATH=/var/run/openai/token
         export WATSONX_PROVIDER_KEY_PATH=/var/run/watsonx/token
         export RHAIIS_PROVIDER_KEY_PATH=/var/run/rhaiis
+        export VERTEX_PROVIDER_KEY_PATH=/var/run/vertex
 
         export PROVIDER_KEY_PATH=/var/run/openai/token
         export PROVIDER=openai
@@ -77,6 +78,9 @@ tests:
         namespace: test-credentials
       - mount_path: /var/run/rhaiis
         name: rhaiis-apitoken
+        namespace: test-credentials
+      - mount_path: /var/run/vertex
+        name: vertex-apitoken
         namespace: test-credentials
       - mount_path: /var/run/insights-stage-upload-offline-token
         name: insights-stage-upload-offline-token
@@ -112,6 +116,7 @@ tests:
         export AZUREOPENAI_PROVIDER_KEY_PATH=/var/run/azure_openai/token
         export OPENAI_PROVIDER_KEY_PATH=/var/run/openai/token
         export WATSONX_PROVIDER_KEY_PATH=/var/run/watsonx/token
+        export VERTEX_PROVIDER_KEY_PATH=/var/run/vertex
 
         tests/scripts/test-evaluation.sh
       credentials:
@@ -123,6 +128,9 @@ tests:
         namespace: test-credentials
       - mount_path: /var/run/watsonx
         name: watsonx-apitoken
+        namespace: test-credentials
+      - mount_path: /var/run/vertex
+        name: vertex-apitoken
         namespace: test-credentials
       dependencies:
       - env: OLS_IMAGE

--- a/ci-operator/config/openshift/lightspeed-service/openshift-lightspeed-service-main__4.20.yaml
+++ b/ci-operator/config/openshift/lightspeed-service/openshift-lightspeed-service-main__4.20.yaml
@@ -51,6 +51,7 @@ tests:
         export OPENAI_PROVIDER_KEY_PATH=/var/run/openai/token
         export WATSONX_PROVIDER_KEY_PATH=/var/run/watsonx/token
         export RHAIIS_PROVIDER_KEY_PATH=/var/run/rhaiis
+        export VERTEX_PROVIDER_KEY_PATH=/var/run/vertex
 
         export PROVIDER_KEY_PATH=/var/run/openai/token
         export PROVIDER=openai
@@ -77,6 +78,9 @@ tests:
         namespace: test-credentials
       - mount_path: /var/run/rhaiis
         name: rhaiis-apitoken
+        namespace: test-credentials
+      - mount_path: /var/run/vertex
+        name: vertex-apitoken
         namespace: test-credentials
       - mount_path: /var/run/insights-stage-upload-offline-token
         name: insights-stage-upload-offline-token
@@ -112,6 +116,7 @@ tests:
         export AZUREOPENAI_PROVIDER_KEY_PATH=/var/run/azure_openai/token
         export OPENAI_PROVIDER_KEY_PATH=/var/run/openai/token
         export WATSONX_PROVIDER_KEY_PATH=/var/run/watsonx/token
+        export VERTEX_PROVIDER_KEY_PATH=/var/run/vertex
 
         tests/scripts/test-evaluation.sh
       credentials:
@@ -123,6 +128,9 @@ tests:
         namespace: test-credentials
       - mount_path: /var/run/watsonx
         name: watsonx-apitoken
+        namespace: test-credentials
+      - mount_path: /var/run/vertex
+        name: vertex-apitoken
         namespace: test-credentials
       dependencies:
       - env: OLS_IMAGE

--- a/ci-operator/config/openshift/lightspeed-service/openshift-lightspeed-service-main__4.21.yaml
+++ b/ci-operator/config/openshift/lightspeed-service/openshift-lightspeed-service-main__4.21.yaml
@@ -51,6 +51,7 @@ tests:
         export OPENAI_PROVIDER_KEY_PATH=/var/run/openai/token
         export WATSONX_PROVIDER_KEY_PATH=/var/run/watsonx/token
         export RHAIIS_PROVIDER_KEY_PATH=/var/run/rhaiis
+        export VERTEX_PROVIDER_KEY_PATH=/var/run/vertex
 
         export PROVIDER_KEY_PATH=/var/run/openai/token
         export PROVIDER=openai
@@ -77,6 +78,9 @@ tests:
         namespace: test-credentials
       - mount_path: /var/run/rhaiis
         name: rhaiis-apitoken
+        namespace: test-credentials
+      - mount_path: /var/run/vertex
+        name: vertex-apitoken
         namespace: test-credentials
       - mount_path: /var/run/insights-stage-upload-offline-token
         name: insights-stage-upload-offline-token
@@ -112,6 +116,7 @@ tests:
         export AZUREOPENAI_PROVIDER_KEY_PATH=/var/run/azure_openai/token
         export OPENAI_PROVIDER_KEY_PATH=/var/run/openai/token
         export WATSONX_PROVIDER_KEY_PATH=/var/run/watsonx/token
+        export VERTEX_PROVIDER_KEY_PATH=/var/run/vertex
 
         tests/scripts/test-evaluation.sh
       credentials:
@@ -123,6 +128,9 @@ tests:
         namespace: test-credentials
       - mount_path: /var/run/watsonx
         name: watsonx-apitoken
+        namespace: test-credentials
+      - mount_path: /var/run/vertex
+        name: vertex-apitoken
         namespace: test-credentials
       dependencies:
       - env: OLS_IMAGE


### PR DESCRIPTION
add vertex credentials saved in vault to ols jobs for e2e tests and evaluation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds Vertex AI provider authentication to the OpenShift Lightspeed Service CI infrastructure, enabling both e2e and evaluation test jobs to access Vertex credentials stored in Vault.

## Changes

The PR updates CI configuration files for the OpenShift Lightspeed Service across multiple OpenShift release branches (4.16–4.21 and main) to:

1. **Export Vertex credentials to test environment**: Adds the `VERTEX_PROVIDER_KEY_PATH=/var/run/vertex` environment variable to e2e test and evaluation job command scripts, making the Vertex provider key path available during test execution.

2. **Mount Vertex credentials from Vault**: Adds credential mounts that provide the `vertex-apitoken` secret (from the `test-credentials` namespace) at the `/var/run/vertex` path in the test container, enabling the test jobs to authenticate with the Vertex provider.

The changes are applied consistently across all configured release branches, ensuring that both e2e cluster testing and periodic evaluation jobs have access to Vertex credentials for testing purposes.

**Total scope**: 7 configuration files modified with +28 lines across all branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->