### PR TITLE
ACM Thanos: bump memory limit

### DIFF
--- a/ci-operator/config/stolostron/thanos/stolostron-thanos-release-2.13.yaml
+++ b/ci-operator/config/stolostron/thanos/stolostron-thanos-release-2.13.yaml
@@ -41,12 +41,21 @@ resources:
 test_binary_build_commands: "true"
 tests:
 - as: test-unit
-  commands: |
-    export SELF="make -f Makefile.prow"
-    make -f Makefile.prow test-local
-  container:
-    from: src
   skip_if_only_changed: ^(?:docs|\.github|\.tekton)|\.md$|^(?:\.gitignore|.golang-ci.yml|OWNERS|LICENSE)$
+  steps:
+    test:
+    - as: test-unit
+      commands: |-
+        export SELF="make -f Makefile.prow"
+        make -f Makefile.prow test-local
+      from: src
+      resources:
+        limits:
+          cpu: "8"
+          memory: 18Gi
+        requests:
+          cpu: "4"
+          memory: 1Gi
 - as: ocm-ci-rbac
   steps:
     workflow: ocm-ci-rbac

--- a/ci-operator/config/stolostron/thanos/stolostron-thanos-release-2.14.yaml
+++ b/ci-operator/config/stolostron/thanos/stolostron-thanos-release-2.14.yaml
@@ -37,12 +37,21 @@ resources:
 test_binary_build_commands: "true"
 tests:
 - as: test-unit
-  commands: |
-    export SELF="make -f Makefile.prow"
-    make -f Makefile.prow test-local
-  container:
-    from: src
   skip_if_only_changed: ^(?:docs|\.github|\.tekton)|\.md$|^(?:\.gitignore|.golang-ci.yml|OWNERS|LICENSE)$
+  steps:
+    test:
+    - as: test-unit
+      commands: |-
+        export SELF="make -f Makefile.prow"
+        make -f Makefile.prow test-local
+      from: src
+      resources:
+        limits:
+          cpu: "8"
+          memory: 18Gi
+        requests:
+          cpu: "4"
+          memory: 1Gi
 - as: ocm-ci-rbac
   steps:
     workflow: ocm-ci-rbac

--- a/ci-operator/config/stolostron/thanos/stolostron-thanos-release-2.15.yaml
+++ b/ci-operator/config/stolostron/thanos/stolostron-thanos-release-2.15.yaml
@@ -27,12 +27,21 @@ resources:
 test_binary_build_commands: "true"
 tests:
 - as: test-unit
-  commands: |
-    export SELF="make -f Makefile.prow"
-    make -f Makefile.prow test-local
-  container:
-    from: src
   skip_if_only_changed: ^(?:docs|\.github|\.tekton)|\.md$|^(?:\.gitignore|.golang-ci.yml|OWNERS|LICENSE)$
+  steps:
+    test:
+    - as: test-unit
+      commands: |-
+        export SELF="make -f Makefile.prow"
+        make -f Makefile.prow test-local
+      from: src
+      resources:
+        limits:
+          cpu: "8"
+          memory: 18Gi
+        requests:
+          cpu: "4"
+          memory: 1Gi
 - as: ocm-ci-rbac
   steps:
     workflow: ocm-ci-rbac

--- a/ci-operator/config/stolostron/thanos/stolostron-thanos-release-2.16.yaml
+++ b/ci-operator/config/stolostron/thanos/stolostron-thanos-release-2.16.yaml
@@ -27,12 +27,21 @@ resources:
 test_binary_build_commands: "true"
 tests:
 - as: test-unit
-  commands: |
-    export SELF="make -f Makefile.prow"
-    make -f Makefile.prow test-local
-  container:
-    from: src
   skip_if_only_changed: ^(?:docs|\.github|\.tekton)|\.md$|^(?:\.gitignore|.golang-ci.yml|OWNERS|LICENSE)$
+  steps:
+    test:
+    - as: test-unit
+      commands: |-
+        export SELF="make -f Makefile.prow"
+        make -f Makefile.prow test-local
+      from: src
+      resources:
+        limits:
+          cpu: "8"
+          memory: 18Gi
+        requests:
+          cpu: "4"
+          memory: 1Gi
 - as: ocm-ci-rbac
   steps:
     workflow: ocm-ci-rbac

--- a/ci-operator/config/stolostron/thanos/stolostron-thanos-release-2.17.yaml
+++ b/ci-operator/config/stolostron/thanos/stolostron-thanos-release-2.17.yaml
@@ -35,12 +35,21 @@ resources:
 test_binary_build_commands: "true"
 tests:
 - as: test-unit
-  commands: |
-    export SELF="make -f Makefile.prow"
-    make -f Makefile.prow test-local
-  container:
-    from: src
   skip_if_only_changed: ^(?:docs|\.github|\.tekton)|\.md$|^(?:\.gitignore|.golang-ci.yml|OWNERS|LICENSE)$
+  steps:
+    test:
+    - as: test-unit
+      commands: |-
+        export SELF="make -f Makefile.prow"
+        make -f Makefile.prow test-local
+      from: src
+      resources:
+        limits:
+          cpu: "8"
+          memory: 18Gi
+        requests:
+          cpu: "4"
+          memory: 1Gi
 - as: ocm-ci-rbac
   steps:
     workflow: ocm-ci-rbac

