### PR TITLE
HYPERFLEET-1068 - ci: update hyperfleet-hooks to v0.1.3

### DIFF
--- a/ci-operator/step-registry/hyperfleet/commitlint/hyperfleet-commitlint-commands.sh
+++ b/ci-operator/step-registry/hyperfleet/commitlint/hyperfleet-commitlint-commands.sh
@@ -9,7 +9,7 @@ if [ -z "${PULL_BASE_SHA:-}" ]; then
     exit 1
 fi
 
-HOOKS_VERSION="v0.1.2"
+HOOKS_VERSION="v0.1.3"
 HOOKS_URL="https://github.com/openshift-hyperfleet/hyperfleet-hooks/releases/download/${HOOKS_VERSION}/hyperfleet-hooks-linux-amd64"
 HOOKS_BIN="/tmp/hyperfleet-hooks"
 


### PR DESCRIPTION
## What

Bumps hyperfleet-hooks from v0.1.2 to v0.1.3 in the commitlint step registry.

## Why

v0.1.3 adds bot author whitelisting to the commitlint validator. Konflux PaC onboarding PRs were failing CI because the bot commit messages (`Red Hat Konflux kflux-prd-rh02 update hyperfleet-api`) don't follow the HyperFleet commit standard. The new version automatically skips validation for commits and PR titles from whitelisted bot accounts.

## Change

One line in `ci-operator/step-registry/hyperfleet/commitlint/hyperfleet-commitlint-commands.sh`:
```
HOOKS_VERSION="v0.1.2" → HOOKS_VERSION="v0.1.3"
```

## Release

https://github.com/openshift-hyperfleet/hyperfleet-hooks/releases/tag/v0.1.3



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR updates the HyperFleet hooks tool used in the commitlint CI validation step from v0.1.2 to v0.1.3. The change is a single-line version bump in the hyperfleet-commitlint step registry configuration.

## Motivation

The v0.1.3 release of hyperfleet-hooks introduces bot author whitelisting to the commitlint validator. This addresses a CI failure issue where Konflux PaC (Pipelines as Code) onboarding PRs were failing the commitlint validation step because automated bot commits don't follow the HyperFleet commit message standards. The new version skips validation for commits and PR titles from whitelisted bot accounts, allowing these automation-driven onboarding flows to proceed without CI blocking.

## Changes

- **File modified**: `ci-operator/step-registry/hyperfleet/commitlint/hyperfleet-commitlint-commands.sh`
- **Change**: Updated `HOOKS_VERSION` from `v0.1.2` to `v0.1.3`

The rest of the commitlint step's control flow remains unchanged—it continues to validate the pull request base SHA, download the hook binary, configure permissions, and execute the commitlint validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->