--- a/ci-operator/config/stolostron/thanos/stolostron-thanos-release-5.0.yaml
+++ b/ci-operator/config/stolostron/thanos/stolostron-thanos-release-5.0.yaml
@@ -35,12 +35,21 @@ resources:
 test_binary_build_commands: "true"
 tests:
 - as: test-unit
-  commands: |
-    export SELF="make -f Makefile.prow"
-    make -f Makefile.prow test-local
-  container:
-    from: src
   skip_if_only_changed: ^(?:docs|\.github|\.tekton)|\.md$|^(?:\.gitignore|.golang-ci.yml|OWNERS|LICENSE)$
+  steps:
+    test:
+    - as: test-unit
+      commands: |-
+        export SELF="make -f Makefile.prow"
+        make -f Makefile.prow test-local
+      from: src
+      resources:
+        limits:
+          cpu: "8"
+          memory: 18Gi
+        requests:
+          cpu: "4"
+          memory: 1Gi
 - as: ocm-ci-rbac
   steps:
     workflow: ocm-ci-rbac

--- a/ci-operator/jobs/stolostron/thanos/stolostron-thanos-release-2.13-presubmits.yaml
+++ b/ci-operator/jobs/stolostron/thanos/stolostron-thanos-release-2.13-presubmits.yaml
@@ -322,7 +322,9 @@ presubmits:
       - args:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
         - --target=test-unit
         command:
         - ci-operator
@@ -341,6 +343,12 @@ presubmits:
           requests:
             cpu: 10m
         volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
@@ -355,6 +363,15 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher

--- a/ci-operator/jobs/stolostron/thanos/stolostron-thanos-release-2.14-presubmits.yaml
+++ b/ci-operator/jobs/stolostron/thanos/stolostron-thanos-release-2.14-presubmits.yaml
@@ -322,7 +322,9 @@ presubmits:
       - args:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
         - --target=test-unit
         command:
         - ci-operator
@@ -341,6 +343,12 @@ presubmits:
           requests:
             cpu: 10m
         volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
@@ -355,6 +363,15 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher

--- a/ci-operator/jobs/stolostron/thanos/stolostron-thanos-release-2.15-presubmits.yaml
+++ b/ci-operator/jobs/stolostron/thanos/stolostron-thanos-release-2.15-presubmits.yaml
@@ -301,6 +301,7 @@ presubmits:
       - args:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --target=test-unit
         command:
@@ -320,6 +321,9 @@ presubmits:
           requests:
             cpu: 10m
         volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
@@ -334,6 +338,12 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher

--- a/ci-operator/jobs/stolostron/thanos/stolostron-thanos-release-2.16-presubmits.yaml
+++ b/ci-operator/jobs/stolostron/thanos/stolostron-thanos-release-2.16-presubmits.yaml
@@ -301,6 +301,7 @@ presubmits:
       - args:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --target=test-unit
         command:
@@ -320,6 +321,9 @@ presubmits:
           requests:
             cpu: 10m
         volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
@@ -334,6 +338,12 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher

--- a/ci-operator/jobs/stolostron/thanos/stolostron-thanos-release-2.17-presubmits.yaml
+++ b/ci-operator/jobs/stolostron/thanos/stolostron-thanos-release-2.17-presubmits.yaml
@@ -301,6 +301,7 @@ presubmits:
       - args:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --target=test-unit
         command:
@@ -320,6 +321,9 @@ presubmits:
           requests:
             cpu: 10m
         volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
@@ -334,6 +338,12 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher

--- a/ci-operator/jobs/stolostron/thanos/stolostron-thanos-release-5.0-presubmits.yaml
+++ b/ci-operator/jobs/stolostron/thanos/stolostron-thanos-release-5.0-presubmits.yaml
@@ -301,6 +301,7 @@ presubmits:
       - args:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --target=test-unit
         command:
@@ -320,6 +321,9 @@ presubmits:
           requests:
             cpu: 10m
         volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
@@ -334,6 +338,12 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher


### PR DESCRIPTION
The tests require a lot of memory, so we bump the limit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Memory limit increase for Thanos CI test steps (per-test, not global)

What changed
- Updated ci-operator job configs for the stolostron/thanos repository so the test-unit test step runs with higher per-container resources.
- Releases affected: release-2.13, release-2.14, release-2.15, release-2.16, release-2.17, release-5.0 (files under ci-operator/config/stolostron/thanos/).
- The test-unit step now sets resources.requests: cpu: "4", memory: 1Gi and resources.limits: cpu: "8", memory: 18Gi (previously per-step/container memory used the top-level wildcard of 6Gi).

Practical effect
- The test-unit container for the ACM Thanos test suite gains a 18Gi memory limit (and higher CPU limit), reducing OOM failures for memory-heavy tests.
- The global wildcard resources ('*': limits.memory: 6Gi) are unchanged, so other tests/jobs that rely on that default are unaffected.

Notes
- The PR author posted "/pj-rehearse max" four times in comments (rehearsal trigger requests); another commenter requested "/test generated-config".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->